### PR TITLE
Fix wrong caret position after sign reverting in NumberBox with 0 value when all text is selected (T601731, T604497)

### DIFF
--- a/js/localization/number.js
+++ b/js/localization/number.js
@@ -234,7 +234,7 @@ var numberLocalization = dependencyInjector({
         });
     },
 
-    _getSign: function(text, format) {
+    getSign: function(text, format) {
         if(text.charAt(0) === "-") {
             return -1;
         }
@@ -312,7 +312,7 @@ var numberLocalization = dependencyInjector({
             return null;
         }
 
-        return parsed * this._getSign(text, format);
+        return parsed * this.getSign(text, format);
     }
 });
 

--- a/js/ui/number_box/number_box.caret.js
+++ b/js/ui/number_box/number_box.caret.js
@@ -1,0 +1,117 @@
+"use strict";
+
+var fitIntoRange = require("../../core/utils/math").fitIntoRange,
+    escapeRegExp = require("../../core/utils/common").escapeRegExp,
+    number = require("../../localization/number");
+
+var getCaretBoundaries = function(text, format) {
+    var signParts = format.split(";"),
+        sign = number.getSign(text, format);
+
+    signParts[1] = signParts[1] || "-" + signParts[0];
+    format = sign < 0 ? signParts[1] : signParts[0];
+
+    var clearedFormat = format.replace(/'([^']*)'/g, "$1"),
+        result = /^([^#0\.,]*)([#0\.,]*)([^#0\.,]*)$/.exec(clearedFormat);
+
+    var startBorder = result[1].length,
+        endBorder = text.length - result[3].length;
+
+    return { start: startBorder, end: endBorder };
+};
+
+var getDigitCountBeforeIndex = function(index, text) {
+    var decimalSeparator = number.getDecimalSeparator(),
+        regExp = new RegExp("[^0-9" + escapeRegExp(decimalSeparator) + "]", "g"),
+        textBeforePosition = text.slice(0, index);
+
+    return textBeforePosition.replace(regExp, '').length;
+};
+
+var reverseText = function(text) {
+    return text.split("").reverse().join("");
+};
+
+var getDigitPositionByIndex = function(digitIndex, text) {
+    if(!digitIndex) {
+        return -1;
+    }
+
+    var regExp = /[0-9]/g,
+        counter = 1,
+        index = null,
+        result = regExp.exec(text);
+
+    while(result) {
+        index = result.index;
+        if(!digitIndex || counter >= digitIndex) {
+            return index;
+        }
+        counter++;
+        result = regExp.exec(text);
+    }
+
+    return index === null ? text.length : index;
+};
+
+var getCaretWithOffset = function(caret, offset) {
+    if(caret.start === undefined) {
+        caret = { start: caret, end: caret };
+    }
+
+    return {
+        start: caret.start + offset,
+        end: caret.end + offset
+    };
+};
+
+var getCaretAfterFormat = function(text, formatted, caret, format) {
+    caret = getCaretWithOffset(caret, 0);
+
+    var point = number.getDecimalSeparator(),
+        pointPosition = text.indexOf(point),
+        newPointPosition = formatted.indexOf(point),
+        textParts = text.split(point),
+        formattedParts = formatted.split(point),
+        isCaretOnFloat = pointPosition !== -1 && caret.start > pointPosition;
+
+    if(isCaretOnFloat) {
+        var relativeIndex = caret.start - pointPosition - 1,
+            digitsBefore = getDigitCountBeforeIndex(relativeIndex, textParts[1]),
+            newPosition = formattedParts[1] ? newPointPosition + 1 + getDigitPositionByIndex(digitsBefore, formattedParts[1]) + 1 : formatted.length;
+
+        return getCaretInBoundaries(newPosition, text, format);
+    } else {
+        var positionFromEnd = textParts[0].length - caret.start,
+            digitsFromEnd = getDigitCountBeforeIndex(positionFromEnd, reverseText(textParts[0])),
+            newPositionFromEnd = getDigitPositionByIndex(digitsFromEnd, reverseText(formattedParts[0])),
+            newPositionFromBegin = formattedParts[0].length - (newPositionFromEnd + 1);
+
+        return getCaretInBoundaries(newPositionFromBegin, formatted, format);
+    }
+};
+
+var isCaretInBoundaries = function(caret, text, format) {
+    caret = getCaretWithOffset(caret, 0);
+
+    var boundaries = getCaretInBoundaries(caret, text, format);
+    return caret.start >= boundaries.start && caret.end <= boundaries.end;
+};
+
+var getCaretInBoundaries = function(caret, text, format) {
+    caret = getCaretWithOffset(caret, 0);
+
+    var boundaries = getCaretBoundaries(text, format),
+        adjustedCaret = {
+            start: fitIntoRange(caret.start, boundaries.start, boundaries.end),
+            end: fitIntoRange(caret.end, boundaries.start, boundaries.end)
+        };
+
+    return adjustedCaret;
+};
+
+exports.getCaretBoundaries = getCaretBoundaries;
+exports.isCaretInBoundaries = isCaretInBoundaries;
+exports.getCaretWithOffset = getCaretWithOffset;
+exports.getCaretInBoundaries = getCaretInBoundaries;
+exports.getCaretAfterFormat = getCaretAfterFormat;

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.caret.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.caret.tests.js
@@ -1,0 +1,112 @@
+"use strict";
+
+var maskCaret = require("ui/number_box/number_box.caret");
+
+QUnit.module("format caret");
+
+QUnit.test("getCaretWithOffset", function(assert) {
+    assert.deepEqual(maskCaret.getCaretWithOffset({ start: 1, end: 2 }, 5), { start: 6, end: 7 });
+    assert.deepEqual(maskCaret.getCaretWithOffset({ start: 4, end: 6 }, -2), { start: 2, end: 4 });
+    assert.deepEqual(maskCaret.getCaretWithOffset({ start: 4, end: 6 }, -2), { start: 2, end: 4 });
+    assert.deepEqual(maskCaret.getCaretWithOffset(5, 1), { start: 6, end: 6 });
+});
+
+QUnit.test("getCaretBoundaries", function(assert) {
+    assert.deepEqual(maskCaret.getCaretBoundaries("$ 123 tst", "$ #0 tst"), { start: 2, end: 5 });
+    assert.deepEqual(maskCaret.getCaretBoundaries("-$ 123 tst", "$ #0 tst"), { start: 3, end: 6 });
+    assert.deepEqual(maskCaret.getCaretBoundaries("(($ 123 tst))", "$ #0 tst;(($ #0 tst))"), { start: 4, end: 7 });
+    assert.deepEqual(maskCaret.getCaretBoundaries("$ ", "$ #.##"), { start: 2, end: 2 });
+    assert.deepEqual(maskCaret.getCaretBoundaries(" kg", "#.## kg"), { start: 0, end: 0 });
+    assert.deepEqual(maskCaret.getCaretBoundaries("$ 0.15 ts", "$ #,##0.## ts;($ #,##0.##) ts"), { start: 2, end: 6 });
+    assert.deepEqual(maskCaret.getCaretBoundaries("$ 1 ts", "$ #,##0.## ts;($ #,##0.##) ts"), { start: 2, end: 3 });
+    assert.deepEqual(maskCaret.getCaretBoundaries("($ 12,345) ts", "$ #,##0.## ts;($ #,##0.##) ts"), {
+        start: 3,
+        end: 9
+    });
+});
+
+QUnit.test("getCaretInBoundaries", function(assert) {
+    assert.deepEqual(maskCaret.getCaretInBoundaries({ start: 1, end: 5 }, "$ 123", "$ #"), { start: 2, end: 5 });
+    assert.deepEqual(maskCaret.getCaretInBoundaries({ start: 1, end: 10 }, "-$ 123 kg", "$ #.## kg"), {
+        start: 3,
+        end: 6
+    });
+});
+
+QUnit.test("isCaretInBoundaries", function(assert) {
+    assert.equal(maskCaret.isCaretInBoundaries(3, "$ 123 st", "$ #0 st"), true);
+    assert.equal(maskCaret.isCaretInBoundaries(2, "$ 123 st", "$ #0 st"), true);
+    assert.equal(maskCaret.isCaretInBoundaries(1, "$ 123 st", "$ #0 st"), false);
+    assert.equal(maskCaret.isCaretInBoundaries(5, "$ 123 st", "$ #0 st"), true);
+    assert.equal(maskCaret.isCaretInBoundaries(7, "$ 123 st", "$ #0 st"), false);
+});
+
+QUnit.test("getCaretAfterFormat with integer part", function(assert) {
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1234.15", "1,234.15", 2, "#,##0.##"), {
+        start: 3,
+        end: 3
+    }, "enter 3 after 2");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("(1234.15)", "(1,234.15)", 4, "#,##0.##;(#,##0.##)"), {
+        start: 5,
+        end: 5
+    }, "enter 3 after 2 in negative");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1,234.15", "<<1,234.15>>", 3, "#,##0.##;<<#,##0.##>>"), {
+        start: 5,
+        end: 5
+    }, "revert sign should save caret position");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1", "$ 1", 1, "$ #"), {
+        start: 3,
+        end: 3
+    }, "enter 1 in a blank field");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1,234", "134", 3, "#,##0.##"), {
+        start: 1,
+        end: 1
+    }, "remove 2 with delete");
+    assert.deepEqual(maskCaret.getCaretAfterFormat(",234", "234", 0, "#,##0.##"), {
+        start: 0,
+        end: 0
+    }, "remove 1 with backspace");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1,234", "4", { start: 0, end: 4 }, "#,##0.##"), {
+        start: 0,
+        end: 0
+    }, "select and remove some digits");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("12534", "1534", 3, "0000"), {
+        start: 2,
+        end: 2
+    }, "enter 5 in the middle of decimal format");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("12345", "2345", 5, "0000"), {
+        start: 4,
+        end: 4
+    }, "enter 5 in the end of decimal format");
+});
+
+QUnit.test("getCaretAfterFormat with float part", function(assert) {
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1234.00", "1,234", 6, "#,##0.##"), {
+        start: 5,
+        end: 5
+    }, "cut zeros in the end");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1.423", "1.42", 3, "#0.00"), {
+        start: 3,
+        end: 3
+    }, "enter 4 in the start");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1.243", "1.24", 4, "#0.00"), {
+        start: 4,
+        end: 4
+    }, "enter 4 in the middle");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1.234", "1.23", 5, "#0.00"), {
+        start: 4,
+        end: 4
+    }, "enter 4 in the end");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1.23", "1.230", 4, "#0.000"), {
+        start: 4,
+        end: 4
+    }, "remove 4 with backspace");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1.24", "1.240", 3, "#0.000"), {
+        start: 3,
+        end: 3
+    }, "remove 3 with backspace");
+    assert.deepEqual(maskCaret.getCaretAfterFormat("1.34", "1.30", 2, "#0.000"), {
+        start: 2,
+        end: 2
+    }, "remove 2 with backspace");
+});

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -206,6 +206,18 @@ QUnit.test("focusout after inverting sign should not lead to value changing", fu
     assert.equal(this.instance.option("value"), 123, "value is correct");
 });
 
