### PR TITLE
Revert "Fix setter for the case if previous value is null"

### DIFF
--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -149,7 +149,7 @@ var compileSetter = function(expr) {
             if(
                 options.merge &&
                 typeUtils.isPlainObject(value) &&
-                (!commonUtils.isDefined(prevTargetValue) || typeUtils.isPlainObject(prevTargetValue)) &&
+                (prevTargetValue === undefined || typeUtils.isPlainObject(prevTargetValue)) &&
                 !(value instanceof $.Event) // NOTE: http://bugs.jquery.com/ticket/15090
             ) {
                 if(!prevTargetValue) {

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -351,34 +351,6 @@ QUnit.test("complex values are merged only when it is plain object", function(as
     assert.equal(obj1.sub.person.lastName, undefined);
 });
 
-QUnit.test("plain objects are cloned if previous value is null (T521407)", function(assert) {
-    var obj = {
-        dataSource: null
-    };
-
-    var dataSource1 = {
-        store: "Store 1"
-    };
-
-    var dataSource2 = {
-        store: "Store 2"
-    };
-
-    SETTER("dataSource")(
-        obj,
-        dataSource1,
-        { merge: true }
-    );
-
-    SETTER("dataSource")(
-        obj,
-        dataSource2,
-        { merge: true }
-    );
-
-    assert.equal(dataSource1.store, "Store 1");
-});
-
 QUnit.module("setter with wrapped variables", {
     beforeEach: function() {
         variableWrapper.inject(mockVariableWrapper);


### PR DESCRIPTION
The behavior that was [fixed](https://github.com/DevExpress/DevExtreme/pull/311) can be used in customers applications in some rare scenarios. So, we decided to provide a workaround for 17.1 and fix the issue in 17.2.