### PR TITLE
fix keyboard mock for testing in MS Edge

### DIFF
--- a/testing/helpers/keyboardMock.js
+++ b/testing/helpers/keyboardMock.js
@@ -194,7 +194,7 @@ var browser;
         });
     }
 
-    if(browser.msie && parseInt(browser.version) < 12) {
+    if(browser.msie) {
         $.extend(KEYS_MAPS.KEY_VALUES_BY_CODE, {
             109: "Subtract"
         });


### PR DESCRIPTION
MS Edge uses an obsolete API to represent keyboardEvents.key values. [MS issue](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15416945/) 
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
