### PR TITLE
Add missing definitions for the `events` module

### DIFF
--- a/build/gulp/modules_metadata.json
+++ b/build/gulp/modules_metadata.json
@@ -137,6 +137,15 @@
     "name": "events/transform"
   },
   {
+    "name": "events",
+    "exports": {
+      "on": "events.on",
+      "one": "events.one",
+      "off": "events.off",
+      "trigger": "events.trigger"
+    }
+  },
+  {
     "name": "framework/command",
     "exports": {
       "default": "framework.dxCommand"


### PR DESCRIPTION
Fix for [T653840](https://www.devexpress.com/Support/Center/Question/Details/T653840/angular-node-modules-devextreme-events-directory-misses-ts-definitions)