### PR TITLE
dxDataGrid: Fix the incorrect work of the cellValue method when visible column index as the second parameter (T607746)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -967,7 +967,12 @@ module.exports = {
                         column;
 
                     if(rowOptions) {
-                        column = this._columnsController.columnOption(columnIdentifier);
+                        if(typeUtils.isString(columnIdentifier)) {
+                            column = this._columnsController.columnOption(columnIdentifier);
+                        } else {
+                            column = this._columnsController.getVisibleColumns()[columnIdentifier];
+                        }
+
                         if(column) {
                             cellOptions = this._getCellOptions({
                                 value: column.calculateCellValue(rowOptions.data),

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -5852,6 +5852,24 @@ QUnit.test("repaintRows should be skipped on saving", function(assert) {
     assert.strictEqual(changeCount, 1, "data is changed once");
 });
 
+//T607746
+QUnit.test("The cellValue method should work correctly with visible index", function(assert) {
+    //arrange
+    var $testElement = $("#container"),
+        visibleColumns;
+
+    this.options.columns = ["name", "age", { dataField: "lastName", visibleIndex: 0 }];
+    this.columnsController.optionChanged({ name: "columns", fullName: "columns" });
+    this.rowsView.render($testElement);
+    visibleColumns = this.columnsController.getVisibleColumns().map(function(column) {
+        return column.dataField;
+    });
+
+    //act, assert
+    assert.strictEqual(this.cellValue(0, 2), 15, "value of the third cell");
+    assert.deepEqual(visibleColumns, ["lastName", "name", "age"], "visible columns");
+});
+
 if(device.ios || device.android) {
     //T322738
     QUnit.testInActiveWindow("Native click is used when allowUpdating is true", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.tests.js
@@ -3206,7 +3206,7 @@ QUnit.test("changeRowSelection for edited data", function(assert) {
     that.setup();
     that.columnHeadersView.render($testElement);
     that.rowsView.render($testElement);
-    that.cellValue(0, 0, "Test");
+    that.cellValue(0, 1, "Test");
 
     //act
     that.selectionController.changeItemSelection(0);


### PR DESCRIPTION
See https://devexpress.com/issue=T607746