### PR TITLE
Fix dxFileUploader - Problem with extension based values of accept attribute when using drag&drop (fix #1698) (T570224) 

### DIFF
--- a/js/ui/file_uploader.js
+++ b/js/ui/file_uploader.js
@@ -974,13 +974,13 @@ var FileUploader = Editor.inherit({
             if(allowedType[0] === ".") {
                 allowedType = allowedType.replace(".", "\\.");
 
-                if(file.name.match(allowedType)) {
+                if(file.name.match(new RegExp(allowedType + "$", "i"))) {
                     return true;
                 }
             } else {
                 allowedType = allowedType.replace("*", "");
 
-                if(file.type.match(allowedType)) {
+                if(file.type.match(new RegExp(allowedType, "i"))) {
                     return true;
                 }
             }

--- a/testing/tests/DevExpress.ui.widgets.editors/fileUploader.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/fileUploader.tests.js
@@ -1848,6 +1848,48 @@ QUnit.test("the 'accept' option should not be ignored on drag&drop (T384800)", f
     assert.deepEqual(fileUploader.option("value"), [], "value is empty");
 });
 
+QUnit.test("the 'accept' option is case insensitive (T570224)", function(assert) {
+    var $fileUploader = $('#fileuploader').dxFileUploader({
+            useDragOver: true,
+            accept: ".jpg"
+        }),
+        fileUploader = $fileUploader.dxFileUploader("instance"),
+        $inputWrapper = $fileUploader.find('.' + FILEUPLOADER_INPUT_WRAPPER_CLASS),
+        files = [{
+            name: "fakefile.JPG",
+        }],
+        event = $.Event($.Event("drop", { dataTransfer: { files: files } }));
+
+    $inputWrapper.trigger(event);
+    assert.deepEqual(fileUploader.option("value"), files, "file is chosen");
+
+    files = [{
+        name: "fakefile.JPG",
+        type: "IMAGE/JPEG"
+    }],
+    fileUploader.option("accept", "image/*");
+    event = $.Event($.Event("drop", { dataTransfer: { files: files } }));
+    $inputWrapper.trigger(event);
+    assert.deepEqual(fileUploader.option("value"), files, "file is chosen");
+});
+
+QUnit.test("the 'accept' option check an extension only at the end of the file (T570224)", function(assert) {
+    var $fileUploader = $('#fileuploader').dxFileUploader({
+            useDragOver: true,
+            accept: ".jpg"
+        }),
+        fileUploader = $fileUploader.dxFileUploader("instance"),
+        $inputWrapper = $fileUploader.find('.' + FILEUPLOADER_INPUT_WRAPPER_CLASS),
+        files = [{
+            name: "fakefile.jpg.bak",
+            type: "image/text",
+        }],
+        event = $.Event($.Event("drop", { dataTransfer: { files: files } }));
+
+    $inputWrapper.trigger(event);
+    assert.deepEqual(fileUploader.option("value"), [], "value is empty");
+});
+
 QUnit.test("the 'accept' option with multiple types should work correctly on drag&drop", function(assert) {
     var fakeFile2 = {
         name: "fakefile2",


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
