### PR TITLE
Force overlays styles recalculation in FireFox (T581681)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -111,6 +111,7 @@
                     mockjax,    // JS library
                     moz,        // Vendor prefix
                     mozilla,
+                    firefox,
                     msie,
                     odata,      // OData
                     rtl,        // Right-to-Left

--- a/js/ui/overlay.js
+++ b/js/ui/overlay.js
@@ -51,14 +51,14 @@ var OVERLAY_CLASS = "dx-overlay",
 var realDevice = devices.real(),
     realVersion = realDevice.version,
 
-    FireFoxDesktop = browser.mozilla && realDevice.deviceType === "desktop",
+    firefoxDesktop = browser.mozilla && realDevice.deviceType === "desktop",
     iOS = realDevice.platform === "ios",
     iOS7_0andBelow = iOS && compareVersions(realVersion, [7, 1]) < 0,
     android4_0nativeBrowser = realDevice.platform === "android" && compareVersions(realVersion, [4, 0], 2) === 0 && navigator.userAgent.indexOf("Chrome") === -1;
 
 var forceRepaint = function($element) {
     // NOTE: force layout recalculation on iOS 6 & iOS 7.0 (B254713) and FF desktop (T581681)
-    if(iOS7_0andBelow || FireFoxDesktop) {
+    if(iOS7_0andBelow || firefoxDesktop) {
         $element.width();
     }
 

--- a/js/ui/overlay.js
+++ b/js/ui/overlay.js
@@ -15,6 +15,7 @@ var $ = require("../core/renderer"),
     commonUtils = require("../core/utils/common"),
     typeUtils = require("../core/utils/type"),
     devices = require("../core/devices"),
+    browser = require("../core/utils/browser"),
     registerComponent = require("../core/component_registrator"),
     Widget = require("./widget/ui.widget"),
     KeyboardProcessor = require("./widget/ui.keyboard_processor"),
@@ -50,13 +51,14 @@ var OVERLAY_CLASS = "dx-overlay",
 var realDevice = devices.real(),
     realVersion = realDevice.version,
 
+    FireFoxDesktop = browser.mozilla && realDevice.deviceType === "desktop",
     iOS = realDevice.platform === "ios",
     iOS7_0andBelow = iOS && compareVersions(realVersion, [7, 1]) < 0,
     android4_0nativeBrowser = realDevice.platform === "android" && compareVersions(realVersion, [4, 0], 2) === 0 && navigator.userAgent.indexOf("Chrome") === -1;
 
 var forceRepaint = function($element) {
-    // NOTE: force layout recalculation on iOS 6 & iOS 7.0 (B254713)
-    if(iOS7_0andBelow) {
+    // NOTE: force layout recalculation on iOS 6 & iOS 7.0 (B254713) and FF desktop (T581681)
+    if(iOS7_0andBelow || FireFoxDesktop) {
         $element.width();
     }
 


### PR DESCRIPTION
Resolve [issue with overlay animation](https://plnkr.co/edit/07nD8Ku8PE6Ti1KWzkex?p=preview) of dxTagBox in FireFox
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
