### PR TITLE
T522830: dxDropDownBox clears its value after opening if data is loaded asynchronously

### DIFF
--- a/js/ui/drop_down_box.js
+++ b/js/ui/drop_down_box.js
@@ -125,6 +125,14 @@ var DropDownBox = DropDownEditor.inherit({
 
             openOnFieldClick: true,
 
+            /**
+             * @name dxDropDownBoxOptions_valueChangeEvent
+             * @publicName valueChangeEvent
+             * @type string
+             * @default "change"
+             */
+            valueChangeEvent: "change",
+
             valueFormat: function(value) {
                 return Array.isArray(value) ? value.join(", ") : value;
             }

--- a/testing/tests/DevExpress.ui/defaultOptions.tests.js
+++ b/testing/tests/DevExpress.ui/defaultOptions.tests.js
@@ -310,7 +310,8 @@ testComponentDefaults(DropDownBox,
     {},
     {
         openOnFieldClick: true,
-        acceptCustomValue: false
+        acceptCustomValue: false,
+        valueChangeEvent: "change"
     }
 );
 

--- a/ts/widgets-base.d.ts
+++ b/ts/widgets-base.d.ts
@@ -1804,6 +1804,9 @@ declare module DevExpress.ui {
 
         /** @docid dxDropDownBoxOptions_dropDownOptions */
         dropDownOptions?: DevExpress.ui.dxPopupOptions;
+
+        /** @docid dxDropDownBoxOptions_valueChangeEvent */
+        valueChangeEvent?: string;
     }
 
     /** @docid dxDropDownBox */


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
