### PR TITLE
Fix T454649: Move the "baseZIndex" method description to the "Common|Utilities|ui|dxOverlay" section

### DIFF
--- a/js/ui/overlay.js
+++ b/js/ui/overlay.js
@@ -1457,7 +1457,12 @@ var Overlay = Widget.inherit({
 });
 
 /**
-* @name dxOverlayMethods_baseZIndex
+* @name ui_dxOverlay
+* @publicName dxOverlay
+* @section utils
+*/
+/**
+* @name ui_dxOverlayMethods_baseZIndex
 * @publicName baseZIndex(zIndex)
 * @param1 zIndex:number
 */


### PR DESCRIPTION
The baseZIndex method doc comment is changed so that the topic is moved to the Common|Utilities|ui|dxOverlay section. The dxOverlay root doc comment is also added.