### PR TITLE
The item selection in the column chooser has been fixed when column visibility is changed via API (T512338)

### DIFF
--- a/js/ui/data_grid/ui.data_grid.column_chooser.js
+++ b/js/ui/data_grid/ui.data_grid.column_chooser.js
@@ -234,22 +234,6 @@ exports.ColumnChooserView = columnsView.ColumnsView.inherit({
         };
     },
 
-    _isListItemSelected: function(key) {
-        if(this._columnChooserList) {
-            var nodes = this._columnChooserList.getNodes(),
-                resultNode;
-
-            $.each(nodes, function(_, node) {
-                if(node.key === key) {
-                    resultNode = node;
-                    return false;
-                }
-            });
-
-            return resultNode && resultNode.selected;
-        }
-    },
-
     _columnOptionChanged: function(e) {
         var optionNames = e.optionNames,
             isSelectMode = this.option("columnChooser.mode") === "select";
@@ -257,8 +241,7 @@ exports.ColumnChooserView = columnsView.ColumnsView.inherit({
         this.callBase(e);
 
         if(isSelectMode) {
-            var visible = this._columnsController.columnOption(e.columnIndex, "visible");
-            if(optionNames.showInColumnChooser || (optionNames.visible && this._isListItemSelected(e.columnIndex) !== visible)) {
+            if(optionNames.showInColumnChooser || optionNames.visible) {
                 this.render(null, true);
             }
         }

--- a/js/ui/data_grid/ui.data_grid.column_chooser.js
+++ b/js/ui/data_grid/ui.data_grid.column_chooser.js
@@ -234,14 +234,33 @@ exports.ColumnChooserView = columnsView.ColumnsView.inherit({
         };
     },
 
+    _isListItemSelected: function(key) {
+        if(this._columnChooserList) {
+            var nodes = this._columnChooserList.getNodes(),
+                resultNode;
+
+            $.each(nodes, function(_, node) {
+                if(node.key === key) {
+                    resultNode = node;
+                    return false;
+                }
+            });
+
+            return resultNode && resultNode.selected;
+        }
+    },
+
     _columnOptionChanged: function(e) {
         var optionNames = e.optionNames,
             isSelectMode = this.option("columnChooser.mode") === "select";
 
         this.callBase(e);
 
-        if(isSelectMode && optionNames.showInColumnChooser) {
-            this.render(null, true);
+        if(isSelectMode) {
+            var visible = this._columnsController.columnOption(e.columnIndex, "visible");
+            if(optionNames.showInColumnChooser || (optionNames.visible && this._isListItemSelected(e.columnIndex) !== visible)) {
+                this.render(null, true);
+            }
         }
     },
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnChooserModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnChooserModule.tests.js
@@ -787,6 +787,10 @@ QUnit.test("CheckBox mode - not update treeview when selected items", function(a
 
     this.renderColumnChooser();
     columnChooserView._columnsController.columnOption = function(columnIndex, optionName, value) {
+        if(!commonUtils.isDefined(value)) {
+            return;
+        }
+
         //assert
         assert.equal(columnIndex, 0, "column index");
         assert.strictEqual(optionName, "visible", "option name is 'visible'");
@@ -883,4 +887,30 @@ QUnit.test("CheckBox mode - check hidden band column", function(assert) {
     assert.ok($checkBoxElements.eq(0).hasClass("dx-checkbox-checked"), "checkbox is checked");
     assert.ok($checkBoxElements.eq(1).hasClass("dx-checkbox-checked"), "checkbox is checked");
     assert.ok(!$checkBoxElements.eq(2).hasClass("dx-checkbox-checked"), "checkbox isn't checked");
+});
+
+QUnit.test("CheckBox mode - Update a selection state when column visibility is changed via API", function(assert) {
+    //arrange
+    var $testElement = $("#container");
+
+    this.options.columnChooser.mode = "select";
+    $.extend(this.columns, [{ caption: "Column 1", index: 0, visible: true, showInColumnChooser: true }, { caption: "Column 2", index: 1, visible: true, showInColumnChooser: true }]);
+    this.setTestElement($testElement);
+
+    //act
+    this.columnChooserView.showColumnChooser();
+    this.clock.tick(1000);
+
+    this.columnsController.columnOption(0, "visible", false);
+    this.columnsController.columnsChanged.fire({
+        columnIndex: 0,
+        optionNames: {
+            visible: true
+        }
+    });
+
+    //assert
+    assert.ok(!this.columnChooserView._columnChooserList.getNodes()[0].selected, "first item is not selected");
+
+    this.columnChooserView.hideColumnChooser();
 });


### PR DESCRIPTION
[T512338: dxDataGrid - The column visibility state is not updated in the Column Chooser when mode = select](https://www.devexpress.com/Support/Center/Question/Details/T512338)