### PR TITLE
Fix select all when filter is applied in TagBox (T569475)

### DIFF
--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -509,7 +509,7 @@ var SelectBox = DropDownList.inherit({
         }).bind(this));
     },
 
-    _prepareSearchValue: function() {
+    _getActualSearchValue: function() {
         return this._dataSource.searchValue();
     },
 
@@ -530,7 +530,7 @@ var SelectBox = DropDownList.inherit({
             if(this.option("showDataBeforeSearch") || this.option("minSearchLength") === 0) {
                 if(this._searchTimer) return;
 
-                var searchValue = this._prepareSearchValue();
+                var searchValue = this._getActualSearchValue();
                 searchValue && this._wasSearch(true);
                 this._filterDataSource(searchValue || null);
             } else {

--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -509,6 +509,10 @@ var SelectBox = DropDownList.inherit({
         }).bind(this));
     },
 
+    _prepareSearchValue: function() {
+        return this._dataSource.searchValue();
+    },
+
     _toggleOpenState: function(isVisible) {
         if(this.option("disabled")) {
             return;
@@ -526,7 +530,7 @@ var SelectBox = DropDownList.inherit({
             if(this.option("showDataBeforeSearch") || this.option("minSearchLength") === 0) {
                 if(this._searchTimer) return;
 
-                var searchValue = this._dataSource.searchValue();
+                var searchValue = this._prepareSearchValue();
                 searchValue && this._wasSearch(true);
                 this._filterDataSource(searchValue || null);
             } else {

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -1122,6 +1122,23 @@ var TagBox = SelectBox.inherit({
         }
     },
 
+    _prepareSearchValue: function() {
+        return this.callBase() || this._searchValue();
+    },
+
+    _clearFilter: function() {
+        if(this.option("opened") && this.option("showSelectionControls")) {
+            return;
+        }
+
+        this.callBase();
+    },
+
+    _popupHidingHandler: function() {
+        this.callBase();
+        this._clearFilter();
+    },
+
     reset: function() {
         this.option("value", []);
 

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -1121,7 +1121,7 @@ var TagBox = SelectBox.inherit({
         }
     },
 
-    _prepareSearchValue: function() {
+    _getActualSearchValue: function() {
         return this.callBase() || this._searchValue();
     },
 

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -590,7 +590,6 @@ var TagBox = SelectBox.inherit({
 
     _restoreInputText: function() {
         this._clearTextValue();
-        this._clearFilter();
     },
 
     _focusOutHandler: function(e) {
@@ -651,7 +650,6 @@ var TagBox = SelectBox.inherit({
             .addClass(NATIVE_CLICK_CLASS);
 
         this._renderInputSize();
-        this._clearFilter();
         this._renderTags();
         this._popup && this._popup.refreshPosition();
     },
@@ -1039,6 +1037,7 @@ var TagBox = SelectBox.inherit({
     _applyButtonHandler: function() {
         this.option("value", this._getListValues());
         this._clearTextValue();
+        this._clearFilter();
         this.callBase();
     },
 
@@ -1124,14 +1123,6 @@ var TagBox = SelectBox.inherit({
 
     _prepareSearchValue: function() {
         return this.callBase() || this._searchValue();
-    },
-
-    _clearFilter: function() {
-        if(this.option("opened") && this.option("showSelectionControls")) {
-            return;
-        }
-
-        this.callBase();
     },
 
     _popupHidingHandler: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -2586,7 +2586,7 @@ QUnit.testInActiveWindow("input should be focused after click on field (searchEn
     assert.ok($input.is(":focus"), "input was focused");
 });
 
-QUnit.test("select all is not applied when filterable items are selected", function(assert) {
+QUnit.test("Select all' checkBox is checked when filtered items are selected only", function(assert) {
     var items = ["111", "222", "333"],
         $element = $("#tagBox").dxTagBox({
             searchTimeout: 0,

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -2586,6 +2586,47 @@ QUnit.testInActiveWindow("input should be focused after click on field (searchEn
     assert.ok($input.is(":focus"), "input was focused");
 });
 
+QUnit.test("select all is not applied when filterable items are selected", function(assert) {
+    var items = ["111", "222", "333"],
+        $element = $("#tagBox").dxTagBox({
+            searchTimeout: 0,
+            items: items,
+            searchEnabled: true,
+            opened: true,
+            showSelectionControls: true,
+            selectAllMode: "allPages"
+        }),
+        instance = $element.dxTagBox("instance"),
+        $input = $element.find("input");
+
+    keyboardMock($input).type("1");
+
+    $(".dx-tagbox-popup-wrapper .dx-list-select-checkbox.dx-checkbox").trigger("dxclick");
+
+    assert.equal(instance.option("selectedItems").length, 1, "selected items count");
+});
+
+QUnit.test("filter should not be cleared when no focusout and no item selection happened", function(assert) {
+    var items = ["111", "222", "333"],
+        $element = $("#tagBox").dxTagBox({
+            searchTimeout: 0,
+            items: items,
+            searchEnabled: true,
+            opened: true,
+            showSelectionControls: true,
+            selectAllMode: "allPages"
+        }),
+        $input = $element.find("input");
+
+    var keyboard = keyboardMock($input);
+    keyboard.type("1");
+    keyboard.press("esc");
+
+    $input.trigger("dxclick");
+
+    assert.equal($(".dx-item").length, 1, "items count of list");
+    assert.equal($.trim($(".dx-item").first().text()), "111", "value of first item");
+});
 
 QUnit.module("popup position and size", moduleSetup);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -2592,7 +2592,6 @@ QUnit.test("select all is not applied when filterable items are selected", funct
             searchTimeout: 0,
             items: items,
             searchEnabled: true,
-            opened: true,
             showSelectionControls: true,
             selectAllMode: "allPages"
         }),
@@ -2600,8 +2599,8 @@ QUnit.test("select all is not applied when filterable items are selected", funct
         $input = $element.find("input");
 
     keyboardMock($input).type("1");
-
-    $(".dx-tagbox-popup-wrapper .dx-list-select-checkbox.dx-checkbox").trigger("dxclick");
+    $input.trigger("focusout");
+    $(".dx-list-item").trigger("dxclick");
 
     assert.equal(instance.option("selectedItems").length, 1, "selected items count");
 });


### PR DESCRIPTION
After performing a search in the dxTagBox, when you select all options in the filtered list, 
All items in the dxTagBox are selected. When the search is enabled, select all mode is set to all pages, and show selection controls is true. 