### PR TITLE
dxTreeList: Re-fix the autoExpandAll option that doesn't work if the refresh method is called when the control is displayed in the Popup container (T622381)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -173,10 +173,12 @@ module.exports = gridCore.Controller.inherit((function() {
             that._customizeRemoteOperations(options, isReload, operationTypes);
 
             if(!options.isCustomLoading) {
-                that._lastLoadOptions = loadOptions;
+                var isRefreshing = that._isRefreshing;
+
+                options.lastLoadOptions = loadOptions;
                 that._isRefreshing = true;
 
-                when(that.refresh(options, isReload, operationTypes)).done(function() {
+                when(isRefreshing || that.refresh(options, isReload, operationTypes)).done(function() {
                     if(that._lastOperationId === options.operationId) {
                         that.load();
                     }
@@ -229,6 +231,10 @@ module.exports = gridCore.Controller.inherit((function() {
             if(!loadOptions) {
                 this._dataSource.cancel(options.operationId);
                 return;
+            }
+
+            if(options.lastLoadOptions) {
+                this._lastLoadOptions = options.lastLoadOptions;
             }
 
             if(localPaging) {

--- a/js/ui/tree_list/ui.tree_list.data_source_adapter.js
+++ b/js/ui/tree_list/ui.tree_list.data_source_adapter.js
@@ -226,7 +226,7 @@ DataSourceAdapter = DataSourceAdapter.inherit((function() {
             if(this.option("autoExpandAll")) {
                 options.remoteOperations.sorting = false;
                 options.remoteOperations.filtering = false;
-                if(isReload && !this._lastLoadOptions && !options.isCustomLoading) {
+                if((!this._lastLoadOptions || operationTypes.filtering && !options.storeLoadOptions.filter) && !options.isCustomLoading) {
                     expandVisibleNodes = true;
                 }
             }
@@ -237,9 +237,12 @@ DataSourceAdapter = DataSourceAdapter.inherit((function() {
                 if(!options.cachedStoreData) {
                     this._hasItemsMap = {};
                 }
-                if(this.option("expandNodesOnFiltering") && (isReload || operationTypes.filtering)) {
-                    if(options.storeLoadOptions.filter || (operationTypes.filtering && this.option("autoExpandAll"))) {
+
+                if(this.option("expandNodesOnFiltering") && (operationTypes.filtering || options.storeLoadOptions.filter)) {
+                    if(options.storeLoadOptions.filter) {
                         expandVisibleNodes = true;
+                    } else {
+                        options.collapseVisibleNodes = true;
                     }
                 }
             }
@@ -436,7 +439,7 @@ DataSourceAdapter = DataSourceAdapter.inherit((function() {
                 this._fillNodes(this._rootNode.children, options, expandedRowKeys);
 
                 this._isNodesInitializing = true;
-                if(expandedRowKeys.length) {
+                if(options.collapseVisibleNodes || expandedRowKeys.length) {
                     this.option("expandedRowKeys", expandedRowKeys);
                 }
                 this.executeAction("onNodesInitialized", { root: this._rootNode });

--- a/testing/tests/DevExpress.ui.widgets.treeList/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/dataController.tests.js
@@ -737,6 +737,33 @@ QUnit.test("Initialize from dataSource with hierarchical structure when 'parentI
     assert.equal(items[3].node.parent.key, items[1].key, "fourth item has parentKey");
 });
 
+// T622381
+QUnit.test("Nodes should be expanded after refresh method is called at boot time (when autoExpandAll is true)", function(assert) {
+    // arrange
+    var items,
+        array = [
+            { name: 'Category1', phone: '55-55-55', id: 1, parentId: 0 },
+            { name: 'SubCategory1', phone: '98-75-21', id: 2, parentId: 1 },
+            { name: 'SubCategory2', phone: '55-66-77', id: 3, parentId: 2 },
+        ],
+        clock = sinon.useFakeTimers();
+
+    try {
+        this.applyOptions({ autoExpandAll: true, dataSource: array, loadingTimeout: 30 });
+
+        // act
+        this.refresh();
+        clock.tick(60);
+
+        // assert
+        items = this.dataController.items();
+        assert.strictEqual(items.length, 3, "item count");
+    } finally {
+        clock.restore();
+    }
+});
+
+
 QUnit.module("Expand/Collapse nodes", { beforeEach: setupModule, afterEach: teardownModule });
 
 QUnit.test("Expand node (plain structure)", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
@@ -391,7 +391,7 @@ QUnit.test("Items should be collapsed after clearing filter, autoExpandAll = fal
     });
 
     this.clock.tick();
-    assert.equal(treeList.$element().find(".dx-data-row").length, 2, "filtered rows are rendered");
+    assert.equal(treeList.$element().find(".dx-data-row").length, 3, "filtered rows are rendered");
 
     // act
     treeList.clearFilter();


### PR DESCRIPTION
See https://devexpress.com/issue=T622381