### PR TITLE
T582565: dxNumberBox shows a wrong decimal text for the 1.1 value when a mask is used

### DIFF
--- a/js/localization/ldml/number.js
+++ b/js/localization/ldml/number.js
@@ -1,9 +1,11 @@
 "use strict";
 
-var escapeRegExp = require("../../core/utils/common").escapeRegExp;
+var escapeRegExp = require("../../core/utils/common").escapeRegExp,
+    fitIntoRange = require("../../core/utils/math").fitIntoRange;
 
 var DEFAULT_CONFIG = { thousandsSeparator: ",", decimalSeparator: "." },
     ESCAPING_CHAR = "'",
+    MAXIMUM_NUMBER_LENGTH = 15,
     MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
 
 function getGroupSizes(formatString) {
@@ -199,9 +201,11 @@ function getFormatter(format, config) {
             maxFloatPrecision = minFloatPrecision + getNonRequiredDigitCount(floatFormatParts[1]),
             minIntegerPrecision = getRequiredDigitCount(floatFormatParts[0]),
             maxIntegerPrecision = getNonRequiredDigitCount(floatFormatParts[0]) ? undefined : minIntegerPrecision,
+            integerLength = Math.floor(value).toString().length,
+            floatPrecision = fitIntoRange(maxFloatPrecision, 0, MAXIMUM_NUMBER_LENGTH - integerLength),
             groupSizes = getGroupSizes(floatFormatParts[0]).reverse();
 
-        var valueParts = value.toFixed(maxFloatPrecision).split(".");
+        var valueParts = value.toFixed(floatPrecision < 0 ? 0 : floatPrecision).split(".");
 
         var valueIntegerPart = normalizeValueString(reverseString(valueParts[0]), minIntegerPrecision, maxIntegerPrecision),
             valueFloatPart = normalizeValueString(valueParts[1], minFloatPrecision, maxFloatPrecision);

--- a/testing/tests/DevExpress.localization/ldml.tests.js
+++ b/testing/tests/DevExpress.localization/ldml.tests.js
@@ -256,6 +256,13 @@ QUnit.test("float with precision formatting", function(assert) {
     assert.strictEqual(formatter(-123.57), "-123.57", "format negative float");
 });
 
+QUnit.test("extra large float part formatting", function(assert) {
+    var formatter = getNumberFormatter("#0.####################");
+
+    assert.strictEqual(formatter(1.1), "1.1", "float format is correct");
+    assert.strictEqual(formatter(1), "1", "integer format is correct");
+});
+
 QUnit.test("float with precision formatting and required integer digit", function(assert) {
     var formatter = getNumberFormatter("#0.00");
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
