### PR TITLE
T585452: dxContextMenu associated with a container element is shown even if the contextmenu event fires for a nested HTML element

### DIFF
--- a/js/ui/context_menu/ui.context_menu.js
+++ b/js/ui/context_menu/ui.context_menu.js
@@ -926,6 +926,7 @@ var ContextMenu = MenuBase.inherit((function() {
                 this._setOptionSilent("visible", true);
                 this._overlay.option("position", position);
                 promise = this._overlay.show();
+                jQEvent && jQEvent.stopPropagation();
 
                 var id = "dx-" + new Guid();
                 this._overlay.$content().attr({ "id": id, role: "menu" });

--- a/js/ui/context_menu/ui.context_menu.js
+++ b/js/ui/context_menu/ui.context_menu.js
@@ -901,8 +901,8 @@ var ContextMenu = MenuBase.inherit((function() {
             showing ? this._show() : this._hide();
         },
 
-        _show: function(jQEvent) {
-            var args = { jQEvent: jQEvent },
+        _show: function(event) {
+            var args = { jQEvent: event },
                 promise = new Deferred().reject().promise();
 
             this._actions.onShowing(args);
@@ -911,7 +911,7 @@ var ContextMenu = MenuBase.inherit((function() {
                 return promise;
             }
 
-            var position = this._positionContextMenu(jQEvent);
+            var position = this._positionContextMenu(event);
 
             if(position) {
                 if(!this._overlay) {
@@ -926,7 +926,7 @@ var ContextMenu = MenuBase.inherit((function() {
                 this._setOptionSilent("visible", true);
                 this._overlay.option("position", position);
                 promise = this._overlay.show();
-                jQEvent && jQEvent.stopPropagation();
+                event && event.stopPropagation();
 
                 var id = "dx-" + new Guid();
                 this._overlay.$content().attr({ "id": id, role: "menu" });

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
@@ -1047,6 +1047,18 @@ QUnit.test("default browser menu should not be prevented if context menu positio
     assert.notOk(e.isDefaultPrevented(), "default behavior should not be prevented");
 });
 
+QUnit.test("show event should not be handled by other menus targeted on the parent div", function(assert) {
+    new ContextMenu(this.$element, {
+        items: [{ text: 1 }],
+        target: "#menuTarget"
+    });
+
+    var e = $.Event("dxcontextmenu");
+
+    $("#menuTarget").trigger(e);
+    assert.ok(e.isPropagationStopped(), "propagation was stopped");
+});
+
 QUnit.test("disabling for nested item should work correctly", function(assert) {
     var instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
