### PR TITLE
Update the "onCustomItemCreating" action behavior

### DIFF
--- a/js/core/errors.js
+++ b/js/core/errors.js
@@ -182,7 +182,7 @@ module.exports = errorUtils({
     * @name Errors and Warnings_E0121
     * @publicName E0121
     */
-    E0121: "The onCustomItemCreating action should return an item or Promise of jQuery Deferred object resolved when an item is created",
+    E0121: "The customItem field of the onCustomItemCreating action should contain an item or Promise of jQuery Deferred object resolved when an item is created",
 
 
     /**
@@ -280,5 +280,11 @@ module.exports = errorUtils({
     * @name Errors and Warnings_W0014
     * @publicName W0014
     */
-    W0014: "{0} - '{1}' type is deprecated in {2}. {3}"
+    W0014: "{0} - '{1}' type is deprecated in {2}. {3}",
+
+    /**
+    * @name Errors and Warnings_W0015
+    * @publicName W0015
+    */
+    W0015: "Instead of returning a value from the '{0}' function, write it into the '{1}' field of the function's parameter."
 });

--- a/js/core/errors.js
+++ b/js/core/errors.js
@@ -182,7 +182,7 @@ module.exports = errorUtils({
     * @name Errors and Warnings_E0121
     * @publicName E0121
     */
-    E0121: "The customItem field of the onCustomItemCreating action should contain an item or Promise of jQuery Deferred object resolved when an item is created",
+    E0121: "The 'customItem' field of the 'onCustomItemCreating' function's parameter should contain a custom item or a Promise that is resolved after the item is created.",
 
 
     /**

--- a/js/core/errors.js
+++ b/js/core/errors.js
@@ -182,7 +182,7 @@ module.exports = errorUtils({
     * @name Errors and Warnings_E0121
     * @publicName E0121
     */
-    E0121: "The 'customItem' field of the 'onCustomItemCreating' function's parameter should contain a custom item or a Promise that is resolved after the item is created.",
+    E0121: "The 'customItem' field of the 'onCustomItemCreating' function's parameter should contain a custom item or Promise that is resolved after the item is created.",
 
 
     /**

--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -713,6 +713,10 @@ var SelectBox = DropDownList.inherit({
             actionResult = this._customItemCreatingAction(params),
             item = commonUtils.ensureDefined(actionResult, params.customItem);
 
+        if(isDefined(actionResult)) {
+            errors.log("W0015", "onCustomItemCreating", "customItem");
+        }
+
         return item;
     },
 

--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -179,7 +179,6 @@ var SelectBox = DropDownList.inherit({
             * @type_function_param1 e:object
             * @type_function_param1_field4 text:string
             * @type_function_param1_field5 customItem:string|object|Promise<any>
-            * @type_function_return string|object|Promise<any>
             * @action
             * @default function(e) { if(!e.customItem) { e.customItem = e.text; } }
             */

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -11,6 +11,7 @@ var $ = require("jquery"),
     CustomStore = require("data/custom_store"),
     fx = require("animation/fx"),
     isRenderer = require("core/utils/type").isRenderer,
+    errors = require("core/errors"),
     config = require("core/config");
 
 require("common.css!");
@@ -1758,7 +1759,7 @@ QUnit.test("T316005 - mousedown on inputWrapper should not be prevented if openO
     assert.ok(!event.isDefaultPrevented(), "default event is not prevented");
 });
 
-QUnit.test("The 'onCustomItemCreating' option", function(assert) {
+QUnit.test("The 'onCustomItemCreating' option should throw a warning if handler returns an item", function(assert) {
     var $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             displayExpr: "display",
@@ -1772,7 +1773,8 @@ QUnit.test("The 'onCustomItemCreating' option", function(assert) {
         }),
         $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)),
         keyboard = keyboardMock($input),
-        customValue = "Custom value";
+        customValue = "Custom value",
+        logStub = sinon.stub(errors, "log");
 
     keyboard
         .type(customValue)
@@ -1780,6 +1782,8 @@ QUnit.test("The 'onCustomItemCreating' option", function(assert) {
 
     assert.equal($selectBox.dxSelectBox("option", "value"), "value " + customValue, "value is correct");
     assert.equal($input.val(), "display " + customValue, "displayed value is correct");
+    assert.ok(logStub.calledOnce, "There was an one message");
+    assert.deepEqual(logStub.firstCall.args, ["W0015", "onCustomItemCreating", "customItem"], "Check warning parameters");
 });
 
 QUnit.test("onCustomItemCreating should not be called when existing item selecting", function(assert) {
@@ -1860,8 +1864,8 @@ QUnit.test("The 'onCustomItemCreating' option with Deferred", function(assert) {
             acceptCustomValue: true,
             displayExpr: "display",
             valueExpr: "value",
-            onCustomItemCreating: function() {
-                return deferred.promise();
+            onCustomItemCreating: function(e) {
+                e.customItem = deferred.promise();
             }
         }),
         $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)),
@@ -1895,7 +1899,7 @@ QUnit.test("The 'onCustomItemCreating' option with Promise", function(assert) {
             acceptCustomValue: true,
             displayExpr: "display",
             valueExpr: "value",
-            onCustomItemCreating: function() { return promise; }
+            onCustomItemCreating: function(e) { e.customItem = promise; }
         }),
         $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)),
         keyboard = keyboardMock($input),
@@ -1927,8 +1931,8 @@ QUnit.test("Value should be reset if the 'onCustomItemCreating' deferred is reje
             acceptCustomValue: true,
             items: [1],
             value: 1,
-            onCustomItemCreating: function() {
-                return deferred.reject().promise();
+            onCustomItemCreating: function(e) {
+                e.customItem = deferred.reject().promise();
             }
         }),
         $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)),
@@ -2033,7 +2037,7 @@ QUnit.test("Custom value should be selected in list if items were modified on cu
         items.push(e.text);
         selectBox.option("items", items);
 
-        return e.text;
+        e.customItem = e.text;
     });
 
     keyboardMock($input)
@@ -4102,7 +4106,7 @@ QUnit.testInActiveWindow("dxSelectBox should not filter a dataSource when the wi
             searchEnabled: true,
             onCustomItemCreating: function(e) {
                 $(e.element).remove();
-                return "";
+                e.customItem = "";
             }
         }).dxSelectBox("instance"),
         $input = instance.$element().find(toSelector(TEXTEDITOR_INPUT_CLASS)),


### PR DESCRIPTION
1. Send a warning on returning a value from the "onCustomItemCreating" handler
2. Update the documentation

[Context](https://www.devexpress.com/Support/Center/Question/Details/T571363/dxtagbox-the-custom-values-functionality-does-not-work-correctly-in-angular-when-tags)