### PR TITLE
T540995: dxTooltip is hidden immediately after showing when the shading option is enabled

### DIFF
--- a/js/ui/tooltip/tooltip.js
+++ b/js/ui/tooltip/tooltip.js
@@ -69,6 +69,11 @@ var Tooltip = Popover.inherit({
         this.callBase();
     },
 
+    _toggleShading: function(visible) {
+        this.callBase(visible);
+        this._$wrapper.css("pointerEvents", this.option("shading") && visible ? "none" : "auto");
+    },
+
     _renderContent: function() {
         this.callBase();
 

--- a/testing/tests/DevExpress.ui.widgets/tooltip.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tooltip.tests.js
@@ -79,6 +79,18 @@ QUnit.test("tooltip should not prevent closeOnOutsideClick handler of other over
     assert.equal(overlay.option("visible"), false, "dxOverlay should be hiding");
 });
 
+QUnit.test("shading should have pointer-events none", function(assert) {
+    new Tooltip($("#tooltip"), {
+        visible: true,
+        shading: true
+    });
+
+    var $wrapper = $("." + TOOLTIP_WRAPPER_CLASS);
+
+    assert.equal($wrapper.css("pointer-events"), "none", "pointer events is none for shading");
+});
+
+
 QUnit.module("base z-index");
 
 QUnit.test("tooltip should have correct z-index", function(assert) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
