### PR TITLE
Fixes T490356: Header Filter - Selection is handled incorrectly

### DIFF
--- a/js/ui/grid_core/ui.grid_core.header_filter_core.js
+++ b/js/ui/grid_core/ui.grid_core.header_filter_core.js
@@ -20,6 +20,14 @@ function resetChildrenItemSelection(items) {
     }
 }
 
+function updateSelectAllState($listContainer, filterValues) {
+    var selectAllCheckBox = $listContainer.find(".dx-list-select-all-checkbox").data("dxCheckBox");
+
+    if(selectAllCheckBox && filterValues && filterValues.length) {
+        selectAllCheckBox.option("value", undefined);
+    }
+}
+
 exports.updateHeaderFilterItemSelectionState = function(item, filterValuesMatch, isExcludeFilter) {
 
     if(filterValuesMatch ^ isExcludeFilter) {
@@ -237,12 +245,13 @@ exports.HeaderFilterView = modules.View.inherit({
                                 }
                             }
                         });
+
+                        updateSelectAllState(e.element, options.filterValues);
                     },
                     onContentReady: function(e) {
                         var component = e.component,
                             items = component.option("items"),
-                            selectedItems = [],
-                            selectAllCheckBox = e.element.find(".dx-list-select-all-checkbox").dxCheckBox("instance");
+                            selectedItems = [];
 
                         $.each(items, function() {
                             if(this.selected) {
@@ -253,10 +262,7 @@ exports.HeaderFilterView = modules.View.inherit({
                         component.option("selectedItems", selectedItems);
                         component._selectedItemsUpdating = false;
 
-                        if(options.filterValues && options.filterValues.length) {
-                            selectAllCheckBox.option("value", undefined);
-                        }
-
+                        updateSelectAllState(e.element, options.filterValues);
                     }
                 }));
         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -1518,9 +1518,13 @@ QUnit.test("Checking filterValues of the column after deselect item of a loaded 
 
     this.headerFilterController.showHeaderFilterMenu(0);
 
-    //act
     $popupContent = this.headerFilterView.getPopupContainer().content();
     $popupContent.find(".dx-list-item").first().trigger("dxclick"); // deselect first item
+
+    //assert
+    assert.ok($popupContent.find(".dx-list-select-all-checkbox").hasClass("dx-checkbox-indeterminate"), "checkbox in an indeterminate state");
+
+    //act
     $popupContent.parent().find(".dx-button").eq(0).trigger("dxclick"); // apply filter
     this.clock.tick(500);
 


### PR DESCRIPTION
[T490356: Header Filter - Selection is handled incorrectly if there are multiple pages of items and an end-user performs selection when only the first page is loaded](https://www.devexpress.com/Support/Center/Question/Details/T490356)