### PR TITLE
T578928: dxTagBox - Widget fails to open in iOS when the multiline option is disabled

### DIFF
--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -524,11 +524,13 @@ var TagBox = SelectBox.inherit({
     _renderPreventBlur: function() {
         var eventName = eventUtils.addNamespace(pointerEvents.down, "dxTagBoxContainer");
 
-        this._$tagsContainer && this._$tagsContainer
-            .off(eventName)
-            .on(eventName, function(e) {
-                e.preventDefault();
-            });
+        if(this._$tagsContainer) {
+            this._$tagsContainer
+                .off(eventName)
+                .on(eventName, function() {
+                    this._preventFocusOut = true;
+                }.bind(this));
+        }
     },
 
     _renderTagRemoveAction: function() {
@@ -602,7 +604,10 @@ var TagBox = SelectBox.inherit({
     },
 
     _focusOutHandler: function(e) {
-        if(this.option("opened") && this.option("applyValueMode") === "useButtons") {
+        var openedUseButtons = this.option("opened") && this.option("applyValueMode") === "useButtons";
+
+        if(openedUseButtons || this._preventFocusOut) {
+            this._preventFocusOut = false;
             return;
         }
 
@@ -1091,6 +1096,7 @@ var TagBox = SelectBox.inherit({
     _clean: function() {
         this.callBase();
         delete this._defaultTagTemplate;
+        delete this._preventFocusOut;
         delete this._tagTemplate;
     },
 

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -3411,15 +3411,18 @@ QUnit.test("tags container should be scrolled on mobile devices", function(asser
     }
 });
 
-QUnit.test("preventDefault should be called - T454876", function(assert) {
-    var spy = sinon.spy();
+QUnit.testInActiveWindow("focusOut should be prevented when tagContainer clicked - T454876", function(assert) {
+    var focusOutHandler = sinon.spy(),
+        $input = this.$element.find("input"),
+        $tagContainer = this.$element.find(".dx-tag-container");
 
-    this.$element.on("dxpointerdown", spy);
+    this.instance.on("focusOut", focusOutHandler);
 
-    this.$element.find(".dx-tag-container").trigger("dxpointerdown");
+    $input.focus();
+    $tagContainer.trigger("dxpointerdown");
+    $input.blur();
 
-    var event = spy.args[0][0];
-    assert.ok(event.isDefaultPrevented(), "default is prevented");
+    assert.equal(focusOutHandler.callCount, 0, "focusout has been prevented");
 });
 
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
