### PR TITLE
Do not set min/max for discrete range

### DIFF
--- a/js/viz/axes/base_axis.js
+++ b/js/viz/axes/base_axis.js
@@ -1090,17 +1090,21 @@ Axis.prototype = {
             categories: options.categories,
             dataType: options.dataType,
             axisType: options.type,
-            min: synchronizedValue,
-            max: synchronizedValue,
             base: options.logarithmBase,
             invert: options.inverted
         });
         const visualRange = this.adjustRange(this._viewport);
 
-        that._seriesData.addRange({
-            min: visualRange[0],
-            max: visualRange[1]
-        });
+        if(options.type !== constants.discrete) {
+            that._seriesData.addRange({
+                min: visualRange[0],
+                max: visualRange[1]
+            });
+            that._seriesData.addRange({
+                min: synchronizedValue,
+                max: synchronizedValue
+            });
+        }
 
         that._seriesData.minVisible = that._seriesData.minVisible === undefined ? that._seriesData.min : that._seriesData.minVisible;
         that._seriesData.maxVisible = that._seriesData.maxVisible === undefined ? that._seriesData.max : that._seriesData.maxVisible;

--- a/testing/tests/DevExpress.viz.core/baseAxis.tests.js
+++ b/testing/tests/DevExpress.viz.core/baseAxis.tests.js
@@ -2649,6 +2649,22 @@ QUnit.test("Set min > max", function(assert) {
     assert.equal(businessRange.maxVisible, 10);
 });
 
+QUnit.test("Do not set min/max for discrete axis", function(assert) {
+    this.updateOptions({ type: "discrete", min: "D", max: "E", synchronizedValue: 0 });
+    this.axis.validate();
+
+    this.axis.setBusinessRange({
+        categories: ["A", "B", "C", "D", "E", "F"]
+    });
+
+    const businessRange = this.translator.updateBusinessRange.lastCall.args[0];
+    assert.deepEqual(businessRange.categories, ["A", "B", "C", "D", "E", "F"]);
+    assert.equal(businessRange.min, undefined);
+    assert.deepEqual(businessRange.max, undefined);
+    assert.equal(businessRange.minVisible, "D");
+    assert.equal(businessRange.maxVisible, "E");
+});
+
 QUnit.module("Set business range. Value axis", {
     beforeEach: function() {
         environment.beforeEach.call(this);


### PR DESCRIPTION
Fixes scroll bar length when min and max options are set
