### PR TITLE
Implement scale breaks and the capability to skip days off 

### DIFF
--- a/js/viz/axes/base_axis.js
+++ b/js/viz/axes/base_axis.js
@@ -126,7 +126,7 @@ function getScaleBreaks(axisOptions, viewport, series, isArgumentAxis) {
     if(axisOptions.type !== "discrete" && axisOptions.dataType === "datetime" && axisOptions.workdaysOnly) {
         breaks = breaks.concat(generateDateBreaks(viewport.minVisible,
             viewport.maxVisible,
-            axisOptions.workweek,
+            axisOptions.workWeek,
             axisOptions.singleWorkdays,
             axisOptions.holidays));
     }
@@ -177,9 +177,7 @@ function generateAutoBreaks(options, series, viewport) {
         }
     }
 
-    breaks.sort(function(a, b) {
-        return a.from - b.from;
-    });
+    sortingBreaks(breaks);
 
     return breaks;
 }

--- a/js/viz/axes/datetime_breaks.js
+++ b/js/viz/axes/datetime_breaks.js
@@ -14,7 +14,7 @@ function getWeekendDays(workdays) {
 }
 
 function getNextDayIndex(dayIndex) {
-    return (++dayIndex) % 7;
+    return (dayIndex + 1) % 7;
 }
 
 function dayBetweenWeekend(weekend, day) {
@@ -191,8 +191,8 @@ function calculateGaps(breaks) {
     });
 }
 
