### PR TITLE
Fixes dxDropDownBox keyboard navigation test when the window is inactive

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
@@ -373,7 +373,7 @@ QUnit.testInActiveWindow("input should get focused when shift+tab pressed on fir
     assert.ok(event.isDefaultPrevented(), "prevent default for focusing it's own input but not an input of the previous editor on the page");
 });
 
-QUnit.test("inner input should be focused after popup opening", function(assert) {
+QUnit.testInActiveWindow("inner input should be focused after popup opening", function(assert) {
     var inputFocusedHandler = sinon.stub(),
         $input = $("<input>", { id: "input1", type: "text" }).on("focus", inputFocusedHandler),
         instance = new DropDownBox(this.$element, {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
