### PR TITLE
Get rid of using `request/cancelAnimationFrame` on scripts loading

### DIFF
--- a/js/animation/frame.js
+++ b/js/animation/frame.js
@@ -13,7 +13,6 @@ var FRAME_ANIMATION_STEP_TIME = 1000 / 60,
         this.clearTimeout(requestID);
     };
 
-
 var setAnimationFrameMethods = callOnce(function() {
     var nativeRequest = window.requestAnimationFrame ||
             window.webkitRequestAnimationFrame ||


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
