### PR TITLE
Fix renderer utility for window object

### DIFF
--- a/js/core/renderer_base.js
+++ b/js/core/renderer_base.js
@@ -35,7 +35,7 @@ var initRender = function(selector, context) {
 
         [].push.apply(this, domAdapter.querySelectorAll(context, selector));
         return this;
-    } else if(domAdapter.isNode(selector)) {
+    } else if(domAdapter.isNode(selector) || typeUtils.isWindow(selector)) {
         this[0] = selector;
         this.length = 1;
         return this;

--- a/testing/tests/DevExpress.core/renderer.tests.js
+++ b/testing/tests/DevExpress.core/renderer.tests.js
@@ -2,6 +2,18 @@
 
 var renderer = require("core/renderer");
 
+QUnit.module("renderer");
+
+QUnit.test("renderer should return correct element if window contains element with id=toArray", function(assert) {
+    var element = renderer("<div>");
+    element.attr("id", "toArray");
+
+    document.getElementById("qunit-fixture").appendChild(element[0]);
+
+    var $window = renderer(window);
+    assert.equal($window[0], window);
+});
+
 QUnit.module("HTML main");
 
 QUnit.test("base", function(assert) {


### PR DESCRIPTION
This fixes **renderer(window)** method. It didn't work correctly if an element with id="toArray" exists on a page.

