### PR TITLE
T547404: Can't select a dxSelectBox item using the Return button on iOS when searching is enabled

### DIFF
--- a/js/ui/drop_down_menu.js
+++ b/js/ui/drop_down_menu.js
@@ -448,7 +448,7 @@ var DropDownMenu = Widget.inherit({
     _attachKeyboardEvents: function() {
         this.callBase.apply(this, arguments);
 
-        this._listProcessor = this._keyboardProcessor.attachChildProcessor();
+        this._listProcessor = this._keyboardProcessor && this._keyboardProcessor.attachChildProcessor();
         if(this._list) {
             this._list.option("_keyboardProcessor", this._listProcessor);
         }

--- a/js/ui/editor/editor.js
+++ b/js/ui/editor/editor.js
@@ -118,7 +118,10 @@ var Editor = Widget.inherit({
         }
 
         this.callBase();
-        this._attachChildKeyboardEvents();
+
+        if(this._keyboardProcessor) {
+            this._attachChildKeyboardEvents();
+        }
     },
 
     _attachChildKeyboardEvents: commonUtils.noop,

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -688,6 +688,7 @@ var Widget = DOMComponent.inherit({
 
         if(this._keyboardProcessor) {
             this._keyboardProcessor.dispose();
+            delete this._keyboardProcessor;
         }
     },
 

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -509,13 +509,14 @@ var Widget = DOMComponent.inherit({
     },
 
     _renderFocusState: function() {
+        this._attachKeyboardEvents();
+
         if(!this.option("focusStateEnabled") || this.option("disabled")) {
             return;
         }
 
         this._renderFocusTarget();
         this._attachFocusEvents();
-        this._attachKeyboardEvents();
         this._renderAccessKey();
     },
 
@@ -643,12 +644,16 @@ var Widget = DOMComponent.inherit({
     },
 
     _attachKeyboardEvents: function() {
-        var processor = this.option("_keyboardProcessor") || new KeyboardProcessor({
-            element: this._keyboardEventBindingTarget(),
-            focusTarget: this._focusTarget()
-        });
+        var processor = this.option("_keyboardProcessor");
 
-        this._keyboardProcessor = processor.reinitialize(this._keyboardHandler, this);
+        if(!processor && this.option("focusStateEnabled")) {
+            processor = new KeyboardProcessor({
+                element: this._keyboardEventBindingTarget(),
+                focusTarget: this._focusTarget()
+            });
+        }
+
+        this._keyboardProcessor = processor && processor.reinitialize(this._keyboardHandler, this);
     },
 
     _keyboardHandler: function(options) {

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -646,14 +646,16 @@ var Widget = DOMComponent.inherit({
     _attachKeyboardEvents: function() {
         var processor = this.option("_keyboardProcessor");
 
-        if(!processor && this.option("focusStateEnabled")) {
-            processor = new KeyboardProcessor({
+        if(processor) {
+            this._keyboardProcessor = processor.reinitialize(this._keyboardHandler, this);
+        } else if(this.option("focusStateEnabled")) {
+            this._keyboardProcessor = new KeyboardProcessor({
                 element: this._keyboardEventBindingTarget(),
-                focusTarget: this._focusTarget()
+                handler: this._keyboardHandler,
+                focusTarget: this._focusTarget(),
+                context: this
             });
         }
-
-        this._keyboardProcessor = processor && processor.reinitialize(this._keyboardHandler, this);
     },
 
     _keyboardHandler: function(options) {

--- a/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
@@ -8,6 +8,7 @@ var $ = require("jquery"),
     List = require("ui/list"),
     executeAsyncMock = require("../../../helpers/executeAsyncMock.js"),
     pointerMock = require("../../../helpers/pointerMock.js"),
+    KeyboardProcessor = require("ui/widget/ui.keyboard_processor"),
     keyboardMock = require("../../../helpers/keyboardMock.js"),
     registerComponent = require("core/component_registrator"),
     DOMComponent = require("core/dom_component"),
@@ -2385,6 +2386,21 @@ QUnit.test("list scroll to hidden focused item after press pageUp", function(ass
 
     assert.roughEqual(instance.scrollTop(), itemHeight, 1.0001, "list scrolled to previous focusedItem");
     assert.ok($items.eq(1).hasClass("dx-state-focused"), "focused item change to last visible item on new page");
+});
+
+QUnit.test("list should attach keyboard events even if focusStateEnabled is false when this option was passed from outer widget", function(assert) {
+    var handler = sinon.stub(),
+        $element = $("#list"),
+        instance = $element.dxList({
+            focusStateEnabled: false,
+            _keyboardProcessor: new KeyboardProcessor({ element: $element }),
+            items: [1, 2, 3]
+        }).dxList("instance");
+
+    instance.registerKeyHandler("enter", handler);
+    $element.trigger($.Event("keydown", { which: 13 }));
+
+    assert.equal(handler.callCount, 1, "keyboardProcessor is attached");
 });
 
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
