### PR TITLE
 dxTagBox: focus state class should be removed after a focusout event

### DIFF
--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -668,7 +668,10 @@ var TagBox = SelectBox.inherit({
         this._scrollContainer("end");
     },
 
-    _restoreInputText: noop,
+    _restoreInputText: function() {
+        this._clearTextValue();
+        this._clearFilter();
+    },
 
     _focusOutHandler: function(e) {
         var openedUseButtons = this.option("opened") && this.option("applyValueMode") === "useButtons";
@@ -680,7 +683,6 @@ var TagBox = SelectBox.inherit({
 
         this.callBase(e);
 
-        this._clearTextValue();
         this._clearTagFocus();
 
         this._scrollContainer("start");

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -668,6 +668,8 @@ var TagBox = SelectBox.inherit({
         this._scrollContainer("end");
     },
 
+    _restoreInputText: noop,
+
     _focusOutHandler: function(e) {
         var openedUseButtons = this.option("opened") && this.option("applyValueMode") === "useButtons";
 
@@ -675,6 +677,8 @@ var TagBox = SelectBox.inherit({
             this._preventFocusOut = false;
             return;
         }
+
+        this.callBase(e);
 
         this._clearTextValue();
         this._clearTagFocus();

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -4374,3 +4374,26 @@ QUnit.testInActiveWindow("focusout event should remove focus class from the widg
     $input.blur();
     assert.notOk($tagBox.hasClass(FOCUSED_CLASS), "focused class was removed");
 });
+
+QUnit.test("search filter should be cleared on close", function(assert) {
+    var $tagBox = $("#tagBox").dxTagBox({
+            items: ["111", "222", "333"],
+            searchTimeout: 0,
+            opened: true,
+            searchEnabled: true
+        }),
+        instance = $tagBox.dxTagBox("instance"),
+        $tagContainer = $tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS),
+        $input = $tagBox.find("input"),
+        kb = keyboardMock($input);
+
+    kb.type("111");
+    this.clock.tick();
+    assert.equal($(instance.content()).find("." + LIST_ITEM_CLASS).length, 1, "filter was applied");
+
+    $tagContainer.trigger("dxclick");
+    $tagContainer.trigger("dxclick");
+
+    assert.equal($input.val(), "", "input was cleared");
+    assert.equal($(instance.content()).find("." + LIST_ITEM_CLASS).length, 3, "filter was cleared");
+});

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -4364,7 +4364,7 @@ QUnit.testInActiveWindow("Searching should work correctly in grouped tagBox (T51
     assert.equal($.trim($tagContainer.text()), "Item1Item3", "selected values are rendered");
 });
 
-QUnit.test("focusout event should remove focus class from the widget", function(assert) {
+QUnit.testInActiveWindow("focusout event should remove focus class from the widget", function(assert) {
     var $tagBox = $("#tagBox").dxTagBox({}),
         $input = $tagBox.find("input");
 

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -4363,3 +4363,14 @@ QUnit.testInActiveWindow("Searching should work correctly in grouped tagBox (T51
     assert.equal($tagContainer.find("." + TAGBOX_TAG_CONTENT_CLASS).length, 2, "selected tags rendered");
     assert.equal($.trim($tagContainer.text()), "Item1Item3", "selected values are rendered");
 });
+
+QUnit.test("focusout event should remove focus class from the widget", function(assert) {
+    var $tagBox = $("#tagBox").dxTagBox({}),
+        $input = $tagBox.find("input");
+
+    $input.focus();
+    assert.ok($tagBox.hasClass(FOCUSED_CLASS), "focused class was applied");
+
+    $input.blur();
+    assert.notOk($tagBox.hasClass(FOCUSED_CLASS), "focused class was removed");
+});


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
