### PR TITLE
dxTreeList / dxDataGrid: Fix missing row parameter in the onEditorPreparing/onEditorPrepared event handler when the event fires for the Select checkbox (T612318)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.selection.js
+++ b/js/ui/grid_core/ui.grid_core.selection.js
@@ -766,38 +766,39 @@ module.exports = {
 
                     if(column.command === "select") {
                         return function(container, options) {
-                            that.renderSelectCheckBoxContainer(column, container, options);
+                            that.renderSelectCheckBoxContainer(container, options);
                         };
                     } else {
                         return that.callBase(column);
                     }
                 },
 
-                renderSelectCheckBoxContainer: function(column, $container, options) {
+                renderSelectCheckBoxContainer: function($container, options) {
                     if(options.rowType === "data" && !options.row.inserted) {
                         $container.addClass(EDITOR_CELL_CLASS);
                         this._attachCheckBoxClickEvent($container);
 
                         this.setAria("label", messageLocalization.format("dxDataGrid-ariaSelectRow"), $container);
-                        this._renderSelectCheckBox($container, options.value, column);
+                        this._renderSelectCheckBox($container, options);
                     }
                 },
 
-                _renderSelectCheckBox: function(container, value, column) {
+                _renderSelectCheckBox: function(container, options) {
                     var groupElement = $("<div>")
                             .addClass(SELECT_CHECKBOX_CLASS)
                             .appendTo(container);
 
-                    this.getController("editorFactory").createEditor(groupElement, extend({}, column, {
+                    this.getController("editorFactory").createEditor(groupElement, extend({}, options.column, {
                         parentType: "dataRow",
                         dataType: "boolean",
-                        value: value,
+                        value: options.value,
                         tabIndex: -1,
                         setValue: function(value, e) {
                             if(e && e.event && e.event.type === "keydown") {
                                 eventsEngine.trigger(container, clickEvent.name, e);
                             }
-                        }
+                        },
+                        row: options.row
                     }));
 
                     return groupElement;

--- a/js/ui/tree_list/ui.tree_list.selection.js
+++ b/js/ui/tree_list/ui.tree_list.selection.js
@@ -78,7 +78,7 @@ treeListCore.registerModule("selection", extend(true, {}, selectionModule, {
 
                     $container.addClass(CELL_FOCUS_DISABLED_CLASS);
 
-                    var $checkbox = rowsView._renderSelectCheckBox($container, model.row.isSelected);
+                    var $checkbox = rowsView._renderSelectCheckBox($container, model);
 
                     rowsView._attachCheckBoxClickEvent($checkbox);
                 },

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -5869,6 +5869,37 @@ QUnit.test("The cellValue method should work correctly with visible index", func
     assert.deepEqual(visibleColumns, ["lastName", "name", "age"], "visible columns");
 });
 
+// T612318
+QUnit.test("EditorPreparing and EditorPrepared events should have correct parameters for the select column", function(assert) {
+    // arrange
+    var $testElement = $("#container"),
+        editorPreparingHandler = sinon.spy(),
+        editorPreparedHandler = sinon.spy(),
+        expectedProperties = ["parentType", "value", "setValue", "width", "cancel", "editorElement", "editorName", "editorOptions", "row"];
+
+    this.options.onEditorPreparing = editorPreparingHandler;
+    this.options.onEditorPrepared = editorPreparedHandler;
+    this.options.selection = {
+        mode: "multiple",
+        showCheckBoxesMode: "always"
+    };
+    this.selectionController.init();
+    this.editorFactoryController.init();
+
+    // act
+    this.rowsView.render($testElement);
+    this.clock.tick();
+
+    // assert
+    assert.strictEqual(editorPreparingHandler.getCall(0).args[0].command, "select", "The editorPreparing event argument - select column");
+    assert.strictEqual(editorPreparedHandler.getCall(0).args[0].command, "select", "The editorPrepared event argument - select column");
+    expectedProperties.forEach(function(item) {
+        assert.ok(editorPreparingHandler.getCall(0).args[0].hasOwnProperty(item), "The editorPreparing event argument - The '" + item + "' property existed");
+        assert.ok(editorPreparedHandler.getCall(0).args[0].hasOwnProperty(item), "The editorPrepared event argument - The '" + item + "' property existed");
+    });
+});
+
+
 if(device.ios || device.android) {
     // T322738
     QUnit.testInActiveWindow("Native click is used when allowUpdating is true", function(assert) {


### PR DESCRIPTION
See https://devexpress.com/issue=T612318