### PR TITLE
DataGrid: Fix comparison of filterOperations & defaultFilterOperations in filterBuilder

### DIFF
--- a/js/ui/grid_core/ui.grid_core.filter_builder.js
+++ b/js/ui/grid_core/ui.grid_core.filter_builder.js
@@ -57,7 +57,7 @@ var FilterBuilderView = modules.View.inherit({
     _getFilterBuilderFields: function() {
         return this.getController("columns").getColumns().map(item => {
             let column = extend(true, {}, item);
-            column.filterOperations = column.filterOperations !== column.defaultFilterOperations ? column.filterOperations : null;
+            column.filterOperations = item.filterOperations !== item.defaultFilterOperations ? column.filterOperations : null;
             return column;
         });
     },

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
@@ -160,6 +160,18 @@ QUnit.module("Common", {
         assert.ok($(".dx-popup-content .dx-filterbuilder-item-operation").length, 1);
     });
 
+    QUnit.test("the 'any of' operation is available in filterBuilderPopup if filterOperations is instance of defaultFilterOperations", function(assert) {
+        // arrange, act
+        this.initFilterBuilderView({
+            columns: [{ dataField: "field", dataType: "string", defaultFilterOperations: ["="] }],
+            filterValue: ["field", "anyof", ["a"]],
+            filterBuilderPopup: { visible: true },
+        });
+
+        // assert
+        assert.equal($(".dx-popup-content .dx-filterbuilder-item-operation").length, 1);
+    });
+
     // T640912
     QUnit.test("the customOperation is available in built-in filterBuilder using dataTypes array", function(assert) {
         // arrange, act


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
