### PR TITLE
Fix test for IE <11

### DIFF
--- a/testing/tests/DevExpress.ui.events/eventsEngine.test.js
+++ b/testing/tests/DevExpress.ui.events/eventsEngine.test.js
@@ -348,10 +348,16 @@ QUnit.test("delegateTarget", function(assert) {
 });
 
 QUnit.test("nativeEvents should work for window", function(assert) {
-    var focusSpy = sinon.spy(window, "focus");
+    var focusCount = 0;
+    var windowMock = {
+        focus: function() {
+            focusCount++;
+        }
+    };
 
-    eventsEngine.trigger(window, "focus");
+    windowMock.window = windowMock;
 
-    assert.ok(focusSpy.calledOnce, "focus called once");
+    eventsEngine.trigger(windowMock, "focus");
+    assert.equal(focusCount, 1, "focus called once");
 });
 


### PR DESCRIPTION
The window.focus method cannot be patched in IE<11, so windowMock was used