### PR TITLE
Remove 'Content-Type' header for view's requests

### DIFF
--- a/js/framework/html/view_engine.js
+++ b/js/framework/html/view_engine.js
@@ -156,7 +156,7 @@ var ViewEngine = Class.inherit({
 
         this._ajaxImpl({
             url: url,
-            contentType: "text/html"
+            dataType: "html"
         }).done(function(data) {
             that._loadTemplatesFromMarkupCore(domUtils.createMarkupFromString(data));
             deferred.resolve();

--- a/testing/tests/DevExpress.framework/html_viewEngine.tests.js
+++ b/testing/tests/DevExpress.framework/html_viewEngine.tests.js
@@ -99,6 +99,29 @@ QUnit.test("Find templates by links (nonexistent template)", function(assert) {
         });
 });
 
+QUnit.test("Find templates by links (right options for jquery.ajax)", function(assert) {
+    var done = assert.async(),
+        url = "../../helpers/someview.html";
+
+    ajaxMock.setup({
+        url: url,
+        status: 200,
+        callback: function(request) {
+            assert.equal(request.dataType, "html");
+            assert.equal(request.contentType, undefined);
+            done();
+        }
+    });
+
+    $("head").append('<li' + 'nk rel="dx-template" type="text/html" href="' + url + '"/>');
+    var engine = new ViewEngineTester({
+        $root: $("<div></div>"),
+        disableInit: true
+    });
+
+    engine.init();
+});
+
 QUnit.test("Load a dynamic view from url", function(assert) {
     var done = assert.async();
 


### PR DESCRIPTION
I don't know why the dataType was removed some times ago and contentType was added. But contentType option forces jQuery to add Content-Type header to the request. If the value of Content-Type header does not equal to 'application/x-www-form-urlencoded', 'multipart/form-data' or 'text/plain', the browser sends preflight OPTIONS request before GET request for CORS requests. OPTIONS requests were forbidden by DevExtreme CDN service until recently. And was allowed only because of this line of code. In the other case, our SPA demos were crushed with 17.2 sources.
