### PR TITLE
Fix possibility to type any symbols after 0 in NumberBox if float part is not required (T605471)

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -342,10 +342,10 @@ var NumberBoxMask = NumberBoxBase.inherit({
         if(separatorIsFirst) {
             return false;
         }
-        if(lastChar === decimalSeparator && onlyOneSeparatorExists) {
+        if(lastChar === decimalSeparator && onlyOneSeparatorExists && this._lastKey === decimalSeparator) {
             return true;
         }
-        if(lastChar !== "0") {
+        if(lastChar !== "0" || this._lastKey !== "0") {
             return false;
         }
 

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -553,6 +553,16 @@ QUnit.test("valueChanged event fires on value apply", function(assert) {
     assert.ok(valueChangedSpy.calledOnce, "valueChanged event called once");
 });
 
+QUnit.test("it should not be possible to input stubs when editor has 0 value", function(assert) {
+    this.instance.option({
+        format: "#0.##",
+        value: 0
+    });
+
+    this.keyboard.caret(1).type("asdf");
+
+    assert.equal(this.input.val(), "0", "value is correct");
+});
 
 QUnit.module("format: percent format", moduleConfig);
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
