### PR TITLE
Fix perf test after update Chrome to version 63

### DIFF
--- a/testing/tests/DevExpress.performance/collectionStyleRecalculations.tests.js
+++ b/testing/tests/DevExpress.performance/collectionStyleRecalculations.tests.js
@@ -57,5 +57,5 @@ QUnit.performanceTest("Accordion should force minimum relayout count on selectio
         $element.dxAccordion("option", "selectedIndex", 1);
     };
 
-    assert.measureStyleRecalculation(measureFunction, 4);
+    assert.measureStyleRecalculation(measureFunction, 5);
 });


### PR DESCRIPTION
Latest Chrome fires one more tiny update layout tree event at item's animation start 
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
