### PR TITLE
Documentation - Hide "auto" value for options that have only that option in accepted values

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_controller.js
+++ b/js/ui/grid_core/ui.grid_core.data_controller.js
@@ -47,14 +47,12 @@ module.exports = {
             /**
              * @name dxDataGridOptions_remoteOperations
              * @publicName remoteOperations
-             * @type string|boolean|object
-             * @default "auto"
+             * @type boolean|object
              */
             /**
              * @name dxTreeListOptions_remoteOperations
              * @publicName remoteOperations
-             * @type string|object
-             * @default "auto"
+             * @type object
              */
             remoteOperations: "auto",
             /**

--- a/js/ui/grid_core/ui.grid_core.filter_sync.js
+++ b/js/ui/grid_core/ui.grid_core.filter_sync.js
@@ -234,9 +234,7 @@ module.exports = {
             /**
              * @name GridBaseOptions_filterSyncEnabled
              * @publicName filterSyncEnabled
-             * @type string|boolean
-             * @default "auto"
-             * @acceptValues "auto" | true | false
+             * @type boolean
              */
             filterSyncEnabled: "auto"
         };

--- a/js/ui/grid_core/ui.grid_core.pager.js
+++ b/js/ui/grid_core/ui.grid_core.pager.js
@@ -156,9 +156,7 @@ module.exports = {
                 /**
                  * @name GridBaseOptions_pager_visible
                  * @publicName visible
-                 * @type string|boolean
-                 * @default "auto"
-                 * @acceptValues "auto" | true | false
+                 * @type boolean
                  */
                 visible: "auto",
                 /**
@@ -171,9 +169,7 @@ module.exports = {
                 /**
                  * @name GridBaseOptions_pager_allowedPageSizes
                  * @publicName allowedPageSizes
-                 * @type Array<number>|string
-                 * @default "auto"
-                 * @acceptValues "auto"
+                 * @type Array<number>
                 */
                 allowedPageSizes: "auto"
                 /**

--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -98,8 +98,7 @@ module.exports = {
                 /**
                  * @name GridBaseOptions_scrolling_useNative
                  * @publicName useNative
-                 * @type string|boolean
-                 * @default "auto"
+                 * @type boolean
                  */
                 useNative: "auto"
                 /**
@@ -132,8 +131,6 @@ module.exports = {
                  * @name GridBaseOptions_loadPanel_enabled
                  * @publicName enabled
                  * @type string|boolean
-                 * @default "auto"
-                 * @acceptValues "auto" | true | false
                  */
                 enabled: "auto",
                 /**

--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -130,7 +130,7 @@ module.exports = {
                 /**
                  * @name GridBaseOptions_loadPanel_enabled
                  * @publicName enabled
-                 * @type string|boolean
+                 * @type boolean
                  */
                 enabled: "auto",
                 /**

--- a/js/ui/pivot_grid/ui.pivot_grid.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.js
@@ -205,8 +205,7 @@ var PivotGrid = Widget.inherit({
                 /**
                  * @name dxPivotGridOptions_scrolling_useNative
                  * @publicName useNative
-                 * @type string|boolean
-                 * @default "auto"
+                 * @type boolean
                  */
                 useNative: "auto",
 


### PR DESCRIPTION
The alternative solution for these cases based on the feedback from https://github.com/DevExpress/DevExtreme/pull/3523.

**Summary:**
 - Enum with one "auto" item looks weird.
 - We do not want Enum.Mode to be used everywhere.
 - We do not want to rework options that use Enum.Mode historically.
 - We will not lose anything omitting "auto" in these cases:
    - It does not make sense to assign an option to "auto" if it is a default.
    - As for the documentation, help topics will look like this:
![image](https://user-images.githubusercontent.com/1420883/38575808-fe78df78-3d04-11e8-979b-d7d24eddfc55.png)
