### PR TITLE
Do not use Knockout's private API (#1209) (#1216)

### DIFF
--- a/js/integration/knockout/template.js
+++ b/js/integration/knockout/template.js
@@ -6,6 +6,18 @@ var $ = require("../../core/renderer"),
     TemplateBase = require("../../ui/widget/ui.template_base"),
     domUtils = require("../../core/utils/dom");
 
+var getParentContext = function() {
+    var parentNode = $("<div>")[0];
+    ko.applyBindingsToNode(parentNode);
+    var parentContext = ko.contextFor(parentNode);
+
+    getParentContext = function() {
+        return parentContext;
+    };
+
+    return parentContext;
+};
+
 var KoTemplate = TemplateBase.inherit({
 
     ctor: function(element) {
@@ -34,7 +46,8 @@ var KoTemplate = TemplateBase.inherit({
             }
         }
 
-        return new ko.bindingContext(data);
+        // workaround for https://github.com/knockout/knockout/pull/651
+        return getParentContext().createChildContext(data);
     },
 
     _renderCore: function(options) {


### PR DESCRIPTION
* Do not use Knockout's private API (#1209)

* Do not use Knockout's private API

* Fix memory leak

* Call getParentContext only method when ko is defined

* Remove unnecessary brackets

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
