### PR TITLE
T548582: A custom date format doesn't display milliseconds if forceIsoDateParsing is true and dates are strings

### DIFF
--- a/js/core/utils/date_serialization.js
+++ b/js/core/utils/date_serialization.js
@@ -10,7 +10,7 @@ var NUMBER_SERIALIZATION_FORMAT = "number",
     DATE_SERIALIZATION_FORMAT = "yyyy/MM/dd",
     DATETIME_SERIALIZATION_FORMAT = "yyyy/MM/dd HH:mm:ss";
 
-var ISO8601_PATTERN = /^(\d{4,})(-)?(\d{2})(-)?(\d{2})(?:T(\d{2})(:)?(\d{2})?(:)?(\d{2}(?:\.(\d+))?)?)?(Z|([\+\-])(\d{2})(:)?(\d{2})?)?$/;
+var ISO8601_PATTERN = /^(\d{4,})(-)?(\d{2})(-)?(\d{2})(?:T(\d{2})(:)?(\d{2})?(:)?(\d{2}(?:\.(\d{3}))?)?)?(Z|([\+\-])(\d{2})(:)?(\d{2})?)?$/;
 var ISO8601_TIME_PATTERN = /^(\d{2}):(\d{2})(:(\d{2}))?$/;
 var ISO8601_PATTERN_PARTS = ["", "yyyy", "", "MM", "", "dd", "THH", "", "mm", "", "ss", ".SSS"];
 

--- a/js/core/utils/date_serialization.js
+++ b/js/core/utils/date_serialization.js
@@ -154,13 +154,14 @@ var parseISO8601String = function(text) {
 
     var hour = timePart(parts[6]) - timeZoneHour,
         minute = timePart(parts[8]) - timeZoneMinute,
-        second = timePart(parts[10]);
+        second = timePart(parts[10]),
+        millisecond = timePart(parts[11]);
 
     if(!!parts[12]) {
-        return new Date(Date.UTC(year, month, day, hour, minute, second));
+        return new Date(Date.UTC(year, month, day, hour, minute, second, millisecond));
     }
 
-    return new Date(year, month, day, hour, minute, second);
+    return new Date(year, month, day, hour, minute, second, millisecond);
 };
 
 var getIso8601Format = function(text, useUtc) {

--- a/testing/tests/DevExpress.core/utils.date_serialization.tests.js
+++ b/testing/tests/DevExpress.core/utils.date_serialization.tests.js
@@ -40,7 +40,13 @@ QUnit.test("serialization/deserialization", function(assert) {
             value: new Date(Date.UTC(2015, 7, 16)),
             serializedValue: "2015-08-16T00:00:00Z",
             format: "yyyy-MM-ddTHH:mm:ssZ"
-        }, {
+        },
+        {
+            value: new Date(Date.UTC(2015, 7, 16, 12, 13, 14, 345)),
+            serializedValue: "2015-08-16T12:13:14.345Z",
+            format: "yyyy-MM-ddTHH:mm:ss.SSSZ"
+        },
+        {
             value: new Date(0, 0, 0, 13, 20),
             serializedValue: "13:20"
         }, {
@@ -50,6 +56,11 @@ QUnit.test("serialization/deserialization", function(assert) {
             value: new Date(2015, 7, 16, 15, 45, 30),
             serializedValue: "20150816T154530",
             format: "yyyyMMddTHHmmss"
+        },
+        {
+            value: new Date(2015, 7, 16, 15, 45, 30, 345),
+            serializedValue: "20150816T154530.345",
+            format: "yyyyMMddTHHmmss.SSS"
         }
     ];
 
@@ -62,7 +73,7 @@ QUnit.test("serialization/deserialization", function(assert) {
         var parsedDate = dateSerialization.deserializeDate(data.serializedValue);
 
         assert.equal(serializedDate, data.serializedValue, data.format);
-        assert.equal(parsedDate.toString(), data.value.toString(), data.format);
+        assert.equal(parsedDate.getTime(), data.value.getTime(), data.format);
     });
 });
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
