### PR TITLE
dxList: Fix "Select All"  incorrectly works with a filtered data source when selectAllMode is "allPages" (T567757)

### DIFF
--- a/js/ui/collection/ui.collection_widget.edit.js
+++ b/js/ui/collection/ui.collection_widget.edit.js
@@ -197,6 +197,10 @@ var CollectionWidget = BaseCollectionWidget.inherit({
         return !!(this._dataSource && this._dataSource.key());
     },
 
+    _getCombinedFilter: function() {
+        return this._dataSource && this._dataSource.filter();
+    },
+
     keyOf: function(item) {
         var key = item,
             store = this._dataSource && this._dataSource.store();
@@ -224,9 +228,7 @@ var CollectionWidget = BaseCollectionWidget.inherit({
                     that._updateSelectedItems(args.addedItems, args.removedItems);
                 }
             },
-            filter: function() {
-                return that._dataSource && that._dataSource.filter();
-            },
+            filter: that._getCombinedFilter.bind(that),
             totalCount: function() {
                 var items = that.option("items");
                 var dataSource = that._dataSource;

--- a/js/ui/list/ui.list.edit.js
+++ b/js/ui/list/ui.list.edit.js
@@ -275,6 +275,20 @@ var ListEdit = ListBase.inherit({
         }
     },
 
+    _getCombinedFilter: function() {
+        var filter,
+            storeLoadOptions,
+            dataSource = this._dataSource;
+
+        if(dataSource) {
+            storeLoadOptions = { filter: dataSource.filter() };
+            dataSource._addSearchFilter(storeLoadOptions);
+            filter = storeLoadOptions.filter;
+        }
+
+        return filter;
+    },
+
     _isPageSelectAll: function() {
         return this.option("selectAllMode") === "page";
     },

--- a/testing/tests/DevExpress.ui.widgets/listParts/editingTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/editingTests.js
@@ -505,6 +505,40 @@ QUnit.test("selection works well after clean all selected items and selectAllMod
     assert.equal(selectionChangedSpy.callCount, 3, "'selectionChanged' event has been fired 3 times");
 });
 
+//T567757
+QUnit.test("Selecting all filtered items when selectAllMode is 'allPages'", function(assert) {
+    //arrange
+    var items = [1, 2, 3, 4, 5],
+        $selectAll;
+
+    var instance = $("#list").dxList({
+        dataSource: {
+            store: items,
+            pageSize: 2,
+            paginate: true
+        },
+        showSelectionControls: true,
+        selectionMode: "all",
+        selectAllMode: "allPages",
+        searchValue: "1"
+    }).dxList("instance");
+
+    //act
+    instance.selectItem(0);
+
+    //assert
+    $selectAll = $("#list").find(".dx-list-select-all-checkbox");
+    assert.ok($selectAll.hasClass("dx-checkbox-checked"), "selectAll checkbox is checked");
+    assert.deepEqual(instance.option("selectedItems"), [1], "selected items");
+
+    //act
+    instance.option("searchValue", "");
+
+    //assert
+    $selectAll = $("#list").find(".dx-list-select-all-checkbox");
+    assert.ok($selectAll.hasClass("dx-checkbox-indeterminate"), "selectAll checkbox is indeterminate");
+});
+
 var LIST_ITEM_SELECTED_CLASS = "dx-list-item-selected";
 
 QUnit.module("selecting in grouped list", {

--- a/testing/tests/DevExpress.ui.widgets/listParts/editingTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/editingTests.js
@@ -509,18 +509,19 @@ QUnit.test("selection works well after clean all selected items and selectAllMod
 QUnit.test("Selecting all filtered items when selectAllMode is 'allPages'", function(assert) {
     //arrange
     var items = [1, 2, 3, 4, 5],
-        $selectAll;
-
-    var instance = $("#list").dxList({
-        dataSource: {
+        $selectAll,
+        ds = new DataSource({
             store: items,
             pageSize: 2,
-            paginate: true
-        },
+            paginate: true,
+            searchValue: "1"
+        });
+
+    var instance = $("#list").dxList({
+        dataSource: ds,
         showSelectionControls: true,
         selectionMode: "all",
-        selectAllMode: "allPages",
-        searchValue: "1"
+        selectAllMode: "allPages"
     }).dxList("instance");
 
     //act
@@ -532,7 +533,8 @@ QUnit.test("Selecting all filtered items when selectAllMode is 'allPages'", func
     assert.deepEqual(instance.option("selectedItems"), [1], "selected items");
 
     //act
-    instance.option("searchValue", "");
+    ds.searchValue("");
+    ds.load();
 
     //assert
     $selectAll = $("#list").find(".dx-list-select-all-checkbox");


### PR DESCRIPTION
See https://devexpress.com/issue=T567757
