### PR TITLE
T557999: dxAccordion doesn't clear selectedItems after clearing dataSource

### DIFF
--- a/js/ui/collection/ui.collection_widget.edit.js
+++ b/js/ui/collection/ui.collection_widget.edit.js
@@ -586,6 +586,10 @@ var CollectionWidget = BaseCollectionWidget.inherit({
                     this._invalidate();
                 }
                 break;
+            case "dataSource":
+                this.option("selectedItemKeys", []);
+                this.callBase(args);
+                break;
             case "selectedIndex":
             case "selectedItem":
             case "selectedItems":

--- a/testing/tests/DevExpress.ui/collectionWidgetParts/editingTests.js
+++ b/testing/tests/DevExpress.ui/collectionWidgetParts/editingTests.js
@@ -551,6 +551,24 @@ var runTests = function() {
         }
     });
 
+    QUnit.test("selectedItems should be cleared if datasource instance has been changed", function(assert) {
+        var instance = new TestComponent($("<div>"), {
+            selectionMode: "multiple",
+            dataSource: [1, 2, 3],
+            selectedItemKeys: [1, 2]
+        });
+
+        assert.deepEqual(instance.option("selectedItems"), [1, 2], "selectedItems is correct");
+        assert.deepEqual(instance.option("selectedItem"), 1, "selectedItem is correct");
+        assert.deepEqual(instance.option("selectedItemKeys"), [1, 2], "selectedItem is correct");
+
+        instance.option("dataSource", null);
+
+        assert.deepEqual(instance.option("selectedItems"), [], "selectedItems was cleared");
+        assert.strictEqual(instance.option("selectedItem"), undefined, "selectedItem was cleared");
+        assert.deepEqual(instance.option("selectedItemKeys"), [], "selectedItemKeys was cleared");
+    });
+
 
     QUnit.module("selecting of item keys", {
         beforeEach: function() {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
