### PR TITLE
Fixes popup element focusing after the dxDropDownBox opening (T511338)

### DIFF
--- a/js/ui/drop_down_box.js
+++ b/js/ui/drop_down_box.js
@@ -225,6 +225,7 @@ var DropDownBox = DropDownEditor.inherit({
             width: this.element().outerWidth(),
             height: "auto",
             tabIndex: -1,
+            dragEnabled: false,
             focusStateEnabled: this.option("focusStateEnabled"),
             onPositioned: null,
             maxHeight: this._getMaxHeight.bind(this)
@@ -238,6 +239,12 @@ var DropDownBox = DropDownEditor.inherit({
             maxHeight = windowHeight - offset.top - $element.outerHeight();
 
         return maxHeight * 0.9;
+    },
+
+    _popupShownHandler: function() {
+        this.callBase();
+        var $firstElement = this._getTabbableElements().first();
+        $firstElement.focus();
     },
 
     _popupOptionChanged: function(args) {

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
@@ -262,6 +262,17 @@ QUnit.test("dimensionChanged should be called once when different popup options 
     assert.equal(dimensionChangedSpy.callCount, 1, "dimensionChanged was called once");
 });
 
+QUnit.test("popup should not be draggable by default", function(assert) {
+    this.$element.dxDropDownBox({
+        opened: true
+    });
+
+    var popup = this.$element.find(".dx-popup").dxPopup("instance");
+
+    assert.strictEqual(popup.option("dragEnabled"), false, "dragging is disabled");
+});
+
+
 QUnit.module("keyboard navigation", moduleConfig);
 
 QUnit.testInActiveWindow("first focusable element inside of content should get focused after tab pressing", function(assert) {
@@ -340,3 +351,17 @@ QUnit.testInActiveWindow("input should get focused when shift+tab pressed on fir
     assert.ok(event.isDefaultPrevented(), "prevent default for focusing it's own input but not an input of the previous editor on the page");
 });
 
+QUnit.test("inner input should be focused after popup opening", function(assert) {
+    var inputFocusedHandler = sinon.stub(),
+        $input = $("<input>", { id: "input1", type: "text" }).on("focus", inputFocusedHandler),
+        instance = new DropDownBox(this.$element, {
+            focusStateEnabled: true,
+            contentTemplate: function(component, $content) {
+                $content.append($input);
+            }
+        });
+
+    instance.open();
+
+    assert.ok(inputFocusedHandler.callCount, 1, "input get focused");
+});


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
