### PR TITLE
dxDataGrid: Fix the"Maximum call stack size exceeded" error occurs on an attempt to filter a lookup column using the Header Filter (T629003)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.header_filter.js
+++ b/js/ui/grid_core/ui.grid_core.header_filter.js
@@ -91,7 +91,11 @@ var HeaderFilterController = modules.ViewController.inherit((function() {
                 displayValue = value;
             }
 
-            item = typeUtils.isObject(item) ? item : {};
+            if(!typeUtils.isObject(item)) {
+                item = {};
+            } else if(item === value) {
+                item = extend({}, item);
+            }
 
             path.push(value);
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -1935,6 +1935,57 @@ QUnit.test("Search by custom column", function(assert) {
     assert.strictEqual(listItems.text(), "test2", "correct item's text");
 });
 
+// T629003
+QUnit.test("No exceptions on an attempt to filter a lookup column when valueExpr is not specified", function(assert) {
+    // arrange
+    try {
+        var that = this,
+            $testElement = $("#container"),
+            $popupContent,
+            headerFilterDataSource = [
+                { value: 1, text: "test1" },
+                { value: 2, text: "test2" }
+            ];
+
+        that.columns[0].lookup = {
+            displayExpr: "text",
+            dataSource: headerFilterDataSource
+        };
+        that.items = [{ Test1: 1, Test2: "test2" }, { Test1: 2, Test2: "test4" }];
+
+        that.setupDataGrid();
+        that.columnHeadersView.render($testElement);
+        that.headerFilterView.render($testElement);
+        that.headerFilterController.showHeaderFilterMenu(0);
+
+        // assert
+        assert.deepEqual(that.headerFilterView.getListContainer().option("items"), [
+            {
+                "text": "(Blanks)",
+                "value": null
+            },
+            {
+                "text": "test1",
+                "value": headerFilterDataSource[0]
+            },
+            {
+                "text": "test2",
+                "value": headerFilterDataSource[1]
+            }], "list items");
+
+        $popupContent = that.headerFilterView.getPopupContainer().$content();
+
+        // act
+        $($popupContent.find(".dx-list-item").last()).trigger("dxclick");
+
+        // assert
+        assert.ok($popupContent.find(".dx-list-item").last().find(".dx-checkbox-checked").length, "checkbox checked");
+    } catch(e) {
+        assert.ok(false, "the error is thrown");
+    }
+});
+
+
 QUnit.module("Header Filter with real columnsController", {
     beforeEach: function() {
         this.items = [{ Test1: "value1", Test2: "value2" }, { Test1: "value3", Test2: "value4" }];


### PR DESCRIPTION
See https://devexpress.com/issue=T629003