### PR TITLE
Fix unexpected List focusing after scrollbar click in dxSelectBox (T594264)

### DIFF
--- a/js/ui/collection/ui.collection_widget.base.js
+++ b/js/ui/collection/ui.collection_widget.base.js
@@ -754,7 +754,7 @@ var CollectionWidget = Widget.inherit({
                 $closestItem = $target.closest(this._itemElements()),
                 $closestFocusable = this._closestFocusable($target);
 
-            if($closestItem.length && inArray($closestFocusable.get(0), this._focusTarget()) !== -1) {
+            if($closestItem.length && $closestFocusable && inArray($closestFocusable.get(0), this._focusTarget()) !== -1) {
                 this.option("focusedElement", getPublicElement($closestItem));
             }
         }.bind(this);
@@ -767,7 +767,7 @@ var CollectionWidget = Widget.inherit({
             return $target;
         } else {
             $target = $target.parent();
-            while($target.length) {
+            while($target.length && !$target.is(document)) {
                 if($target.is(selectors.focusable)) {
                     return $target;
                 }

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -608,7 +608,7 @@ var DropDownList = DropDownEditor.inherit({
             indicateLoading: false,
             keyExpr: this._getListKeyExpr(),
             groupTemplate: this.option("groupTemplate"),
-            tabIndex: -1,
+            tabIndex: null,
             onItemClick: this._listItemClickAction.bind(this),
             dataSource: this._getDataSource(),
             _keyboardProcessor: this._childKeyboardProcessor,

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -158,6 +158,19 @@ QUnit.test("focusout should not be fired on input element", function(assert) {
     assert.equal(onFocusOutStub.callCount, 0, "onFocusOut wasn't fired");
 });
 
+QUnit.test("list should not have tab index to prevent its focusing when scrollbar clicked", function(assert) {
+    this.instance.option({
+        items: [1, 2, 3, 4, 5, 6],
+        opened: true,
+        value: null
+    });
+
+    var $content = $(this.instance.content()),
+        $list = $content.find(".dx-list");
+
+    assert.notOk($list.attr("tabIndex"), "list have no tabindex");
+});
+
 QUnit.testInActiveWindow("popup hides on tab", function(assert) {
     this.$input.focusin();
     assert.ok(this.$element.hasClass(STATE_FOCUSED_CLASS), "element is focused");

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -2832,12 +2832,12 @@ QUnit.test("the list item value should not be displayed in input after click on 
         clock.tick();
         var $input = this.$selectBox.find("." + TEXTEDITOR_INPUT_CLASS);
 
-        assert.equal($input.val(), "2", "input value is correct");
+        assert.equal($input.val(), "", "input value should not be changed when selection is not complete");
 
         listItem.trigger("dxclick");
         $input = this.$selectBox.find("." + TEXTEDITOR_INPUT_CLASS);
 
-        assert.equal($input.val(), "2", "input value is correct");
+        assert.equal($input.val(), "2", "input value should be changed after selection complete");
         clock.tick(100000);
     } finally {
         clock.restore();


### PR DESCRIPTION
The test changed in this PR was created for fix T404589. The unexpected behavior described in T404589 is still fixed but the behavior of the selectBox was changed to correct variant when text does not appear in the editor until mouse button released