### PR TITLE
Fix conflict with 'name' and 'inputAttr.name' options in text editors (T590748)

### DIFF
--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -371,6 +371,11 @@ var TextEditorBase = Editor.inherit({
         return $input;
     },
 
+    _setSubmitElementName: function(name) {
+        var inputAttrName = this.option("inputAttr.name");
+        return this.callBase(name || inputAttrName || "");
+    },
+
     _applyInputAttributes: function($input, customAttributes) {
         $input.attr("autocomplete", "off")
             .attr(customAttributes)

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -374,6 +374,27 @@ QUnit.test("the 'inputAttr' option", function(assert) {
     }
 });
 
+QUnit.test("name option should not conflict with inputAttr.name option", function(assert) {
+    this.instance.option("inputAttr", { name: "some_name" });
+
+    assert.equal(this.input.attr("name"), "some_name", "inputAttr should be applied");
+
+    this.instance.option("name", "new_name");
+    assert.equal(this.input.attr("name"), "new_name", "inputAttr should be redefined by name");
+
+    this.instance.option("name", "");
+    assert.equal(this.input.attr("name"), "some_name", "inputAttr should be restored");
+
+    this.instance.option("inputAttr", { name: null });
+    assert.notOk(this.input.get(0).hasAttribute("name"), "name attribute has been removed");
+
+    this.instance.option("name", "test_name");
+    assert.equal(this.input.attr("name"), "test_name", "name should be applied");
+
+    this.instance.option("name", "");
+    assert.notOk(this.input.get(0).hasAttribute("name"), "name attribute has been removed");
+});
+
 QUnit.test("the 'inputAttr' option should preserve widget specific classes", function(assert) {
     var $element = $("<div>").appendTo("body");
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
