### PR TITLE
Fix calendar dxDateBox picker is rendered incorrectly in IE in the Android theme (T570262)

### DIFF
--- a/js/ui/date_box/ui.date_box.strategy.calendar_with_time.js
+++ b/js/ui/date_box/ui.date_box.strategy.calendar_with_time.js
@@ -137,7 +137,7 @@ var CalendarWithTimeStrategy = CalendarStrategy.inherit({
                     if(this._box.option("_layoutStrategy") === "fallback") {
                         var clockMinWidth = this._getPopup().$content().find(".dx-timeview-clock").css("minWidth");
 
-                        this._timeView.$element().css("width", clockMinWidth);
+                        this._timeView.$element().css("minWidth", clockMinWidth);
                     }
                 }).bind(this),
             });

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -2665,11 +2665,6 @@ QUnit.test("DateBox should have time part when pickerType is rollers", function(
 });
 
 QUnit.test("DateBox with time should be rendered correctly in IE, templatesRenderAsynchronously=true", function(assert) {
-    if(!browser.msie) {
-        assert.expect(0);
-        return;
-    }
-
     var clock = sinon.useFakeTimers();
     try {
         var dateBox = $("#dateBox").dxDateBox({


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
