### PR TITLE
Disable NuGet customizations and caching for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
 cache:
   directories:
     - node_modules
-    - dotnet_packages
 
 script:
 
@@ -29,7 +28,6 @@ script:
     docker run -t
     -e TARGET=$TARGET
     -e CONSTEL=$CONSTEL
-    -e NUGET_PACKAGES=/devextreme/dotnet_packages
     -v $TRAVIS_BUILD_DIR:/devextreme
     docker.io/devexpress/devextreme-build:17_2
     ./docker-ci.sh

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -3,7 +3,6 @@
 # Run inside https://hub.docker.com/r/devexpress/devextreme-build/
 
 export DEVEXTREME_DOCKER_CI=true
-export NUGET_PACKAGES=$PWD/dotnet_packages
 
 function run_lint {
     npm i eslint eslint-plugin-spellcheck jshint

--- a/shippable.yml
+++ b/shippable.yml
@@ -14,7 +14,7 @@ build:
 
   pre_ci_boot:
     image_name: docker.io/devexpress/devextreme-build
-    image_tag: 17_2
+    image_tag: "17_2"
     pull: true
 
   ci:
@@ -24,4 +24,3 @@ build:
   cache_dir_list:
     - $SHIPPABLE_BUILD_DIR/.git
     - $SHIPPABLE_BUILD_DIR/node_modules
-    - /root/.nuget


### PR DESCRIPTION
After updating the build image to .NET Core 2.0, we started getting .NET build errors when the content of the custom `NUGET_PACKAGES` dir is restored from the cache. Probably, a filesystem permissions issue.

```
You can read more about .NET Core tools telemetry @ https://aka.ms/dotnet-cli-telemetry.
e/build/style-compiler/style-compiler.csproj...
  Generating MSBuild file /devextreme/build/style-compiler/obj/style-compiler.csproj.nuget.g.props.
  Generating MSBuild file /devextreme/build/style-compiler/obj/style-compiler.csproj.nuget.g.targets.
  Restore completed in 1.27 sec for /devextreme/build/style-compiler/style-compiler.csproj.
Copyright (C) Microsoft Corporation. All rights reserved.
LessRegistry.cs(71,10): warning CS1030: #warning: 'TODO deprecated in 16.1' [/devextreme/build/style-compiler/style-compiler.csproj]
LessRegistry.cs(255,10): warning CS1030: #warning: 'TODO deprecated in 16.1' [/devextreme/build/style-compiler/style-compiler.csproj]
PersistentCache.cs(7,28): error CS0234: The type or namespace name 'PlatformAbstractions' does not exist in the namespace 'Microsoft.Extensions' (are you missing an assembly reference?) [/devextreme/build/style-compiler/style-compiler.csproj]
Program.cs(6,28): error CS0234: The type or namespace name 'CommandLineUtils' does not exist in the namespace 'Microsoft.Extensions' (are you missing an assembly reference?) [/devextreme/build/style-compiler/style-compiler.csproj]
Utils.cs(4,28): error CS0234: The type or namespace name 'PlatformAbstractions' does not exist in the namespace 'Microsoft.Extensions' (are you missing an assembly reference?) [/devextreme/build/style-compiler/style-compiler.csproj]
Program.cs(165,50): error CS0246: The type or namespace name 'CommandOption' could not be found (are you missing a using directive or an assembly reference?) [/devextreme/build/style-compiler/style-compiler.csproj]
```

