### PR TITLE
Fix dxTreeView crash when item clicked in filtered dataSource (T612990)

### DIFF
--- a/js/ui/hierarchical_collection/ui.data_converter.js
+++ b/js/ui/hierarchical_collection/ui.data_converter.js
@@ -169,7 +169,7 @@ var DataConverter = Class.inherit({
                 var currentElementKey = element.internalFields && element.internalFields.key || that._dataAccessors.getters.key(element),
                     items = that._dataAccessors.getters.items(element);
 
-                if(currentElementKey === key) {
+                if(currentElementKey.toString() === key.toString()) {
                     result = element;
                     return false;
                 }

--- a/testing/tests/DevExpress.ui.widgets/treeView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/treeView.tests.js
@@ -155,7 +155,7 @@ window.dataID = [
     { id: 2, "elternId": 1, text: "Cat" },
     { id: 3, "elternId": 2, text: "Abyssinian" },
     { id: 4, "elternId": 0, text: "Birds" },
-    { id: 5, "elternId": 4, text: "Akekee" },
+    { id: 5, "elternId": 4, text: "Akekee" }
 ];
 
 window.initTree = function(options) {
@@ -200,7 +200,6 @@ require("./treeViewParts/accessibility.js");
 require("./treeViewParts/animation.js");
 require("./treeViewParts/checkboxes.js");
 require("./treeViewParts/events.js");
-require("./treeViewParts/expandedItems.js");
 require("./treeViewParts/expandedItems.js");
 require("./treeViewParts/focusing.js");
 require("./treeViewParts/initialization.js");

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/selection.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/selection.js
@@ -2,7 +2,8 @@
 
 /* global initTree */
 
-var $ = require("jquery");
+var $ = require("jquery"),
+    keyboardMock = require("../../../helpers/keyboardMock.js");
 
 QUnit.module("selection common");
 
@@ -335,4 +336,24 @@ QUnit.test("item selection correctly reset when dataSource is filtered", functio
     var checkedCheckBoxCount = $treeView.find(".dx-checkbox-checked").length;
     assert.equal(checkedCheckBoxCount, 1, "There is only one checked checkBox");
     assert.ok($treeView.find(CHECK_BOX_SELECTOR).eq(0).hasClass("dx-checkbox-checked"), "Correct checkbox checked");
+});
+
+QUnit.test("items should be selectable after the search", function(assert) {
+    var clickHandler = sinon.spy(),
+        $treeView = initTree({
+            dataSource: [{ text: "Stores" }],
+            searchEnabled: true,
+            searchTimeout: 0,
+            selectionMode: "single",
+            onItemClick: clickHandler
+        }),
+        $input = $treeView.find(".dx-texteditor-input"),
+        kb = keyboardMock($input);
+
+    kb.type("s");
+
+    var $item = $treeView.find(".dx-treeview-item").eq(0);
+    $($item).trigger("dxclick");
+
+    assert.equal(clickHandler.callCount, 1, "click works");
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
