### PR TITLE
 dxFilterBuilder - Fix empty value in lookup with ODataStore  (T597637) (#2586)

### DIFF
--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -375,6 +375,10 @@ function getFieldFormat(field) {
 }
 
 function getCurrentLookupValueText(field, value, handler) {
+    if(value === "") {
+        handler("");
+        return;
+    }
     var dataSource = new DataSource(field.lookup.dataSource);
     dataSource.filter(field.lookup.valueExpr, value);
     dataSource.load().done(function(result) {

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -991,4 +991,25 @@ QUnit.module("Lookup Value", function() {
             assert.equal(r, "");
         });
     });
+
+    //T597637
+    QUnit.test("lookup with ODataStore shouldn't send getValueText query when value is empty", function(assert) {
+        var fakeStore = {
+            load: function() {
+                assert.ok(false, "load shoudn't execute");
+            }
+        };
+        var field = {
+                lookup: {
+                    dataSource: {
+                        store: fakeStore
+                    }
+                }
+            },
+            value = "";
+
+        utils.getCurrentLookupValueText(field, value, function(r) {
+            assert.equal(r, "");
+        });
+    });
 });


### PR DESCRIPTION
* dxFilterBuilder - Fix lookup with ODataStore & value = empty (T597637)
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
