### PR TITLE
Fix design issues in Scheduler after current-time indicator implementation

### DIFF
--- a/js/ui/scheduler/ui.scheduler.currentTimeShader.vertical.js
+++ b/js/ui/scheduler/ui.scheduler.currentTimeShader.vertical.js
@@ -62,7 +62,7 @@ var VerticalCurrentTimeShader = Shader.inherit({
     },
 
     _getShaderOffset: function(i, width) {
-        var offset = i > 0 ? this._workspace._getCellCount() * this._workspace._getRoundedCellWidth(i - 1) * i : 0;
+        var offset = this._workspace._getCellCount() * this._workspace._getRoundedCellWidth(i - 1) * i;
         return this._workspace.option("rtlEnabled") ? this._$container.outerWidth() - offset - this._workspace.getTimePanelWidth() - width : offset;
     },
 

--- a/js/ui/scheduler/ui.scheduler.currentTimeShader.vertical.js
+++ b/js/ui/scheduler/ui.scheduler.currentTimeShader.vertical.js
@@ -19,9 +19,9 @@ var VerticalCurrentTimeShader = Shader.inherit({
         if(shaderHeight > 0) {
             this._$shader.height(shaderHeight);
 
-            var shaderWidth = this._workspace.getIndicationWidth();
             var groupCount = this._workspace._getGroupCount() || 1;
             for(var i = 0; i < groupCount; i++) {
+                var shaderWidth = this._workspace.getIndicationWidth(i);
                 this._renderTopShader(this._$shader, shaderHeight, shaderWidth, i);
 
                 this._renderBottomShader(this._$shader, maxHeight - shaderHeight, shaderWidth, i);
@@ -62,7 +62,7 @@ var VerticalCurrentTimeShader = Shader.inherit({
     },
 
     _getShaderOffset: function(i, width) {
-        var offset = this._workspace._getCellCount() * this._workspace._getRoundedCellWidth() * i;
+        var offset = i > 0 ? this._workspace._getCellCount() * this._workspace._getRoundedCellWidth(i - 1) * i : 0;
         return this._workspace.option("rtlEnabled") ? this._$container.outerWidth() - offset - this._workspace.getTimePanelWidth() - width : offset;
     },
 

--- a/js/ui/scheduler/ui.scheduler.timeline.js
+++ b/js/ui/scheduler/ui.scheduler.timeline.js
@@ -184,7 +184,8 @@ var SchedulerTimeline = SchedulerWorkSpace.inherit({
         return cellCount * cellWidth;
     },
 
-    _renderIndicator: function(width, height, rtlOffset, $container) {
+    _renderIndicator: function(height, rtlOffset, $container) {
+        var width = this.getIndicationWidth();
         var $indicator = this._createIndicator($container);
         $indicator.height($container.outerHeight());
         $indicator.css("left", rtlOffset ? rtlOffset - width : width);

--- a/js/ui/scheduler/ui.scheduler.work_space.indicator.js
+++ b/js/ui/scheduler/ui.scheduler.work_space.indicator.js
@@ -39,19 +39,19 @@ var SchedulerWorkSpaceIndicator = SchedulerWorkSpace.inherit({
             if(this.option("showCurrentTimeIndicator") && this._needRenderDateTimeIndicator()) {
                 var groupCount = isVertical && this._getGroupCount() || 1,
                     $container = this._dateTableScrollable.$content(),
-                    width = this.getIndicationWidth(0),
                     height = this.getIndicationHeight(),
                     rtlOffset = this._getRtlOffset(this.getCellWidth());
 
                 if(height > 0) {
-                    this._renderIndicator(width, height, rtlOffset, $container, groupCount);
+                    this._renderIndicator(height, rtlOffset, $container, groupCount);
                 }
             }
         }
     },
 
-    _renderIndicator: function(width, height, rtlOffset, $container, groupCount) {
+    _renderIndicator: function(height, rtlOffset, $container, groupCount) {
         for(var i = 0; i < groupCount; i++) {
+            var width = this.getIndicationWidth(i);
             var $indicator = this._createIndicator($container);
             var offset = this._getCellCount() * this._getRoundedCellWidth(i) * i + (width - this.getCellWidth());
 
@@ -95,14 +95,14 @@ var SchedulerWorkSpaceIndicator = SchedulerWorkSpace.inherit({
         return true;
     },
 
-    getIndicationWidth: function(i) {
+    getIndicationWidth: function(groupIndex) {
         var today = this._getToday(),
             firstViewDate = new Date(this._firstViewDate),
             maxWidth = this.getCellWidth() * this._getCellCount();
 
         var timeDiff = today.getTime() - firstViewDate.getTime(),
             difference = Math.ceil(timeDiff / toMs("day")),
-            width = difference * this._getRoundedCellWidth(i, difference);
+            width = difference * this._getRoundedCellWidth(groupIndex, difference);
 
         return maxWidth < width ? maxWidth : width;
     },

--- a/js/ui/scheduler/ui.scheduler.work_space.indicator.js
+++ b/js/ui/scheduler/ui.scheduler.work_space.indicator.js
@@ -39,7 +39,7 @@ var SchedulerWorkSpaceIndicator = SchedulerWorkSpace.inherit({
             if(this.option("showCurrentTimeIndicator") && this._needRenderDateTimeIndicator()) {
                 var groupCount = isVertical && this._getGroupCount() || 1,
                     $container = this._dateTableScrollable.$content(),
-                    width = this.getIndicationWidth(),
+                    width = this.getIndicationWidth(0),
                     height = this.getIndicationHeight(),
                     rtlOffset = this._getRtlOffset(this.getCellWidth());
 
@@ -53,7 +53,7 @@ var SchedulerWorkSpaceIndicator = SchedulerWorkSpace.inherit({
     _renderIndicator: function(width, height, rtlOffset, $container, groupCount) {
         for(var i = 0; i < groupCount; i++) {
             var $indicator = this._createIndicator($container);
-            var offset = this._getCellCount() * this._getRoundedCellWidth() * i + (width - this._getRoundedCellWidth());
+            var offset = this._getCellCount() * this._getRoundedCellWidth(i) * i + (width - this.getCellWidth());
 
             $indicator.width(this.getCellWidth());
             $indicator.css("left", rtlOffset ? rtlOffset - offset : offset);
@@ -95,28 +95,33 @@ var SchedulerWorkSpaceIndicator = SchedulerWorkSpace.inherit({
         return true;
     },
 
-    getIndicationWidth: function() {
+    getIndicationWidth: function(i) {
         var today = this._getToday(),
             firstViewDate = new Date(this._firstViewDate),
             maxWidth = this.getCellWidth() * this._getCellCount();
 
         var timeDiff = today.getTime() - firstViewDate.getTime(),
             difference = Math.ceil(timeDiff / toMs("day")),
-            width = difference * this.getCellWidth();
+            width = difference * this._getRoundedCellWidth(i, difference);
 
         return maxWidth < width ? maxWidth : width;
     },
 
-    _getRoundedCellWidth: function() {
+    _getRoundedCellWidth: function(groupIndex, cellCount) {
+        if(groupIndex < 0) {
+            return 0;
+        }
+
         var $row = this.$element().find("." + this._getDateTableRowClass()).eq(0),
             width = 0,
             $cells = $row.find("." + this._getDateTableCellClass()),
-            cellCount = $cells.length;
+            totalCellCount = this._getCellCount() * groupIndex;
 
-        $cells.each(function(_, cell) {
+        cellCount = cellCount || this._getCellCount();
 
-            width = width + $(cell).outerWidth();
-        });
+        for(var i = totalCellCount; i < totalCellCount + cellCount; i++) {
+            width = width + $($cells).eq(i).outerWidth();
+        }
 
         return width / cellCount;
     },

--- a/styles/widgets/base/scheduler.less
+++ b/styles/widgets/base/scheduler.less
@@ -82,8 +82,7 @@
 @SCHEDULER_TIME_INDICATOR_SHADOW_COLOR: rgba(255, 255, 255, 0.10);
 @SCHEDULER_TIME_INDICATOR_SHADOW: 0 1px 0 0px @SCHEDULER_TIME_INDICATOR_SHADOW_COLOR;
 @SCHEDULER_TIME_INDICATOR_TEXT_SHADOW: @SCHEDULER_TIME_INDICATOR_SHADOW_COLOR 1px 0px 0px;
-@SCHEDULER_HEADER_PANEL_CURRENT_TIME_BOX_SHADOW: inset 0px -2px 0px 0px @SCHEDULER_TIME_INDICATOR_COLOR;
-@SCHEDULER_TIME_PANEL_CURRENT_TIME_BOX_SHADOW: inset -2px 0px 0px 0px @SCHEDULER_TIME_INDICATOR_COLOR;
+@SCHEDULER_CURRENT_TIME_CELL_BORDER_SIZE: 2px;
 
 .dx-scheduler-pseudo-cell {
     &:before {
@@ -454,8 +453,16 @@
 }
 
 .dx-scheduler-header-panel-cell.dx-scheduler-header-panel-current-time-cell {
-    .box-shadow(@SCHEDULER_HEADER_PANEL_CURRENT_TIME_BOX_SHADOW);
     color: @SCHEDULER_APPOINTMENT_BASE_COLOR;
+    &:before {
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            width: 100%;
+            height: @SCHEDULER_CURRENT_TIME_CELL_BORDER_SIZE;
+            content: '';
+            background-color: @SCHEDULER_TIME_INDICATOR_COLOR;
+        }
 }
 
 .dx-scheduler-date-time-shader-all-day {
@@ -1284,6 +1291,7 @@
 }
 
 .dx-scheduler-header-panel-cell {
+    position: relative;
     border-left: @SCHEDULER_BASE_BORDER;
     border-right: @SCHEDULER_BASE_BORDER;
     color: @SCHEDULER_PANEL_TEXT_COLOR;
@@ -1408,8 +1416,16 @@
     }
 
     &.dx-scheduler-time-panel-current-time-cell {
-        .box-shadow(@SCHEDULER_TIME_PANEL_CURRENT_TIME_BOX_SHADOW);
         color: @SCHEDULER_APPOINTMENT_BASE_COLOR;
+        &:before {
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: @SCHEDULER_CURRENT_TIME_CELL_BORDER_SIZE;
+            height: inherit;
+            content: '';
+            background-color: @SCHEDULER_TIME_INDICATOR_COLOR;
+        }
     }
 }
 

--- a/styles/widgets/base/scheduler.less
+++ b/styles/widgets/base/scheduler.less
@@ -578,8 +578,11 @@
     }
 
     .dx-scheduler-header-panel-cell.dx-scheduler-header-panel-current-time-cell {
-        border-bottom: 2px solid @SCHEDULER_APPOINTMENT_BASE_COLOR;
+        border-bottom: 2px solid @SCHEDULER_TIME_INDICATOR_COLOR;
         .box-shadow(none);
+        &:before {
+            content: none;
+        }
     }
 }
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/currentTimeIndicator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/currentTimeIndicator.tests.js
@@ -162,7 +162,7 @@ var stubInvokeMethod = function(instance, options) {
         assert.equal($indicators.length, 2, "Indicator count is correct");
         assert.equal($indicators.eq(0).position().left, 0);
         assert.equal($indicators.eq(0).position().top, 9.5 * cellHeight);
-        assert.equal($indicators.eq(1).position().left, this.instance._getRoundedCellWidth());
+        assert.equal($indicators.eq(1).position().left, this.instance._getRoundedCellWidth(1));
         assert.equal($indicators.eq(1).position().top, 9.5 * cellHeight);
     });
 
@@ -181,7 +181,7 @@ var stubInvokeMethod = function(instance, options) {
         assert.equal($indicators.length, 2, "Indicator count is correct");
         assert.equal($indicators.eq(0).position().left, 0);
         assert.equal($indicators.eq(0).position().top, 9.5 * cellHeight);
-        assert.equal($indicators.eq(1).position().left, this.instance._getRoundedCellWidth());
+        assert.equal($indicators.eq(1).position().left, this.instance._getRoundedCellWidth(1));
         assert.equal($indicators.eq(1).position().top, 9.5 * cellHeight);
     });
 
@@ -322,10 +322,10 @@ var stubInvokeMethod = function(instance, options) {
         assert.roughEqual($shader.outerWidth(), 6 * cellWidth, 5, "Indicator has correct width");
         assert.roughEqual($firstTopShader.outerWidth(), 2 * cellWidth, 1, "Top indicator has correct width");
         assert.roughEqual($firstBottomShader.outerWidth(), cellWidth, 1, "Bottom indicator has correct width");
-        assert.roughEqual($firstAllDayShader.outerWidth(), 2 * cellWidth, 1, "AllDay indicator has correct width");
-        assert.roughEqual($secondTopShader.outerWidth(), 2 * cellWidth, 1, "Top indicator has correct width");
-        assert.roughEqual($secondBottomShader.outerWidth(), cellWidth, 1, "Bottom indicator has correct width");
-        assert.roughEqual($secondAllDayShader.outerWidth(), 2 * cellWidth, 1, "AllDay indicator has correct width");
+        assert.roughEqual($firstAllDayShader.outerWidth(), 2 * cellWidth, 2.5, "AllDay indicator has correct width");
+        assert.roughEqual($secondTopShader.outerWidth(), 2 * cellWidth, 2.5, "Top indicator has correct width");
+        assert.roughEqual($secondBottomShader.outerWidth(), cellWidth, 2.5, "Bottom indicator has correct width");
+        assert.roughEqual($secondAllDayShader.outerWidth(), 2 * cellWidth, 2.5, "AllDay indicator has correct width");
     });
 
     QUnit.test("Shader should be rendered correctly, Day view with crossScrollingEnabled", function(assert) {


### PR DESCRIPTION
1. Fix cell-size calculation in Chrome
2. Fix css box-shadow problem, when border-collapse is set
