### PR TITLE
Fixed issue in dxRangeSelector.render method

### DIFF
--- a/js/viz/range_selector/range_selector.js
+++ b/js/viz/range_selector/range_selector.js
@@ -1010,12 +1010,6 @@ var dxRangeSelector = require("../core/base_widget").inherit({
     _setContentSize: function() {
         this.__isResizing = this._changes.count() === 2;
         this.callBase.apply(this, arguments);
-    },
-
-    render: function(isResizing) {
-        this.__isResizing = isResizing;
-        this.callBase.apply(this, arguments);
-        this._requestChange(["MOSTLY_TOTAL"]);
     }
 });
 

--- a/testing/tests/DevExpress.viz.rangeSelector/common.part3.tests.js
+++ b/testing/tests/DevExpress.viz.rangeSelector/common.part3.tests.js
@@ -1401,14 +1401,25 @@ QUnit.test("custom backgroundColor", function(assert) {
 
 QUnit.module("API", commons.environment);
 
-QUnit.test("render", function(assert) {
+QUnit.test("Render. Container size is changed - redraw widget", function(assert) {
     var spy = sinon.spy(),
         widget = this.createWidget({ onDrawn: spy });
 
     widget.element().height(widget.element().height() + 1);
-    widget.render(true);
+    spy.reset();
+    widget.render();
 
-    assert.strictEqual(spy.callCount, 3);
+    assert.strictEqual(spy.callCount, 1);
+});
+
+QUnit.test("Render. Container size is not changed - do not redraw widget", function(assert) {
+    var spy = sinon.spy(),
+        widget = this.createWidget({ onDrawn: spy });
+
+    spy.reset();
+    widget.render();
+
+    assert.strictEqual(spy.callCount, 0);
 });
 
 QUnit.module("dataSource integration", commons.environment);


### PR DESCRIPTION
On container resize the dxRangeSelector.render method redraws widget with animation, which is wrong.
Now widget is redrawn without animation.