### PR TITLE
T537604: dxDataGrid - The Column Chooser window cannot be dragged below its original position when the page height is greater than the browser window size

### DIFF
--- a/js/ui/overlay.js
+++ b/js/ui/overlay.js
@@ -1072,6 +1072,14 @@ var Overlay = Widget.inherit({
             containerWidth = $container.outerWidth(),
             containerHeight = $container.outerHeight();
 
+        if(this._isWindow($container)) {
+            var fullPageHeight = Math.max($(document).outerHeight(), containerHeight),
+                fullPageWidth = Math.max($(document).outerWidth(), containerWidth);
+
+            containerHeight = fullPageHeight;
+            containerWidth = fullPageWidth;
+        }
+
         return {
             width: containerWidth - contentWidth,
             height: containerHeight - contentHeight

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -2353,7 +2353,7 @@ QUnit.test("overlay can be dragged out of target if viewport and container is no
 
         var $container = $(window),
             viewWidth = $container.outerWidth(),
-            viewHeight = $container.outerHeight(),
+            viewHeight = Math.max($(document).outerHeight(), $container.outerHeight()),
             position = $overlayContent.position();
 
         var startEvent = pointer.start().dragStart().lastEvent();


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
