### PR TITLE
dxTreeList/dxDataGrid: Fix incorrect work minWidth when widget has a small width (T604970)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.grid_view.js
+++ b/js/ui/grid_core/ui.grid_core.grid_view.js
@@ -232,7 +232,7 @@ var ResizingController = modules.ViewController.inherit({
 
     _correctColumnWidths: function(resultWidths, visibleColumns) {
         var that = this,
-            i = 0,
+            i,
             hasPercentWidth = false,
             hasAutoWidth = false,
             isColumnWidthsCorrected = false,
@@ -241,7 +241,7 @@ var ResizingController = modules.ViewController.inherit({
             averageColumnsWidth,
             lastColumnIndex;
 
-        while(i < visibleColumns.length) {
+        for(i = 0; i < visibleColumns.length; i++) {
             var index = i,
                 column = visibleColumns[index],
                 isHiddenColumn = resultWidths[index] === HIDDEN_COLUMNS_WIDTH,
@@ -262,7 +262,6 @@ var ResizingController = modules.ViewController.inherit({
             if(isPercentWidth(column.width)) {
                 hasPercentWidth = true;
             }
-            i++;
         }
 
         if($element && that._maxWidth) {

--- a/js/ui/grid_core/ui.grid_core.grid_view.js
+++ b/js/ui/grid_core/ui.grid_core.grid_view.js
@@ -232,6 +232,7 @@ var ResizingController = modules.ViewController.inherit({
 
     _correctColumnWidths: function(resultWidths, visibleColumns) {
         var that = this,
+            i = 0,
             hasPercentWidth = false,
             hasAutoWidth = false,
             isColumnWidthsCorrected = false,
@@ -240,36 +241,29 @@ var ResizingController = modules.ViewController.inherit({
             averageColumnsWidth,
             lastColumnIndex;
 
-        each(visibleColumns, function(index) {
-            var isMinWidthApplied = false,
+        while(i < visibleColumns.length) {
+            var index = i,
+                column = visibleColumns[index],
                 isHiddenColumn = resultWidths[index] === HIDDEN_COLUMNS_WIDTH,
                 width = resultWidths[index];
 
-            if(width === undefined && this.minWidth) {
-                if(averageColumnsWidth === undefined) {
-                    averageColumnsWidth = that._getAverageColumnsWidth(resultWidths);
-                }
+            if(width === undefined && column.minWidth) {
+                averageColumnsWidth = that._getAverageColumnsWidth(resultWidths);
                 width = averageColumnsWidth;
             }
-
-            if(width < this.minWidth && !isHiddenColumn) {
-                resultWidths[index] = this.minWidth;
+            if(width < column.minWidth && !isHiddenColumn) {
+                resultWidths[index] = column.minWidth;
                 isColumnWidthsCorrected = true;
-                isMinWidthApplied = true;
+                i = -1;
             }
-            if(this.width !== "auto") {
-                if(this.width) {
-                    if(!isHiddenColumn && !isMinWidthApplied) {
-                        resultWidths[index] = this.width;
-                    }
-                } else {
-                    hasAutoWidth = true;
-                }
+            if(!column.width) {
+                hasAutoWidth = true;
             }
-            if(isPercentWidth(this.width)) {
+            if(isPercentWidth(column.width)) {
                 hasPercentWidth = true;
             }
-        });
+            i++;
+        }
 
         if($element && that._maxWidth) {
             delete that._maxWidth;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/gridView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/gridView.tests.js
@@ -1730,6 +1730,34 @@ function createGridView(options, userOptions) {
         assert.strictEqual($colElements.get(3).style.width, "70px", "width of a fourth column");
         assert.strictEqual($colElements.get(4).style.width, "150px", "width of a fifth column");
     });
+
+    //T604970
+    QUnit.test("Column widths should be correctly updated when all columns have minWidth and the grid has a large width", function(assert) {
+        //arrange
+        var $colElements,
+            gridView = this.createGridView({}, {
+                columns: [
+                    { caption: "Column 1", minWidth: 100 },
+                    { caption: "Column 2", minWidth: 50 },
+                    { caption: "Column 3", minWidth: 20 },
+                    { caption: "Column 4", minWidth: 70 },
+                    { caption: "Column 5", minWidth: 150 }
+                ]
+            }),
+            $testElement = $("<div />").width(400).appendTo($("#container"));
+
+        //act
+        gridView.render($testElement);
+
+        //assert
+        $colElements = $testElement.find(".dx-datagrid-headers").find("col");
+
+        assert.strictEqual($colElements.get(0).style.width, "100px", "width of a first column");
+        assert.strictEqual($colElements.get(1).style.width, "50px", "width of a second column");
+        assert.strictEqual($colElements.get(2).style.width, "auto", "width of a third column");
+        assert.strictEqual($colElements.get(3).style.width, "70px", "width of a fourth column");
+        assert.strictEqual($colElements.get(4).style.width, "150px", "width of a fifth column");
+    });
 }());
 
 ///Fixed columns///

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/gridView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/gridView.tests.js
@@ -1702,6 +1702,34 @@ function createGridView(options, userOptions) {
         //assert
         assert.ok(stub.calledOnce);
     });
+
+    //T604970
+    QUnit.test("Column widths should be correctly updated when all columns have minWidth and the grid has a small width", function(assert) {
+        //arrange
+        var $colElements,
+            gridView = this.createGridView({}, {
+                columns: [
+                    { caption: "Column 1", minWidth: 100 },
+                    { caption: "Column 2", minWidth: 50 },
+                    { caption: "Column 3", minWidth: 30 },
+                    { caption: "Column 4", minWidth: 70 },
+                    { caption: "Column 5", minWidth: 150 }
+                ]
+            }),
+            $testElement = $("<div />").width(250).appendTo($("#container"));
+
+        //act
+        gridView.render($testElement);
+
+        //assert
+        $colElements = $testElement.find(".dx-datagrid-headers").find("col");
+
+        assert.strictEqual($colElements.get(0).style.width, "100px", "width of a first column");
+        assert.strictEqual($colElements.get(1).style.width, "50px", "width of a second column");
+        assert.strictEqual($colElements.get(2).style.width, "30px", "width of a third column");
+        assert.strictEqual($colElements.get(3).style.width, "70px", "width of a fourth column");
+        assert.strictEqual($colElements.get(4).style.width, "150px", "width of a fifth column");
+    });
 }());
 
 ///Fixed columns///


### PR DESCRIPTION
See https://devexpress.com/issue=T604970