### PR TITLE
Get rid of affecting `defaultOptions` method on the parent classes

### DIFF
--- a/js/animation/presets/presets.js
+++ b/js/animation/presets/presets.js
@@ -18,7 +18,6 @@ var optionPrefix = "preset_";
 var AnimationPresetCollection = Component.inherit({
     ctor: function() {
         this.callBase.apply(this, arguments);
-        this._customRules = [];
         this._registeredPresets = [];
         this.resetToDefaults();
     },

--- a/js/animation/presets/presets.js
+++ b/js/animation/presets/presets.js
@@ -231,8 +231,8 @@ var AnimationPresetCollection = Component.inherit({
 
     applyChanges: function() {
         var that = this;
+        var customRules = [];
 
-        this._customRules.length = 0;
         $.each(this._registeredPresets, function(index, preset) {
             var rule = {
                 device: preset.config.device,
@@ -240,9 +240,10 @@ var AnimationPresetCollection = Component.inherit({
             };
 
             rule.options[that._getPresetOptionName(preset.name)] = preset.config.animation;
-            that._customRules.push(rule);
+            customRules.push(rule);
         });
-        this._setOptionsByDevice();
+
+        this._setOptionsByDevice(customRules);
     },
 
     getPreset: function(name) {

--- a/js/core/component.js
+++ b/js/core/component.js
@@ -95,10 +95,6 @@ var Component = Class.inherit({
     _setOptionsByDevice: function(userRules) {
         var rules = this._defaultOptionsRules();
 
-        if(this._customRules) {
-            rules = rules.concat(this._customRules);
-        }
-
         if(Array.isArray(userRules)) {
             rules = rules.concat(userRules);
         }

--- a/js/core/component.js
+++ b/js/core/component.js
@@ -139,12 +139,11 @@ var Component = Class.inherit({
     },
 
     _isInitialOptionValue: function(name) {
-        var isCustomOption = this._customRules && this._convertRulesToOptions(this._customRules).hasOwnProperty(name),
-            optionValue = this.option(name),
+        var optionValue = this.option(name),
             initialOptionValue = this.initialOption(name),
             isInitialOption = isFunction(optionValue) && isFunction(initialOptionValue) ? optionValue.toString() === initialOptionValue.toString() : commonUtils.equalByValue(optionValue, initialOptionValue);
 
-        return !isCustomOption && isInitialOption;
+        return isInitialOption;
     },
 
     _setOptionsByReference: function() {

--- a/js/core/component.js
+++ b/js/core/component.js
@@ -92,11 +92,11 @@ var Component = Class.inherit({
         return [];
     },
 
-    _setOptionsByDevice: function(userRules) {
+    _setOptionsByDevice: function(customRules) {
         var rules = this._defaultOptionsRules();
 
-        if(Array.isArray(userRules)) {
-            rules = rules.concat(userRules);
+        if(Array.isArray(customRules)) {
+            rules = rules.concat(customRules);
         }
 
         var rulesOptions = this._convertRulesToOptions(rules);

--- a/js/core/dom_component.js
+++ b/js/core/dom_component.js
@@ -98,6 +98,14 @@ var DOMComponent = Component.inherit({
         this._attachWindowResizeCallback();
     },
 
+    _setOptionsByDevice: function(userRules) {
+        this.callBase([].concat(userRules || [], this._getCustomRules()));
+    },
+
+    _getCustomRules: function() {
+        return [];
+    },
+
     _attachWindowResizeCallback: function() {
         if(this._isDimensionChangeSupported()) {
             var windowResizeCallBack = this._windowResizeCallBack = this._dimensionChanged.bind(this);
@@ -365,8 +373,15 @@ DOMComponent.getInstance = function($element) {
 * @param1_field2 options:Object
 */
 DOMComponent.defaultOptions = function(rule) {
-    this.prototype._customRules = this.prototype._customRules || [];
-    this.prototype._customRules.push(rule);
+    var customRules = this._customRules = this._customRules || [];
+
+    customRules.push(rule);
+
+    this.redefine({
+        _getCustomRules: function() {
+            return customRules;
+        }
+    });
 };
 
 

--- a/js/core/dom_component.js
+++ b/js/core/dom_component.js
@@ -102,6 +102,12 @@ var DOMComponent = Component.inherit({
         this.callBase([].concat(this.constructor._classCustomRules || [], instanceCustomRules || []));
     },
 
+    _isInitialOptionValue: function(name) {
+        var isCustomOption = this.constructor._classCustomRules && this._convertRulesToOptions(this.constructor._classCustomRules).hasOwnProperty(name);
+
+        return !isCustomOption && this.callBase(name);
+    },
+
     _attachWindowResizeCallback: function() {
         if(this._isDimensionChangeSupported()) {
             var windowResizeCallBack = this._windowResizeCallBack = this._dimensionChanged.bind(this);

--- a/js/core/dom_component.js
+++ b/js/core/dom_component.js
@@ -98,12 +98,8 @@ var DOMComponent = Component.inherit({
         this._attachWindowResizeCallback();
     },
 
-    _setOptionsByDevice: function(userRules) {
-        this.callBase([].concat(userRules || [], this._getCustomRules()));
-    },
-
-    _getCustomRules: function() {
-        return [];
+    _setOptionsByDevice: function(instanceCustomRules) {
+        this.callBase([].concat(this.constructor._classCustomRules || [], instanceCustomRules || []));
     },
 
     _attachWindowResizeCallback: function() {
@@ -373,15 +369,8 @@ DOMComponent.getInstance = function($element) {
 * @param1_field2 options:Object
 */
 DOMComponent.defaultOptions = function(rule) {
-    var customRules = this._customRules = this._customRules || [];
-
-    customRules.push(rule);
-
-    this.redefine({
-        _getCustomRules: function() {
-            return customRules;
-        }
-    });
+    this._classCustomRules = this._classCustomRules || [];
+    this._classCustomRules.push(rule);
 };
 
 

--- a/testing/tests/DevExpress.core/domComponent.tests.js
+++ b/testing/tests/DevExpress.core/domComponent.tests.js
@@ -498,6 +498,52 @@ QUnit.test("customizing default option rules", function(assert) {
     assert.notEqual(new TestComponent($("<div/>")).option("test"), "value", "test option is not customized for android");
 });
 
+QUnit.test("customizing default option rules applies only on the target component class", function(assert) {
+    var TestComponent1 = DOMComponent.inherit({
+        _getDefaultOptions: function() {
+            return $.extend(this.callBase(), {
+                test: "Initial value 1"
+            });
+        }
+    });
+
+    var TestComponent2 = TestComponent1.inherit({
+        _getDefaultOptions: function() {
+            return $.extend(this.callBase(), {
+                test: "Initial value 2"
+            });
+        }
+    });
+
+    registerComponent("TestComponent1", TestComponent1);
+    registerComponent("TestComponent2", TestComponent2);
+
+    TestComponent1.defaultOptions({
+        device: { platform: "ios" },
+        options: {
+            anotherOption: "Another option value"
+        }
+    });
+
+    TestComponent1.defaultOptions({
+        device: { platform: "ios" },
+        options: {
+            test: "Custom value 1"
+        }
+    });
+
+    TestComponent2.defaultOptions({
+        device: { platform: "ios" },
+        options: {
+            test: "Custom value 2"
+        }
+    });
+
+    devices._currentDevice = { platform: "ios" };
+    assert.equal(new TestComponent1($("<div/>")).option("test"), "Custom value 1", "Child rule should not affect on the parent");
+    assert.equal(new TestComponent1($("<div/>")).option("anotherOption"), "Another option value", "Multiple calls should not clean previous rules");
+});
+
 QUnit.test("DevExpress.rtlEnabled proxied to DOMComponent", function(assert) {
     assert.equal(coreConfig().rtlEnabled, false, "DevExpress.rtlEnabled equals false by default");
     assert.equal(new DOMComponent($("<div/>")).option("rtlEnabled"), false, "false by default");


### PR DESCRIPTION
Fix for [T524410](https://www.devexpress.com/Support/Center/Question/Details/T524410/the-defaultoptions-method-affects-editors-of-different-types)