### PR TITLE
Fix parsing of negative numbers in rtl mode (#3613)

### DIFF
--- a/js/localization/number.js
+++ b/js/localization/number.js
@@ -236,7 +236,7 @@ var numberLocalization = dependencyInjector({
     },
 
     getSign: function(text, format) {
-        if(text.charAt(0) === "-") {
+        if(text.replace(/[^0-9\-]/g, "").charAt(0) === "-") {
             return -1;
         }
         if(!format) {

--- a/testing/tests/DevExpress.localization/localization.custom.tests.js
+++ b/testing/tests/DevExpress.localization/localization.custom.tests.js
@@ -98,3 +98,7 @@ QUnit.test("format number by LDML pattern", function(assert) {
 QUnit.test("parse number by LDML pattern", function(assert) {
     assert.equal(numberLocalization.parse("١,٢٣٤.٥٠", "#,#0.00"), 1234.5);
 });
+
+QUnit.test("parse negative number in rtl mode", function(assert) {
+    assert.equal(numberLocalization.parse("\u061C-١٢٣"), -123);
+});


### PR DESCRIPTION
* Fix parsing of negative numbers in rtl mode

* Refactoring

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
