### PR TITLE
Fix failed test for FireFox

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
@@ -347,7 +347,7 @@ QUnit.test("maxHeight should be 90% of maximum of top or bottom offsets includin
         var popup = $(".dx-popup").dxPopup("instance"),
             maxHeight = popup.option("maxHeight");
 
-        assert.equal(Math.floor(maxHeight()), 523, "maxHeight is correct");
+        assert.roughEqual(Math.floor(maxHeight()), 523, 2, "maxHeight is correct");
 
     } finally {
         scrollTop.restore();


### PR DESCRIPTION
Calculated MaxHeight is differing in different browsers. I have added non-strict match to make this test actual for all browsers
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
