### PR TITLE
Parse primitive numbers as invalid date in the built-in localization (T633812)

### DIFF
--- a/js/localization/date.js
+++ b/js/localization/date.js
@@ -146,7 +146,7 @@ var dateLocalization = dependencyInjector({
         }
 
         if(!format) {
-            return new Date(text);
+            return this.parse(text, "shortdate");
         }
 
         if(format.parser) {

--- a/testing/tests/DevExpress.localization/localization.base.tests.js
+++ b/testing/tests/DevExpress.localization/localization.base.tests.js
@@ -463,7 +463,7 @@ QUnit.test("parse with shortDate format (T478962, T511282)", function(assert) {
 });
 
 QUnit.test("date parser should not parse primitive numbers", function(assert) {
-    assert.equal(localization.parseDate("2"), undefined);
+    assert.equal(localization.parse("2"), undefined);
 });
 
 QUnit.test("firstDayOfWeekIndex", function(assert) {

--- a/testing/tests/DevExpress.localization/localization.base.tests.js
+++ b/testing/tests/DevExpress.localization/localization.base.tests.js
@@ -463,7 +463,7 @@ QUnit.test("parse with shortDate format (T478962, T511282)", function(assert) {
 });
 
 QUnit.test("date parser should not parse primitive numbers", function(assert) {
-    assert.equal(localization.parse("2"), undefined);
+    assert.equal(dateLocalization.parse("2"), undefined);
 });
 
 QUnit.test("firstDayOfWeekIndex", function(assert) {

--- a/testing/tests/DevExpress.localization/localization.base.tests.js
+++ b/testing/tests/DevExpress.localization/localization.base.tests.js
@@ -462,6 +462,10 @@ QUnit.test("parse with shortDate format (T478962, T511282)", function(assert) {
     assert.equal(dateLocalization.parse("2/20/", "shortDate"), undefined);
 });
 
+QUnit.test("date parser should not parse primitive numbers", function(assert) {
+    assert.equal(localization.parseDate("2"), undefined);
+});
+
 QUnit.test("firstDayOfWeekIndex", function(assert) {
     assert.equal(dateLocalization.firstDayOfWeekIndex(), 0);
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -449,13 +449,13 @@ QUnit.test("T437211: Custom dxDateBox value formatter is not called if the same 
     $input.val("");
     $input.val("1/01/2016");
     $input.change();
-    assert.equal(expectedDisplayValue, instance.option("text"), "input value was formatted");
+    assert.equal(instance.option("text"), expectedDisplayValue, "input value was formatted");
 
     $input.val("");
     $input.val("1/01/2016");
     $input.change();
 
-    assert.equal(expectedDisplayValue, instance.option("text"), "input value was formatted");
+    assert.equal(instance.option("text"), expectedDisplayValue, "input value was formatted");
 });
 
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