+QUnit.test("pressing minus button should revert selected number", function(assert) {
+    this.instance.option({
+        format: "$ #0.00",
+        value: 0
+    });
+
+    this.keyboard.caret({ start: 0, end: 5 }).keyDown(MINUS_KEY).type("-");
+    assert.equal(this.input.val(), "-$ 0.00", "text is correct");
+    assert.deepEqual(this.keyboard.caret(), { start: 3, end: 3 }, "caret is good");
+});
+
+
 QUnit.module("format: fixed point format", moduleConfig);
 
 QUnit.test("value should be formatted on first input", function(assert) {
@@ -458,7 +470,10 @@ QUnit.test("select and replace all text", function(assert) {
 });
 
 QUnit.test("decimal point should move the caret before float part only", function(assert) {
-    this.instance.option("value", 123.45);
+    this.instance.option({
+        format: "#0.00",
+        value: 123.45
+    });
     this.keyboard.caret(2).type(".");
 
     assert.equal(this.input.val(), "123.45", "value is right");
@@ -467,6 +482,17 @@ QUnit.test("decimal point should move the caret before float part only", functio
     this.keyboard.caret(3).type(".");
     assert.equal(this.input.val(), "123.45", "value is right");
     assert.deepEqual(this.keyboard.caret(), { start: 4, end: 4 }, "caret was moved to the float part");
+});
+
+QUnit.test("input after 0 should not move caret to float part", function(assert) {
+    this.instance.option({
+        format: "#0.00",
+        value: 0
+    });
+
+    this.keyboard.caret(1).type("1");
+
+    assert.equal(this.keyboard.caret().start, 1, "caret is good");
 });
 
 QUnit.test("ctrl+v should not be prevented", function(assert) {
@@ -651,11 +677,11 @@ QUnit.test("removing non required char with negative value", function(assert) {
     assert.equal(this.input.val(), "-123", "value is correct");
 });
 
-QUnit.test("removing non required zero should be possible", function(assert) {
+QUnit.test("last non required zero should not be typed", function(assert) {
     this.instance.option("format", "#.##");
-    this.keyboard.type("1.50").press("backspace");
+    this.keyboard.type("1.50");
 
-    assert.equal(this.input.val(), "1.5", "zero has been removed");
+    assert.equal(this.input.val(), "1.5", "zero type was prevented");
 });
 
 QUnit.test("removing with group separators using delete key", function(assert) {
@@ -666,20 +692,15 @@ QUnit.test("removing with group separators using delete key", function(assert) {
 
     assert.equal(this.input.val(), "$ 1,234,567,890 d", "value is correct");
 
-    this.keyboard.caret(2).keyDown("del");
-    assert.notOk(this.keyboard.event.isDefaultPrevented(), "delete should not be prevented");
-    this.keyboard.input("del");
+    this.keyboard.caret(2).press("del");
     assert.equal(this.input.val(), "$ 234,567,890 d", "value is correct");
     assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, "caret is good");
 
-    this.keyboard.caret(5).keyDown("del");
-    assert.ok(this.keyboard.event.isDefaultPrevented(), "delete was prevented before separator");
+    this.keyboard.caret(5).press("del");
+    assert.equal(this.input.val(), "$ 234,567,890 d", "value is correct");
+    assert.deepEqual(this.keyboard.caret(), { start: 6, end: 6 }, "caret is good");
 
-    this.keyboard.caret({ start: 4, end: 11 }).keyDown("del");
-    assert.notOk(this.keyboard.event.isDefaultPrevented(), "delete should not be prevented");
-    this.input.val("$ 2390 d");
-    this.keyboard.caret({ start: 4, end: 4 });
-    this.keyboard.input("del");
+    this.keyboard.caret({ start: 4, end: 11 }).press("del");
     assert.equal(this.input.val(), "$ 2,390 d", "value is correct");
     assert.deepEqual(this.keyboard.caret(), { start: 5, end: 5 }, "caret is good after selection removing");
 });
@@ -692,27 +713,41 @@ QUnit.test("removing with group separators using backspace key", function(assert
 
     assert.equal(this.input.val(), "$ 1,234,567,890 d", "value is correct");
 
-    this.keyboard.caret(3).keyDown("backspace");
-    assert.notOk(this.keyboard.event.isDefaultPrevented(), "delete should not be prevented");
-    this.keyboard.input("backspace");
+    this.keyboard.caret(3).press("backspace");
+
     assert.equal(this.input.val(), "$ 234,567,890 d", "value is correct");
     assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, "caret is good");
 
-    this.keyboard.caret(6).keyDown("backspace");
-    assert.ok(this.keyboard.event.isDefaultPrevented(), "delete was prevented after separator");
+    this.keyboard.caret(6).press("backspace");
+    assert.equal(this.input.val(), "$ 234,567,890 d", "value is correct");
+    assert.deepEqual(this.keyboard.caret(), { start: 5, end: 5 }, "caret is good");
 
-    this.keyboard.caret({ start: 4, end: 11 }).keyDown("backspace");
-    assert.notOk(this.keyboard.event.isDefaultPrevented(), "delete should not be prevented");
-    this.keyboard.input("backspace");
+    this.keyboard.caret({ start: 4, end: 11 }).press("backspace");
     assert.equal(this.input.val(), "$ 2,390 d", "value is correct");
 });
 
 QUnit.test("removing required last char should replace it to 0", function(assert) {
-    this.instance.option("value", 1);
+    this.instance.option({
+        format: "#0.00",
+        value: 1
+    });
     this.keyboard.caret(1).press("backspace");
 
-    assert.equal(this.input.val(), "0", "value is correct");
+    assert.equal(this.input.val(), "0.00", "value is correct");
+    assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret is good");
 });
+
+QUnit.test("removing required last char should replace it to 0 if there are stubs before", function(assert) {
+    this.instance.option({
+        format: "$#0.00",
+        value: 1
+    });
+    this.keyboard.caret(2).press("backspace");
+
+    assert.equal(this.input.val(), "$0.00", "value is correct");
+    assert.equal(this.keyboard.caret().start, 2, "caret is good");
+});
+
 
 QUnit.test("removing required last char should replace it to 0 if percent format", function(assert) {
     this.instance.option("format", "#0%");
@@ -767,6 +802,21 @@ QUnit.test("removing all digits but not all characters should change value to 0"
 
     assert.strictEqual(this.input.val(), "0.0 kg", "value is correct");
     assert.strictEqual(this.instance.option("value"), 0, "value is reseted");
+});
+
+QUnit.test("removing all digits with backspace should be possible when required zeros are in the end", function(assert) {
+    this.instance.option({
+        format: "#0.00",
+        value: 1
+    });
+
+    this.keyboard.caret(5)
+        .press("backspace")
+        .press("backspace")
+        .press("backspace")
+        .press("backspace");
+
+    assert.equal(this.input.val(), "0.00", "value is correct");
 });
 
 QUnit.test("removing all digits should save the sign", function(assert) {
@@ -824,7 +874,6 @@ QUnit.test("removing decimal separator should be possible if float part is not r
     });
 
     this.keyboard.caret(4)
-        .press("backspace")
         .press("backspace");
 
     assert.equal(this.input.val(), "12 kg", "decimal separator has been removed");

--- a/testing/tests/DevExpress.ui.widgets.editors/numberbox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberbox.tests.js
@@ -16,5 +16,6 @@ QUnit.testStart(function() {
 });
 
 require("./numberBoxParts/common.tests.js");
+require("./numberBoxParts/mask.caret.tests.js");
 require("./numberBoxParts/mask.tests.js");
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
