### PR TITLE
Fix TagBox 'text' option when 'value' is 0

### DIFF
--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -1055,7 +1055,9 @@ var TagBox = SelectBox.inherit({
     },
 
     _lastValue: function() {
-        return this._getValue().slice(-1).pop() || null;
+        var values = this._getValue(),
+            lastValue = values[values.length - 1];
+        return commonUtils.isDefined(lastValue) ? lastValue : null;
     },
 
     _valueChangeEventHandler: noop,

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -1057,7 +1057,7 @@ var TagBox = SelectBox.inherit({
     _lastValue: function() {
         var values = this._getValue(),
             lastValue = values[values.length - 1];
-        return commonUtils.isDefined(lastValue) ? lastValue : null;
+        return isDefined(lastValue) ? lastValue : null;
     },
 
     _valueChangeEventHandler: noop,

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -417,6 +417,15 @@ QUnit.test("tag should have correct value when item value is zero", function(ass
     assert.equal($.trim($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text()), "01", "selected first and second items");
 });
 
+QUnit.test("'text' option should have correct value when item value is zero", function(assert) {
+    var tagBox = $("#tagBox").dxTagBox({
+        value: [0],
+        items: [0, 1]
+    }).dxTagBox("instance");
+
+    assert.equal(tagBox.option("text"), "0");
+});
+
 QUnit.test("tag should have correct value when item value is an empty string", function(assert) {
     var $tagBox = $("#tagBox").dxTagBox({
         items: ["", 1, 2, 3],


### PR DESCRIPTION
Cherry-pick of #744.