### PR TITLE
dxDataGrid / dxPivotGrid - Changing the default height of the headerFilter (by design)

### DIFF
--- a/js/ui/data_grid/ui.data_grid.header_filter.js
+++ b/js/ui/data_grid/ui.data_grid.header_filter.js
@@ -473,16 +473,16 @@ gridCore.registerModule("headerFilter", {
                  * @name dxDataGridOptions_headerFilter_width
                  * @publicName width
                  * @type number
-                 * @default 250
+                 * @default 252
                  */
                 width: 252,
                 /**
                  * @name dxDataGridOptions_headerFilter_height
                  * @publicName height
                  * @type number
-                 * @default 300
+                 * @default 325
                  */
-                height: 300,
+                height: 325,
                 /**
                  * @name dxDataGridOptions_headerFilter_texts
                  * @publicName texts

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -63,7 +63,7 @@ var FieldChooserBase = Widget.inherit(gridCoreUtils.columnStateMixin).inherit(so
             allowFieldDragging: true,
             headerFilter: {
                 width: 252,
-                height: 300,
+                height: 325,
                 texts: {
                     emptyValue: messageLocalization.format("dxDataGrid-headerFilterEmptyValue"),
                     ok: messageLocalization.format("dxDataGrid-headerFilterOK"),


### PR DESCRIPTION
Changing the default height so the last visible item is not clipped:

![untitled-1 40 229 25 28layer 3 2c rgb_8 29 _ 2017-04-06 15 52 08](https://cloud.githubusercontent.com/assets/23191430/26102277/09d31e04-3a3d-11e7-8081-c5d5b8821716.png)