### PR TITLE
Fix dxDataGrid that does not switch a cell to editing mode under certain conditions when the editCell method is called in the onContentReady event handler (T621703)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -25,7 +25,8 @@ var $ = require("../../core/renderer"),
     holdEvent = require("../../events/hold"),
     deferredUtils = require("../../core/utils/deferred"),
     when = deferredUtils.when,
-    Deferred = deferredUtils.Deferred;
+    Deferred = deferredUtils.Deferred,
+    commonUtils = require("../../core/utils/common");
 
 var EDIT_FORM_CLASS = "edit-form",
     EDIT_FORM_ITEM_CLASS = "edit-form-item",
@@ -795,7 +796,9 @@ var EditingController = modules.ViewController.inherit((function() {
                     }
 
                     if(that._prepareEditCell(params, item, columnIndex, editRowIndex)) {
-                        that._repaintEditCell(column, oldColumn, oldEditRowIndex);
+                        commonUtils.deferRender(function() {
+                            that._repaintEditCell(column, oldColumn, oldEditRowIndex);
+                        });
                     }
 
                 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -5247,6 +5247,37 @@ QUnit.test("Runtime operation should be asynchronously", function(assert) {
     assert.equal(dataGrid.$element().find(".dx-data-row").length, 1, "filtered data rows are rendered");
 });
 
+// T621703
+QUnit.testInActiveWindow("Edit cell on onContentReady", function(assert) {
+    // arrange
+    var clock = sinon.useFakeTimers();
+
+    try {
+        var $cellElement,
+            dataGrid = createDataGrid({
+                dataSource: [{ firstName: "Andrey", lastName: "Prohorov" }],
+                editing: {
+                    mode: "cell",
+                    allowUpdating: true
+                },
+                onContentReady: function(e) {
+                    // act
+                    e.component.editCell(0, 1);
+                }
+            });
+
+        clock.tick();
+
+        // assert
+        $cellElement = $(dataGrid.getCellElement(0, 1));
+        assert.ok($cellElement.hasClass("dx-editor-cell"), "cell has editor");
+        assert.ok($cellElement.find(".dx-texteditor-input").is(":focus"), "cell editor is focused");
+    } finally {
+        clock.restore();
+    }
+});
+
+
 QUnit.module("Assign options", {
     beforeEach: function() {
         this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
See https://devexpress.com/issue=T621703