### PR TITLE
Documentation: Add a string type for summaryType options

### DIFF
--- a/js/ui/data_grid/ui.data_grid.summary.js
+++ b/js/ui/data_grid/ui.data_grid.summary.js
@@ -333,7 +333,7 @@ gridCore.registerModule("summary", {
                  */
                 /**
                  * @name dxDataGridOptions.summary.groupItems.summaryType
-                 * @type Enums.SummaryType
+                 * @type Enums.SummaryType|string
                  * @default undefined
                  */
                 /**
@@ -396,7 +396,7 @@ gridCore.registerModule("summary", {
                  */
                 /**
                  * @name dxDataGridOptions.summary.totalItems.summaryType
-                 * @type Enums.SummaryType
+                 * @type Enums.SummaryType|string
                  * @default undefined
                  */
                 /**

--- a/js/ui/pivot_grid/data_source.js
+++ b/js/ui/pivot_grid/data_source.js
@@ -721,7 +721,7 @@ module.exports = Class.inherit((function() {
              */
             /**
              * @name PivotGridDataSourceOptions.fields.summaryType
-             * @type Enums.SummaryType
+             * @type Enums.SummaryType|string
              * @default 'count'
              */
             /**


### PR DESCRIPTION
### About changes:
This PR adds the `string` type for following `summaryType` options:
```
dxDataGridOptions.summary.groupItems.summaryType
dxDataGridOptions.summary.totalItems.summaryType
PivotGridDataSourceOptions.fields.summaryType
```

### DevExtreme MVC Controls side:
It helps to generate `SummaryType(string value)` overload to specify a custom aggregator name on the server side. 

For instance, an user will be able to write:
```
.SummaryType ("stdev")
```
instead of:
```
.Option("summaryType", "stdev")
```
when custom aggregator registered:
``` 
DevExtreme.AspNet.Data.Aggregation.CustomAggregators.RegisterAggregator("stdev", typeof(StandardDiviationAggregator<>));
```
See also:
- https://devexpress.github.io/DevExtreme.AspNet.Data/net/api/DevExtreme.AspNet.Data.Aggregation.CustomAggregators.html
- https://github.com/DevExpress/DevExtreme.AspNet.Data/pull/205/

### API Reference:
`Type` and `Accepted Values` will not be affected. We are going to describe custom aggregator specifics on a server side in ["When using the widget as an ASP.NET MVC Control..." paragraph](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/summary/groupItems/#summaryType).

### TS definitions:
The `string` type wil be added to corresponding defintions in the `dx.all.d.ts` file.
`summaryType?: 'avg' | 'count' | 'custom' | 'max' | 'min' | 'sum' | string;`

### How to test:
To check these changes, run metadata tools on the local machine and review changes in result files.