### PR TITLE
Loading panel visibility when data source is empty and sate is loaded has been fixed (T542359 )

### DIFF
--- a/js/ui/data_grid/ui.data_grid.state_storing.js
+++ b/js/ui/data_grid/ui.data_grid.state_storing.js
@@ -162,6 +162,23 @@ gridCore.registerModule("stateStoring", {
         stateStoring: stateStoringCore.StateStoringController
     },
     extenders: {
+        views: {
+            rowsView: {
+                init: function() {
+                    var that = this;
+                    var dataController = that.getController("data");
+
+                    that.callBase();
+
+                    dataController.stateLoaded.add(function() {
+                        if(dataController.isLoaded()) {
+                            that.setLoading(false);
+                            that.renderNoDataText();
+                        }
+                    });
+                }
+            }
+        },
         controllers: {
             stateStoring: {
                 init: function() {
@@ -197,8 +214,10 @@ gridCore.registerModule("stateStoring", {
                     return stateStoringController.isEnabled() && !stateStoringController.isLoaded() ? [] : visibleColumns;
                 }
             },
-
             data: {
+                callbackNames: function() {
+                    return this.callBase().concat(["stateLoaded"]);
+                },
                 _refreshDataSource: function() {
                     var that = this,
                         callBase = that.callBase,
@@ -211,6 +230,7 @@ gridCore.registerModule("stateStoring", {
                             stateStoringController.load().always(function() {
                                 that._restoreStateTimeoutID = null;
                                 callBase.call(that);
+                                that.stateLoaded.fire();
                             });
                         });
                     } else if(!that.isStateLoading()) {

--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -712,8 +712,6 @@ module.exports = {
                     return this.option("noDataText");
                 },
 
-                _renderNoDataText: gridCoreUtils.renderNoDataText,
-
                 _rowClick: function(e) {
                     var item = this._dataController.items()[e.rowIndex] || {};
                     this.executeAction("onRowClick", extend({
@@ -917,6 +915,8 @@ module.exports = {
 
                     return parameters;
                 },
+
+                renderNoDataText: gridCoreUtils.renderNoDataText,
 
                 getCellOptions: function(rowIndex, columnIdentifier) {
                     var rowOptions = this._dataController.items()[rowIndex],
@@ -1133,7 +1133,7 @@ module.exports = {
                     that._updateRowHeight();
                     commonUtils.deferRender(function() {
                         that._renderScrollable();
-                        that._renderNoDataText();
+                        that.renderNoDataText();
                         that.updateFreeSpaceRowHeight();
                     });
                     that._updateScrollable();
@@ -1306,7 +1306,7 @@ module.exports = {
                             args.handled = true;
                             break;
                         case "noDataText":
-                            that._renderNoDataText();
+                            that.renderNoDataText();
                             args.handled = true;
                             break;
                     }

--- a/js/ui/grid_core/ui.grid_core.utils.js
+++ b/js/ui/grid_core/ui.grid_core.utils.js
@@ -189,6 +189,10 @@ module.exports = (function() {
             var that = this;
             $element = $element || this.element();
 
+            if(!$element) {
+                return;
+            }
+
             var noDataClass = that.addWidgetPrefix(NO_DATA_CLASS),
                 noDataElement = $element.find("." + noDataClass).last(),
                 isVisible = this._dataController.isEmpty(),

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
@@ -7,6 +7,14 @@ var $ = require("jquery"),
     ArrayStore = require("data/array_store");
 
 require("ui/data_grid/ui.data_grid");
+require("common.css!");
+require("generic_light.css!");
+
+QUnit.testStart(function() {
+    var markup = '<div id="container" class="dx-datagrid"></div>';
+
+    $("#qunit-fixture").html(markup);
+});
 
 QUnit.module('Local storage', {
     beforeEach: function() {
@@ -424,7 +432,7 @@ QUnit.module('State Storing with real controllers', {
     beforeEach: function() {
         this.clock = sinon.useFakeTimers();
         this.setupDataGridModules = function(options, ignoreClockTick) {
-            setupDataGridModules(this, ['data', 'columns', 'stateStoring', 'filterRow', 'search', 'pager', 'selection'], {
+            setupDataGridModules(this, ['data', 'columns', 'rows', 'gridView', 'stateStoring', 'filterRow', 'search', 'pager', 'selection'], {
                 initDefaultOptions: true,
                 initViews: true,
                 options: options
@@ -1036,4 +1044,50 @@ QUnit.test("Update state when applying header filter", function(assert) {
         visible: true,
         visibleIndex: 0
     }]);
+});
+
+QUnit.test("Hide loading when dataSource is empty", function(assert) {
+    //arrange, act
+    this.element = function() {
+        return $("#container");
+    };
+
+    this.setupDataGridModules({
+        stateStoring: {
+            enabled: true,
+            type: 'custom',
+            customLoad: function() { return {}; },
+            customSave: function() { }
+        },
+        loadingTimeout: null
+    }, true);
+
+    this.gridView.render(this.element());
+    this.clock.tick(200);
+
+    //assert
+    assert.equal($(".dx-loadpanel-content.dx-state-invisible").length, 1, "loading panel should be hidden");
+});
+
+QUnit.test("Show NoData message when dataSource is empty and state is loaded", function(assert) {
+    //arrange, act
+    this.element = function() {
+        return $("#container");
+    };
+
+    this.setupDataGridModules({
+        stateStoring: {
+            enabled: true,
+            type: 'custom',
+            customLoad: function() { return {}; },
+            customSave: function() { }
+        },
+        loadingTimeout: null
+    }, true);
+
+    this.gridView.render(this.element());
+    this.clock.tick(200);
+
+    //assert
+    assert.equal($(".dx-datagrid-nodata").length, 1, "NoData message should be shown");
 });


### PR DESCRIPTION
Loading panel is continuous shown when a data source is empty and state is loaded. And "No Data" message is not displayed for this scenario.