### PR TITLE
Fix hide submenu on mouseleave event when relatedTarget is children of target

### DIFF
--- a/js/events/core/events_engine.js
+++ b/js/events/core/events_engine.js
@@ -101,7 +101,10 @@ var getHandlersController = function(element, eventName) {
     return {
         addHandler: function(handler, selector, data) {
             var callHandler = function(e, extraParameters) {
-                var handlerArgs = [e];
+                var handlerArgs = [e],
+                    target = e.currentTarget,
+                    relatedTarget = e.relatedTarget,
+                    result;
 
                 if(extraParameters !== undefined) {
                     handlerArgs.push(extraParameters);
@@ -109,7 +112,9 @@ var getHandlersController = function(element, eventName) {
 
                 special.callMethod(eventName, "handle", element, [ e, data ]);
 
-                var result = handler.apply(e.currentTarget, handlerArgs);
+                if(!relatedTarget || (relatedTarget !== target && !(target && e.currentTarget.contains(relatedTarget)))) {
+                    result = handler.apply(target, handlerArgs);
+                }
 
                 if(result === false) {
                     e.preventDefault();

--- a/js/events/core/events_engine.js
+++ b/js/events/core/events_engine.js
@@ -104,7 +104,7 @@ var getHandlersController = function(element, eventName) {
                 var handlerArgs = [e],
                     target = e.currentTarget,
                     relatedTarget = e.relatedTarget,
-                    secondaryTargetIsOutside = !relatedTarget || (relatedTarget !== target && !(target && e.currentTarget.contains(relatedTarget))),
+                    secondaryTargetIsOutside = !relatedTarget || !target || relatedTarget !== target && !target.contains(relatedTarget),
                     result;
 
                 if(extraParameters !== undefined) {

--- a/js/events/core/events_engine.js
+++ b/js/events/core/events_engine.js
@@ -104,6 +104,7 @@ var getHandlersController = function(element, eventName) {
                 var handlerArgs = [e],
                     target = e.currentTarget,
                     relatedTarget = e.relatedTarget,
+                    secondaryTargetIsOutside = !relatedTarget || (relatedTarget !== target && !(target && e.currentTarget.contains(relatedTarget))),
                     result;
 
                 if(extraParameters !== undefined) {
@@ -112,7 +113,7 @@ var getHandlersController = function(element, eventName) {
 
                 special.callMethod(eventName, "handle", element, [ e, data ]);
 
-                if(!relatedTarget || (relatedTarget !== target && !(target && e.currentTarget.contains(relatedTarget)))) {
+                if(secondaryTargetIsOutside) {
                     result = handler.apply(target, handlerArgs);
                 }
 

--- a/testing/tests/DevExpress.ui.events/eventsEngine.tests.js
+++ b/testing/tests/DevExpress.ui.events/eventsEngine.tests.js
@@ -247,9 +247,9 @@ QUnit.test("Event bubbling", function(assert) {
 
 QUnit.test("Should not fire event when relatedTarget is children of a target", function(assert) {
     var div = document.createElement("div"),
-        div2 = document.createElement("div"),
+        childNode = document.createElement("div"),
         fired = 0;
-    div.appendChild(div2);
+    div.appendChild(childNode);
 
     document.body.appendChild(div);
 
@@ -257,7 +257,7 @@ QUnit.test("Should not fire event when relatedTarget is children of a target", f
         fired++;
     });
 
-    var event = new eventsEngine.Event("someEvent", { target: div, relatedTarget: div.children[0] });
+    var event = new eventsEngine.Event("someEvent", { target: div, relatedTarget: childNode });
 
     eventsEngine.trigger(div, event);
 

--- a/testing/tests/DevExpress.ui.events/eventsEngine.tests.js
+++ b/testing/tests/DevExpress.ui.events/eventsEngine.tests.js
@@ -245,6 +245,25 @@ QUnit.test("Event bubbling", function(assert) {
     assert.equal(fired.focus, 0);
 });
 
+QUnit.test("Should not fire event when relatedTarget is children of a target", function(assert) {
+    var div = document.createElement("div"),
+        div2 = document.createElement("div"),
+        fired = 0;
+    div.appendChild(div2);
+
+    document.body.appendChild(div);
+
+    eventsEngine.on(div, "someEvent", function() {
+        fired++;
+    });
+
+    var event = new eventsEngine.Event("someEvent", { target: div, relatedTarget: div.children[0] });
+
+    eventsEngine.trigger(div, event);
+
+    assert.equal(fired, 0);
+});
+
 QUnit.test("'on' signatures", function(assert) {
     var fired = 0;
     var hasData = 0;

--- a/testing/tests/DevExpress.ui.widgets/menu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menu.tests.js
@@ -5,7 +5,6 @@ var $ = require("jquery"),
     fx = require("animation/fx"),
     viewPort = require("core/utils/view_port").value,
     isRenderer = require("core/utils/type").isRenderer,
-    eventsEngine = require("events/core/events_engine"),
     config = require("core/config"),
     Submenu = require("ui/menu/ui.submenu"),
     resizeCallbacks = require("core/utils/window").resizeCallbacks,
@@ -1262,8 +1261,8 @@ QUnit.test("Menu should not hide after mouseleave to children of a target", func
         }),
         $rootMenuItem = $(menu.element).find("." + DX_MENU_ITEM_CLASS);
 
-    eventsEngine.trigger(menu.element, $.Event("click", { target: $rootMenuItem.eq(0).get(0) }));
-    eventsEngine.trigger(menu.element, $.Event("mouseleave", { target: $rootMenuItem.eq(0).get(0), relatedTarget: $rootMenuItem.eq(0).children()[2] }));
+    $(menu.element).trigger($.Event("click", { target: $rootMenuItem.eq(0).get(0) }));
+    $(menu.element).trigger($.Event("mouseleave", { target: $rootMenuItem.eq(0).get(0), relatedTarget: $rootMenuItem.eq(0).children()[2] }));
     this.clock.tick(0);
 
     var submenu = getSubMenuInstance($rootMenuItem);

--- a/testing/tests/DevExpress.ui.widgets/menu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menu.tests.js
@@ -5,6 +5,7 @@ var $ = require("jquery"),
     fx = require("animation/fx"),
     viewPort = require("core/utils/view_port").value,
     isRenderer = require("core/utils/type").isRenderer,
+    eventsEngine = require("events/core/events_engine"),
     config = require("core/config"),
     Submenu = require("ui/menu/ui.submenu"),
     resizeCallbacks = require("core/utils/window").resizeCallbacks,
@@ -1249,6 +1250,24 @@ QUnit.test("Menu should hide after mouseleave when hideOnMouseLeave = true", fun
     this.clock.tick(0);
 
     assert.notOk(submenu.option("visible"), "submenu hidden");
+});
+
+QUnit.test("Menu should not hide after mouseleave to children of a target", function(assert) {
+    if(!isDeviceDesktop(assert)) return;
+
+    var menu = createMenu({
+            items: [{ text: "Item 1", items: [{ text: "item 11" }] }, { text: "Item 2" }],
+            showFirstSubmenuMode: { name: "onHover", delay: 0 },
+            hideSubmenuOnMouseLeave: true
+        }),
+        $rootMenuItem = $(menu.element).find("." + DX_MENU_ITEM_CLASS);
+
+    eventsEngine.trigger(menu.element, $.Event("click", { target: $rootMenuItem.eq(0).get(0) }));
+    eventsEngine.trigger(menu.element, $.Event("mouseleave", { target: $rootMenuItem.eq(0).get(0), relatedTarget: $rootMenuItem.eq(0).children()[2] }));
+    this.clock.tick(0);
+
+    var submenu = getSubMenuInstance($rootMenuItem);
+    assert.ok(submenu.option("visible"), "submenu shown");
 });
 
 QUnit.test("Menu should show after it's submenu has been selected", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/scrollable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollable.tests.js
@@ -3400,7 +3400,7 @@ QUnit.test("leaving inner scroller and releasing in outer scroller should hide i
     // start scrolling inner
     pointerMock($scrollableContainer).start().down().move(0, 10);
     // leaving inner
-    $scrollableContainer.trigger($.Event("mouseleave", { relatedTarget: $wrapScrollableContainer }));
+    $scrollableContainer.trigger($.Event("mouseleave", { relatedTarget: $wrapScrollableContainer.get(0) }));
     // up on outer
     pointerMock($wrapScrollableContainer).up();
 

--- a/testing/tests/DevExpress.ui.widgets/scrollable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollable.tests.js
@@ -3436,7 +3436,7 @@ QUnit.test("scrollbar is visible for parent scrollable after mouse leave for chi
     assert.equal(parentScrollbar.option("visible"), false, "parent scrollbar is hidden");
     assert.equal(childrenScrollbar.option("visible"), true, "children scrollbar is visible");
 
-    $childScrollable.triggerHandler($.Event("mouseleave", { relatedTarget: $parentContainer }));
+    $childScrollable.triggerHandler($.Event("mouseleave", { relatedTarget: $parentContainer.get(0) }));
 
     assert.equal(parentScrollbar.option("visible"), true, "parent scrollbar is visible");
     assert.equal(childrenScrollbar.option("visible"), false, "children scrollbar is hidden");


### PR DESCRIPTION
Fix [T612637](https://www.devexpress.com/Support/Center/Question/Details/T612637/menu-is-closed-immediately-after-being-opened-if-hidesubmenuonmouseleave-is-set-to-true)
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
