### PR TITLE
DataGrid: Fix error after click by "Reset" when "Between" is active and filterSync is enabled (T649282)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.filter_row.js
+++ b/js/ui/grid_core/ui.grid_core.filter_row.js
@@ -499,8 +499,8 @@ var ColumnHeadersViewFilterRowExtender = (function() {
                             options[isOnClickMode ? "bufferedFilterValue" : "filterValue"] = null;
                         }
                     } else {
-                        options[isOnClickMode ? "bufferedSelectedFilterOperation" : "selectedFilterOperation"] = column.defaultSelectedFilterOperation || null;
                         options[isOnClickMode ? "bufferedFilterValue" : "filterValue"] = null;
+                        options[isOnClickMode ? "bufferedSelectedFilterOperation" : "selectedFilterOperation"] = column.defaultSelectedFilterOperation || null;
                     }
 
                     that._columnsController.columnOption(column.index, options);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
@@ -857,6 +857,25 @@ QUnit.module("Real dataGrid", {
         assert.deepEqual(dataGrid.columnOption("field", "selectedFilterOperation"), "=");
     });
 
+    QUnit.test("'Reset' operation click when 'Between' operation is active", function(assert) {
+        // arrange
+        var dataGrid = this.initDataGrid({
+            columns: [{ dataField: "dateField", dataType: "date" }],
+            filterValue: ["dateField", "between", [new Date(), new Date()]]
+        });
+
+        var filterMenu = $(dataGrid.element()).find('.dx-menu .dx-menu-item');
+        filterMenu.trigger("dxclick");
+        var filterMenuItems = $('.dx-filter-menu.dx-overlay-content').first().find('li'),
+            resetItem = filterMenuItems.find('.dx-menu-item').last();
+
+        // act
+        resetItem.trigger('dxclick');
+
+        // assert
+        assert.deepEqual(dataGrid.option("filterValue"), null);
+    });
+
     QUnit.test("do not sync if filterSyncEnabled = false", function(assert) {
         // arrange
         var dataGrid = this.initDataGrid({

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
@@ -864,12 +864,11 @@ QUnit.module("Real dataGrid", {
             filterValue: ["dateField", "between", [new Date(), new Date()]]
         });
 
+        // act
         var filterMenu = $(dataGrid.element()).find('.dx-menu .dx-menu-item');
         filterMenu.trigger("dxclick");
         var filterMenuItems = $('.dx-filter-menu.dx-overlay-content').first().find('li'),
             resetItem = filterMenuItems.find('.dx-menu-item').last();
-
-        // act
         resetItem.trigger('dxclick');
 
         // assert

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
@@ -857,6 +857,7 @@ QUnit.module("Real dataGrid", {
         assert.deepEqual(dataGrid.columnOption("field", "selectedFilterOperation"), "=");
     });
 
+    // T649282
     QUnit.test("'Reset' operation click when 'Between' operation is active", function(assert) {
         // arrange
         var dataGrid = this.initDataGrid({


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
