### PR TITLE
Fix group panel drag'n'drop on toolbar items updated runtime (resolves #2269)

### DIFF
--- a/js/ui/data_grid/ui.data_grid.grouping.js
+++ b/js/ui/data_grid/ui.data_grid.grouping.js
@@ -376,9 +376,11 @@ var GroupingHeaderPanelExtender = (function() {
 
         _appendGroupingItem: function(items) {
             var that = this,
+                isRendered = false,
                 groupPanelRenderedCallback = function(e) {
                     that._updateGroupPanelContent($(e.itemElement).find("." + DATAGRID_GROUP_PANEL_CLASS));
-                    that.renderCompleted.fire();
+                    isRendered && that.renderCompleted.fire();
+                    isRendered = true;
                 };
 
             if(that._isGroupPanelVisible()) {

--- a/js/ui/data_grid/ui.data_grid.grouping.js
+++ b/js/ui/data_grid/ui.data_grid.grouping.js
@@ -378,6 +378,7 @@ var GroupingHeaderPanelExtender = (function() {
             var that = this,
                 groupPanelRenderedCallback = function(e) {
                     that._updateGroupPanelContent($(e.itemElement).find("." + DATAGRID_GROUP_PANEL_CLASS));
+                    that.renderCompleted.fire();
                 };
 
             if(that._isGroupPanelVisible()) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -5334,6 +5334,28 @@ QUnit.test("Correct update group panel items runtime", function(assert) {
     assert.equal($groupPanelItems.length, 1, "count of group panel items");
 });
 
+QUnit.test("Check group panel items are draggable when toolbar items updated runtime", function(assert) {
+    //arrange
+    var dataGrid = $("#dataGrid").dxDataGrid({
+        columns: [{ dataField: "field1", groupIndex: 0 }, "field2"],
+        groupPanel: { visible: true },
+        dataSource: {
+            store: [{ field1: "1", field2: "2" }, { field1: "3", field2: "4" }, { field1: "5", field2: "6" }]
+        }
+    }).dxDataGrid("instance");
+
+    this.clock.tick();
+
+    //act
+    var toolbar = dataGrid.$element().find(".dx-toolbar").dxToolbar("instance");
+    toolbar.option("items", toolbar.option("items"));
+    this.clock.tick();
+
+    //assert
+    var $groupPanelItems = $("#dataGrid").find(".dx-toolbar .dx-datagrid-drag-action");
+    assert.equal($groupPanelItems.length, 1, "count of group panel items");
+});
+
 //T113684
 QUnit.test("Height rows view = height content", function(assert) {
     //arrange, act

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -5336,7 +5336,13 @@ QUnit.test("Correct update group panel items runtime", function(assert) {
 
 QUnit.test("Check group panel items are draggable when toolbar items updated runtime", function(assert) {
     //arrange
+    var renderCompletedCallCount = 0;
     var dataGrid = $("#dataGrid").dxDataGrid({
+        onInitialized: function(e) {
+            e.component.getView("headerPanel").renderCompleted.add(function() {
+                renderCompletedCallCount++;
+            });
+        },
         columns: [{ dataField: "field1", groupIndex: 0 }, "field2"],
         groupPanel: { visible: true },
         dataSource: {
@@ -5354,6 +5360,7 @@ QUnit.test("Check group panel items are draggable when toolbar items updated run
     //assert
     var $groupPanelItems = $("#dataGrid").find(".dx-toolbar .dx-datagrid-drag-action");
     assert.equal($groupPanelItems.length, 1, "count of group panel items");
+    assert.equal(renderCompletedCallCount, 3, "renderCompleted call count");
 });
 
 //T113684


### PR DESCRIPTION
Fire `renderCompleted` event on `groupPanelRenderedCallback` to fix the issue.
For detail information please check the issue's description (#2269).
