### PR TITLE
AspNet - Escape exotic characters in component selector (fixes T531137)

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -140,7 +140,8 @@
             id = id || ("dx-" + new Guid());
 
             var render = function(_, container) {
-                var $component = $("#" + id, container)[name](options);
+                var selector = "#" + id.replace(/\W/g, "\\$&"),
+                    $component = $(selector, container)[name](options);
                 if($.isPlainObject(validatorOptions)) {
                     $component.dxValidator(validatorOptions);
                 }

--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -140,7 +140,7 @@
             id = id || ("dx-" + new Guid());
 
             var render = function(_, container) {
-                var selector = "#" + id.replace(/\W/g, "\\$&"),
+                var selector = "#" + id.replace(/[^\w-]/g, "\\$&"),
                     $component = $(selector, container)[name](options);
                 if($.isPlainObject(validatorOptions)) {
                     $component.dxValidator(validatorOptions);

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -217,7 +217,7 @@
                 assert.equal($result.dxValidator("option", "validationGroup"), "my-group");
             });
 
-            QUnit.test("Component ID that contains non-word characters should be escaped (T531137)", function(assert) {
+            QUnit.test("Exotic characters in component ID should be escaped (T531137)", function(assert) {
                 var $result = renderTemplate("#templateWithExoticId");
                 assert.ok($result.dxButton("instance"));
             });

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -157,6 +157,12 @@
                     </div>\
                     </script>\
                     \
+                    <script id="templateWithExoticId" type="text/html">\
+                    <div id="templateContent">\
+                        <%= DevExpress.aspnet.renderComponent("dxButton", { }, "id-_1α♠!#$%&()*+,./:;<=>?@[\]^`{|}~") %>\
+                    </div>\
+                    </script>\
+                    \
                     <script id="templateWithValidator" type="text/html">\
                     <div id="templateContent">\
                         <%= DevExpress.aspnet.renderComponent("dxTextBox", { }, "test-id", { validationGroup: "my-group" }) %>\
@@ -209,6 +215,11 @@
             QUnit.test("Component element rendering with validator", function(assert) {
                 var $result = renderTemplate("#templateWithValidator");
                 assert.equal($result.dxValidator("option", "validationGroup"), "my-group");
+            });
+
+            QUnit.test("Component ID that contains non-word characters should be escaped (T531137)", function(assert) {
+                var $result = renderTemplate("#templateWithExoticId");
+                assert.ok($result.dxButton("instance"));
             });
         }
     );


### PR DESCRIPTION
From [jQuery API Documentation](http://api.jquery.com/category/selectors/):
"To use any of the meta-characters ( such as  !"#$%&'()*+,./:;<=>?@[\]^`{|}~ ) as a literal part of a name, it must be escaped with with two backslashes: \\\\. For example, an element with id="foo.bar", can use the selector $("#foo\\.bar")."