### PR TITLE
Fix rise onValueChanged event in Safari on Mac (T611368)

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -84,7 +84,8 @@ var NumberBoxMask = NumberBoxBase.inherit({
 
     _isValueDirty: function() {
         // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15181565/
-        return browser.msie && this._isInputTriggered;
+        // https://bugreport.apple.com/web/?problemID=38133794 but this bug tracker is private
+        return (browser.msie || browser.safari) && this._isInputTriggered;
     },
 
     _arrowHandler: function(step, e) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
