### PR TITLE
dxPivotGrid: fix colspan calculation in the case all items are hidden (T492326)

### DIFF
--- a/js/ui/pivot_grid/ui.pivot_grid.data_controller.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.data_controller.js
@@ -190,6 +190,10 @@ exports.DataController = Class.inherit((function() {
                 var hideTotals = options.showTotals === false || dataFields.length > 0 && (dataFields.length === options.hiddenTotals.length),
                     hideData = dataFields.length > 0 && options.hiddenValues.length === dataFields.length;
 
+                if(hideData && hideTotals) {
+                    depthSize = 1;
+                }
+
                 if(!hideTotals || options.layout === "tree") {
                     addAdditionalTotalHeaderItems(viewHeaderItems, headerDescriptions, options.showTotalsPrior, options.layout === "tree");
                 }
@@ -588,7 +592,7 @@ exports.DataController = Class.inherit((function() {
         return info;
     }
 
-    function getHeaderIndexedItems(headerItems, maxDepth, options) {
+    function getHeaderIndexedItems(headerItems, options) {
         var visibleIndex = 0,
             indexedItems = [];
 
@@ -950,10 +954,10 @@ exports.DataController = Class.inherit((function() {
                 };
 
             if(!commonUtils.isDefined(data.grandTotalRowIndex)) {
-                data.grandTotalRowIndex = getHeaderIndexedItems(data.rows, rowFields.length - 1, rowOptions).length;
+                data.grandTotalRowIndex = getHeaderIndexedItems(data.rows, rowOptions).length;
             }
             if(!commonUtils.isDefined(data.grandTotalColumnIndex)) {
-                data.grandTotalColumnIndex = getHeaderIndexedItems(data.columns, columnFields.length - 1, columnOptions).length;
+                data.grandTotalColumnIndex = getHeaderIndexedItems(data.columns, columnOptions).length;
             }
 
             dataSource._changeLoadingCount(1, 0.8);

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/dataController.tests.js
@@ -3386,6 +3386,50 @@ QUnit.test("Format cell with error value", function(assert) {
     assert.equal(dataController.getCellsInfo()[0][1].text, "Error");
 });
 
+QUnit.test("T492326. Not set colspan in rowInfo item if all values and totals are hidden", function(assert) {
+    var dataController = new DataController({
+        dataSource: {
+            fields: [
+                { area: "row" },
+                { area: "row" },
+                { area: "column" },
+                {
+                    caption: 'Sum', format: 'decimal', area: "data",
+                    showValues: false,
+                    showTotals: false,
+                    showGrandTotals: true,
+                }
+            ],
+            rows: [{
+                index: 0,
+                value: "1",
+                children: [
+                    {
+                        value: "2",
+                        index: 1
+                    }
+                ]
+            }],
+            columns: [{
+                value: 'A', index: 1
+            }],
+            values: [
+                [[1], [3], [5]],
+                [[1], [3], [5]]
+            ]
+        }
+    });
+
+    assert.deepEqual(dataController.getRowsInfo(), [
+        [{
+            "isLast": true,
+            "text": undefined,
+            "type": "GT"
+        }]
+    ]);
+});
+
+
 QUnit.module("Showing total on the top", moduleConfig);
 
 QUnit.test("Get header info. Show column totals near", function(assert) {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
