### PR TITLE
Fix setter for the case if previous value is null

### DIFF
--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -149,7 +149,7 @@ var compileSetter = function(expr) {
             if(
                 options.merge &&
                 typeUtils.isPlainObject(value) &&
-                (prevTargetValue === undefined || typeUtils.isPlainObject(prevTargetValue)) &&
+                (!commonUtils.isDefined(prevTargetValue) || typeUtils.isPlainObject(prevTargetValue)) &&
                 !(value instanceof $.Event) // NOTE: http://bugs.jquery.com/ticket/15090
             ) {
                 if(!prevTargetValue) {

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -351,6 +351,34 @@ QUnit.test("complex values are merged only when it is plain object", function(as
     assert.equal(obj1.sub.person.lastName, undefined);
 });
 
+QUnit.test("plain objects are cloned if previous value is null (T521407)", function(assert) {
+    var obj = {
+        dataSource: null
+    };
+
+    var dataSource1 = {
+        store: "Store 1"
+    };
+
+    var dataSource2 = {
+        store: "Store 2"
+    };
+
+    SETTER("dataSource")(
+        obj,
+        dataSource1,
+        { merge: true }
+    );
+
+    SETTER("dataSource")(
+        obj,
+        dataSource2,
+        { merge: true }
+    );
+
+    assert.equal(dataSource1.store, "Store 1");
+});
+
 QUnit.module("setter with wrapped variables", {
     beforeEach: function() {
         variableWrapper.inject(mockVariableWrapper);

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
@@ -3721,7 +3721,7 @@ QUnit.test("DataController creation", function(assert) {
 
     var dataControllerOptions = pivotGridDataController.DataController.lastCall.args[0];
 
-    assert.strictEqual(dataControllerOptions.dataSource, this.testOptions.dataSource);
+    assert.deepEqual(dataControllerOptions.dataSource, this.testOptions.dataSource);
     assert.deepEqual(dataControllerOptions.texts, texts);
 
     assert.strictEqual(dataControllerOptions.showColumnGrandTotals, "customShowColumnGrandTotals");
@@ -3777,7 +3777,7 @@ QUnit.test("Change DataController options", function(assert) {
 
     assert.strictEqual(dataController.updateViewOptions.callCount, 8);
 
-    assert.strictEqual(dataControllerOptions.dataSource, this.testOptions.dataSource);
+    assert.deepEqual(dataControllerOptions.dataSource, this.testOptions.dataSource);
     assert.deepEqual(dataControllerOptions.texts, 0);
 
     assert.strictEqual(dataControllerOptions.showColumnGrandTotals, 1);


### PR DESCRIPTION
The plain object should be cloned in this case (T521407).
See https://github.com/DevExpress/DevExtreme/pull/311 for more information.