### PR TITLE
Fix numerous small issues in the new color schemes

### DIFF
--- a/js/viz/core/themes/generic.carmine.js
+++ b/js/viz/core/themes/generic.carmine.js
@@ -2,7 +2,7 @@
 
 var themeModule = require("../../themes"),
     registerTheme = themeModule.registerTheme,
-
+    ACCENT_COLOR = "#f05b41",
     BACKGROUND_COLOR = "#fff",
     TITLE_COLOR = "#333",
     SUBTITLE_COLOR = "#8899a8",
@@ -101,6 +101,17 @@ registerTheme({
                     color: SUBTITLE_COLOR
                 }
             }
+        }
+    },
+    map: {
+        "layer:marker:dot": {
+            color: ACCENT_COLOR
+        },
+        "layer:marker:bubble": {
+            color: ACCENT_COLOR
+        },
+        legend: {
+            markerColor: ACCENT_COLOR
         }
     }
 }, "generic.light");

--- a/js/viz/core/themes/generic.carmine.js
+++ b/js/viz/core/themes/generic.carmine.js
@@ -83,11 +83,16 @@ registerTheme({
         scale: {
             breakStyle: { color: "#c1c5c7" },
             tick: {
-                opacity: 1
-            },
-            minorTick: {
-                opacity: 0.5
+                opacity: 0.12
             }
+        },
+        selectedRangeColor: ACCENT_COLOR,
+        sliderMarker: {
+            color: ACCENT_COLOR
+        },
+        sliderHandle: {
+            color: ACCENT_COLOR,
+            opacity: 0.5
         }
     },
     sparkline: {

--- a/js/viz/core/themes/generic.darkmoon.js
+++ b/js/viz/core/themes/generic.darkmoon.js
@@ -2,7 +2,7 @@
 
 var themeModule = require("../../themes"),
     registerTheme = themeModule.registerTheme,
-
+    ACCENT_COLOR = "#3debd3",
     BACKGROUND_COLOR = "#465672",
     TITLE_COLOR = "#fff",
     SUBTITLE_COLOR = "#919bac",
@@ -105,6 +105,19 @@ registerTheme({
     map: {
         background: {
             borderColor: BORDER_COLOR
+        },
+        "layer:area": {
+            color: "#97a3b6",
+            borderColor: BACKGROUND_COLOR
+        },
+        "layer:marker:dot": {
+            color: ACCENT_COLOR
+        },
+        "layer:marker:bubble": {
+            color: ACCENT_COLOR
+        },
+        legend: {
+            markerColor: ACCENT_COLOR
         }
     },
     rangeSelector: {

--- a/js/viz/core/themes/generic.darkmoon.js
+++ b/js/viz/core/themes/generic.darkmoon.js
@@ -127,11 +127,19 @@ registerTheme({
         scale: {
             breakStyle: { color: "#73869e" },
             tick: {
-                opacity: 1
-            },
-            minorTick: {
-                opacity: 0.5
+                opacity: 0.2
             }
+        },
+        selectedRangeColor: ACCENT_COLOR,
+        sliderMarker: {
+            color: ACCENT_COLOR,
+            font: {
+                color: "#000"
+            }
+        },
+        sliderHandle: {
+            color: ACCENT_COLOR,
+            opacity: 0.5
         }
     }
 }, "generic.dark");

--- a/js/viz/core/themes/generic.darkviolet.js
+++ b/js/viz/core/themes/generic.darkviolet.js
@@ -106,11 +106,19 @@ registerTheme({
         scale: {
             breakStyle: { color: "#575e6b" },
             tick: {
-                opacity: 1
-            },
-            minorTick: {
-                opacity: 0.5
+                opacity: 0.2
             }
+        },
+        selectedRangeColor: ACCENT_COLOR,
+        sliderMarker: {
+            color: ACCENT_COLOR,
+            font: {
+                color: "#fff"
+            }
+        },
+        sliderHandle: {
+            color: ACCENT_COLOR,
+            opacity: 0.5
         }
     },
     map: {

--- a/js/viz/core/themes/generic.darkviolet.js
+++ b/js/viz/core/themes/generic.darkviolet.js
@@ -2,7 +2,7 @@
 
 var themeModule = require("../../themes"),
     registerTheme = themeModule.registerTheme,
-
+    ACCENT_COLOR = "#9c63ff",
     BACKGROUND_COLOR = "#17171f",
     TITLE_COLOR = "#f5f6f7",
     SUBTITLE_COLOR = "#fff",
@@ -111,6 +111,17 @@ registerTheme({
             minorTick: {
                 opacity: 0.5
             }
+        }
+    },
+    map: {
+        "layer:marker:dot": {
+            color: ACCENT_COLOR
+        },
+        "layer:marker:bubble": {
+            color: ACCENT_COLOR
+        },
+        legend: {
+            markerColor: ACCENT_COLOR
         }
     }
 }, "generic.dark");

--- a/js/viz/core/themes/generic.greenmist.js
+++ b/js/viz/core/themes/generic.greenmist.js
@@ -2,7 +2,7 @@
 
 var themeModule = require("../../themes"),
     registerTheme = themeModule.registerTheme,
-
+    ACCENT_COLOR = "#3cbab2",
     BACKGROUND_COLOR = "#f5f5f5",
     TITLE_COLOR = "#28484f",
     SUBTITLE_COLOR = "#7eb2be",
@@ -111,6 +111,17 @@ registerTheme({
             minorTick: {
                 opacity: 0.5
             }
+        }
+    },
+    map: {
+        "layer:marker:dot": {
+            color: ACCENT_COLOR
+        },
+        "layer:marker:bubble": {
+            color: ACCENT_COLOR
+        },
+        legend: {
+            markerColor: ACCENT_COLOR
         }
     }
 }, "generic.light");

--- a/js/viz/core/themes/generic.greenmist.js
+++ b/js/viz/core/themes/generic.greenmist.js
@@ -104,13 +104,15 @@ registerTheme({
             color: BACKGROUND_COLOR
         },
         scale: {
-            breakStyle: { color: "#c1c1c1" },
-            tick: {
-                opacity: 1
-            },
-            minorTick: {
-                opacity: 0.5
-            }
+            breakStyle: { color: "#c1c1c1" }
+        },
+        selectedRangeColor: ACCENT_COLOR,
+        sliderMarker: {
+            color: ACCENT_COLOR
+        },
+        sliderHandle: {
+            color: ACCENT_COLOR,
+            opacity: 0.5
         }
     },
     map: {

--- a/js/viz/core/themes/generic.softblue.js
+++ b/js/viz/core/themes/generic.softblue.js
@@ -83,11 +83,16 @@ registerTheme({
         scale: {
             breakStyle: { color: "#cfd2d3" },
             tick: {
-                opacity: 1
-            },
-            minorTick: {
-                opacity: 0.5
+                opacity: 0.12
             }
+        },
+        selectedRangeColor: ACCENT_COLOR,
+        sliderMarker: {
+            color: ACCENT_COLOR
+        },
+        sliderHandle: {
+            color: ACCENT_COLOR,
+            opacity: 0.5
         }
     },
     sparkline: {

--- a/js/viz/core/themes/generic.softblue.js
+++ b/js/viz/core/themes/generic.softblue.js
@@ -2,7 +2,7 @@
 
 var themeModule = require("../../themes"),
     registerTheme = themeModule.registerTheme,
-
+    ACCENT_COLOR = "#7ab8eb",
     BACKGROUND_COLOR = "#fff",
     TITLE_COLOR = "#333",
     SUBTITLE_COLOR = "#99a1a8",
@@ -101,6 +101,17 @@ registerTheme({
                     color: SUBTITLE_COLOR
                 }
             }
+        }
+    },
+    map: {
+        "layer:marker:dot": {
+            color: ACCENT_COLOR
+        },
+        "layer:marker:bubble": {
+            color: ACCENT_COLOR
+        },
+        legend: {
+            markerColor: ACCENT_COLOR
         }
     }
 }, "generic.light");

--- a/js/viz/themes.js
+++ b/js/viz/themes.js
@@ -158,8 +158,6 @@ function patchAxes(theme) {
     mergeScalar(theme.gauge.scale.label.font, colorFieldName, null, theme.axisLabelColor);
     mergeScalar(theme.gauge.scale.tick, colorFieldName, null, theme.backgroundColor);
     mergeScalar(theme.gauge.scale.minorTick, colorFieldName, null, theme.backgroundColor);
-    mergeScalar(theme.rangeSelector.scale.tick, colorFieldName, null, theme.axisColor);
-    mergeScalar(theme.rangeSelector.scale.minorTick, colorFieldName, null, theme.axisColor);
     mergeScalar(theme.rangeSelector.scale.label.font, colorFieldName, null, theme.axisLabelColor);
 }
 

--- a/styles/widgets/base/scheduler.less
+++ b/styles/widgets/base/scheduler.less
@@ -1908,6 +1908,7 @@
     color: @SCHEDULER_APPOINTMENT_TEXT_COLOR;
 
     &.dx-button,
+    &.dx-button.dx-state-hover,
     &.dx-button.dx-state-active,
     &.dx-button.dx-state-focused {
         background-color: @SCHEDULER_APPOINTMENT_BASE_COLOR;

--- a/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
+++ b/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
@@ -846,7 +846,7 @@
 * @type color
 * @group overlays.toasts
 */
-@toast-color: @base-inverted-text-color;
+@toast-color: #fff;
 @toast-shadow-color: transparent;
 
 @toast-border-radius: @base-border-radius-large;

--- a/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
+++ b/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
@@ -561,7 +561,7 @@
 * @type color
 * @group overlays.toasts
 */
-@toast-color: @base-inverted-text-color;
+@toast-color: #fff;
 
 @dropdowneditor-button-hover-border-color: @base-border-color;
 @dropdowneditor-button-active-border-color: transparent;

--- a/styles/widgets/generic/color-schemes/dark/generic.dark.less
+++ b/styles/widgets/generic/color-schemes/dark/generic.dark.less
@@ -844,7 +844,7 @@
 * @type color
 * @group overlays.toasts
 */
-@toast-color: @base-inverted-text-color;
+@toast-color: #fff;
 @toast-shadow-color: transparent;
 
 @toast-border-radius: @base-border-radius-large;

--- a/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
+++ b/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
@@ -1791,14 +1791,14 @@
 * @type color
 * @group scheduler
 */
-@SCHEDULER_APPOINTMENT_BASE_COLOR: #cbdaf2;
+@SCHEDULER_APPOINTMENT_BASE_COLOR: #2cc9b4;
 
 /**
 * @name 40. Appointment text color
 * @type color
 * @group scheduler
 */
-@SCHEDULER_APPOINTMENT_TEXT_COLOR: @base-inverted-text-color;
+@SCHEDULER_APPOINTMENT_TEXT_COLOR: #fff;
 @scheduler-appointment-focus-color: @SCHEDULER_APPOINTMENT_TEXT_COLOR;
 /**
 * @name 35. Start appointment color
@@ -1844,7 +1844,7 @@
 
 @SCHEDULER_TIME_INDICATOR_COLOR: lighten(@SCHEDULER_CURRENT_TIME_CELL_COLOR, 15%);
 
-@SCHEDULER_DD_APPOINTMENT_HOVER_TEXT_COLOR: darken(@base-inverted-text-color, 20%);
+@SCHEDULER_DD_APPOINTMENT_HOVER_TEXT_COLOR: #fff;
 
 @scheduler-popup-title-bg: @SCHEDULER_WORKSPACE_BACKGROUND_COLOR;
 

--- a/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
+++ b/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
@@ -848,7 +848,7 @@
 * @type color
 * @group overlays.toasts
 */
-@toast-color: @base-inverted-text-color;
+@toast-color: #fff;
 @toast-shadow-color: transparent;
 
 @toast-border-radius: @base-border-radius-large;

--- a/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
+++ b/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
@@ -1597,7 +1597,7 @@
 * @type color
 * @group treelist
 */
-@treelist-selection-spin-icon-color: @treelist-spin-icon-color;
+@treelist-selection-spin-icon-color: @base-bg;
 
 /**
 * @name 160. Highlighted text background color

--- a/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
+++ b/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
@@ -853,7 +853,7 @@
 * @type color
 * @group overlays.toasts
 */
-@toast-color: @base-inverted-text-color;
+@toast-color: #fff;
 @toast-shadow-color: transparent;
 
 @toast-border-radius: @base-border-radius-large;

--- a/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
+++ b/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
@@ -843,7 +843,7 @@
 * @type color
 * @group overlays.toasts
 */
-@toast-color: @base-inverted-text-color;
+@toast-color: #fff;
 @toast-shadow-color: transparent;
 
 @toast-border-radius: @base-border-radius-large;

--- a/styles/widgets/generic/color-schemes/light/generic.light.less
+++ b/styles/widgets/generic/color-schemes/light/generic.light.less
@@ -843,7 +843,7 @@
 * @type color
 * @group overlays.toasts
 */
-@toast-color: @base-inverted-text-color;
+@toast-color: #fff;
 @toast-shadow-color: transparent;
 
 @toast-border-radius: @base-border-radius-large;

--- a/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
+++ b/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
@@ -848,7 +848,7 @@
 * @type color
 * @group overlays.toasts
 */
-@toast-color: @base-inverted-text-color;
+@toast-color: #fff;
 @toast-shadow-color: transparent;
 
 @toast-border-radius: @base-border-radius-large;

--- a/testing/tests/DevExpress.viz.core/themes.tests.js
+++ b/testing/tests/DevExpress.viz.core/themes.tests.js
@@ -161,8 +161,6 @@ QUnit.test("Patched properties on register theme", function(assert) {
     assert.deepEqual(theme.polar.commonAxisSettings.minorGrid.color, theme.axisColor, "axisColor");
     assert.deepEqual(theme.polar.commonAxisSettings.tick.color, theme.axisColor, "axisColor");
     assert.deepEqual(theme.polar.commonAxisSettings.minorTick.color, theme.axisColor, "axisColor");
-    assert.deepEqual(theme.rangeSelector.scale.tick.color, theme.axisColor, "axisColor");
-    assert.deepEqual(theme.rangeSelector.scale.minorTick.color, theme.axisColor, "axisColor");
 
     //axisLabelColor
     assert.strictEqual(theme.gauge.scale.label.font.color, theme.axisLabelColor, "axisLabelColor");


### PR DESCRIPTION
1. Fix Toast text color (all generic color schemes)
2. Fix Scheduler appointments drop down menu button styles (all generic color schemes)
3. Fix Scheduler appointment background and text colors (generic dark moon)
4. Fix TreeList spin color for selected rows (generic dark moon)
5. Fix VectorMap marker colors (all new generic color schemes)
6. Fix VectorMap area layer color (generic dark moon)
7. Fix RangeSelector selected range and slider colors (all new generic color schemes)
8. Remove inheritance of RangeSelector scale ticks color from axis color