### PR TITLE
Fix headers centering on Scheduler workWeek view (#4328)

### DIFF
--- a/styles/widgets/material/scheduler.material.less
+++ b/styles/widgets/material/scheduler.material.less
@@ -192,7 +192,8 @@
 
     .dx-scheduler-work-space.dx-scheduler-timeline.dx-scheduler-timeline-week &,
     .dx-scheduler-work-space.dx-scheduler-timeline.dx-scheduler-timeline-work-week & {
-        &:not(.dx-scheduler-header-panel-week-cell){
+        &:not(.dx-scheduler-header-panel-week-cell) {
+            justify-content: left;
             height: @MATERIAL_SCHEDULER_WORKSPACE_MONTH_TIMELINE__TIME_HEIGHT;
             font-size: @MATERIAL_SCHEDULER_TIME_PANEL_FONT_SIZE;
             padding-left: @MATERIAL_SCHEDULER_HEADER_PANEL_MARGIN;
@@ -202,7 +203,6 @@
     }
 
     &.dx-scheduler-header-panel-week-cell {
-        justify-content: left;
         border-bottom: @SCHEDULER_BASE_BORDER;
         flex-flow: column;
         justify-content: flex-end;


### PR DESCRIPTION
Fix headers centering on Scheduler workWeek view

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
