### PR TITLE
Fix dxDataGrid that does not switch a cell to editing mode under certain conditions when the editCell method is called in the onContentReady event handler (T621703)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -23,7 +23,8 @@ var $ = require("../../core/renderer"),
     deferredUtils = require("../../core/utils/deferred"),
     when = deferredUtils.when,
     Deferred = deferredUtils.Deferred,
-    deepExtendArraySafe = require("../../core/utils/object").deepExtendArraySafe;
+    deepExtendArraySafe = require("../../core/utils/object").deepExtendArraySafe,
+    commonUtils = require("../../core/utils/common");
 
 var EDIT_FORM_CLASS = "edit-form",
     EDIT_FORM_ITEM_CLASS = "edit-form-item",
@@ -749,7 +750,9 @@ var EditingController = modules.ViewController.inherit((function() {
                     }
 
                     if(that._prepareEditCell(params, item, columnIndex, editRowIndex)) {
-                        that._repaintEditCell(column, oldColumn, oldEditRowIndex);
+                        commonUtils.deferRender(function() {
+                            that._repaintEditCell(column, oldColumn, oldEditRowIndex);
+                        });
                     }
 
                 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -4765,6 +4765,37 @@ QUnit.test("Scroll to third page if expanded grouping is enabled and scrolling m
     assert.strictEqual(dataGrid.getVisibleRows()[80].data.key, 41);
 });
 
+// T621703
+QUnit.testInActiveWindow("Edit cell on onContentReady", function(assert) {
+    // arrange
+    var clock = sinon.useFakeTimers();
+
+    try {
+        var $cellElement,
+            dataGrid = createDataGrid({
+                dataSource: [{ firstName: "Andrey", lastName: "Prohorov" }],
+                editing: {
+                    mode: "cell",
+                    allowUpdating: true
+                },
+                onContentReady: function(e) {
+                    // act
+                    e.component.editCell(0, 1);
+                }
+            });
+
+        clock.tick();
+
+        // assert
+        $cellElement = $(dataGrid.getCellElement(0, 1));
+        assert.ok($cellElement.hasClass("dx-editor-cell"), "cell has editor");
+        assert.ok($cellElement.find(".dx-texteditor-input").is(":focus"), "cell editor is focused");
+    } finally {
+        clock.restore();
+    }
+});
+
+
 QUnit.module("Assign options", {
     beforeEach: function() {
         this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
See https://devexpress.com/issue=T621703