### PR TITLE
Fix editing of an element with the "contenteditable" attribute (T596394)

### DIFF
--- a/js/ui/scroll_view/ui.scrollable.js
+++ b/js/ui/scroll_view/ui.scrollable.js
@@ -259,7 +259,7 @@ var Scrollable = DOMComponent.inherit({
             $wrapper = this._$wrapper = $("<div>").addClass(SCROLLABLE_WRAPPER_CLASS),
             $content = this._$content = $("<div>").addClass(SCROLLABLE_CONTENT_CLASS);
 
-        if(beforeActivateExists()) {
+        if(beforeActivateExists() && browser.msie && browser.version < 12) {
             eventsEngine.on($element, eventUtils.addNamespace("beforeactivate", SCROLLABLE), function(e) {
                 if(!$(e.target).is(selectors.focusable)) {
                     e.preventDefault();

--- a/js/ui/widget/selectors.js
+++ b/js/ui/widget/selectors.js
@@ -12,9 +12,10 @@ var focusable = function(element, tabIndex) {
         isDisabled = element.disabled,
         isDefaultFocus = /^(input|select|textarea|button|object|iframe)$/.test(nodeName),
         isHyperlink = nodeName === "a",
-        isFocusable = true;
+        isFocusable = true,
+        isContentEditable = element.isContentEditable;
 
-    if(isDefaultFocus) {
+    if(isDefaultFocus || isContentEditable) {
         isFocusable = !isDisabled;
     } else {
         if(isHyperlink) {

--- a/testing/tests/DevExpress.jquery/selectors.tests.js
+++ b/testing/tests/DevExpress.jquery/selectors.tests.js
@@ -17,6 +17,8 @@ QUnit.testStart(function() {
         <iframe class="focusable tabbable"></iframe>\
         <a class="focusable tabbable" href="#">1</a>\
         <a class="focusable tabbable" tabindex="0">1</a>\
+        <div class="focusable tabbable" tabindex="0" contenteditable="true"></div>\
+        <div contenteditable="true"><div class="focusable tabbable" tabindex="0"></div></div>\
         \
         <div class="focusable nottabbable" tabindex="-1"></div>\
         \


### PR DESCRIPTION
`beforeActivateExists ` handler fixes a impossibility to scroll ScrollView's content via arrow keys. This problem isn't actual for the MS Edge. Issue with the `contenteditable` attribite fixed by correction the "focusable" utility
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
