### PR TITLE
Make XHR available in AJAX done callback

### DIFF
--- a/js/core/utils/ajax.js
+++ b/js/core/utils/ajax.js
@@ -122,19 +122,19 @@ var postProcess = function(deferred, xhr, dataType) {
 
         case "script":
             evalScript(data);
-            deferred.resolve(data, SUCCESS);
+            deferred.resolve(data, SUCCESS, xhr);
             break;
 
         case "json":
             try {
-                deferred.resolve(JSON.parse(data), SUCCESS);
+                deferred.resolve(JSON.parse(data), SUCCESS, xhr);
             } catch(e) {
                 deferred.reject(xhr, PARSER_ERROR, e);
             }
             break;
 
         default:
-            deferred.resolve(data, SUCCESS);
+            deferred.resolve(data, SUCCESS, xhr);
     }
 };
 
@@ -251,7 +251,7 @@ var sendRequest = function(options) {
 
     if(callbackName) {
         window[callbackName] = function(data) {
-            d.resolve(data, SUCCESS);
+            d.resolve(data, SUCCESS, xhr);
         };
     }
 
@@ -261,7 +261,7 @@ var sendRequest = function(options) {
             },
             resolve = function() {
                 if(dataType === "jsonp") return;
-                d.resolve(null, SUCCESS);
+                d.resolve(null, SUCCESS, xhr);
             };
 
         evalCrossDomainScript(url).then(resolve, reject);
@@ -292,7 +292,7 @@ var sendRequest = function(options) {
                 if(hasContent(xhr.status)) {
                     postProcess(d, xhr, dataType);
                 } else {
-                    d.resolve(null, NO_CONTENT);
+                    d.resolve(null, NO_CONTENT, xhr);
                 }
             } else {
                 d.reject(xhr, xhr.customStatus || ERROR);

--- a/testing/tests/DevExpress.core/utils.ajax.tests.js
+++ b/testing/tests/DevExpress.core/utils.ajax.tests.js
@@ -613,6 +613,32 @@ QUnit.test("cache=false for dataType=json", function(assert) {
     assert.ok(/_=\d+/.test(this.requests[0].url));
 });
 
+QUnit.test("xhr is available in done", function(assert) {
+    var xhrCount = 0;
+    var requests = this.requests;
+
+    function check(dataType, statusCode, responseText, options) {
+        options = options || { };
+        options.dataType = dataType;
+
+        ajax.sendRequest(options).done(function(data, statusText, xhr) {
+            if("getResponseHeader" in xhr) {
+                xhrCount++;
+            }
+        });
+
+        requests.pop().respond(statusCode, { }, responseText);
+    }
+
+    check("json", 200, "{}");
+    check("jsonp", 200, "cb({})", { jsonpCallback: "cb" });
+    check("script", 200, ";");
+    check("text", 200, "");
+    check(null, 204, null);
+
+    assert.equal(xhrCount, 5);
+});
+
 QUnit.module("sendRequest async tests");
 
 QUnit.test("Handle error", function(assert) {


### PR DESCRIPTION
According to http://api.jquery.com/jquery.ajax/

```js
jqXHR.done(function( data, textStatus, jqXHR ) {});
```

Reason: in [DevExtreme.AspNet.Data](https://github.com/DevExpress/DevExtreme.AspNet.Data) I need to read response headers from XHR.