### PR TITLE
Update DateBox width test - popup extraWidth is added for the Android theme but not for the Android platform

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -2746,12 +2746,25 @@ QUnit.test("rendered list markup", function(assert) {
 });
 
 QUnit.test("width option test", function(assert) {
-    var device = devices.current(),
-        extraWidth = 0;
+    this.dateBox.option("opened", false);
+    this.dateBox.option("width", "auto");
+    this.dateBox.option("opened", true);
 
-    if(device.platform === "android") {
-        extraWidth = 32;
-    }
+    var popup = this.$dateBox.find(".dx-popup").dxPopup("instance");
+
+    assert.equal(this.$dateBox.outerWidth(), popup.option("width"), "timebox popup has equal width with timebox with option width 'auto'");
+
+    this.dateBox.option("opened", false);
+    this.dateBox.option("width", "153px");
+    this.dateBox.option("opened", true);
+    assert.equal(this.$dateBox.outerWidth(), popup.option("width"), "timebox popup has equal width with timebox with option width in pixels");
+});
+
+QUnit.test("width option test for Android theme", function(assert) {
+    var origIsAndroid5 = themes.isAndroid5;
+    themes.isAndroid5 = function() { return "android5.light"; };
+
+    var extraWidth = 32;
 
     this.dateBox.option("opened", false);
     this.dateBox.option("width", "auto");
@@ -2765,6 +2778,8 @@ QUnit.test("width option test", function(assert) {
     this.dateBox.option("width", "153px");
     this.dateBox.option("opened", true);
     assert.equal(this.$dateBox.outerWidth() + extraWidth, popup.option("width"), "timebox popup has equal width with timebox with option width in pixels");
+
+    themes.isAndroid5 = origIsAndroid5;
 });
 
 QUnit.test("list should contain correct values if min/max does not specified", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -2299,7 +2299,7 @@ QUnit.test("calendar views should be positioned correctly", function(assert) {
 
 QUnit.test("List picker popup should be positioned correctly for Android devices", function(assert) {
     var origIsAndroid5 = themes.isAndroid5;
-    themes.isAndroid5 = function() { return "android5.light"; };
+    themes.isAndroid5 = function() { return true; };
 
     var $dateBox = $("#dateBox").dxDateBox({
         type: "time",

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -2762,7 +2762,7 @@ QUnit.test("width option test", function(assert) {
 
 QUnit.test("width option test for Android theme", function(assert) {
     var origIsAndroid5 = themes.isAndroid5;
-    themes.isAndroid5 = function() { return "android5.light"; };
+    themes.isAndroid5 = function() { return true; };
 
     var extraWidth = 32;
 


### PR DESCRIPTION
… theme but not for the Android platform

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
