### PR TITLE
T582887: dxNumberBox - It is impossible to edit a value if a percent is screened

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -331,6 +331,14 @@ QUnit.test("percent format should work properly on value change", function(asser
     assert.equal(this.instance.option("value"), 0.45, "value is correct");
 });
 
+QUnit.test("escaped percent should be parsed correctly", function(assert) {
+    this.instance.option("format", "#0'%'");
+    this.keyboard.type("123").change();
+
+    assert.equal(this.input.val(), "123%", "text is correct");
+    assert.equal(this.instance.option("value"), 123, "value is correct");
+});
+
 QUnit.test("non-ldml percent format should work properly on value change", function(assert) {
     this.instance.option("value", "");
     this.instance.option("format", "percent");


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
