### PR TITLE
Fixes incorrect dxPopover visibility behavior when another popover clicked (T518459)

### DIFF
--- a/js/ui/popover.js
+++ b/js/ui/popover.js
@@ -369,6 +369,7 @@ var Popover = Popup.inherit({
         if(this._isOutsideClick(e)) {
             return this.callBase(e);
         }
+        return true;
     },
 
     _isOutsideClick: function(e) {

--- a/testing/tests/DevExpress.ui.widgets/popover.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/popover.tests.js
@@ -1746,3 +1746,20 @@ QUnit.test("hideEvent set as object", function(assert) {
     this.clock.tick(500);
     assert.ok(!instance.option("visible"), "Popover was hidden");
 });
+
+QUnit.test("second popover should be hidden by click on the first's target", function(assert) {
+    var markup = "<div id='popover1'></div>" +
+            "<div id='popover2'></div>" +
+            "<div id='target1'></div>" +
+            "<div id='target2'><div id='clicktarget2'></div></div>";
+
+    $(markup).appendTo("body");
+
+    var popover1 = new Popover($("#popover1"), { visible: true, animation: false, target: "#target1" }),
+        popover2 = new Popover($("#popover2"), { visible: true, animation: false, target: "#target2" });
+
+    $("#clicktarget2").trigger("dxpointerdown");
+
+    assert.ok(popover2.option("visible"), "popover2 is still visible");
+    assert.notOk(popover1.option("visible"), "popover1 is hidden");
+});


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
