### PR TITLE
Fix possible 'Cannot create property on string' error in AJAX

### DIFF
--- a/js/core/utils/ajax.js
+++ b/js/core/utils/ajax.js
@@ -198,15 +198,16 @@ var getJsonpOptions = function(options) {
 var getRequestOptions = function(options, headers) {
 
     var params = options.data,
+        paramsAlreadyString = typeof params === "string",
         url = options.url || window.location.href;
 
-    if(!options.cache) {
+    if(!paramsAlreadyString && !options.cache) {
         params = params || {};
         params["_"] = Date.now();
     }
 
     if(params && !options.upload) {
-        if(typeof params !== "string") {
+        if(!paramsAlreadyString) {
             params = paramsConvert(params);
         }
 

--- a/testing/tests/DevExpress.core/utils.ajax.tests.js
+++ b/testing/tests/DevExpress.core/utils.ajax.tests.js
@@ -608,6 +608,24 @@ QUnit.test("cache=false for dataType=json", function(assert) {
     assert.ok(/_=\d+/.test(this.requests[0].url));
 });
 
+QUnit.test("cache=false, POST string", function(assert) {
+    var options = {
+        url: "/",
+        dataType: "json",
+        cache: false
+    };
+
+    // customization (e.g. onBeforeSend in DevExtreme.AspNet.Data)
+    options.method = "POST";
+    options.data = "payload";
+
+    ajax.sendRequest(options);
+
+    var xhr = this.requests[0];
+    assert.equal(xhr.url, "/");
+    assert.equal(xhr.requestBody, "payload");
+});
+
 QUnit.test("xhr is available in done", function(assert) {
     var xhrCount = 0;
     var requests = this.requests;


### PR DESCRIPTION
@MikeVitik stumbled upon this error during heavy customization of AJAX options for DevExtreme.AspNet.Data