### PR TITLE
dxFilterBuilder - Fix an error if the field dataField option is not specified (T603218)

### DIFF
--- a/js/ui/filter_builder/filter_builder.js
+++ b/js/ui/filter_builder/filter_builder.js
@@ -442,8 +442,9 @@ var FilterBuilder = Widget.inherit({
 
     _updateFilter: function() {
         this._disableInvalidateForValue = true;
-        var value = extend(true, [], this._model);
-        this.option("value", utils.getNormalizedFilter(value, this.option("fields")));
+        var value = extend(true, [], this._model),
+            normalizedFields = utils.getNormalizedFields(this.option("fields"));
+        this.option("value", utils.getNormalizedFilter(value, normalizedFields));
         this._disableInvalidateForValue = false;
     },
 

--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -305,15 +305,18 @@ function convertToInnerStructure(value) {
 }
 
 function getNormalizedFields(fields) {
-    return fields.map(function(field) {
-        var normalizedField = {};
-        for(var key in field) {
-            if(field[key] && AVAILABLE_FIELD_PROPERTIES.indexOf(key) > -1) {
-                normalizedField[key] = field[key];
+    return fields.reduce(function(result, field) {
+        if(typeof field.dataField !== "undefined") {
+            var normalizedField = {};
+            for(var key in field) {
+                if(field[key] && AVAILABLE_FIELD_PROPERTIES.indexOf(key) > -1) {
+                    normalizedField[key] = field[key];
+                }
             }
+            result.push(normalizedField);
         }
-        return normalizedField;
-    });
+        return result;
+    }, []);
 }
 
 function getNormalizedFilter(group, fields) {

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -460,6 +460,21 @@ QUnit.module("Utils", function() {
         field = utils.getField("State", [{ dataField: "State.Name" }, { dataField: "Company" }]);
         assert.equal(field.dataField, "State");
     });
+
+    //T603218
+    QUnit.test("getNormalizedFields", function(assert) {
+        var normalizedFields = utils.getNormalizedFields([{
+            dataField: "Weight",
+            dataType: 'number',
+            width: 100
+        }, {
+        }]);
+
+        assert.deepEqual(normalizedFields, [{
+            dataField: "Weight",
+            dataType: 'number'
+        }]);
+    });
 });
 
 QUnit.module("Add item", function() {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
