### PR TITLE
T555430: dxTextBox Mask: showMaskMode 'onFocus' does not work when mask contains stub symbols and useMaskedValue is true

### DIFF
--- a/js/ui/text_box/ui.text_editor.mask.js
+++ b/js/ui/text_box/ui.text_editor.mask.js
@@ -297,7 +297,7 @@ var TextEditorMask = TextEditorBase.inherit({
     },
 
     _isValueEmpty: function() {
-        return stringUtils.isEmpty(this._convertToValue());
+        return stringUtils.isEmpty(this._value);
     },
 
     _shouldShowMask: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -661,7 +661,7 @@ QUnit.test("show mask on focus only", function(assert) {
     assert.equal($input.val(), "", "input is empty");
 });
 
-QUnit.test("show mask on focus only with useMAskedValue and stub symbols", function(assert) {
+QUnit.test("show mask on focus only with useMaskedValue and stub symbols", function(assert) {
     var $textEditor = $("#texteditor").dxTextEditor({
             mask: "0-0",
             useMaskedValue: true,

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -659,7 +659,30 @@ QUnit.test("show mask on focus only", function(assert) {
     $input.blur();
     assert.equal(textEditor.option("text"), "", "editor is empty");
     assert.equal($input.val(), "", "input is empty");
+});
 
+QUnit.test("show mask on focus only with useMAskedValue and stub symbols", function(assert) {
+    var $textEditor = $("#texteditor").dxTextEditor({
+            mask: "0-0",
+            useMaskedValue: true,
+            showMaskMode: "onFocus"
+        }),
+        textEditor = $textEditor.dxTextEditor("instance"),
+        $input = $textEditor.find(".dx-texteditor-input"),
+        keyboard = keyboardMock($input, true);
+
+    assert.equal(textEditor.option("text"), "", "editor is empty");
+    assert.equal($input.val(), "", "input is empty");
+
+    $input.focus();
+    this.clock.tick();
+    assert.equal(textEditor.option("text"), "_-_", "editor is not empty");
+    assert.equal($input.val(), "_-_", "input is not empty");
+    assert.deepEqual(keyboard.caret(), { start: 0, end: 0 }, "caret position is on the start");
+
+    $input.blur();
+    assert.equal(textEditor.option("text"), "", "editor is empty");
+    assert.equal($input.val(), "", "input is empty");
 });
 
 QUnit.test("change mask visibility", function(assert) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
