### PR TITLE
T554205: dxSelectBox - Items binding throws the "Cannot read property 'length' of undefined" error if the target member is not defined

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -393,9 +393,10 @@ var DropDownList = DropDownEditor.inherit({
     },
 
     _loadItem: function(value) {
-        var selectedItem = commonUtils.grep(this._getPlainItems(this.option("items") || []), (function(item) {
-            return this._isValueEquals(this._valueGetter(item), value);
-        }).bind(this))[0];
+        var plainItems = this._getPlainItems(this.option("items")),
+            selectedItem = commonUtils.grep(plainItems, (function(item) {
+                return this._isValueEquals(this._valueGetter(item), value);
+            }).bind(this))[0];
 
         return selectedItem !== undefined
             ? $.Deferred().resolve(selectedItem).promise()
@@ -404,6 +405,8 @@ var DropDownList = DropDownEditor.inherit({
 
     _getPlainItems: function(items) {
         var plainItems = [];
+
+        items = items || [];
 
         for(var i = 0; i < items.length; i++) {
             if(items[i] && items[i].items) {

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -393,7 +393,7 @@ var DropDownList = DropDownEditor.inherit({
     },
 
     _loadItem: function(value) {
-        var selectedItem = commonUtils.grep(this._getPlainItems(this.option("items")) || [], (function(item) {
+        var selectedItem = commonUtils.grep(this._getPlainItems(this.option("items") || []), (function(item) {
             return this._isValueEquals(this._valueGetter(item), value);
         }).bind(this))[0];
 

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -212,6 +212,16 @@ QUnit.test("default value is null", function(assert) {
     assert.strictEqual(instance.option("value"), null, "value is null on default");
 });
 
+QUnit.test("widget should render with empty items", function(assert) {
+    var $dropDownList = $("#dropDownList").dxDropDownList({
+            items: null,
+            opened: true
+        }),
+        instance = $dropDownList.dxDropDownList("instance");
+
+    assert.ok(instance, "widget was rendered");
+});
+
 QUnit.test("items option contains items from dataSource after load", function(assert) {
     var dataSource = [1, 2, 3];
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
