### PR TITLE
Add possibility to customize the color of hovered item in dxMenu

### DIFF
--- a/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
+++ b/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
@@ -1892,6 +1892,13 @@
 * @type color
 * @group navigations.menu
 */
+@menu-item-hovered-color: @menu-color;
+
+/**
+* @name 58. Expanded item text color
+* @type color
+* @group navigations.menu
+*/
 @menu-item-expanded-color: @menu-color;
 
 /**

--- a/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
+++ b/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
@@ -1371,6 +1371,7 @@
 * @paletteColorOpacity .15
 */
 @menu-item-hover-bg: @base-hover-color;
+@menu-item-hovered-color: @base-text-color;
 @menu-item-expanded-color: @base-text-color;
 /**
 * @name 60. Selected item background color

--- a/styles/widgets/generic/color-schemes/dark/generic.dark.less
+++ b/styles/widgets/generic/color-schemes/dark/generic.dark.less
@@ -1895,6 +1895,13 @@
 * @type color
 * @group navigations.menu
 */
+@menu-item-hovered-color: @menu-color;
+
+/**
+* @name 58. Expanded item text color
+* @type color
+* @group navigations.menu
+*/
 @menu-item-expanded-color: @menu-color;
 
 /**

--- a/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
+++ b/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
@@ -1899,6 +1899,13 @@
 * @type color
 * @group navigations.menu
 */
+@menu-item-hovered-color: @menu-color;
+
+/**
+* @name 58. Expanded item text color
+* @type color
+* @group navigations.menu
+*/
 @menu-item-expanded-color: @menu-color;
 
 /**

--- a/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
+++ b/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
@@ -1904,6 +1904,13 @@
 * @type color
 * @group navigations.menu
 */
+@menu-item-hovered-color: @menu-color;
+
+/**
+* @name 58. Expanded item text color
+* @type color
+* @group navigations.menu
+*/
 @menu-item-expanded-color: @menu-color;
 
 /**

--- a/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
+++ b/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
@@ -1891,6 +1891,13 @@
 * @type color
 * @group navigations.menu
 */
+@menu-item-hovered-color: @menu-color;
+
+/**
+* @name 58. Expanded item text color
+* @type color
+* @group navigations.menu
+*/
 @menu-item-expanded-color: @menu-color;
 
 /**

--- a/styles/widgets/generic/color-schemes/light/generic.light.less
+++ b/styles/widgets/generic/color-schemes/light/generic.light.less
@@ -1889,6 +1889,13 @@
 * @type color
 * @group navigations.menu
 */
+@menu-item-hovered-color: @menu-color;
+
+/**
+* @name 58. Expanded item text color
+* @type color
+* @group navigations.menu
+*/
 @menu-item-expanded-color: @menu-color;
 
 /**

--- a/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
+++ b/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
@@ -1894,6 +1894,13 @@
 * @type color
 * @group navigations.menu
 */
+@menu-item-hovered-color: @menu-color;
+
+/**
+* @name 58. Expanded item text color
+* @type color
+* @group navigations.menu
+*/
 @menu-item-expanded-color: @menu-color;
 
 /**

--- a/styles/widgets/generic/menuBase.generic.less
+++ b/styles/widgets/generic/menuBase.generic.less
@@ -19,6 +19,7 @@
     color: @menu-color;
 
     &.dx-state-hover {
+        color: @menu-item-hovered-color;
         background-color: @menu-item-hover-bg;
     }
 


### PR DESCRIPTION
https://www.devexpress.com/Support/Center/Question/Details/T598535/themebuilder-the-hovered-menu-item-text-color-is-not-applied-for-second-level-sub-items
