### PR TITLE
Error is not thrown when focus is navigated to adaptive form via 'tab' key (T562062)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -515,7 +515,7 @@ var KeyboardNavigationController = core.ViewController.inherit({
                 this._updateFocusedCellPosition(this._getCellElementFromTarget(eventTarget));
                 $cell = this._getNextCell(direction);
 
-                if(this._handleTabKeyOnMasterDetailCell($cell, direction)) {
+                if(!$cell || this._handleTabKeyOnMasterDetailCell($cell, direction)) {
                     return;
                 }
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
@@ -3635,25 +3635,25 @@ QUnit.module("Keyboard navigation", {
     setupModule: function() {
         this.$dataGrid = $(".dx-datagrid").width(200);
 
-        this.columns = [
+        this.columns = this.columns || [
             { dataField: 'firstName', index: 0, allowEditing: true, allowExporting: true },
             { dataField: 'lastName', index: 1, allowEditing: true, allowExporting: true },
             { dataField: 'fullName', index: 1, allowEditing: true, allowExporting: true }
         ];
 
-        this.items = [
+        this.items = this.items || [
             { firstName: 'Blablablablablablablablablabla', lastName: "Psy", fullName: "Full Name" },
             { firstName: 'Super', lastName: "Star", fullName: "Full Name" }
         ];
 
-        this.options = {
+        this.options = $.extend({
             useKeyboard: true,
             tabIndex: 0,
             editing: {
                 mode: 'batch',
                 allowUpdating: true
             }
-        };
+        }, this.options);
         setupDataGrid(this, $("#container"));
 
         this.gridView.render($("#container"));
@@ -3675,7 +3675,6 @@ QUnit.module("Keyboard navigation", {
 
     beforeEach: function() {
         this.clock = sinon.useFakeTimers();
-        this.setupModule();
     },
 
     afterEach: function() {
@@ -3684,6 +3683,7 @@ QUnit.module("Keyboard navigation", {
 }, function() {
     QUnit.testInActiveWindow("Edit next an adaptive detail item by tab key", function(assert) {
         //arrange
+        this.setupModule();
         this.triggerFormItemClick(0);
 
         //assert
@@ -3702,6 +3702,7 @@ QUnit.module("Keyboard navigation", {
 
     QUnit.testInActiveWindow("Edit previous an adaptive detail item by shift + tab key", function(assert) {
         //arrange
+        this.setupModule();
         this.triggerFormItemClick(1);
 
         //assert
@@ -3720,6 +3721,7 @@ QUnit.module("Keyboard navigation", {
 
     QUnit.testInActiveWindow("Editable cell is closed when focus moving outside detail form", function(assert) {
         //arrange
+        this.setupModule();
         this.triggerFormItemClick(1);
 
         //act
@@ -3738,6 +3740,7 @@ QUnit.module("Keyboard navigation", {
 
     QUnit.testInActiveWindow("Skip hidden column when use a keyboard navigation via 'tab' key", function(assert) {
         //arrange
+        this.setupModule();
         this.editingController.editCell(0, 0);
         this.clock.tick();
 
@@ -3748,5 +3751,32 @@ QUnit.module("Keyboard navigation", {
 
         //assert
         assert.equal(this.getActiveInputElement().val(), "Super");
+    });
+
+    QUnit.testInActiveWindow("Error is not thrown when via keyboard navigation to adaptive form for new row", function(assert) {
+        //arrange
+        this.items = [];
+        this.columns = [
+            { dataField: 'firstName', index: 0, allowEditing: true, width: 200 },
+            { dataField: 'lastName', index: 1, allowEditing: true, width: 200 },
+            { dataField: 'fullName', index: 1, allowEditing: true, width: 200 }
+        ];
+        this.options = {
+            editing: {
+                allowAdding: true,
+                mode: "row"
+            }
+        };
+        this.setupModule();
+        this.editingController.addRow();
+        this.clock.tick();
+
+        //act
+        var e = $.Event('keydown');
+        e.which = 9;
+        this.getActiveInputElement().trigger(e);
+
+        //assert
+        assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { columnIndex: 0, rowIndex: 0 });
     });
 });


### PR DESCRIPTION
The "Cannot read property 'is' of null" error occurs on an attempt to navigate from the last row cell