### PR TITLE
Mask editor improvements

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -243,6 +243,13 @@ var DropDownEditor = TextBox.inherit({
             * @hidden
             * @extend_doc
             */
+
+            /**
+             * @name dxDropDownEditorOptions_showMaskMode
+             * @publicName showMaskMode
+             * @hidden
+             * @extend_doc
+             */
         });
     },
 

--- a/js/ui/number_box/number_box.js
+++ b/js/ui/number_box/number_box.js
@@ -146,6 +146,13 @@ var NumberBox = TextEditor.inherit({
             */
 
             /**
+            * @name dxNumberBoxOptions_showMaskMode
+            * @publicName showMaskMode
+            * @hidden
+            * @extend_doc
+            */
+
+            /**
             * @name dxNumberBoxOptions_spellcheck
             * @publicName spellcheck
             * @hidden

--- a/js/ui/text_area.js
+++ b/js/ui/text_area.js
@@ -104,6 +104,13 @@ var TextArea = TextBox.inherit({
             * @hidden
             * @extend_doc
             */
+
+            /**
+             * @name dxTextAreaOptions_showMaskMode
+             * @publicName showMaskMode
+             * @hidden
+             * @extend_doc
+             */
         });
     },
 

--- a/js/ui/text_box/text_box.js
+++ b/js/ui/text_box/text_box.js
@@ -45,7 +45,6 @@ var TextBox = TextEditor.inherit({
             * @default null
             */
             maxLength: null
-
         });
     },
 

--- a/js/ui/text_box/text_box.js
+++ b/js/ui/text_box/text_box.js
@@ -45,6 +45,7 @@ var TextBox = TextEditor.inherit({
             * @default null
             */
             maxLength: null
+
         });
     },
 

