### PR TITLE
Fixes editor focusing inside the edit form when the tab key is pressed and the master detail option is enabled (T506748)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -196,15 +196,19 @@ var EditingController = modules.ViewController.inherit((function() {
 
         getFirstEditableColumnIndex: function() {
             var columnsController = this.getController("columns"),
-                visibleColumns = columnsController.getVisibleColumns(),
                 columnIndex;
 
-            $.each(visibleColumns, function(index, column) {
-                if(column.allowEditing) {
-                    columnIndex = index;
-                    return false;
-                }
-            });
+            if(getEditMode(this) === EDIT_MODE_FORM && this._firstFormItem) {
+                columnIndex = this._firstFormItem.column.index;
+            } else {
+                var visibleColumns = columnsController.getVisibleColumns();
+                $.each(visibleColumns, function(index, column) {
+                    if(column.allowEditing) {
+                        columnIndex = index;
+                        return false;
+                    }
+                });
+            }
 
             return columnIndex;
         },
@@ -1289,6 +1293,8 @@ var EditingController = modules.ViewController.inherit((function() {
                     });
                 }
 
+                that._firstFormItem = undefined;
+
                 that._createComponent($("<div>").appendTo($container), Form, extend({ scrollingEnabled: isScrollingEnabled }, editFormOptions, {
                     items: items,
                     formID: "dx-" + new Guid(),
@@ -1302,6 +1308,11 @@ var EditingController = modules.ViewController.inherit((function() {
                             item.column = column;
                             if(column.formItem) {
                                 extend(item, column.formItem);
+                            }
+
+                            var itemVisible = commonUtils.isDefined(item.visible) ? item.visible : true;
+                            if(!that._firstFormItem && itemVisible) {
+                                that._firstFormItem = item;
                             }
                         }
                         userCustomizeItem && userCustomizeItem.call(this, item);

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -421,6 +421,10 @@ var KeyboardNavigationController = core.ViewController.inherit({
         }
     },
 
+    _isInsideEditForm: function(element) {
+        return $(element).closest("." + this.addWidgetPrefix(EDIT_FORM_CLASS)).length > 0;
+    },
+
     _isMasterDetailCell: function(element) {
         var $masterDetailCell = $(element).closest("." + MASTER_DETAIL_CELL_CLASS),
             $masterDetailGrid = $masterDetailCell.closest("." + this.getWidgetContainerClass()).parent();
@@ -431,8 +435,11 @@ var KeyboardNavigationController = core.ViewController.inherit({
     _handleTabKeyOnMasterDetailCell: function(target, direction) {
         if(this._isMasterDetailCell(target)) {
             this._updateFocusedCellPosition($(target).closest("." + MASTER_DETAIL_CELL_CLASS));
+
             var $nextCell = this._getNextCell(direction, "row");
-            $nextCell && $nextCell.attr("tabindex", 0);
+            if(!this._isInsideEditForm($nextCell)) {
+                $nextCell && $nextCell.attr("tabindex", 0);
+            }
 
             return true;
         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -4974,6 +4974,131 @@ QUnit.testInActiveWindow('Hide focus overlay before update on editing cell', fun
     assert.ok(testElement.find('.dx-datagrid-focus-overlay').is(":visible"), 'visible focus overlay');
 });
 
+QUnit.test("Get first editable column index when form edit mode", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.masterDetail = {
+        enabled: true
+    };
+
+    that.options.editing = {
+        allowUpdating: true,
+        mode: "form"
+    };
+
+    rowsView.render(testElement);
+
+    that.editRow(0);
+
+    //act
+    var editableIndex = this.editingController.getFirstEditableColumnIndex();
+
+    //assert
+    assert.equal(editableIndex, 0, "editable index");
+});
+
+QUnit.test("Get first editable column index when form edit mode and custom form items is defined", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.masterDetail = {
+        enabled: true
+    };
+
+    that.options.editing = {
+        allowUpdating: true,
+        mode: "form",
+        form: {
+            items: [
+                {
+                    itemType: "group",
+                    items: ["phone", "room"]
+                },
+                {
+                    itemType: "group",
+                    items: ["name", "age"]
+                }
+            ]
+        }
+    };
+
+    rowsView.render(testElement);
+
+    that.editRow(0);
+
+    //act
+    var editableIndex = this.editingController.getFirstEditableColumnIndex();
+
+    //assert
+    assert.equal(editableIndex, 3, "editable index");
+});
+
+QUnit.test("Get correct first editable column index when form edit mode and form items are changed dynamically", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.masterDetail = {
+        enabled: true
+    };
+
+    that.options.editing = {
+        allowUpdating: true,
+        mode: "form"
+    };
+
+    rowsView.render(testElement);
+
+    that.editRow(0);
+
+    //act
+    this.editingController.option("editing.form", { items: ["phone", "room"] });
+    this.editingController.optionChanged({ name: "editing" });
+
+    that.editRow(0);
+
+    var editableIndex = this.editingController.getFirstEditableColumnIndex();
+
+    //assert
+    assert.equal(editableIndex, 3, "editable index");
+});
+
+QUnit.test("Get correct first editable column index when visible option for item set via formItem option", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.masterDetail = {
+        enabled: true
+    };
+
+    that.options.editing = {
+        allowUpdating: true,
+        mode: "form"
+    };
+
+    rowsView.render(testElement);
+
+    that.columnsController.columnOption("name", {
+        formItem: {
+            visible: false
+        }
+    });
+
+    that.editRow(0);
+
+    var editableIndex = this.editingController.getFirstEditableColumnIndex();
+
+    //assert
+    assert.equal(editableIndex, 1, "editable index");
+});
 
 if(device.ios || device.android) {
     //T322738

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.tests.js
@@ -4047,6 +4047,43 @@ QUnit.testInActiveWindow("Move up when a focused cell is located on invalid posi
     assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { columnIndex: 0, rowIndex: 6 });
 });
 
+QUnit.testInActiveWindow('Tab index is not applied when focus is located inside edit form and master detail is enabled', function(assert) {
+    //arrange
+    this.options = {
+        editing: {
+            mode: 'form',
+            allowAdding: true,
+        },
+        commonColumnSettings: {
+            allowEditing: true
+        },
+        columns: ["name", "age", "phone"],
+        dataSource: [],
+        masterDetail: {
+            enabled: true
+        }
+    };
+
+    setupModules(this, { initViews: true });
+
+    var $testElement = $('#container');
+
+    this.gridView.render($testElement);
+    this.editingController.addRow();
+
+    //act
+    var $input = $testElement.find(".dx-texteditor-input").first();
+
+    $input.trigger("dxpointerdown.dxDataGridKeyboardNavigation");
+    this.clock.tick();
+
+    this.triggerKeyDown("tab", false, false, $testElement.find(":focus").get(0));
+    this.clock.tick();
+
+    //assert
+    assert.ok(!$(".dx-datagrid-edit-form-item[tabindex=\"0\"]").length, "tabIndex is not applied");
+});
+
 QUnit.module("Rows view", {
     beforeEach: function() {
         this.items = [


### PR DESCRIPTION
[T506748: dxDataGrid - A form item is focused with a caption on the Tab key navigation if the masterDetail option is enabled](https://isc.devexpress.com/Thread/WorkplaceDetails/T506748)