### PR TITLE
Fix fake isAndroid5 function for DateBox width test

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -2423,7 +2423,7 @@ QUnit.test("calendar views should be positioned correctly", function(assert) {
 
 QUnit.test("List picker popup should be positioned correctly for Android devices", function(assert) {
     var origIsAndroid5 = themes.isAndroid5;
-    themes.isAndroid5 = function() { return "android5.light"; };
+    themes.isAndroid5 = function() { return true; };
 
     var $dateBox = $("#dateBox").dxDateBox({
         type: "time",

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -2883,7 +2883,7 @@ QUnit.test("width option test", function(assert) {
 
 QUnit.test("width option test for Android theme", function(assert) {
     var origIsAndroid5 = themes.isAndroid5;
-    themes.isAndroid5 = function() { return "android5.light"; };
+    themes.isAndroid5 = function() { return true; };
 
     var extraWidth = 32;
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
