### PR TITLE
Fix handling of special data values in AJAX

### DIFF
--- a/js/core/utils/ajax.js
+++ b/js/core/utils/ajax.js
@@ -25,7 +25,17 @@ var paramsConvert = function(params) {
     var result = [];
 
     for(var name in params) {
-        result.push(encodeURIComponent(name) + "=" + encodeURIComponent(params[name]));
+        var value = params[name];
+
+        if(value === undefined) {
+            continue;
+        }
+
+        if(value === null) {
+            value = "";
+        }
+
+        result.push(encodeURIComponent(name) + "=" + encodeURIComponent(value));
     }
 
     return result.join("&");

--- a/testing/tests/DevExpress.core/utils.ajax.tests.js
+++ b/testing/tests/DevExpress.core/utils.ajax.tests.js
@@ -639,6 +639,29 @@ QUnit.test("xhr is available in done", function(assert) {
     assert.equal(xhrCount, 5);
 });
 
+QUnit.test("special values in data", function(assert) {
+    ajax.sendRequest({
+        url: "any",
+        data: {
+            a: undefined,
+            b: null,
+            c: NaN
+        }
+    });
+
+    var url = this.requests[0].url;
+
+    // undefined values are excluded
+    assert.ok(url.indexOf("a=") < 0);
+
+    // null values included as empty strings
+    assert.ok(url.indexOf("b=") > -1);
+    assert.ok(url.indexOf("b=null") < 0);
+
+    // NaN values are kept
+    assert.ok(url.indexOf("c=NaN") > -1);
+});
+
 QUnit.module("sendRequest async tests");
 
 QUnit.test("Handle error", function(assert) {


### PR DESCRIPTION
The test case is written so that it passes both in jQuery and no-jQuery modes.
