### PR TITLE
Add possibility to change buttons' type in toolbar in material theme (T640406)

### DIFF
--- a/js/ui/button.js
+++ b/js/ui/button.js
@@ -20,6 +20,7 @@ var BUTTON_CLASS = "dx-button",
     BUTTON_CONTENT_CLASS = "dx-button-content",
     BUTTON_HAS_TEXT_CLASS = "dx-button-has-text",
     BUTTON_HAS_ICON_CLASS = "dx-button-has-icon",
+    BUTTON_STYLE_TEXT = "dx-button-flat",
 
     TEMPLATE_WRAPPER_CLASS = "dx-template-wrapper",
 
@@ -131,7 +132,9 @@ var Button = Widget.inherit({
             */
             useSubmitBehavior: false,
 
-            useInkRipple: false
+            useInkRipple: false,
+            style: null
+
             /**
             * @name dxButtonDefaultTemplate
             * @type object
@@ -197,6 +200,7 @@ var Button = Widget.inherit({
         this._renderType();
 
         this.option("useInkRipple") && this._renderInkRipple();
+        this.option("style") && this._addStyleClass();
         this._renderClick();
 
         this.setAria("role", "button");
@@ -271,6 +275,16 @@ var Button = Widget.inherit({
 
         if(this.option("useSubmitBehavior")) {
             this._renderSubmitInput();
+        }
+    },
+
+    _addStyleClass: function() {
+        var style = this.option("style");
+        var $element = this.$element();
+
+        $element.removeClass(BUTTON_STYLE_TEXT);
+        if(style === "text") {
+            $element.addClass(BUTTON_STYLE_TEXT);
         }
     },
 
@@ -395,6 +409,9 @@ var Button = Widget.inherit({
                 break;
             case "useSubmitBehavior":
                 this._invalidate();
+                break;
+            case "style":
+                this._addStyleClass();
                 break;
             default:
                 this.callBase(args);

--- a/js/ui/button.js
+++ b/js/ui/button.js
@@ -20,7 +20,6 @@ var BUTTON_CLASS = "dx-button",
     BUTTON_CONTENT_CLASS = "dx-button-content",
     BUTTON_HAS_TEXT_CLASS = "dx-button-has-text",
     BUTTON_HAS_ICON_CLASS = "dx-button-has-icon",
-    BUTTON_STYLE_TEXT = "dx-button-flat",
 
     TEMPLATE_WRAPPER_CLASS = "dx-template-wrapper",
 
@@ -132,8 +131,7 @@ var Button = Widget.inherit({
             */
             useSubmitBehavior: false,
 
-            useInkRipple: false,
-            style: null
+            useInkRipple: false
 
             /**
             * @name dxButtonDefaultTemplate
@@ -200,7 +198,6 @@ var Button = Widget.inherit({
         this._renderType();
 
         this.option("useInkRipple") && this._renderInkRipple();
-        this.option("style") && this._addStyleClass();
         this._renderClick();
 
         this.setAria("role", "button");
@@ -275,16 +272,6 @@ var Button = Widget.inherit({
 
         if(this.option("useSubmitBehavior")) {
             this._renderSubmitInput();
-        }
-    },
-
-    _addStyleClass: function() {
-        var style = this.option("style");
-        var $element = this.$element();
-
-        $element.removeClass(BUTTON_STYLE_TEXT);
-        if(style === "text") {
-            $element.addClass(BUTTON_STYLE_TEXT);
         }
     },
 
@@ -409,9 +396,6 @@ var Button = Widget.inherit({
                 break;
             case "useSubmitBehavior":
                 this._invalidate();
-                break;
-            case "style":
-                this._addStyleClass();
                 break;
             default:
                 this.callBase(args);

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -149,7 +149,7 @@ var Toolbar = ToolbarBase.inherit({
             * @inheritdoc
             */
 
-            _useFlatButtons: false
+            useFlatButtons: false
         });
 
     },
