### PR TITLE
Fix unit test in MS browsers after PR#2950

### DIFF
--- a/js/ui/date_box/ui.date_box.strategy.calendar_with_time.js
+++ b/js/ui/date_box/ui.date_box.strategy.calendar_with_time.js
@@ -135,7 +135,7 @@ var CalendarWithTimeStrategy = CalendarStrategy.inherit({
         var calendarPopupConfig = this.callBase(popupConfig),
             result = extend(calendarPopupConfig, {
                 onShowing: (function() {
-                    if(this._box.option("layoutStrategy") === "fallback") {
+                    if(this._box.option("_layoutStrategy") === "fallback") {
                         var clockMinWidth = this._getPopup().$content().find(".dx-timeview-clock").css("minWidth");
 
                         this._timeView.$element().css("maxWidth", clockMinWidth);

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -6,7 +6,7 @@ var $ = require("jquery"),
     browser = require("core/utils/browser"),
     support = require("core/utils/support"),
     dateUtils = require("core/utils/date"),
-    commonUtils = require("core/utils/common"),
+    typeUtils = require("core/utils/type"),
     uiDateUtils = require("ui/date_box/ui.date_utils"),
     devices = require("core/devices"),
     DateBox = require("ui/date_box"),
@@ -410,7 +410,7 @@ QUnit.test("set maxWidth for time view when fallback strategy is used", function
     dateBox.option("opened", true);
 
     var maxWidth = $("." + TIMEVIEW_CLASS).css("maxWidth");
-    assert.ok(commonUtils.isDefined(maxWidth), "maxWidth is defined");
+    assert.ok(typeUtils.isDefined(maxWidth), "maxWidth is defined");
     assert.equal(maxWidth, $("." + TIMEVIEW_CLOCK_CLASS).css("minWidth"), "minWidth of time view clock should be equal maxWidth");
 });
 


### PR DESCRIPTION
Causes:
1. `Box.layoutStrategy` option was renamed to `_layoutStrategy` in https://github.com/DevExpress/DevExtreme/pull/2317/.
2. `isDefined` utility was moved from `core/utils/common` to `core/utils/type` in https://github.com/DevExpress/DevExtreme/pull/525.