### PR TITLE
ASPNET template engine - Remove unnecessary semicolon after 'with' block

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -79,7 +79,7 @@
                 acceptText(bag, tmp[1]);
             }
 
-            bag.push("};", "return _.join('')");
+            bag.push("}", "return _.join('')");
 
             return new Function("obj", bag.join(''));
         };


### PR DESCRIPTION
Cherry-pick of #968.