### PR TITLE
dxPieChart: Fix regression after #1481

### DIFF
--- a/js/viz/series/points/pie_point.js
+++ b/js/viz/series/points/pie_point.js
@@ -157,6 +157,7 @@ module.exports = _extend({}, symbolPoint, {
 
         // this function is called for drawing labels without points for checking size of labels
         this._isLabelDrawingWithoutPoints = true;
+        this._label.clearVisibility();
         this._drawLabel();
         this._isLabelDrawingWithoutPoints = false;
     },

--- a/testing/tests/DevExpress.viz.core.series/piePoint.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/piePoint.tests.js
@@ -1022,6 +1022,11 @@ QUnit.test("not columns", function(assert) {
     assert.deepEqual(coord, { x: 10, y: 10 });
 });
 
+QUnit.test("Show hidden label in the correct position (using the 'resolveLabelOverlapping' option) after calling the 'show' method (T561563)", function(assert) {
+    var point = createPointWithStubLabelForDraw.call(this, { 0: 170, 10: 210, 20: 250 }, true);
+
+    assert.ok(point._label.clearVisibility.calledOnce);
+});
 
 QUnit.module("update Coord", {
     beforeEach: environmentWithStubLabels


### PR DESCRIPTION
The pie chart label was shown in the incorrect position after fixing 'show' method
