### PR TITLE
Displaying the revert button when row updating is canceled for a cell edit mode has been fixed (T506863)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -839,7 +839,7 @@ var EditingController = modules.ViewController.inherit((function() {
         _saveEditDataCore: function(deferreds, processedKeys) {
             var that = this,
                 store = that._dataController.store(),
-                hasCanceledData = false;
+                isDataSaved = true;
 
             function executeEditingAction(actionName, params, func) {
                 var deferred = $.Deferred();
@@ -902,14 +902,17 @@ var EditingController = modules.ViewController.inherit((function() {
                 if(deferred) {
                     doneDeferred = $.Deferred();
                     deferred
-                        .always(function() { processedKeys.push(editData.key); })
+                        .always(function(data) {
+                            isDataSaved = data !== "cancel";
+                            processedKeys.push(editData.key);
+                        })
                         .always(doneDeferred.resolve);
 
                     deferreds.push(doneDeferred.promise());
                 }
             });
 
-            return hasCanceledData;
+            return isDataSaved;
         },
         _processSaveEditDataResult: function(results, processedKeys) {
             var that = this,
@@ -993,7 +996,9 @@ var EditingController = modules.ViewController.inherit((function() {
                 return result.resolve().promise();
             }
 
-            that._saveEditDataCore(deferreds, processedKeys);
+            if(!that._saveEditDataCore(deferreds, processedKeys) && editMode === EDIT_MODE_CELL) {
+                that._focusEditingCell();
+            }
 
             if(deferreds.length) {
                 that._saving = true;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8148,6 +8148,42 @@ QUnit.test("It's impossible to save new data when editing form is invalid", func
     assert.equal($formRow.find(".dx-invalid").length, 1, "There is one invalid editor in first row");
 });
 
+//T506863
+QUnit.testInActiveWindow("Show the revert button when a row updating is canceled", function(assert) {
+    //arrange
+    var rowsView = this.rowsView,
+        testElement = $('#container');
+
+    this.applyOptions({
+        editing: {
+            allowUpdating: true,
+            mode: 'cell'
+        },
+        onRowUpdating: function(params) {
+            params.cancel = true;
+        }
+    });
+
+    this.editingController.optionChanged({
+        name: "onRowUpdating",
+        value: function(params) {
+            params.cancel = true;
+        }
+    });
+    rowsView.render(testElement);
+    var $cell = testElement.find('td').first();
+    $cell.trigger('dxclick'); //Edit
+    this.clock.tick();
+
+    var $input = getInputElements(testElement).first();
+    $input.val(101);
+    $input.trigger('change');
+
+    this.editingController.saveEditData();
+    this.clock.tick();
+
+    assert.ok(testElement.find(".dx-revert-button").length, "the revert button is shown");
+});
 
 QUnit.module('Editing with real dataController with grouping, masterDetail', {
     beforeEach: function() {


### PR DESCRIPTION
… edit mode has been fixed

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
