### PR TITLE
Fix incorrect behavior of the dxForm.itemOption function (T566218)

### DIFF
--- a/js/ui/form/ui.form.js
+++ b/js/ui/form/ui.form.js
@@ -1464,7 +1464,7 @@ var Form = Widget.inherit({
     },
 
     _getTextWithoutSpaces: function(text) {
-        return text ? text.replace(" ", "") : undefined;
+        return text ? text.replace(/\s/g, '') : undefined;
     },
 
     _isExpectedItem: function(item, fieldName) {

--- a/js/ui/form/ui.form.js
+++ b/js/ui/form/ui.form.js
@@ -1436,7 +1436,7 @@ var Form = Widget.inherit({
             } else {
                 break;
             }
-        } while(path.length && result !== false);
+        } while(path.length && !typeUtils.isDefined(result));
 
         return result;
     },
@@ -1450,7 +1450,7 @@ var Form = Widget.inherit({
             result;
 
         each(items, function(index, groupItem) {
-            result = that._getItemByFieldPath(path, fieldName, groupItem);
+            result = that._getItemByFieldPath(path.slice(), fieldName, groupItem);
             if(result) {
                 return false;
             }

--- a/testing/tests/DevExpress.ui.widgets.form/form.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.tests.js
@@ -2903,6 +2903,66 @@ QUnit.test("Use 'itemOption' with tabs", function(assert) {
     assert.equal($testContainer.find("." + internals.FIELD_ITEM_LABEL_CLASS).eq(4).text(), "NEWLABEL:", "new label rendered");
 });
 
+QUnit.test("'itemOption' should get an item with several spaces in the caption", function(assert) {
+    //arrange
+    var $testContainer = $("#form").dxForm({
+            formData: { EmployeeID: 1, LastName: "John", FirstName: "Dow" },
+            items: [
+                "EmployeeID",
+                {
+                    itemType: "group",
+                    caption: "Test group item",
+                    items: [
+                        "FirstName", "LastName"
+                    ]
+                }
+            ] }
+        ),
+        form = $testContainer.dxForm("instance");
+
+    //act
+    var groupItem = form.itemOption("Testgroupitem"),
+        innerGroupItem = form.itemOption("Testgroupitem.FirstName");
+
+    assert.deepEqual(groupItem, {
+        itemType: "group",
+        caption: "Test group item",
+        items: [ { dataField: "FirstName" }, { dataField: "LastName" }]
+    }, "Correct group item");
+
+    form.itemOption("Testgroupitem.LastName", "label", { text: "NEWLABEL" });
+
+    //assert
+    assert.equal(innerGroupItem.dataField, "FirstName", "corrected item received");
+    assert.equal($testContainer.find("." + internals.FIELD_ITEM_LABEL_CLASS).last().text(), "NEWLABEL:", "new label rendered");
+});
+
+QUnit.test("'itemOption' should get an item with several spaces in the caption and long path", function(assert) {
+    //arrange
+    var $testContainer = $("#form").dxForm({
+            formData: { EmployeeID: 1, LastName: "John", FirstName: "Dow" },
+            items: [
+                "EmployeeID",
+                {
+                    itemType: "group",
+                    caption: "Test group 1",
+                    items: [{
+                        itemType: "group",
+                        caption: "Test group 2",
+                        items: ["FirstName", "LastName"]
+                    }]
+                }
+            ] }
+        ),
+        form = $testContainer.dxForm("instance");
+
+    //act
+    var innerGroupItem = form.itemOption("Testgroup1.Testgroup2.FirstName");
+
+    //assert
+    assert.deepEqual(innerGroupItem, { dataField: "FirstName" }, "corrected item received");
+});
+
 function getID(form, dataField) {
     return "dx_" + form.option("formID") + "_" + dataField;
 }

--- a/testing/tests/DevExpress.ui.widgets.form/form.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.tests.js
@@ -2963,6 +2963,35 @@ QUnit.test("'itemOption' should get an item with several spaces in the caption a
     assert.deepEqual(innerGroupItem, { dataField: "FirstName" }, "corrected item received");
 });
 
+QUnit.test("'itemOption' should get an group inner item located into tabbed item", function(assert) {
+    //arrange
+    var $testContainer = $("#form").dxForm({
+            formData: { EmployeeID: 1, LastName: "John", FirstName: "Dow" },
+            items: [
+                {
+                    itemType: "tabbed",
+                    tabs: [{
+                        title: "Test Tab 1",
+                        items: ["EmployeeID"]
+                    }, {
+                        title: "Test Tab 2",
+                        items: [{
+                            itemType: "group",
+                            caption: "Test Group 1",
+                            items: ["FirstName", "LastName"]
+                        }]
+                    }]
+                }]
+        }),
+        form = $testContainer.dxForm("instance");
+
+    //act
+    var innerGroupItem = form.itemOption("TestTab2.TestGroup1.FirstName");
+
+    //assert
+    assert.deepEqual(innerGroupItem, { dataField: "FirstName" }, "corrected item received");
+});
+
 function getID(form, dataField) {
     return "dx_" + form.option("formID") + "_" + dataField;
 }


### PR DESCRIPTION
It was impossible to get an item with a caption contains multiple spaces

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
