### PR TITLE
dxNumberBox: Remove unnecessary condition from the test

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/numberbox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberbox.tests.js
@@ -984,17 +984,6 @@ QUnit.test("value starts from decimal", function(assert) {
 
     var $input = this.element.find("." + INPUT_CLASS);
 
-    var expectedResult,
-        device = devices.real(),
-        version = device.version,
-        isAndroid = device.android;
-
-    if(isAndroid && version[0] === 4 && version[1] === 0) {
-        expectedResult = null;
-    } else {
-        expectedResult = 0.1;
-    }
-
     $input.get(0)
         .focus();
 
@@ -1003,7 +992,7 @@ QUnit.test("value starts from decimal", function(assert) {
         .val(".1")
         .trigger("change");
 
-    assert.equal(this.instance.option("value"), expectedResult, "value is right");
+    assert.equal(this.instance.option("value"), 0.1, "value is right");
 });
 
 QUnit.test("showSpinButtons", function(assert) {


### PR DESCRIPTION
This behavior was tested on Android 4.0.4 real device and the input returns 0.1 but not null as the value. This is correct behavior.
This test passes on the farm emulator because it use userAgent from different version of Android

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
