### PR TITLE
Performance for rendering hidden columns has been fixed (T555949)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.adaptivity.js
+++ b/js/ui/grid_core/ui.grid_core.adaptivity.js
@@ -352,11 +352,12 @@ var AdaptiveColumnsController = modules.ViewController.inherit({
 
         if(view && view.isVisible() && column) {
             rowsCount = view.getRowsCount();
+            var $rowElements = view._getRowElements();
             for(rowIndex = 0; rowIndex < rowsCount; rowIndex++) {
                 if(rowIndex !== editFormRowIndex || viewName !== ROWS_VIEW) {
                     currentVisibleIndex = viewName === COLUMN_HEADERS_VIEW ? this._columnsController.getVisibleIndex(column.index, rowIndex) : visibleIndex;
                     if(currentVisibleIndex >= 0) {
-                        $cellElement = view.getCellElements(rowIndex).eq(currentVisibleIndex);
+                        $cellElement = $rowElements.eq(rowIndex).children().eq(currentVisibleIndex);
                         this._isCellValid($cellElement) && $cellElement.addClass(cssClassName);
                     }
                 }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
@@ -1485,6 +1485,19 @@ QUnit.test("Apply a hidden css class on cell prepared event of rows view", funct
     assert.ok($cells.eq(1).hasClass("dx-datagrid-hidden-column"));
 });
 
+QUnit.test("Row elements are should get only once when CSS for hidden column is applied", function(assert) {
+    //arrange, act
+    $(".dx-datagrid").width(200);
+    setupDataGrid(this);
+    this.rowsView.render($("#container"));
+    sinon.spy(this.rowsView, "_getRowElements");
+    this.resizingController.updateDimensions();
+    this.clock.tick();
+
+    //assert
+    assert.ok(this.rowsView._getRowElements.calledOnce);
+});
+
 QUnit.module("API", {
     beforeEach: function() {
         this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
The `getRowElements` method is thrown many times when specific CSS class for hidden columns is applied. Browser freezes up as result.