### PR TITLE
Bring majorTickInterval deprecation declaration back

### DIFF
--- a/js/viz/docs/docrangeselector.js
+++ b/js/viz/docs/docrangeselector.js
@@ -154,56 +154,56 @@ var dxRangeSelector = {
         * @publicName majorTickInterval
         * @type number|object|Enums.VizTimeInterval
         * @default undefined
-        * @deprecated dxrangeselectoroptions_scale_tickInterval
+        * @deprecated dxrangeselectoroptions_scale_tickinterval
         */
         majorTickInterval: {
             /**
             * @name dxrangeselectoroptions_scale_majortickinterval_years
             * @publicName years
             * @type number
-            * @deprecated dxrangeselectoroptions_scale_tickInterval_years
+            * @deprecated dxrangeselectoroptions_scale_tickinterval
             */
             years: undefined,
             /**
             * @name dxrangeselectoroptions_scale_majortickinterval_months
             * @publicName months
             * @type number
-            * @deprecated dxrangeselectoroptions_scale_tickInterval_months
+            * @deprecated dxrangeselectoroptions_scale_tickinterval
             */
             months: undefined,
             /**
             * @name dxrangeselectoroptions_scale_majortickinterval_days
             * @publicName days
             * @type number
-            * @deprecated dxrangeselectoroptions_scale_tickInterval_days
+            * @deprecated dxrangeselectoroptions_scale_tickinterval
             */
             days: undefined,
             /**
             * @name dxrangeselectoroptions_scale_majortickinterval_hours
             * @publicName hours
             * @type number
-            * @deprecated dxrangeselectoroptions_scale_tickInterval_hours
+            * @deprecated dxrangeselectoroptions_scale_tickinterval
             */
             hours: undefined,
             /**
             * @name dxrangeselectoroptions_scale_majortickinterval_minutes
             * @publicName minutes
             * @type number
-            * @deprecated dxrangeselectoroptions_scale_tickInterval_minutes
+            * @deprecated dxrangeselectoroptions_scale_tickinterval
             */
             minutes: undefined,
             /**
             * @name dxrangeselectoroptions_scale_majortickinterval_seconds
             * @publicName seconds
             * @type number
-            * @deprecated dxrangeselectoroptions_scale_tickInterval_seconds
+            * @deprecated dxrangeselectoroptions_scale_tickinterval
             */
             seconds: undefined,
             /**
             * @name dxrangeselectoroptions_scale_majortickinterval_milliseconds
             * @publicName milliseconds
             * @type number
-            * @deprecated dxrangeselectoroptions_scale_tickInterval_milliseconds
+            * @deprecated dxrangeselectoroptions_scale_tickinterval
             */
             milliseconds: undefined
         },


### PR DESCRIPTION
This reverts commit b64862cabf5d2a06002347e46f0aba3ff74f40d5.

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
