### PR TITLE
T544461: dxSelectBox doesn't clear the previous filter after searching and clearing a value using the using "Ctrl + A" and "Backspace" keys

### DIFF
--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -521,6 +521,8 @@ var SelectBox = DropDownList.inherit({
             this._wasSearch(false);
 
             if(this.option("showDataBeforeSearch") || this.option("minSearchLength") === 0) {
+                if(this._searchTimer) return;
+
                 var searchValue = this._dataSource.searchValue();
                 searchValue && this._wasSearch(true);
                 this._filterDataSource(searchValue || null);

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -1936,6 +1936,29 @@ QUnit.test("filter should be cleared if all text was removed using backspace", f
     assert.equal(selectBox.content().find(".dx-list-item").length, 3, "filter was cleared");
 });
 
+QUnit.test("search timer should not be cleared when the widget is opening", function(assert) {
+    var $selectBox = $("#selectBox").dxSelectBox({
+            searchEnabled: true,
+            searchTimeout: 100,
+            openOnFieldClick: false,
+            opened: true,
+            items: [1, 2, 3]
+        }),
+        selectBox = $selectBox.dxSelectBox("instance"),
+        $input = $selectBox.find(".dx-texteditor-input"),
+        $button = $selectBox.find(".dx-dropdowneditor-button"),
+        keyboard = keyboardMock($input);
+
+    keyboard.type("4");
+    this.clock.tick(100);
+    assert.equal(selectBox.content().find(".dx-list-item").length, 0, "items are filtered");
+
+    keyboard.press("backspace");
+    $button.trigger("dxclick");
+    this.clock.tick(TIME_TO_WAIT);
+    assert.equal(selectBox.content().find(".dx-list-item").length, 3, "filter was cleared");
+});
+
 QUnit.test("Custom value should be selected in list if items were modified on custom item creation", function(assert) {
     var items = [1, 2, 3],
         $selectBox = $("#selectBox").dxSelectBox({


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
