### PR TITLE
SelectBox - Refactor "_renderInputValueAsync" method

### DIFF
--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -383,7 +383,9 @@ var SelectBox = DropDownList.inherit({
     },
 
     _renderInputValue: function() {
-        return this.callBase().always(this._renderInputValueAsync.bind(this));
+        return this.callBase().always(function() {
+            this._renderInputValueAsync();
+        }.bind(this));
     },
 
     _renderInputValueAsync: function() {
@@ -778,6 +780,11 @@ var SelectBox = DropDownList.inherit({
             endPosition = inputElement.value.length;
         inputElement.selectionStart = endPosition;
         inputElement.selectionEnd = endPosition;
+    },
+
+    _dispose: function() {
+        this._renderInputValueAsync = commonUtils.noop;
+        this.callBase();
     },
 
     _optionChanged: function(args) {

--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -383,15 +383,13 @@ var SelectBox = DropDownList.inherit({
     },
 
     _renderInputValue: function() {
-        this._renderInputValueAsync = function() {
-            this._renderTooltip();
-            this._renderInputValueImpl();
-            this._refreshSelected();
-        };
+        return this.callBase().always(this._renderInputValueAsync.bind(this));
+    },
 
-        return this.callBase().always((function() {
-            this._renderInputValueAsync();
-        }).bind(this));
+    _renderInputValueAsync: function() {
+        this._renderTooltip();
+        this._renderInputValueImpl();
+        this._refreshSelected();
     },
 
     _renderInputValueImpl: function() {
@@ -780,11 +778,6 @@ var SelectBox = DropDownList.inherit({
             endPosition = inputElement.value.length;
         inputElement.selectionStart = endPosition;
         inputElement.selectionEnd = endPosition;
-    },
-
-    _dispose: function() {
-        this._renderInputValueAsync = commonUtils.noop;
-        this.callBase();
     },
 
     _optionChanged: function(args) {

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -2874,6 +2874,9 @@ QUnit.test("selectbox should not render own components if it was disposed (T5174
     try {
         var instance = $("#selectBox").dxSelectBox({
             dataSource: {
+                load: function() {
+                    return [1];
+                },
                 byKey: function() {
                     var d = $.Deferred();
                     setTimeout(function() {


### PR DESCRIPTION
Defining _renderInputValueAsync method in dxSelectBox.prototype.