### PR TITLE
Fix FilterBuilder: Make "between" operation and defaultCalculateFilterExpression available in calculateFilterExpression (T624888)

### DIFF
--- a/js/ui/filter_builder/between.js
+++ b/js/ui/filter_builder/between.js
@@ -58,24 +58,12 @@ function customizeText(conditionInfo) {
                 + (isDefined(endValue) ? formatUtils.getFormattedValueText(conditionInfo.field, endValue) : "?");
 }
 
-function calculateFilterExpression(filterValue, field) {
-    if(!filterValue || filterValue.length < 2) return null;
-
-    var startValue = filterValue[0],
-        endValue = filterValue[1];
-    if(!isDefined(startValue) && !isDefined(endValue)) {
-        return null;
-    }
-    return [[field.dataField, ">=", startValue], "and", [field.dataField, "<=", endValue]];
-}
-
 function getConfig(caption) {
     return {
         name: "between",
         caption: caption,
         icon: "range",
         dataTypes: ["number", "date", "datetime"],
-        calculateFilterExpression: calculateFilterExpression,
         editorTemplate: editorTemplate,
         customizeText: customizeText
     };

--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -350,6 +350,7 @@ function getNormalizedFields(fields) {
                     normalizedField[key] = field[key];
                 }
             }
+            normalizedField.defaultCalculateFilterExpression = filterUtils.defaultCalculateFilterExpression;
             result.push(normalizedField);
         }
         return result;
@@ -366,7 +367,7 @@ function getConditionFilterExpression(condition, fields, customOperations, targe
     } else if(field.calculateFilterExpression) {
         return field.calculateFilterExpression.apply(field, [filterExpression[2], filterExpression[1], target]);
     } else {
-        return filterUtils.defaultCalculateFilterExpression.apply(field, [filterExpression[2], filterExpression[1], target]);
+        return field.defaultCalculateFilterExpression.apply(field, [filterExpression[2], filterExpression[1], target]);
     }
 }
 

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/commonTests.js
@@ -810,7 +810,8 @@ QUnit.module("Create editor", function() {
 
         assert.strictEqual(args.value, "value", "filter value");
         assert.strictEqual(args.filterOperation, "=", "filter operation");
-        assert.deepEqual(args.field, fields[0], "field");
+        assert.strictEqual(args.field.dataField, fields[0].dataField);
+        assert.strictEqual(args.field.editorTemplate, fields[0].editorTemplate);
         assert.ok(args.setValue, "has setValue");
     });
 
@@ -842,7 +843,8 @@ QUnit.module("Create editor", function() {
 
         assert.strictEqual(args.value, 2, "filter value");
         assert.strictEqual(args.filterOperation, "lastDays", "filter operation");
-        assert.deepEqual(args.field, fields[0], "field");
+        assert.strictEqual(args.field.dataField, fields[0].dataField);
+        assert.strictEqual(args.field.editorTemplate, fields[0].editorTemplate);
         assert.ok(args.setValue, "has setValue");
     });
 
@@ -1205,6 +1207,32 @@ QUnit.module("Methods", function() {
             ],
             "and",
             ["OrderDate", ">", "1"]
+        ]);
+    });
+
+    // T624888
+    QUnit.test("between is available in field.calculateFilterExpression", function(assert) {
+        // arrange
+        var instance = $("#container").dxFilterBuilder({
+            value: [
+                ["field", "between", [1, 5]]
+            ],
+            fields: [{
+                dataField: "field",
+                dataType: "number",
+                calculateFilterExpression: function(filterValue, selectedFieldOperation, target) {
+                    assert.strictEqual(target, "filterBuilder");
+                    assert.strictEqual(selectedFieldOperation, "between");
+                    return [[this.dataField, ">", filterValue[0]], "and", [this.dataField, "<", filterValue[1]]];
+                }
+            }]
+        }).dxFilterBuilder("instance");
+
+        // act, assert
+        assert.deepEqual(instance.getFilterExpression(), [
+            ["field", ">", 1],
+            "and",
+            ["field", "<", 5]
         ]);
     });
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
