### PR TITLE
Fix T525720: Interface 'dxLoadPanelOptions' incorrectly extends interface 'dxOverlayOptions'

### DIFF
--- a/js/ui/load_panel.js
+++ b/js/ui/load_panel.js
@@ -68,12 +68,14 @@ var LoadPanel = Overlay.inherit({
             * @name dxLoadPanelOptions_animation_show
             * @publicName show
             * @default null
+            * @type animationConfig
             * @extend_doc
             */
             /**
             * @name dxLoadPanelOptions_animation_hide
             * @publicName hide
             * @default null
+            * @type animationConfig
             * @extend_doc
             */
             animation: null,

--- a/ts/widgets-base.d.ts
+++ b/ts/widgets-base.d.ts
@@ -1385,11 +1385,15 @@ declare module DevExpress.ui {
         /** @docid_ignore dxLoadPanelOptions_accessKey */
         /** @docid_ignore dxLoadPanelOptions_tabIndex */
         /** @docid_ignore dxLoadPanelOptions_shadingColor */
-        /** @docid_ignore dxLoadPanelOptions_animation_show */
-        /** @docid_ignore dxLoadPanelOptions_animation_hide */
 
         /** @docid dxLoadPanelOptions_animation */
-        animation?: fx.AnimationOptions;
+        animation?: {
+            /** @docid dxLoadPanelOptions_animation_show */
+            show?: fx.AnimationOptions;
+
+            /** @docid dxLoadPanelOptions_animation_hide */
+            hide?: fx.AnimationOptions;
+        };
 
         /** @docid dxLoadPanelOptions_delay */
         delay?: number;


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
