### PR TITLE
Fix wrong caret position in the dxNumberBox after enter extra decimal digits (T587320)

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -467,9 +467,10 @@ var NumberBoxMask = NumberBoxBase.inherit({
             caret = this._caret(),
             caretDelta = 0,
             isFirstInput = this._formattedValue === "",
+            allStubsAfterCaret = this._isStub(text.slice(caret.start), true),
             isOneCharInput = Math.abs(formatted.length - text.length) === 1;
 
-        if((isOneCharInput && this._isCaretOnFloat()) || isFirstInput) {
+        if((isOneCharInput && this._isCaretOnFloat() && !allStubsAfterCaret) || isFirstInput) {
             caretDelta = 0;
         } else if(formatted.length && this._lastKey === text) {
             caretDelta = formatted.indexOf(text) - caret.start + 1;
@@ -495,9 +496,10 @@ var NumberBoxMask = NumberBoxBase.inherit({
         var format = this._getFormatPattern(),
             caret = this._caret(),
             parsed = this._parseValue(),
-            formatted = number.format(parsed, format) || "";
+            formatted = number.format(parsed, format) || "",
+            newCaret = caret.start + this._getCaretDelta(formatted);
 
-        this._setInputText(formatted, caret.start + this._getCaretDelta(formatted));
+        this._setInputText(formatted, newCaret);
     },
 
     _formatValue: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -867,3 +867,25 @@ QUnit.test("move caret to the start when only stubs remain in the input", functi
 
     assert.deepEqual(this.keyboard.caret(), { start: 0, end: 0 }, "caret was adjusted");
 });
+
+QUnit.test("caret should not move out of the boundaries when decimal separator was typed in percent format", function(assert) {
+    this.instance.option({
+        format: "#0%",
+        value: 0.01
+    });
+
+    this.keyboard.caret(1).type(".");
+
+    assert.equal(this.keyboard.caret().start, 1, "caret should not move when decimal part is disabled");
+});
+
+QUnit.test("caret should not move out of the boundaries when non-available digit was typed", function(assert) {
+    this.instance.option({
+        format: "#0.00 kg",
+        value: 1.23
+    });
+
+    this.keyboard.caret(4).type("1");
+
+    assert.equal(this.keyboard.caret().start, 4, "caret should not move");
+});


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