@@ -193,7 +193,7 @@ var Toolbar = ToolbarBase.inherit({
                     return themes.isMaterial();
                 },
                 options: {
-                    _useFlatButtons: true
+                    useFlatButtons: true
                 }
             }
         ]);
@@ -389,7 +389,7 @@ var Toolbar = ToolbarBase.inherit({
 
         switch(name) {
             case "submenuType":
-            case "_useFlatButtons":
+            case "useFlatButtons":
                 this._invalidate();
                 break;
             case "visible":

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -55,7 +55,7 @@ var Toolbar = ToolbarBase.inherit({
             * @acceptValues 'actionSheet'|'listTop'|'listBottom'|'dropDownMenu'
             * @hidden
             */
-            submenuType: "dropDownMenu"
+            submenuType: "dropDownMenu",
 
             /**
             * @name dxToolbarItemTemplate.location
@@ -148,6 +148,8 @@ var Toolbar = ToolbarBase.inherit({
             * @hidden
             * @inheritdoc
             */
+
+            buttonsStyle: null
         });
 
     },
@@ -184,6 +186,14 @@ var Toolbar = ToolbarBase.inherit({
                 },
                 options: {
                     submenuType: "listTop"
+                }
+            },
+            {
+                device: function() {
+                    return themes.isMaterial();
+                },
+                options: {
+                    buttonsStyle: "text"
                 }
             }
         ]);
@@ -379,6 +389,7 @@ var Toolbar = ToolbarBase.inherit({
 
         switch(name) {
             case "submenuType":
+            case "buttonsStyle":
                 this._invalidate();
                 break;
             case "visible":

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -149,7 +149,7 @@ var Toolbar = ToolbarBase.inherit({
             * @inheritdoc
             */
 
-            buttonsStyle: null
+            _useFlatButtons: false
         });
 
     },
@@ -193,7 +193,7 @@ var Toolbar = ToolbarBase.inherit({
                     return themes.isMaterial();
                 },
                 options: {
-                    buttonsStyle: "text"
+                    _useFlatButtons: true
                 }
             }
         ]);
