### PR TITLE
Fix currentTime indicator rendering in Scheduler (T566333)

### DIFF
--- a/js/ui/scheduler/ui.scheduler.currentTimeShader.vertical.js
+++ b/js/ui/scheduler/ui.scheduler.currentTimeShader.vertical.js
@@ -16,7 +16,7 @@ var VerticalCurrentTimeShader = Shader.inherit({
             shaderHeight = maxHeight;
         }
 
-        if(shaderHeight > 0) {
+        if(shaderHeight >= 0) {
             this._$shader.height(shaderHeight);
 
             var groupCount = this._workspace._getGroupCount() || 1;

--- a/js/ui/scheduler/ui.scheduler.work_space.indicator.js
+++ b/js/ui/scheduler/ui.scheduler.work_space.indicator.js
@@ -116,7 +116,7 @@ var SchedulerWorkSpaceIndicator = SchedulerWorkSpace.inherit({
         var today = this._getToday(),
             firstViewDate = new Date(this._firstViewDate);
 
-        var timeDiff = today.getTime() - firstViewDate.getTime();
+        var timeDiff = today.getTime() - firstViewDate.getTime() + 1;
 
         return Math.ceil(timeDiff / toMs("day"));
     },
@@ -150,7 +150,7 @@ var SchedulerWorkSpaceIndicator = SchedulerWorkSpace.inherit({
             date = new Date(this._firstViewDate);
 
         if(this._needRenderDateTimeIndicator()) {
-            date.setDate(today.getDate());
+            date.setFullYear(today.getFullYear(), today.getMonth(), today.getDate());
         }
 
         var duration = today.getTime() - date.getTime(),

--- a/testing/tests/DevExpress.ui.widgets.scheduler/currentTimeIndicator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/currentTimeIndicator.tests.js
@@ -293,6 +293,49 @@ var stubInvokeMethod = function(instance, options) {
         assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom indicator has correct width");
     });
 
+    QUnit.test("Shader should have correct height & width, Day view with intervalCount, different months", function(assert) {
+        this.instance.option({
+            currentDate: new Date(2017, 8, 30),
+            indicatorTime: new Date(2017, 9, 1, 12, 45),
+            intervalCount: 3
+        });
+
+        var $element = this.instance.$element(),
+            $shader = $element.find("." + SCHEDULER_DATE_TIME_SHADER_CLASS),
+            $topShader = $element.find("." + SCHEDULER_DATE_TIME_SHADER_TOP_CLASS),
+            $bottomShader = $element.find("." + SCHEDULER_DATE_TIME_SHADER_BOTTOM_CLASS),
+            $cell = this.instance.$element().find(".dx-scheduler-date-table-cell").eq(0),
+            cellHeight = $cell.outerHeight(),
+            cellWidth = $cell.outerWidth();
+
+        assert.roughEqual($shader.outerHeight(), 9.5 * cellHeight, 1, "Indicator has correct height");
+        assert.roughEqual($topShader.outerHeight(), 9.5 * cellHeight, 1, "Top indicator has correct height");
+        assert.roughEqual($bottomShader.outerHeight(), 22.5 * cellHeight, 1, "Bottom indicator has correct height");
+
+        assert.roughEqual($shader.outerWidth(), 3 * cellWidth, 2, "Indicator has correct width");
+        assert.roughEqual($topShader.outerWidth(), 2 * cellWidth, 1, "Top indicator has correct width");
+        assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom indicator has correct width");
+    });
+
+    QUnit.test("Shader should have correct height & width, Day view with intervalCount, indicatorTime = startDayHour", function(assert) {
+        this.instance.option({
+            indicatorTime: new Date(2017, 8, 6, 12, 0),
+            startDayHour: 12,
+            intervalCount: 3
+        });
+
+        var $element = this.instance.$element(),
+            $topShader = $element.find("." + SCHEDULER_DATE_TIME_SHADER_TOP_CLASS),
+            $bottomShader = $element.find("." + SCHEDULER_DATE_TIME_SHADER_BOTTOM_CLASS),
+            $cell = this.instance.$element().find(".dx-scheduler-date-table-cell").eq(0),
+            cellHeight = $cell.outerHeight(),
+            cellWidth = $cell.outerWidth();
+
+        assert.roughEqual($topShader.outerHeight(), 0, 1, "Top indicator has correct height");
+        assert.roughEqual($bottomShader.outerHeight(), 24 * cellHeight, 1, "Bottom indicator has correct height");
+        assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom indicator has correct width");
+    });
+
     QUnit.test("Shader should be rendered correctly, Day view with groups", function(assert) {
         this.instance.option({
             indicatorTime: new Date(2017, 8, 6, 12, 45),

--- a/testing/tests/DevExpress.ui.widgets.scheduler/currentTimeIndicator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/currentTimeIndicator.tests.js
@@ -284,13 +284,13 @@ var stubInvokeMethod = function(instance, options) {
             cellHeight = $cell.outerHeight(),
             cellWidth = $cell.outerWidth();
 
-        assert.roughEqual($shader.outerHeight(), 9.5 * cellHeight, 1, "Indicator has correct height");
-        assert.roughEqual($topShader.outerHeight(), 9.5 * cellHeight, 1, "Top indicator has correct height");
-        assert.roughEqual($bottomShader.outerHeight(), 22.5 * cellHeight, 1, "Bottom indicator has correct height");
+        assert.roughEqual($shader.outerHeight(), 9.5 * cellHeight, 1, "Shader has correct height");
+        assert.roughEqual($topShader.outerHeight(), 9.5 * cellHeight, 1, "Top shader has correct height");
+        assert.roughEqual($bottomShader.outerHeight(), 22.5 * cellHeight, 1, "Bottom shader has correct height");
 
-        assert.roughEqual($shader.outerWidth(), 3 * cellWidth, 2, "Indicator has correct width");
-        assert.roughEqual($topShader.outerWidth(), 2 * cellWidth, 1, "Top indicator has correct width");
-        assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom indicator has correct width");
+        assert.roughEqual($shader.outerWidth(), 3 * cellWidth, 2, "Shader has correct width");
+        assert.roughEqual($topShader.outerWidth(), 2 * cellWidth, 1, "Top shader has correct width");
+        assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom shader has correct width");
     });
 
     QUnit.test("Shader should have correct height & width, Day view with intervalCount, different months", function(assert) {
@@ -309,12 +309,12 @@ var stubInvokeMethod = function(instance, options) {
             cellWidth = $cell.outerWidth();
 
         assert.roughEqual($shader.outerHeight(), 9.5 * cellHeight, 1, "Indicator has correct height");
-        assert.roughEqual($topShader.outerHeight(), 9.5 * cellHeight, 1, "Top indicator has correct height");
-        assert.roughEqual($bottomShader.outerHeight(), 22.5 * cellHeight, 1, "Bottom indicator has correct height");
+        assert.roughEqual($topShader.outerHeight(), 9.5 * cellHeight, 1, "Top shader has correct height");
+        assert.roughEqual($bottomShader.outerHeight(), 22.5 * cellHeight, 1, "Bottom shader has correct height");
 
         assert.roughEqual($shader.outerWidth(), 3 * cellWidth, 2, "Indicator has correct width");
-        assert.roughEqual($topShader.outerWidth(), 2 * cellWidth, 1, "Top indicator has correct width");
-        assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom indicator has correct width");
+        assert.roughEqual($topShader.outerWidth(), 2 * cellWidth, 1, "Top shader has correct width");
+        assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom shader has correct width");
     });
 
     QUnit.test("Shader should have correct height & width, Day view with intervalCount, indicatorTime = startDayHour", function(assert) {
@@ -331,9 +331,9 @@ var stubInvokeMethod = function(instance, options) {
             cellHeight = $cell.outerHeight(),
             cellWidth = $cell.outerWidth();
 
-        assert.roughEqual($topShader.outerHeight(), 0, 1, "Top indicator has correct height");
-        assert.roughEqual($bottomShader.outerHeight(), 24 * cellHeight, 1, "Bottom indicator has correct height");
-        assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom indicator has correct width");
+        assert.roughEqual($topShader.outerHeight(), 0, 1, "Top shader has correct height");
+        assert.roughEqual($bottomShader.outerHeight(), 24 * cellHeight, 1, "Bottom shader has correct height");
+        assert.roughEqual($bottomShader.outerWidth(), cellWidth, 1, "Bottom shader has correct width");
     });
 
     QUnit.test("Shader should be rendered correctly, Day view with groups", function(assert) {


### PR DESCRIPTION
1. Fix currentTime indicator rendering when view displays different months.
2. Fix currentTime indicator rendering when indicatorTime = startDayHour.
