### PR TITLE
Add a demand mode for applying changes in the FieldChooser widget

### DIFF
--- a/js/docEnums.js
+++ b/js/docEnums.js
@@ -720,6 +720,11 @@
  */
 
 /**
+ * @typedef {string} Enums.ApplyChangesMode
+ * @enum {'instantly'|'onDemand'}
+ */
+
+/**
  * @typedef {string} Enums.PivotGridSummaryDisplayMode
  * @enum {'absoluteVariation'|'percentOfColumnGrandTotal'|'percentOfColumnTotal'|'percentOfGrandTotal'|'percentOfRowGrandTotal'|'percentOfRowTotal'|'percentVariation'}
  */

--- a/js/ui/hierarchical_collection/ui.data_adapter.js
+++ b/js/ui/hierarchical_collection/ui.data_adapter.js
@@ -310,7 +310,9 @@ var DataAdapter = Class.inherit({
         var result = null;
 
         each(this._dataStructure, function(_, node) {
-            if(node.internalFields.item === item) {
+            var item1 = JSON.stringify(node.internalFields.item),
+                item2 = JSON.stringify(item);
+            if(item1 == item2) {
                 result = node;
                 return false;
             }

--- a/js/ui/hierarchical_collection/ui.data_adapter.js
+++ b/js/ui/hierarchical_collection/ui.data_adapter.js
@@ -310,9 +310,7 @@ var DataAdapter = Class.inherit({
         var result = null;
 
         each(this._dataStructure, function(_, node) {
-            var item1 = JSON.stringify(node.internalFields.item),
-                item2 = JSON.stringify(item);
-            if(item1 === item2) {
+            if(node.internalFields.item === item) {
                 result = node;
                 return false;
             }

--- a/js/ui/hierarchical_collection/ui.data_adapter.js
+++ b/js/ui/hierarchical_collection/ui.data_adapter.js
@@ -312,7 +312,7 @@ var DataAdapter = Class.inherit({
         each(this._dataStructure, function(_, node) {
             var item1 = JSON.stringify(node.internalFields.item),
                 item2 = JSON.stringify(item);
-            if(item1 == item2) {
+            if(item1 === item2) {
                 result = node;
                 return false;
             }

--- a/js/ui/pivot_grid/data_source.js
+++ b/js/ui/pivot_grid/data_source.js
@@ -1276,7 +1276,7 @@ module.exports = Class.inherit((function() {
         * @param1 state:object
         */
 
-        state: function(state) {
+        state: function(state, skipLoading) {
             var that = this;
 
             if(arguments.length) {
@@ -1290,14 +1290,14 @@ module.exports = Class.inherit((function() {
                     when(getFields(that)).done(function(fields) {
                         that._fields = setFieldsState(state.fields, fields);
                         that._fieldsPrepared(fields);
-                        that.load(state);
+                        !skipLoading && that.load(state);
                     }).always(function() {
                         that.endLoading();
                     });
                 } else {
                     that._fields = setFieldsState(state.fields, that._fields);
                     that._descriptions = that._createDescriptions();
-                    that.load(state);
+                    !skipLoading && that.load(state);
                 }
 
             } else {

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -250,6 +250,7 @@ var FieldChooser = BaseFieldChooser.inherit({
                 func();
             });
             that._fireContentReadyAction();
+            that.option("state", null);
         };
 
         if(that._dataSource) {
@@ -520,7 +521,7 @@ var FieldChooser = BaseFieldChooser.inherit({
             treeView = that._createComponent(container, TreeView, {
                 dataSource: that._createFieldsDataSource(dataSource),
                 showCheckBoxesMode: 'normal',
-                keyExpr: "key",
+                keyExpr: "dataField",
                 searchEnabled: that.option("allowSearch"),
                 itemTemplate: function(itemData, itemIndex, itemElement) {
                     if(itemData.icon) {
@@ -690,6 +691,34 @@ var FieldChooser = BaseFieldChooser.inherit({
         if(treeView) {
             treeView.option("searchValue", "");
             treeView.collapseAll();
+        }
+    },
+
+    /**
+    * @name dxPivotGridFieldChooserMethods_applyChanges
+    * @publicName applyChanges()
+    * @return PivotGridDataSource
+    */
+    applyChanges: function() {
+        var state = this.option("state");
+
+        if(isDefined(state)) {
+            state && this._dataSource.state(state);
+            this.option("state", null);
+        }
+    },
+
+    /**
+    * @name dxPivotGridFieldChooserMethods_cancelChanges
+    * @publicName cancelChanges()
+    * @return PivotGridDataSource
+    */
+    cancelChanges: function() {
+        if(isDefined(this.option("state"))) {
+            var state = this._dataSource.state();
+            this.option("state", null);
+
+            this._dataSource.state(state);
         }
     },
 

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -250,7 +250,6 @@ var FieldChooser = BaseFieldChooser.inherit({
                 func();
             });
             that._fireContentReadyAction();
-            that.option("state", null);
         };
 
         if(that._dataSource) {
@@ -590,15 +589,18 @@ var FieldChooser = BaseFieldChooser.inherit({
                         });
                         dataSource.load();
                     } else {
-                        var extendedField = extend(true, {}, field);
-                        that._setInitialState();
-                        if(area) {
-                            that._updateState(extendedField, { area: area, areaIndex: that._getFieldsArea(area).find("dx-area-field").length });
-                            that._updateTargetArea(extendedField, { area: area });
-                        } else {
-                            that._updateState(extendedField, { area: null, areaIndex: null });
-                            that._removeFromSourceArea(extendedField);
-                        }
+                        var startState = dataSource.state(),
+                            state = that.option("state") || startState;
+
+                        dataSource.state(state, true);
+                        dataSource.field(field.index, {
+                            area: area,
+                            areaIndex: undefined
+                        });
+                        var newState = dataSource.state();
+                        that.option("state", newState);
+                        that.repaint();
+                        dataSource.state(startState, true);
                     }
                 }
             }),

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -307,7 +307,8 @@ var FieldChooser = BaseFieldChooser.inherit({
         }
     },
 
-    _clean: function() {
+    _clean: function(saveState) {
+        !saveState && this.option("state", null);
         this.$element().children("." + FIELDCHOOSER_CONTAINER_CLASS).remove();
     },
 

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -518,7 +518,6 @@ var FieldChooser = BaseFieldChooser.inherit({
             treeView = that._createComponent(container, TreeView, {
                 dataSource: that._createFieldsDataSource(dataSource),
                 showCheckBoxesMode: 'normal',
-                keyExpr: "dataField",
                 searchEnabled: that.option("allowSearch"),
                 itemTemplate: function(itemData, itemIndex, itemElement) {
                     if(itemData.icon) {

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -303,9 +303,6 @@ var FieldChooser = BaseFieldChooser.inherit({
             case "onContextMenuPreparing":
                 that._actions[args.name] = that._createActionByOption(args.name);
                 break;
-            case "currentState":
-            case "applyChangesMode":
-                break;
             default:
                 that.callBase(args);
         }

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -589,18 +589,10 @@ var FieldChooser = BaseFieldChooser.inherit({
                         });
                         dataSource.load();
                     } else {
-                        var startState = dataSource.state(),
-                            state = that.option("state") || startState;
-
-                        dataSource.state(state, true);
-                        dataSource.field(field.index, {
+                        that._changeState(field, {
                             area: area,
                             areaIndex: undefined
                         });
-                        var newState = dataSource.state();
-                        that.option("state", newState);
-                        that.repaint();
-                        dataSource.state(startState, true);
                     }
                 }
             }),

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -548,10 +548,6 @@ var FieldChooser = BaseFieldChooser.inherit({
                         needSelectDefaultItem = true,
                         area;
 
-                    if(!e.event && !that._applyValueInstantly()) {
-                        return;
-                    }
-
                     if(data.items) {
                         if(data.selected) {
                             treeView.unselectItem(data);
@@ -610,19 +606,6 @@ var FieldChooser = BaseFieldChooser.inherit({
             };
 
         that._dataChangedHandlers.push(dataChanged);
-    },
-
-    _getTreeViewFields: function(nodes, result) {
-        var that = this;
-        result = result || [];
-
-        if(!nodes[0].field) {
-            each(nodes, function(_, node) {
-                result = node.items && node.items.length ? that._getTreeViewFields(node.items, result) : result.concat(nodes);
-            });
-        }
-
-        return result.concat(nodes);
     },
 
     _renderAreaFields: function($container, area, fields) {

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -622,6 +622,26 @@ var FieldChooser = BaseFieldChooser.inherit({
         that._dataChangedHandlers.push(dataChanged);
     },
 
+    _getTreeViewFields: function(nodes, result) {
+        var that = this;
+
+        result = result || [];
+
+        if(nodes[0].field) {
+            result = result.concat(nodes);
+        } else {
+            each(nodes, function(_, node) {
+                if(node.items && node.items.length) {
+                    result = that._getTreeViewFields(node.items, result);
+                } else {
+                    result = result.concat(nodes);
+                }
+            });
+        }
+
+        return result;
+    },
+
     _renderAreaFields: function($container, area, fields) {
         var that = this;
 

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -676,7 +676,6 @@ var FieldChooser = BaseFieldChooser.inherit({
     /**
     * @name dxPivotGridFieldChooserMethods_applyChanges
     * @publicName applyChanges()
-    * @return Promise<void>
     */
     applyChanges: function() {
         var state = this.option("state");
@@ -690,7 +689,6 @@ var FieldChooser = BaseFieldChooser.inherit({
     /**
     * @name dxPivotGridFieldChooserMethods_cancelChanges
     * @publicName cancelChanges()
-    * @return Promise<void>
     */
     cancelChanges: function() {
         if(isDefined(this.option("state"))) {

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -184,13 +184,13 @@ var FieldChooser = BaseFieldChooser.inherit({
             /**
             * @name dxPivotGridFieldChooserOptions_applyChangesMode
             * @publicName applyChangesMode
-            * @type string
+            * @type Enums.ApplyChangesMode
             * @default "instantly"
             */
            /**
             * @name dxPivotGridFieldChooserOptions_state
             * @publicName state
-            * @type string
+            * @type object
             * @default null
             */
             /**
@@ -676,7 +676,7 @@ var FieldChooser = BaseFieldChooser.inherit({
     /**
     * @name dxPivotGridFieldChooserMethods_applyChanges
     * @publicName applyChanges()
-    * @return PivotGridDataSource
+    * @return Promise<void>
     */
     applyChanges: function() {
         var state = this.option("state");
@@ -690,7 +690,7 @@ var FieldChooser = BaseFieldChooser.inherit({
     /**
     * @name dxPivotGridFieldChooserMethods_cancelChanges
     * @publicName cancelChanges()
-    * @return PivotGridDataSource
+    * @return Promise<void>
     */
     cancelChanges: function() {
         if(isDefined(this.option("state"))) {

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -608,8 +608,10 @@ var FieldChooser = BaseFieldChooser.inherit({
         that._dataChangedHandlers.push(dataChanged);
     },
 
-    _renderAreaFields: function($container, area, fields) {
-        var that = this;
+    _renderAreaFields: function($container, area) {
+        var that = this,
+            dataSource = that._dataSource,
+            fields = dataSource ? dataSource.getAreaFields(area, true) : [];
 
         $container.empty();
         each(fields, function(_, field) {
@@ -644,8 +646,7 @@ var FieldChooser = BaseFieldChooser.inherit({
         if(area !== "all") {
             $fieldsContent = $(DIV).addClass("dx-area-field-container").appendTo($fieldsContainer);
             render = function() {
-                var fields = that._dataSource ? that._dataSource.getAreaFields(area, true) : [];
-                that._renderAreaFields($fieldsContent, area, fields);
+                that._renderAreaFields($fieldsContent, area);
             };
 
             that._dataChangedHandlers.push(render);

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -577,20 +577,11 @@ var FieldChooser = BaseFieldChooser.inherit({
                             fields = [field];
                         }
                     }
-                    if(that._applyValueInstantly()) {
-                        each(fields, function(_, field) {
-                            dataSource.field(field.index, {
-                                area: area,
-                                areaIndex: undefined
-                            });
-                        });
-                        dataSource.load();
-                    } else {
-                        that._changeState(field, {
-                            area: area,
-                            areaIndex: undefined
-                        });
-                    }
+
+                    that._applyChanges(fields, {
+                        area: area,
+                        areaIndex: undefined
+                    });
                 }
             }),
 
@@ -691,7 +682,7 @@ var FieldChooser = BaseFieldChooser.inherit({
         var state = this.option("state");
 
         if(isDefined(state)) {
-            state && this._dataSource.state(state);
+            this._dataSource.state(state);
             this.option("state", null);
         }
     },

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser.js
@@ -620,22 +620,15 @@ var FieldChooser = BaseFieldChooser.inherit({
 
     _getTreeViewFields: function(nodes, result) {
         var that = this;
-
         result = result || [];
 
-        if(nodes[0].field) {
-            result = result.concat(nodes);
-        } else {
+        if(!nodes[0].field) {
             each(nodes, function(_, node) {
-                if(node.items && node.items.length) {
-                    result = that._getTreeViewFields(node.items, result);
-                } else {
-                    result = result.concat(nodes);
-                }
+                result = node.items && node.items.length ? that._getTreeViewFields(node.items, result) : result.concat(nodes);
             });
         }
 
-        return result;
+        return result.concat(nodes);
     },
 
     _renderAreaFields: function($container, area, fields) {

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -284,17 +284,6 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
         dataSource.state(startState, true);
     },
 
-    _getFieldFromState: function(dataField) {
-        var result;
-        this.option("state").fields.some(function(field) {
-            if(field.dataField === dataField) {
-                result = field;
-                return true;
-            }
-        });
-        return result;
-    },
-
     _adjustSortableOnChangedArgs: function(e) {
         e.removeSourceElement = false;
         e.removeTargetElement = true;

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -247,37 +247,37 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
                 that._adjustSortableOnChangedArgs(e);
 
                 if(field) {
-                    var targetArea = e.targetGroup;
-
-                    if(that._applyValueInstantly()) {
-                        dataSource.field(getMainGroupField(dataSource, field).index, {
-                            area: targetArea,
-                            areaIndex: e.targetIndex
-                        });
-                        dataSource.load();
-                    } else {
-                        that._changeState(getMainGroupField(dataSource, field), {
-                            area: targetArea,
-                            areaIndex: e.targetIndex
-                        });
-                    }
+                    that._applyChanges([getMainGroupField(dataSource, field)], {
+                        area: e.targetGroup,
+                        areaIndex: e.targetIndex
+                    });
                 }
             }
         }, that._getSortableOptions()));
     },
 
-    _applyValueInstantly: function() {
-        return this.option("applyChangesMode") === "instantly";
+    _applyChanges(fields, props) {
+        const dataSource = this._dataSource;
+        if(this.option("applyChangesMode") === "instantly") {
+            fields.forEach(({ index })=>{
+                dataSource.field(index, props);
+            });
+            dataSource.load();
+        } else {
+            fields.forEach(({ index })=>{
+                this._changeState(index, props);
+            });
+        }
     },
 
-    _changeState: function(field, props) {
+    _changeState(fieldIndex, props) {
         var that = this,
             dataSource = that._dataSource,
             startState = dataSource.state(),
             state = that.option("state") || startState;
 
         dataSource.state(state, true);
-        dataSource.field(field.index, props);
+        dataSource.field(fieldIndex, props);
 
         that.option("state", dataSource.state());
         that._clean(true);
@@ -332,31 +332,16 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
                         },
 
                         apply: function() {
-                            if(that._applyValueInstantly()) {
-                                dataSource.field(mainGroupField.index, {
-                                    filterValues: this.filterValues,
-                                    filterType: this.filterType
-                                });
-                                dataSource.load();
-                            } else {
-                                that._changeState(mainGroupField, {
-                                    filterValues: this.filterValues,
-                                    filterType: this.filterType
-                                });
-                            }
+                            that._applyChanges([mainGroupField], {
+                                filterValues: this.filterValues,
+                                filterType: this.filterType
+                            });
                         }
                     }));
                 } else if(field.allowSorting && field.area !== "data") {
-                    if(that._applyValueInstantly()) {
-                        dataSource.field(field.index, {
-                            sortOrder: field.sortOrder === "desc" ? "asc" : "desc"
-                        });
-                        dataSource.load();
-                    } else {
-                        that._changeState(field, {
-                            sortOrder: field.sortOrder === "desc" ? "asc" : "desc"
-                        });
-                    }
+                    that._applyChanges([field], {
+                        sortOrder: field.sortOrder === "desc" ? "asc" : "desc"
+                    });
                 }
             };
 

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -179,7 +179,7 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
             case "applyChangesMode":
                 break;
             case "state":
-                if(args.value === null) {
+                if(args.value === null && args.previousValue !== null) {
                     this._dataSource.load();
                 }
                 break;
@@ -340,7 +340,16 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
                                 treeView.selectItem($item);
                             }
                         } else if(!targetArea) {
-                            treeView.unselectItem(extendedField);
+                            var treeViewNodes = that._getTreeViewFields(that._createFieldsDataSource(that._dataSource)),
+                                treeViewNode;
+
+                            treeViewNodes.some(function(node) {
+                                if(node.field.dataField === extendedField.dataField) {
+                                    treeViewNode = node;
+                                    return true;
+                                }
+                            });
+                            treeView.unselectItem(treeViewNode);
                             props = { area: null, areaIndex: null };
                         }
 

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -111,7 +111,7 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
                 break;
             case "state":
                 if(args.value === null && args.previousValue !== null) {
-                    this._dataSource.load();
+                    this.repaint();
                 }
                 break;
             case "headerFilter":
@@ -280,7 +280,8 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
         dataSource.field(field.index, props);
 
         that.option("state", dataSource.state());
-        that.repaint();
+        that._clean(true);
+        that._renderComponent();
         dataSource.state(startState, true);
     },
 

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -157,7 +157,7 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
 
         if(option === null) {
             state = {
-                fields: this._dataSource.fields()
+                fields: extend(true, [], this._dataSource.fields())
             };
             this.option("state", state);
         }
@@ -175,6 +175,13 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
         switch(args.name) {
             case "dataSource":
                 this._refreshDataSource();
+                break;
+            case "applyChangesMode":
+                break;
+            case "state":
+                if(args.value === null) {
+                    this._dataSource.load();
+                }
                 break;
             case "headerFilter":
             case "allowFieldDragging":
@@ -333,7 +340,7 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
                                 treeView.selectItem($item);
                             }
                         } else if(!targetArea) {
-                            treeView.unselectItem(extendedField.dataField);
+                            treeView.unselectItem(extendedField);
                             props = { area: null, areaIndex: null };
                         }
 

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -256,18 +256,10 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
                         });
                         dataSource.load();
                     } else {
-                        var startState = dataSource.state(),
-                            state = that.option("state") || startState;
-
-                        dataSource.state(state, true);
-                        dataSource.field(getMainGroupField(dataSource, field).index, {
+                        that._changeState(getMainGroupField(dataSource, field), {
                             area: targetArea,
                             areaIndex: e.targetIndex
                         });
-
-                        that.option("state", dataSource.state());
-                        that.repaint();
-                        dataSource.state(startState, true);
                     }
                 }
             }
@@ -276,6 +268,20 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
 
     _applyValueInstantly: function() {
         return this.option("applyChangesMode") === "instantly";
+    },
+
+    _changeState: function(field, props) {
+        var that = this,
+            dataSource = that._dataSource,
+            startState = dataSource.state(),
+            state = that.option("state") || startState;
+
+        dataSource.state(state, true);
+        dataSource.field(field.index, props);
+
+        that.option("state", dataSource.state());
+        that.repaint();
+        dataSource.state(startState, true);
     },
 
     _getFieldFromState: function(dataField) {
@@ -343,18 +349,10 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
                                 });
                                 dataSource.load();
                             } else {
-                                var startState = dataSource.state(),
-                                    state = that.option("state") || startState;
-
-                                dataSource.state(state, true);
-                                dataSource.field(mainGroupField.index, {
+                                that._changeState(mainGroupField, {
                                     filterValues: this.filterValues,
                                     filterType: this.filterType
                                 });
-
-                                that.option("state", dataSource.state());
-                                that.repaint();
-                                dataSource.state(startState, true);
                             }
                         }
                     }));
@@ -365,17 +363,9 @@ var FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).in
                         });
                         dataSource.load();
                     } else {
-                        var startState = dataSource.state(),
-                            state = that.option("state") || startState;
-
-                        dataSource.state(state, true);
-                        dataSource.field(field.index, {
+                        that._changeState(field, {
                             sortOrder: field.sortOrder === "desc" ? "asc" : "desc"
                         });
-
-                        that.option("state", dataSource.state());
-                        that.repaint();
-                        dataSource.state(startState, true);
                     }
                 }
             };

--- a/js/ui/pivot_grid/ui.pivot_grid.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.js
@@ -270,7 +270,14 @@ var PivotGrid = Widget.inherit({
                  * @type number
                  * @default 600
                  */
-                height: 600
+                height: 600,
+                /**
+                 * @name dxPivotGridOptions_fieldChooser_applyChangesMode
+                 * @publicName applyChangesMode
+                 * @type string
+                 * @default "instantly"
+                 */
+                applyChangesMode: "instantly"
                 /**
                  * @name dxPivotGridOptions_fieldChooser_texts
                  * @publicName texts
@@ -1129,6 +1136,31 @@ var PivotGrid = Widget.inherit({
         var that = this,
             container = that._pivotGridContainer,
             fieldChooserOptions = that.option("fieldChooser") || {},
+            toolbarItems = fieldChooserOptions.applyChangesMode === "onDemand" ? [
+                {
+                    toolbar: "bottom",
+                    location: "after",
+                    widget: "dxButton",
+                    options: {
+                        text: messageLocalization.format("OK"),
+                        onClick: function(e) {
+                            that._fieldChooserPopup.$content().dxPivotGridFieldChooser("applyChanges");
+                            that._fieldChooserPopup.hide();
+                        }
+                    }
+                },
+                {
+                    toolbar: "bottom",
+                    location: "after",
+                    widget: "dxButton",
+                    options: {
+                        text: messageLocalization.format("Cancel"),
+                        onClick: function(e) {
+                            that._fieldChooserPopup.hide();
+                        }
+                    }
+                }
+            ] : [],
             fieldChooserComponentOptions = {
                 layout: fieldChooserOptions.layout,
                 texts: fieldChooserOptions.texts || {},
@@ -1137,7 +1169,8 @@ var PivotGrid = Widget.inherit({
                 width: undefined,
                 height: undefined,
                 headerFilter: that.option("headerFilter"),
-                encodeHtml: that.option("encodeHtml")
+                encodeHtml: that.option("encodeHtml"),
+                applyChangesMode: fieldChooserOptions.applyChangesMode
             },
             popupOptions = {
                 shading: false,
@@ -1148,6 +1181,7 @@ var PivotGrid = Widget.inherit({
                 resizeEnabled: true,
                 minWidth: fieldChooserOptions.minWidth,
                 minHeight: fieldChooserOptions.minHeight,
+                toolbarItems: toolbarItems,
                 onResize: function(e) {
                     e.component.$content().dxPivotGridFieldChooser("updateDimensions");
                 },
@@ -1155,7 +1189,9 @@ var PivotGrid = Widget.inherit({
                     that._createComponent(e.component.content(), PivotGridFieldChooser, fieldChooserComponentOptions);
                 },
                 onHidden: function(e) {
-                    e.component.$content().dxPivotGridFieldChooser("resetTreeView");
+                    var fieldChooser = e.component.$content().dxPivotGridFieldChooser("instance");
+                    fieldChooser.resetTreeView();
+                    fieldChooser.option("state", null);
                 }
             };
 

--- a/js/ui/pivot_grid/ui.pivot_grid.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.js
@@ -274,7 +274,7 @@ var PivotGrid = Widget.inherit({
                 /**
                  * @name dxPivotGridOptions_fieldChooser_applyChangesMode
                  * @publicName applyChangesMode
-                 * @type string
+                 * @type Enums.ApplyChangesMode
                  * @default "instantly"
                  */
                 applyChangesMode: "instantly"

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
@@ -2108,15 +2108,8 @@ QUnit.test("Apply filters", function(assert) {
 });
 
 QUnit.test("applyChanges", function(assert) {
-    this.fieldChooser = $("#pgfc").dxPivotGridFieldChooser({
-        applyChangesMode: "onDemand",
-        dataSource: new PivotGridDataSource({
-            fields: [
-                { dataField: "Field1", area: 'column', areaIndex: 0 },
-            ],
-            store: []
-        })
-    }).dxPivotGridFieldChooser("instance");
+    this.setup({ fields: [{ dataField: "Field1", area: 'column', areaIndex: 0 }] });
+    this.clock.tick(500);
 
     var changedArgs = {
         sourceGroup: "column",
@@ -2124,7 +2117,7 @@ QUnit.test("applyChanges", function(assert) {
         targetGroup: "row"
     };
 
-    changedArgs.sourceElement = renderer($("#pgfc").find(".dx-area-field").eq(0));
+    changedArgs.sourceElement = renderer(this.$container.find(".dx-area-field").eq(0));
 
     var sortable = this.fieldChooser.$element().dxSortable("instance"),
         onChangedHandler = sortable.option("onChanged");
@@ -2134,6 +2127,7 @@ QUnit.test("applyChanges", function(assert) {
 
     this.fieldChooser.applyChanges();
     this.clock.tick(1000);
+
     var state = this.fieldChooser.getDataSource().state();
     assert.equal(state.fields.length, 1, "one field");
     assert.deepEqual(state.fields[0].dataField, "Field1");
@@ -2141,15 +2135,7 @@ QUnit.test("applyChanges", function(assert) {
 });
 
 QUnit.test("cancelChanges", function(assert) {
-    this.fieldChooser = $("#pgfc").dxPivotGridFieldChooser({
-        applyChangesMode: "onDemand",
-        dataSource: new PivotGridDataSource({
-            fields: [
-                { dataField: "Field1", area: 'column', areaIndex: 0 },
-            ],
-            store: []
-        })
-    }).dxPivotGridFieldChooser("instance");
+    this.setup({ fields: [{ dataField: "Field1", area: 'column', areaIndex: 0 }] });
 
     var changedArgs = {
         sourceGroup: "column",
@@ -2157,7 +2143,7 @@ QUnit.test("cancelChanges", function(assert) {
         targetGroup: "row"
     };
 
-    changedArgs.sourceElement = renderer($("#pgfc").find(".dx-area-field").eq(0));
+    changedArgs.sourceElement = renderer(this.$container.find(".dx-area-field").eq(0));
 
     var sortable = this.fieldChooser.$element().dxSortable("instance"),
         onChangedHandler = sortable.option("onChanged");

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
@@ -2102,11 +2102,18 @@ QUnit.test("move from area to treeview", function(assert) {
         onChangedHandler = sortable.option("onChanged");
     // act
     onChangedHandler(changedArgs);
+    this.clock.tick(1000);
 
     var fields = this.fieldChooser.option("state").fields;
     assert.deepEqual(fields[0], { dataField: "Field1", area: 'column', areaIndex: 0, index: 0 });
     assert.deepEqual(fields[1], { dataField: "Field2", area: null, areaIndex: null, index: 1 });
     assert.deepEqual(fields[2], { dataField: "Field3", area: 'column', areaIndex: 1, index: 2 });
+
+    var checkboxes = this.$container.find(".dx-checkbox");
+    assert.equal(checkboxes.length, 3, "checkboxes");
+
+    var checked = this.$container.find(".dx-checkbox-checked");
+    assert.equal(checked.length, 2, "checked checkboxes");
 });
 
 QUnit.test("select in treeview", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
@@ -1984,9 +1984,9 @@ QUnit.module("applyChangesMode: onDemand", {
 QUnit.test("change position between areas", function(assert) {
     var dataSource = {};
     dataSource.fields = [
-        { dataField: "Field1", area: 'column', areaIndex: 0 },
-        { dataField: "Field2", area: 'column', areaIndex: 1 },
-        { dataField: "Field3", area: 'row', areaIndex: 0 }
+        { dataField: "Field1", area: 'column', areaIndex: 0, index: 0 },
+        { dataField: "Field2", area: 'column', areaIndex: 1, index: 1 },
+        { dataField: "Field3", area: 'row', areaIndex: 0, index: 2 }
     ];
     this.setup(dataSource);
     this.clock.tick(500);
@@ -2007,13 +2007,13 @@ QUnit.test("change position between areas", function(assert) {
 
     var state = this.fieldChooser.option("state").fields;
     assert.equal(state[0].dataField, "Field1");
-    assert.equal(state[0].areaIndex, "0");
+    assert.equal(state[0].areaIndex, 0);
     assert.equal(state[0].area, "row");
     assert.equal(state[1].dataField, "Field2");
-    assert.equal(state[1].areaIndex, "0");
+    assert.equal(state[1].areaIndex, 0);
     assert.equal(state[1].area, "column");
     assert.equal(state[2].dataField, "Field3");
-    assert.equal(state[2].areaIndex, "1");
+    assert.equal(state[2].areaIndex, 1);
     assert.equal(state[2].area, "row");
 });
 
@@ -2108,7 +2108,7 @@ QUnit.test("Apply filters", function(assert) {
 });
 
 QUnit.test("applyChanges", function(assert) {
-    this.setup({ fields: [{ dataField: "Field1", area: 'column', areaIndex: 0 }] });
+    this.setup({ fields: [{ dataField: "Field1", area: 'column', areaIndex: 0, index: 0 }] });
     this.clock.tick(500);
 
     var changedArgs = {

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
@@ -2156,3 +2156,26 @@ QUnit.test("cancelChanges", function(assert) {
 
     assert.strictEqual(this.fieldChooser.option("state"), null);
 });
+
+QUnit.test("cancel changes on field chooser repaint", function(assert) {
+    this.setup({ fields: [{ dataField: "Field1", area: 'column', areaIndex: 0 }] });
+
+    var changedArgs = {
+        sourceGroup: "column",
+        targetIndex: 0,
+        targetGroup: "row"
+    };
+
+    changedArgs.sourceElement = renderer(this.$container.find(".dx-area-field").eq(0));
+
+    var sortable = this.fieldChooser.$element().dxSortable("instance"),
+        onChangedHandler = sortable.option("onChanged");
+
+    // act
+    onChangedHandler(changedArgs);
+
+    this.fieldChooser.repaint();
+    this.clock.tick(1000);
+
+    assert.strictEqual(this.fieldChooser.option("state"), null);
+});

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
@@ -695,6 +695,87 @@ QUnit.test("clear selection and filtering in field chooser treeview on popup hid
     assert.ok(resetTreeView.calledOnce, 'resetTreeView was called');
 });
 
+QUnit.test("create toolbar buttons in applyChangesMode onDemand case", function(assert) {
+    var pivotGrid = createPivotGrid({
+            dataSource: this.dataSource,
+            fieldChooser: {
+                applyChangesMode: "onDemand"
+            }
+        }, assert),
+        fieldChooserPopup = pivotGrid.getFieldChooserPopup();
+
+    this.clock.tick();
+
+    // act
+    fieldChooserPopup.show();
+    this.clock.tick(500);
+    // assert
+    assert.equal($(fieldChooserPopup._$bottom).find(".dx-toolbar-button").length, 2, '2 buttons in toolbar');
+});
+
+QUnit.test("apply changes in fieldchooser on button click in onDemand mode", function(assert) {
+    this.dataSource.fields[0].dataField = "field1";
+
+    var pivotGrid = createPivotGrid({
+            dataSource: this.dataSource,
+            allowSorting: true,
+            fieldChooser: {
+                applyChangesMode: "onDemand"
+            }
+        }, assert),
+        fieldChooserPopup = pivotGrid.getFieldChooserPopup();
+
+    this.clock.tick();
+
+    // act
+    fieldChooserPopup.show();
+    this.clock.tick(500);
+
+    var sortIcon = $(fieldChooserPopup.content()).find(".dx-sort").eq(0);
+    sortIcon.trigger("dxclick");
+    this.clock.tick(500);
+
+    assert.ok(sortIcon.hasClass("dx-sort-down"));
+    assert.notEqual(pivotGrid.getDataSource().state().fields[0].sortOrder, "desc", "ds state is not changed yet");
+
+    var applyButton = $(fieldChooserPopup._$bottom).find(".dx-button").eq(0);
+    applyButton.trigger("dxclick");
+    this.clock.tick(500);
+
+    assert.equal(pivotGrid.getDataSource().state().fields[0].sortOrder, "desc", "ds state is changed");
+});
+
+QUnit.test("cancel changes on fieldchooser hidding in onDemand mode", function(assert) {
+    this.dataSource.fields[0].dataField = "field1";
+
+    var pivotGrid = createPivotGrid({
+            dataSource: this.dataSource,
+            allowSorting: true,
+            fieldChooser: {
+                applyChangesMode: "onDemand"
+            }
+        }, assert),
+        fieldChooserPopup = pivotGrid.getFieldChooserPopup();
+
+    this.clock.tick();
+
+    // act
+    fieldChooserPopup.show();
+    this.clock.tick(500);
+
+    var sortIcon = $(fieldChooserPopup.content()).find(".dx-sort").eq(0);
+    sortIcon.trigger("dxclick");
+    this.clock.tick(500);
+
+    assert.ok(sortIcon.hasClass("dx-sort-down"));
+    assert.notEqual(pivotGrid.getDataSource().state().fields[0].sortOrder, "desc", "ds state is not changed yet");
+
+    fieldChooserPopup.hide();
+    this.clock.tick(500);
+
+    assert.notEqual(pivotGrid.getDataSource().state().fields[0].sortOrder, "desc", "ds state is not changed yet");
+});
+
 QUnit.test("Field panel should be updated on change headerFilter at runtime", function(assert) {
     var pivotGrid = createPivotGrid({
         dataSource: this.dataSource,

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
@@ -735,7 +735,6 @@ QUnit.test("apply changes in fieldchooser on button click in onDemand mode", fun
     sortIcon.trigger("dxclick");
     this.clock.tick(500);
 
-    assert.ok(sortIcon.hasClass("dx-sort-down"));
     assert.notEqual(pivotGrid.getDataSource().state().fields[0].sortOrder, "desc", "ds state is not changed yet");
 
     var applyButton = $(fieldChooserPopup._$bottom).find(".dx-button").eq(0);
@@ -767,7 +766,6 @@ QUnit.test("cancel changes on fieldchooser hidding in onDemand mode", function(a
     sortIcon.trigger("dxclick");
     this.clock.tick(500);
 
-    assert.ok(sortIcon.hasClass("dx-sort-down"));
     assert.notEqual(pivotGrid.getDataSource().state().fields[0].sortOrder, "desc", "ds state is not changed yet");
 
     fieldChooserPopup.hide();


### PR DESCRIPTION
1. FieldChooser as separate widget
    - "**_applyChangesMode_**": "instantly" | "onDemand"
    - "**_state_**": null | Object() - changed after every interaction with FieldChooser
    - **_applyChanges()_** - method for applying changes stored in "state" option
    - **_cancelChanges()_** - method to discard all changes, sets null value to the "state" option and synchronizes with current DataSource state
2. FieldChooser inside Popup in PivotGrid
    - "**_applyChangesMode_**": "instantly" | "onDemand" - adds the bottom toolbar in Field Chooser Popup with "OK" and "Cancel" buttons
![image](https://user-images.githubusercontent.com/22657165/38173559-b7807588-35c8-11e8-9028-320987643589.png)
