### PR TITLE
 dxFilterBuilder - Add test checks datebox sets its value as null when a value of condition is specified as an empty string (T589531)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/commonTests.js
@@ -590,6 +590,17 @@ QUnit.module("Rendering", function() {
         assert.notOk(container.find(".dx-texteditor").length);
         assert.ok(container.find("." + FILTER_BUILDER_ITEM_VALUE_TEXT_CLASS).length);
     });
+
+    //T589531
+    QUnit.test("datebox returns null when a date value is specified as an empty string", function(assert) {
+        $("#container").dxFilterBuilder({
+            value: ["Date", "=", ""],
+            fields: fields
+        });
+
+        $("." + FILTER_BUILDER_ITEM_VALUE_TEXT_CLASS).click();
+        assert.equal($(".dx-datebox").dxDateBox("instance").option("value"), null);
+    });
 });
 
 QUnit.module("Create editor by field dataType", function() {


### PR DESCRIPTION
Just a test because the problem was solved in PR [#2327](https://github.com/DevExpress/DevExtreme/pull/2327)
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
