### PR TITLE
Fix overlapping in ie after adding advancedRendering

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_view.js
+++ b/js/ui/grid_core/ui.grid_core.columns_view.js
@@ -704,6 +704,9 @@ exports.ColumnsView = modules.View.inherit(columnStateMixin).inherit({
                 if(width === "adaptiveHidden") {
                     width = HIDDEN_COLUMNS_WIDTH;
                 }
+                if(typeof width === "number") {
+                    width = width.toFixed(3) + "px";
+                }
                 $cols.eq(columnIndex).css("width", width || "auto");
                 columnIndex++;
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15967379/36492560-79741f90-173e-11e8-9a67-aa9fabc40598.png)
