### PR TITLE
ASPNET - Extract "createComponent" method (helps to fix T540706)

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -135,21 +135,25 @@
         return items;
     }
 
+    function createComponent(name, options, id, validatorOptions) {
+        var render = function(_, container) {
+            var selector = "#" + id.replace(/[^\w-]/g, "\\$&"),
+                $component = $(selector, container)[name](options);
+            if($.isPlainObject(validatorOptions)) {
+                $component.dxValidator(validatorOptions);
+            }
+            templateRendered.remove(render);
+        };
+
+        templateRendered.add(render);
+    }
+
     return {
+        createComponent: createComponent,
+
         renderComponent: function(name, options, id, validatorOptions) {
             id = id || ("dx-" + new Guid());
-
-            var render = function(_, container) {
-                var selector = "#" + id.replace(/[^\w-]/g, "\\$&"),
-                    $component = $(selector, container)[name](options);
-                if($.isPlainObject(validatorOptions)) {
-                    $component.dxValidator(validatorOptions);
-                }
-                templateRendered.remove(render);
-            };
-
-            templateRendered.add(render);
-
+            createComponent(name, options, id, validatorOptions);
             return "<div id=\"" + id + "\"></div>";
         },
 

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -139,6 +139,12 @@
                 $("#qunit-fixture").html(
                     '<div id="button"></div>\
                     \
+                    <script id="templateWithCreateComponent" type="text/html">\
+                    <div id="templateContent">\
+                        <div id="inner-button"></div>\
+                        <% DevExpress.aspnet.createComponent("dxButton", { text: "text" }, "inner-button"); %>\
+                    </div>\
+                    </script>\
                     <script id="simpleTemplate" type="text/html">\
                     <div id="templateContent">\
                         <%= DevExpress.aspnet.renderComponent("dxButton") %>\
@@ -191,6 +197,11 @@
 
                 return $("#templateContent").children();
             }
+
+            QUnit.test("Create component", function(assert) {
+                var $result = renderTemplate("#templateWithCreateComponent");
+                assert.ok($result.is(".dx-button"));
+            });
 
             QUnit.test("Component element rendering", function(assert) {
                 var $result = renderTemplate("#simpleTemplate");


### PR DESCRIPTION
The "DevExtreme.aspnet.renderComponent" method does not support the ability to specify a component element content.

This PR introduces new "DevExtreme.aspnet.renderComponent" method that can be used in such manner for these needs:
```
<div id="ID_FROM_SERVER">
    <b>CONTENT FROM SERVER</b>
</div>
<% DevExpress.aspnet.createComponent("dxScrollView", { }, "ID_FROM_SERVER"); %>
```

Thus, the ScrollView content can be rendered on the MVC Controls side. It will help to fix [this case](https://www.devexpress.com/Support/Center/Question/Details/T540706/).