### PR TITLE
fix the focusing the NumberBox when the caret is updated on the focus out  event (T630894)

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -65,11 +65,13 @@ var NumberBoxMask = NumberBoxBase.inherit({
     },
 
     _focusOutHandler: function(e) {
+        this._focusOutOccurs = true;
         if(this._useMaskBehavior()) {
             this._updateFormattedValue();
         }
 
         this.callBase(e);
+        this._focusOutOccurs = false;
     },
 
     _updateFormattedValue: function() {
@@ -336,7 +338,9 @@ var NumberBoxMask = NumberBoxBase.inherit({
         this._input().val(newValue);
         this._formattedValue = text;
 
-        this._caret(newCaret);
+        if(!this._focusOutOccurs) {
+            this._caret(newCaret);
+        }
     },
 
     _useMaskBehavior: function() {
@@ -566,6 +570,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
         delete this._lastKey;
         delete this._parsedValue;
         delete this._isDirty;
+        delete this._focusOutOccurs;
     },
 
     _clean: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -602,6 +602,25 @@ QUnit.test("valueChanged event fires on value apply", function(assert) {
     assert.ok(valueChangedSpy.calledOnce, "valueChanged event called once");
 });
 
+QUnit.testInActiveWindow("caret position is not changed when the focus out event has occurred", function(assert) {
+    var _caret = this.instance._caret,
+        caretIsUpdatedOnFocusOut,
+        $input = $(this.instance.element()).find(".dx-texteditor-input");
+
+    this.instance._caret = (function(newCaret) {
+        var result = _caret.apply(this.instance, newCaret);
+        if(!$input.is(":focus") && newCaret) {
+            caretIsUpdatedOnFocusOut = true;
+        }
+        return result;
+    }).bind(this);
+    this.keyboard.type(".").blur();
+
+    this.instance._caret = _caret;
+
+    assert.notOk(caretIsUpdatedOnFocusOut);
+});
+
 
 QUnit.module("format: incomplete value", moduleConfig);
 


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
