### PR TITLE
Return workaround to the panorama test for getting css background-position-x property value in ie11

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/panorama.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/panorama.tests.js
@@ -57,7 +57,9 @@ var position = function($element) {
 };
 
 var backgroundPosition = function($element) {
-    return parseInt($element.css("backgroundPositionX"), 10);
+    return parseInt($element.css("backgroundPosition").split(" ")[0], 10);
+    // TODO: use when jQuery solve bug in ie11
+    // return parseInt($element.css("backgroundPositionX"), 10);
 };
 
 var moveBackground = function($element, position) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
