### PR TITLE
Add capability to split widget rendering into two parts

### DIFF
--- a/js/core/dom_component.js
+++ b/js/core/dom_component.js
@@ -139,17 +139,9 @@ var DOMComponent = Component.inherit({
 
     _renderComponent: function() {
         this._initMarkup();
-        this._mount();
-    },
-
-    _mount: function() {
-        if(this._isReadyToMount()) {
+        if(windowUtils.hasWindow()) {
             this._render();
         }
-    },
-
-    _isReadyToMount: function() {
-        return windowUtils.hasWindow();
     },
 
     _initMarkup: function() {

--- a/js/core/dom_component.js
+++ b/js/core/dom_component.js
@@ -2,6 +2,7 @@
 
 var $ = require("../core/renderer"),
     eventsEngine = require("../events/core/events_engine"),
+    windowUtils = require("../core/utils/window"),
     extend = require("./utils/extend").extend,
     config = require("./config"),
     errors = require("./errors"),
@@ -136,8 +137,26 @@ var DOMComponent = Component.inherit({
         return this._dimensionChanged !== abstract;
     },
 
-    _render: function() {
+    _renderComponent: function() {
+        this._initMarkup();
+        this._mount();
+    },
+
+    _mount: function() {
+        if(this._isReadyToMount()) {
+            this._render();
+        }
+    },
+
+    _isReadyToMount: function() {
+        return windowUtils.hasWindow();
+    },
+
+    _initMarkup: function() {
         this._renderElementAttributes();
+    },
+
+    _render: function() {
         this._toggleRTLDirection(this.option("rtlEnabled"));
         this._renderVisibilityChange();
         this._renderDimensions();
@@ -239,7 +258,7 @@ var DOMComponent = Component.inherit({
 
     _refresh: function() {
         this._clean();
-        this._render();
+        this._renderComponent();
     },
 
     _dispose: function() {
@@ -382,7 +401,7 @@ var DOMComponent = Component.inherit({
 
         if(!this._updateLockCount) {
             if(requireRender) {
-                this._render();
+                this._renderComponent();
             } else if(this._requireRefresh) {
                 this._requireRefresh = false;
                 this._refresh();

--- a/js/ui/scroll_view/ui.scroll_view.js
+++ b/js/ui/scroll_view/ui.scroll_view.js
@@ -116,7 +116,7 @@ var ScrollView = Scrollable.inherit({
         this._loadingIndicatorEnabled = true;
     },
 
-    _initMarkup: function() {
+    _initScrollableMarkup: function() {
         this.callBase();
         this.$element().addClass(SCROLLVIEW_CLASS);
 

--- a/js/ui/scroll_view/ui.scrollable.js
+++ b/js/ui/scroll_view/ui.scrollable.js
@@ -237,7 +237,7 @@ var Scrollable = DOMComponent.inherit({
 
     _init: function() {
         this.callBase();
-        this._initMarkup();
+        this._initScrollableMarkup();
         this._attachNativeScrollbarsCustomizationCss();
         this._locked = false;
     },
@@ -253,7 +253,7 @@ var Scrollable = DOMComponent.inherit({
         }
     },
 
-    _initMarkup: function() {
+    _initScrollableMarkup: function() {
         var $element = this.$element().addClass(SCROLLABLE_CLASS),
             $container = this._$container = $("<div>").addClass(SCROLLABLE_CONTAINER_CLASS),
             $wrapper = this._$wrapper = $("<div>").addClass(SCROLLABLE_WRAPPER_CLASS),

--- a/testing/tests/DevExpress.serverSide/widgetsCreation.tests.js
+++ b/testing/tests/DevExpress.serverSide/widgetsCreation.tests.js
@@ -75,11 +75,22 @@ var widgets = {
 
 QUnit.module("Scripts loading");
 
-QUnit.test("Widgets", function(assert) {
-    for(var widget in widgets) {
-        assert.ok(widgets[widget], widget);
-    }
+Object.keys(widgets).forEach(function(widget) {
+    QUnit.test(widget, function(assert) {
+        assert.ok(widgets[widget], "it's possible to import " + widget);
+    });
 });
+
+
+var notDisposableWidgets = [
+    "ActionSheet",
+    "ContextMenu",
+    "Gallery",
+    "LoadIndicator",
+    "Lookup",
+    "ProgressBar",
+    "Toolbar"
+];
 
 QUnit.module("Widget creation", {
     beforeEach: function() {
@@ -88,11 +99,39 @@ QUnit.module("Widget creation", {
         fixture.appendChild(this.element);
     },
     afterEach: function() {
-        this.instance.dispose();
+        if(notDisposableWidgets.indexOf(this.instance.NAME.substr(2)) === -1) {
+            this.instance.dispose();
+        }
     }
 });
 
-QUnit.test("Button", function(assert) {
-    this.instance = new widgets.Button(this.element);
-    assert.ok(this.instance);
+Object.keys(widgets).forEach(function(widget) {
+    var excludedWidgets = [
+        "BarGauge",
+        "Bullet",
+        "Chart",
+        "CircularGauge",
+        "DataGrid",
+        "Funnel",
+        "LinearGauge",
+        "List",
+        "PieChart",
+        "PivotGrid",
+        "PolarChart",
+        "RangeSelector",
+        "ScrollView",
+        "Sparkline",
+        "TileView",
+        "Toast",
+        "TreeMap",
+        "Validator",
+        "VectorMap",
+    ];
+
+    if(excludedWidgets.indexOf(widget) > -1) return;
+
+    QUnit.test(widget, function(assert) {
+        this.instance = new widgets[widget](this.element);
+        assert.ok(true, "it's possible to create " + widget);
+    });
 });


### PR DESCRIPTION
Widget rendering was split into two parts:
1) _initMarkup() - first part of widget rendering. You can't get elements sizes here. It's possible to create elements and set classes only.
2) _render() - Second part of rendering. It's possible to use DOM sizes and other browsers API.