### PR TITLE
Focusing for the first editor inside an edit form has been fixed (T504297)

### DIFF
--- a/js/ui/data_grid/ui.data_grid.editing.js
+++ b/js/ui/data_grid/ui.data_grid.editing.js
@@ -1159,7 +1159,8 @@ exports.EditingController = gridCore.ViewController.inherit((function() {
                                 $.extend(item, column.formItem);
                             }
 
-                            if(!that._firstFormItem) {
+                            var itemVisible = commonUtils.isDefined(item.visible) ? item.visible : true;
+                            if(!that._firstFormItem && itemVisible) {
                                 that._firstFormItem = item;
                             }
                         }

--- a/js/ui/data_grid/ui.data_grid.editing.js
+++ b/js/ui/data_grid/ui.data_grid.editing.js
@@ -180,15 +180,19 @@ exports.EditingController = gridCore.ViewController.inherit((function() {
 
         getFirstEditableColumnIndex: function() {
             var columnsController = this.getController("columns"),
-                visibleColumns = columnsController.getVisibleColumns(),
                 columnIndex;
 
-            $.each(visibleColumns, function(index, column) {
-                if(column.allowEditing) {
-                    columnIndex = index;
-                    return false;
-                }
-            });
+            if(getEditMode(this) === DATAGRID_EDIT_MODE_FORM && this._firstFormItem) {
+                columnIndex = this._firstFormItem.column.index;
+            } else {
+                var visibleColumns = columnsController.getVisibleColumns();
+                $.each(visibleColumns, function(index, column) {
+                    if(column.allowEditing) {
+                        columnIndex = index;
+                        return false;
+                    }
+                });
+            }
 
             return columnIndex;
         },
@@ -1151,6 +1155,10 @@ exports.EditingController = gridCore.ViewController.inherit((function() {
                             item.column = column;
                             if(column.formItem) {
                                 $.extend(item, column.formItem);
+                            }
+
+                            if(!that._firstFormItem) {
+                                that._firstFormItem = item;
                             }
                         }
                         userCustomizeItem && userCustomizeItem.call(this, item);

--- a/js/ui/data_grid/ui.data_grid.editing.js
+++ b/js/ui/data_grid/ui.data_grid.editing.js
@@ -1142,6 +1142,8 @@ exports.EditingController = gridCore.ViewController.inherit((function() {
                     });
                 }
 
+                that._firstFormItem = undefined;
+
                 that._createComponent($("<div>").appendTo($container), Form, $.extend({}, editFormOptions, {
                     items: items,
                     formID: new Guid(),

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -5008,6 +5008,37 @@ QUnit.test("Get first editable column index when form edit mode and custom form 
     assert.equal(editableIndex, 3, "editable index");
 });
 
+QUnit.test("Get correct first editable column index when form edit mode and form items are changed dynamically", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.masterDetail = {
+        enabled: true
+    };
+
+    that.options.editing = {
+        allowUpdating: true,
+        mode: "form"
+    };
+
+    rowsView.render(testElement);
+
+    that.editRow(0);
+
+    //act
+    this.editingController.option("editing.form", { items: ["phone", "room"] });
+    this.editingController.optionChanged({ name: "editing" });
+
+    that.editRow(0);
+
+    var editableIndex = this.editingController.getFirstEditableColumnIndex();
+
+    //assert
+    assert.equal(editableIndex, 3, "editable index");
+});
+
 if(device.ios || device.android) {
     //T322738
     QUnit.testInActiveWindow("Native click is used when allowUpdating is true", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -5039,6 +5039,37 @@ QUnit.test("Get correct first editable column index when form edit mode and form
     assert.equal(editableIndex, 3, "editable index");
 });
 
+QUnit.test("Get correct first editable column index when visible option for item set via formItem option", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.masterDetail = {
+        enabled: true
+    };
+
+    that.options.editing = {
+        allowUpdating: true,
+        mode: "form"
+    };
+
+    rowsView.render(testElement);
+
+    that.columnsController.columnOption("name", {
+        formItem: {
+            visible: false
+        }
+    });
+
+    that.editRow(0);
+
+    var editableIndex = this.editingController.getFirstEditableColumnIndex();
+
+    //assert
+    assert.equal(editableIndex, 1, "editable index");
+});
+
 if(device.ios || device.android) {
     //T322738
     QUnit.testInActiveWindow("Native click is used when allowUpdating is true", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -4944,6 +4944,69 @@ QUnit.testInActiveWindow('Hide focus overlay before update on editing cell', fun
     assert.ok(testElement.find('.dx-datagrid-focus-overlay').is(":visible"), 'visible focus overlay');
 });
 
+QUnit.test("Get first editable column index when form edit mode", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.masterDetail = {
+        enabled: true
+    };
+
+    that.options.editing = {
+        allowUpdating: true,
+        mode: "form"
+    };
+
+    rowsView.render(testElement);
+
+    that.editRow(0);
+
+    //act
+    var editableIndex = this.editingController.getFirstEditableColumnIndex();
+
+    //assert
+    assert.equal(editableIndex, 0, "editable index");
+});
+
+QUnit.test("Get first editable column index when form edit mode and custom form items is defined", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.masterDetail = {
+        enabled: true
+    };
+
+    that.options.editing = {
+        allowUpdating: true,
+        mode: "form",
+        form: {
+            items: [
+                {
+                    itemType: "group",
+                    items: ["phone", "room"]
+                },
+                {
+                    itemType: "group",
+                    items: ["name", "age"]
+                }
+            ]
+        }
+    };
+
+    rowsView.render(testElement);
+
+    that.editRow(0);
+
+    //act
+    var editableIndex = this.editingController.getFirstEditableColumnIndex();
+
+    //assert
+    assert.equal(editableIndex, 3, "editable index");
+});
 
 if(device.ios || device.android) {
     //T322738


### PR DESCRIPTION
[T504297: dxDataGrid focuses the second editor in edit form mode if the masterDetail option is enabled](https://isc.devexpress.com/Thread/WorkplaceDetails/T504297)