@@ -389,7 +389,7 @@ var Toolbar = ToolbarBase.inherit({
 
         switch(name) {
             case "submenuType":
-            case "buttonsStyle":
+            case "_useFlatButtons":
                 this._invalidate();
                 break;
             case "visible":

--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -56,7 +56,7 @@ var ToolbarBase = CollectionWidget.inherit({
 
                 if(data.widget === "dxButton") {
                     if(data.options) {
-                        var buttonContainerClass = this.option("_useFlatButtons") ? BUTTON_FLAT_CLASS : "";
+                        var buttonContainerClass = this.option("useFlatButtons") ? BUTTON_FLAT_CLASS : "";
                         if(data.options.elementAttr) {
                             var customClass = data.options.elementAttr.class;
                             if(customClass) {

--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -52,6 +52,10 @@ var ToolbarBase = CollectionWidget.inherit({
                 if(data.html) {
                     $container.html(data.html);
                 }
+
+                if(data.widget === "dxButton") {
+                    data.options = extend(data.options, { style: this.option("buttonsStyle") });
+                }
             } else {
                 $container.text(String(data));
             }

--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -54,9 +54,9 @@ var ToolbarBase = CollectionWidget.inherit({
                     $container.html(data.html);
                 }
 
-                if(data.widget === "dxButton") {
+                if(data.widget === "dxButton" && this.option("_useFlatButtons")) {
                     if(data.options) {
-                        var buttonContainerClass = this.option("_useFlatButtons") ? BUTTON_FLAT_CLASS : "";
+                        var buttonContainerClass = BUTTON_FLAT_CLASS;
                         if(data.options.elementAttr && data.options.elementAttr.class) {
                             buttonContainerClass += (" " + data.options.elementAttr.class);
                         }

--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -22,6 +22,7 @@ var TOOLBAR_CLASS = "dx-toolbar",
     TOOLBAR_ITEMS_CONTAINER_CLASS = "dx-toolbar-items-container",
     TOOLBAR_GROUP_CLASS = "dx-toolbar-group",
     TOOLBAR_LABEL_SELECTOR = "." + TOOLBAR_LABEL_CLASS,
+    BUTTON_FLAT_CLASS = "dx-button-flat",
 
     TOOLBAR_ITEM_DATA_KEY = "dxToolbarItemDataKey";
 
@@ -54,7 +55,14 @@ var ToolbarBase = CollectionWidget.inherit({
                 }
 
                 if(data.widget === "dxButton") {
-                    data.options = extend(data.options, { style: this.option("buttonsStyle") });
+                    if(data.options) {
+                        var buttonContainerClass = this.option("_useFlatButtons") ? BUTTON_FLAT_CLASS : "";
+                        if(data.options.elementAttr && data.options.elementAttr.class) {
+                            buttonContainerClass += (" " + data.options.elementAttr.class);
+                        }
+
+                        data.options = extend(data.options, { elementAttr: { class: buttonContainerClass } });
+                    }
                 }
             } else {
                 $container.text(String(data));

--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -54,11 +54,15 @@ var ToolbarBase = CollectionWidget.inherit({
                     $container.html(data.html);
                 }
 
-                if(data.widget === "dxButton" && this.option("_useFlatButtons")) {
+                if(data.widget === "dxButton") {
                     if(data.options) {
-                        var buttonContainerClass = BUTTON_FLAT_CLASS;
-                        if(data.options.elementAttr && data.options.elementAttr.class) {
-                            buttonContainerClass += (" " + data.options.elementAttr.class);
+                        var buttonContainerClass = this.option("_useFlatButtons") ? BUTTON_FLAT_CLASS : "";
+                        if(data.options.elementAttr) {
+                            var customClass = data.options.elementAttr.class;
+                            if(customClass) {
+                                customClass = customClass.replace(BUTTON_FLAT_CLASS, "");
+                                buttonContainerClass += (" " + customClass);
+                            }
                         }
 
                         data.options = extend(data.options, { elementAttr: { class: buttonContainerClass } });

--- a/styles/widgets/material/toolbar.material.less
+++ b/styles/widgets/material/toolbar.material.less
@@ -120,8 +120,11 @@
 
     .dx-toolbar-item-content,
     .dx-toolbar-button {
-        > .dx-button {
-            .dx-button-flat-styling(@base-icon-color);
+        > .dx-button.dx-button-normal {
+            .dx-icon {
+                color: @base-icon-color;
+            }
+            color: @base-icon-color;
         }
     }
 }

--- a/testing/tests/DevExpress.ui.widgets/button.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/button.tests.js
@@ -77,13 +77,6 @@ QUnit.test("disabled", function(assert) {
     assert.ok(this.element.hasClass("dx-state-disabled"));
 });
 
-QUnit.test("style", function(assert) {
-    this.instance.option("style", "text");
-    assert.ok(this.element.hasClass("dx-button-flat"));
-    this.instance.option("style", null);
-    assert.notOk(this.element.hasClass("dx-button-flat"));
-});
-
 QUnit.test("T325811 - 'text' option change should not lead to widget clearing", function(assert) {
     var $testElement = $("<div>").appendTo(this.element);
     assert.ok($testElement.parent().hasClass("dx-button"), "test element is in button");

--- a/testing/tests/DevExpress.ui.widgets/button.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/button.tests.js
@@ -77,6 +77,13 @@ QUnit.test("disabled", function(assert) {
     assert.ok(this.element.hasClass("dx-state-disabled"));
 });
 
+QUnit.test("style", function(assert) {
+    this.instance.option("style", "text");
+    assert.ok(this.element.hasClass("dx-button-flat"));
+    this.instance.option("style", null);
+    assert.notOk(this.element.hasClass("dx-button-flat"));
+});
+
 QUnit.test("T325811 - 'text' option change should not lead to widget clearing", function(assert) {
     var $testElement = $("<div>").appendTo(this.element);
     assert.ok($testElement.parent().hasClass("dx-button"), "test element is in button");

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -8,7 +8,8 @@ var $ = require("jquery"),
     fx = require("animation/fx"),
     hideTopOverlayCallback = require("mobile/hide_top_overlay").hideCallback,
     resizeCallbacks = require("core/utils/resize_callbacks"),
-    pointerMock = require("../../helpers/pointerMock.js");
+    pointerMock = require("../../helpers/pointerMock.js"),
+    themes = require("ui/themes");
 
 require("common.css!");
 require("ui/button");
@@ -131,6 +132,46 @@ QUnit.test("Center element has correct margin with RTL", function(assert) {
         margin = element.find("." + TOOLBAR_CLASS + "-center").get(0).style.margin;
 
     assert.equal(margin, "0px auto", "aligned by center");
+});
+
+QUnit.test("Buttons has 'text' style in Material theme by default", function(assert) {
+    var origIsMaterial = themes.isMaterial;
+    themes.isMaterial = function() { return true; };
+    var element = this.element.dxToolbar({
+            items: [{
+                location: 'before',
+                widget: 'dxButton',
+                options: {
+                    type: 'default',
+                    text: 'Back'
+                }
+            }]
+        }),
+        button = element.find(".dx-button");
+
+    assert.ok(button.hasClass("dx-button-flat"));
+
+    element.dxToolbar("instance").option("buttonsStyle", null);
+    button = element.find(".dx-button");
+
+    assert.notOk(button.hasClass("dx-button-flat"));
+    themes.isMaterial = origIsMaterial;
+});
+
+QUnit.test("Buttons has default style in generic theme", function(assert) {
+    var element = this.element.dxToolbar({
+            items: [{
+                location: 'before',
+                widget: 'dxButton',
+                options: {
+                    type: 'default',
+                    text: 'Back'
+                }
+            }]
+        }),
+        button = element.find(".dx-button");
+
+    assert.notOk(button.hasClass("dx-button-flat"));
 });
 
 

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -143,18 +143,25 @@ QUnit.test("Buttons has 'text' style in Material theme by default", function(ass
                 widget: 'dxButton',
                 options: {
                     type: 'default',
+                    text: 'Back',
+                    elementAttr: { class: 'custom-class' }
+                }
+            }, {
+                location: 'before',
+                widget: 'dxButton',
+                options: {
+                    type: 'default',
                     text: 'Back'
                 }
             }]
         }),
-        button = element.find(".dx-button");
+        button1 = element.find(".dx-button").first(),
+        button2 = element.find(".dx-button").last();
 
-    assert.ok(button.hasClass("dx-button-flat"));
+    assert.ok(button1.hasClass("dx-button-flat"));
+    assert.ok(button1.hasClass("custom-class"));
+    assert.ok(button2.hasClass("dx-button-flat"));
 
-    element.dxToolbar("instance").option("buttonsStyle", null);
-    button = element.find(".dx-button");
-
-    assert.notOk(button.hasClass("dx-button-flat"));
     themes.isMaterial = origIsMaterial;
 });
 

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -134,7 +134,32 @@ QUnit.test("Center element has correct margin with RTL", function(assert) {
     assert.equal(margin, "0px auto", "aligned by center");
 });
 
-QUnit.test("Buttons has 'text' style in Material theme by default", function(assert) {
+QUnit.test("_useFlatButtons change dx-button-flat class in runtime in Material", function(assert) {
+    var origIsMaterial = themes.isMaterial;
+    themes.isMaterial = function() { return true; };
+    var element = this.element.dxToolbar({
+            items: [{
+                location: 'before',
+                widget: 'dxButton',
+                options: {
+                    type: 'default',
+                    text: 'Back'
+                }
+            }]
+        }),
+        button = element.find(".dx-button").first();
+
+    assert.ok(button.hasClass("dx-button-flat"));
+
+    element.dxToolbar("instance").option("_useFlatButtons", false);
+    button = element.find(".dx-button").first();
+
+    assert.notOk(button.hasClass("dx-button-flat"));
+
+    themes.isMaterial = origIsMaterial;
+});
+
+QUnit.test("Button save elementAttr.class class on container in Material", function(assert) {
     var origIsMaterial = themes.isMaterial;
     themes.isMaterial = function() { return true; };
     var element = this.element.dxToolbar({
@@ -144,31 +169,15 @@ QUnit.test("Buttons has 'text' style in Material theme by default", function(ass
                 options: {
                     type: 'default',
                     text: 'Back',
-                    elementAttr: { class: 'custom-class' }
-                }
-            }, {
-                location: 'before',
-                widget: 'dxButton',
-                options: {
-                    type: 'default',
-                    text: 'Back'
+                    elementAttr: { class: 'custom-class1 custom-class2' }
                 }
             }]
         }),
-        button1 = element.find(".dx-button").first(),
-        button2 = element.find(".dx-button").last();
+        button = element.find(".dx-button").first();
 
-    assert.ok(button1.hasClass("dx-button-flat"));
-    assert.ok(button1.hasClass("custom-class"));
-    assert.ok(button2.hasClass("dx-button-flat"));
-
-    element.dxToolbar("instance").option("_useFlatButtons", false);
-    button1 = element.find(".dx-button").first();
-    button2 = element.find(".dx-button").last();
-
-    assert.notOk(button1.hasClass("dx-button-flat"));
-    assert.ok(button1.hasClass("custom-class"));
-    assert.notOk(button2.hasClass("dx-button-flat"));
+    assert.ok(button.hasClass("dx-button-flat"));
+    assert.ok(button.hasClass("custom-class1"));
+    assert.ok(button.hasClass("custom-class2"));
 
     themes.isMaterial = origIsMaterial;
 });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -162,6 +162,14 @@ QUnit.test("Buttons has 'text' style in Material theme by default", function(ass
     assert.ok(button1.hasClass("custom-class"));
     assert.ok(button2.hasClass("dx-button-flat"));
 
+    element.dxToolbar("instance").option("_useFlatButtons", false);
+    button1 = element.find(".dx-button").first();
+    button2 = element.find(".dx-button").last();
+
+    assert.notOk(button1.hasClass("dx-button-flat"));
+    assert.ok(button1.hasClass("custom-class"));
+    assert.notOk(button2.hasClass("dx-button-flat"));
+
     themes.isMaterial = origIsMaterial;
 });
 

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -134,7 +134,7 @@ QUnit.test("Center element has correct margin with RTL", function(assert) {
     assert.equal(margin, "0px auto", "aligned by center");
 });
 
-QUnit.test("_useFlatButtons change dx-button-flat class in runtime in Material", function(assert) {
+QUnit.test("useFlatButtons change dx-button-flat class in runtime in Material", function(assert) {
     var origIsMaterial = themes.isMaterial;
     themes.isMaterial = function() { return true; };
     var element = this.element.dxToolbar({
@@ -151,7 +151,7 @@ QUnit.test("_useFlatButtons change dx-button-flat class in runtime in Material",
 
     assert.ok(button.hasClass("dx-button-flat"));
 
-    element.dxToolbar("instance").option("_useFlatButtons", false);
+    element.dxToolbar("instance").option("useFlatButtons", false);
     button = element.find(".dx-button").first();
 
     assert.notOk(button.hasClass("dx-button-flat"));


### PR DESCRIPTION
Remove hard customization of buttons in Toolbar in material theme. Just add the 'dx-button-flat' class to buttons to change its type 'text'.