### PR TITLE
Fix width of time view in DateBox for IE browser (T597602)

### DIFF
--- a/js/ui/date_box/ui.date_box.strategy.calendar_with_time.js
+++ b/js/ui/date_box/ui.date_box.strategy.calendar_with_time.js
@@ -137,7 +137,7 @@ var CalendarWithTimeStrategy = CalendarStrategy.inherit({
                     if(this._box.option("layoutStrategy") === "fallback") {
                         var clockMinWidth = this._getPopup().$content().find(".dx-timeview-clock").css("minWidth");
 
-                        this._timeView.$element().css("minWidth", clockMinWidth);
+                        this._timeView.$element().css("maxWidth", clockMinWidth);
                     }
                 }).bind(this),
             });

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -6,6 +6,7 @@ var $ = require("jquery"),
     browser = require("core/utils/browser"),
     support = require("core/utils/support"),
     dateUtils = require("core/utils/date"),
+    commonUtils = require("core/utils/common"),
     uiDateUtils = require("ui/date_box/ui.date_utils"),
     devices = require("core/devices"),
     DateBox = require("ui/date_box"),
@@ -44,6 +45,7 @@ var currentDate = new Date(2015, 11, 31),
     BOX_CLASS = "dx-box",
     CALENDAR_CLASS = "dx-calendar",
     TIMEVIEW_CLASS = "dx-timeview",
+    TIMEVIEW_CLOCK_CLASS = "dx-timeview-clock",
     TEXTEDITOR_INPUT_CLASS = "dx-texteditor-input",
 
     DATEBOX_CLASS = "dx-datebox",
@@ -391,6 +393,25 @@ QUnit.test("T378630 - the displayFormat should not be changed if the type option
         }).dxDateBox("instance");
 
     assert.equal(instance.option("displayFormat"), displayFormat, "the displayFormat option is not changed");
+});
+
+QUnit.test("set maxWidth for time view when fallback strategy is used", function(assert) {
+    if(!browser.msie) {
+        assert.ok(true);
+        return;
+    }
+
+    var dateBox = $("#dateBox").dxDateBox({
+        type: "datetime",
+        pickerType: "calendarWithTime",
+        value: new Date()
+    }).dxDateBox("instance");
+
+    dateBox.option("opened", true);
+
+    var maxWidth = $("." + TIMEVIEW_CLASS).css("maxWidth");
+    assert.ok(commonUtils.isDefined(maxWidth), "maxWidth is defined");
+    assert.equal(maxWidth, $("." + TIMEVIEW_CLOCK_CLASS).css("minWidth"), "minWidth of time view clock should be equal maxWidth");
 });
 
 QUnit.test("the 'displayFormat' option should accept format objects (T378753)", function(assert) {


### PR DESCRIPTION
(cherry picked from commit a412b0b)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