--- a/js/ui/text_box/ui.text_editor.mask.js
+++ b/js/ui/text_box/ui.text_editor.mask.js
@@ -320,7 +320,10 @@ var TextEditorMask = TextEditorBase.inherit({
 
     _maskFocusHandler: function() {
         this._direction(FORWARD_DIRECTION);
-        this._adjustCaret();
+        var caret = this._getAdjustedCaret();
+        this._caretTimeout = setTimeout(function() {
+            this._caret({ start: caret, end: caret });
+        }.bind(this), 0);
     },
 
     _maskKeyDownHandler: function() {
@@ -532,8 +535,13 @@ var TextEditorMask = TextEditorBase.inherit({
         return !currentCaret || currentCaret !== this._caret().start;
     },
 
-    _adjustCaret: function(char) {
+    _getAdjustedCaret: function(char) {
         var caret = this._maskRulesChain.adjustedCaret(this._caret().start, this._isForwardDirection(), char);
+        return caret;
+    },
+
+    _adjustCaret: function(char) {
+        var caret = this._getAdjustedCaret(char);
         this._caret({ start: caret, end: caret });
     },
 
@@ -596,6 +604,7 @@ var TextEditorMask = TextEditorBase.inherit({
     _dispose: function() {
         clearTimeout(this._inputHandlerTimer);
         clearTimeout(this._backspaceHandlerTimeout);
+        clearTimeout(this._caretTimeout);
         this.callBase();
     },
 

--- a/js/ui/text_box/ui.text_editor.mask.js
+++ b/js/ui/text_box/ui.text_editor.mask.js
@@ -296,18 +296,18 @@ var TextEditorMask = TextEditorBase.inherit({
         this._caret(caret);
     },
 
-    _isValueNotEmpty: function() {
+    _isValueEmpty: function() {
         var value = this._convertToValue().replace(/\s+$/, "");
 
-        return !!(value.replace(/\s+/g, ""));
+        return !(value.replace(/\s+/g, ""));
     },
 
     _shouldShowMask: function() {
         var showMaskMode = this.option("showMaskMode");
 
         if(showMaskMode === "always") return true;
-        if(showMaskMode === "never") return this._isValueNotEmpty();
-        if(showMaskMode === "onFocus") return this._input().is(":focus") || this._isValueNotEmpty();
+        if(showMaskMode === "never") return !this._isValueEmpty();
+        if(showMaskMode === "onFocus") return this._input().is(":focus") || !this._isValueEmpty();
     },
 
     _showMaskPlaceholder: function() {
@@ -358,7 +358,7 @@ var TextEditorMask = TextEditorBase.inherit({
     },
 
     _maskBlurHandler: function() {
-        if(this.option("showMaskMode") === "onFocus" && !this._isValueNotEmpty()) {
+        if(this.option("showMaskMode") === "onFocus" && this._isValueEmpty()) {
             this.option("text", "");
             this._renderDisplayText("");
         }

--- a/js/ui/text_box/ui.text_editor.mask.js
+++ b/js/ui/text_box/ui.text_editor.mask.js
@@ -181,8 +181,8 @@ var TextEditorMask = TextEditorBase.inherit({
     _attachMaskEventHandlers: function() {
         var $input = this._input();
 
-        eventsEngine.on($input, eventUtils.addNamespace("focus", MASK_EVENT_NAMESPACE), this._maskFocusHandler.bind(this));
-        eventsEngine.on($input, eventUtils.addNamespace("blur", MASK_EVENT_NAMESPACE), this._maskBlurHandler.bind(this));
+        eventsEngine.on($input, eventUtils.addNamespace("focusin", MASK_EVENT_NAMESPACE), this._maskFocusHandler.bind(this));
+        eventsEngine.on($input, eventUtils.addNamespace("focusout", MASK_EVENT_NAMESPACE), this._maskBlurHandler.bind(this));
         eventsEngine.on($input, eventUtils.addNamespace("keydown", MASK_EVENT_NAMESPACE), this._maskKeyDownHandler.bind(this));
         eventsEngine.on($input, eventUtils.addNamespace("keypress", MASK_EVENT_NAMESPACE), this._maskKeyPressHandler.bind(this));
         eventsEngine.on($input, eventUtils.addNamespace("input", MASK_EVENT_NAMESPACE), this._maskInputHandler.bind(this));

--- a/js/ui/text_box/ui.text_editor.mask.js
+++ b/js/ui/text_box/ui.text_editor.mask.js
@@ -314,7 +314,9 @@ var TextEditorMask = TextEditorBase.inherit({
         if(this._shouldShowMask()) {
             var text = this._maskRulesChain.text();
             this.option("text", text);
-            this._renderDisplayText(text);
+            if(this.option("showMaskMode") === "onFocus") {
+                this._renderDisplayText(text);
+            }
         }
     },
 

--- a/js/ui/text_box/ui.text_editor.mask.rule.js
+++ b/js/ui/text_box/ui.text_editor.mask.rule.js
@@ -43,6 +43,11 @@ var BaseMaskRule = Class.inherit({
     reset: noop,
     clear: noop,
 
+    first: function(index) {
+        index = index || 0;
+        return this.next().first(index + 1);
+    },
+
     isAccepted: function() {
         return false;
     },
@@ -72,6 +77,10 @@ var EmptyMaskRule = BaseMaskRule.inherit({
 
     value: function() {
         return "";
+    },
+
+    first: function() {
+        return 0;
     },
 
     rawValue: function() {
@@ -149,6 +158,12 @@ var MaskRule = BaseMaskRule.inherit({
             return !!this._isAccepted;
         }
         this._isAccepted = !!value;
+    },
+
+    first: function(index) {
+        return this._value === EMPTY_CHAR
+            ? index || 0
+            : this.callBase(index);
     },
 
     _isAllowed: function(char, args) {
@@ -242,6 +257,11 @@ var StubMaskRule = MaskRule.inherit({
 
     _isValid: function(char) {
         return char === this.maskChar;
+    },
+
+    first: function(index) {
+        index = index || 0;
+        return this.next().first(index + 1);
     },
 
     _adjustedForward: function(caret, index, char) {

--- a/testing/helpers/keyboardMock.js
+++ b/testing/helpers/keyboardMock.js
@@ -413,7 +413,7 @@ var browser;
             },
 
             focus: function() {
-                this.triggerEvent("focus");
+                !$element.is(":focus") && this.triggerEvent("focus");
                 return this;
             },
 
@@ -483,9 +483,10 @@ var browser;
             },
 
             type: function(string) {
+                this.focus();
+
                 for(var i = 0; i < string.length; i++) {
                     var char = string.charAt(i);
-                    this.focus();
                     this.keyDown(char);
 
                     if(!this.event.isDefaultPrevented()) {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -31,6 +31,10 @@ var moduleConfig = {
         this.input = this.element.find("." + INPUT_CLASS);
         this.instance = this.element.data("dxTextEditor");
         this.keyboard = keyboardMock(this.input);
+        this.clock = sinon.useFakeTimers();
+    },
+    afterEach: function() {
+        this.clock.restore();
     }
 };
 
@@ -965,6 +969,8 @@ QUnit.test("TextEditor with mask option should firing the 'onChange' event", fun
     caretWorkaround($input);
 
     $input.triggerHandler("focus");
+    this.clock.tick();
+
     keyboard.type("123").press("enter");
     assert.equal(handler.callCount, 1, "'change' event is fired on enter after value change");
 

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -651,6 +651,7 @@ QUnit.test("show mask on focus only", function(assert) {
     assert.equal($input.val(), "", "input is empty");
 
     $input.focus();
+    this.clock.tick();
     assert.equal(textEditor.option("text"), "__", "editor is not empty");
     assert.equal($input.val(), "__", "input is not empty");
     assert.deepEqual(keyboard.caret(), { start: 0, end: 0 }, "caret position is on the start");
@@ -661,27 +662,10 @@ QUnit.test("show mask on focus only", function(assert) {
 
 });
 
-QUnit.test("never show mask", function(assert) {
-    var $textEditor = $("#texteditor").dxTextEditor({
-            mask: "XX",
-            showMaskMode: "never",
-            maskRules: {
-                "X": "x"
-            }
-        }),
-        textEditor = $textEditor.dxTextEditor("instance"),
-        $input = $textEditor.find(".dx-texteditor-input");
-
-    assert.equal(textEditor.option("text"), "", "editor is empty");
-
-    $input.focus();
-    assert.equal(textEditor.option("text"), "", "editor is not empty");
-});
-
 QUnit.test("change mask visibility", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
-            showMaskMode: "never",
+            showMaskMode: "always",
             maskRules: {
                 "X": "x"
             }
@@ -689,9 +673,6 @@ QUnit.test("change mask visibility", function(assert) {
         textEditor = $textEditor.dxTextEditor("instance"),
         $input = $textEditor.find(".dx-texteditor-input");
 
-    assert.equal(textEditor.option("text"), "", "placeholder is hidden");
-
-    textEditor.option("showMaskMode", "always");
     assert.equal(textEditor.option("text"), "__", "placeholder is visible");
 
     textEditor.option("showMaskMode", "onFocus");
@@ -724,7 +705,7 @@ QUnit.testInActiveWindow("cursor should be set after fixed mask letters", functi
 
 QUnit.testInActiveWindow("selection should consider fixed mask letters", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
-        mask: "X))",
+        mask: ")X))",
         maskRules: {
             "X": "x"
         }
@@ -752,7 +733,7 @@ QUnit.testInActiveWindow("Editor with mask isn't focused after render", function
 
 QUnit.testInActiveWindow("caret should be in start position on first editor focusing", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
-        mask: "XX",
+        mask: "00",
         focusStateEnabled: true
     });
 
@@ -764,6 +745,24 @@ QUnit.testInActiveWindow("caret should be in start position on first editor focu
 
     assert.equal(keyboard.caret().start, 0, "caret is at the start");
     assert.equal(keyboard.caret().end, 0, "caret is at the start");
+});
+
+QUnit.testInActiveWindow("caret should be at the last symbol when input is incomplete", function(assert) {
+    var $textEditor = $("#texteditor").dxTextEditor({
+        mask: "00",
+        focusStateEnabled: true
+    });
+
+    var $input = $textEditor.find(".dx-texteditor-input");
+    var keyboard = keyboardMock($input, true);
+
+    keyboard.type("1");
+    $input.blur();
+    $input.focus();
+    this.clock.tick();
+
+    assert.equal(keyboard.caret().start, 1, "caret is at the last symbol");
+    assert.equal(keyboard.caret().end, 1, "caret is at the last symbol");
 });
 
 
@@ -1308,7 +1307,7 @@ QUnit.test("mask should support drag", function(assert) {
 
     this.clock.tick();
 
-    assert.equal($input.val(), "(x_)", "mask is corrected");
+    assert.equal($input.val(), "(x_)", "mask is correct");
 });
 
 QUnit.test("mask should support drag with spaces", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -616,6 +616,82 @@ QUnit.test("all selected chars should be deleted on del key", function(assert) {
     assert.equal(keyboard.caret().start, 1, "caret position set to start");
 });
 
+QUnit.module("showMaskMode", moduleConfig);
+
+QUnit.test("show mask always", function(assert) {
+    var $textEditor = $("#texteditor").dxTextEditor({
+            mask: "XX",
+            showMaskMode: "always",
+            maskRules: {
+                "X": "x"
+            }
+        }),
+        textEditor = $textEditor.dxTextEditor("instance"),
+        $input = $textEditor.find(".dx-texteditor-input");
+
+    assert.equal(textEditor.option("text"), "__", "editor is empty");
+
+    $input.focus();
+    assert.equal(textEditor.option("text"), "__", "editor is not empty");
+});
+
+QUnit.test("show mask on focus only", function(assert) {
+    var $textEditor = $("#texteditor").dxTextEditor({
+            mask: "XX",
+            showMaskMode: "onFocus",
+            maskRules: {
+                "X": "x"
+            }
+        }),
+        textEditor = $textEditor.dxTextEditor("instance"),
+        $input = $textEditor.find(".dx-texteditor-input");
+
+    assert.equal(textEditor.option("text"), "", "editor is empty");
+
+    $input.focus();
+    assert.equal(textEditor.option("text"), "__", "editor is not empty");
+});
+
+QUnit.test("never show mask", function(assert) {
+    var $textEditor = $("#texteditor").dxTextEditor({
+            mask: "XX",
+            showMaskMode: "never",
+            maskRules: {
+                "X": "x"
+            }
+        }),
+        textEditor = $textEditor.dxTextEditor("instance"),
+        $input = $textEditor.find(".dx-texteditor-input");
+
+    assert.equal(textEditor.option("text"), "", "editor is empty");
+
+    $input.focus();
+    assert.equal(textEditor.option("text"), "", "editor is not empty");
+});
+
+QUnit.test("change mask visibility", function(assert) {
+    var $textEditor = $("#texteditor").dxTextEditor({
+            mask: "XX",
+            showMaskMode: "never",
+            maskRules: {
+                "X": "x"
+            }
+        }),
+        textEditor = $textEditor.dxTextEditor("instance"),
+        $input = $textEditor.find(".dx-texteditor-input");
+
+    assert.equal(textEditor.option("text"), "", "placeholder is hidden");
+
+    textEditor.option("showMaskMode", "always");
+    assert.equal(textEditor.option("text"), "__", "placeholder is visible");
+
+    textEditor.option("showMaskMode", "onFocus");
+    assert.equal(textEditor.option("text"), "", "placeholder is hidden");
+
+    $input.focus();
+    assert.equal(textEditor.option("text"), "__", "placeholder is visible");
+});
+
 
 QUnit.module("focusing", moduleConfig);
 
@@ -1241,7 +1317,7 @@ QUnit.test("mask should support drag with spaces", function(assert) {
 
     this.clock.tick();
 
-    assert.equal($input.val(), "(x__y)", "mask is corrected");
+    assert.equal($input.val(), "(xy__)", "mask is corrected");
 });
 
 

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -665,6 +665,22 @@ QUnit.testInActiveWindow("Editor with mask isn't focused after render", function
     assert.notOk($textEditor.hasClass("dx-state-focused"), "editor isn't focused");
 });
 
+QUnit.testInActiveWindow("caret should be in start position on first editor focusing", function(assert) {
+    var $textEditor = $("#texteditor").dxTextEditor({
+        mask: "XX",
+        focusStateEnabled: true
+    });
+
+    var $input = $textEditor.find(".dx-texteditor-input");
+    var keyboard = keyboardMock($input, true);
+
+    keyboard.caret(1);
+    this.clock.tick();
+
+    assert.equal(keyboard.caret().start, 0, "caret is at the start");
+    assert.equal(keyboard.caret().end, 0, "caret is at the start");
+});
+
 
 QUnit.module("value", moduleConfig);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -652,7 +652,7 @@ QUnit.test("show mask on focus only", function(assert) {
 
     $input.focus();
     assert.equal(textEditor.option("text"), "__", "editor is not empty");
-    assert.equal($input.val(), "__", "input is empty");
+    assert.equal($input.val(), "__", "input is not empty");
     assert.deepEqual(keyboard.caret(), { start: 0, end: 0 }, "caret position is on the start");
 
     $input.blur();

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -25,6 +25,19 @@ var testMaskRule = function(title, config) {
     });
 };
 
+var moduleConfig = {
+    beforeEach: function() {
+        this.clock = sinon.useFakeTimers();
+        this.focusAndTick = function($input, delay) {
+            $input.focus();
+            this.clock.tick(delay);
+        };
+    },
+
+    afterEach: function() {
+        this.clock.restore();
+    }
+};
 
 QUnit.module("rendering");
 
@@ -56,7 +69,7 @@ QUnit.test("render mask with fixed chars", function(assert) {
 });
 
 
-QUnit.module("typing");
+QUnit.module("typing", moduleConfig);
 
 QUnit.test("accept only allowed chars", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
@@ -126,6 +139,8 @@ QUnit.test("two chars with different maskRules surrounded by fixed chars", funct
     var keyboard = keyboardMock($input, true);
 
     caretWorkaround($input);
+
+    this.focusAndTick($input);
 
     keyboard.type("x").type("y");
     assert.equal($input.val(), "(xy)", "mask rendered correctly");
@@ -375,14 +390,7 @@ QUnit.test("press enter when caret position in the middle of the text", function
 });
 
 
-QUnit.module("backspace key", {
-    beforeEach: function() {
-        this.clock = sinon.useFakeTimers();
-    },
-    afterEach: function() {
-        this.clock.restore();
-    }
-});
+QUnit.module("backspace key", moduleConfig);
 
 QUnit.test("backspace should remove last char and move caret backward", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
@@ -531,14 +539,7 @@ QUnit.test("delete should remove only selected valuable chars (T242341)", functi
 });
 
 
-QUnit.module("selection", {
-    beforeEach: function() {
-        this.clock = sinon.useFakeTimers();
-    },
-    afterEach: function() {
-        this.clock.restore();
-    }
-});
+QUnit.module("selection", moduleConfig);
 
 QUnit.test("all selected chars should be deleted on key press", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
@@ -616,7 +617,7 @@ QUnit.test("all selected chars should be deleted on del key", function(assert) {
 });
 
 
-QUnit.module("focusing");
+QUnit.module("focusing", moduleConfig);
 
 QUnit.testInActiveWindow("cursor should be set after fixed mask letters", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
@@ -631,6 +632,7 @@ QUnit.testInActiveWindow("cursor should be set after fixed mask letters", functi
 
     keyboard.caret(0);
     $input.focus();
+    this.clock.tick();
 
     assert.equal(keyboard.caret().start, 1, "caret position set before first rule");
 });
@@ -648,6 +650,8 @@ QUnit.testInActiveWindow("selection should consider fixed mask letters", functio
 
     keyboard.caret(3);
     $input.focus();
+    this.clock.tick();
+
     assert.equal(keyboard.caret().start, 1, "caret position set before last fixed mask letter");
     assert.equal(keyboard.caret().end, 1, "caret position set before last fixed mask letter");
 });
@@ -662,7 +666,7 @@ QUnit.testInActiveWindow("Editor with mask isn't focused after render", function
 });
 
 
-QUnit.module("value");
+QUnit.module("value", moduleConfig);
 
 QUnit.test("value considers mask", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
@@ -762,6 +766,7 @@ QUnit.test("option change should be fired during typing", function(assert) {
     var keyboard = keyboardMock($input);
 
     caretWorkaround($input);
+    this.focusAndTick($input);
 
     keyboard.type("x");
     $input.trigger("change");
@@ -994,14 +999,7 @@ QUnit.test("mask should be displayed instead of empty string after clear button 
 });
 
 
-QUnit.module("paste", {
-    beforeEach: function() {
-        this.clock = sinon.useFakeTimers();
-    },
-    afterEach: function() {
-        this.clock.restore();
-    }
-});
+QUnit.module("paste", moduleConfig);
 
 QUnit.test("paste on empty editor", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
@@ -1096,6 +1094,7 @@ QUnit.test("paste handles stub correctly", function(assert) {
     var $input = $textEditor.find(".dx-texteditor-input");
     var keyboard = keyboardMock($input, true);
 
+    this.focusAndTick($input);
     keyboard.caret(0).paste("+1(999)888-77-66");
 
     assert.equal($input.val(), "+1(999)888-77-66", "paste handled correctly");
@@ -1112,7 +1111,9 @@ QUnit.test("paste move cursor after inserted text", function(assert) {
     var $input = $textEditor.find(".dx-texteditor-input");
     var keyboard = keyboardMock($input, true);
 
-    keyboard.caret(0).paste("xx");
+    keyboard.caret(0);
+    this.clock.tick();
+    keyboard.paste("xx");
 
     // NOTE: wait for textEditor async paste handler
     this.clock.tick();
@@ -1147,6 +1148,7 @@ QUnit.test("paste considers stub maskRules", function(assert) {
     var $input = $textEditor.find(".dx-texteditor-input");
     var keyboard = keyboardMock($input, true);
 
+    this.focusAndTick($input);
     keyboard.caret(0).paste("x");
 
     assert.equal(keyboard.caret().start, 2, "caret has correct position");
@@ -1188,14 +1190,7 @@ QUnit.test("paste event should be fired in the FireFox when ctrl+V pressed", fun
 });
 
 
-QUnit.module("drag text", {
-    beforeEach: function() {
-        this.clock = sinon.useFakeTimers();
-    },
-    afterEach: function() {
-        this.clock.restore();
-    }
-});
+QUnit.module("drag text", moduleConfig);
 
 QUnit.test("mask should support drag", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
@@ -1255,7 +1250,7 @@ QUnit.test("cut handled correctly", function(assert) {
     assert.equal($input.val(), "x_x", "cut handled correctly");
 });
 
-QUnit.module("build-in mask rules");
+QUnit.module("build-in mask rules", moduleConfig);
 
 testMaskRule("'0' is digit only", { mask: "0000000", text: "+- Az9$", result: " 9" });
 testMaskRule("'9' is digit or space", { mask: "9999999", text: "+- Az9$", result: " 9" });
@@ -1268,7 +1263,7 @@ testMaskRule("'A' is alphanumeric", { mask: "AAAAAAA", text: " Az9$яШ", result
 testMaskRule("'a' is alphanumeric or space", { mask: "aaaaaaa", text: " Az9$яШ", result: " Az9яШ" });
 
 
-QUnit.module("custom mask maskRules");
+QUnit.module("custom mask maskRules", moduleConfig);
 
 testMaskRule("string custom rule", { mask: "xxxxx", maskRules: { "x": "y" }, text: "z0y$ ", result: "y" });
 testMaskRule("array of chars custom rule", { mask: "xxxxx", maskRules: { "x": ["y", "z"] }, text: "z0y$ ", result: "zy" });
@@ -1452,13 +1447,7 @@ QUnit.test("validation after value changed", function(assert) {
 });
 
 
-QUnit.module("T9", {
-    beforeEach: function() {
-        this.clock = sinon.useFakeTimers();
-    }, afterEach: function() {
-        this.clock.restore();
-    }
-});
+QUnit.module("T9", moduleConfig);
 
 QUnit.test("mask works when keypress is not fired", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
@@ -1520,6 +1509,7 @@ QUnit.test("Last char remove correctly when keypress fired after backspace", fun
     var $input = $textEditor.find(".dx-texteditor-input");
     var keyboard = keyboardMock($input, true);
 
+    this.focusAndTick($input);
     keyboard.type("xx");
     this.clock.tick();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -644,12 +644,21 @@ QUnit.test("show mask on focus only", function(assert) {
             }
         }),
         textEditor = $textEditor.dxTextEditor("instance"),
-        $input = $textEditor.find(".dx-texteditor-input");
+        $input = $textEditor.find(".dx-texteditor-input"),
+        keyboard = keyboardMock($input, true);
 
     assert.equal(textEditor.option("text"), "", "editor is empty");
+    assert.equal($input.val(), "", "input is empty");
 
     $input.focus();
     assert.equal(textEditor.option("text"), "__", "editor is not empty");
+    assert.equal($input.val(), "__", "input is empty");
+    assert.deepEqual(keyboard.caret(), { start: 0, end: 0 }, "caret position is on the start");
+
+    $input.blur();
+    assert.equal(textEditor.option("text"), "", "editor is empty");
+    assert.equal($input.val(), "", "input is empty");
+
 });
 
 QUnit.test("never show mask", function(assert) {

--- a/testing/tests/DevExpress.ui/defaultOptions.tests.js
+++ b/testing/tests/DevExpress.ui/defaultOptions.tests.js
@@ -279,6 +279,13 @@ testComponentDefaults(TextEditor,
     }
 );
 
+testComponentDefaults(TextEditor,
+    {},
+    {
+        showMaskMode: "always"
+    }
+);
+
 testComponentDefaults(DropDownEditor,
     [
         { platform: "generic" }

--- a/ts/widgets-base.d.ts
+++ b/ts/widgets-base.d.ts
@@ -400,6 +400,9 @@ declare module DevExpress.ui {
         /** @docid dxTextEditorOptions_useMaskedValue */
         useMaskedValue?: boolean;
 
+        /** @docid dxTextEditorOptions_showMaskMode */
+        showMaskMode?: string;
+
         /** @docid dxTextEditorOptions_name */
         name?: string;
     }
@@ -437,6 +440,7 @@ declare module DevExpress.ui {
         /** @docid_ignore dxTextAreaOptions_maskChar */
         /** @docid_ignore dxTextAreaOptions_maskRules */
         /** @docid_ignore dxTextAreaOptions_maskInvalidMessage */
+        /** @docid_ignore dxTextAreaOptions_showMaskMode */
         /** @docid_ignore dxTextAreaOptions_useMaskedValue */
 
         /** @docid dxTextAreaOptions_spellcheck */
@@ -1745,6 +1749,7 @@ declare module DevExpress.ui {
         /** @docid_ignore dxDropDownEditorOptions_maskRules */
         /** @docid_ignore dxDropDownEditorOptions_maskInvalidMessage */
         /** @docid_ignore dxDropDownEditorOptions_useMaskedValue */
+        /** @docid_ignore dxDropDownEditorOptions_showMaskMode */
         /** @docid_ignore dxDropDownEditorOptions_mode */
 
         /** @docid dxDropDownEditorOptions_value */

--- a/ts/widgets-base.d.ts
+++ b/ts/widgets-base.d.ts
@@ -1025,6 +1025,7 @@ declare module DevExpress.ui {
         /** @docid_ignore dxNumberBoxOptions_maskRules */
         /** @docid_ignore dxNumberBoxOptions_maskInvalidMessage */
         /** @docid_ignore dxNumberBoxOptions_useMaskedValue */
+        /** @docid_ignore dxNumberBoxOptions_showMaskMode */
         /** @docid_ignore dxNumberBoxOptions_spellcheck */
 
         /** @docid dxNumberBoxOptions_max */


### PR DESCRIPTION
1. Set caret on focus to the start if the editor is empty
2. Set caret on focus to the first unentered symbol if the editor is not empty
3. Add possibility to hide mask placeholder if the editor is blurred and empty