### PR TITLE
Guard the use of setTemplateEngine (ASP.NET script)

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -166,7 +166,9 @@
         },
 
         setTemplateEngine: function() {
-            setTemplateEngine(createTemplateEngine());
+            if(setTemplateEngine) {
+                setTemplateEngine(createTemplateEngine());
+            }
         },
 
         createValidationSummaryItems: function(validationGroup, editorNames) {


### PR DESCRIPTION
The fix of [T492768](https://devexpress.com/issue=T492768) has caused [another issue](https://devexpress.com/issue=T541502).

Instead of not rendering `setTemplateEngine` in the View, I suggest to guard its use on the script level.
It's already [allowed to be absent](https://github.com/DevExpress/DevExtreme/blob/17.1.4/js/aspnet.js#L20-L21).