### PR TITLE
ASPNET template engine - Fix evaluation of expressions without semicolon ending

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -56,7 +56,7 @@
                 bag.push(encode ? encodeHtml(value) : value);
                 bag.push(");");
             } else {
-                bag.push(code);
+                bag.push(code + "\n");
             }
         }
 

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -270,6 +270,11 @@
             ""
         );
 
+        testTemplate("Evalute expr w/ semicolon",
+            "<% text %>abc",
+            "abc"
+        );
+
         testTemplate("For loop",
             "<% for(var i = 0; i < 5; i++) { %><%= i %><% } %>",
             "01234"


### PR DESCRIPTION
The "Unexpected identifier" error is raised compiling the template source like below:
`<% console.log('123') %> other template content`

It happens because compiled template function looks:
`(function(obj) {
var _ = [];with(obj||{}) { console.log('123')_.push("other template content");};return _.join('')
})`