### PR TITLE
Documentation: Use VizTimeInterval enum from docEnums.js

### DIFF
--- a/js/viz/docs/docBaseWidget.js
+++ b/js/viz/docs/docBaseWidget.js
@@ -653,17 +653,11 @@ var ScaleBreak = {
 
 /**
 * @name VizTimeInterval
-* @type object
+* @type number|object|Enums.VizTimeInterval
+* @default undefined
 * @hidden
 */
 var tickInterval = {
-    /**
-    * @pseudo VizTimeIntervalEnum
-    * @type number|object|string
-    * @default undefined
-    * @acceptValues 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
-    */
-
     /**
     * @name VizTimeInterval.years
     * @type number

--- a/js/viz/docs/doccharts.js
+++ b/js/viz/docs/doccharts.js
@@ -1333,13 +1333,11 @@ var dxChart = {
     argumentAxis: {
         /**
         * @name dxChartOptions.argumentAxis.tickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         tickInterval: {},
         /**
         * @name dxChartOptions.argumentAxis.minorTickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         minorTickInterval: {},
@@ -1401,7 +1399,6 @@ var dxChart = {
         aggregationGroupWidth: 10,
         /**
         * @name dxChartOptions.argumentAxis.aggregationInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         aggregationInterval: undefined,
@@ -1622,13 +1619,11 @@ var dxChart = {
         multipleAxesSpacing: 5,
         /**
         * @name dxChartOptions.valueAxis.tickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         tickInterval: {},
         /**
         * @name dxChartOptions.valueAxis.minorTickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         minorTickInterval: {},
@@ -2769,13 +2764,11 @@ var dxPolarChart = {
         originValue: undefined,
         /**
         * @name dxPolarChartOptions.argumentAxis.tickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         tickInterval: {},
         /**
         * @name dxPolarChartOptions.argumentAxis.minorTickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         minorTickInterval: {},
@@ -2929,13 +2922,11 @@ var dxPolarChart = {
         showZero: undefined,
         /**
         * @name dxPolarChartOptions.valueAxis.tickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         tickInterval: {},
         /**
         * @name dxPolarChartOptions.valueAxis.minorTickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         minorTickInterval: {},

--- a/js/viz/docs/docrangeselector.js
+++ b/js/viz/docs/docrangeselector.js
@@ -61,7 +61,6 @@ var dxRangeSelector = {
         endValue: undefined,
         /**
         * @name dxRangeSelectorOptions.scale.minorTickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         minorTickInterval: {},
@@ -123,7 +122,6 @@ var dxRangeSelector = {
         },
         /**
         * @name dxRangeSelectorOptions.scale.tickInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         tickInterval: {},
@@ -135,13 +133,11 @@ var dxRangeSelector = {
         placeholderHeight: undefined,
         /**
         * @name dxRangeSelectorOptions.scale.minRange
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         minRange: {},
         /**
         * @name dxRangeSelectorOptions.scale.maxRange
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         maxRange: {},
@@ -355,7 +351,6 @@ var dxRangeSelector = {
         aggregationGroupWidth: 10,
         /**
         * @name dxRangeSelectorOptions.scale.aggregationInterval
-        * @extends VizTimeIntervalEnum
         * @inherits VizTimeInterval
         */
         aggregationInterval: undefined,


### PR DESCRIPTION
This PR contains changes to use `VizTimeInterval` enum from the `docEnums.js` file for following options:
```
dxChart.argumentAxis.aggregationInterval
dxChart.argumentAxis.minorTickInterval
dxChart.argumentAxis.tickInterval
dxChart.valueAxis.minorTickInterval
dxChart.valueAxis.tickInterval
dxPolarChart.argumentAxis.minorTickInterval
dxPolarChart.argumentAxis.tickInterval
dxPolarChart.valueAxis.minorTickInterval
dxPolarChart.valueAxis.tickInterval
dxRangeSelector.scale.maxRange
dxRangeSelector.scale.minorTickInterval
dxRangeSelector.scale.minRange
dxRangeSelector.scale.tickInterval
dxRangeSelector.scale.aggregationInterval
```
The `VizTimeIntervalEnum` pseudo element removed and the `VizTimeInterval` type extended. Also removed all occurences the 'VizTimeIntervalEnum' pseudo element in the `doccharts.js` file and the `docrangeselector.js` file.

If you want to check these changes, run metadata tools on the local machine to review changes in result files.