### PR TITLE
Publish `dxremove` event

### DIFF
--- a/js/core/remove_event.js
+++ b/js/core/remove_event.js
@@ -8,6 +8,14 @@ var registerEvent = require("../events/core/event_registrator");
 var eventName = "dxremove";
 var eventPropName = "dxRemoveEvent";
 
+/**
+  * @name ui events_dxremove
+  * @publicName dxremove
+  * @type eventType
+  * @type_function_param1 event:event
+  * @module events/remove
+*/
+
 beforeCleanData(function(elements) {
     elements = [].slice.call(elements);
     for(var i = 0; i < elements.length; i++) {


### PR DESCRIPTION
This event was described in [DevExtreme 3rd-Party Frameworks Integration API](https://js.devexpress.com/Documentation/Guide/Widgets/Common/Advanced/3rd-Party_Frameworks_Integration_API/#Advanced_Configuration) but was not published.