### PR TITLE
Skip device test for menu hover (Fix test after #2318)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/menu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menu.tests.js
@@ -160,6 +160,10 @@ QUnit.test("Render vertical rtl content delimiter", function(assert) {
 });
 
 QUnit.test("container border should not be hidden when non-top level submenu hides", function(assert) {
+    if(!isDeviceDesktop(assert)) {
+        return;
+    }
+
     var menu = createMenuInWindow({
             showSubmenuMode: "onHover",
             items: [{


### PR DESCRIPTION
This bug could not be reproduced without hover events because next menu will be shown immediately after the previous menu hiding. This test needs to be skipped because there are no hover events on mobile devices
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
