### PR TITLE
dxFilterBuilder - Fix for test on android device

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/commonTests.js
@@ -614,8 +614,9 @@ QUnit.module("Rendering", function() {
         });
 
         $("." + FILTER_BUILDER_ITEM_VALUE_TEXT_CLASS).click();
-        $(".dx-datebox input").val("12/12/2017");
+        $(".dx-datebox input").val("2017-12-12");
         $(".dx-datebox input").trigger("change");
+
         assert.equal($("." + FILTER_BUILDER_ITEM_VALUE_TEXT_CLASS).text(), "12.12.2017");
     });
 

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/commonTests.js
@@ -4,6 +4,7 @@
 
 var $ = require("jquery"),
     isRenderer = require("core/utils/type").isRenderer,
+    devices = require("core/devices"),
     config = require("core/config");
 
 require("ui/filter_builder/filter_builder");
@@ -604,6 +605,11 @@ QUnit.module("Rendering", function() {
 
     //T589341
     QUnit.test("the formatter is applied to a field with the date type", function(assert) {
+        if(devices.real().deviceType !== "desktop") {
+            assert.ok(true, "This test is not actual for mobile devices");
+            return;
+        }
+
         $("#container").dxFilterBuilder({
             value: ["Date", "=", ""],
             fields: [{
@@ -614,7 +620,7 @@ QUnit.module("Rendering", function() {
         });
 
         $("." + FILTER_BUILDER_ITEM_VALUE_TEXT_CLASS).click();
-        $(".dx-datebox input").val("2017-12-12");
+        $(".dx-datebox input").val("12/12/2017");
         $(".dx-datebox input").trigger("change");
 
         assert.equal($("." + FILTER_BUILDER_ITEM_VALUE_TEXT_CLASS).text(), "12.12.2017");


### PR DESCRIPTION
Value does not apply to android device because the specified value "12/12/2017" does not conform to the required format, "yyyy-MM-dd"
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
