### PR TITLE
dxTreeList: Fix the autoExpandAll option that doesn't work if the refresh method is called when the control is displayed in the Popup container (T622381)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -204,11 +204,13 @@ module.exports = gridCore.Controller.inherit((function() {
             that._customizeRemoteOperations(options, isReload, operationTypes);
 
             if(!options.isCustomLoading) {
+                var isRefreshing = that._isRefreshing;
+
                 options.pageIndex = dataSource.pageIndex();
-                that._lastLoadOptions = loadOptions;
+                options.lastLoadOptions = loadOptions;
                 that._isRefreshing = true;
 
-                when(that.refresh(options, isReload, operationTypes)).done(function() {
+                when(isRefreshing || that.refresh(options, isReload, operationTypes)).done(function() {
                     if(that._lastOperationId === options.operationId) {
                         that.load();
                     }
@@ -268,6 +270,10 @@ module.exports = gridCore.Controller.inherit((function() {
             if(!loadOptions) {
                 this._dataSource.cancel(options.operationId);
                 return;
+            }
+
+            if(options.lastLoadOptions) {
+                this._lastLoadOptions = options.lastLoadOptions;
             }
 
             if(localPaging) {

--- a/testing/tests/DevExpress.ui.widgets.treeList/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/dataController.tests.js
@@ -740,6 +740,32 @@ QUnit.test("Initialize from dataSource with hierarchical structure when 'parentI
     assert.equal(items[3].node.parent.key, items[1].key, "fourth item has parentKey");
 });
 
+// T622381
+QUnit.test("Nodes should be expanded after refresh method is called at boot time (when autoExpandAll is true)", function(assert) {
+    // arrange
+    var items,
+        array = [
+            { name: 'Category1', phone: '55-55-55', id: 1, parentId: 0 },
+            { name: 'SubCategory1', phone: '98-75-21', id: 2, parentId: 1 },
+            { name: 'SubCategory2', phone: '55-66-77', id: 3, parentId: 2 },
+        ],
+        clock = sinon.useFakeTimers();
+
+    try {
+        this.applyOptions({ autoExpandAll: true, dataSource: array, loadingTimeout: 30 });
+
+        // act
+        this.refresh();
+        clock.tick(60);
+
+        // assert
+        items = this.dataController.items();
+        assert.strictEqual(items.length, 3, "item count");
+    } finally {
+        clock.restore();
+    }
+});
+
 QUnit.module("Expand/Collapse nodes", { beforeEach: setupModule, afterEach: teardownModule });
 
 QUnit.test("Expand node (plain structure)", function(assert) {


### PR DESCRIPTION
See https://devexpress.com/issue=T622381