### PR TITLE
fixes dxToolbar's overflow button visible state in the case when menu contains only invisible items (T532170)

### DIFF
--- a/js/ui/toolbar/ui.toolbar.strategy.drop_down_menu.js
+++ b/js/ui/toolbar/ui.toolbar.strategy.drop_down_menu.js
@@ -45,8 +45,9 @@ var DropDownMenuStrategy = ToolbarStrategy.inherit({
     },
 
     _getMenuItems: function() {
-        var menuItems = this.callBase();
-        this._toggleMenuVisibility(menuItems.length);
+        var menuItems = this.callBase(),
+            isMenuVisible = menuItems.length && this._hasVisibleMenuItems(menuItems);
+        this._toggleMenuVisibility(isMenuVisible);
         return menuItems;
     },
 

--- a/js/ui/toolbar/ui.toolbar.strategy.js
+++ b/js/ui/toolbar/ui.toolbar.strategy.js
@@ -49,8 +49,8 @@ var ToolbarStrategy = Class.inherit({
 
     _menuWidgetClass: abstract,
 
-    _hasVisibleMenuItems: function() {
-        var menuItems = this._toolbar.option("items"),
+    _hasVisibleMenuItems: function(items) {
+        var menuItems = items || this._toolbar.option("items"),
             result = false;
 
         var optionGetter = compileGetter("visible"),

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -1091,6 +1091,22 @@ QUnit.test("dropdown menu should be rendered if there is hidden overflow items",
     assert.equal($dropDownMenu.length, 1);
 });
 
+QUnit.test("dropdown menu button should be invisible if there is hidden invisible overflow items", function(assert) {
+    var $element = $("#widget").dxToolbar({
+        items: [
+            { location: "before", template: function() { return $("<div>").width(100); } },
+            { location: "center", template: function() { return $("<div>").width(150); } },
+            { location: "after", locateInMenu: "auto", template: function() { return $("<div>").width(100); } },
+            { locateInMenu: "always", visible: false, template: function() { return $("<div>").width(100); } }
+        ]
+    });
+
+    var $dropDownMenu = $element.find("." + DROP_DOWN_MENU_CLASS);
+
+    assert.equal($dropDownMenu.length, 1, "button is rendered");
+    assert.notOk($dropDownMenu.is(":visible"), "button is invisible");
+});
+
 QUnit.test("all overflow items should be hidden on render", function(assert) {
     var $element = $("#toolbarWithMenu").dxToolbar({
         items: [


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
