### PR TITLE
Fix the stopPropagation call when the gestureHandling option of google map is cooperative

### DIFF
--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -440,7 +440,7 @@ var Map = Widget.inherit({
     },
 
     _cancelEvent: function(e) {
-        var cancelByProvider = this._provider && this._provider.cancelEvents && !this.option("disabled");
+        var cancelByProvider = this._provider && this._provider.isEventsCanceled() && !this.option("disabled");
         if(!(config.designMode) && cancelByProvider) {
             e.stopPropagation();
         }

--- a/js/ui/map/provider.dynamic.google.js
+++ b/js/ui/map/provider.dynamic.google.js
@@ -4,6 +4,7 @@
 
 var $ = require("../../core/renderer"),
     noop = require("../../core/utils/common").noop,
+    devices = require("../../core/devices"),
     Promise = require("../../core/polyfills/promise"),
     extend = require("../../core/utils/extend").extend,
     DynamicProvider = require("./provider.dynamic"),
@@ -262,6 +263,14 @@ var GoogleProvider = DynamicProvider.inherit({
         });
 
         return Promise.resolve();
+    },
+
+    isEventsCanceled: function() {
+        var gestureHandling = this._map.get("gestureHandling");
+        if(devices.real().deviceType !== "desktop" && gestureHandling === "cooperative") {
+            return false;
+        }
+        return this.callBase();
     },
 
     _renderMarker: function(options) {

--- a/js/ui/map/provider.dynamic.google.js
+++ b/js/ui/map/provider.dynamic.google.js
@@ -266,7 +266,7 @@ var GoogleProvider = DynamicProvider.inherit({
     },
 
     isEventsCanceled: function() {
-        var gestureHandling = this._map.get("gestureHandling");
+        var gestureHandling = this._map && this._map.get("gestureHandling");
         if(devices.real().deviceType !== "desktop" && gestureHandling === "cooperative") {
             return false;
         }

--- a/js/ui/map/provider.dynamic.js
+++ b/js/ui/map/provider.dynamic.js
@@ -7,9 +7,6 @@ var $ = require("../../core/renderer"),
     abstract = Provider.abstract;
 
 var DynamicProvider = Provider.inherit({
-
-    cancelEvents: true,
-
     _geocodeLocation: function(location) {
         return new Promise(function(resolve) {
             var cache = this._geocodedLocations,
@@ -199,6 +196,10 @@ var DynamicProvider = Provider.inherit({
 
     adjustViewport: function() {
         return this._fitBounds();
+    },
+
+    isEventsCanceled: function() {
+        return true;
     },
 
     _fitBounds: abstract,

--- a/js/ui/map/provider.js
+++ b/js/ui/map/provider.js
@@ -25,8 +25,6 @@ var Provider = Class.inherit({
         return "#0000FF";
     },
 
-    cancelEvents: false,
-
     ctor: function(map, $container) {
         this._mapWidget = map;
         this._$container = $container;
@@ -91,6 +89,10 @@ var Provider = Class.inherit({
 
     map: function() {
         return this._map;
+    },
+
+    isEventsCanceled: function() {
+        return false;
     },
 
     _option: function(name, value) {

--- a/testing/helpers/forMap/googleMock.js
+++ b/testing/helpers/forMap/googleMock.js
@@ -106,6 +106,9 @@ var google = window.google = {
                     google.fitBoundsCallback();
                 }
             };
+            this.get = function(option) {
+                return google[option];
+            };
             this.getBounds = function() {
                 if(!google.boundsValue) {
                     return new google.maps.LatLngBounds();
@@ -144,6 +147,7 @@ var google = window.google = {
                 google.assignedOptions.zoomControl = options.zoomControl;
                 google.assignedOptions.mapTypeControl = options.mapTypeControl;
                 google.assignedOptions.streetViewControl = options.streetViewControl;
+                google.gestureHandling = options.gestureHandling;
             };
             this.setStreetView = function() {};
             this.setTilt = function() {};

--- a/testing/tests/DevExpress.ui.widgets/mapParts/googleStaticTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/googleStaticTests.js
@@ -471,3 +471,24 @@ QUnit.test("click", function(assert) {
         assert.equal(eventFired, 1);
     });
 });
+
+QUnit.test("StopPropagation is not called on the pointer down event", function(assert) {
+    var isPropagationStopped;
+    return new Promise(function(resolve) {
+        new Map($("#map"), {
+            provider: "googleStatic",
+            width: 400,
+            height: 500,
+            onReady: function(e) {
+                e.element.on("dxpointerdown", function(e) {
+                    isPropagationStopped = e.isPropagationStopped();
+                });
+                e.element.children().trigger("dxpointerdown");
+
+                resolve();
+            }
+        });
+    }).then(function() {
+        assert.ok(!isPropagationStopped);
+    });
+});

--- a/testing/tests/DevExpress.ui.widgets/mapParts/googleStaticTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/googleStaticTests.js
@@ -472,7 +472,7 @@ QUnit.test("click", function(assert) {
     });
 });
 
-QUnit.test("StopPropagation is not called on the pointer down event", function(assert) {
+QUnit.test("the pointer down event propagation should be canceled", function(assert) {
     var isPropagationStopped;
     return new Promise(function(resolve) {
         new Map($("#map"), {


### PR DESCRIPTION
This is fixed in according to [google map API documentation](https://developers.google.com/maps/documentation/javascript/examples/interaction-cooperative)