### PR TITLE
Fix T517945: dxTreeView - scroll jumps down on 'All' clicking (#347)

### DIFF
--- a/js/ui/tree_view.js
+++ b/js/ui/tree_view.js
@@ -1461,7 +1461,7 @@ var TreeView = HierarchicalCollectionWidget.inherit({
     _attachClickEvent: function() {
         var that = this,
             clickSelector = "." + this._itemClass(),
-            pointerDownSelector = "." + NODE_CLASS,
+            pointerDownSelector = "." + NODE_CLASS + ", ." + SELECT_ALL_ITEM_CLASS,
             eventName = eventUtils.addNamespace(clickEvent.name, that.NAME),
             pointerDownEvent = eventUtils.addNamespace(pointerEvents.down, this.NAME);
 
@@ -1548,9 +1548,9 @@ var TreeView = HierarchicalCollectionWidget.inherit({
             return;
         }
 
-        var $target = $(e.target).closest("." + NODE_CLASS);
+        var $target = $(e.target).closest("." + NODE_CLASS + ", ." + SELECT_ALL_ITEM_CLASS);
 
-        if(!$target.hasClass(NODE_CLASS)) {
+        if(!$target.length) {
             return;
         }
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/focusing.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/focusing.js
@@ -8,6 +8,7 @@ var $ = require("jquery"),
 
 var NODE_CLASS = "dx-treeview-node",
     ITEM_CLASS = "dx-treeview-item",
+    SELECT_ALL_ITEM_CLASS = "dx-treeview-select-all-item",
     TOGGLE_ITEM_VISIBILITY_CLASS = "dx-treeview-toggle-item-visibility";
 
 QUnit.module("Focusing");
@@ -125,7 +126,7 @@ QUnit.test("PointerDown event at expansion arrow should not be ignored", functio
     assert.equal(pointerDownStub.callCount, 1, "itemPointerDownHandler was called");
 });
 
-QUnit.test("Scroll should not jump down when focusing on item (T492496, T517945)", function(assert) {
+QUnit.test("Scroll should not jump down when focusing on item (T492496)", function(assert) {
     //arrange
     var $treeView = initTree({
             items: [{ id: 1, text: "item 1" }, { id: 2, text: "item 2", expanded: true, items: [{ id: 3, text: "item 3" }] }],
@@ -154,6 +155,45 @@ QUnit.test("Scroll should not jump down when focusing on item (T492496, T517945)
         assert.equal(scrollable.scrollTop(), 0, "scroll top position");
 
         $items.first().trigger("dxpointerdown");
+        clock.tick();
+
+        //assert
+        assert.equal(scrollable.scrollTop(), 0, "scroll top position");
+    } finally {
+        clock.restore();
+    }
+});
+
+QUnit.test("Scroll should not jump down when focusing on Select All (T517945)", function(assert) {
+    //arrange
+    var $treeView = initTree({
+            items: [{ id: 1, text: "item 1" }, { id: 2, text: "item 2", expanded: true, items: [{ id: 3, text: "item 3" }] }],
+            showCheckBoxesMode: "selectAll",
+            focusStateEnabled: true,
+            height: 40
+        }),
+        $items = $treeView.find("." + ITEM_CLASS),
+        scrollable = $treeView.find(".dx-scrollable").dxScrollable("instance"),
+        clock = sinon.useFakeTimers();
+
+    try {
+        $items.last().trigger("dxpointerdown");
+
+        //assert
+        assert.equal(scrollable.scrollTop(), 106, "scroll top position");
+
+        scrollable.scrollTo({ y: 0 });
+
+        //assert
+        assert.equal(scrollable.scrollTop(), 0, "scroll top position");
+
+        //act
+        $treeView.trigger("focusin");
+
+        //assert
+        assert.equal(scrollable.scrollTop(), 0, "scroll top position");
+
+        $treeView.find("." + SELECT_ALL_ITEM_CLASS).first().trigger("dxpointerdown");
         clock.tick();
 
         //assert


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
