### PR TITLE
Fix unnecessary a load calls of custom store when item is selected in the TagBox (T589462)

### DIFF
--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -1166,7 +1166,7 @@ var TagBox = SelectBox.inherit({
             dataSource.filter(this._dataSourceFilterFunction.bind(this));
         }
 
-        dataSource.reload();
+        dataSource.load();
     },
 
     _dataSourceFilterExpr: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -4392,6 +4392,34 @@ QUnit.test("Select All should use cache", function(assert) {
     assert.equal(isValueEqualsSpy.callCount, 0, "_isValueEquals is not called");
 });
 
+QUnit.test("Unnecessary a load calls do not happen of custom store when item is selected", function(assert) {
+    var loadCallCounter = 0,
+        store = new CustomStore({
+            key: "id",
+            loadMode: "raw",
+            load: function() {
+                loadCallCounter++;
+                return [{ id: 1, text: "item 1" }, { id: 2, text: "item 2" }];
+            }
+        });
+
+    $("#tagBox").dxTagBox({
+        dataSource: {
+            store: store
+        },
+        valueExpr: "id",
+        displayExpr: "text",
+        opened: true,
+        hideSelectedItems: true
+    });
+
+    var $item = $(".dx-list-item").eq(0);
+
+    $item.trigger("dxclick");
+
+    assert.equal(loadCallCounter, 1);
+});
+
 QUnit.module("deprecated options");
 
 QUnit.test("the 'values' option should work correctly", function(assert) {


### PR DESCRIPTION
When I'm selecting the first tag it calls the load method for the custom store once again. And it happens for every selection.
