### PR TITLE
Prevent extra selectionChanged event in dxSelectBox when displayExpr is a number (T648181)

### DIFF
--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -573,7 +573,7 @@ var SelectBox = DropDownList.inherit({
             }
 
             var oldSelectedItem = this.option("selectedItem");
-            if(this._displayGetter(oldSelectedItem) === this._searchValue()) {
+            if((this._displayGetter(oldSelectedItem) || "").toString() === this._searchValue()) {
                 return;
             }
 

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -1697,6 +1697,31 @@ QUnit.test("selectionChanged should not fire if selectedItem was not changed", f
     assert.equal(selectionChangedHandler.callCount, 1, "selectionChanged should not fire twice");
 });
 
+QUnit.test("selectionChanged should not fire if selectedItem was not changed and displayValue is a number", function(assert) {
+    var selectionChangedHandler = sinon.spy(),
+        $element = $("#selectBox").dxSelectBox({
+            dataSource: {
+                load: function() {
+                    return [{ id: 1, text: 1 }];
+                },
+
+                byKey: function(key) {
+                    return { id: key, text: key };
+                }
+            },
+            onSelectionChanged: selectionChangedHandler,
+            valueExpr: "id",
+            displayExpr: "text",
+            opened: true,
+            value: 1
+        }),
+        $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+
+    $input.focusout();
+
+    assert.equal(selectionChangedHandler.callCount, 1, "selectionChanged does not rise twice");
+});
+
 
 QUnit.test("set non existing item is not reset after dataSource changing", function(assert) {
     var $selectBox = $("#selectBox").dxSelectBox({


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
