### PR TITLE
Fix T511282: dxDateBox - Range validation does not work for years less than 100

### DIFF
--- a/js/core/utils/date.js
+++ b/js/core/utils/date.js
@@ -506,9 +506,9 @@ var normalizeDateByWeek = function(date, currentDate) {
 
 var dateInRange = function(date, min, max, format) {
     if(format === "date") {
-        min = min && new Date(min.getFullYear(), min.getMonth(), min.getDate());
-        max = max && new Date(max.getFullYear(), max.getMonth(), max.getDate());
-        date = date && new Date(date.getFullYear(), date.getMonth(), date.getDate());
+        min = min && dateUtils.correctDateWithUnitBeginning(min, "day");
+        max = max && dateUtils.correctDateWithUnitBeginning(max, "day");
+        date = date && dateUtils.correctDateWithUnitBeginning(date, "day");
     }
 
     return normalizeDate(date, min, max) === date;

--- a/js/localization/date.js
+++ b/js/localization/date.js
@@ -456,12 +456,16 @@ var PARSERS = {
         return PARSERS.year(year);
     },
     "shortdate": function(text) {
-        if(!/^(0?[1-9]|1[012])\/(0?[1-9]|[12][0-9]|3[01])\/\d{4}/.test(text)) {
+        if(!/^(0?[1-9]|1[012])\/(0?[1-9]|[12][0-9]|3[01])\/\d{1,4}/.test(text)) {
             return;
         }
         var parts = text.split("/");
 
-        return new Date(Number(parts[2]), Number(parts[0]) - 1, Number(parts[1]));
+        var date = new Date(Number(parts[2]), Number(parts[0]) - 1, Number(parts[1]));
+
+        if(parts[2].length < 4) date.setFullYear(parts[2]);
+
+        return date;
     },
 
     "longtime": function(text) {

--- a/js/localization/date.js
+++ b/js/localization/date.js
@@ -463,7 +463,9 @@ var PARSERS = {
 
         var date = new Date(Number(parts[2]), Number(parts[0]) - 1, Number(parts[1]));
 
-        if(parts[2].length < 4) date.setFullYear(parts[2]);
+        if(parts[2].length < 3) {
+            date.setFullYear(Number(parts[2]), Number(parts[0]) - 1, Number(parts[1]));
+        }
 
         return date;
     },

--- a/testing/tests/DevExpress.core/utils.date.tests.js
+++ b/testing/tests/DevExpress.core/utils.date.tests.js
@@ -30,6 +30,37 @@ QUnit.test('normalizeDateByWeek', function(assert) {
     assert.deepEqual(dateUtils.normalizeDateByWeek(dateOfPrevWeek, date), new Date(2016, 0, 16));
 });
 
+QUnit.module('dateInRange', {
+    beforeEach: function() {
+        this.dateInRange = dateUtils.dateInRange;
+    }
+});
+
+QUnit.test('dateInRange, date is in range', function(assert) {
+    var date = new Date(2016, 0, 15),
+        min = new Date(2016, 0, 12),
+        max = new Date(2016, 0, 17);
+
+    assert.ok(this.dateInRange(date, min, max, "date"));
+});
+
+QUnit.test('dateInRange, date is out of range', function(assert) {
+    var date = new Date(2016, 0, 11),
+        min = new Date(2016, 0, 12),
+        max = new Date(2016, 0, 17);
+
+    assert.notOk(this.dateInRange(date, min, max, "date"));
+});
+
+QUnit.test('dateInRange, year of date is less than 100', function(assert) {
+    var date = new Date(99, 0, 11),
+        min = new Date(1900, 0, 12),
+        max = new Date(2016, 0, 17);
+
+    date.setFullYear(99);
+    assert.notOk(this.dateInRange(date, min, max, "date"));
+});
+
 QUnit.module('DateTime functions', {
     beforeEach: function() {
         this.getDateIntervalByString = dateUtils.getDateIntervalByString;

--- a/testing/tests/DevExpress.localization/localization.base.tests.js
+++ b/testing/tests/DevExpress.localization/localization.base.tests.js
@@ -412,16 +412,17 @@ QUnit.test("parse", function(assert) {
     assert.notOk(dateLocalization.parse(), "without date");
 });
 
-QUnit.test("parse with shortDate format (T478962)", function(assert) {
+QUnit.test("parse with shortDate format (T478962, T511282)", function(assert) {
     assert.equal(dateLocalization.parse("2/20/2015", "shortDate"), String(new Date(2015, 1, 20)));
     assert.equal(dateLocalization.parse("02/20/2015", "shortDate"), String(new Date(2015, 1, 20)));
     assert.equal(dateLocalization.parse("02/02/2015", "shortDate"), String(new Date(2015, 1, 2)));
     assert.equal(dateLocalization.parse("2/2/2015", "shortDate"), String(new Date(2015, 1, 2)));
+    assert.equal(dateLocalization.parse("1/1/99", "shortDate"), String(new Date(new Date(99, 0, 1).setFullYear(99))));
+    assert.equal(dateLocalization.parse("2/20/1", "shortDate"), String(new Date(new Date(1, 1, 20).setFullYear(1))));
+
     assert.equal(dateLocalization.parse("22/20/2015", "shortDate"), undefined);
     assert.equal(dateLocalization.parse("2/120/2015", "shortDate"), undefined);
     assert.equal(dateLocalization.parse("2/20/", "shortDate"), undefined);
-    //TODO: fix this case
-    //assert.equal(dateLocalization.parse("2/20/1", "shortDate"), String(new Date(1, 1, 20)));
 });
 
 QUnit.test("firstDayOfWeekIndex", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -3407,6 +3407,22 @@ QUnit.test("Internal validation shouldn't be reset value if localization return 
     assert.equal(dateBox.option("text"), "abc2/1/2016", "text option shouldn't be reset");
 });
 
+QUnit.test("Validation should be correct when year of the value less than 100", function(assert) {
+    var dateBox = $("#dateBox").dxDateBox({
+        min: new Date(2015, 6, 10),
+        max: new Date(2015, 6, 14),
+        value: new Date(2015, 6, 12),
+        valueChangeEvent: "change",
+    }).dxDateBox("instance");
+
+    var $input = dateBox.element().find("." + TEXTEDITOR_INPUT_CLASS);
+    $input.val("1/1/99");
+    $input.change();
+
+    assert.notOk(dateBox.option("isValid"), "datebox is invalid");
+    var validationError = dateBox.option("validationError").message;
+    assert.equal(validationError, "Value is out of range", "validation message is correct");
+});
 
 QUnit.module("DateBox number and string value support", {
     beforeEach: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -3413,6 +3413,7 @@ QUnit.test("Validation should be correct when year of the value less than 100", 
         max: new Date(2015, 6, 14),
         value: new Date(2015, 6, 12),
         valueChangeEvent: "change",
+        pickerType: "calendar"
     }).dxDateBox("instance");
 
     var $input = dateBox.element().find("." + TEXTEDITOR_INPUT_CLASS);


### PR DESCRIPTION
- fix dateInRange checking for the dates like 1/1/99
- fix localization parser for the dates like 1/1/99