### PR TITLE
T544461: dxSelectBox doesn't clear the previous filter after searching and clearing a value using the using "Ctrl + A" and "Backspace" keys

### DIFF
--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -747,9 +747,10 @@ var SelectBox = DropDownList.inherit({
 
     _valueSubstituted: function() {
         var input = this._input().get(0),
+            isAllSelected = input.selectionStart === 0 && input.selectionEnd === this._searchValue().length,
             inputHasSelection = input.selectionStart !== input.selectionEnd;
 
-        return this._wasSearch() && inputHasSelection;
+        return this._wasSearch() && inputHasSelection && !isAllSelected;
     },
 
     _shouldSubstitutionBeRendered: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -1913,6 +1913,29 @@ QUnit.test("Filter should be cleared if the 'onCustomItemCreating' deferred is r
     assert.equal(selectBox.content().find(".dx-list-item").length, 3, "filter was cleared");
 });
 
+QUnit.test("filter should be cleared if all text was removed using backspace", function(assert) {
+    var $selectBox = $("#selectBox").dxSelectBox({
+            searchEnabled: true,
+            opened: true,
+            items: [1, 2, 3]
+        }),
+        selectBox = $selectBox.dxSelectBox("instance"),
+        $input = $selectBox.find(".dx-texteditor-input"),
+        keyboard = keyboardMock($input);
+
+    keyboard.type("456");
+    this.clock.tick(TIME_TO_WAIT);
+    assert.equal(selectBox.content().find(".dx-list-item").length, 0, "filter is applied");
+
+    $input.get(0).setSelectionRange(0, 3);
+    keyboard.caret({ start: 0, end: 3 });
+    keyboard.press("backspace");
+    this.clock.tick(TIME_TO_WAIT);
+
+    assert.equal($input.val(), "", "value was cleared");
+    assert.equal(selectBox.content().find(".dx-list-item").length, 3, "filter was cleared");
+});
+
 QUnit.test("Custom value should be selected in list if items were modified on custom item creation", function(assert) {
     var items = [1, 2, 3],
         $selectBox = $("#selectBox").dxSelectBox({


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
