### PR TITLE
Fix wrong Toolbar items appearance for Edge browser and jQuery 2.x (T602655)

### DIFF
--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -211,23 +211,24 @@ var ToolbarBase = CollectionWidget.inherit({
     },
 
     _alignSectionLabels: function(labels, difference, expanding) {
+        var getRealLabelWidth = function(label) { return label.getBoundingClientRect().width; };
+
         for(var i = 0; i < labels.length; i++) {
             var $label = $(labels[i]),
-                currentLabelWidth = Math.ceil($label.outerWidth()),
+                currentLabelWidth = Math.ceil(getRealLabelWidth(labels[i])),
                 labelMaxWidth;
 
             if(expanding) {
                 $label.css("maxWidth", "inherit");
             }
 
-            var possibleLabelWidth = Math.ceil(expanding ? $($label).outerWidth() : currentLabelWidth);
+            var possibleLabelWidth = Math.ceil(expanding ? getRealLabelWidth(labels[i]) : currentLabelWidth);
 
             if(possibleLabelWidth < difference) {
                 labelMaxWidth = expanding ? possibleLabelWidth : 0;
                 difference = difference - possibleLabelWidth;
             } else {
                 labelMaxWidth = expanding ? currentLabelWidth + difference : currentLabelWidth - difference;
-
                 $label.css("maxWidth", labelMaxWidth);
                 break;
             }

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -97,6 +97,22 @@ QUnit.test("items - label", function(assert) {
     assert.ok(label.hasClass(TOOLBAR_LABEL_CLASS));
 });
 
+QUnit.test("label correctly fits into container", function(assert) {
+    this.element.dxToolbar({
+        items: [
+            { location: 'before', text: 'Summary' }
+        ]
+    });
+
+    var labelElement = this.element.find("." + TOOLBAR_ITEM_CLASS)[0],
+        labelMaxWidth = parseInt(labelElement.style.maxWidth);
+
+    labelElement.style.maxWidth = "";
+
+    var labelWidth = labelElement.getBoundingClientRect().width;
+    assert.ok(labelWidth <= labelMaxWidth, "Real label width less or equal to the max width");
+});
+
 QUnit.test("items - long labels", function(assert) {
     this.element.dxToolbar({
         items: [


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
