### PR TITLE
dxDataGrid: Fix getCellElement method in "form" editing mode when there are hidden columns (T627688)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -2100,23 +2100,26 @@ module.exports = {
                 },
                 _getVisibleColumnIndex: function($cells, rowIndex, columnIdentifier) {
                     var item,
-                        visibleIndex = this.callBase($cells, rowIndex, columnIdentifier),
+                        column,
+                        visibleIndex,
                         editFormRowIndex = this._editingController.getEditFormRowIndex();
 
-                    if(editFormRowIndex === rowIndex) {
-                        var visibleColumn = this._columnsController.getVisibleColumns()[visibleIndex];
+                    if(editFormRowIndex === rowIndex && typeUtils.isString(columnIdentifier)) {
+                        column = this._columnsController.columnOption(columnIdentifier);
 
                         each($cells, function(index, cellElement) {
                             item = $(cellElement).find(".dx-field-item-content").data("dx-form-item");
 
-                            if(item && item.column && visibleColumn && item.column.index === visibleColumn.index) {
+                            if(item && item.column && column && item.column.index === column.index) {
                                 visibleIndex = index;
                                 return false;
                             }
                         });
+
+                        return visibleIndex;
                     }
 
-                    return visibleIndex;
+                    return this.callBase.apply(this, arguments);
                 },
                 publicMethods: function() {
                     return this.callBase().concat(["cellValue"]);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -11236,8 +11236,10 @@ QUnit.test("getCellElement when form with custom items", function(assert) {
     // assert
     $editorElements = $testElement.find(".dx-datagrid-edit-form-item");
     assert.equal($editorElements.length, 2, "count editor of the form");
-    assert.deepEqual($(that.getCellElement(0, 0))[0], $editorElements[1], "second editor");
+    assert.deepEqual($(that.getCellElement(0, 0))[0], $editorElements[0], "first editor");
     assert.deepEqual($(that.getCellElement(0, "age"))[0], $editorElements[0], "first editor");
+    assert.deepEqual($(that.getCellElement(0, 1))[0], $editorElements[1], "second editor");
+    assert.deepEqual($(that.getCellElement(0, "name"))[0], $editorElements[1], "second editor");
 });
 
 // T435429
@@ -11393,8 +11395,36 @@ QUnit.test("getCellElement returns correct editor with form editing and enabled 
     $editorElements = $testElement.find(".dx-datagrid-edit-form-item");
 
     // assert
-    assert.deepEqual($(that.getCellElement(1, 1))[0], $editorElements[0], "first editor");
+    assert.deepEqual($(that.getCellElement(1, 0))[0], $editorElements[0], "first editor");
+    assert.deepEqual($(that.getCellElement(1, "name"))[0], $editorElements[0], "first editor");
+    assert.deepEqual($(that.getCellElement(1, 1))[0], $editorElements[1], "second editor");
     assert.deepEqual($(that.getCellElement(1, "age"))[0], $editorElements[1], "second editor");
+});
+
+// T627688
+QUnit.test("getCellElement for a hidden column", function(assert) {
+    // arrange
+    var $editorElements,
+        $testElement = $('#container');
+
+    this.options.editing = {
+        mode: "form",
+        allowUpdating: true
+    };
+    this.options.columns[3] = { dataField: 'phone', formItem: { visible: false } };
+    this.options.columns[4] = { dataField: "room", visible: false };
+
+    this.setupModules(this);
+    this.rowsView.render($testElement);
+
+    // act
+    this.editRow(0);
+
+    // assert
+    $editorElements = $testElement.find(".dx-datagrid-edit-form-item");
+    assert.equal($editorElements.length, 4, "count editor of the form");
+    assert.deepEqual($(this.getCellElement(0, 3))[0], $editorElements[3], "editor of a hidden column");
+    assert.deepEqual($(this.getCellElement(0, "room"))[0], $editorElements[3], "editor of a hidden column");
 });
 
 


### PR DESCRIPTION
See https://devexpress.com/issue=T627688