### PR TITLE
 Fix incorrect extra large value parsing in the dxNumberBox

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -394,7 +394,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
 
     _lightParse: function(text) {
         var value = +text;
-        return isNaN(value) ? null : value;
+        return isNaN(value) || Math.abs(value) > 999999999999999 ? null : value;
     },
 
     _parseValue: function(text) {

--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -15,7 +15,8 @@ var eventsEngine = require("../../events/core/events_engine"),
 var NUMBER_FORMATTER_NAMESPACE = "dxNumberFormatter",
     STUB_CHAR_REG_EXP = "[^0-9.]",
     MOVE_FORWARD = 1,
-    MOVE_BACKWARD = -1;
+    MOVE_BACKWARD = -1,
+    MAXIMUM_FLOAT_LIMIT = 999999999999999;
 
 var NumberBoxMask = NumberBoxBase.inherit({
 
@@ -394,7 +395,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
 
     _lightParse: function(text) {
         var value = +text;
-        return isNaN(value) || Math.abs(value) > 999999999999999 ? null : value;
+        return isNaN(value) || Math.abs(value) > MAXIMUM_FLOAT_LIMIT ? null : value;
     },
 
     _parseValue: function(text) {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -115,6 +115,20 @@ QUnit.test("invert sign should be prevented if minimum is larger than 0", functi
     assert.equal(this.input.val(), "4", "reverting was prevented");
 });
 
+QUnit.test("17-digit value should not be parsed", function(assert) {
+    this.instance.option("value", 999999999999999);
+    this.keyboard.type("9");
+
+    assert.equal(this.input.val(), "999999999999999", "input was prevented");
+});
+
+QUnit.test("17-digit negative value should not be parsed", function(assert) {
+    this.instance.option("value", -999999999999999);
+    this.keyboard.type("9");
+
+    assert.equal(this.input.val(), "-999999999999999", "input was prevented");
+});
+
 
 QUnit.module("format: text input", moduleConfig);
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
