### PR TITLE
Add capability to define eventsStrategy as a function

### DIFF
--- a/js/core/events_mixin.js
+++ b/js/core/events_mixin.js
@@ -18,6 +18,10 @@ module.exports = {
     },
 
     setEventsStrategy: function(strategy) {
+        if(typeof strategy === "function") {
+            strategy = strategy(this);
+        }
+
         this._eventsStrategy = strategy;
     },
 

--- a/testing/tests/DevExpress.ui/eventsStrategy.tests.js
+++ b/testing/tests/DevExpress.ui/eventsStrategy.tests.js
@@ -53,6 +53,43 @@ QUnit.test("setup event strategy", function(assert) {
     $("#element").remove();
 });
 
+QUnit.test("setup event strategy as function", function(assert) {
+    assert.expect(6);
+
+    var eventName = "testEventName";
+    var checkEventMethod = function(name) {
+        if(name === eventName) {
+            assert.ok(true, "event subscribed");
+        }
+    };
+
+    var eventsStrategy = function() {
+        return {
+            on: checkEventMethod,
+            off: checkEventMethod,
+            fireEvent: checkEventMethod,
+            hasEvent: function(name) {
+                checkEventMethod(name);
+                return true;
+            },
+            dispose: function() {
+                assert.ok(true, "strategy disposed");
+            }
+        };
+    };
+
+    var instance = $("#element").dxWidget({
+        eventsStrategy: eventsStrategy
+    }).dxWidget("instance");
+
+    instance.on(eventName, function() {});
+    instance.off(eventName, function() {});
+    assert.ok(instance.hasEvent(eventName));
+    instance.fireEvent(eventName);
+
+    $("#element").remove();
+});
+
 QUnit.test("callbacks should have correct context", function(assert) {
     assert.expect(1);
 


### PR DESCRIPTION
It is necessary to create a new instance of strategy for each nested widget. This changes will allow passing strategy from Angular integration for nested widgets