### PR TITLE
Ensure localization.format returns a string

### DIFF
--- a/js/localization/date.js
+++ b/js/localization/date.js
@@ -108,7 +108,7 @@ var FORMATTERS = {
     },
 
     "day": function(date) {
-        return date.getDate();
+        return String(date.getDate());
     },
     "dayofweek": function(date) {
         return days[date.getDay()];
@@ -125,7 +125,7 @@ var FORMATTERS = {
     },
 
     "year": function(date) {
-        return date.getFullYear();
+        return String(date.getFullYear());
     },
     "shortyear": function(date) {
         return String(date.getFullYear()).substr(2, 2);
@@ -192,10 +192,10 @@ var FORMATTERS = {
     },
 
     "d": function(date) {
-        return formatNumber(FORMATTERS["day"](date), 1);
+        return formatNumber(date.getDate(), 1);
     },
     "dd": function(date) {
-        return formatNumber(FORMATTERS["day"](date), 2);
+        return formatNumber(date.getDate(), 2);
     },
 
     "d MMMM": function(date) {

--- a/testing/tests/DevExpress.localization/localization.base.tests.js
+++ b/testing/tests/DevExpress.localization/localization.base.tests.js
@@ -247,7 +247,9 @@ QUnit.test("format", function(assert) {
         data = $.makeArray(data);
 
         $.each(data, function(_, data) {
-            assert.equal(dateLocalization.format(data.date, format), data.expected, data.date + " in " + format + " format");
+            var localizedDate = dateLocalization.format(data.date, format);
+            assert.equal(typeof (localizedDate), "string");
+            assert.equal(localizedDate, data.expected, data.date + " in " + format + " format");
         });
     });
 


### PR DESCRIPTION
Fix for [T538542](https://www.devexpress.com/Support/Center/Question/Details/T538542/dxdatagrid-setting-a-column-s-format-year-throws-an-error)