### PR TITLE
Fixes incorrect firing time of the onItemExpanded when animation is not completed yet in dxTreeView

### DIFF
--- a/js/ui/tree_view.js
+++ b/js/ui/tree_view.js
@@ -1190,16 +1190,13 @@ var TreeView = HierarchicalCollectionWidget.inherit({
     },
 
     _updateExpandedItem: function(node, state, e) {
-        var $node = this._getNodeElement(node),
-            $nodeContainer = $node.children("." + NODE_CONTAINER_CLASS);
-
-        this._animateNodeContainer($nodeContainer, state);
-        this.setAria("expanded", state, $node);
-        this._fireExpandedStateUpdatedEvent(state, node, e);
+        this._animateNodeContainer(node, state, e);
     },
 
-    _animateNodeContainer: function($nodeContainer, state) {
-        var nodeHeight = $nodeContainer.height();
+    _animateNodeContainer: function(node, state, e) {
+        var $node = this._getNodeElement(node),
+            $nodeContainer = $node.children("." + NODE_CONTAINER_CLASS),
+            nodeHeight = $nodeContainer.height();
 
         fx.stop($nodeContainer, true);
         fx.animate($nodeContainer, {
@@ -1217,7 +1214,9 @@ var TreeView = HierarchicalCollectionWidget.inherit({
             complete: (function() {
                 $nodeContainer.css("max-height", "none");
                 $nodeContainer.toggleClass(OPENED_NODE_CONTAINER_CLASS, state);
+                this.setAria("expanded", state, $node);
                 this._scrollableContainer.update();
+                this._fireExpandedStateUpdatedEvent(state, node, e);
             }).bind(this)
         });
     },

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/accessibility.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/accessibility.js
@@ -5,16 +5,20 @@
 QUnit.module("aria accessibility", {
     beforeEach: function() {
         this.$element = initTree({
+            animationEnabled: false,
             items: [{ id: 1, text: "Item 1", expanded: true, items: [{ id: 3, text: "Item 11" }, { id: 4, text: "Item 12" }] }, { id: 2, text: "Item 2", expanded: false }],
             selectNodesRecursive: true,
             showCheckBoxesMode: "normal"
-        }),
-            this.instance = this.$element.dxTreeView("instance");
+        });
+
+        this.instance = this.$element.dxTreeView("instance");
+        this.clock = sinon.useFakeTimers();
     },
 
     afterEach: function() {
         this.$treeView = undefined;
         this.instance = undefined;
+        this.clock.restore();
     }
 });
 
@@ -47,6 +51,7 @@ QUnit.test("aria expanded for items", function(assert) {
     assert.equal($item1.attr("aria-expanded"), "true", "expanded item has aria-expanded as true");
 
     this.instance.collapseItem($itemElements[0]);
+    this.clock.tick(0);
     assert.equal($item1.attr("aria-expanded"), "false", "aria-expanded changing on item collapsing");
 });
 
@@ -88,7 +93,9 @@ QUnit.test("'Expanded' attr should be applied correctly when item was expanded o
         $itemElements = this.instance.itemElements();
 
     this.instance.collapseItem($itemElements[0]);
+    this.clock.tick(0);
     this.instance.expandItem($itemElements[0]);
+    this.clock.tick(0);
 
     assert.equal($item1.attr("aria-expanded"), "true", "aria-expanded changing on item expanding");
 });
@@ -101,6 +108,7 @@ QUnit.test("'Expanded' attr should be applied correctly when item was expanded o
         $itemElements = this.instance.itemElements();
 
     this.instance.expandItem($itemElements[0]);
+    this.clock.tick(0);
 
     assert.equal($item1.attr("aria-expanded"), "true", "aria-expanded changing on item expanding");
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
