### PR TITLE
Get rid of 'templatesRenderAsynchronously' flag from pivot_tabs

### DIFF
--- a/js/ui/pivot/ui.pivot_tabs.js
+++ b/js/ui/pivot/ui.pivot_tabs.js
@@ -177,17 +177,6 @@ var PivotTabs = CollectionWidget.inherit({
         this._renderGhostTab();
     },
 
-    _renderContent: function() {
-        var that = this;
-
-        this.callBase();
-        if(this.option("templatesRenderAsynchronously")) {
-            this._resizeEventTimer = setTimeout(function() {
-                that._dimensionChanged();
-            }, 0);
-        }
-    },
-
     _renderGhostTab: function() {
         this._itemContainer().append(this._$ghostTab);
         this._toggleGhostTab(false);


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
