### PR TITLE
Documentation - Mark the "DropDownList.displayValue" option as read-only

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -84,6 +84,7 @@ var DropDownList = DropDownEditor.inherit({
             * @name dxDropDownListOptions_displayValue
             * @publicName displayValue
             * @type string
+            * @readonly
             * @default undefined
             * @ref
             */


### PR DESCRIPTION
Motivation:
"The value you pass to this option does not affect widget behavior. Pass an observable variable to this option to get the value currently displayed by the widget."
See [the "displayValue" description](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxSelectBox/Configuration/#displayValue) and compare with [the "selectedItem" one](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxSelectBox/Configuration/#selectedItem).

