### PR TITLE
Fix parsing of incomplete float value in dxNumberBox with stubs after the caret

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -3,12 +3,13 @@
 var eventsEngine = require("../../events/core/events_engine"),
     extend = require("../../core/utils/extend").extend,
     ensureDefined = require("../../core/utils/common").ensureDefined,
+    escapeRegExp = require("../../core/utils/common").escapeRegExp,
     number = require("../../localization/number"),
     NumberBoxBase = require("./number_box.base"),
     eventUtils = require("../../events/utils");
 
 var NUMBER_FORMATTER_NAMESPACE = "dxNumberFormatter",
-    STUB_CHAR_REG_EXP = "[^0-9]",
+    STUB_CHAR_REG_EXP = "[^0-9.]",
     MOVE_FORWARD = 1,
     MOVE_BACKWARD = -1;
 
@@ -75,7 +76,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
             index--;
         }
 
-        while(this._isStub(text.charAt(index)) && text.charAt(index) !== number.getDecimalSeparator()) {
+        while(this._isStub(text.charAt(index))) {
             index += direction;
         }
 
@@ -130,9 +131,12 @@ var NumberBoxMask = NumberBoxBase.inherit({
 
         if(this._isStub(char)) {
             e.preventDefault();
-            if(char === number.getDecimalSeparator()) {
-                this._moveCaret(this._isDeleteKey(e.key) ? 1 : -1);
-            }
+            return;
+        }
+
+        if(char === number.getDecimalSeparator()) {
+            this._moveCaret(this._isDeleteKey(e.key) ? 1 : -1);
+            e.preventDefault();
             return;
         }
 
@@ -357,7 +361,8 @@ var NumberBoxMask = NumberBoxBase.inherit({
     },
 
     _endsWith: function(string, suffix) {
-        return string.indexOf(suffix, string.length - suffix.length) !== -1;
+        var regExp = new RegExp(escapeRegExp(suffix) + STUB_CHAR_REG_EXP + "*$", "ig");
+        return regExp.test(string);
     },
 
     _revertSign: function(e) {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -365,6 +365,18 @@ QUnit.test("leading zeros without stubs should be parsed", function(assert) {
     assert.equal(this.input.val(), "1$", "value is correct");
 });
 
+QUnit.test("incomplete enter should not be prevented when there are stubs after the caret", function(assert) {
+    this.instance.option({
+        format: "#0.## kg",
+        value: 123
+    });
+
+    this.keyboard.caret(3).type(".45");
+
+    assert.equal(this.input.val(), "123.45 kg", "value is correct");
+});
+
+
 QUnit.module("format: removing", moduleConfig);
 
 QUnit.test("delete key should remove a char", function(assert) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
