### PR TITLE
T578928: dxTagBox - Widget fails to open in iOS when the multiline option is disabled

### DIFF
--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -593,18 +593,17 @@ var TagBox = SelectBox.inherit({
         if(this._$tagsContainer) {
             eventsEngine.off(this._$tagsContainer, eventName);
             eventsEngine.on(this._$tagsContainer, eventName, function(e) {
-                e.preventDefault();
-            });
+                this._preventFocusOut = true;
+            }.bind(this));
         }
     },
 
     _renderTagRemoveAction: function() {
         var tagRemoveAction = this._createAction(this._removeTagHandler.bind(this));
         var eventName = eventUtils.addNamespace(clickEvent.name, "dxTagBoxTagRemove");
-        var $container = this.$element().find("." + TEXTEDITOR_CONTAINER_CLASS);
 
-        eventsEngine.off($container, eventName);
-        eventsEngine.on($container, eventName, "." + TAGBOX_TAG_REMOVE_BUTTON_CLASS, function(e) {
+        eventsEngine.off(this._$tagsContainer, eventName);
+        eventsEngine.on(this._$tagsContainer, eventName, "." + TAGBOX_TAG_REMOVE_BUTTON_CLASS, function(e) {
             tagRemoveAction({ event: e });
         });
 
@@ -668,7 +667,10 @@ var TagBox = SelectBox.inherit({
     },
 
     _focusOutHandler: function(e) {
-        if(this.option("opened") && this.option("applyValueMode") === "useButtons") {
+        var openedUseButtons = this.option("opened") && this.option("applyValueMode") === "useButtons";
+
+        if(openedUseButtons || this._preventFocusOut) {
+            this._preventFocusOut = false;
             return;
         }
 
@@ -1206,6 +1208,7 @@ var TagBox = SelectBox.inherit({
     _clean: function() {
         this.callBase();
         delete this._defaultTagTemplate;
+        delete this._preventFocusOut;
         delete this._tagTemplate;
     },
 

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -3688,15 +3688,18 @@ QUnit.test("tags container should be scrolled on mobile devices", function(asser
     }
 });
 
-QUnit.test("preventDefault should be called - T454876", function(assert) {
-    var spy = sinon.spy();
+QUnit.testInActiveWindow("focusOut should be prevented when tagContainer clicked - T454876", function(assert) {
+    var focusOutHandler = sinon.spy(),
+        $input = this.$element.find("input"),
+        $tagContainer = this.$element.find(".dx-tag-container");
 
-    $(this.$element).on("dxpointerdown", spy);
+    this.instance.on("focusOut", focusOutHandler);
 
-    $(this.$element.find(".dx-tag-container")).trigger("dxpointerdown");
+    $input.focus();
+    $tagContainer.trigger("dxpointerdown");
+    $input.blur();
 
-    var event = spy.args[0][0];
-    assert.ok(event.isDefaultPrevented(), "default is prevented");
+    assert.equal(focusOutHandler.callCount, 0, "focusout has been prevented");
 });
 
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
