### PR TITLE
dxTreeView - fixes expand a childless node on double click on it (T522469)

### DIFF
--- a/js/ui/tree_view.js
+++ b/js/ui/tree_view.js
@@ -1013,7 +1013,11 @@ var TreeView = HierarchicalCollectionWidget.inherit({
         $itemsContainer
             .off("." + EXPAND_EVENT_NAMESPACE, itemSelector)
             .on(expandedEventName, itemSelector, function(e) {
-                that._toggleExpandedState(e.currentTarget, undefined, e);
+                var $nodeElement = $(e.currentTarget.parentNode);
+
+                if(!$nodeElement.hasClass(IS_LEAF)) {
+                    that._toggleExpandedState(e.currentTarget, undefined, e);
+                }
             });
     },
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/virtualMode.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/virtualMode.js
@@ -1074,6 +1074,20 @@ QUnit.test("the passed function is called on widget initialization", function(as
     assert.equal(spy.args[0][0], null, "'null' is passed as argument for the root item loading");
 });
 
+QUnit.test("'createChildren' callback didn't called at dblclick on item without children", function(assert) {
+    var $treeView = $("#treeView"),
+        spy = sinon.spy(),
+        treeView = $treeView.dxTreeView({
+            dataStructure: "plain",
+            items: [{ id: 1, text: "one", hasChildren: false }]
+        }).dxTreeView("instance");
+
+    treeView.option("createChildren", spy);
+    $treeView.find(".dx-treeview-item").trigger("dxdblclick");
+
+    assert.ok(spy.notCalled, "the callback didn't called");
+});
+
 QUnit.test("the passed function is called on node expansion", function(assert) {
     var $treeView = $("#treeView"),
         treeView = $treeView.dxTreeView({


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
