### PR TITLE
dxDataGrid: Fix impossibility to cancel changes if data source fields are observable (T566012)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -401,12 +401,12 @@ var EditingController = modules.ViewController.inherit((function() {
                     case DATA_EDIT_DATA_UPDATE_TYPE:
                         item.modified = true;
                         item.oldData = item.data;
-                        item.data = deepExtendArraySafe(deepExtendArraySafe({}, item.data), data);
+                        item.data = deepExtendArraySafe(deepExtendArraySafe({}, item.data), data, false, true);
                         item.modifiedValues = generateDataValues(data, columns);
                         break;
                     case DATA_EDIT_DATA_REMOVE_TYPE:
                         if(editMode === EDIT_MODE_BATCH) {
-                            item.data = deepExtendArraySafe(deepExtendArraySafe({}, item.data), data);
+                            item.data = deepExtendArraySafe(deepExtendArraySafe({}, item.data), data, false, true);
                         }
                         item.removed = true;
                         break;
@@ -1375,7 +1375,7 @@ var EditingController = modules.ViewController.inherit((function() {
                 options.type = that._editData[editDataIndex].type || options.type;
                 deepExtendArraySafe(that._editData[editDataIndex], { data: options.data, type: options.type });
                 if(row) {
-                    row.data = deepExtendArraySafe(deepExtendArraySafe({}, row.data), options.data);
+                    row.data = deepExtendArraySafe(deepExtendArraySafe({}, row.data), options.data, false, true);
                 }
             }
 

--- a/testing/tests/DevExpress.knockout/dataGrid.tests.js
+++ b/testing/tests/DevExpress.knockout/dataGrid.tests.js
@@ -362,7 +362,7 @@ QUnit.module("Editing", {
     }
 }, function() {
     //T566012
-    QUnit.test("Row mode: DataSource fields should be not changed when editing row", function(assert) {
+    QUnit.test("Row mode: DataSource fields should not be changed when editing row", function(assert) {
         //arrange
         var $input,
             dataGrid = this.createDataGrid();
@@ -382,7 +382,7 @@ QUnit.module("Editing", {
     });
 
     //T566012
-    QUnit.test("Batch mode: DataSource fields should be not changed when editing row", function(assert) {
+    QUnit.test("Batch mode: DataSource fields should not be changed when editing cell", function(assert) {
         //arrange
         this.editing.mode = "batch";
         var dataGrid = this.createDataGrid();


### PR DESCRIPTION
See https://devexpress.com/issue=T566012