### PR TITLE
dxDataGrid / dxTreeList / dxPivotGrid - Changing the default height of the headerFilter (by design)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.header_filter.js
+++ b/js/ui/grid_core/ui.grid_core.header_filter.js
@@ -474,16 +474,16 @@ module.exports = {
                  * @name GridBaseOptions_headerFilter_width
                  * @publicName width
                  * @type number
-                 * @default 250
+                 * @default 252
                  */
                 width: 252,
                 /**
                  * @name GridBaseOptions_headerFilter_height
                  * @publicName height
                  * @type number
-                 * @default 300
+                 * @default 325
                  */
-                height: 300,
+                height: 325,
                 /**
                  * @name GridBaseOptions_headerFilter_texts
                  * @publicName texts

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -65,7 +65,7 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
             allowFieldDragging: true,
             headerFilter: {
                 width: 252,
-                height: 300,
+                height: 325,
                 texts: {
                     emptyValue: messageLocalization.format("dxDataGrid-headerFilterEmptyValue"),
                     ok: messageLocalization.format("dxDataGrid-headerFilterOK"),


### PR DESCRIPTION
Changing the default height so the last visible item is not clipped:

![untitled-1 40 229 25 28layer 3 2c rgb_8 29 _ 2017-04-06 15 52 08](https://cloud.githubusercontent.com/assets/23191430/26102661/b1fff11e-3a3e-11e7-88d5-df841c487a5a.png)
