### PR TITLE
Fix T555400: Resource headers have an incorrect custom height if the crossScrollingEnabled option is enabled on the Day view

### DIFF
--- a/js/ui/scheduler/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/ui.scheduler.work_space.js
@@ -847,9 +847,16 @@ var SchedulerWorkSpace = Widget.inherit({
             headerHeight = this.invoke("getHeaderHeight"),
             allDayPanelHeight = this.supportAllDayRow() && this.option("showAllDayPanel") ? this.getAllDayHeight() : 0;
 
+        headerPanelHeight && this._headerScrollable && this._headerScrollable.$element().height(headerPanelHeight + allDayPanelHeight);
+
         headerPanelHeight && this._dateTableScrollable.element().css({
             "padding-bottom": allDayPanelHeight + headerPanelHeight + "px",
             "margin-bottom": -1 * ((parseInt(headerPanelHeight, 10)) + allDayPanelHeight) + "px"
+        });
+
+        headerPanelHeight && this._sidebarScrollable && this._sidebarScrollable.$element().css({
+            "padding-bottom": allDayPanelHeight + headerPanelHeight + "px",
+            "marginBottom": -1 * ((parseInt(headerPanelHeight, 10)) + allDayPanelHeight) + "px"
         });
 
         this._$allDayTitle && this._$allDayTitle.css("top", headerHeight + headerPanelHeight + "px");

--- a/js/ui/scheduler/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/ui.scheduler.work_space.js
@@ -847,14 +847,14 @@ var SchedulerWorkSpace = Widget.inherit({
             headerHeight = this.invoke("getHeaderHeight"),
             allDayPanelHeight = this.supportAllDayRow() && this.option("showAllDayPanel") ? this.getAllDayHeight() : 0;
 
-        headerPanelHeight && this._headerScrollable && this._headerScrollable.$element().height(headerPanelHeight + allDayPanelHeight);
+        headerPanelHeight && this._headerScrollable && this._headerScrollable.element().height(headerPanelHeight + allDayPanelHeight);
 
         headerPanelHeight && this._dateTableScrollable.element().css({
             "padding-bottom": allDayPanelHeight + headerPanelHeight + "px",
             "margin-bottom": -1 * ((parseInt(headerPanelHeight, 10)) + allDayPanelHeight) + "px"
         });
 
-        headerPanelHeight && this._sidebarScrollable && this._sidebarScrollable.$element().css({
+        headerPanelHeight && this._sidebarScrollable && this._sidebarScrollable.element().css({
             "padding-bottom": allDayPanelHeight + headerPanelHeight + "px",
             "marginBottom": -1 * ((parseInt(headerPanelHeight, 10)) + allDayPanelHeight) + "px"
         });

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integrationParts/workSpace.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integrationParts/workSpace.tests.js
@@ -1210,11 +1210,19 @@ QUnit.test("WorkSpace recalculation works fine after render dateCellTemplate if 
         schedulerHeaderPanelHeight = parseInt(this.instance.element().find(".dx-scheduler-header-panel").outerHeight(true), 10),
         $allDayTitle = this.instance.element().find(".dx-scheduler-all-day-title"),
         $dateTableScrollable = this.instance.element().find(".dx-scheduler-date-table-scrollable"),
-        allDayPanelHeight = this.instance._workSpace.getAllDayHeight();
+        allDayPanelHeight = this.instance._workSpace.getAllDayHeight(),
+        $sidebarScrollable = this.instance.$element().find(".dx-scheduler-sidebar-scrollable"),
+        $headerScrollable = this.instance.$element().find(".dx-scheduler-header-scrollable");
+
 
     assert.equal(parseInt($allDayTitle.css("top"), 10), schedulerHeaderHeight + schedulerHeaderPanelHeight, "All day title element top value");
     assert.roughEqual(parseInt($dateTableScrollable.css("padding-bottom"), 10), schedulerHeaderPanelHeight + allDayPanelHeight, 1, "dateTableScrollable element padding bottom");
     assert.roughEqual(parseInt($dateTableScrollable.css("margin-bottom"), 10), -1 * (schedulerHeaderPanelHeight + allDayPanelHeight), 1, "dateTableScrollable element margin bottom");
+
+    assert.roughEqual(parseInt($sidebarScrollable.css("padding-bottom"), 10), schedulerHeaderPanelHeight + allDayPanelHeight, 1, "sidebarScrollable element padding bottom");
+    assert.roughEqual(parseInt($sidebarScrollable.css("margin-bottom"), 10), -1 * (schedulerHeaderPanelHeight + allDayPanelHeight), 1, "sidebarScrollable element margin bottom");
+    assert.roughEqual($headerScrollable.outerHeight(), schedulerHeaderPanelHeight + allDayPanelHeight, 1, "headerScrollable height is correct");
+
 });
 
 QUnit.test("Timepanel text should be calculated correctly if DST makes sense (T442904)", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integrationParts/workSpace.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integrationParts/workSpace.tests.js
@@ -1182,11 +1182,17 @@ QUnit.test("WorkSpace recalculation works fine after render resourceCellTemplate
         schedulerHeaderPanelHeight = parseInt(this.instance.element().find(".dx-scheduler-header-panel").outerHeight(true), 10),
         $allDayTitle = this.instance.element().find(".dx-scheduler-all-day-title"),
         $dateTableScrollable = this.instance.element().find(".dx-scheduler-date-table-scrollable"),
-        allDayPanelHeight = this.instance._workSpace.getAllDayHeight();
+        allDayPanelHeight = this.instance._workSpace.getAllDayHeight(),
+        $sidebarScrollable = this.instance.element().find(".dx-scheduler-sidebar-scrollable"),
+        $headerScrollable = this.instance.element().find(".dx-scheduler-header-scrollable");
 
     assert.equal(parseInt($allDayTitle.css("top"), 10), schedulerHeaderHeight + schedulerHeaderPanelHeight, "All day title element top value");
     assert.roughEqual(parseInt($dateTableScrollable.css("padding-bottom"), 10), schedulerHeaderPanelHeight + allDayPanelHeight, 1, "dateTableScrollable element padding bottom");
     assert.roughEqual(parseInt($dateTableScrollable.css("margin-bottom"), 10), -1 * (schedulerHeaderPanelHeight + allDayPanelHeight), 1, "dateTableScrollable element margin bottom");
+
+    assert.roughEqual(parseInt($sidebarScrollable.css("padding-bottom"), 10), schedulerHeaderPanelHeight + allDayPanelHeight, 1, "sidebarScrollable element padding bottom");
+    assert.roughEqual(parseInt($sidebarScrollable.css("margin-bottom"), 10), -1 * (schedulerHeaderPanelHeight + allDayPanelHeight), 1, "sidebarScrollable element margin bottom");
+    assert.roughEqual($headerScrollable.outerHeight(), schedulerHeaderPanelHeight + allDayPanelHeight, 1, "headerScrollable height is correct");
 });
 
 QUnit.test("WorkSpace recalculation works fine after render dateCellTemplate if workspace has allDay appointment", function(assert) {
@@ -1222,7 +1228,6 @@ QUnit.test("WorkSpace recalculation works fine after render dateCellTemplate if 
     assert.roughEqual(parseInt($sidebarScrollable.css("padding-bottom"), 10), schedulerHeaderPanelHeight + allDayPanelHeight, 1, "sidebarScrollable element padding bottom");
     assert.roughEqual(parseInt($sidebarScrollable.css("margin-bottom"), 10), -1 * (schedulerHeaderPanelHeight + allDayPanelHeight), 1, "sidebarScrollable element margin bottom");
     assert.roughEqual($headerScrollable.outerHeight(), schedulerHeaderPanelHeight + allDayPanelHeight, 1, "headerScrollable height is correct");
-
 });
 
 QUnit.test("Timepanel text should be calculated correctly if DST makes sense (T442904)", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integrationParts/workSpace.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integrationParts/workSpace.tests.js
@@ -1211,8 +1211,8 @@ QUnit.test("WorkSpace recalculation works fine after render dateCellTemplate if 
         $allDayTitle = this.instance.element().find(".dx-scheduler-all-day-title"),
         $dateTableScrollable = this.instance.element().find(".dx-scheduler-date-table-scrollable"),
         allDayPanelHeight = this.instance._workSpace.getAllDayHeight(),
-        $sidebarScrollable = this.instance.$element().find(".dx-scheduler-sidebar-scrollable"),
-        $headerScrollable = this.instance.$element().find(".dx-scheduler-header-scrollable");
+        $sidebarScrollable = this.instance.element().find(".dx-scheduler-sidebar-scrollable"),
+        $headerScrollable = this.instance.element().find(".dx-scheduler-header-scrollable");
 
 
     assert.equal(parseInt($allDayTitle.css("top"), 10), schedulerHeaderHeight + schedulerHeaderPanelHeight, "All day title element top value");


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
