### PR TITLE
Correct caret behavior in the dxSelectBox with 'startwith' search mode and numbers as items (T642358)

### DIFF
--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -818,11 +818,10 @@ var SelectBox = DropDownList.inherit({
         }
 
         var inputElement = $input.get(0),
-            displayValue = this._displayGetter(item);
+            displayValue = this._displayGetter(item).toString();
 
         inputElement.value = displayValue;
-        inputElement.selectionStart = valueLength;
-        inputElement.selectionEnd = displayValue.length;
+        this._caret({ start: valueLength, end: displayValue.length });
     },
 
     _cleanInputSelection: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -2755,6 +2755,19 @@ QUnit.test("search timeout should be cleared if new search have been initiated",
     }
 });
 
+QUnit.test("caret should be at the end of the input if search is used with 'startswith' mode and items are numbers", function(assert) {
+    this.reinit({
+        dataSource: [1, 2, 3],
+        value: null,
+        searchTimeout: 0,
+        searchMode: 'startswith',
+        searchEnabled: true
+    });
+
+    this.keyboard.type("1");
+    assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret is good");
+});
+
 QUnit.test("search value should not be substituted if the 'autocompletionEnabled' is false", function(assert) {
     this.reinit({
         items: [this.item],


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
