### PR TITLE
Documentation - Use Enums.Mode for options that have only "auto" in accepted values

### DIFF
--- a/js/ui/grid_core/ui.grid_core.filter_sync.js
+++ b/js/ui/grid_core/ui.grid_core.filter_sync.js
@@ -233,9 +233,8 @@ module.exports = {
             /**
              * @name GridBaseOptions_filterSyncEnabled
              * @publicName filterSyncEnabled
-             * @type string|boolean
+             * @type Enums.Mode|boolean
              * @default "auto"
-             * @acceptValues "auto" | true | false
              */
             filterSyncEnabled: "auto"
         };

--- a/js/ui/grid_core/ui.grid_core.pager.js
+++ b/js/ui/grid_core/ui.grid_core.pager.js
@@ -156,9 +156,8 @@ module.exports = {
                 /**
                  * @name GridBaseOptions_pager_visible
                  * @publicName visible
-                 * @type string|boolean
+                 * @type Enums.Mode|boolean
                  * @default "auto"
-                 * @acceptValues "auto" | true | false
                  */
                 visible: "auto",
                 /**
@@ -171,9 +170,8 @@ module.exports = {
                 /**
                  * @name GridBaseOptions_pager_allowedPageSizes
                  * @publicName allowedPageSizes
-                 * @type Array<number>|string
+                 * @type Array<number>|Enums.Mode
                  * @default "auto"
-                 * @acceptValues "auto"
                 */
                 allowedPageSizes: "auto"
                 /**

--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -131,9 +131,8 @@ module.exports = {
                 /**
                  * @name GridBaseOptions_loadPanel_enabled
                  * @publicName enabled
-                 * @type string|boolean
+                 * @type Enums.Mode|boolean
                  * @default "auto"
-                 * @acceptValues "auto" | true | false
                  */
                 enabled: "auto",
                 /**


### PR DESCRIPTION
Сonsistently with:
https://github.com/DevExpress/DevExtreme/blob/5cf6845a9476869d82a5fd5be4905aa0c702a7af/js/ui/box.js#L789-L792
https://github.com/DevExpress/DevExtreme/blob/615ad101f6bb7347817d13167ede9b6b1c8dd1b2/js/ui/data_grid/ui.data_grid.grouping.js#L745-L748
https://github.com/DevExpress/DevExtreme/blob/1da1f301737e56bca94891f9829f32c6cd4277a2/js/ui/form/ui.form.js#L76-L79
https://github.com/DevExpress/DevExtreme/blob/7fa0c31705ad8a8197b401f90c0f5b4c8bb79a59/js/ui/responsive_box.js#L41-L44

**Pros:**
- Use one way for similar cases.
- Get rid of strange "Accepted Values: 'auto' | true | false" in API reference. For instance: https://js.devexpress.com/Documentation/18_1/ApiReference/UI_Widgets/dxDataGrid/Configuration/pager/#visible
- More strongly-typed `OptionX(Mode)` overload on MVC Controls side (`OptionX(string)` now).
- In TS definitions, we will get `"auto" | boolean` instead of `string | boolean` after enums support.

**Cons:**
- Enums.Mode contains only one item.
- Name "Mode" is too general.