### PR TITLE
Knockout integration - Fix options changing after component created

### DIFF
--- a/js/integration/knockout/component_registrator.js
+++ b/js/integration/knockout/component_registrator.js
@@ -110,9 +110,9 @@ var registerComponentKoBinding = function(componentName, componentClass) {
                 },
                 optionNameToModelMap = {};
 
-            var applyModelValueToOption = function(optionName, modelValue) {
+            var applyModelValueToOption = function(optionName, modelValue, unwrap) {
                 var locks = $element.data(LOCKS_DATA_KEY),
-                    optionValue = ko.unwrap(modelValue); // must unwrap always to keep computeds alive
+                    optionValue = unwrap ? ko.unwrap(modelValue) : modelValue;
 
                 if(ko.isWriteableObservable(modelValue)) {
                     optionNameToModelMap[optionName] = modelValue;
@@ -185,7 +185,7 @@ var registerComponentKoBinding = function(componentName, componentClass) {
 
                     ko.computed(function() {
                         var propertyValue = currentModel[propertyName];
-                        applyModelValueToOption(propertyPath, propertyValue);
+                        applyModelValueToOption(propertyPath, propertyValue, true);
                         unwrappedPropertyValue = ko.unwrap(propertyValue);
                     }, null, { disposeWhenNodeIsRemoved: domNode });
 
@@ -195,7 +195,7 @@ var registerComponentKoBinding = function(componentName, componentClass) {
                         }
                     }
                 } else {
-                    ctorOptions[propertyPath] = currentModel[propertyName];
+                    applyModelValueToOption(propertyPath, currentModel[propertyName], false);
                 }
             };
 

--- a/testing/tests/DevExpress.knockout/componentRegistration.tests.js
+++ b/testing/tests/DevExpress.knockout/componentRegistration.tests.js
@@ -1538,4 +1538,27 @@ QUnit.module("predicate for manual option binding control", {
             [ "objectProperty.nestedProperty", "nestedProperty", vm.objectProperty ]
         ]);
     });
+
+    QUnit.test("options changing after component created", function(assert) {
+        var isBindingProperty = function() {
+            return false;
+        };
+
+        var vm = {
+            options: ko.observable({
+                isBindingProperty: isBindingProperty,
+                option1: true
+            })
+        };
+
+        var markup = $("<div></div>").attr("data-bind", "dxTest: $data").appendTo(FIXTURE_ELEMENT);
+        ko.applyBindings(vm.options, markup[0]);
+
+        vm.options({
+            isBindingProperty: isBindingProperty,
+            option1: false
+        });
+
+        assert.equal(markup.dxTest("option", "option1"), false);
+    });
 });


### PR DESCRIPTION
This PR fixes a null reference exception during options changing after component created when binding property predicate is set.