### PR TITLE
OData: resolve T560045

### DIFF
--- a/js/data/odata/query_adapter.js
+++ b/js/data/odata/query_adapter.js
@@ -376,7 +376,8 @@ var createODataQueryAdapter = function(queryOptions) {
                     withCredentials: queryOptions.withCredentials,
                     countOnly: _countQuery,
                     deserializeDates: queryOptions.deserializeDates,
-                    fieldTypes: queryOptions.fieldTypes
+                    fieldTypes: queryOptions.fieldTypes,
+                    isPaged: isFinite(_take)
                 }
             );
         },

--- a/js/data/odata/utils.js
+++ b/js/data/odata/utils.js
@@ -217,7 +217,7 @@ var sendRequest = function(protocolVersion, request, options) {
                 d.reject(new errors.Error("E4018"));
             }
 
-        } else if(nextUrl) {
+        } else if(nextUrl && !options.isPaged) {
             if(!isAbsoluteUrl(nextUrl)) {
                 nextUrl = toAbsoluteUrl(ajaxOptions.url, nextUrl);
             }

--- a/testing/tests/DevExpress.data/odataQuery.tests.js
+++ b/testing/tests/DevExpress.data/odataQuery.tests.js
@@ -1043,6 +1043,29 @@ QUnit.test("$skiptoken support", function(assert) {
         .always(done);
 });
 
+QUnit.test("T560045 - ignore next link when $top is specified", function(assert) {
+    var done = assert.async(),
+        urlPrefix = "https://graph.microsoft.com/v1.0/me/messages";
+
+    $.mockjax({
+        url: urlPrefix,
+        response: function(bag) {
+            this.responseText = {
+                "@odata.nextLink": urlPrefix + "?$top=1&$skip=" + (bag.data.$top + bag.data.$skip),
+                "value": [ 1 ]
+            };
+        }
+    });
+
+    QUERY(urlPrefix)
+        .slice(400, 1)
+        .enumerate()
+        .done(function(r) {
+            assert.equal(r.length, 1);
+            done();
+        });
+});
+
 QUnit.module("Switching to array mode", moduleWithMockConfig);
 QUnit.test("sort by function", function(assert) {
     assert.expect(1);


### PR DESCRIPTION
Original issue: https://devexpress.com/issue=T560045

The behavior is specific to [Microsoft Graph](https://developer.microsoft.com/en-us/graph/docs/concepts/paging).

The essence of the fix is that if the number of items in a result is limited by `$top`, then `nextLink` is ignored even if it's present.