### PR TITLE
Fix bullet color and sparkline min/max colors in new generic themes

### DIFF
--- a/js/viz/core/themes/generic.carmine.js
+++ b/js/viz/core/themes/generic.carmine.js
@@ -96,7 +96,9 @@ registerTheme({
         }
     },
     sparkline: {
-        pointColor: BACKGROUND_COLOR
+        pointColor: BACKGROUND_COLOR,
+        minColor: "#f0ad4e",
+        maxColor: "#f74d61"
     },
     treeMap: {
         group: {
@@ -118,5 +120,8 @@ registerTheme({
         legend: {
             markerColor: ACCENT_COLOR
         }
+    },
+    bullet: {
+        color: ACCENT_COLOR
     }
 }, "generic.light");

--- a/js/viz/core/themes/generic.darkmoon.js
+++ b/js/viz/core/themes/generic.darkmoon.js
@@ -90,7 +90,9 @@ registerTheme({
         }
     },
     sparkline: {
-        pointColor: BACKGROUND_COLOR
+        pointColor: BACKGROUND_COLOR,
+        minColor: "#f0ad4e",
+        maxColor: "#f9517e"
     },
     treeMap: {
         group: {
@@ -141,5 +143,8 @@ registerTheme({
             color: ACCENT_COLOR,
             opacity: 0.5
         }
+    },
+    bullet: {
+        color: ACCENT_COLOR
     }
 }, "generic.dark");

--- a/js/viz/core/themes/generic.darkviolet.js
+++ b/js/viz/core/themes/generic.darkviolet.js
@@ -87,7 +87,9 @@ registerTheme({
         }
     },
     sparkline: {
-        pointColor: BACKGROUND_COLOR
+        pointColor: BACKGROUND_COLOR,
+        minColor: "#f0ad4e",
+        maxColor: "#d9534f"
     },
     treeMap: {
         group: {
@@ -131,5 +133,8 @@ registerTheme({
         legend: {
             markerColor: ACCENT_COLOR
         }
+    },
+    bullet: {
+        color: ACCENT_COLOR
     }
 }, "generic.dark");

--- a/js/viz/core/themes/generic.greenmist.js
+++ b/js/viz/core/themes/generic.greenmist.js
@@ -87,7 +87,9 @@ registerTheme({
         }
     },
     sparkline: {
-        pointColor: BACKGROUND_COLOR
+        pointColor: BACKGROUND_COLOR,
+        minColor: "#ffc852",
+        maxColor: "#f74a5e"
     },
     treeMap: {
         group: {
@@ -128,5 +130,8 @@ registerTheme({
         legend: {
             markerColor: ACCENT_COLOR
         }
+    },
+    bullet: {
+        color: ACCENT_COLOR
     }
 }, "generic.light");

--- a/js/viz/core/themes/generic.softblue.js
+++ b/js/viz/core/themes/generic.softblue.js
@@ -96,7 +96,9 @@ registerTheme({
         }
     },
     sparkline: {
-        pointColor: BACKGROUND_COLOR
+        pointColor: BACKGROUND_COLOR,
+        minColor: "#f0ad4e",
+        maxColor: "#d9534f"
     },
     treeMap: {
         group: {
@@ -118,5 +120,8 @@ registerTheme({
         legend: {
             markerColor: ACCENT_COLOR
         }
+    },
+    bullet: {
+        color: ACCENT_COLOR
     }
 }, "generic.light");


### PR DESCRIPTION
Changes were made:
1) use base-warning and base-danger colors as sparkline min and max colors;
2) use accent color as a color of bullet.