### PR TITLE
Fix dxMap geocoding error in a case when the "center" option is null (T585186)

### DIFF
--- a/js/ui/map/provider.dynamic.google.js
+++ b/js/ui/map/provider.dynamic.google.js
@@ -10,11 +10,11 @@ var $ = require("../../core/renderer"),
     DynamicProvider = require("./provider.dynamic"),
     errors = require("../widget/ui.errors"),
     Color = require("../../color"),
-    ajax = require("../../core/utils/ajax");
+    ajax = require("../../core/utils/ajax"),
+    isDefined = require("../../core/utils/type").isDefined;
 
 var GOOGLE_MAP_READY = "_googleScriptReady",
-    GOOGLE_URL = "https://maps.google.com/maps/api/js?sensor=false&callback=" + GOOGLE_MAP_READY;
-
+    GOOGLE_URL = "https://maps.googleapis.com/maps/api/js?callback=" + GOOGLE_MAP_READY;
 
 var CustomMarker;
 
@@ -108,6 +108,11 @@ var GoogleProvider = DynamicProvider.inherit({
     _geocodedLocations: {},
     _geocodeLocationImpl: function(location) {
         return new Promise(function(resolve) {
+            if(!isDefined(location)) {
+                resolve(new google.maps.LatLng(0, 0));
+                return;
+            }
+
             var geocoder = new google.maps.Geocoder();
             geocoder.geocode({ 'address': location }, function(results, status) {
                 if(status === google.maps.GeocoderStatus.OK) {

--- a/testing/tests/DevExpress.ui.widgets/mapParts/googleTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/googleTests.js
@@ -304,6 +304,30 @@ QUnit.test("center with geocode error", function(assert) {
     });
 });
 
+QUnit.test("'center' option is null", function(assert) {
+    var done = assert.async(),
+        d1 = $.Deferred(),
+        map = $("#map").dxMap({
+            provider: "google",
+            center: null,
+            onReady: function() {
+                assert.equal(window.google.geocodeCalled, 0, "geocode not used");
+                assert.deepEqual(window.google.assignedCenter, window.geocodedWithErrorLocation, "center changed");
+
+                d1.resolve();
+            }
+        }).dxMap("instance");
+
+    d1.done(function() {
+        map.option("onUpdated", function() {
+            assert.equal(window.google.geocodeCalled, 1, "geocode used");
+            assert.deepEqual(window.google.assignedCenter, window.geocodedLocation, "center changed");
+            done();
+        });
+        map.option("center", LOCATIONS[0]);
+    });
+});
+
 QUnit.test("geocode should be called once for equal locations", function(assert) {
     var done = assert.async();
     var d1 = $.Deferred(),


### PR DESCRIPTION
I've updated a request URL too. For now, the [`sensor` parameter](https://developers.google.com/maps/documentation/javascript/geolocation#SpecifyingSensor) is obsolete
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
