### PR TITLE
Validation for a batch edit mode when a column has showEditorAlways has been fixed (T539721)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -487,12 +487,13 @@ module.exports = {
                     }
                 },
 
-                updateFieldValue: function() {
+                updateFieldValue: function(e) {
                     var that = this;
 
                     that.callBase.apply(that, arguments);
 
-                    if(that.getEditMode() === EDIT_MODE_ROW) {
+                    if(that.getEditMode() === EDIT_MODE_ROW ||
+                        (that.getEditMode() === EDIT_MODE_BATCH && e.column.showEditorAlways)) {
                         var currentValidator = that.getController("validating").getValidator();
                         currentValidator && currentValidator.validate();
                     }

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -488,12 +488,12 @@ module.exports = {
                 },
 
                 updateFieldValue: function(e) {
-                    var that = this;
+                    var that = this,
+                        editMode = that.getEditMode();
 
                     that.callBase.apply(that, arguments);
 
-                    if(that.getEditMode() === EDIT_MODE_ROW ||
-                        (that.getEditMode() === EDIT_MODE_BATCH && e.column.showEditorAlways)) {
+                    if(editMode === EDIT_MODE_ROW || (editMode === EDIT_MODE_BATCH && e.column.showEditorAlways)) {
                         var currentValidator = that.getController("validating").getValidator();
                         currentValidator && currentValidator.validate();
                     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8742,6 +8742,43 @@ QUnit.test("Cell edit mode - The validation should not work for column with 'sho
     assert.notOk($cellElement.hasClass("dx-datagrid-invalid"), "first cell is valid");
 });
 
+QUnit.testInActiveWindow("Batch edit mode - Validation message should be shown when column has showEditorAlways", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container'),
+        inputElement;
+
+    rowsView.render(testElement);
+
+    that.applyOptions({
+        editing: {
+            mode: "batch"
+        },
+        columns: [{
+            dataField: 'name',
+            validationRules: [{
+                type: "required"
+            }],
+            showEditorAlways: true
+        }]
+    });
+
+    //act
+
+    that.editCell(0, 0);
+
+    inputElement = getInputElements(testElement).first();
+    inputElement.focus();
+    this.clock.tick();
+    inputElement.val("");
+    inputElement.trigger('change');
+
+    //assert
+    var cells = rowsView.element().find('tbody > tr').first().find("td");
+    assert.ok(cells.eq(0).hasClass("dx-datagrid-invalid"), "validation border should be shown");
+});
+
 QUnit.module('Editing with real dataController with grouping, masterDetail', {
     beforeEach: function() {
         this.array = [

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8769,10 +8769,11 @@ QUnit.testInActiveWindow("Batch edit mode - Validation message should be shown w
     that.editCell(0, 0);
 
     inputElement = getInputElements(testElement).first();
-    inputElement.focus();
+    inputElement
+        .val("")
+        .trigger('change');
+
     this.clock.tick();
-    inputElement.val("");
-    inputElement.trigger('change');
 
     //assert
     var cells = rowsView.element().find('tbody > tr').first().find("td");


### PR DESCRIPTION
Validation message and validation border are not shown after editing cell when a column has the showEditorAlways option. This [video](https://www.screencast.com/t/uJzC17tDRiQg) illustrates that.