### PR TITLE
Remove possibility to clear masked dxNumberBox using keyboard (T601824)

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -301,7 +301,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
         }
 
         if(editedText === "") {
-            return null;
+            parsed = 0;
         }
 
         if(isNaN(parsed)) {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -695,11 +695,11 @@ QUnit.test("removing with group separators using backspace key", function(assert
     assert.equal(this.input.val(), "$ 2,390 d", "value is correct");
 });
 
-QUnit.test("removing required last char should not replace it to 0", function(assert) {
+QUnit.test("removing required last char should replace it to 0", function(assert) {
     this.instance.option("value", 1);
     this.keyboard.caret(1).press("backspace");
 
-    assert.equal(this.input.val(), "", "value is correct");
+    assert.equal(this.input.val(), "0", "value is correct");
 });
 
 QUnit.test("removing required last char should replace it to 0 if percent format", function(assert) {
@@ -741,8 +741,8 @@ QUnit.test("removing all characters should change value to null", function(asser
 
     this.keyboard.caret({ start: 0, end: 2 }).press("backspace").change();
 
-    assert.strictEqual(this.input.val(), "", "value is correct");
-    assert.strictEqual(this.instance.option("value"), null, "value is reseted");
+    assert.strictEqual(this.input.val(), "$0", "value is correct");
+    assert.strictEqual(this.instance.option("value"), 0, "value is reseted");
 });
 
 QUnit.test("removing all digits but not all characters should change value to 0", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -733,7 +733,7 @@ QUnit.test("removing integer digit using backspace if group separator is hiding"
     assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, "caret position is correct");
 });
 
-QUnit.test("removing all characters should change value to null", function(assert) {
+QUnit.test("removing all characters should change value to 0", function(assert) {
     this.instance.option({
         format: "$#0",
         value: 1


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
