### PR TITLE
ASPNET template engine - Remove unnecessary semicolon after 'with' block

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -77,7 +77,7 @@
                 acceptText(bag, tmp[1]);
             }
 
-            bag.push("};", "return _.join('')");
+            bag.push("}", "return _.join('')");
 
             return new Function("obj", bag.join(''));
         };


### PR DESCRIPTION
Now, template function compiled to:
```
function(obj) {
    var _ = [];
    with(obj||{}) {
       // ...
    };
    return _.join('')
}  
```

This PR removes unnecessary semicolon after 'with' block.