### PR TITLE
Fix negative decimals formatting

### DIFF
--- a/js/localization/number.js
+++ b/js/localization/number.js
@@ -133,15 +133,16 @@ var numberLocalization = dependencyInjector({
 
     _addZeroes: function(value, precision) {
         var multiplier = Math.pow(10, precision);
+        var sign = value < 0 ? "-" : "";
 
-        value = ((value * multiplier) >>> 0) / multiplier;
+        value = ((Math.abs(value) * multiplier) >>> 0) / multiplier;
 
         var result = value.toString();
         while(result.length < precision) {
             result = "0" + result;
         }
 
-        return result;
+        return sign + result;
     },
 
     _addGroupSeparators: function(value) {

--- a/testing/tests/DevExpress.localization/localization.base.tests.js
+++ b/testing/tests/DevExpress.localization/localization.base.tests.js
@@ -758,6 +758,7 @@ QUnit.test('Percent numeric formats', function(assert) {
 QUnit.test('Decimal numeric formats', function(assert) {
     assert.equal(numberLocalization.format(437, { type: "decimAl" }), '437');
     assert.equal(numberLocalization.format(437, { type: "deCimal", precision: 5 }), '00437');
+    assert.equal(numberLocalization.format(-437, { type: "decimal", precision: 0 }), '-437');
 });
 
 QUnit.test('format as function', function(assert) {


### PR DESCRIPTION
Fixes [T610858](https://www.devexpress.com/Support/Center/Question/Details/T610858/decimal-format-with-precision-works-wrong-for-negative-numbers)