### PR TITLE
Fix dxFilterBuilder gets an incorrect value after deleting items if they are added without the "And" operator (T584233)

### DIFF
--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -283,7 +283,7 @@ function isGroup(criteria) {
         return false;
     }
 
-    return criteria.length === 1 || criteria.some(function(item) {
+    return criteria.length < 2 || criteria.some(function(item) {
         return Array.isArray(item);
     });
 }

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -139,6 +139,7 @@ QUnit.module("Utils", function() {
     QUnit.test("isGroup", function(assert) {
         assert.ok(utils.isGroup([[], "and", []]));
         assert.ok(utils.isGroup(["and"]));
+        assert.ok(utils.isGroup([]));
     });
 
     QUnit.test("isEmptyGroup", function(assert) {
@@ -773,6 +774,14 @@ QUnit.module("Filter normalization", function() {
         group = utils.getNormalizedFilter(group, fields);
 
         assert.equal(group, null);
+    });
+
+    QUnit.test("get normalized filter from group with condition and empty inner group", function(assert) {
+        var group = [condition1, "or", []];
+
+        group = utils.getNormalizedFilter(group, fields);
+
+        assert.equal(group, condition1);
     });
 
     QUnit.test("get normalized filter from group with many inner groups", function(assert) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
