### PR TITLE
Fix unexpected number cutting after press "." when integer only allowed (T600819)

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -293,9 +293,13 @@ var NumberBoxMask = NumberBoxBase.inherit({
         var editedText = this._getEditedText(text, selection, char),
             format = this._getFormatPattern(),
             parsed = number.parse(editedText, format),
+            maxPrecision = this._getMaxPrecision(format, parsed),
             isValueChanged = parsed !== this._parsedValue;
 
-        if(!isValueChanged && char !== MINUS && !this._isValueIncomplete(editedText)) {
+        var isDecimalPointRestricted = char === number.getDecimalSeparator() && maxPrecision === 0,
+            isUselessCharRestricted = !isValueChanged && char !== MINUS && !this._isValueIncomplete(editedText);
+
+        if(isDecimalPointRestricted || isUselessCharRestricted) {
             return undefined;
         }
 
@@ -307,8 +311,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
             return undefined;
         }
 
-        var precision = this._getMaxPrecision(format, parsed),
-            pow = Math.pow(10, precision),
+        var pow = Math.pow(10, maxPrecision),
             value = (parsed === null ? this._parsedValue : parsed);
 
         parsed = Math.round(value * pow) / pow;

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -463,6 +463,18 @@ QUnit.test("ctrl+v should not be prevented", function(assert) {
     assert.strictEqual(this.keyboard.event.isDefaultPrevented(), false, "keydown event is not prevented");
 });
 
+QUnit.test("decimal point input should be prevented when it is restricted by the format", function(assert) {
+    this.instance.option({
+        format: "#0",
+        value: 123
+    });
+
+    this.keyboard.caret(1).type(".");
+
+    assert.equal(this.input.val(), "123", "value is correct");
+    assert.equal(this.keyboard.caret().start, 1, "caret should not be moved");
+});
+
 QUnit.test("incomplete input should not be prevented when there are stubs and zeros after the caret", function(assert) {
     this.instance.option({
         format: "#0.## kg",


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
