### PR TITLE
Fix Renderer.find method for selectors contained "," and "\\," characters

### DIFF
--- a/js/core/renderer.js
+++ b/js/core/renderer.js
@@ -244,7 +244,7 @@ if(!useJQueryRenderer) {
                     }
                     queryId = "[id='" + queryId + "'] ";
 
-                    var querySelector = queryId + selector.replace(",", ", " + queryId);
+                    var querySelector = queryId + selector.replace(/([^\\])(\,)/g, "$1, " + queryId);
                     nodes.push.apply(nodes, element.querySelectorAll(querySelector));
                     setAttributeValue(element, "id", elementId);
                 } else if(element.nodeType === Node.DOCUMENT_NODE) {


### PR DESCRIPTION
Renderer.find method works incorrectly with cases below:
element.find(".class1, .class2, .class3")
element.find(".class1, .c\\,lass2")

This PR fixes tests with "No jQuery" flag.