### PR TITLE
 dxChart: Correct position of the label when showing (T561563)

### DIFF
--- a/js/viz/series/points/label.js
+++ b/js/viz/series/points/label.js
@@ -176,10 +176,13 @@ Label.prototype = {
     },
 
     show: function() {
-        var that = this;
+        var that = this,
+            needToCorrectPosition = !that._group || !that._group.attr("visibility");
         if(that._point.hasValue()) {
             that._draw();
-            that._point.correctLabelPosition(that);
+            if(needToCorrectPosition) {
+                that._point.correctLabelPosition(that);
+            }
         }
     },
 

--- a/testing/tests/DevExpress.viz.core.series/label.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/label.tests.js
@@ -177,6 +177,19 @@ QUnit.test("Hide", function(assert) {
     assert.deepEqual(label._group.stub("attr").lastCall.args[0], { visibility: "hidden" });
 });
 
+QUnit.test("Manual switching Hide/Show", function(assert) {
+    var label = this.createLabel();
+    label.show();
+
+    label.hide();
+    label.show();
+
+    assert.equal(label._group.stub("attr").callCount, 5);
+    assert.deepEqual(label._group.stub("attr").getCall(1).args[0], { visibility: "hidden" });
+    assert.deepEqual(label._group.stub("attr").lastCall.args[0], { visibility: "visible" });
+    assert.equal(label._point.correctLabelPosition.callCount, 1);
+});
+
 QUnit.test("Draw label", function(assert) {
     var label = this.createAndDrawLabel();
 
@@ -660,7 +673,7 @@ QUnit.test("Set options on empty text", function(assert) {
     label.setOptions(this.options);
     label.show();
 
-    assert.strictEqual(label._group.stub("attr").callCount, 2);
+    assert.strictEqual(label._group.stub("attr").callCount, 3);
     assert.deepEqual(label._group.stub("attr").lastCall.args[0], { visibility: "hidden" });
 });
 

--- a/testing/tests/DevExpress.viz.core.series/label.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/label.tests.js
@@ -177,7 +177,7 @@ QUnit.test("Hide", function(assert) {
     assert.deepEqual(label._group.stub("attr").lastCall.args[0], { visibility: "hidden" });
 });
 
-QUnit.test("Manual switching Hide/Show", function(assert) {
+QUnit.test("Show hidden label in the correct position (using the 'resolveLabelOverlapping' option) after calling the 'show' method (T561563)", function(assert) {
     var label = this.createLabel();
     label.show();
 


### PR DESCRIPTION

The hidden label was shown in the incorrect position after calling the 'show' method - the 'resolveLabelOverlapping' parameter was ignored
