### PR TITLE
dxDataGrid: Fix the Lookup column option setting operates incorrectly if the grid contains banded columns (T622771)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -36,6 +36,8 @@ var USER_STATE_FIELD_NAMES_15_1 = ["filterValues", "filterType", "fixed", "fixed
     IGNORE_COLUMN_OPTION_NAMES = { visibleWidth: true, bestFitWidth: true, bufferedFilterValue: true },
     COMMAND_EXPAND_CLASS = "dx-command-expand";
 
+var regExp = /columns\[(\d+)\]\.?/gi;
+
 module.exports = {
     defaultOptions: function() {
         return {
@@ -1194,7 +1196,7 @@ module.exports = {
                 var column,
                     columnIndexes = [];
 
-                path.replace(/columns\[(\d+)\]\.?/gi, function(_, columnIndex) {
+                path.replace(regExp, function(_, columnIndex) {
                     columnIndexes.push(parseInt(columnIndex));
                     return "";
                 });
@@ -1528,7 +1530,7 @@ module.exports = {
                 _columnOptionChanged: function(args) {
                     var columnOptionValue = {},
                         column = getColumnByPath(this, args.fullName),
-                        columnOptionName = args.fullName.replace(/columns\[(\d+)\]\.?/gi, "");
+                        columnOptionName = args.fullName.replace(regExp, "");
 
                     if(column) {
                         if(columnOptionName) {

--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -1243,7 +1243,10 @@ module.exports = {
                         // T346972
                         if(inArray(optionName, USER_STATE_FIELD_NAMES) < 0 && optionName !== "visibleWidth") {
                             columns = that.option("columns");
-                            column = columns && columns[columnIndex];
+                            column = findColumn({
+                                columns: columns,
+                                columnIndex: columnIndex
+                            });
                             if(typeUtils.isString(column)) {
                                 column = columns[columnIndex] = { dataField: column };
                             }
@@ -1356,6 +1359,32 @@ module.exports = {
                 }
 
                 return str;
+            };
+
+            var findColumn = function(options) {
+                var column,
+                    children,
+                    columns = options.columns,
+                    columnIndex = options.columnIndex;
+
+                options.index = options.index || 0;
+
+                for(var i = 0; i < columns.length; i++) {
+                    if(options.index === columnIndex) {
+                        return columns[i];
+                    }
+                    options.index++;
+                    children = columns[i].columns;
+
+                    if(Array.isArray(children) && children.length) {
+                        options.columns = children;
+                        column = findColumn(options);
+
+                        if(column) {
+                            return column;
+                        }
+                    }
+                }
             };
 
             var mergeColumns = (columns, commandColumns, needToExtend) => {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -8216,3 +8216,25 @@ QUnit.module("Customization of the command columns", {
         }, "group column");
     });
 });
+
+// T622771
+QUnit.test("Update dataSource of the column lookup", function(assert) {
+    // arrange
+    this.applyOptions({
+        columns: [
+            { dataField: "TestField1", caption: "Column 1" },
+            {
+                caption: "Band Column 1", columns: [
+                    { dataField: "TestField2", caption: "Column 2" },
+                    { dataField: "TestField3", caption: "Column 3", lookup: { dataSource: [] } }
+                ]
+            }
+        ]
+    });
+
+    // act
+    this.columnOption("TestField3", "lookup.dataSource", [1, 2, 3]);
+
+    // assert
+    assert.deepEqual(this.columnOption("TestField3", "lookup.dataSource"), [1, 2, 3], "lookup datasource");
+});


### PR DESCRIPTION
See https://devexpress.com/issue=T622771
