### PR TITLE
fixes impossibility of changing the seconds or milliseconds in the case when dxDateBox type is "time" (T543052)

### DIFF
--- a/js/ui/date_box/ui.date_utils.js
+++ b/js/ui/date_box/ui.date_utils.js
@@ -66,7 +66,7 @@ var dateUtils = {
             getStandardPattern: function() {
                 return "HH:mm";
             },
-            components: ["hours", "minutes"]
+            components: ["hours", "minutes", "seconds", "milliseconds"]
         },
         "datetime": {
             getStandardPattern: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -802,6 +802,38 @@ QUnit.test("incorrect work of mergeDates function if previous value not valid (Q
     assert.deepEqual(this.instance.option("value"), date);
 });
 
+QUnit.test("mergeDates must merge seconds when type is 'time'", function(assert) {
+    this.instance.option({
+        type: "time",
+        value: new Date(2000, 6, 31, 1, 1, 1),
+        pickerType: "list",
+        displayFormat: "longTime"
+    });
+
+    this.$input()
+        .val("1:1:16")
+        .trigger("change");
+
+    var date = new Date(2000, 6, 31, 1, 1, 16);
+    assert.deepEqual(this.instance.option("value"), date);
+});
+
+QUnit.test("mergeDates must merge milliseconds when type is 'time'", function(assert) {
+    this.instance.option({
+        type: "time",
+        value: new Date(1),
+        pickerType: "list",
+        displayFormat: "millisecond"
+    });
+
+    this.$input()
+        .val("16")
+        .trigger("change");
+
+    var date = new Date(16);
+    assert.deepEqual(this.instance.option("value"), date);
+});
+
 
 QUnit.module("dateView integration", {
     beforeEach: function() {


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
