### PR TITLE
Fix lockers issue for AngularJS

### DIFF
--- a/js/integration/angular/component_registrator.js
+++ b/js/integration/angular/component_registrator.js
@@ -242,7 +242,7 @@ var ComponentBuilder = Class.inherit({
             };
 
             if(isActivePhase) {
-                that._digestCallbacks.end.add(releaseOption);
+                that._digestCallbacks.end.addPrioritized(releaseOption);
             } else {
                 releaseOption();
             }

--- a/js/integration/angular/components.js
+++ b/js/integration/angular/components.js
@@ -5,6 +5,7 @@ var Callbacks = require("../../core/utils/callbacks"),
 
 ngModule.service("dxDigestCallbacks", ["$rootScope", function($rootScope) {
     var begin = Callbacks(),
+        prioritizedEnd = Callbacks(),
         end = Callbacks();
 
     var digestPhase = false;
@@ -19,6 +20,7 @@ ngModule.service("dxDigestCallbacks", ["$rootScope", function($rootScope) {
 
         $rootScope.$$postDigest(function() {
             digestPhase = false;
+            prioritizedEnd.fire();
             end.fire();
         });
     });
@@ -33,6 +35,10 @@ ngModule.service("dxDigestCallbacks", ["$rootScope", function($rootScope) {
             },
             remove: begin.remove.bind(begin)
         },
-        end: end
+        end: {
+            add: end.add.bind(end),
+            addPrioritized: prioritizedEnd.add.bind(prioritizedEnd),
+            remove: end.remove.bind(end)
+        }
     };
 }]);


### PR DESCRIPTION
We have the lockers in AngularJS integration to avoid an infinite recursion of changing the option and the bound scope value. After some option was changed, we lock it at the beginning of the digest phase and release on the end of it.
The issue occurred because another widget executes an action on the end of digest phase, but before the locker of the changed option was released. So the option's lockers count was increased and it was not released anymore.
The lockers releasing was prioritized to fix the issue,