### PR TITLE
Fix touch action in the MultiView for IE and Edge browsers only (T600380)

### DIFF
--- a/styles/widgets/common/multiView.less
+++ b/styles/widgets/common/multiView.less
@@ -2,7 +2,7 @@
     overflow: hidden;
     width: 100%;
     height: 100%;
-    .touch-action(pinch-zoom);
+    .touch-action(pinch-zoom pan-y);
 }
 
 .dx-multiview-item-container {


### PR DESCRIPTION
The swipe is not worked inside MultiView in IE and Edge browsers if not use the pinch-zoom of touch-action CSS style. But this style does not allow a swiping by vertical in other browsers on devices. So I adding this style only for IE and Edge.
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
