### PR TITLE
Fix the "Cannot read property 'Field Name' of undefined" exception when undefined is set as the formData (T597389)

### DIFF
--- a/js/ui/form/ui.form.js
+++ b/js/ui/form/ui.form.js
@@ -782,8 +782,15 @@ var Form = Widget.inherit({
         this._removeHiddenElement();
     },
 
+    _prepareFormData: function() {
+        if(!typeUtils.isDefined(this.option("formData"))) {
+            this.option("formData", {});
+        }
+    },
+
     _render: function() {
         this._clearCachedInstances();
+        this._prepareFormData();
 
         this.callBase();
         this.$element().addClass(FORM_CLASS);

--- a/testing/tests/DevExpress.knockout/form.tests.js
+++ b/testing/tests/DevExpress.knockout/form.tests.js
@@ -554,3 +554,15 @@ QUnit.test("Tab template", function(assert) {
     assert.equal($form.find("#tabTemplate").length, 1);
     assert.equal($form.find("#tabTemplate").first().text(), "Test tab template");
 });
+
+QUnit.test("The formData is empty object when formData has 'undefined' value", function(assert) {
+    //arrange
+    var viewModel = {
+        formData: ko.observable(),
+        items: [{ dataField: "City" }]
+    };
+    ko.applyBindings(viewModel, $("#formWithItems").get(0));
+
+    //assert
+    assert.deepEqual(viewModel.formData(), { });
+});

--- a/testing/tests/DevExpress.ui.widgets.form/form.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.tests.js
@@ -1136,6 +1136,42 @@ QUnit.test("Refresh form when visibility changed to 'true' in msie browser", fun
     refreshStub.restore();
 });
 
+QUnit.test("The formData is updated correctly when formData has 'undefined' value", function(assert) {
+    //arrange
+    var $testContainer = $("#form").dxForm({
+            formData: undefined,
+            items: [{ dataField: "City" }]
+        }),
+        form = $testContainer.dxForm("instance");
+
+    //act
+    var editor = form.getEditor("City");
+    editor.option("value", "New York");
+
+    //assert
+    var formData = form.option("formData");
+    assert.deepEqual(formData, { City: "New York" }, "updated formData");
+    assert.equal($testContainer.find(".dx-field-item").length, 1, "form item is rendered");
+});
+
+QUnit.test("The formData with composite object is updated correctly when formData has 'undefined' value", function(assert) {
+    //arrange
+    var $testContainer = $("#form").dxForm({
+            formData: undefined,
+            items: [{ dataField: "Employee.City" }]
+        }),
+        form = $testContainer.dxForm("instance");
+
+    //act
+    var editor = form.getEditor("Employee.City");
+    editor.option("value", "New York");
+
+    //assert
+    var formData = form.option("formData");
+    assert.deepEqual(formData, { Employee: { City: "New York" } }, "formData is updated");
+    assert.equal($testContainer.find(".dx-field-item").length, 1, "form item is rendered");
+});
+
 QUnit.module("Grouping");
 
 QUnit.test("Render groups", function(assert) {


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
