### PR TITLE
Fix dxDateBox rollers ability to select a date in January when the min and max options allow choosing a date in December of the current year and January of the next year  (T584111)

### DIFF
--- a/js/ui/date_box/ui.date_view.js
+++ b/js/ui/date_box/ui.date_view.js
@@ -232,7 +232,7 @@ var DateView = Editor.inherit({
             this._createRollerConfig(ROLLER_TYPE.month);
             var monthRollerConfig = this._rollerConfigs[ROLLER_TYPE.month];
 
-            if(monthRollerConfig.displayItems.length !== monthRoller.option("items").length) {
+            if(monthRollerConfig.displayItems.toString() !== monthRoller.option("items").toString()) {
                 monthRoller.option({
                     items: monthRollerConfig.displayItems,
                     selectedIndex: monthRollerConfig.selectedIndex

--- a/testing/tests/DevExpress.ui.widgets.editors/dateView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dateView.tests.js
@@ -305,6 +305,21 @@ QUnit.test("check state rollers", function(assert) {
     assert.equal(rollers.year.option("selectedIndex"), date.getFullYear() - minDate.getFullYear());
 });
 
+//T584111
+QUnit.test("rollers are able to select a date in January when the min and max options allow choosing a date in the subsequent year", function(assert) {
+    this.instance.option({
+        value: new Date("2017-12-07"),
+        minDate: new Date("2017-12-05"),
+        maxDate: new Date("2018-01-31")
+    });
+
+    var rollers = this.instance._rollers;
+    assert.deepEqual(rollers.month.option("items"), ["December"]);
+
+    rollers.year.option("selectedIndex", 1);
+    assert.deepEqual(rollers.month.option("items"), ["January"]);
+});
+
 QUnit.test("'value' option should depend on rollers position", function(assert) {
     var date = new Date(2012, 9, 10),
         minDate = new Date(2000, 1);


### PR DESCRIPTION
…n and max options allow choosing a date in December of the current year and January of the next year  (T584111) (#2279)

* Fix dxDateBox rollers ablity to select a date in January when the min and max options allow choosing a date in December of the current year and January of the next year

* Month items do not reload after change of day

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
