### PR TITLE
Fix `config.useJquery` for modules and for bundles

### DIFF
--- a/js/bundles/modules/core.js
+++ b/js/bundles/modules/core.js
@@ -93,9 +93,6 @@ DevExpress.formatHelper = require("../../format_helper");
 
 var config = DevExpress.config = require("../../core/config");
 
-var jquery = require("jquery");
-config({ "useJQuery": config().useJQuery && !!jquery });
-
 /**
  * @name rtlEnabled
  * @publicName rtlEnabled

--- a/js/core/config.js
+++ b/js/core/config.js
@@ -60,7 +60,7 @@ var config = {
     * @publicName useJQuery
     * @type boolean
     */
-    useJQuery: true
+    useJQuery: undefined
 };
 
 var configMethod = function() {

--- a/js/integration/jquery.js
+++ b/js/integration/jquery.js
@@ -3,22 +3,19 @@
 var jQuery = require("jquery");
 var compareVersions = require("../core/utils/version").compare;
 var errors = require("../core/utils/error");
-var useJQuery = require("../core/config")().useJQuery;
+var useJQuery = require("./jquery/use_jquery")();
 
-// Check availability in global environment
-if(jQuery && useJQuery) {
-    if(compareVersions(jQuery.fn.jquery, [1, 10]) < 0) {
-        throw errors.Error("E0012");
-    }
-
-    require("./jquery/renderer");
-    require("./jquery/hooks");
-    require("./jquery/deferred");
-    require("./jquery/hold_ready");
-    require("./jquery/events");
-    require("./jquery/easing");
-    require("./jquery/element_data");
-    require("./jquery/element");
-    require("./jquery/component_registrator");
-    require("./jquery/ajax");
+if(useJQuery && compareVersions(jQuery.fn.jquery, [1, 10]) < 0) {
+    throw errors.Error("E0012");
 }
+
+require("./jquery/renderer");
+require("./jquery/hooks");
+require("./jquery/deferred");
+require("./jquery/hold_ready");
+require("./jquery/events");
+require("./jquery/easing");
+require("./jquery/element_data");
+require("./jquery/element");
+require("./jquery/component_registrator");
+require("./jquery/ajax");

--- a/js/integration/jquery/ajax.js
+++ b/js/integration/jquery/ajax.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var jQuery = require("jquery"),
-    ajax = require("../../core/utils/ajax"),
-    useJQuery = require("../../core/config")().useJQuery;
+var jQuery = require("jquery");
+var ajax = require("../../core/utils/ajax");
+var useJQuery = require("./use_jquery")();
 
-if(jQuery && useJQuery) {
+if(useJQuery) {
     ajax.setStrategy(jQuery.ajax);
 }

--- a/js/integration/jquery/deferred.js
+++ b/js/integration/jquery/deferred.js
@@ -2,10 +2,10 @@
 
 var jQuery = require("jquery");
 var deferredUtils = require("../../core/utils/deferred");
-var useJQuery = require("../../core/config")().useJQuery;
+var useJQuery = require("./use_jquery")();
 var compareVersion = require("../../core/utils/version").compare;
 
-if(jQuery && useJQuery) {
+if(useJQuery) {
     var Deferred = jQuery.Deferred;
     var strategy = { Deferred: Deferred };
 

--- a/js/integration/jquery/element.js
+++ b/js/integration/jquery/element.js
@@ -1,13 +1,12 @@
 "use strict";
 
-var jQuery = require("jquery");
 var setPublicElementWrapper = require("../../core/utils/dom").setPublicElementWrapper;
-var useJQuery = require("../../core/config")().useJQuery;
+var useJQuery = require("./use_jquery")();
 
 var getPublicElement = function($element) {
     return $element;
 };
 
-if(jQuery && useJQuery) {
+if(useJQuery) {
     setPublicElementWrapper(getPublicElement);
 }

--- a/js/integration/jquery/element_data.js
+++ b/js/integration/jquery/element_data.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var jQuery = require("jquery"),
-    dataUtils = require("../../core/element_data"),
-    useJQuery = require("../../core/config")().useJQuery;
+var jQuery = require("jquery");
+var dataUtils = require("../../core/element_data");
+var useJQuery = require("./use_jquery")();
 
-if(jQuery && useJQuery) {
+if(useJQuery) {
     dataUtils.setDataStrategy(jQuery);
 }

--- a/js/integration/jquery/events.js
+++ b/js/integration/jquery/events.js
@@ -2,10 +2,10 @@
 
 var jQuery = require("jquery");
 var eventsEngine = require("../../events/core/events_engine");
-var useJQuery = require("../../core/config")().useJQuery;
+var useJQuery = require("./use_jquery")();
 var registerEventCallbacks = require("../../events/core/event_registrator_callbacks");
 
-if(jQuery && useJQuery) {
+if(useJQuery) {
     registerEventCallbacks.add(function(name, eventObject) {
         jQuery.event.special[name] = eventObject;
     });

--- a/js/integration/jquery/hooks.js
+++ b/js/integration/jquery/hooks.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var jQuery = require("jquery");
-var useJQuery = require("../../core/config")().useJQuery;
+var useJQuery = require("./use_jquery")();
 var compareVersion = require("../../core/utils/version").compare;
 var each = require("../../core/utils/iterator").each;
 var isNumeric = require("../../core/utils/type").isNumeric;
@@ -9,7 +9,7 @@ var setEventFixMethod = require("../../events/utils").setEventFixMethod;
 var registerEvent = require("../../events/core/event_registrator");
 var hookTouchProps = require("../../events/core/hook_touch_props");
 
-if(jQuery && useJQuery) {
+if(useJQuery) {
     if(compareVersion(jQuery.fn.jquery, [3]) < 0) {
         var POINTER_TYPE_MAP = {
             2: "touch",

--- a/js/integration/jquery/renderer.js
+++ b/js/integration/jquery/renderer.js
@@ -2,8 +2,8 @@
 
 var jQuery = require("jquery");
 var rendererBase = require("../../core/renderer_base");
-var useJQuery = require("../../core/config")().useJQuery;
+var useJQuery = require("./use_jquery")();
 
-if(jQuery && useJQuery) {
+if(useJQuery) {
     rendererBase.set(jQuery);
 }

--- a/js/integration/jquery/use_jquery.js
+++ b/js/integration/jquery/use_jquery.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var jQuery = require("jquery");
+var config = require("../../core/config");
+var useJQuery = config().useJQuery;
+
+if(jQuery && useJQuery !== false) {
+    config({ useJQuery: true });
+}
+
+module.exports = function() {
+    return jQuery && config().useJQuery;
+};

--- a/testing/runner/Views/Main/RunSuite.cshtml
+++ b/testing/runner/Views/Main/RunSuite.cshtml
@@ -156,11 +156,12 @@
                 }
             }
 
-            window.DevExpress = window.DevExpress || {};
-
-            window.DevExpress.config = {
-                useJQuery: !@Html.Raw(Json.Serialize(Model.NoJQuery))
-            };
+            if(@Html.Raw(Json.Serialize(Model.NoJQuery))) {
+                window.DevExpress = window.DevExpress || {};
+                window.DevExpress.config = {
+                    useJQuery: false
+                };
+            }
 
             SystemJS.config({
                 baseURL: '@Url.Content("~/js")',

--- a/testing/tests/DevExpress.core/config_bundled_nojquery.tests.js
+++ b/testing/tests/DevExpress.core/config_bundled_nojquery.tests.js
@@ -7,6 +7,6 @@ define(function(require) {
 
     QUnit.test("config value useJQuery should be false if jquery is not included", function(assert) {
         var config = DevExpress.config;
-        assert.equal(config().useJQuery, false);
+        assert.equal(!!config().useJQuery, false);
     });
 });

--- a/testing/tests/DevExpress.core/config_nojquery.tests.js
+++ b/testing/tests/DevExpress.core/config_nojquery.tests.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var config = require("core/config");
+
+QUnit.module("config.useJQuery");
+
+QUnit.test("config value useJQuery should be false if jquery is not included", function(assert) {
+    assert.equal(!!config().useJQuery, false);
+});

--- a/testing/tests/DevExpress.jquery/bundled.tests.js
+++ b/testing/tests/DevExpress.jquery/bundled.tests.js
@@ -1,18 +1,24 @@
 "use strict";
 
 define(function(require) {
-    if(QUnit.urlParams["nojquery"]) {
-        return;
-    }
+    var $ = require("jquery");
 
-    require("/js/bundles/dx.all.js");
+    require("/artifacts/js/dx.mobile.debug.js");
+
+    var noJQuery = QUnit.urlParams["nojquery"];
 
     QUnit.module("jquery integration");
 
-    QUnit.test("renderer uses jquery strategy", function(assert) {
+    QUnit.test("renderer uses correct strategy", function(assert) {
         var node = document.createElement("div");
         var element = new DevExpress.ui.dxButton(node).element();
 
-        assert.ok(element instanceof window.jQuery);
+        assert[noJQuery ? "notOk" : "ok"](element instanceof window.jQuery);
+    });
+
+    QUnit.test("$.fn plugins works with both strategies", function(assert) {
+        var $element = $("<div>");
+
+        assert.equal(typeof $element.dxButton, "function");
     });
 });


### PR DESCRIPTION
- Value of the field `config.useJquery` should be `false` if `jQuery` integration is not included (modular approach)
- Some modules of `jQuery` integration should be included even if the value of the field `config.useJquery` is `false` (bundled approach)