### PR TITLE
Synchronize doc comments for dxTreeView onSelectionChanged and onItemSelectionChanged options (T594751)

### DIFF
--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -206,6 +206,7 @@ var TreeViewBase = HierarchicalCollectionWidget.inherit({
             * @type function(e)
             * @type_function_param1 e:object
             * @type_function_param1_field7 node:dxTreeViewNode
+             * @type_function_param1_field8 itemElement:dxElement
             * @action
             */
             onItemSelectionChanged: null,
@@ -347,8 +348,6 @@ var TreeViewBase = HierarchicalCollectionWidget.inherit({
             * @extends Action
             * @type function(e)
             * @type_function_param1 e:object
-            * @type_function_param1_field4 addedItems:Array<any>
-            * @type_function_param1_field5 removedItems:Array<any>
             * @action
             * @inheritdoc
             */
@@ -474,7 +473,8 @@ var TreeViewBase = HierarchicalCollectionWidget.inherit({
             * @deprecated dxTreeViewOptions_onItemSelectionChanged
             * @type function(e)
             * @type_function_param1 e:object
-            * @type_function_param1_field7 node:dxTreeViewNode
+             * @type_function_param1_field7 itemElement:dxElement
+             * @type_function_param1_field8 node:dxTreeViewNode
             * @action
             */
             "onItemSelected": { since: "16.1", alias: "onItemSelectionChanged" }

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/selection.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/selection.js
@@ -89,6 +89,26 @@ QUnit.test("selectionChanged should fire only when selection was changed", funct
     assert.equal(selectionChanged, 2, "selectionChanged should call twice");
 });
 
+QUnit.test("onItemSelectionChanged should have correct arguments", function(assert) {
+    var itemSelectionChanged = sinon.spy(),
+        $treeview = initTree({
+            items: [{ text: "Item 1", id: 1 }],
+            onItemSelectionChanged: itemSelectionChanged
+        }),
+        instance = $treeview.dxTreeView("instance");
+
+    instance.selectItem(1);
+    instance.unselectItem(1);
+
+    assert.equal(itemSelectionChanged.callCount, 2, "selection was changed 2 times");
+
+    //note: other parameters are redundant but they were saved in the code to prevent a BC
+    assert.strictEqual(itemSelectionChanged.getCall(0).args[0].component, instance, "component is correct");
+    assert.strictEqual(itemSelectionChanged.getCall(0).args[0].element, $treeview.get(0), "element is correct");
+    assert.deepEqual(itemSelectionChanged.getCall(0).args[0].node, instance.getNodes()[0], "node is correct");
+    assert.strictEqual(itemSelectionChanged.getCall(0).args[0].itemElement, $treeview.find(".dx-treeview-item").get(0), "itemElement is correct");
+});
+
 QUnit.test("itemSelected should fire when select", function(assert) {
     var items = [{ text: "item 1", selected: true }, { text: "item 2" }],
         itemSelected = 0,


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
