### PR TITLE
Hide selectedItems option of ContextMenu

### DIFF
--- a/js/ui/context_menu/ui.context_menu.js
+++ b/js/ui/context_menu/ui.context_menu.js
@@ -204,6 +204,13 @@ var ContextMenu = MenuBase.inherit((function() {
                 * @extend_doc
                 */
 
+                /**
+                * @name dxContextMenuOptions_selectedItems
+                * @publicName selectedItems
+                * @hidden
+                * @extend_doc
+                */
+
 
                 onLeftFirstItem: null,
                 onLeftLastItem: null,


### PR DESCRIPTION
dxContextMenu (like as dxMenu) didn't support a multiple selection. This option must be hidden
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
