### PR TITLE
DataGrid: Fix closing of 'any of' operation popup when jquery is not using (T646013)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.filter_custom_operations.js
+++ b/js/ui/grid_core/ui.grid_core.filter_custom_operations.js
@@ -3,6 +3,7 @@
 import { renderValueText } from "../filter_builder/filter_builder";
 
 var $ = require("../../core/renderer"),
+    eventsEngine = require("../../events/core/events_engine"),
     messageLocalization = require("../../localization/message"),
     extend = require("../../core/utils/extend").extend,
     DataSourceModule = require("../../data/data_source/data_source"),
@@ -93,7 +94,7 @@ function baseOperation(grid) {
                     headerFilterController.hideHeaderFilterMenu();
                 },
                 onHidden: function() {
-                    $("body").trigger("dxpointerdown");
+                    eventsEngine.trigger($("body"), "dxpointerdown");
                 },
                 isFilterBuilder: true
             });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
@@ -3,6 +3,7 @@
 import "ui/data_grid/ui.data_grid";
 
 import $ from "jquery";
+import fx from "animation/fx";
 import dataGridMocks from "../../helpers/dataGridMocks.js";
 
 const setupDataGridModules = dataGridMocks.setupDataGridModules;
@@ -263,5 +264,38 @@ QUnit.module("Common", {
 
         assert.deepEqual(filterBuilderFields.length, 1);
         assert.deepEqual(filterBuilderFields[0].dataField, "field");
+    });
+});
+
+QUnit.module("Real dataGrid", {
+    beforeEach: function() {
+        this.initDataGrid = function(options) {
+            this.dataGrid = $("#container").dxDataGrid($.extend({
+                dataSource: [{}]
+            }, options)).dxDataGrid("instance");
+            return this.dataGrid;
+        };
+
+        fx.off = true;
+    },
+    afterEach: function() {
+        this.dataGrid.dispose();
+        fx.off = false;
+    }
+}, function() {
+    // T646013
+    QUnit.test("the 'any of' doesn't throw exception when popup is hiding (without jQuery)", function(assert) {
+        // arrange, act
+        this.initDataGrid({
+            columns: [{ dataField: "field", dataType: "string", defaultFilterOperations: ["anyof"] }],
+            filterValue: ["field", "anyof", ["text"]],
+            filterBuilderPopup: { visible: true },
+        });
+
+        $(".dx-popup-content .dx-filterbuilder-item-value-text").trigger("dxclick");
+        $(".dx-header-filter-menu.dx-popup").dxPopup("instance").hide();
+
+        // assert
+        assert.equal($(".dx-popup-content .dx-filterbuilder-item-value-text").text(), "text");
     });
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
