### PR TITLE
 Fix unexpected reset of the Form editor's "readOnly" option (T599228)

### DIFF
--- a/js/ui/form/ui.form.layout_manager.js
+++ b/js/ui/form/ui.form.layout_manager.js
@@ -854,7 +854,7 @@ var LayoutManager = Widget.inherit({
         readOnlyState && instance.option("readOnly", readOnlyState);
 
         that.on("optionChanged", function(args) {
-            if(args.name === "readOnly") {
+            if(args.name === "readOnly" && !typeUtils.isDefined(editorOptions.readOnly)) {
                 instance.option(args.name, args.value);
             }
         });

--- a/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.tests.js
@@ -339,7 +339,8 @@ QUnit.test("Editor's read only state should not be reset on the dxForm 'readOnly
     layoutManager.option("readOnly", false);
 
     //assert
-    assert.ok($testContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor").hasClass("dx-state-readonly"), "editor is read only");
+    var $textEditor = $testContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor");
+    assert.ok($textEditor.hasClass("dx-state-readonly"), "editor is read only");
 });
 
 QUnit.test("Layout strategy when flex is not supported", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.tests.js
@@ -320,6 +320,28 @@ QUnit.test("Check readOnly state for editor when readOnly is enabled in the edit
     assert.ok($testContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor").hasClass("dx-state-readonly"), "editor is read only");
 });
 
+QUnit.test("Editor's read only state should not be reset on the dxForm 'readOnly' option changing", function(assert) {
+    //arrange, act
+    var $testContainer = $("#container").dxLayoutManager({
+            items: [
+                {
+                    dataField: "name",
+                    editorType: "dxTextBox",
+                    editorOptions: {
+                        readOnly: true
+                    }
+                }
+            ]
+        }),
+        layoutManager = $testContainer.dxLayoutManager("instance");
+
+    layoutManager.option("readOnly", true);
+    layoutManager.option("readOnly", false);
+
+    //assert
+    assert.ok($testContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor").hasClass("dx-state-readonly"), "editor is read only");
+});
+
 QUnit.test("Layout strategy when flex is not supported", function(assert) {
     //arrange, act
     var items = [


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