-exports.generateDateBreaks = function(min, max, workweek, singleWorkdays, holidays) {
-    var weekendDayIndices = getWeekEndDayIndices(workweek),
+exports.generateDateBreaks = function(min, max, workWeek, singleWorkdays, holidays) {
+    var weekendDayIndices = getWeekEndDayIndices(workWeek),
         breaks = generateDateBreaksForWeekend(min, max, weekendDayIndices);
 
     breaks.push.apply(breaks, generateBreaksForHolidays(min, max, holidays || [], weekendDayIndices));

--- a/js/viz/axes/datetime_breaks.js
+++ b/js/viz/axes/datetime_breaks.js
@@ -1,0 +1,201 @@
+"use strict";
+
+var dateUtils = require("../../core/utils/date"),
+    days = [0, 1, 2, 3, 4, 5, 6];
+
+function getWeekendDays(workdays) {
+    return days.filter(function(day) {
+        return !workdays.some(function(workDay) {
+            return workDay === day;
+        });
+    }).map(function(day) {
+        return days.indexOf(day);
+    });
+}
+
+function getNextDayIndex(dayIndex) {
+    return (++dayIndex) % 7;
+}
+
+function dayBetweenWeekend(weekend, day) {
+    var start = weekend.start,
+        end = weekend.end;
+
+    while(start !== end) {
+        if(start === day) {
+            return true;
+        }
+        start = getNextDayIndex(start);
+    }
+
+    return false;
+}
+
+function getDaysDistance(day, end) {
+    var length = 0;
+
+    while(day !== end) {
+        day = getNextDayIndex(day);
+        length++;
+    }
+
+    return length;
+}
+
+function separateBreak(scaleBreak, day) {
+    var result = [],
+        dayEnd = new Date(day);
+
+    dayEnd.setDate(day.getDate() + 1);
+
+    if(day > scaleBreak.from) {
+        result.push({
+            from: scaleBreak.from,
+            to: day
+        });
+    }
+
+    if(dayEnd < scaleBreak.to) {
+        result.push({
+            from: dayEnd,
+            to: scaleBreak.to
+        });
+    }
+
+    return result;
+}
+
+function getWeekEndDayIndices(workDays) {
+    return getWeekendDays(workDays).sort(function(day1, day2) {
+        return getNextDayIndex(day1) - getNextDayIndex(day2);
+    });
+}
+
+function generateDateBreaksForWeekend(min, max, weekendDayIndices) {
+    var day = min.getDate(),
+        breaks = [],
+        weekends = weekendDayIndices.reduce(function(obj, day) {
+            var currentWeekEnd = obj[1];
+            if(currentWeekEnd.start === undefined) {
+                currentWeekEnd = {
+                    start: day,
+                    end: getNextDayIndex(day)
+                };
+                obj[0].push(currentWeekEnd);
+                return [obj[0], currentWeekEnd];
+            } else if(currentWeekEnd.end === day) {
+                currentWeekEnd.end = getNextDayIndex(day);
+                return obj;
+            }
+            currentWeekEnd = {
+                start: day,
+                end: getNextDayIndex(day)
+            };
+            obj[0].push(currentWeekEnd);
+            return [obj[0], currentWeekEnd];
+
+        }, [[], {}]);
+
+    weekends[0].forEach(function(weekend) {
+        var currentDate = new Date(min);
+        currentDate = dateUtils.trimTime(currentDate);
+
+        while(currentDate < max) {
+            day = currentDate.getDay();
+
+            var date = currentDate.getDate();
+
+            if(dayBetweenWeekend(weekend, day)) {
+                var from = new Date(currentDate),
+                    to;
+
+                currentDate.setDate(date + getDaysDistance(day, weekend.end));
+
+                to = new Date(currentDate);
+
+                breaks.push({
+                    from: from,
+                    to: to
+                });
+            }
+
+            currentDate.setDate(currentDate.getDate() + 1);
+        }
+    });
+
+    return breaks;
+}
+
+function excludeWorkDaysFromWeekEndBreaks(breaks, exactWorkDays) {
+    var result = breaks.slice(),
+        i,
+        processWorkDay = function(workday) {
+            workday = dateUtils.trimTime(new Date(workday));
+            if(result[i].from <= workday && result[i].to > workday) {
+                var separatedBreak = separateBreak(result[i], workday);
+                if(separatedBreak.length === 2) {
+                    result.splice(i, 1, separatedBreak[0], separatedBreak[1]);
+                } else if(separatedBreak.length === 1) {
+                    result.splice(i, 1, separatedBreak[0]);
+                } else {
+                    result.splice(i, 1);
+                }
+            }
+        };
+
+    for(i = 0; i < result.length; i++) {
+        exactWorkDays.forEach(processWorkDay);
+    }
+
+    return result;
+}
+
+function generateBreaksForHolidays(min, max, holidays, weekendDayIndices) {
+    var day,
+        dayInWeekend = function(dayIndex) {
+            return dayIndex === day;
+        },
+        adjustedMin = dateUtils.trimTime(min),
+        adjustedMax = dateUtils.trimTime(max);
+
+    adjustedMax.setDate(max.getDate() + 1);
+
+    return holidays.reduce(function(breaks, holiday) {
+        var holidayStart,
+            holidayEnd;
+
+        holiday = new Date(holiday);
+        day = holiday.getDay();
+
+        if(!weekendDayIndices.some(dayInWeekend) && holiday >= adjustedMin && holiday <= adjustedMax) {
+            holidayStart = dateUtils.trimTime(holiday);
+            holidayEnd = new Date(holidayStart);
+            holidayEnd.setDate(holidayStart.getDate() + 1);
+
+            breaks.push({
+                from: holidayStart,
+                to: holidayEnd
+            });
+        }
+        return breaks;
+    }, []);
+}
+
+function calculateGaps(breaks) {
+    return breaks.map(function(b) {
+        return {
+            from: b.from,
+            to: b.to,
+            gapSize: dateUtils.convertMillisecondsToDateUnits(b.to - b.from)
+        };
+    });
+}
+
+exports.generateDateBreaks = function(min, max, workweek, singleWorkdays, holidays) {
+    var weekendDayIndices = getWeekEndDayIndices(workweek),
+        breaks = generateDateBreaksForWeekend(min, max, weekendDayIndices);
+
+    breaks.push.apply(breaks, generateBreaksForHolidays(min, max, holidays || [], weekendDayIndices));
+
+    return calculateGaps(excludeWorkDaysFromWeekEndBreaks(breaks, singleWorkdays || []));
+};

--- a/js/viz/chart.js
+++ b/js/viz/chart.js
@@ -429,7 +429,10 @@ var dxChart = AdvancedChart.inherit({
     },
 
     _prepareAxisOptions: function(typeSelector, userOptions, rotated) {
-        return { isHorizontal: (typeSelector === "argumentAxis") !== rotated };
+        return {
+            isHorizontal: (typeSelector === "argumentAxis") !== rotated,
+            containerColor: this._themeManager.getOptions("containerBackgroundColor")
+        };
     },
 
     _checkPaneName: function(seriesTheme) {
@@ -657,6 +660,9 @@ var dxChart = AdvancedChart.inherit({
         if(!drawOptions.adjustAxes) {
             drawAxesWithTicks(verticalAxes, !rotated && synchronizeMultiAxes, panesCanvases, panesBorderOptions);
             drawAxesWithTicks(horizontalAxes, rotated && synchronizeMultiAxes, panesCanvases, panesBorderOptions);
+            that._valueAxes.forEach(function(axis) {
+                axis.drawScaleBreaks();
+            });
             return;
         }
 

--- a/js/viz/chart_components/advanced_chart.js
+++ b/js/viz/chart_components/advanced_chart.js
@@ -310,6 +310,7 @@ var AdvancedChart = BaseChart.inherit({
         that._axesGroup.linkAppend();
         that._constantLinesGroup.linkAppend();
         that._labelAxesGroup.linkAppend();
+        that._scaleBreaksGroup.linkAppend();
     },
 
     _populateBusinessRange: function() {
@@ -320,13 +321,19 @@ var AdvancedChart = BaseChart.inherit({
             argRange = new rangeModule.Range({ rotated: !!rotated }),
             argumentMarginOptions = {},
             bubbleSize = estimateBubbleSize(that.getSize(), that.panes.length, that._themeManager.getOptions("maxBubbleSize"), that._isRotated()),
-            groupsData = that._groupsData;
+            groupsData = that._groupsData,
+            countAxesPerPane;
 
         that.businessRanges = null;
 
         _each(argAxes, function(_, axis) {
             argRange.addRange(axis.getRangeData());
         });
+
+        countAxesPerPane = that._valueAxes.reduce(function(prev, axis) {
+            prev[axis.pane] = (prev[axis.pane] || 0) + 1;
+            return prev;
+        }, {});
 
         that._valueAxes.forEach(function(valueAxis) {
             var groupRange = new rangeModule.Range({
@@ -360,7 +367,8 @@ var AdvancedChart = BaseChart.inherit({
                 groupRange.correctValueZeroLevel();
             }
 
-            valueAxis.setBusinessRange(groupRange);
+            valueAxis.setGroupSeries(groupSeries);
+            valueAxis.setBusinessRange(groupRange, countAxesPerPane[valueAxis.pane] > 1);
             valueAxis.setMarginOptions(marginOptions);
 
             businessRanges.push({ val: groupRange, arg: argRange });
@@ -447,6 +455,7 @@ var AdvancedChart = BaseChart.inherit({
                 stripsGroup: that._stripsGroup,
                 labelAxesGroup: that._labelAxesGroup,
                 constantLinesGroup: that._constantLinesGroup,
+                scaleBreaksGroup: that._scaleBreaksGroup,
                 axesContainerGroup: that._axesGroup,
                 gridGroup: that._gridGroup,
                 isArgumentAxis: typeSelector === "argumentAxis"

--- a/js/viz/chart_components/base_chart.js
+++ b/js/viz/chart_components/base_chart.js
@@ -435,6 +435,7 @@ var BaseChart = BaseWidget.inherit({
         that._seriesGroup = renderer.g().attr({ "class": "dxc-series-group" }).linkOn(root, "series");
         that._labelsGroup = renderer.g().attr({ "class": "dxc-labels-group" }).linkOn(root, "labels");
         that._crosshairCursorGroup = renderer.g().attr({ "class": "dxc-crosshair-cursor" }).linkOn(root, "crosshair");
+        that._scaleBreaksGroup = renderer.g().attr({ "class": "dxc-scale-breaks" }).linkOn(root, "scale-breaks");
         that._legendGroup = renderer.g().attr({ "class": "dxc-legend", "clip-path": that._getCanvasClipRectID() }).linkOn(root, "legend");
         that._scrollBarGroup = renderer.g().attr({ "class": "dxc-scroll-bar" }).linkOn(root, "scroll-bar");
     },
@@ -491,6 +492,7 @@ var BaseChart = BaseWidget.inherit({
         unlinkGroup("_crosshairCursorGroup");
         unlinkGroup("_legendGroup");
         unlinkGroup("_scrollBarGroup");
+        unlinkGroup("_scaleBreaksGroup");
 
         disposeObject("_canvasClipRect");
         disposeObject("_panesBackgroundGroup");
@@ -507,6 +509,7 @@ var BaseChart = BaseWidget.inherit({
         disposeObject("_crosshairCursorGroup");
         disposeObject("_legendGroup");
         disposeObject("_scrollBarGroup");
+        disposeObject("_scaleBreaksGroup");
     },
 
     _getAnimationOptions: function() {
@@ -802,6 +805,7 @@ var BaseChart = BaseWidget.inherit({
         //that._seriesGroup.linkRemove().clear();
         that._labelsGroup.linkRemove().clear();
         that._crosshairCursorGroup.linkRemove().clear();
+        that._scaleBreaksGroup.linkRemove().clear();
     },
 
     _createLegend: function() {

--- a/js/viz/core/renderers/renderer.js
+++ b/js/viz/core/renderers/renderer.js
@@ -23,7 +23,11 @@ var $ = require("../../../core/renderer"),
     PI_DIV_180 = mathPI / 180,
     _parseInt = parseInt,
     SHARPING_CORRECTION = 0.5,
-    ARC_COORD_PREC = 5;
+    ARC_COORD_PREC = 5,
+    WAVED_LINE_LENGTH = 24,
+    WAVED_LINE_TOP = 0,
+    WAVED_LINE_CENTER = 2,
+    WAVED_LINE_BOTTOM = 4;
 
 var pxAddingExceptions = {
     "column-count": true,
@@ -1671,6 +1675,73 @@ Renderer.prototype = {
         ///#ENDDEBUG
 
         return pattern;
+    },
+
+    _getPointsWithYOffset: function(points, offset) {
+        return points.map(function(point, index) {
+            if(index % 2 !== 0) {
+                return point + offset;
+            }
+            return point;
+        });
+    },
+
+    linePattern: function(options) {
+        var that = this,
+            id = getNextDefsSvgId(),
+            size = options.size,
+            strokeWidth = 1,
+            attr = {
+                "stroke-width": strokeWidth,
+                stroke: options.borderColor,
+                sharp: !options.isWaved ? options.isHorizontal ? "h" : "v" : undefined
+            },
+            elements = [],
+            lineParams = options.isWaved ? {
+                points: [0, 2,
+                    WAVED_LINE_LENGTH / 4, WAVED_LINE_TOP,
+                    WAVED_LINE_LENGTH / 4, WAVED_LINE_TOP,
+                    WAVED_LINE_LENGTH / 2, WAVED_LINE_CENTER,
+                    3 * WAVED_LINE_LENGTH / 4, WAVED_LINE_BOTTOM,
+                    3 * WAVED_LINE_LENGTH / 4, WAVED_LINE_BOTTOM,
+                    WAVED_LINE_LENGTH, WAVED_LINE_CENTER],
+                type: "bezier",
+                width: WAVED_LINE_LENGTH / options.canvasLength,
+                maxSize: WAVED_LINE_BOTTOM + size
+            } : {
+                points: [0, 0, size, 0],
+                type: "line",
+                width: size / options.canvasLength,
+                maxSize: size
+            },
+            line = that._createElement("pattern", {
+                id: id,
+                width: options.isHorizontal ? 1 : lineParams.width,
+                height: options.isHorizontal ? lineParams.width : 1
+            }).append(that._defs);
+
+        elements.push(that.path(that._getPointsWithYOffset(lineParams.points, size / 2), lineParams.type)
+            .attr({ stroke: options.color, "stroke-width": size, "stroke-linecap": "round" }));
+        elements.push(that.path(that._getPointsWithYOffset(lineParams.points, 0), lineParams.type).attr(attr));
+        elements.push(that.path(that._getPointsWithYOffset(lineParams.points, size), lineParams.type).attr(attr));
+
+        if(options.isHorizontal) {
+            elements.forEach(function(element) {
+                element.rotate(90, lineParams.maxSize / 2, lineParams.maxSize / 2);
+            });
+        }
+        elements.forEach(function(element) {
+            element.append(line);
+        });
+
+        line.id = id;
+        line.size = lineParams.maxSize + strokeWidth * 2;
+
+        ///#DEBUG
+        line.elements = elements;
+        ///#ENDDEBUG
+
+        return line;
     },
 
     //appended automatically

--- a/js/viz/core/themes/generic.contrast.js
+++ b/js/viz/core/themes/generic.contrast.js
@@ -106,6 +106,11 @@ registerTheme({
         },
         scrollBar: {
             color: WHITE
+        },
+        commonAxisSettings: {
+            breakStyle: {
+                color: "#cf00d7"
+            }
         }
     },
     pie: {
@@ -186,6 +191,9 @@ registerTheme({
             },
             minorTick: {
                 opacity: 0.12
+            },
+            breakStyle: {
+                color: "#cf00d7"
             }
         },
         selectedRangeColor: CONTRAST_ACTIVE,

--- a/js/viz/core/themes/generic.dark.js
+++ b/js/viz/core/themes/generic.dark.js
@@ -84,6 +84,11 @@ registerTheme({
             border: {
                 color: "#494949"
             }
+        },
+        commonAxisSettings: {
+            breakStyle: {
+                color: "#818181"
+            }
         }
     },
     gauge: {
@@ -120,6 +125,9 @@ registerTheme({
             minorTick: {
                 color: WHITE,
                 opacity: 0.1
+            },
+            breakStyle: {
+                color: "#818181"
             }
         },
         selectedRangeColor: RANGE_COLOR,

--- a/js/viz/core/themes/generic.light.js
+++ b/js/viz/core/themes/generic.light.js
@@ -668,7 +668,7 @@ registerTheme({
             constantLines: []
         },
         argumentAxis: {
-            workweek: [1, 2, 3, 4, 5]
+            workWeek: [1, 2, 3, 4, 5]
         },
         valueAxis: {
             endOnTick: true,
@@ -1040,7 +1040,7 @@ registerTheme({
                 label: {}
             },
             logarithmBase: 10,
-            workweek: [1, 2, 3, 4, 5],
+            workWeek: [1, 2, 3, 4, 5],
             breakStyle: { width: 5, color: "#ababab", line: "waved" }
         },
         selectedRangeColor: "#606060",

--- a/js/viz/core/themes/generic.light.js
+++ b/js/viz/core/themes/generic.light.js
@@ -608,6 +608,7 @@ registerTheme({
         commonAxisSettings: {
             multipleAxesSpacing: 5,
             forceUserTickInterval: false,
+            breakStyle: { width: 5, color: "#ababab", line: "waved" },
             label: {
                 displayMode: "standard",
                 overlappingBehavior: "hide",
@@ -666,12 +667,16 @@ registerTheme({
             },
             constantLines: []
         },
-        argumentAxis: {},
+        argumentAxis: {
+            workweek: [1, 2, 3, 4, 5]
+        },
         valueAxis: {
             endOnTick: true,
             grid: {
                 visible: true
-            }
+            },
+            autoBreaksEnabled: false,
+            maxAutoBreakCount: undefined
         },
         commonPaneSettings: {
             backgroundColor: NONE,
@@ -1034,7 +1039,9 @@ registerTheme({
                 textTopIndent: 11,
                 label: {}
             },
-            logarithmBase: 10
+            logarithmBase: 10,
+            workweek: [1, 2, 3, 4, 5],
+            breakStyle: { width: 5, color: "#ababab", line: "waved" }
         },
         selectedRangeColor: "#606060",
         sliderMarker: {

--- a/js/viz/docs/docObjectsDxChart.js
+++ b/js/viz/docs/docObjectsDxChart.js
@@ -69,3 +69,9 @@ var chartPointObject = {
     */
     getBoundingRect: function() { }
 };
+
+/**
+* @name ScaleBreak
+* @publicName ScaleBreak
+* @type Array<Date, string>| Array<number>
+*/

--- a/js/viz/docs/doccharts.js
+++ b/js/viz/docs/doccharts.js
@@ -1006,6 +1006,42 @@ var dxChart = {
         */
         placeholderSize: null,
         /**
+        * @name dxchartoptions_commonaxissettings_breaks
+        * @publicName breaks
+        * @type Array<ScaleBreak>
+        * @default undefined
+        */
+        breaks: undefined,
+        /**
+        * @name dxchartoptions_commonaxissettings_breakStyle
+        * @publicName breakStyle
+        * @type object
+        */
+        breakStyle: {
+            /**
+            * @name dxchartoptions_commonaxissettings_breakStyle_width
+            * @publicName width
+            * @type number
+            * @default 5
+            */
+            width: 5,
+            /**
+            * @name dxchartoptions_commonaxissettings_breakStyle_color
+            * @publicName color
+            * @type string
+            * @default "#ababab"
+            */
+            color: "#ababab",
+            /**
+            * @name dxchartoptions_commonaxissettings_breakStyle_line
+            * @publicName line
+            * @type string
+            * @default "waved"
+            * @acceptValues 'waved'| 'straight'
+            */
+            line: "waved"
+        },
+        /**
         * @name dxchartoptions_commonaxissettings_label
         * @publicName label
         * @type object
@@ -1623,6 +1659,34 @@ var dxChart = {
             text: undefined
         },
         /**
+        * @name dxchartoptions_argumentaxis_workdaysonly
+        * @publicName workdaysOnly
+        * @type boolean
+        * @default false
+        */
+        workdaysOnly: false,
+        /**
+        * @name dxchartoptions_argumentaxis_workweek
+        * @publicName workweek
+        * @type Array<number>
+        * @default [1, 2, 3, 4, 5]
+        */
+        workweek: [1, 2, 3, 4, 5],
+        /**
+        * @name dxchartoptions_argumentaxis_holidays
+        * @publicName holidays
+        * @type Array<Date, string>| Array<number>
+        * @default undefined
+        */
+        holidays: undefined,
+        /**
+        * @name dxchartoptions_argumentaxis_singleworkdays
+        * @publicName singleWorkdays
+        * @type Array<Date, string>| Array<number>
+        * @default undefined
+        */
+        singleWorkdays: undefined,
+        /**
         * @name dxchartoptions_argumentaxis_label
         * @publicName label
         * @type object
@@ -1898,6 +1962,20 @@ var dxChart = {
         * @default undefined
         */
         minorTickCount: undefined,
+        /**
+        * @name dxchartoptions_valueaxis_autobreaksenabled
+        * @publicName autoBreaksEnabled
+        * @type boolean
+        * @default false
+        */
+        autoBreaksEnabled: false,
+        /**
+        * @name dxchartoptions_valueaxis_maxautobreakcount
+        * @publicName maxAutoBreakCount
+        * @type numeric
+        * @default undefined
+        */
+        maxAutoBreakCount: undefined,
         /**
         * @name dxchartoptions_valueaxis_title
         * @publicName title

--- a/js/viz/docs/doccharts.js
+++ b/js/viz/docs/doccharts.js
@@ -1667,11 +1667,11 @@ var dxChart = {
         workdaysOnly: false,
         /**
         * @name dxchartoptions_argumentaxis_workweek
-        * @publicName workweek
+        * @publicName workWeek
         * @type Array<number>
         * @default [1, 2, 3, 4, 5]
         */
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         /**
         * @name dxchartoptions_argumentaxis_holidays
         * @publicName holidays

--- a/js/viz/docs/docrangeselector.js
+++ b/js/viz/docs/docrangeselector.js
@@ -102,11 +102,11 @@ var dxRangeSelector = {
         workdaysOnly: false,
         /**
         * @name dxrangeselectoroptions_scale_workweek
-        * @publicName workweek
+        * @publicName workWeek
         * @type Array<number>
         * @default [1, 2, 3, 4, 5]
         */
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         /**
         * @name dxrangeselectoroptions_scale_holidays
         * @publicName holidays

--- a/js/viz/docs/docrangeselector.js
+++ b/js/viz/docs/docrangeselector.js
@@ -87,6 +87,70 @@ var dxRangeSelector = {
         */
         minorTickInterval: {},
         /**
+        * @name dxrangeselectoroptions_scale_breaks
+        * @publicName breaks
+        * @type Array<ScaleBreak>
+        * @default undefined
+        */
+        breaks: undefined,
+        /**
+        * @name dxrangeselectoroptions_scale_workdaysonly
+        * @publicName workdaysOnly
+        * @type boolean
+        * @default false
+        */
+        workdaysOnly: false,
+        /**
+        * @name dxrangeselectoroptions_scale_workweek
+        * @publicName workweek
+        * @type Array<number>
+        * @default [1, 2, 3, 4, 5]
+        */
+        workweek: [1, 2, 3, 4, 5],
+        /**
+        * @name dxrangeselectoroptions_scale_holidays
+        * @publicName holidays
+        * @type Array<Date, string>| Array<number>
+        * @default undefined
+        */
+        holidays: undefined,
+        /**
+        * @name dxrangeselectoroptions_scale_singleworkdays
+        * @publicName singleWorkdays
+        * @type Array<Date, string> | Array<number>
+        * @default undefined
+        */
+        singleWorkdays: undefined,
+        /**
+        * @name dxrangeselectoroptions_scale_breakStyle
+        * @publicName breakStyle
+        * @type object
+        */
+        breakStyle: {
+            /**
+            * @name dxrangeselectoroptions_scale_breakStyle_width
+            * @publicName width
+            * @type number
+            * @default 5
+            */
+            width: 5,
+            /**
+            * @name dxrangeselectoroptions_scale_breakStyle_color
+            * @publicName color
+            * @type string
+            * @default "#ababab"
+            */
+            color: "#ababab",
+            /**
+            * @name dxrangeselectoroptions_scale_breakStyle_line
+            * @publicName line
+            * @type string
+            * @default "waved"
+            * @acceptValues 'waved'| 'straight'
+            */
+            line: "waved"
+        },
+        /**
         * @name dxrangeselectoroptions_scale_majortickinterval
         * @publicName majorTickInterval
         * @type number|object|string

--- a/js/viz/range_selector/range_selector.js
+++ b/js/viz/range_selector/range_selector.js
@@ -478,7 +478,7 @@ function updateScaleOptions(scaleOptions, seriesDataSource, translatorRange, tic
     }
 }
 
-function prepareScaleOptions(scaleOption, seriesDataSource, incidentOccurred) {
+function prepareScaleOptions(scaleOption, seriesDataSource, incidentOccurred, containerColor) {
     var parsedValue = 0,
         valueType = parseUtils.correctValueType(_normalizeEnum(scaleOption.valueType)),
         parser,
@@ -508,6 +508,8 @@ function prepareScaleOptions(scaleOption, seriesDataSource, incidentOccurred) {
         scaleOption.type = DISCRETE;
         valueType = STRING;
     }
+
+    scaleOption.containerColor = containerColor;
 
     scaleOption.valueType = valueType;
     scaleOption.dataType = valueType;
@@ -638,6 +640,7 @@ var dxRangeSelector = require("../core/base_widget").inherit({
             rangeViewGroup,
             slidersGroup,
             scaleGroup,
+            scaleBreaksGroup,
             trackersGroup;
 
         // TODO: Move it to the SlidersEventManager
@@ -651,11 +654,13 @@ var dxRangeSelector = require("../core/base_widget").inherit({
         rangeViewGroup = renderer.g().attr({ "class": "dxrs-view" }).append(root);
         slidersGroup = renderer.g().attr({ "class": "dxrs-slidersContainer", "clip-path": that._clipRect.id }).append(root);
         scaleGroup = renderer.g().attr({ "class": "dxrs-scale", "clip-path": that._clipRect.id }).append(root);
+        scaleBreaksGroup = renderer.g().attr({ "class": "dxrs-scale-breaks" }).append(root);
         trackersGroup = renderer.g().attr({ "class": "dxrs-trackers" }).append(root);
 
         that._axis = new AxisWrapper({
             renderer: renderer,
             root: scaleGroup,
+            scaleBreaksGroup: scaleBreaksGroup,
             updateSelectedRange: function(range) { that.setValue(parseSelectedRange(range)); },
             incidentOccurred: that._incidentOccurred
         });
@@ -864,7 +869,7 @@ var dxRangeSelector = require("../core/base_widget").inherit({
             chartOptions = that.option("chart"),
             seriesDataSource = that._createSeriesDataSource(chartOptions),
             isCompactMode = !((seriesDataSource && seriesDataSource.isShowChart()) || that.option("background.image.url")),
-            scaleOptions = prepareScaleOptions(that._getOption("scale"), seriesDataSource, that._incidentOccurred),
+            scaleOptions = prepareScaleOptions(that._getOption("scale"), seriesDataSource, that._incidentOccurred, this._getOption("containerBackgroundColor", true)),
             argTranslatorRange = calculateTranslatorRange(seriesDataSource, scaleOptions),
             tickIntervalsInfo = updateTickIntervals(scaleOptions, canvas.width, that._incidentOccurred, argTranslatorRange),
             sliderMarkerOptions,
@@ -1097,6 +1102,7 @@ function AxisWrapper(params) {
     this._axis = new axisModule.Axis({
         renderer: params.renderer,
         axesContainerGroup: params.root,
+        scaleBreaksGroup: params.scaleBreaksGroup,
         incidentOccurred: params.incidentOccurred,
         // TODO: These dependencies should be statically resolved (not for every new instance)
         axisType: "xyAxes",
@@ -1133,6 +1139,7 @@ AxisWrapper.prototype = {
             // TODO: Check who is responsible for destroying events
             createDateMarkersEvent(options, axis.getMarkerTrackers(), this._updateSelectedRangeCallback);
         }
+        axis.drawScaleBreaks({ start: canvas.top, end: canvas.top + canvas.height });
     },
 
     getFullTicks: function() {

--- a/js/viz/series/base_series.js
+++ b/js/viz/series/base_series.js
@@ -225,6 +225,10 @@ Series.prototype = {
         return this._points;
     },
 
+    getPointsInViewPort: function() {
+        return rangeCalculator.getPointsInViewPort(this);
+    },
+
     _createPoint: function(data, pointsArray, index) {
         data.index = index;
         var that = this,
@@ -505,12 +509,16 @@ Series.prototype = {
             errorBars: that._errorBarGroup
         };
 
-        _each(points, function(i, p) {
+        points.forEach(function(p, i) {
             p.translate();
-            if(p.hasValue()) {
+
+            if(p.hasValue() && p.hasCoords()) {
                 that._drawPoint({ point: p, groups: groupForPoint, hasAnimation: animationEnabled, firstDrawing: firstDrawing });
                 segment.push(p);
             } else {
+                if(!p.hasCoords()) {
+                    p.setInvisibility();
+                }
                 if(segment.length) {
                     that._drawSegment(segment, animationEnabled, segmentCount++);
                     segment = [];

--- a/js/viz/series/helpers/range_data_calculator.js
+++ b/js/viz/series/helpers/range_data_calculator.js
@@ -163,5 +163,50 @@ module.exports = {
             });
         }
         return range;
+    },
+
+    getPointsInViewPort: function(series) {
+        var argumentViewPortFilter = getViewPortFilter(series.getArgumentAxis().getViewport() || {}),
+            valueViewPort = series.getValueAxis().getViewport() || {},
+            valueViewPortFilter = getViewPortFilter(valueViewPort),
+            points = series.getPoints(),
+            addValue = function(values, point) {
+                var minValue = point.getMinValue(),
+                    maxValue = point.getMaxValue();
+                if(valueViewPortFilter(minValue)) {
+                    values.push(minValue);
+                }
+                if(maxValue !== minValue && valueViewPortFilter(maxValue)) {
+                    values.push(maxValue);
+                }
+            },
+            checkPointInViewport = function(prev, point, index) {
+                if(argumentViewPortFilter(point.argument)) {
+                    addValue(prev, point);
+                } else {
+                    var prevPoint = points[index - 1],
+                        nextPoint = points[index + 1];
+
+                    if(nextPoint && argumentViewPortFilter(nextPoint.argument)) {
+                        addValue(prev, point);
+                    }
+
+                    if(prevPoint && argumentViewPortFilter(prevPoint.argument)) {
+                        addValue(prev, point);
+                    }
+
+                }
+                return prev;
+            },
+            values = points.reduce(checkPointInViewport, []);
+
+        if(valueViewPort.min) {
+            values.push(valueViewPort.min);
+        }
+        if(valueViewPort.max) {
+            values.push(valueViewPort.max);
+        }
+
+        return values;
     }
 };

--- a/js/viz/series/points/base_point.js
+++ b/js/viz/series/points/base_point.js
@@ -409,6 +409,7 @@ Point.prototype = {
     hasValue: function() {
         return this.value !== null && this.minValue !== null;
     },
+    hasCoords: _noop,
     correctPosition: _noop,
     correctRadius: _noop,
     correctLabelRadius: _noop,

--- a/js/viz/series/points/range_bar_point.js
+++ b/js/viz/series/points/range_bar_point.js
@@ -60,6 +60,8 @@ module.exports = _extend({}, barPoint, {
         }
     },
 
+    hasCoords: rangeSymbolPointMethods.hasCoords,
+
     _updateData: rangeSymbolPointMethods._updateData,
 
     _getLabelPosition: rangeSymbolPointMethods._getLabelPosition,

--- a/js/viz/series/points/range_symbol_point.js
+++ b/js/viz/series/points/range_symbol_point.js
@@ -413,6 +413,10 @@ module.exports = _extend({}, symbolPoint, {
         that.width = rotated ? _abs(that.x - that.minX) : 0;
     },
 
+    hasCoords: function() {
+        return symbolPoint.hasCoords.call(this) && !(this.minX === null || this.minY === null);
+    },
+
     _updateData: function(data) {
         var that = this;
         symbolPoint._updateData.call(that, data);

--- a/js/viz/series/points/symbol_point.js
+++ b/js/viz/series/points/symbol_point.js
@@ -166,6 +166,10 @@ module.exports = {
         }
     },
 
+    hasCoords: function() {
+        return this.x !== null && this.y !== null;
+    },
+
     correctValue: function(correction) {
         var that = this;
         if(that.hasValue()) {

--- a/js/viz/translators/datetime_translator.js
+++ b/js/viz/translators/datetime_translator.js
@@ -5,10 +5,7 @@ var numericTranslator = require("./numeric_translator");
 module.exports = {
     translate: numericTranslator.translate,
 
-    untranslate: function() {
-        var result = numericTranslator.untranslate.apply(this, arguments);
-        return result === null ? result : new Date(result);
-    },
+    untranslate: numericTranslator.untranslate,
 
     _getValue: numericTranslator._getValue,
     getInterval: numericTranslator.getInterval,
@@ -29,7 +26,8 @@ module.exports = {
     to: numericTranslator.to,
 
     from: function(position) {
-        return new Date(numericTranslator.from.call(this, position));
+        var result = numericTranslator.from.call(this, position);
+        return result === null ? result : new Date(result);
     },
 
     _add: require("../../core/utils/date").addDateInterval,

--- a/js/viz/translators/logarithmic_translator.js
+++ b/js/viz/translators/logarithmic_translator.js
@@ -14,13 +14,13 @@ module.exports = {
         if(isDefined(specialValue)) {
             return specialValue;
         }
-        return numericTranslator.translate.call(that, getLog(bp, that._businessRange.base));
+        if(that._isValueOutOfCanvas(getLog(bp, that._businessRange.base))) {
+            return null;
+        }
+        return that.to(bp);
     },
 
-    untranslate: function() {
-        var result = numericTranslator.untranslate.apply(this, arguments);
-        return result === null ? result : raiseTo(result, this._businessRange.base);
-    },
+    untranslate: numericTranslator.untranslate,
 
     getInterval: numericTranslator.getInterval,
 
@@ -53,7 +53,8 @@ module.exports = {
     },
 
     from: function(position) {
-        return raiseTo(numericTranslator.from.call(this, position), this._businessRange.base);
+        var result = numericTranslator.from.call(this, position);
+        return result !== null ? raiseTo(result, this._businessRange.base) : result;
     },
 
     _add: function(value, diff, dir) {

--- a/js/viz/translators/translator2d.js
+++ b/js/viz/translators/translator2d.js
@@ -50,6 +50,38 @@ function valuesIsDefinedAndEqual(val1, val2) {
     return isDefined(val1) && isDefined(val2) && val1.valueOf() === val2.valueOf();
 }
 
+function prepareBreaks(breaks, range) {
+    var transform = range.axisType === 'logarithmic' ? function(value) {
+            return getLog(value, range.base);
+        } : function(value) {
+            return value;
+        },
+        array = [],
+        br,
+        transformFrom,
+        transformTo,
+        i,
+        length = breaks.length,
+        sum = 0;
+
+    for(i = 0; i < length; i++) {
+        br = breaks[i];
+        transformFrom = transform(br.from);
+        transformTo = transform(br.to);
+        sum += transformTo - transformFrom;
+        array.push({
+            trFrom: transformFrom,
+            trTo: transformTo,
+            from: br.from,
+            to: br.to,
+            length: sum,
+            cumulativeWidth: br.cumulativeWidth
+        });
+    }
+
+    return array;
+}
+
 function getCanvasBounds(range) {
     var min = range.min,
         max = range.max,
@@ -100,6 +132,41 @@ function getCanvasBounds(range) {
     return { base: base, rangeMin: min, rangeMax: max, rangeMinVisible: minVisible, rangeMaxVisible: maxVisible };
 }
 
+function getCheckingMethodsAboutBreaks(inverted) {
+    return {
+        isStartSide: !inverted ? function(pos, breaks, start, end) {
+            return pos < breaks[0][start];
+        } : function(pos, breaks, start, end) {
+            return pos <= breaks[breaks.length - 1][end];
+        },
+        isEndSide: !inverted ? function(pos, breaks, start, end) {
+            return pos >= breaks[breaks.length - 1][end];
+        } : function(pos, breaks, start, end) {
+            return pos > breaks[0][start];
+        },
+        isInBreak: !inverted ? function(pos, br, start, end) {
+            return pos >= br[start] && pos < br[end];
+        } : function(pos, br, start, end) {
+            return pos > br[end] && pos <= br[start];
+        },
+        isBetweenBreaks: !inverted ? function(pos, br, prevBreak, start, end) {
+            return pos < br[start] && pos >= prevBreak[end];
+        } : function(pos, br, prevBreak, start, end) {
+            return pos >= br[end] && pos < prevBreak[start];
+        },
+        getLength: !inverted ? function(br) {
+            return br.length;
+        } : function(br, lastBreak) {
+            return lastBreak.length - br.length;
+        },
+        getBreaksSize: !inverted ? function(br) {
+            return br.cumulativeWidth;
+        } : function(br, lastBreak) {
+            return lastBreak.cumulativeWidth - br.cumulativeWidth;
+        }
+    };
+}
+
 exports.Translator2D = _Translator2d = function(businessRange, canvas, options) {
     this.update(businessRange, canvas, options);
 };
@@ -147,6 +214,63 @@ _Translator2d.prototype = {
         that._conversionValue = options.conversionValue ? function(value) { return value; } : function(value) { return Math.round(value); };
 
         that._calculateSpecialValues();
+        that._checkingMethodsAboutBreaks = [
+            getCheckingMethodsAboutBreaks(false),
+            getCheckingMethodsAboutBreaks(that.isInverted())
+        ];
+        that._translateBreaks();
+    },
+
+    _translateBreaks: function() {
+        var breaks = this._breaks,
+            size = this._options.breaksSize,
+            i,
+            b,
+            end,
+            length;
+        if(breaks === undefined) {
+            return;
+        }
+        for(i = 0, length = breaks.length; i < length; i++) {
+            b = breaks[i];
+            end = this.translate(b.to);
+            b.end = end;
+            b.start = !b.gapSize ? (!this.isInverted() ? end - size : end + size) : end;
+        }
+    },
+
+    _checkValueAboutBreaks: function(breaks, pos, start, end, methods) {
+        var i,
+            length,
+            prop = { length: 0, breaksSize: undefined, inBreak: false },
+            br,
+            prevBreak,
+            lastBreak = breaks[breaks.length - 1];
+
+        if(methods.isStartSide(pos, breaks, start, end)) {
+            return prop;
+        } else if(methods.isEndSide(pos, breaks, start, end)) {
+            return { length: lastBreak.length, breaksSize: lastBreak.cumulativeWidth, inBreak: false };
+        }
+
+        for(i = 0, length = breaks.length; i < length; i++) {
+            br = breaks[i];
+            prevBreak = breaks[i - 1];
+            if(methods.isInBreak(pos, br, start, end)) {
+                prop.inBreak = true;
+                prop.break = br;
+                break;
+            }
+            if(prevBreak && methods.isBetweenBreaks(pos, br, prevBreak, start, end)) {
+                prop = { length: methods.getLength(prevBreak, lastBreak), breaksSize: methods.getBreaksSize(prevBreak, lastBreak), inBreak: false };
+                break;
+            }
+        }
+        return prop;
+    },
+
+    isInverted: function() {
+        return !(this._options.isHorizontal ^ this._businessRange.invert);
     },
 
     _getDiscreteInterval: function(categoriesLength, canvasOptions) {
@@ -159,7 +283,8 @@ _Translator2d.prototype = {
             businessRange = that._businessRange,
             canvasOptions = that._canvasOptions = getCanvasBounds(businessRange),
             length,
-            canvas = that._canvas;
+            canvas = that._canvas,
+            breaks = that._breaks;
 
         if(that._options.isHorizontal) {
             canvasOptions.startPoint = canvas.left;
@@ -177,6 +302,11 @@ _Translator2d.prototype = {
         canvasOptions.rangeDoubleError = Math.pow(10, getPower(canvasOptions.rangeMax - canvasOptions.rangeMin) - getPower(length) - 2); //B253861
         canvasOptions.ratioOfCanvasRange = canvasOptions.canvasLength / (canvasOptions.rangeMaxVisible - canvasOptions.rangeMinVisible);
 
+        if(breaks !== undefined) {
+            canvasOptions.ratioOfCanvasRange = (canvasOptions.canvasLength - breaks[breaks.length - 1].cumulativeWidth) /
+                (canvasOptions.rangeMaxVisible - canvasOptions.rangeMinVisible - breaks[breaks.length - 1].length);
+        }
+
         return canvasOptions;
     },
 
@@ -186,14 +316,21 @@ _Translator2d.prototype = {
     },
 
     updateBusinessRange: function(businessRange) {
-        this._businessRange = validateBusinessRange(businessRange);
-        this.reinit();
+        var that = this,
+            breaks = businessRange.breaks || [];
+
+        that._businessRange = validateBusinessRange(businessRange);
+
+        that._breaks = breaks.length ? prepareBreaks(breaks, that._businessRange) : undefined;
+
+        that.reinit();
     },
 
     update: function(businessRange, canvas, options) {
         var that = this;
         that._options = extend(that._options || {}, options);
         that._canvas = validateCanvas(canvas);
+
         that.updateBusinessRange(businessRange);
     },
 
@@ -261,6 +398,12 @@ _Translator2d.prototype = {
         return canvasOptions.invert ? canvasOptions.rangeMaxVisible.valueOf() - distance : canvasOptions.rangeMinVisible.valueOf() + distance;
     },
 
+    _isValueOutOfCanvas: function(bp) {
+        var canvasOptions = this._canvasOptions,
+            doubleError = canvasOptions.rangeDoubleError;
+
+        return isNaN(bp) || bp.valueOf() + doubleError < canvasOptions.rangeMin || bp.valueOf() - doubleError > canvasOptions.rangeMax;
+    },
     getMinBarSize: function(minBarSize) {
         var visibleArea = this.getCanvasVisibleArea(),
             minValue = this.untranslate(visibleArea.min + minBarSize);

--- a/testing/helpers/chartMocks.js
+++ b/testing/helpers/chartMocks.js
@@ -843,6 +843,9 @@
             hasValue: function() {
                 return this.value !== null && this.minValue !== null && this.highValue !== null && this.lowValue !== null;
             },
+            hasCoords: function() {
+                return true;
+            },
             getDefaultCoords: function() {
                 return $.extend({ defaultCoords: true }, this);
             },
@@ -880,7 +883,8 @@
                 };
             },
             setHole: function() { },
-            resetHoles: function() { }
+            resetHoles: function() { },
+            setInvisibility: sinon.spy()
         });
 
 
@@ -900,6 +904,7 @@
 
                 this._axisElementsGroup =
                 this._constantLinesGroup =
+                this._scaleBreaksGroup =
                 this._renderer =
                 this._labelAxesGroup =
                 this._orthogonalTranslator =
@@ -927,6 +932,8 @@
             updateSize: sinon.stub(),
 
             setBusinessRange: sinon.stub(),
+
+            setGroupSeries: sinon.stub(),
 
             restoreBusinessRange: sinon.stub(),
 
@@ -989,6 +996,7 @@
             _stripsGroup: renderOptions.stripsGroup,
             _labelAxesGroup: renderOptions.labelAxesGroup,
             _constantLinesGroup: renderOptions.constantLinesGroup,
+            _scaleBreaksGroup: renderOptions.scaleBreaksGroup,
             axesContainerGroup: renderOptions.axesContainerGroup,
             gridGroup: renderOptions.gridGroup,
             isArgumentAxis: renderOptions.isArgumentAxis,
@@ -1012,6 +1020,7 @@
             resetZoom: function() {
 
             },
+            drawScaleBreaks: sinon.spy(),
             resetTypes: sinon.spy(),
             setMarginOptions: sinon.spy()
         };

--- a/testing/tests/DevExpress.viz.charts/chart.part2.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chart.part2.tests.js
@@ -29,6 +29,17 @@ QUnit.test("Pass rotation info to Business range (rotated = false)", function(as
     assert.strictEqual(chart._argumentAxes[0].setBusinessRange.lastCall.args[0].rotated, false);
 });
 
+QUnit.test("setBusinessRange with multiple axes and panes", function(assert) {
+    var chart = this.createChart({
+        valueAxis: [{ pane: "pane0" }, { pane: "pane1" }, { pane: "pane1" }],
+        panes: [{ name: "pane0" }, { name: "pane1" }]
+    });
+
+    assert.equal(chart._valueAxes[0].setBusinessRange.lastCall.args[1], false);
+    assert.equal(chart._valueAxes[1].setBusinessRange.lastCall.args[1], true);
+    assert.equal(chart._valueAxes[2].setBusinessRange.lastCall.args[1], true);
+});
+
 QUnit.test("Calculate business range for continuous without indent", function(assert) {
     seriesMockData.series.push(new MockSeries({
         range: {

--- a/testing/tests/DevExpress.viz.charts/chart.part3.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chart.part3.tests.js
@@ -562,6 +562,27 @@ QUnit.test("Create Vertical Continuous Axis, Horizontal Continuous axis (rotated
     assertCommonAxesProperties(assert, valueAxis, {});
 });
 
+QUnit.test("Creation axes, container color and group of the scale breaks should be passed to axes", function(assert) {
+    //Arrange
+    var stubSeries = new MockSeries({
+        range: { val: { min: 1, max: 3 } }
+    });
+    seriesMockData.series.push(stubSeries);
+
+    //act
+    var chart = this.createChart({
+        series: {
+            type: "line"
+        },
+        containerBackgroundColor: "color"
+    });
+
+    assert.ok(chart._argumentAxes[0]._scaleBreaksGroup);
+    assert.ok(chart._valueAxes[0]._scaleBreaksGroup);
+    assert.equal(chart._argumentAxes[0].getOptions().containerColor, "color");
+    assert.equal(chart._valueAxes[0].getOptions().containerColor, "color");
+});
+
 QUnit.test("Panes - named Horizontal Category Axis, named Vertical Continuous axis", function(assert) {
     //Arrange
     var stubSeries = new MockSeries({

--- a/testing/tests/DevExpress.viz.charts/chartAxisDrawing.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chartAxisDrawing.tests.js
@@ -90,6 +90,7 @@ function createAxisStubs() {
         updateSize: sinon.spy(function(arg) { this.updateSize_test_arg = $.extend({}, arg); }),
         shift: sinon.spy(function(arg) { this.shift_test_arg = $.extend({}, arg); }),
         hideTitle: sinon.spy(),
+        drawScaleBreaks: sinon.spy(),
         hideOuterElements: sinon.spy()
     };
 
@@ -1393,6 +1394,7 @@ QUnit.test("Do not recalculate canvas on zooming - only draw axes in old canvas"
     argAxisStub.updateSize.reset();
     argAxisStub.shift.reset();
     argAxisStub.createTicks.reset();
+    argAxisStub.drawScaleBreaks.reset();
 
     var valAxisStub = this.axisStub.getCall(1).returnValue;
 
@@ -1402,6 +1404,7 @@ QUnit.test("Do not recalculate canvas on zooming - only draw axes in old canvas"
     valAxisStub.updateSize.reset();
     valAxisStub.shift.reset();
     valAxisStub.createTicks.reset();
+    valAxisStub.drawScaleBreaks.reset();
 
     scrollBar.updateSize.reset();
 
@@ -1443,6 +1446,8 @@ QUnit.test("Do not recalculate canvas on zooming - only draw axes in old canvas"
 
     assert.equal(argAxisStub.shift.called, false);
     assert.equal(valAxisStub.shift.called, false);
+
+    assert.ok(valAxisStub.drawScaleBreaks.called, "draw scaleBreaks for value axis");
 });
 
 QUnit.module("Axes synchronization", environment);

--- a/testing/tests/DevExpress.viz.charts/chartSync.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chartSync.tests.js
@@ -1160,6 +1160,7 @@ var environment = {
         assert.ok(chart._crosshairCursorGroup.linkRemove.called, "crosshair group should be detached");
         assert.ok(chart._crosshairCursorGroup.stub("clear").called, "crosshair should be cleared");
         assert.ok(chart._crosshairCursorGroup.linkAppend.called, "crosshair group should be added to root");
+        assert.ok(chart._scaleBreaksGroup.linkAppend.called, "scalebreaks group should be added to root");
 
         withNewData && assert.ok(getTrackerStub().stub("update").called, "Tracker should be initialized");
         options.noTrackerUpdateCheck || assert.ok(getTrackerStub().stub("update").called, "Tracker should be prepared");
@@ -1648,6 +1649,7 @@ var environment = {
         mockObjectDispose("_crosshair");
         mockObjectDispose("_scrollGroup");
         mockObjectDispose("_backgroundRect");
+        mockObjectDispose("_scaleBreaksGroup");
 
         //act
         this.$container.remove();
@@ -1708,6 +1710,8 @@ var environment = {
         assert.strictEqual(chart._labelsGroup, null, "labels group is null");
         assert.ok(chart._crosshairCursorGroupDisposed, "_crossHairCursorGroup");
         assert.strictEqual(chart._crosshairCursorGroup, null, "crosshair cursor group is null");
+        assert.ok(chart._scaleBreaksGroupDisposed, "_scaleBreaksGroup");
+        assert.strictEqual(chart._scaleBreaksGroup, null, "scalebreaks group is null");
 
         assert.deepEqual(loadIndicator.dispose.lastCall.args, [], "load indicator dispose args");
         assert.strictEqual(chart._loadingIndicator, null, "load indicator is null");
@@ -1798,6 +1802,9 @@ function resetMocksInChart(chart) {
     chart._crosshairCursorGroup.stub("linkAppend").reset();
     chart._crosshairCursorGroup.stub("linkRemove").reset();
     chart._crosshairCursorGroup.stub("clear").reset();
+    chart._scaleBreaksGroup.stub("linkAppend").reset();
+    chart._scaleBreaksGroup.stub("linkRemove").reset();
+    chart._scaleBreaksGroup.stub("clear").reset();
 
     chart.canvasClipRect && chart.canvasClipRect.stub("remove").reset();
     chart.canvasClipRect && chart.canvasClipRect.stub("clear").reset();

--- a/testing/tests/DevExpress.viz.charts/integrationWithAssertions.tests.js
+++ b/testing/tests/DevExpress.viz.charts/integrationWithAssertions.tests.js
@@ -650,6 +650,7 @@ var VALIDATE_GROUPS = [
     "dxc-series-group",
     "dxc-labels-group",
     "dxc-crosshair-cursor",
+    "dxc-scale-breaks",
     //"dxc-title",
     "dxc-legend"
 ];

--- a/testing/tests/DevExpress.viz.charts/themeManager.tests.js
+++ b/testing/tests/DevExpress.viz.charts/themeManager.tests.js
@@ -1990,13 +1990,14 @@ function createThemeManager(options, themeGroupName) {
     QUnit.test('get valueAxis for rangeSelector', function(assert) {
         var themeManager = createThemeManager(this.getOptions({}));
         themeManager.setTheme("getOptionsTheme");
-        assert.deepEqual(themeManager.getOptions('valueAxisRangeSelector'), {
-            endOnTick: true,
-            valueAxisTheme: true,
-            grid: {
-                visible: true
-            }
+
+        var valueOptions = themeManager.getOptions('valueAxisRangeSelector');
+
+        assert.equal(valueOptions.endOnTick, true);
+        assert.deepEqual(valueOptions.grid, {
+            visible: true
         });
+        assert.equal(valueOptions.valueAxisTheme, true);
     });
 
     QUnit.test('get valueAxis for rangeSelector with preset values', function(assert) {
@@ -2007,16 +2008,14 @@ function createThemeManager(options, themeGroupName) {
             }
         }));
         themeManager.setTheme("getOptionsTheme");
+        var valueOptions = themeManager.getOptions('valueAxisRangeSelector');
 
-        assert.deepEqual(themeManager.getOptions('valueAxisRangeSelector'), {
-            endOnTick: true,
-            grid: {
-                visible: true
-            },
-            logarithmBase: 2,
-            someField: 'someValue',
-            valueAxisTheme: true
+        assert.equal(valueOptions.endOnTick, true);
+        assert.deepEqual(valueOptions.grid, {
+            visible: true
         });
+        assert.equal(valueOptions.logarithmBase, 2);
+        assert.equal(valueOptions.someField, 'someValue');
+        assert.equal(valueOptions.valueAxisTheme, true);
     });
-
 })();

--- a/testing/tests/DevExpress.viz.core.series/areaSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/areaSeries.tests.js
@@ -87,6 +87,7 @@ var createPoint = function() {
     stub.argument = 1;
     stub.hasValue.returns(true);
     stub.isInVisibleArea.returns(true);
+    stub.hasCoords.returns(true);
     stub.getCoords.withArgs(true).returns({ x: 0, y: 0 });
     stub.getDefaultCoords.returns({ x: 0, y: 0 });
     return stub;
@@ -103,6 +104,7 @@ var environmentWithSinonStubPoint = {
             stub.angle = -data.argument;
             stub.radius = data.value;
             stub.hasValue.returns(true);
+            stub.hasCoords.returns(true);
             stub.isInVisibleArea.returns(true);
             stub.draw.reset();
             stub.animate.reset();

--- a/testing/tests/DevExpress.viz.core.series/barPoint.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/barPoint.tests.js
@@ -332,7 +332,6 @@ QUnit.test("Point is out of boundaries on the left", function(assert) {
     assert.strictEqual(point.minY, 300, "minY");
     assert.strictEqual(point.height, 50, "height");
     assert.strictEqual(point.x, 0, "x");
-    assert.strictEqual(point.minX, 0, "minX");
     assert.strictEqual(point.width, 50, "width");
 
     assert.equal(point.vx, 25, "crosshair x Coord");
@@ -350,7 +349,6 @@ QUnit.test("Point is partially out of boundaries on the left and bottom", functi
     assert.strictEqual(point.minY, 300, "minY");
     assert.strictEqual(point.height, 75, "height");
     assert.strictEqual(point.x, 100, "x");
-    assert.strictEqual(point.minX, 100, "minX");
     assert.strictEqual(point.width, 30, "width");
 });
 
@@ -365,7 +363,6 @@ QUnit.test("Point is partially out of boundaries at the top and bottom", functio
     assert.strictEqual(point.minY, 300, "minY");
     assert.strictEqual(point.height, 100, "height");
     assert.strictEqual(point.x, 200, "x");
-    assert.strictEqual(point.minX, 200, "minX");
     assert.strictEqual(point.width, 50, "width");
 });
 
@@ -380,7 +377,6 @@ QUnit.test("Point is partially out of boundaries at the bottom", function(assert
     assert.strictEqual(point.minY, 300, "minY");
     assert.strictEqual(point.height, 50, "height");
     assert.strictEqual(point.x, 300, "x");
-    assert.strictEqual(point.minX, 300, "minX");
     assert.strictEqual(point.width, 50, "width");
 });
 
@@ -395,7 +391,6 @@ QUnit.test("Point is partially out of boundaries at the top", function(assert) {
     assert.strictEqual(point.minY, 300, "minY");
     assert.strictEqual(point.height, 100, "height");
     assert.strictEqual(point.x, 400, "x");
-    assert.strictEqual(point.minX, 400, "minX");
     assert.strictEqual(point.width, 50, "width");
 });
 
@@ -410,7 +405,6 @@ QUnit.test("Point is partially out of boundaries on the right", function(assert)
     assert.strictEqual(point.minY, 300, "minY");
     assert.strictEqual(point.height, 75, "height");
     assert.strictEqual(point.x, 480, "x");
-    assert.strictEqual(point.minX, 480, "minX");
     assert.strictEqual(point.width, 20, "width");
 });
 
@@ -425,20 +419,22 @@ QUnit.test("Point is out of boundaries on the right", function(assert) {
     assert.strictEqual(point.minY, 300, "minY");
     assert.strictEqual(point.height, 75, "height");
     assert.strictEqual(point.x, 600, "x");
-    assert.strictEqual(point.minX, 600, "minX");
     assert.strictEqual(point.width, 50, "width");
 });
 
-QUnit.test("Point's value is translated to null", function(assert) {
-    var point = createPoint(this.series, { argument: 4, value: 0.1 }, this.opt);
+QUnit.test("hasCoords returns false if point doesn't have x", function(assert) {
+    this.continuousTranslators.arg = new MockTranslator({
+        translate: { 6: null },
+        getCanvasVisibleArea: { min: 30, max: 300 }
+    });
+    this.series.getVisibleArea = function() { return { minX: 0, maxX: 300, minY: 100, maxY: 500 }; };
+
+    var point = createPoint(this.series, { argument: 6, value: 5 }, this.opt);
 
     point.width = 50;
     point.translate();
 
-    assert.strictEqual(point.inVisibleArea, true, "inVisibleArea");
-    assert.strictEqual(point.y, 300, "y");
-    assert.strictEqual(point.minY, 300, "minY");
-    assert.strictEqual(point.height, 0, "height");
+    assert.ok(!point.hasCoords());
 });
 
 QUnit.module("Point coordinates translation with correction on canvas visible area. Rotated.", {
@@ -487,7 +483,6 @@ QUnit.test("Point is out of boundaries on the left", function(assert) {
 
     assert.strictEqual(point.inVisibleArea, false, "inVisibleArea");
     assert.strictEqual(point.y, 0, "y");
-    assert.strictEqual(point.minY, 0, "minY");
     assert.strictEqual(point.height, 50, "height");
     assert.strictEqual(point.x, 250, "x");
     assert.strictEqual(point.minX, 300, "minX");
@@ -505,7 +500,6 @@ QUnit.test("Point is partially out of boundaries on the left and bottom", functi
 
     assert.strictEqual(point.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(point.y, 100, "y");
-    assert.strictEqual(point.minY, 100, "minY");
     assert.strictEqual(point.height, 30, "height");
     assert.strictEqual(point.x, 225, "x");
     assert.strictEqual(point.minX, 300, "minX");
@@ -520,7 +514,6 @@ QUnit.test("Point is partially out of boundaries at the top and bottom", functio
 
     assert.strictEqual(point.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(point.y, 200, "y");
-    assert.strictEqual(point.minY, 200, "minY");
     assert.strictEqual(point.height, 50, "height");
     assert.strictEqual(point.x, 200, "x");
     assert.strictEqual(point.minX, 300, "minX");
@@ -535,7 +528,6 @@ QUnit.test("Point is partially out of boundaries at the bottom", function(assert
 
     assert.strictEqual(point.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(point.y, 300, "y");
-    assert.strictEqual(point.minY, 300, "minY");
     assert.strictEqual(point.height, 50, "height");
     assert.strictEqual(point.x, 250, "x");
     assert.strictEqual(point.minX, 300, "minX");
@@ -550,7 +542,6 @@ QUnit.test("Point is partially out of boundaries at the top", function(assert) {
 
     assert.strictEqual(point.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(point.y, 400, "y");
-    assert.strictEqual(point.minY, 400, "minY");
     assert.strictEqual(point.height, 50, "height");
     assert.strictEqual(point.x, 200, "x");
     assert.strictEqual(point.minX, 300, "minX");
@@ -565,7 +556,6 @@ QUnit.test("Point is partially out of boundaries on the right", function(assert)
 
     assert.strictEqual(point.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(point.y, 480, "y");
-    assert.strictEqual(point.minY, 480, "minY");
     assert.strictEqual(point.height, 20, "height");
     assert.strictEqual(point.x, 225, "x");
     assert.strictEqual(point.minX, 300, "minX");
@@ -580,23 +570,10 @@ QUnit.test("Point is out of boundaries on the right", function(assert) {
 
     assert.strictEqual(point.inVisibleArea, false, "inVisibleArea");
     assert.strictEqual(point.y, 600, "y");
-    assert.strictEqual(point.minY, 600, "minY");
     assert.strictEqual(point.height, 50, "height");
     assert.strictEqual(point.x, 225, "x");
     assert.strictEqual(point.minX, 300, "minX");
     assert.strictEqual(point.width, 75, "width");
-});
-
-QUnit.test("Point's value is translated to null", function(assert) {
-    var point = createPoint(this.series, { argument: 4, value: 0.1 }, this.opt);
-
-    point.height = 50;
-    point.translate();
-
-    assert.strictEqual(point.inVisibleArea, true, "inVisibleArea");
-    assert.strictEqual(point.x, 300, "x");
-    assert.strictEqual(point.minX, 300, "minX");
-    assert.strictEqual(point.width, 0, "width");
 });
 
 QUnit.module("Point coordinates correction", {
@@ -616,7 +593,6 @@ QUnit.module("Point coordinates correction", {
         this.point.rotated = false;
         this.point.x = 50;
         this.point.y = 100;
-        this.point.minX = 50;
         this.point.minY = 300;
         this.point.height = 200;
         this.point.width = 0;
@@ -634,7 +610,6 @@ QUnit.test("Negative offset", function(assert) {
     assert.equal(this.point.width, 20, "width");
     assert.equal(this.point.x, 50, "x");
     assert.equal(this.point.xCorrection, -20, "xCorrection");
-    assert.equal(this.point.minX, 50, "minX");
 
     assert.equal(this.point.y, 100, "y");
     assert.equal(this.point.height, 200, "height");
@@ -651,7 +626,6 @@ QUnit.test("Zero offset", function(assert) {
     assert.equal(this.point.width, 50, "width");
     assert.equal(this.point.x, 50, "x");
     assert.equal(this.point.xCorrection, -25, "xCorrection");
-    assert.equal(this.point.minX, 50, "minX");
 
     assert.equal(this.point.y, 100, "y");
     assert.equal(this.point.height, 200, "height");
@@ -668,7 +642,6 @@ QUnit.test("Positive offset", function(assert) {
     assert.equal(this.point.width, 10, "width");
     assert.equal(this.point.x, 50, "x");
     assert.equal(this.point.xCorrection, 5, "xCorrection");
-    assert.equal(this.point.minX, 50, "minX");
 
     assert.equal(this.point.y, 100, "y");
     assert.equal(this.point.height, 200, "height");
@@ -748,7 +721,6 @@ QUnit.test("Not integer offset", function(assert) {
     assert.equal(this.point.width, 10, "width");
     assert.equal(this.point.x, 50, "x");
     assert.equal(this.point.xCorrection, 5, "xCorrection");
-    assert.equal(this.point.minX, 50, "minX");
 
     assert.equal(this.point.y, 100, "y");
     assert.equal(this.point.height, 200, "height");

--- a/testing/tests/DevExpress.viz.core.series/barSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/barSeries.tests.js
@@ -55,6 +55,7 @@ var createPoint = function() {
     var stub = sinon.createStubInstance(pointModule.Point);
     stub.argument = 1;
     stub.hasValue.returns(true);
+    stub.hasCoords.returns(true);
     stub.isInVisibleArea.returns(true);
 
     stub._options = {};//see T243839
@@ -75,6 +76,7 @@ var environment = {
             stub.argument = 1;
             stub.getMarkerCoords.returns({ x: 1, y: 2, width: 20, height: 10 });
             stub.hasValue.returns(true);
+            stub.hasCoords.returns(true);
             stub.isInVisibleArea.returns(true);
             stub.draw.reset();
             stub.animate.reset();

--- a/testing/tests/DevExpress.viz.core.series/baseSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/baseSeries.tests.js
@@ -170,6 +170,7 @@ var createPoint = function() {
     var stub = sinon.createStubInstance(pointModule.Point);
     stub.argument = 1;
     stub.hasValue.returns(true);
+    stub.hasCoords.returns(true);
     stub.isInVisibleArea.returns(true);
     return stub;
 };
@@ -185,6 +186,7 @@ var environmentWithSinonStubPoint = {
             stub.value = data.value || 11;
             stub.fullState = 0;
             stub.hasValue.returns(true);
+            stub.hasCoords.returns(true);
             stub.isInVisibleArea.returns(true);
             stub.draw.reset();
             stub.update.reset();

--- a/testing/tests/DevExpress.viz.core.series/bubbleSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/bubbleSeries.tests.js
@@ -52,6 +52,7 @@ var createPoint = function() {
     var stub = sinon.createStubInstance(pointModule.Point);
     stub.argument = 1;
     stub.hasValue.returns(true);
+    stub.hasCoords.returns(true);
     stub.isInVisibleArea.returns(true);
 
     stub._options = {};//see T243839

--- a/testing/tests/DevExpress.viz.core.series/financialPoint.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/financialPoint.tests.js
@@ -93,6 +93,60 @@ QUnit.test("Translation", function(assert) {
     assert.equal(point.lowY, 111);
 });
 
+QUnit.test("hasCoords returns true if point has x, lowY, highY", function(assert) {
+    this.setTranslators();
+
+    var point = createPoint(this.series, { argument: 1, openValue: 3, closeValue: 2, highValue: 4, lowValue: 1 }, this.opt);
+
+    point.translate();
+
+    assert.ok(point.hasCoords());
+});
+
+QUnit.test("hasCoords returns false if point does not have x", function(assert) {
+    this.setTranslators();
+    this.translators.arg = new MockTranslator({
+        translate: { 1: null }
+    });
+    var point = createPoint(this.series, { argument: 1, openValue: 3, closeValue: 2, highValue: 4, lowValue: 1 }, this.opt);
+
+    point.translate();
+    assert.ok(!point.hasCoords());
+});
+
+QUnit.test("hasCoords returns false if point does not have lowY", function(assert) {
+    this.setTranslators();
+    this.translators.val = new MockTranslator({
+        translate: { 1: null, 2: 2, 3: 3, 4: 4 }
+    });
+    var point = createPoint(this.series, { argument: 1, openValue: 3, closeValue: 2, highValue: 4, lowValue: 1 }, this.opt);
+
+    point.translate();
+    assert.ok(!point.hasCoords());
+});
+
+QUnit.test("hasCoords returns false if point does not have highY", function(assert) {
+    this.setTranslators();
+    this.translators.val = new MockTranslator({
+        translate: { 1: 1, 2: 2, 3: 3, 4: null }
+    });
+    var point = createPoint(this.series, { argument: 1, openValue: 3, closeValue: 2, highValue: 4, lowValue: 1 }, this.opt);
+
+    point.translate();
+    assert.ok(!point.hasCoords());
+});
+
+QUnit.test("hasCoords returns true if point does not have closeY or openY", function(assert) {
+    this.setTranslators();
+    this.translators.val = new MockTranslator({
+        translate: { 1: 1, 2: null, 3: null, 4: 4 }
+    });
+    var point = createPoint(this.series, { argument: 1, openValue: 3, closeValue: 2, highValue: 4, lowValue: 1 }, this.opt);
+
+    point.translate();
+    assert.ok(point.hasCoords());
+});
+
 QUnit.test("getCrosshairData", function(assert) {
     this.series.axis = "valueAxisName";
     this.setTranslators();

--- a/testing/tests/DevExpress.viz.core.series/financialSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/financialSeries.tests.js
@@ -14,6 +14,7 @@ var createPoint = function() {
     var stub = sinon.createStubInstance(pointModule.Point);
     stub.argument = 1;
     stub.hasValue.returns(true);
+    stub.hasCoords.returns(true);
     stub.isInVisibleArea.returns(true);
 
     stub._options = {};//see T243839

--- a/testing/tests/DevExpress.viz.core.series/pieSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/pieSeries.tests.js
@@ -56,6 +56,7 @@ var createPoint = function(series, data) {
     var stub = sinon.createStubInstance(pointModule.Point);
     stub.argument = 1;
     stub.hasValue.returns(true);
+    stub.hasCoords.returns(true);
     stub.isInVisibleArea.returns(true);
     stub.coordsIn.resetBehavior();
     stub._label = sinon.createStubInstance(labelModule.Label);

--- a/testing/tests/DevExpress.viz.core.series/rangeDataCalculator.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/rangeDataCalculator.tests.js
@@ -2500,3 +2500,103 @@ QUnit.test("Discrete data", function(assert) {
     assert.equal(rangeData.min, undefined, "min Y");
     assert.equal(rangeData.max, undefined, "max Y");
 });
+
+QUnit.module("Get points in viewport", {
+    beforeEach: function() {
+        var argumentViewPort,
+            valueViewPort;
+        this.zoomArgument = function(min, max) {
+            argumentViewPort = { min: min, max: max };
+        };
+        this.zoomValue = function(min, max) {
+            valueViewPort = { min: min, max: max };
+        };
+        this.argumentAxis = {
+            getViewport: function() {
+                return argumentViewPort;
+            }
+        };
+        this.valueAxis = {
+            getViewport: function() {
+                return valueViewPort;
+            }
+        };
+    }
+});
+
+QUnit.test("Simple series with zoom. Do not include value of edge points if they out of the valueAxis range", function(assert) {
+    var data = [
+            { arg: 1, val: 10 },
+            { arg: 2, val: 20 },
+            { arg: 3, val: 30 },
+            { arg: 4, val: 40 },
+            { arg: 5, val: 50 },
+            { arg: 6, val: 80 },
+            { arg: 7, val: 70 }
+        ],
+        series = createSeries({ type: "line", argumentAxisType: "continuous" }, { argumentAxis: this.argumentAxis, valueAxis: this.valueAxis });
+
+    series.updateData(data);
+
+    this.zoomArgument(2, 5.5);
+    this.zoomValue(35, 70);
+
+    assert.deepEqual(series.getPointsInViewPort(), [40, 50, 35, 70]);
+});
+
+QUnit.test("Include value of edge points that out of argument viewport but they are in valueAxis viewport", function(assert) {
+    var data = [
+            { arg: 1, val: 10 },
+            { arg: 2, val: 44 },
+            { arg: 3, val: 30 },
+            { arg: 4, val: 40 },
+            { arg: 5, val: 50 },
+            { arg: 6, val: 60 },
+            { arg: 7, val: 70 }
+        ],
+        series = createSeries({ type: "line", argumentAxisType: "continuous" }, { argumentAxis: this.argumentAxis, valueAxis: this.valueAxis });
+
+    series.updateData(data);
+
+    this.zoomArgument(2.5, 5.5);
+    this.zoomValue(25, 70);
+
+    assert.deepEqual(series.getPointsInViewPort(), [44, 30, 40, 50, 60, 25, 70]);
+});
+
+QUnit.test("Simple series without zoom", function(assert) {
+    var data = [
+        { arg: 1, val: 10 },
+        { arg: 2, val: 20 },
+        { arg: 3, val: 30 },
+        { arg: 4, val: 40 },
+        { arg: 5, val: 50 },
+        { arg: 6, val: 60 },
+        { arg: 7, val: 70 }
+        ],
+        series = createSeries({ type: "line", argumentAxisType: "continuous" }, { argumentAxis: this.argumentAxis, valueAxis: this.valueAxis });
+
+    series.updateData(data);
+
+    assert.deepEqual(series.getPointsInViewPort(), [10, 20, 30, 40, 50, 60, 70]);
+});
+
+QUnit.test("Range series", function(assert) {
+    var data = [
+            { arg: 1, val1: 10, val2: 25 },
+            { arg: 2, val1: 20, val2: 35 },
+            { arg: 3, val1: 30, val2: 45 },
+            { arg: 4, val1: 40, val2: 55 },
+            { arg: 5, val1: 50, val2: 65 },
+            { arg: 6, val1: 60, val2: 75 },
+            { arg: 7, val1: 70, val2: 85 }
+        ],
+        series = createSeries({ type: "rangebar", argumentAxisType: "continuous" }, { argumentAxis: this.argumentAxis, valueAxis: this.valueAxis });
+
+    series.updateData(data);
+
+    this.zoomArgument(2, 5.5);
+    this.zoomValue(25, 55);
+
+    assert.deepEqual(series.getPointsInViewPort(), [25, 35, 30, 45, 40, 55, 50, 25, 55]);
+});

--- a/testing/tests/DevExpress.viz.core.series/rangePoint.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/rangePoint.tests.js
@@ -135,6 +135,111 @@ QUnit.test("Width and height, not rotated", function(assert) {
     assert.equal(pt.minY, 600);
 });
 
+QUnit.test("getCoords returns false if minValue coord is null", function(assert) {
+    this.continuousTranslators.val = new MockTranslator({
+        translate: { 1: null, 5: 10 }
+    });
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(!pt.hasCoords());
+});
+
+QUnit.test("getCoords returns false if minValue coord is null, rotated", function(assert) {
+    this.opt.rotated = true;
+
+    this.continuousTranslators.val = new MockTranslator({
+        translate: { 1: null, 5: 10 }
+    });
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(!pt.hasCoords());
+});
+
+QUnit.test("getCoords returns false if value coord is null", function(assert) {
+    this.continuousTranslators.val = new MockTranslator({
+        translate: { 1: 1, 5: null }
+    });
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(!pt.hasCoords());
+});
+
+QUnit.test("getCoords returns true if point has argument, value and min value coords", function(assert) {
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(pt.hasCoords());
+});
+
+QUnit.test("RangeBar. getCoords returns false if minValue coord is null", function(assert) {
+    this.opt.type = "rangebar";
+
+    this.continuousTranslators.val = new MockTranslator({
+        translate: { 1: null, 5: 10 },
+        getCanvasVisibleArea: { min: 8, max: 600 }
+    });
+
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(!pt.hasCoords());
+});
+
+QUnit.test("RangeBar. getCoords returns false if minValue coord is null, rotated", function(assert) {
+    this.opt.rotated = true;
+    this.opt.type = "rangebar";
+
+    this.continuousTranslators.val = new MockTranslator({
+        translate: { 1: null, 5: 10 }
+    });
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(!pt.hasCoords());
+});
+
+QUnit.test("RangeBar. getCoords returns false if argument coord is null", function(assert) {
+    this.opt.type = "rangebar";
+    this.continuousTranslators.arg = new MockTranslator({
+        translate: { 1: null }
+    });
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(!pt.hasCoords());
+});
+
+QUnit.test("RangeBar. getCoords returns false if value coord is null", function(assert) {
+    this.opt.type = "rangebar";
+    this.continuousTranslators.val = new MockTranslator({
+        translate: { 1: 1, 5: null }
+    });
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(!pt.hasCoords());
+});
+
+QUnit.test("RangeBar. getCoords returns true if point has argument, value and minValue coords", function(assert) {
+    this.opt.type = "rangebar";
+    var pt = createPoint(this.series, { argument: 1, value: 5, minValue: 1 }, this.opt);
+
+    pt.translate();
+
+    assert.ok(pt.hasCoords());
+});
+
 QUnit.test("getCrosshair data", function(assert) {
     this.series.axis = "valueAxisName";
     var pt = createPoint(this.series, { argument: 1, value: 5, minValue: "default" }, this.opt);
@@ -2463,7 +2568,6 @@ QUnit.test("Point is out of boundaries on the left", function(assert) {
     assert.strictEqual(pt.minY, 290, "minY");
     assert.strictEqual(pt.height, 40, "height");
     assert.strictEqual(pt.x, 0, "x");
-    assert.strictEqual(pt.minX, 0, "minX");
     assert.strictEqual(pt.width, 50, "width");
 });
 
@@ -2478,7 +2582,6 @@ QUnit.test("Point is partially out of boundaries on the left and bottom", functi
     assert.strictEqual(pt.minY, 300, "minY");
     assert.strictEqual(pt.height, 75, "height");
     assert.strictEqual(pt.x, 100, "x");
-    assert.strictEqual(pt.minX, 100, "minX");
     assert.strictEqual(pt.width, 30, "width");
 });
 
@@ -2493,7 +2596,6 @@ QUnit.test("Point is partially out of boundaries at the top and bottom", functio
     assert.strictEqual(pt.minY, 300, "minY");
     assert.strictEqual(pt.height, 100, "height");
     assert.strictEqual(pt.x, 200, "x");
-    assert.strictEqual(pt.minX, 200, "minX");
     assert.strictEqual(pt.width, 50, "width");
 });
 
@@ -2508,7 +2610,6 @@ QUnit.test("Point is partially out of boundaries at the bottom", function(assert
     assert.strictEqual(pt.minY, 300, "minY");
     assert.strictEqual(pt.height, 50, "height");
     assert.strictEqual(pt.x, 300, "x");
-    assert.strictEqual(pt.minX, 300, "minX");
     assert.strictEqual(pt.width, 50, "width");
 });
 
@@ -2523,7 +2624,6 @@ QUnit.test("Point is partially out of boundaries at the top", function(assert) {
     assert.strictEqual(pt.minY, 250, "minY");
     assert.strictEqual(pt.height, 50, "height");
     assert.strictEqual(pt.x, 400, "x");
-    assert.strictEqual(pt.minX, 400, "minX");
     assert.strictEqual(pt.width, 50, "width");
 });
 
@@ -2538,7 +2638,6 @@ QUnit.test("Point is partially out of boundaries on the right", function(assert)
     assert.strictEqual(pt.minY, 290, "minY");
     assert.strictEqual(pt.height, 65, "height");
     assert.strictEqual(pt.x, 480, "x");
-    assert.strictEqual(pt.minX, 480, "minX");
     assert.strictEqual(pt.width, 20, "width");
 });
 
@@ -2553,7 +2652,6 @@ QUnit.test("Point is out of boundaries on the right", function(assert) {
     assert.strictEqual(pt.minY, 300, "minY");
     assert.strictEqual(pt.height, 75, "height");
     assert.strictEqual(pt.x, 600, "x");
-    assert.strictEqual(pt.minX, 600, "minX");
     assert.strictEqual(pt.width, 50, "width");
 });
 
@@ -2601,7 +2699,6 @@ QUnit.test("Point is out of boundaries on the left", function(assert) {
 
     assert.strictEqual(pt.inVisibleArea, false, "inVisibleArea");
     assert.strictEqual(pt.y, 0, "y");
-    assert.strictEqual(pt.minY, 0, "minY");
     assert.strictEqual(pt.height, 50, "height");
     assert.strictEqual(pt.x, 250, "x");
     assert.strictEqual(pt.minX, 290, "minX");
@@ -2616,7 +2713,6 @@ QUnit.test("Point is partially out of boundaries on the left and bottom", functi
 
     assert.strictEqual(pt.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(pt.y, 100, "y");
-    assert.strictEqual(pt.minY, 100, "minY");
     assert.strictEqual(pt.height, 30, "height");
     assert.strictEqual(pt.x, 225, "x");
     assert.strictEqual(pt.minX, 300, "minX");
@@ -2631,7 +2727,6 @@ QUnit.test("Point is partially out of boundaries at the top and bottom", functio
 
     assert.strictEqual(pt.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(pt.y, 200, "y");
-    assert.strictEqual(pt.minY, 200, "minY");
     assert.strictEqual(pt.height, 50, "height");
     assert.strictEqual(pt.x, 200, "x");
     assert.strictEqual(pt.minX, 300, "minX");
@@ -2646,7 +2741,6 @@ QUnit.test("Point is partially out of boundaries at the bottom", function(assert
 
     assert.strictEqual(pt.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(pt.y, 300, "y");
-    assert.strictEqual(pt.minY, 300, "minY");
     assert.strictEqual(pt.height, 50, "height");
     assert.strictEqual(pt.x, 250, "x");
     assert.strictEqual(pt.minX, 300, "minX");
@@ -2661,7 +2755,6 @@ QUnit.test("Point is partially out of boundaries at the top", function(assert) {
 
     assert.strictEqual(pt.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(pt.y, 400, "y");
-    assert.strictEqual(pt.minY, 400, "minY");
     assert.strictEqual(pt.height, 50, "height");
     assert.strictEqual(pt.x, 200, "x");
     assert.strictEqual(pt.minX, 250, "minX");
@@ -2676,7 +2769,6 @@ QUnit.test("Point is partially out of boundaries on the right", function(assert)
 
     assert.strictEqual(pt.inVisibleArea, true, "inVisibleArea");
     assert.strictEqual(pt.y, 480, "y");
-    assert.strictEqual(pt.minY, 480, "minY");
     assert.strictEqual(pt.height, 20, "height");
     assert.strictEqual(pt.x, 225, "x");
     assert.strictEqual(pt.minX, 290, "minX");
@@ -2691,7 +2783,6 @@ QUnit.test("Point is out of boundaries on the right", function(assert) {
 
     assert.strictEqual(pt.inVisibleArea, false, "inVisibleArea");
     assert.strictEqual(pt.y, 600, "y");
-    assert.strictEqual(pt.minY, 600, "minY");
     assert.strictEqual(pt.height, 50, "height");
     assert.strictEqual(pt.x, 225, "x");
     assert.strictEqual(pt.minX, 300, "minX");

--- a/testing/tests/DevExpress.viz.core.series/scatterSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/scatterSeries.tests.js
@@ -59,6 +59,7 @@ var createPoint = function() {
     var stub = sinon.createStubInstance(pointModule.Point);
     stub.argument = 1;
     stub.hasValue.returns(true);
+    stub.hasCoords.returns(true);
     stub.isInVisibleArea.returns(true);
     stub._label = sinon.createStubInstance(labelModule.Label);
     return stub;

--- a/testing/tests/DevExpress.viz.core.series/symbolPoint.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/symbolPoint.tests.js
@@ -954,6 +954,36 @@ QUnit.test("TriangleDown", function(assert) {
     assert.deepEqual(point.graphic.data.lastCall.args, [{ 'chart-data-point': point }]);
 });
 
+QUnit.test("hasCoords returns true if point has x and y", function(assert) {
+    var point = createPoint(this.series, { argument: 1, value: 1 }, this.options);
+
+    point.translate();
+
+    assert.ok(point.hasCoords());
+});
+
+QUnit.test("hasCoords returns false if point doesn't have y", function(assert) {
+    this.translators.val = new MockTranslator({
+        translate: { 1: null }
+    });
+    var point = createPoint(this.series, { argument: 1, value: 1 }, this.options);
+
+    point.translate();
+
+    assert.ok(!point.hasCoords());
+});
+
+QUnit.test("hasCoords returns false if point doesn't have x", function(assert) {
+    this.translators.arg = new MockTranslator({
+        translate: { 1: null }
+    });
+    var point = createPoint(this.series, { argument: 1, value: 1 }, this.options);
+
+    point.translate();
+
+    assert.ok(!point.hasCoords());
+});
+
 QUnit.test("TriangleUp", function(assert) {
     this.options.symbol = "triangleUp";
     var point = createPoint(this.series, { argument: 1, value: 1 }, this.options);

--- a/testing/tests/DevExpress.viz.core/axesTicksGeneration.tests.js
+++ b/testing/tests/DevExpress.viz.core/axesTicksGeneration.tests.js
@@ -2128,7 +2128,7 @@ QUnit.test("Do not tune day off scale break", function(assert) {
         tickInterval: { days: 1 },
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5]
+        workWeek: [1, 2, 3, 4, 5]
     });
 
     this.axis.setBusinessRange({ minVisible: new Date(2017, 8, 13), maxVisible: new Date(2017, 8, 20), addRange: function() { return this; } });
@@ -2150,7 +2150,7 @@ QUnit.test("Do not remove day off scale break if it less than tickInterval", fun
         tickInterval: { weeks: 1 },
         breakStyle: { width: 0 },
         workdaysOnly: true,
-        workweek: [1, 2, 3, 4, 5]
+        workWeek: [1, 2, 3, 4, 5]
     });
 
     this.axis.setBusinessRange({ minVisible: new Date(2017, 8, 13), maxVisible: new Date(2017, 9, 20), addRange: function() { return this; } });
@@ -2192,7 +2192,7 @@ QUnit.test("Move datetime ticks to work day", function(assert) {
         breakStyle: { width: 0 },
         tickInterval: { hours: 14 },
         workdaysOnly: true,
-        workweek: [1, 2, 3, 4, 5]
+        workWeek: [1, 2, 3, 4, 5]
     });
 
     this.axis.setBusinessRange({ minVisible: new Date(2017, 8, 15), maxVisible: new Date(2017, 8, 19), addRange: function() { return this; } });
@@ -2216,7 +2216,7 @@ QUnit.test("Move datetime ticks to work day. Tick interval data - move tick to s
         breakStyle: { width: 0 },
         tickInterval: { days: 1 },
         workdaysOnly: true,
-        workweek: [1, 2, 3, 4, 5]
+        workWeek: [1, 2, 3, 4, 5]
     });
 
     this.axis.setBusinessRange({ minVisible: new Date(2017, 8, 15), maxVisible: new Date(2017, 8, 19), addRange: function() { return this; } });
@@ -2239,7 +2239,7 @@ QUnit.test("Do not move datetime ticks to work day if work day has tick", functi
         breakStyle: { width: 0 },
         tickInterval: { days: 2 },
         workdaysOnly: true,
-        workweek: [1, 2, 3, 4, 5]
+        workWeek: [1, 2, 3, 4, 5]
     });
 
     this.axis.setBusinessRange({ minVisible: new Date(2017, 8, 16), maxVisible: new Date(2017, 8, 22), addRange: function() { return this; } });

--- a/testing/tests/DevExpress.viz.core/axisDrawing.tests.js
+++ b/testing/tests/DevExpress.viz.core/axisDrawing.tests.js
@@ -8957,7 +8957,7 @@ QUnit.test("Datetime. Drawing user breaks with generated workday breaks. Should 
         containerColor: "#ffffff",
         workdaysOnly: true,
         argumentType: "datetime",
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         breaks: [[new Date(2017, 10, 7), new Date(2017, 10, 8) ]],
         breakStyle: {
             color: "black",

--- a/testing/tests/DevExpress.viz.core/axisDrawing.tests.js
+++ b/testing/tests/DevExpress.viz.core/axisDrawing.tests.js
@@ -52,7 +52,8 @@ var environment = {
                 return {
                     ticks: that.generatedTicks || [],
                     minorTicks: that.generatedMinorTicks || [],
-                    tickInterval: that.generatedTickInterval
+                    tickInterval: that.generatedTickInterval,
+                    breaks: arguments[7]
                 };
             };
         });
@@ -66,7 +67,8 @@ var environment = {
             labelAxesGroup = this.renderer.g(),
             constantLinesGroup = this.renderer.g(),
             axesContainerGroup = this.renderer.g(),
-            gridGroup = this.renderer.g();
+            gridGroup = this.renderer.g(),
+            scaleBreaksGroup = this.renderer.g();
 
         this.renderer.g.reset();
 
@@ -76,11 +78,28 @@ var environment = {
             labelAxesGroup: labelAxesGroup,
             constantLinesGroup: constantLinesGroup,
             axesContainerGroup: axesContainerGroup,
+            scaleBreaksGroup: scaleBreaksGroup,
             gridGroup: gridGroup,
             axisType: "xyAxes",
             drawingType: "linear",
             isArgumentAxis: true
         }, options));
+    },
+    createAxisWithBreaks: function(options, group) {
+        var scaleBreaksGroup = this.renderer.g();
+        this.createAxis({ scaleBreaksGroup: group || scaleBreaksGroup });
+        this.updateOptions($.extend({
+            isHorizontal: false,
+            containerColor: "#ffffff",
+            breaks: [[10, 20]],
+            breakStyle: {
+                color: "black",
+                line: "waved",
+                width: 10
+            }
+        }, options));
+        this.axis.setBusinessRange({ min: 0, max: 30 });
+        this.axis.draw(this.zeroMarginCanvas);
     },
     afterEach: function() {
         translator2DModule.Translator2D.restore();
@@ -8642,4 +8661,315 @@ QUnit.test("Update strip labels coords", function(assert) {
 
     assert.deepEqual(renderer.text.getCall(0).returnValue.attr.lastCall.args, [{ x: 20 + 10, y: 30 }]);
     assert.deepEqual(renderer.text.getCall(1).returnValue.attr.lastCall.args, [{ x: 60 + 15, y: 30 }]);
+});
+
+
+QUnit.module("Scale breaks drawing", $.extend({}, environment, {
+    beforeEach: function() {
+        environment.beforeEach.call(this);
+        this.renderer.linePattern = sinon.stub().returns({ id: "scaleBreak_id", size: 6, dispose: sinon.stub() });
+    }
+}));
+
+QUnit.test("Drawing scale breaks for value axis", function(assert) {
+    //arrange
+    var scaleBreaksGroup = this.renderer.g();
+    this.createAxisWithBreaks({}, scaleBreaksGroup);
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.ok(this.renderer.linePattern.called);
+    assert.deepEqual(this.renderer.linePattern.lastCall.args[0], {
+        borderColor: "black",
+        canvasLength: 80,
+        color: "#ffffff",
+        isHorizontal: false,
+        isWaved: true,
+        size: 10
+    }, "pattern was created");
+
+    assert.equal(this.renderer.rect.callCount, 1);
+    assert.ok(scaleBreaksGroup.clear.called);
+    assert.deepEqual(this.renderer.rect.lastCall.args, [10, 20, 80, 6]);
+    assert.deepEqual(this.renderer.rect.lastCall.returnValue.attr.args[0][0], { fill: "scaleBreak_id" });
+    assert.equal(this.renderer.rect.lastCall.returnValue.append.args[0][0], scaleBreaksGroup);
+});
+
+QUnit.test("Drawing scale breaks using drawScaleBreaks method", function(assert) {
+    //arrange
+    var scaleBreaksGroup = this.renderer.g();
+    this.createAxisWithBreaks({}, scaleBreaksGroup);
+
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+    this.axis.draw(this.canvas);
+
+    //act
+    this.axis.drawScaleBreaks();
+    //assert
+    assert.ok(this.renderer.linePattern.called);
+    assert.deepEqual(this.renderer.linePattern.lastCall.args[0], {
+        borderColor: "black",
+        canvasLength: 80,
+        color: "#ffffff",
+        isHorizontal: false,
+        isWaved: true,
+        size: 10
+    }, "pattern was created");
+
+    assert.equal(this.renderer.rect.callCount, 1);
+    assert.deepEqual(this.renderer.rect.lastCall.args, [10, 20, 80, 6]);
+    assert.deepEqual(this.renderer.rect.lastCall.returnValue.attr.args[0][0], { fill: "scaleBreak_id" });
+    assert.equal(this.renderer.rect.lastCall.returnValue.append.args[0][0], scaleBreaksGroup);
+});
+
+QUnit.test("Drawing scale with custom canvas", function(assert) {
+    //arrange
+    var scaleBreaksGroup = this.renderer.g();
+    this.createAxisWithBreaks({}, scaleBreaksGroup);
+
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+    this.axis.draw(this.canvas);
+
+    //act
+    this.axis.drawScaleBreaks({
+        start: 30,
+        end: 90
+    });
+    //assert
+    assert.ok(this.renderer.linePattern.called);
+    assert.deepEqual(this.renderer.linePattern.lastCall.args[0], {
+        borderColor: "black",
+        canvasLength: 60,
+        color: "#ffffff",
+        isHorizontal: false,
+        isWaved: true,
+        size: 10
+    }, "pattern was created");
+
+    assert.equal(this.renderer.rect.callCount, 1);
+    assert.deepEqual(this.renderer.rect.lastCall.args, [30, 20, 60, 6]);
+    assert.deepEqual(this.renderer.rect.lastCall.returnValue.attr.args[0][0], { fill: "scaleBreak_id" });
+    assert.equal(this.renderer.rect.lastCall.returnValue.append.args[0][0], scaleBreaksGroup);
+});
+
+QUnit.test("Drawing scale breaks for value axis, chart is rotated", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({ isHorizontal: true });
+    this.translator.stub("isInverted").returns(false);
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.deepEqual(this.renderer.rect.lastCall.args, [12, 30, 6, 40]);
+});
+
+QUnit.test("Drawing scale breaks for value axis, axis is visible, position is left", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({
+        visible: true,
+        position: "left"
+    });
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.deepEqual(this.renderer.rect.lastCall.args, [7, 20, 83, 6]);
+});
+
+QUnit.test("Drawing scale breaks for value axis, axis is visible, position is right", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({
+        visible: true,
+        position: "right"
+    });
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.deepEqual(this.renderer.rect.lastCall.args, [10, 20, 83, 6]);
+});
+
+QUnit.test("Drawing scale breaks for value axis, chart is rotated, axis is visible, position is top", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({
+        isHorizontal: true,
+        visible: true,
+        position: "top"
+    });
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(false);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.deepEqual(this.renderer.rect.lastCall.args, [12, 27, 6, 43]);
+});
+
+QUnit.test("Drawing scale breaks for value axis, chart is rotated, axis is visible, position is bottom", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({
+        isHorizontal: true,
+        visible: true,
+        position: "bottom"
+    });
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(false);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.deepEqual(this.renderer.rect.lastCall.args, [12, 30, 6, 43]);
+});
+
+QUnit.test("The scale break shouldn't created without breaks", function(assert) {
+    //arrange
+    this.createAxis();
+    this.updateOptions({
+        isHorizontal: false,
+        breakStyle: {
+            color: "black",
+            line: "waved",
+            width: 10
+        }
+    });
+    this.axis.setBusinessRange({ min: 0, max: 30 });
+    this.axis.draw(this.zeroMarginCanvas);
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.ok(!this.renderer.linePattern.called);
+    assert.ok(!this.renderer.rect.called);
+});
+
+QUnit.test("The scale break shouldn't created if break is out of the range", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({
+        breaks: [[50, 60]]
+    });
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.ok(!this.renderer.linePattern.called);
+    assert.ok(!this.renderer.rect.called);
+});
+
+QUnit.test("Style 'straight' of the scale break", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({
+        breakStyle: {
+            line: "straight"
+        }
+    });
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.ok(this.renderer.linePattern.called);
+    assert.deepEqual(this.renderer.linePattern.lastCall.args[0].isWaved, false);
+});
+
+QUnit.test("Style 'straight' set with upper case", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({
+        breakStyle: {
+            line: "StraIght"
+        }
+    });
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.ok(this.renderer.linePattern.called);
+    assert.deepEqual(this.renderer.linePattern.lastCall.args[0].isWaved, false);
+});
+
+QUnit.test("Invalid style, 'waved' style should be by default", function(assert) {
+    //arrange
+    this.createAxisWithBreaks({
+        breakStyle: {
+            line: "style"
+        }
+    });
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.ok(this.renderer.linePattern.called);
+    assert.deepEqual(this.renderer.linePattern.lastCall.args[0].isWaved, true);
+});
+
+QUnit.test("Creation breaks several times, breaks should be disposed", function(assert) {
+    //arrange
+    this.createAxisWithBreaks();
+
+    //act
+    this.translator.stub("translate").withArgs(20).returns(20);
+    this.translator.stub("isInverted").returns(true);
+
+    this.axis.updateSize(this.canvas);
+    this.axis.updateSize(this.canvas);
+    this.axis.updateSize(this.canvas);
+    this.axis.updateSize(this.canvas);
+
+    //assert
+    assert.ok(this.renderer.linePattern.returnValues[0].dispose.called);
+    assert.ok(this.renderer.linePattern.returnValues[1].dispose.called);
+    assert.ok(this.renderer.linePattern.returnValues[2].dispose.called);
+    assert.ok(this.renderer.linePattern.returnValues[3].dispose.called);
+});
+
+QUnit.test("Datetime. Drawing user breaks with generated workday breaks. Should drawn only user scale break", function(assert) {
+    this.createAxis({ scaleBreaksGroup: this.renderer.g() });
+    this.updateOptions({
+        isHorizontal: false,
+        isArgumentAxis: true,
+        containerColor: "#ffffff",
+        workdaysOnly: true,
+        argumentType: "datetime",
+        workweek: [1, 2, 3, 4, 5],
+        breaks: [[new Date(2017, 10, 7), new Date(2017, 10, 8) ]],
+        breakStyle: {
+            color: "black",
+            line: "waved",
+            width: 10
+        }
+    });
+    this.axis.setBusinessRange({ min: new Date(2017, 10, 6), max: new Date(2017, 10, 15) });
+    this.axis.draw(this.zeroMarginCanvas);
+
+    //act
+    this.axis.updateSize(this.canvas);
+
+    assert.equal(this.renderer.rect.callCount, 1);
 });

--- a/testing/tests/DevExpress.viz.core/baseAxis.tests.js
+++ b/testing/tests/DevExpress.viz.core/baseAxis.tests.js
@@ -2269,7 +2269,7 @@ QUnit.test("Generate weekend breaks", function(assert) {
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 10 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime"
     });
 
@@ -2293,7 +2293,7 @@ QUnit.test("Do not generate weekend breaks if dataType is not datetime", functio
     this.updateOptions({
         workdaysOnly: false,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "number"
     });
 
@@ -2310,7 +2310,7 @@ QUnit.test("Do not generate weekend breaks if workdaysOnly is set to false", fun
     this.updateOptions({
         workdaysOnly: false,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime"
     });
 
@@ -2327,7 +2327,7 @@ QUnit.test("Do not generate weekend breaks if axis type is discrete", function(a
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         type: "discrete"
     });
@@ -2345,7 +2345,7 @@ QUnit.test("Generate two breaks when two days off on week", function(assert) {
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 4, 5],
+        workWeek: [1, 2, 4, 5],
         dataType: "datetime"
     });
 
@@ -2379,7 +2379,7 @@ QUnit.test("The break starts with min if the range starts on a weekend", functio
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime"
     });
 
@@ -2414,7 +2414,7 @@ QUnit.test("End of the scale break is max of the range if range ends on a weeken
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime"
     });
 
@@ -2442,7 +2442,7 @@ QUnit.test("All range is in weekend", function(assert) {
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime"
     });
 
@@ -2459,7 +2459,7 @@ QUnit.test("Exclude exactWorkDays from weekend when it at the end of the weekend
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         singleWorkdays: [new Date(2017, 8, 10, 8, 20)]
     });
@@ -2482,7 +2482,7 @@ QUnit.test("Exclude exactWorkDays from weekend when it at the begin of the weeke
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         singleWorkdays: [new Date(2017, 8, 9, 8, 20)]
     });
@@ -2505,7 +2505,7 @@ QUnit.test("Separate a weekend if exactWorkDays in the middle of the break", fun
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [2, 3, 4, 5],
+        workWeek: [2, 3, 4, 5],
         dataType: "datetime",
         singleWorkdays: [new Date(2017, 8, 10, 8, 20)]
     });
@@ -2526,7 +2526,7 @@ QUnit.test("Axis has not breaks if exactWorkDays in the weekend", function(asser
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         singleWorkdays: [new Date(2017, 8, 9, 8, 20), new Date(2017, 8, 10, 8, 20)]
     });
@@ -2544,7 +2544,7 @@ QUnit.test("Generate breaks for holidays", function(assert) {
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [0, 1, 2, 3, 4, 5, 6],
+        workWeek: [0, 1, 2, 3, 4, 5, 6],
         dataType: "datetime",
         holidays: [new Date(2017, 8, 10, 8, 20)]
     });
@@ -2567,7 +2567,7 @@ QUnit.test("The break starts with min range if holiday starts early then min", f
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [0, 1, 2, 3, 4, 5, 6],
+        workWeek: [0, 1, 2, 3, 4, 5, 6],
         dataType: "datetime",
         holidays: [new Date(2017, 8, 6, 6, 20)]
     });
@@ -2592,7 +2592,7 @@ QUnit.test("The break ends with max range if holiday ends later then max", funct
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [0, 1, 2, 3, 4, 5, 6],
+        workWeek: [0, 1, 2, 3, 4, 5, 6],
         dataType: "datetime",
         holidays: [new Date(2017, 8, 13, 6, 20)]
     });
@@ -2617,7 +2617,7 @@ QUnit.test("Do not generate the breaks for holiday if it in the weekend", functi
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         holidays: [new Date(2017, 8, 10, 8, 20)]
     });
@@ -2642,7 +2642,7 @@ QUnit.test("sort generated breaks", function(assert) {
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         holidays: [new Date(2017, 8, 6)]
     });
@@ -2677,7 +2677,7 @@ QUnit.test("Recalculate the breaks on zoom", function(assert) {
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 5],
+        workWeek: [1, 2, 3, 5],
         dataType: "datetime"
     });
 
@@ -2707,7 +2707,7 @@ QUnit.test("Correct generation of the breaks if workdays set with uppercase", fu
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime"
     });
 
@@ -2731,7 +2731,7 @@ QUnit.test("Correct generation of the breaks if holidays set with string", funct
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [0, 1, 2, 3, 4, 5, 6],
+        workWeek: [0, 1, 2, 3, 4, 5, 6],
         dataType: "datetime",
         holidays: ['September 11, 2017']
     });
@@ -2756,7 +2756,7 @@ QUnit.test("Correct generation of the breaks if exactWorkdays set with string", 
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         singleWorkdays: ['September 10, 2017']
     });
@@ -2781,7 +2781,7 @@ QUnit.test("Concatenate generated breaks with user breaks", function(assert) {
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 0 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         breaks: [[ new Date(2017, 8, 12), new Date(2017, 8, 13)]]
     });
@@ -2812,7 +2812,7 @@ QUnit.test("Merge generated breaks with user breaks", function(assert) {
     this.updateOptions({
         workdaysOnly: true,
         breakStyle: { width: 10 },
-        workweek: [1, 2, 3, 4, 5],
+        workWeek: [1, 2, 3, 4, 5],
         dataType: "datetime",
         breaks: [[new Date(2017, 8, 10), new Date(2017, 8, 13)]]
     });

--- a/testing/tests/DevExpress.viz.core/baseAxis.tests.js
+++ b/testing/tests/DevExpress.viz.core/baseAxis.tests.js
@@ -65,14 +65,11 @@ function Axis(settings) {
 Axis.prototype = $.extend({}, originalAxis.prototype, {
     _setType: noop,
 
-    _getScreenDelta: sinon.stub().returns(300),
     _getMinMax: sinon.stub().returns({ min: 0, max: 100 }),
     _getStick: sinon.stub().returns(true),
     _getSpiderCategoryOption: sinon.stub().returns(false),
 
     _getTranslatedValue: sinon.stub().returns({ x: "x", y: "y" }),
-
-    _getCanvasStartEnd: sinon.stub().returns({ }),
 
     _boundaryTicksVisibility: { min: true, max: true },
 
@@ -921,6 +918,15 @@ QUnit.module("Data margins calculations", {
         });
 
         environment.beforeEach.call(this);
+
+        this.canvas = {
+            top: 200,
+            bottom: 200,
+            left: 200,
+            right: 200,
+            width: 700,
+            height: 400
+        };
     },
     afterEach: function() {
         translator2DModule.Translator2D.restore();
@@ -961,19 +967,19 @@ QUnit.module("Data margins calculations", {
 
         axis.createTicks(this.canvas);
 
-        assert.strictEqual(this.translator.stub("updateBusinessRange").callCount, 1);
+        assert.strictEqual(this.translator.stub("updateBusinessRange").callCount, 1, "update range call count");
 
         var range = this.translator.stub("updateBusinessRange").lastCall.args[0],
             value = data.options.dataType === "datetime" ?
                 function(v) { return v.getTime(); } :
                 function(v) { return v; };
 
-        assert.equal(value(range.min), value(data.expectedRange.min));
-        assert.equal(value(range.max), value(data.expectedRange.max));
-        assert.equal(value(range.minVisible), value(data.expectedRange.minVisible));
-        assert.equal(value(range.maxVisible), value(data.expectedRange.maxVisible));
-        "interval" in data.expectedRange && assert.equal(range.interval, data.expectedRange.interval);
-        "categories" in data.expectedRange && assert.deepEqual(range.categories, data.expectedRange.categories);
+        assert.equal(value(range.min), value(data.expectedRange.min), "min value");
+        assert.equal(value(range.max), value(data.expectedRange.max), "max value");
+        assert.equal(value(range.minVisible), value(data.expectedRange.minVisible), "minVisible value");
+        assert.equal(value(range.maxVisible), value(data.expectedRange.maxVisible), "maxVisible value");
+        "interval" in data.expectedRange && assert.equal(range.interval, data.expectedRange.interval, "interval");
+        "categories" in data.expectedRange && assert.deepEqual(range.categories, data.expectedRange.categories, "categorties");
     }
 });
 
@@ -1702,10 +1708,16 @@ QUnit.test("updateSize - margins and interval are recalculated", function(assert
     });
 
     axis.draw(this.canvas);
-    axis._getScreenDelta = sinon.stub().returns(500);
     this.translator.stub("updateBusinessRange").reset();
 
-    axis.updateSize(this.canvas);
+    axis.updateSize({
+        top: 200,
+        bottom: 200,
+        left: 200,
+        right: 200,
+        width: 900,
+        height: 400
+    });
 
     assert.strictEqual(this.translator.stub("updateBusinessRange").callCount, 1);
 
@@ -1741,6 +1753,50 @@ QUnit.test("Margins and skipViewportExtending = true - do not extend range with 
     });
 });
 
+QUnit.test("Apply margins taking into account breakStyle.width", function(assert) {
+    var axis = this.createAxis(false, {
+        valueMarginsEnabled: true,
+        breakStyle: { width: 50 },
+        breaks: [[100, 900]]
+    });
+
+    axis.setBusinessRange({
+        min: 50,
+        max: 1000
+    });
+    axis.setMarginOptions({ size: 100 });
+
+    axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[0], {
+        min: 0,
+        max: 1050,
+        categories: undefined
+    });
+});
+
+QUnit.test("Apply margins taking into account breaks range size", function(assert) {
+    var axis = this.createAxis(true, {
+        valueMarginsEnabled: true,
+        minValueMargin: 0.1,
+        maxValueMargin: 0.2,
+        breakStyle: { width: 0 },
+        breaks: [[110, 190]]
+    });
+
+    axis.setBusinessRange({
+        min: 100,
+        max: 200
+    });
+
+    axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[0], {
+        min: 98,
+        max: 204,
+        categories: undefined
+    });
+});
 
 QUnit.module("Data margins calculations after zooming", {
     beforeEach: function() {
@@ -1750,6 +1806,15 @@ QUnit.module("Data margins calculations after zooming", {
         });
 
         environment.beforeEach.call(this);
+
+        this.canvas = {
+            top: 200,
+            bottom: 200,
+            left: 200,
+            right: 200,
+            width: 700,
+            height: 400
+        };
     },
     afterEach: function() {
         translator2DModule.Translator2D.restore();
@@ -1991,4 +2056,1128 @@ QUnit.test("Value axis, endOnTick = true - extend range to boundary ticks", func
         },
         isArgumentAxis: false
     });
+});
+
+QUnit.module("Scale breaks", $.extend({}, environment, {
+    beforeEach: function() {
+
+        var that = this;
+        environment.beforeEach.call(this);
+
+        sinon.stub(translator2DModule, "Translator2D", function() {
+            return that.translator;
+        });
+
+        this.axis = new Axis({
+            renderer: this.renderer,
+        });
+
+        this.axis.parser = function(value) {
+            return value;
+        };
+    },
+    afterEach: function() {
+        environment.afterEach.call(this);
+        translator2DModule.Translator2D.restore();
+    }
+}));
+
+QUnit.test("Get scale breaks in the viewport", function(assert) {
+    this.updateOptions({
+        dataType: "number",
+        breakStyle: { width: 10 },
+        breaks: [[10, 100], [200, 300], [310, 360], [500, 600]]
+    });
+
+    this.axis.setBusinessRange({ min: 0, max: 1000, addRange: function() { return this; } });
+
+    this.axis.zoom(250, 540);
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [
+        { from: 250, to: 300, cumulativeWidth: 10 },
+        { from: 310, to: 360, cumulativeWidth: 20 },
+        { from: 500, to: 540, cumulativeWidth: 30 }
+    ]);
+});
+
+QUnit.test("Do not get scale break if viewport inside it", function(assert) {
+    this.updateOptions({
+        dataType: "number",
+        breakStyle: { width: 0 },
+        breaks: [[200, 500]]
+    });
+
+    this.axis.setBusinessRange({ min: 0, max: 1000, addRange: function() { return this; } });
+
+    this.axis.zoom(250, 340);
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, []);
+});
+
+QUnit.test("Do not get scale break if multiple value axes", function(assert) {
+    this.updateOptions({
+        dataType: "number",
+        breakStyle: { width: 0 },
+        breaks: [[200, 500]]
+    });
+
+    this.axis.setBusinessRange({ min: 0, max: 1000, addRange: function() { return this; } }, true);
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, []);
+});
+
+QUnit.test("Sorting of the breaks if user set not sorted breaks", function(assert) {
+    this.updateOptions({
+        dataType: "number",
+        breakStyle: { width: 0 },
+        breaks: [[200, 500], [100, 150]]
+    });
+
+    this.axis.setBusinessRange({ min: 0, max: 700, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{
+        from: 100,
+        to: 150,
+        cumulativeWidth: 0
+    }, {
+        from: 200,
+        to: 500,
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Correct the breaks if user set 'from' > 'to'", function(assert) {
+    this.updateOptions({
+        dataType: "number",
+        breakStyle: { width: 0 },
+        breaks: [[150, 100], [500, 200]]
+    });
+
+    this.axis.setBusinessRange({ min: 0, max: 700, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{
+        from: 100,
+        to: 150,
+        cumulativeWidth: 0
+    }, {
+        from: 200,
+        to: 500,
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Filter the breaks if user set them with null and undefined values", function(assert) {
+    this.updateOptions({
+        dataType: "number",
+        breakStyle: { width: 0 },
+        breaks: [
+            [100, null],
+            [null, 150],
+            [200, 500],
+            [null, null],
+            [undefined, undefined],
+            [undefined, 700],
+            [710, undefined]
+        ]
+    });
+
+    this.axis.setBusinessRange({ min: 0, max: 750, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{
+        from: 200,
+        to: 500,
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Merge breaks if they cross each other", function(assert) {
+    this.updateOptions({
+        dataType: "number",
+        breakStyle: { width: 0 },
+        breaks: [
+            [ 50, 100 ],
+            [ 70, 150 ],
+            [ 60, 65 ],
+            [ 150, 160 ]
+        ]
+    });
+    this.axis.setBusinessRange({ min: 0, max: 750, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{
+        from: 50,
+        to: 150,
+        cumulativeWidth: 0
+    },
+    {
+        from: 150,
+        to: 160,
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Merge breaks if they cross each other and last the break more than maxVisible", function(assert) {
+    this.updateOptions({
+        dataType: "number",
+        breakStyle: { width: 0 },
+        breaks: [
+            [50, 100 ],
+            [70, 150 ]
+        ]
+    });
+
+    this.axis.setBusinessRange({ min: 0, max: 140, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{
+        from: 50,
+        to: 140,
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.module("Datetime scale breaks. Weekends and holidays", $.extend({}, environment, {
+    beforeEach: function() {
+        environment.beforeEach.call(this);
+
+        this.axis = new Axis({
+            renderer: this.renderer
+        });
+
+        this.axis.parser = function(value) {
+            return value;
+        };
+    }
+}));
+
+QUnit.test("Generate weekend breaks", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 10 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 11), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 9),
+        to: new Date(2017, 8, 11),
+        gapSize: {
+            days: 2
+        },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Do not generate weekend breaks if dataType is not datetime", function(assert) {
+    this.updateOptions({
+        workdaysOnly: false,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "number"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 11), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, []);
+});
+
+QUnit.test("Do not generate weekend breaks if workdaysOnly is set to false", function(assert) {
+    this.updateOptions({
+        workdaysOnly: false,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 11), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, []);
+});
+
+QUnit.test("Do not generate weekend breaks if axis type is discrete", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        type: "discrete"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 11), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, []);
+});
+
+QUnit.test("Generate two breaks when two days off on week", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 4, 5],
+        dataType: "datetime"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 11), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [
+        {
+            from: new Date(2017, 8, 6),
+            to: new Date(2017, 8, 7),
+            gapSize: {
+                days: 1
+            },
+            cumulativeWidth: 0
+        },
+        {
+            from: new Date(2017, 8, 9),
+            to: new Date(2017, 8, 11),
+            gapSize: {
+                days: 2
+            },
+            cumulativeWidth: 0
+        }
+    ]);
+});
+
+QUnit.test("The break starts with min if the range starts on a weekend", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 3, 8, 20), max: new Date(2017, 8, 11), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [
+        {
+            from: new Date(2017, 8, 3, 8, 20),
+            to: new Date(2017, 8, 4),
+            gapSize: {
+                hours: 15,
+                minutes: 40
+            },
+            cumulativeWidth: 0
+        },
+        {
+            from: new Date(2017, 8, 9),
+            to: new Date(2017, 8, 11),
+            gapSize: {
+                days: 2
+            },
+            cumulativeWidth: 0
+        }
+    ]);
+});
+
+QUnit.test("End of the scale break is max of the range if range ends on a weekend", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4), max: new Date(2017, 8, 10, 8, 20), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [
+        {
+            from: new Date(2017, 8, 9),
+            to: new Date(2017, 8, 10, 8, 20),
+            gapSize: {
+                days: 1,
+                hours: 8,
+                minutes: 20
+            },
+            cumulativeWidth: 0
+        }
+    ]);
+});
+
+QUnit.test("All range is in weekend", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 10), max: new Date(2017, 8, 10, 8, 20), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, []);
+});
+
+QUnit.test("Exclude exactWorkDays from weekend when it at the end of the weekend", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        singleWorkdays: [new Date(2017, 8, 10, 8, 20)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 9),
+        to: new Date(2017, 8, 10),
+        gapSize: { days: 1 },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Exclude exactWorkDays from weekend when it at the begin of the weekend", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        singleWorkdays: [new Date(2017, 8, 9, 8, 20)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 10),
+        to: new Date(2017, 8, 11),
+        gapSize: { days: 1 },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Separate a weekend if exactWorkDays in the middle of the break", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [2, 3, 4, 5],
+        dataType: "datetime",
+        singleWorkdays: [new Date(2017, 8, 10, 8, 20)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 6, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [
+        { from: new Date(2017, 8, 9), to: new Date(2017, 8, 10), gapSize: { days: 1 }, cumulativeWidth: 0 },
+        { from: new Date(2017, 8, 11), to: new Date(2017, 8, 12), gapSize: { days: 1 }, cumulativeWidth: 0 }
+    ]);
+});
+
+QUnit.test("Axis has not breaks if exactWorkDays in the weekend", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        singleWorkdays: [new Date(2017, 8, 9, 8, 20), new Date(2017, 8, 10, 8, 20)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 6, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, []);
+});
+
+QUnit.test("Generate breaks for holidays", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [0, 1, 2, 3, 4, 5, 6],
+        dataType: "datetime",
+        holidays: [new Date(2017, 8, 10, 8, 20)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 6, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 10),
+        to: new Date(2017, 8, 11),
+        gapSize: { days: 1 },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("The break starts with min range if holiday starts early then min", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [0, 1, 2, 3, 4, 5, 6],
+        dataType: "datetime",
+        holidays: [new Date(2017, 8, 6, 6, 20)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 6, 8, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 6, 8, 0, 0),
+        to: new Date(2017, 8, 7),
+        gapSize: {
+            hours: 16
+        },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("The break ends with max range if holiday ends later then max", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [0, 1, 2, 3, 4, 5, 6],
+        dataType: "datetime",
+        holidays: [new Date(2017, 8, 13, 6, 20)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 6, 8, 0, 0), max: new Date(2017, 8, 13, 19, 0), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 13),
+        to: new Date(2017, 8, 13, 19, 0),
+        gapSize: {
+            hours: 19
+        },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Do not generate the breaks for holiday if it in the weekend", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        holidays: [new Date(2017, 8, 10, 8, 20)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 6, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 9),
+        to: new Date(2017, 8, 11),
+        gapSize: {
+            days: 2
+        },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("sort generated breaks", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        holidays: [new Date(2017, 8, 6)]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [
+        {
+            from: new Date(2017, 8, 6),
+            to: new Date(2017, 8, 7),
+            gapSize: {
+                days: 1
+            },
+            cumulativeWidth: 0
+        },
+        {
+            from: new Date(2017, 8, 9),
+            to: new Date(2017, 8, 11),
+            gapSize: {
+                days: 2
+            },
+            cumulativeWidth: 0
+        }
+    ]);
+});
+
+QUnit.test("Recalculate the breaks on zoom", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 5],
+        dataType: "datetime"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 11), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    //act
+    this.axis.zoom(new Date(2017, 8, 8, 8, 0, 0), new Date(2017, 8, 11));
+    this.axis.createTicks(this.canvas);
+
+    //assert
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+    assert.deepEqual(breaks, [
+        {
+            from: new Date(2017, 8, 9),
+            to: new Date(2017, 8, 11),
+            gapSize: {
+                days: 2
+            },
+            cumulativeWidth: 0
+        }
+    ]);
+});
+
+QUnit.test("Correct generation of the breaks if workdays set with uppercase", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime"
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 11), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 9),
+        to: new Date(2017, 8, 11),
+        gapSize: {
+            days: 2
+        },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Correct generation of the breaks if holidays set with string", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [0, 1, 2, 3, 4, 5, 6],
+        dataType: "datetime",
+        holidays: ['September 11, 2017']
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 6, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 11),
+        to: new Date(2017, 8, 12),
+        gapSize: {
+            days: 1
+        },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Correct generation of the breaks if exactWorkdays set with string", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        singleWorkdays: ['September 10, 2017']
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4, 8, 0, 0), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [{
+        from: new Date(2017, 8, 9),
+        to: new Date(2017, 8, 10),
+        gapSize: {
+            days: 1
+        },
+        cumulativeWidth: 0
+    }]);
+});
+
+QUnit.test("Concatenate generated breaks with user breaks", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 0 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        breaks: [[ new Date(2017, 8, 12), new Date(2017, 8, 13)]]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [
+        {
+            from: new Date(2017, 8, 9),
+            to: new Date(2017, 8, 11),
+            gapSize: {
+                days: 2
+            },
+            cumulativeWidth: 0
+        },
+        {
+            from: new Date(2017, 8, 12),
+            to: new Date(2017, 8, 13),
+            cumulativeWidth: 0
+        }
+    ]);
+});
+
+QUnit.test("Merge generated breaks with user breaks", function(assert) {
+    this.updateOptions({
+        workdaysOnly: true,
+        breakStyle: { width: 10 },
+        workweek: [1, 2, 3, 4, 5],
+        dataType: "datetime",
+        breaks: [[new Date(2017, 8, 10), new Date(2017, 8, 13)]]
+    });
+
+    this.axis.setBusinessRange({ min: new Date(2017, 8, 4), max: new Date(2017, 8, 13), addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    var breaks = this.tickGeneratorSpy.lastCall.args[7];
+
+    assert.deepEqual(breaks, [
+        {
+            from: new Date(2017, 8, 9),
+            to: new Date(2017, 8, 13),
+            gapSize: undefined,
+            cumulativeWidth: 10
+        }
+    ]);
+});
+
+QUnit.module("Auto scale breaks", $.extend({}, environment, {
+    beforeEach: function() {
+        environment.beforeEach.call(this);
+
+        this.axis = new Axis({
+            renderer: this.renderer
+        });
+
+        this.axis.parser = function(value) {
+            return value;
+        };
+    },
+    stubSeries: function(values) {
+        var series = new vizMocks.stubClass();
+
+        series.getPointsInViewPort = sinon.stub().returns(values);
+        return series;
+    }
+}));
+
+QUnit.test("Several series with not sorted values", function(assert) {
+    this.series = [
+        this.stubSeries([3, 10, 100, 40]),
+        this.stubSeries([80, 120, 40])
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 2
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 120, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{ from: 10, to: 40, cumulativeWidth: 0 }, { from: 40, to: 80, cumulativeWidth: 0 }]);
+});
+
+QUnit.test("Very big difference beetwen the values", function(assert) {
+    this.series = [
+        this.stubSeries([5500, 5100, 300, 5]),
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 2
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 6000, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [
+        { from: 300, to: 5100, cumulativeWidth: 0 },
+        { from: 5100, to: 5500, cumulativeWidth: 0 }
+    ]);
+});
+
+QUnit.test("Small difference beetween the values, breaks are not generated", function(assert) {
+    this.series = [
+        this.stubSeries([2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 2
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 10, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], []);
+});
+
+QUnit.test("maxCountOfBreaks option is set to zero. Without breaks", function(assert) {
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 0
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 100, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], []);
+});
+
+QUnit.test("Argument axis. Without breaks", function(assert) {
+    var axis = new Axis({
+        renderer: this.renderer,
+        isArgumentAxis: true
+    });
+    axis.updateOptions({
+        autoBreaksEnabled: true,
+        maxAutoBreakCount: 2,
+        isHorizontal: true,
+        label: {
+            visible: true,
+            overlappingBehavior: {}
+        }
+    });
+
+    axis.setGroupSeries(this.series);
+    axis.setBusinessRange({ min: 2, max: 100, addRange: function() { return this; } });
+    axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], []);
+});
+
+QUnit.test("Discrete. Without breaks", function(assert) {
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        maxAutoBreakCount: 2,
+        breakStyle: { width: 0 },
+        type: "discrete"
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 100, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], []);
+});
+
+QUnit.test("Datetime. Without breaks", function(assert) {
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        maxAutoBreakCount: 2,
+        breakStyle: { width: 0 },
+        dataType: "datetime"
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 100, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], []);
+});
+
+QUnit.test("Without breaks, autoScaleBreaks option is false", function(assert) {
+    this.updateOptions({
+        autoBreaksEnabled: false,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 2
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 100, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], []);
+});
+
+QUnit.test("Two values and range is equal to this values", function(assert) {
+    this.series = [
+        this.stubSeries([3, 100]),
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 1
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 3, max: 100, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], []);
+});
+
+QUnit.test("Option maxCountOfBreaks is more than generated breaks", function(assert) {
+    this.series = [
+        this.stubSeries([3, 100]),
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 2
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 0, max: 100, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{ from: 3, to: 100, cumulativeWidth: 0 }]);
+});
+
+QUnit.test("Option maxCountOfBreaks is undefined", function(assert) {
+    this.series = [
+        this.stubSeries([3, 10, 100, 40]),
+        this.stubSeries([80, 120, 40])
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: undefined
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 120, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [
+        { from: 3, to: 10, cumulativeWidth: 0 },
+        { from: 10, to: 40, cumulativeWidth: 0 },
+        { from: 40, to: 80, cumulativeWidth: 0 },
+        { from: 80, to: 100, cumulativeWidth: 0 },
+        { from: 100, to: 120, cumulativeWidth: 0 }
+    ]);
+});
+
+QUnit.test("Logarithmic axis", function(assert) {
+    this.series = [
+        this.stubSeries([0.1, 1, 10, 100, 1000, 10000000])
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        type: "logarithmic",
+        breakStyle: { width: 0 },
+        logarithmBase: 10
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 0.1, max: 10000000, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{ from: 1000, to: 10000000, cumulativeWidth: 0 }]);
+});
+
+QUnit.test("Concatenate auto breaks with user breaks", function(assert) {
+    this.series = [
+        this.stubSeries([3, 10, 35, 43, 45, 100, 40]),
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        maxAutoBreakCount: 2,
+        breakStyle: { width: 0 },
+        breaks: [[36, 40]]
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 100, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [
+        { from: 10, to: 35, cumulativeWidth: 0 },
+        { from: 36, to: 40, cumulativeWidth: 0 },
+        { from: 45, to: 100, cumulativeWidth: 0 }
+    ]);
+});
+
+QUnit.test("Filter scalebreaks on zoom", function(assert) {
+    this.series = [
+        this.stubSeries([3, 10, 100, 40]),
+        this.stubSeries([80, 120, 40])
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 2
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 120, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    this.axis.zoom(50, 100);
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{ from: 50, to: 80, cumulativeWidth: 0 }]);
+});
+
+QUnit.test("Recalculate scale breaks on zoom", function(assert) {
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        maxAutoBreakCount: 2,
+        breakStyle: {
+            width: 0
+        }
+    });
+
+    this.axis.setGroupSeries([
+        this.stubSeries([3, 10, 40]),
+        this.stubSeries([80, 120, 40])
+    ]);
+    this.axis.setBusinessRange({ min: 2, max: 120, addRange: function() { return this; } });
+    this.axis.createTicks(this.canvas);
+
+    this.axis.setGroupSeries([
+        this.stubSeries([3, 10]),
+        this.stubSeries([80, 120, 40])
+    ]);
+
+    this.axis.zoom(50, 100);
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{ from: 80, to: 100, cumulativeWidth: 0 }]);
+});
+
+
+QUnit.test("Reset zoom", function(assert) {
+    this.series = [
+        this.stubSeries([3, 10, 100, 40]),
+        this.stubSeries([80, 120, 40])
+    ];
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        breakStyle: { width: 0 },
+        maxAutoBreakCount: 2
+    });
+
+    this.axis.setGroupSeries(this.series);
+    this.axis.setBusinessRange({ min: 2, max: 120, addRange: function() { return this; } });
+
+    this.axis.zoom(50, 100);
+    this.axis.createTicks(this.canvas);
+
+    this.axis.zoom(2, 120);
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], [{ from: 10, to: 40, cumulativeWidth: 0 }, { from: 40, to: 80, cumulativeWidth: 0 }]);
+});
+
+QUnit.test("Do not generate scale breaks on zooming if multiple axis", function(assert) {
+    this.updateOptions({
+        autoBreaksEnabled: true,
+        maxAutoBreakCount: 2
+    });
+
+    this.axis.setGroupSeries([
+        this.stubSeries([3, 10, 40]),
+        this.stubSeries([80, 120, 40])
+    ]);
+    this.axis.setBusinessRange({ min: 2, max: 120, addRange: function() { return this; } }, true);
+    this.axis.createTicks(this.canvas);
+
+
+    this.axis.setGroupSeries([
+        this.stubSeries([3, 10]),
+        this.stubSeries([80, 120, 40])
+    ]);
+
+    this.axis.zoom(50, 100);
+    this.axis.createTicks(this.canvas);
+
+    assert.deepEqual(this.tickGeneratorSpy.lastCall.args[7], []);
 });

--- a/testing/tests/DevExpress.viz.core/translator2D.tests.js
+++ b/testing/tests/DevExpress.viz.core/translator2D.tests.js
@@ -3,6 +3,35 @@
 var $ = require("jquery"),
     translator2DModule = require("viz/translators/translator2d");
 
+function prepareScaleBreaks(array, breakSize) {
+    var breaks = [],
+        lastBreak,
+        i;
+    for(i = 0; i < array.length; i++) {
+        lastBreak = breaks[breaks.length - 1];
+        if(lastBreak) {
+            breaks.push({
+                from: array[i].from,
+                to: array[i].to,
+                cumulativeWidth: !array[i].gapSize ? breakSize + lastBreak.cumulativeWidth : lastBreak.cumulativeWidth
+            });
+        } else {
+            breaks.push({
+                from: array[i].from,
+                to: array[i].to,
+                cumulativeWidth: !array[i].gapSize ? breakSize : 0
+            });
+        }
+    }
+    return breaks;
+}
+
+function createTranslatorWithScaleBreaks(options) {
+    var breakSize = options.breakSize || 20,
+        breaks = prepareScaleBreaks(options.breaks || [{ from: 150, to: 200 }, { from: 350, to: 370 }, { from: 590, to: 650 }], breakSize);
+    return this.createTranslator({ min: options.min || 100, max: options.max || 700, breaks: breaks, invert: options.invert }, null, { breaksSize: breakSize });
+}
+
 var canvasTemplate = {
         width: 610,
         height: 400,
@@ -44,10 +73,9 @@ var environment = {
     _createTranslator: function(range, canvas, options) {
         return new translator2DModule.Translator2D(range, canvas, options);
     },
-    createTranslator: function(range) {
-        return this._createTranslator($.extend({ axisType: 'continuous', dataType: 'numeric', interval: 1, invert: false }, range),
-            { width: 2000, height: 2000, left: 500, top: 500, right: 500, bottom: 500 },
-            { isHorizontal: true });
+    createTranslator: function(range, canvas, options) {
+        return this._createTranslator($.extend({ axisType: 'continuous', dataType: 'numeric' }, range),
+            canvas || { width: 2000, height: 2000, left: 500, top: 500, right: 500, bottom: 500 }, $.extend({}, { isHorizontal: true, breaksSize: 0 }, options));
     }
 };
 
@@ -58,7 +86,7 @@ QUnit.test('Create vertical translator', function(assert) {
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas, { isHorizontal: false });
 
     assert.ok(translator);
     assert.deepEqual(translator._canvas, { width: 610, height: 400, left: 70, top: 10, right: 30, bottom: 60 });
@@ -87,7 +115,7 @@ QUnit.test('Create horizontal translator', function(assert) {
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas, optionsHorizontal);
+    translator = this.createTranslator(range, canvas, optionsHorizontal);
 
     assert.ok(translator);
     assert.deepEqual(translator._canvas, { width: 610, height: 400, left: 70, top: 10, right: 30, bottom: 60 });
@@ -116,7 +144,7 @@ QUnit.test('Create numeric translator', function(assert) {
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.deepEqual(translator._canvas, { width: 610, height: 400, left: 70, top: 10, right: 30, bottom: 60 });
@@ -138,7 +166,7 @@ QUnit.test('Create numeric translator when business range delta = 0, Min = max =
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin, 99, 'range min is correct');
@@ -160,7 +188,7 @@ QUnit.test('Create numeric translator when business range delta = 0, Min = max =
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin, 0, 'range min is correct');
@@ -182,7 +210,7 @@ QUnit.test('Create numeric translator when business range delta = 0, min < minVi
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin, 10, 'range min is correct');
@@ -204,7 +232,7 @@ QUnit.test('Create numeric translator when business range delta = 0, min < minVi
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin, -10, 'range min is correct');
@@ -226,7 +254,7 @@ QUnit.test('Create numeric translator when business range delta = 0, min = minVi
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin, 10, 'range min is correct');
@@ -248,7 +276,7 @@ QUnit.test('Create numeric translator when business range delta = 0, min < minVi
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin, 10, 'range min is correct');
@@ -262,7 +290,7 @@ QUnit.test('Create datetime translator', function(assert) {
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.deepEqual(translator._canvas, { width: 610, height: 400, left: 70, top: 10, right: 30, bottom: 60 });
@@ -287,7 +315,7 @@ QUnit.test('Create datetime translator when business range delta = 0. min = minV
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin.valueOf(), new Date(2000, 1, 1).valueOf() - correction, 'range min is correct');
@@ -310,7 +338,7 @@ QUnit.test('Create datetime translator when business range delta = 0. min < minV
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin.valueOf(), new Date(1990, 1, 1).valueOf(), 'range min is correct');
@@ -333,7 +361,7 @@ QUnit.test('Create datetime translator when business range delta = 0. min = minV
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin.valueOf(), new Date(2000, 1, 1).valueOf(), 'range min is correct');
@@ -356,7 +384,7 @@ QUnit.test('Create datetime translator when business range delta = 0. min < minV
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas);
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin.valueOf(), new Date(1990, 1, 1).valueOf(), 'range min is correct');
@@ -370,7 +398,7 @@ QUnit.test('Create discrete translator (Stick = false, invert = false)', functio
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas, $.extend({ stick: false }, optionsHorizontal));
+    translator = this.createTranslator(range, canvas, $.extend({ stick: false }, optionsHorizontal));
 
     assert.ok(translator);
     assert.deepEqual(translator._canvas, { width: 610, height: 400, left: 70, top: 10, right: 30, bottom: 60 });
@@ -395,7 +423,7 @@ QUnit.test('Create discrete translator (Stick = true, invert = true)', function(
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas, $.extend({ stick: true }, optionsHorizontal));
+    translator = this.createTranslator(range, canvas, $.extend({ stick: true }, optionsHorizontal));
 
     assert.equal(translator._canvasOptions.interval, 170);
     assert.deepEqual(translator._categoriesToPoints, {
@@ -410,7 +438,7 @@ QUnit.test('Create discrete translator (Stick = true, addSpiderCategory = true)'
     var canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(discreteRange, canvas, $.extend({ addSpiderCategory: true, stick: true }, optionsHorizontal));
+    translator = this.createTranslator(discreteRange, canvas, $.extend({ stick: false }, optionsHorizontal));
 
     assert.equal(translator._canvasOptions.interval, 127.5);
     assert.deepEqual(translator._categoriesToPoints, {
@@ -427,7 +455,7 @@ QUnit.test('Can create Discrete translator without categories. B253644', functio
         translator;
     range.categories = null;
 
-    translator = new translator2DModule.Translator2D(range, canvas, $.extend({ stick: true }, optionsHorizontal));
+    translator = this.createTranslator(range, canvas, $.extend({ stick: false }, optionsHorizontal));
 
     assert.ok(translator);
     assert.ok($.isFunction(translator.translate));
@@ -443,7 +471,7 @@ QUnit.test('Create logarithmic translator', function(assert) {
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas, { isHorizontal: false });
 
     assert.ok(translator);
     assert.deepEqual(translator._canvas, { width: 610, height: 400, left: 70, top: 10, right: 30, bottom: 60 });
@@ -468,7 +496,7 @@ QUnit.test('Create logarithmic translator. Min = max = minVisible = maxVisible =
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas, { isHorizontal: false });
 
     assert.ok(translator);
     assert.deepEqual(translator._canvas, { width: 610, height: 400, left: 70, top: 10, right: 30, bottom: 60 });
@@ -493,7 +521,7 @@ QUnit.test('Create logarithmic translator. Base = 2', function(assert) {
         canvas = $.extend({}, canvasTemplate),
         translator;
 
-    translator = new translator2DModule.Translator2D(range, canvas);
+    translator = this.createTranslator(range, canvas, { isHorizontal: false });
 
     assert.ok(translator);
     assert.deepEqual(translator._canvas, { width: 610, height: 400, left: 70, top: 10, right: 30, bottom: 60 });
@@ -672,7 +700,7 @@ QUnit.test('Translate. Negative values. Invert = true', function(assert) {
 QUnit.test('Translate. not round values', function(assert) {
     var translator = this._createTranslator($.extend({ axisType: 'continuous', dataType: 'numeric', interval: 1, invert: false }, { min: 200, max: 700 }),
             { width: 2000, height: 2000, left: 500, top: 500, right: 500, bottom: 500 },
-            { isHorizontal: true, conversionValue: function(value) { return value; } });
+            { isHorizontal: true, breaksSize: 0, conversionValue: function(value) { return value; } });
 
     assert.equal(translator.translate(322.33), 744.66, 'value should not be rounded');
 });
@@ -680,7 +708,7 @@ QUnit.test('Translate. not round values', function(assert) {
 QUnit.test("translate. conversion is not a function", function(assert) {
     var translator = this._createTranslator($.extend({ axisType: 'continuous', dataType: 'numeric', interval: 1, invert: false }, { min: 200, max: 700 }),
             { width: 2000, height: 2000, left: 500, top: 500, right: 500, bottom: 500 },
-            { isHorizontal: true, conversionValue: "" });
+            { isHorizontal: true, breaksSize: 0, conversionValue: "" });
 
     assert.equal(translator.translate(322.33), 745, 'value should rounded');
 });
@@ -745,6 +773,115 @@ QUnit.test('Untranslate. T176895. Range min/max are undefined', function(assert)
     assert.equal(translator.untranslate(1000), null);
 });
 
+QUnit.test('Translate. Scale breaks is empty array', function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, { min: 200, max: 700, breaks: [] });
+
+    assert.equal(translator.translate(300), 700, 'BP inside range');
+    assert.equal(translator.translate(200), 500, 'BP on the min');
+    assert.equal(translator.translate(700), 1500, 'BP on the max');
+});
+
+QUnit.test('Translate. Update translator with business range with empty scale breaks', function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        min: 200, max: 700
+    });
+
+    translator.updateBusinessRange({ min: 200, max: 700, breaks: [] });
+
+    assert.strictEqual(translator.translate(450), 1000);
+});
+
+QUnit.test("Translate. Scale breaks. Values out of the breaks and should be traslated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {});
+
+    assert.strictEqual(translator.translate(100), 500);
+    assert.strictEqual(translator.translate(149), 598);
+    assert.strictEqual(translator.translate(200), 620);
+    assert.strictEqual(translator.translate(300), 820);
+    assert.strictEqual(translator.translate(450), 1100);
+    assert.strictEqual(translator.translate(700), 1500);
+});
+
+QUnit.test("Translate. Scale breaks. Values inside the breaks and shouldn't be translated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {});
+
+    assert.strictEqual(translator.translate(150), null);
+    assert.strictEqual(translator.translate(160), null);
+    assert.strictEqual(translator.translate(360), null);
+    assert.strictEqual(translator.translate(620), null);
+});
+
+QUnit.test("isValid. Scale breaks.Values inside of the breaks should be not valid", function(assert) {
+    var breaks = [{ from: 150, to: 200 }, { from: 350, to: 370 }, { from: 590, to: 650 }],
+        translator = this.createTranslator({ min: 100, max: 700, breaks: breaks }, null, { breaksSize: 20 });
+
+    assert.strictEqual(translator.isValid(150), false);
+    assert.strictEqual(translator.isValid(120), true);
+});
+
+QUnit.test("Translate. Scale breaks. Inverted axis", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        invert: true
+    });
+
+    assert.strictEqual(translator.translate(100), 1500);
+    assert.strictEqual(translator.translate(450), 900);
+    assert.strictEqual(translator.translate(700), 500);
+});
+
+QUnit.test("Untranslate. Scale breaks. Values not on the breaks and should be untranslated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {});
+
+    assert.strictEqual(translator.untranslate(500), 100);
+    assert.strictEqual(translator.untranslate(820), 300);
+    assert.strictEqual(translator.untranslate(1100), 450);
+    assert.strictEqual(translator.untranslate(1500), 700);
+});
+
+QUnit.test("Untranslate. Scale breaks. Values on the breaks and should not be untranslated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {});
+
+    assert.strictEqual(translator.untranslate(610), null);
+    assert.strictEqual(translator.untranslate(1390), null);
+});
+
+QUnit.test("Untranslate. Scale breaks. Values on the breaks and should be untranslated to left side of break if direction<0", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {});
+
+    assert.strictEqual(translator.from(610, -1), 150);
+    assert.strictEqual(translator.from(1390, -1), 590);
+});
+
+QUnit.test("Untranslate. Scale breaks. Values on the breaks and should be untranslated to right side of break if direction>0", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {});
+
+    assert.strictEqual(translator.from(610, 1), 200);
+    assert.strictEqual(translator.from(1390, 1), 650);
+});
+
+QUnit.test("Untranslate. Scale breaks. Inverted axis. Values on the breaks and should be untranslated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        invert: true
+    });
+
+    assert.strictEqual(translator.untranslate(500), 700);
+    assert.strictEqual(translator.untranslate(600), 650);
+    assert.strictEqual(translator.untranslate(700), 550);
+    assert.strictEqual(translator.untranslate(820), 490);
+    assert.strictEqual(translator.untranslate(1180), 300);
+    assert.strictEqual(translator.untranslate(1500), 100);
+});
+
+QUnit.test("Untranslate. Scale breaks. Inverted axis. Values on the breaks and should not be untranslated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        invert: true
+    });
+
+    assert.strictEqual(translator.untranslate(402), null);
+    assert.strictEqual(translator.untranslate(1062), null);
+    assert.strictEqual(translator.untranslate(1382), null);
+});
+
 QUnit.test('GetInterval', function(assert) {
     var translator = this.createTranslator({ min: 200, max: 700, interval: 10.55 });
 
@@ -767,10 +904,10 @@ QUnit.test("isValid", function(assert) {
 
 QUnit.module('Datetime translator', {
     beforeEach: function() {
-        this.createTranslator = function(range) {
+        this.createTranslator = function(range, _, options) {
             return new translator2DModule.Translator2D($.extend({ axisType: 'continuous', dataType: 'datetime', interval: 1, invert: false }, range),
                 { width: 2000, height: 2000, left: 500, top: 500, right: 500, bottom: 500 },
-                { isHorizontal: true });
+                $.extend({}, { isHorizontal: true, breaksSize: 0 }, options));
         };
     }
 });
@@ -826,6 +963,31 @@ QUnit.test('Untranslate. Invert = true', function(assert) {
     assert.deepEqual(translator.untranslate(1000), new Date(2012, 8, 1, 12), 'Coord inside range');
 });
 
+QUnit.test("Untranslate. With scale breaks. Values not in the breaks and translated. Mix scale breaks and gaps(weekends)", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        min: new Date(2012, 8, 1), max: new Date(2012, 8, 2),
+        breaks: [
+            { from: new Date(2012, 8, 1, 10), to: new Date(2012, 8, 1, 11) },
+            { from: new Date(2012, 8, 1, 20), to: new Date(2012, 8, 1, 21), gapSize: "some size" },
+            { from: new Date(2012, 8, 1, 22), to: new Date(2012, 8, 1, 23) }
+        ]
+    });
+
+    assert.deepEqual(translator.untranslate(500), new Date(2012, 8, 1));
+    assert.deepEqual(translator.untranslate(1160), new Date(2012, 8, 1, 15));
+    assert.deepEqual(translator.untranslate(1400), new Date(2012, 8, 1, 21, 15));
+    assert.deepEqual(translator.untranslate(1500), new Date(2012, 8, 2));
+});
+
+QUnit.test("Untranslate. With scale breaks. Value in the scale break and shouldn't translated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        min: new Date(2012, 8, 1), max: new Date(2012, 8, 2),
+        breaks: [{ from: new Date(2012, 8, 1, 10), to: new Date(2012, 8, 1, 11) }, { from: new Date(2012, 8, 1, 20), to: new Date(2012, 8, 1, 21) }]
+    });
+
+    assert.deepEqual(translator.untranslate(950), null);
+});
+
 QUnit.test('GetInterval', function(assert) {
     var translator = this.createTranslator({ min: new Date(2012, 8, 1), max: new Date(2012, 8, 2), interval: 1000 * 60 * 60 });
 
@@ -840,10 +1002,10 @@ QUnit.test('GetInterval when interval is 0', function(assert) {
 
 QUnit.module('Logarithmic translator', {
     beforeEach: function() {
-        this.createTranslator = function(range) {
+        this.createTranslator = function(range, _, options) {
             return new translator2DModule.Translator2D($.extend({ axisType: 'logarithmic', dataType: 'numeric', interval: 1, invert: false, base: 10 }, range),
                 { width: 2000, height: 2000, left: 500, top: 500, right: 500, bottom: 500 },
-                { isHorizontal: true });
+                $.extend({}, { isHorizontal: true, breaksSize: 0 }, options));
         };
     }
 });
@@ -953,6 +1115,57 @@ QUnit.test('Untranslate. Small numbers. Invert = true', function(assert) {
     assert.roughEqual(translator.untranslate(500), 0.01, doubleDelta * 0.01, 'Coord on the min');
     assert.roughEqual(translator.untranslate(1500), 0.0001, doubleDelta * 0.0001, 'Coord on the max');
     assert.roughEqual(translator.untranslate(1000), 0.001, doubleDelta * 0.001, 'Coord inside range');
+});
+
+QUnit.test("Translate. Scale breaks. Values inside of the breaks and should be translated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        min: 0.0001, max: 1000000,
+        breaks: [{ from: 0.001, to: 0.1 }, { from: 100, to: 10000 }],
+        breakSize: 50
+    });
+
+    assert.strictEqual(translator.translate(0.0001), 500);
+    assert.strictEqual(translator.translate(1), 850);
+    assert.strictEqual(translator.translate(10), 1000);
+    assert.strictEqual(translator.translate(100000), 1350);
+    assert.strictEqual(translator.translate(1000000), 1500);
+});
+
+QUnit.test("Translate. Scale breaks. Values out of the breaks and shouldn't be translated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        min: 0.0001, max: 1000000,
+        breaks: [{ from: 0.001, to: 0.1 }, { from: 100, to: 10000 }],
+        breakSize: 50
+    });
+
+    assert.strictEqual(translator.translate(0.01), null);
+    assert.strictEqual(translator.translate(1000), null);
+});
+
+QUnit.test("Untranslate. Scale breaks. Values not on the breaks and should be untranslated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+            min: 0.0001, max: 1000000,
+            breaks: [{ from: 0.001, to: 0.1 }, { from: 100, to: 10000 }],
+            breakSize: 50
+        }),
+        doubleDelta = 0.00001;
+
+    assert.roughEqual(translator.untranslate(500), 0.0001, doubleDelta);
+    assert.roughEqual(translator.untranslate(850), 1, doubleDelta);
+    assert.roughEqual(translator.untranslate(1000), 10, doubleDelta);
+    assert.roughEqual(translator.untranslate(1350), 100000, doubleDelta);
+    assert.roughEqual(translator.untranslate(1500), 1000000, doubleDelta);
+});
+
+QUnit.test("Untranslate. Scale breaks. Values on the breaks and should not be untranslated", function(assert) {
+    var translator = createTranslatorWithScaleBreaks.call(this, {
+        min: 0.0001, max: 1000000,
+        breaks: [{ from: 0.001, to: 0.1 }, { from: 100, to: 10000 }],
+        breakSize: 50
+    });
+
+    assert.strictEqual(translator.untranslate(670), null);
+    assert.strictEqual(translator.untranslate(1170), null);
 });
 
 QUnit.test('GetInterval', function(assert) {
@@ -1858,7 +2071,7 @@ QUnit.module('Translate special cases', {
         this.createTranslator = function(range, options) {
             return new translator2DModule.Translator2D(range,
                 { width: 2000, height: 2000, left: 500, top: 500, right: 500, bottom: 500 },
-                $.extend({ isHorizontal: true }, options));
+                $.extend({ isHorizontal: true, breaksSize: 0 }, options));
         };
     }
 });
@@ -1965,7 +2178,7 @@ QUnit.test('scroll', function(assert) {
         translator,
         zoom;
 
-    translator = new translator2DModule.Translator2D(range, canvas, optionsHorizontal);
+    translator = new translator2DModule.Translator2D(range, canvas, { isHorizontal: true, breaksSize: 0 });
 
     assert.ok(translator);
 
@@ -2022,7 +2235,7 @@ QUnit.test('scroll. Logarithmic axis', function(assert) {
         translator,
         zoom;
 
-    translator = new translator2DModule.Translator2D(range, canvas, optionsHorizontal);
+    translator = new translator2DModule.Translator2D(range, canvas, { isHorizontal: true, breaksSize: 0 });
 
     assert.ok(translator);
 
@@ -2072,7 +2285,7 @@ QUnit.test('scroll. Canvas start point is zero', function(assert) {
         translator,
         zoom;
 
-    translator = new translator2DModule.Translator2D(range, canvas, optionsHorizontal);
+    translator = new translator2DModule.Translator2D(range, canvas, { isHorizontal: true, breaksSize: 0 });
 
     assert.ok(translator);
 
@@ -2098,7 +2311,7 @@ QUnit.test('scroll inverted range', function(assert) {
         translator,
         zoom;
 
-    translator = new translator2DModule.Translator2D(range, canvas, optionsHorizontal);
+    translator = new translator2DModule.Translator2D(range, canvas, { isHorizontal: true, breaksSize: 0 });
 
     assert.ok(translator);
 
@@ -2156,7 +2369,7 @@ QUnit.test('scale without scroll', function(assert) {
         translator,
         zoom;
 
-    translator = new translator2DModule.Translator2D(range, canvas, optionsHorizontal);
+    translator = new translator2DModule.Translator2D(range, canvas, { isHorizontal: true, breaksSize: 0 });
 
     assert.ok(translator);
     assert.equal(translator._canvasOptions.rangeMin, 0);

--- a/testing/tests/DevExpress.viz.core/xyAxes.tests.js
+++ b/testing/tests/DevExpress.viz.core/xyAxes.tests.js
@@ -243,7 +243,8 @@ QUnit.test("Linear axis updates translator on option changed", function(assert) 
     });
 
     assert.strictEqual(translator2DModule.Translator2D.callCount, 1, "created single translator instance");
-    assert.deepEqual(translator.update.lastCall.args[2], { isHorizontal: true, interval: 0.2, stick: true });
+    assert.equal(translator.update.lastCall.args[2].isHorizontal, true);
+    assert.equal(translator.update.lastCall.args[2].interval, 0.2);
 });
 
 QUnit.test("Linear axis updates translator, valueMarginsEnabled = true - stick false", function(assert) {
@@ -262,6 +263,49 @@ QUnit.test("Linear axis updates translator, valueMarginsEnabled = true - stick f
     });
 
     assert.strictEqual(translator.update.lastCall.args[2].stick, false);
+});
+
+QUnit.test("Linear axis with scale breaks", function(assert) {
+    var axis = new Axis({
+            renderer: this.renderer,
+            axisType: "xyAxes",
+            drawingType: "linear"
+        }),
+        translator = translator2DModule.Translator2D.lastCall.returnValue;
+
+    sinon.spy(translator, "update");
+
+    axis.updateOptions({
+        isHorizontal: true,
+        semiDiscreteInterval: 0.2,
+        breaks: [{ from: 0, to: 10 }],
+        breakStyle: { width: 20 },
+        label: {}
+    });
+
+    assert.strictEqual(translator2DModule.Translator2D.callCount, 1, "created single translator instance");
+    assert.equal(translator.update.lastCall.args[2].breaksSize, 20);
+});
+
+QUnit.test("Linear axis with scale breaks, breaksSize is not set", function(assert) {
+    var axis = new Axis({
+            renderer: this.renderer,
+            axisType: "xyAxes",
+            drawingType: "linear"
+        }),
+        translator = translator2DModule.Translator2D.lastCall.returnValue;
+
+    sinon.spy(translator, "update");
+
+    axis.updateOptions({
+        isHorizontal: true,
+        semiDiscreteInterval: 0.2,
+        breaks: [{ from: 0, to: 10 }],
+        label: {}
+    });
+
+    assert.strictEqual(translator2DModule.Translator2D.callCount, 1, "created single translator instance");
+    assert.equal(translator.update.lastCall.args[2].breaksSize, 0);
 });
 
 QUnit.test("Update canvas", function(assert) {

--- a/testing/tests/DevExpress.viz.rangeSelector/common.part1.tests.js
+++ b/testing/tests/DevExpress.viz.rangeSelector/common.part1.tests.js
@@ -55,6 +55,15 @@ QUnit.test("deprecated options", function(assert) {
     assert.strictEqual(options.minorTick.visible, "show-minor-ticks", "minorTick.visible");
 });
 
+QUnit.test("Pass containerBackgroundColor to scale", function(assert) {
+    this.createWidget({
+        containerBackgroundColor: "red"
+    });
+
+    var options = this.axis.updateOptions.lastCall.args[0];
+    assert.deepEqual(options.containerColor, "red");
+});
+
 QUnit.test("default selected range", function(assert) {
     this.createWidget({
         scale: {

--- a/testing/tests/DevExpress.viz.rangeSelector/common.part3.tests.js
+++ b/testing/tests/DevExpress.viz.rangeSelector/common.part3.tests.js
@@ -1060,6 +1060,8 @@ QUnit.test("Axis creation - check axis parameters", function(assert) {
     assert.equal(axisModule.Axis.getCall(0).args[0].widgetClass, "dxrs");
     assert.equal(axisModule.Axis.getCall(0).args[0].axisClass, "range-selector");
     assert.equal(axisModule.Axis.getCall(0).args[0].axesContainerGroup.attr.firstCall.args[0].class, "dxrs-scale");
+    assert.equal(axisModule.Axis.getCall(0).args[0].scaleBreaksGroup.attr.firstCall.args[0].class, "dxrs-scale-breaks");
+    assert.equal(axisModule.Axis.getCall(0).args[0].scaleBreaksGroup.append.lastCall.args[0], this.renderer.root);
     assert.equal(axisModule.Axis.getCall(0).args[0].isArgumentAxis, true);
 });
 
@@ -1079,6 +1081,19 @@ QUnit.test("Update axis canvas", function(assert) {
         width: 299
     }, "canvas passed to draw");
     assert.deepEqual(this.axis.shift.lastCall.args, [{ left: 0, bottom: 8 }], "shift arguments");
+});
+
+QUnit.test("Draw scale breaks", function(assert) {
+    this.createWidget({
+        margin: {
+            top: 20
+        }
+    });
+
+    assert.deepEqual(this.axis.drawScaleBreaks.lastCall.args[0], {
+        start: 20,
+        end: 44
+    }, "drawScaleBreaks called with custom canvas");
 });
 
 QUnit.test("range container canvas with no indents. scale's labels half width as indent", function(assert) {

--- a/testing/tests/DevExpress.viz.rangeSelector/slidersController.tests.js
+++ b/testing/tests/DevExpress.viz.rangeSelector/slidersController.tests.js
@@ -522,6 +522,26 @@ QUnit.test("data-like string values", function(assert) {
     this.check(assert, [1170, 1659], [new Date("02/01/2010"), new Date("05/01/2010")]);
 });
 
+QUnit.test("Start value in the scale break", function(assert) {
+    this.translator.update({
+        minVisible: 10,
+        maxVisible: 30,
+        min: 10,
+        max: 30,
+        breaks: [{
+            from: 12,
+            to: 17,
+            cumulativeWidth: 0
+        }]
+    }, { left: 1000, width: 3000 }, { isHorizontal: true, breaksSize: 0 });
+
+    this.update();
+
+    this.setRange(15, 25);
+
+    this.check(assert, [1000, 2333], [10, 25]);
+});
+
 QUnit.module("Clouds processing", $.extend({}, environment, {
     beforeEach: function() {
         environment.beforeEach.apply(this, arguments);

--- a/testing/tests/DevExpress.viz.renderers/Renderer.tests.js
+++ b/testing/tests/DevExpress.viz.renderers/Renderer.tests.js
@@ -17,6 +17,36 @@ function getMockElement() {
     };
 }
 
+function checkScaleBreakPattern(assert, linePattern, renderer, parameters) {
+    assert.ok(linePattern instanceof renderers.SvgElement);
+    assert.deepEqual(linePattern.ctorArgs, [renderer, "pattern", undefined]);
+    assert.equal(linePattern.id, "DevExpressId", "id");
+    assert.equal(linePattern.size, parameters.size, "size");
+    assert.deepEqual(linePattern.attr.lastCall.args[0], { height: parameters.height, width: parameters.width, id: "DevExpressId" }, "pattern's attr params");
+    assert.equal(linePattern.append.lastCall.args[0], renderers.SvgElement.getCall(1).returnValue, "pattern is appended to defs");
+
+    assert.ok(linePattern.elements[0], "middle line");
+    assert.ok(linePattern.elements[0] instanceof renderers.PathSvgElement);
+    assert.deepEqual(linePattern.elements[0].ctorArgs, [renderer, parameters.type]);
+    assert.deepEqual(linePattern.elements[0].stub("attr").firstCall.args[0].points, parameters.points1, "points of middle line");
+    assert.deepEqual(linePattern.elements[0].stub("attr").lastCall.args[0], { stroke: "white", "stroke-width": 10, "stroke-linecap": "round" }, "attr of middle line");
+    assert.equal(linePattern.elements[0].stub("append").firstCall.args[0], linePattern, "middle line is appended to pattern");
+
+    assert.ok(linePattern.elements[1], "first border line");
+    assert.ok(linePattern.elements[1] instanceof renderers.PathSvgElement);
+    assert.deepEqual(linePattern.elements[1].ctorArgs, [renderer, parameters.type]);
+    assert.deepEqual(linePattern.elements[1].stub("attr").firstCall.args[0].points, parameters.points2, "points of the first border line");
+    assert.deepEqual(linePattern.elements[1].stub("attr").lastCall.args[0], { sharp: parameters.sharp, stroke: "black", "stroke-width": 1 }, "attr of the first border line");
+    assert.equal(linePattern.elements[1].stub("append").firstCall.args[0], linePattern, "first border line is appended to pattern");
+
+    assert.ok(linePattern.elements[2], "second border line");
+    assert.ok(linePattern.elements[2] instanceof renderers.PathSvgElement);
+    assert.deepEqual(linePattern.elements[2].ctorArgs, [renderer, parameters.type]);
+    assert.deepEqual(linePattern.elements[2].stub("attr").firstCall.args[0].points, parameters.points3, "points of the second border line");
+    assert.deepEqual(linePattern.elements[2].stub("attr").lastCall.args[0], { sharp: parameters.sharp, stroke: "black", "stroke-width": 1 }, "attr of the second border line");
+    assert.equal(linePattern.elements[2].stub("append").firstCall.args[0], linePattern, "second border line is appended to pattern");
+}
+
 renderers.DEBUG_set_getNextDefsSvgId(function() { return "DevExpressId"; });
 
 QUnit.testDone(function() {
@@ -631,6 +661,100 @@ QUnit.test('clipRect disposing', function(assert) {
 
     //assert
     assert.ok(clipRect.clipPath.stub("dispose").called);
+});
+
+QUnit.test("Scale break. Straight line", function(assert) {
+    var linePattern = this.renderer.linePattern({
+        color: "white",
+        borderColor: "black",
+        size: 10,
+        canvasLength: 600,
+        isHorizontal: false,
+        isWaved: false
+    });
+
+    checkScaleBreakPattern(assert, linePattern, this.renderer, {
+        size: 12,
+        height: 1,
+        width: 10 / 600,
+        points1: [0, 5, 10, 5],
+        points2: [0, 0, 10, 0],
+        points3: [0, 10, 10, 10],
+        sharp: 'v',
+        type: 'line'
+    });
+});
+
+QUnit.test("Scale break. Waved line", function(assert) {
+    var linePattern = this.renderer.linePattern({
+        color: "white",
+        borderColor: "black",
+        size: 10,
+        canvasLength: 600,
+        isHorizontal: false,
+        isWaved: true
+    });
+
+    checkScaleBreakPattern(assert, linePattern, this.renderer, {
+        size: 16,
+        height: 1,
+        width: 24 / 600,
+        points1: [0, 7, 6, 5, 6, 5, 12, 7, 18, 9, 18, 9, 24, 7],
+        points2: [0, 2, 6, 0, 6, 0, 12, 2, 18, 4, 18, 4, 24, 2],
+        points3: [0, 12, 6, 10, 6, 10, 12, 12, 18, 14, 18, 14, 24, 12],
+        sharp: undefined,
+        type: 'bezier'
+    });
+});
+
+QUnit.test("Vertical scale break. Straigh line", function(assert) {
+    var linePattern = this.renderer.linePattern({
+        color: "white",
+        borderColor: "black",
+        size: 10,
+        canvasLength: 600,
+        isHorizontal: true,
+        isWaved: false
+    });
+
+    checkScaleBreakPattern(assert, linePattern, this.renderer, {
+        size: 12,
+        height: 10 / 600,
+        width: 1,
+        points1: [0, 5, 10, 5],
+        points2: [0, 0, 10, 0],
+        points3: [0, 10, 10, 10],
+        sharp: 'h',
+        type: 'line'
+    });
+    assert.deepEqual(linePattern.elements[0].stub("rotate").lastCall.args, [90, 5, 5]);
+    assert.deepEqual(linePattern.elements[1].stub("rotate").lastCall.args, [90, 5, 5]);
+    assert.deepEqual(linePattern.elements[2].stub("rotate").lastCall.args, [90, 5, 5]);
+});
+
+QUnit.test("Vertical scale break. Waved line", function(assert) {
+    var linePattern = this.renderer.linePattern({
+        color: "white",
+        borderColor: "black",
+        size: 10,
+        canvasLength: 600,
+        isHorizontal: true,
+        isWaved: true
+    });
+
+    checkScaleBreakPattern(assert, linePattern, this.renderer, {
+        size: 16,
+        height: 24 / 600,
+        width: 1,
+        points1: [0, 7, 6, 5, 6, 5, 12, 7, 18, 9, 18, 9, 24, 7],
+        points2: [0, 2, 6, 0, 6, 0, 12, 2, 18, 4, 18, 4, 24, 2],
+        points3: [0, 12, 6, 10, 6, 10, 12, 12, 18, 14, 18, 14, 24, 12],
+        sharp: undefined,
+        type: 'bezier'
+    });
+    assert.deepEqual(linePattern.elements[0].stub("rotate").lastCall.args, [90, 7, 7]);
+    assert.deepEqual(linePattern.elements[1].stub("rotate").lastCall.args, [90, 7, 7]);
+    assert.deepEqual(linePattern.elements[2].stub("rotate").lastCall.args, [90, 7, 7]);
 });
 
 QUnit.test('shadowFilter with params', function(assert) {

--- a/ts/legacy/viz-charts.d.ts
+++ b/ts/legacy/viz-charts.d.ts
@@ -258,6 +258,7 @@ declare module DevExpress.viz.charts {
         endValue?: any;
     }
 
+    /** @docid_ignore ScaleBreak */
 
     // Series
 
@@ -1562,6 +1563,12 @@ declare module DevExpress.viz.charts {
         /** @docid dxchartoptions_commonaxissettings_placeholdersize */
         placeholderSize?: number;
 
+        /** @docid dxchartoptions_commonaxissettings_breaks */
+        breaks?: Array<Array<any>>;
+
+        /** @docid dxchartoptions_commonaxissettings_breakStyle */
+        breakStyle?: viz.core.BreakStyle,
+
         /** @docid dxchartoptions_commonaxissettings_stripstyle */
         stripStyle?: {
 
@@ -1785,6 +1792,11 @@ declare module DevExpress.viz.charts {
           */
         pane?: string;
 
+        /** @docid dxchartoptions_valueaxis_autobreaksenabled */
+        autoBreaksEnabled?: boolean;
+
+        /** @docid dxchartoptions_valueaxis_maxautobreakcount */
+        maxAutoBreakCount?: number;
         /**
         * @docid dxchartoptions_argumentaxis_strips
         * @docid dxchartoptions_valueaxis_strips
@@ -1879,7 +1891,20 @@ declare module DevExpress.viz.charts {
         hoverMode?: string;
     }
 
-    export interface ChartArgumentAxis extends ChartAxis, ArgumentAxis { }
+    export interface ChartArgumentAxis extends ChartAxis, ArgumentAxis {
+        /** @docid dxchartoptions_argumentaxis_workdaysonly */
+        workdaysOnly?: boolean;
+
+        /** @docid dxchartoptions_argumentaxis_workweek */
+        workweek?: Array<number>;
+
+        /** @docid dxchartoptions_argumentaxis_holidays */
+        holidays?: any;
+
+        /** @docid dxchartoptions_argumentaxis_singleworkdays */
+        singleWorkdays?: any;
+    }
+
     export interface PolarArgumentAxis extends PolarAxis, ArgumentAxis {
         /** @docid dxpolarchartoptions_argumentaxis_startangle */
         startAngle?: number;

--- a/ts/legacy/viz-charts.d.ts
+++ b/ts/legacy/viz-charts.d.ts
@@ -1896,7 +1896,7 @@ declare module DevExpress.viz.charts {
         workdaysOnly?: boolean;
 
         /** @docid dxchartoptions_argumentaxis_workweek */
-        workweek?: Array<number>;
+        workWeek?: Array<number>;
 
         /** @docid dxchartoptions_argumentaxis_holidays */
         holidays?: any;

--- a/ts/legacy/viz-core.d.ts
+++ b/ts/legacy/viz-core.d.ts
@@ -472,6 +472,26 @@ declare module DevExpress.viz.core {
         cornerRadius?: number;
     }
 
+    export interface BreakStyle {
+
+        /**
+        * @docid dxchartoptions_commonaxissettings_breakStyle_width
+        * @docid dxrangeselectoroptions_scale_breakStyle_width
+        */
+        width?: number;
+        /**
+        * @docid dxrangeselectoroptions_scale_breakStyle_color
+        * @docid dxchartoptions_commonaxissettings_breakStyle_color
+        */
+        color?: string;
+
+        /**
+        * @docid dxchartoptions_commonaxissettings_breakStyle_line
+        * @docid dxrangeselectoroptions_scale_breakStyle_line
+        */
+        line?: string;
+    }
+
     export interface BaseLegend {
         /**
         * @docid basechartoptions_legend_backgroundcolor

--- a/ts/legacy/viz-rangeselector.d.ts
+++ b/ts/legacy/viz-rangeselector.d.ts
@@ -142,7 +142,7 @@ declare module DevExpress.viz.rangeSelector {
             workdaysOnly?: boolean;
 
             /** @docid dxrangeselectoroptions_scale_workweek */
-            workweek?: Array<number>;
+            workWeek?: Array<number>;
 
             /** @docid dxrangeselectoroptions_scale_holidays */
             holidays?: any;

--- a/ts/legacy/viz-rangeselector.d.ts
+++ b/ts/legacy/viz-rangeselector.d.ts
@@ -135,6 +135,24 @@ declare module DevExpress.viz.rangeSelector {
             /** @docid dxrangeselectoroptions_scale_endvalue */
             endValue?: any;
 
+            /** @docid dxrangeselectoroptions_scale_breaks */
+            breaks?: Array<any>;
+
+            /** @docid dxrangeselectoroptions_scale_workdaysonly */
+            workdaysOnly?: boolean;
+
+            /** @docid dxrangeselectoroptions_scale_workweek */
+            workweek?: Array<number>;
+
+            /** @docid dxrangeselectoroptions_scale_holidays */
+            holidays?: any;
+
+            /** @docid dxrangeselectoroptions_scale_singleworkdays */
+            singleWorkdays?: any;
+
+             /** @docid dxrangeselectoroptions_scale_breakStyle */
+            breakStyle?: viz.core.BreakStyle;
+
             /** @docid dxrangeselectoroptions_scale_label */
             label?: {
 


### PR DESCRIPTION
This PR implements the following features:
- auto scale breaks on a value axis:
```javascript
valueAxis: {
   autoBreaksEnabled: true,
   maxAutoBreakCount: 3
}
```
- custom scale breaks on both axes:
```javascript
valueAxis: { // or argumentAxis
    breaks: [[300, 700], [1020, 1400]]
}
```
- scale breaks' appearance customization:
```javascript
commonAxisSettings: {
    breakStyle: { 
        width: 5,
        color: "#ababab",
        line: "waved" // or "straight"
    }
}
```
- the capability to skip holidays and days off on a DateTime argument axis:
```javascript
argumentAxis: {
   workdaysOnly: true,   
   workWeek: [1, 2, 3, 4, 5],  //default value
   holidays: [new Date(2017, 11, 25)]
}
```