### PR TITLE
Fixes editor focusing inside the edit form when the tab key is pressed and the master detail option is enabled (T506748)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -421,6 +421,10 @@ var KeyboardNavigationController = core.ViewController.inherit({
         }
     },
 
+    _isInsideEditForm: function(element) {
+        return $(element).closest("." + this.addWidgetPrefix(EDIT_FORM_CLASS)).length > 0;
+    },
+
     _isMasterDetailCell: function(element) {
         var $masterDetailCell = $(element).closest("." + MASTER_DETAIL_CELL_CLASS),
             $masterDetailGrid = $masterDetailCell.closest("." + this.getWidgetContainerClass()).parent();
@@ -431,8 +435,11 @@ var KeyboardNavigationController = core.ViewController.inherit({
     _handleTabKeyOnMasterDetailCell: function(target, direction) {
         if(this._isMasterDetailCell(target)) {
             this._updateFocusedCellPosition($(target).closest("." + MASTER_DETAIL_CELL_CLASS));
+
             var $nextCell = this._getNextCell(direction, "row");
-            $nextCell && $nextCell.attr("tabindex", 0);
+            if(!this._isInsideEditForm($nextCell)) {
+                $nextCell && $nextCell.attr("tabindex", 0);
+            }
 
             return true;
         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.tests.js
@@ -4047,6 +4047,43 @@ QUnit.testInActiveWindow("Move up when a focused cell is located on invalid posi
     assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { columnIndex: 0, rowIndex: 6 });
 });
 
+QUnit.testInActiveWindow('Tab index is not applied when focus is located inside edit form and master detail is enabled', function(assert) {
+    //arrange
+    this.options = {
+        editing: {
+            mode: 'form',
+            allowAdding: true,
+        },
+        commonColumnSettings: {
+            allowEditing: true
+        },
+        columns: ["name", "age", "phone"],
+        dataSource: [],
+        masterDetail: {
+            enabled: true
+        }
+    };
+
+    setupModules(this, { initViews: true });
+
+    var $testElement = $('#container');
+
+    this.gridView.render($testElement);
+    this.editingController.addRow();
+
+    //act
+    var $input = $testElement.find(".dx-texteditor-input").first();
+
+    $input.trigger("dxpointerdown.dxDataGridKeyboardNavigation");
+    this.clock.tick();
+
+    this.triggerKeyDown("tab", false, false, $testElement.find(":focus").get(0));
+    this.clock.tick();
+
+    //assert
+    assert.ok(!$(".dx-datagrid-edit-form-item[tabindex=\"0\"]").length, "tabIndex is not applied");
+});
+
 QUnit.module("Rows view", {
     beforeEach: function() {
         this.items = [


### PR DESCRIPTION
[T506748: dxDataGrid - A form item is focused with a caption on the Tab key navigation if the masterDetail option is enabled](https://isc.devexpress.com/Thread/WorkplaceDetails/T506748)