### PR TITLE
Wrong row index for new row has been fixed (T541129)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -440,9 +440,13 @@ var EditingController = modules.ViewController.inherit((function() {
         },
 
         _getInsertIndex: function() {
-            return this._editData.filter(function(editItem) {
-                return editItem.type === DATA_EDIT_DATA_INSERT_TYPE;
-            }).length + 1;
+            var maxInsertIndex = 0;
+            this._editData.forEach(function(editItem) {
+                if(editItem.type === DATA_EDIT_DATA_INSERT_TYPE && editItem.key[INSERT_INDEX] > maxInsertIndex) {
+                    maxInsertIndex = editItem.key[INSERT_INDEX];
+                }
+            });
+            return maxInsertIndex + 1;
         },
 
         /**

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -5460,6 +5460,38 @@ QUnit.testInActiveWindow("The lookup column should keep focus after changing val
     assert.ok($cellElement.hasClass("dx-focused"), "cell is focused");
 });
 
+QUnit.test("Batch mode - Correct insert row index for a new row when a previous new row is deleted_T541129", function(assert) {
+    //arrange
+    var that = this,
+        rowsView = this.rowsView,
+        testElement = $('#container');
+
+    that.options.editing = {
+        allowAdding: true,
+        allowUpdating: true,
+        allowDeleting: true,
+        mode: 'batch',
+        texts: {
+            addRow: "Add New Item",
+            saveGridChanges: "Save changes",
+            cancelGridChanges: "Cancel changes"
+        }
+    };
+
+    rowsView.render(testElement);
+
+    //act
+    this.addRow();
+    this.addRow();
+    this.deleteRow(1);
+    this.addRow();
+
+    //assert
+    var items = this.dataController.items();
+    assert.ok(items[0].inserted, "first row is inserted");
+    assert.ok(items[1].inserted, "second row is inserted");
+});
+
 if(device.ios || device.android) {
     //T322738
     QUnit.testInActiveWindow("Native click is used when allowUpdating is true", function(assert) {


### PR DESCRIPTION
Index of the new row is calculated as increment a count of new rows by one. That brings to error when a first new row is deleted because a next new row has index similar to the previous new row.