### PR TITLE
Fix events module metadata

### DIFF
--- a/build/gulp/modules_metadata.json
+++ b/build/gulp/modules_metadata.json
@@ -137,6 +137,16 @@
     "name": "events/transform"
   },
   {
+    "name": "events",
+    "exports": {
+      "on": "events.on",
+      "one": "events.one",
+      "off": "events.off",
+      "trigger": "events.trigger",
+      "triggerHandler": "events.triggerHandler"
+    }
+  },
+  {
     "name": "framework/command",
     "exports": {
       "default": "framework.dxCommand"

--- a/js/events.js
+++ b/js/events.js
@@ -29,6 +29,41 @@ var eventsEngine = require("./events/core/events_engine");
 * @export on
 */
 
+/**
+* @name eventsMethods.on
+* @publicName on(element, eventName, selector, handler)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 eventName:string
+* @param3 selector:string
+* @param4 handler:function
+* @module events
+* @export on
+*/
+
+/**
+* @name eventsMethods.on
+* @publicName on(element, eventName, data, handler)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 eventName:string
+* @param3 data:object
+* @param4 handler:function
+* @module events
+* @export on
+*/
+
+/**
+* @name eventsMethods.on
+* @publicName on(element, eventName, handler)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 eventName:string
+* @param3 handler:function
+* @module events
+* @export on
+*/
+
 exports.on = eventsEngine.on;
 
 /**
@@ -40,6 +75,41 @@ exports.on = eventsEngine.on;
 * @param3 selector:string
 * @param4 data:object
 * @param5 handler:function
+* @module events
+* @export one
+*/
+
+/**
+* @name eventsMethods.one
+* @publicName one(element, eventName, selector, handler)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 eventName:string
+* @param3 selector:string
+* @param4 handler:function
+* @module events
+* @export one
+*/
+
+/**
+* @name eventsMethods.one
+* @publicName one(element, eventName, data, handler)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 eventName:string
+* @param3 data:object
+* @param4 handler:function
+* @module events
+* @export one
+*/
+
+/**
+* @name eventsMethods.one
+* @publicName one(element, eventName, handler)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 eventName:string
+* @param3 handler:function
 * @module events
 * @export one
 */
@@ -58,6 +128,28 @@ exports.one = eventsEngine.one;
 * @export off
 */
 
+/**
+* @name eventsMethods.off
+* @publicName off(element, eventName, selector)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 eventName:string
+* @param3 selector:string
+* @module events
+* @export off
+*/
+
+/**
+* @name eventsMethods.off
+* @publicName off(element, eventName, handler)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 eventName:string
+* @param3 handler:function
+* @module events
+* @export off
+*/
+
 exports.off = eventsEngine.off;
 
 /**
@@ -71,6 +163,16 @@ exports.off = eventsEngine.off;
 * @export trigger
 */
 
+/**
+* @name eventsMethods.trigger
+* @publicName trigger(element, event)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 event:string|event
+* @module events
+* @export trigger
+*/
+
 exports.trigger = eventsEngine.trigger;
 
 /**
@@ -80,6 +182,16 @@ exports.trigger = eventsEngine.trigger;
 * @param1 element:Node|Array<Node>
 * @param2 event:string|event
 * @param3 extraParameters:object
+* @module events
+* @export triggerHandler
+* @hidden
+*/
+/**
+* @name eventsMethods.triggerHandler
+* @publicName triggerHandler(element, event)
+* @namespace DevExpress.events
+* @param1 element:Node|Array<Node>
+* @param2 event:string|event
 * @module events
 * @export triggerHandler
 * @hidden

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -767,21 +767,6 @@ declare module DevExpress {
         /** Gets an endpoint with a specific key. */
         urlFor(key: string): string;
     }
-    /** Hides the last displayed overlay widget. */
-    export function hideTopOverlay(): boolean;
-    /** Processes the hardware back button click. */
-    export function processHardwareBackButton(): void;
-    /** An object that serves as a namespace for DevExtreme UI widgets as well as for methods implementing UI logic in DevExtreme sites/applications. */
-    export class ui {
-        /** Creates a toast message. */
-        static notify(message: string, type?: string, displayTime?: number): void;
-        /** Creates a toast message. */
-        static notify(options: any, type?: string, displayTime?: number): void;
-        /** Sets a template engine. */
-        static setTemplateEngine(templateEngineName: string): void;
-        /** Sets a custom template engine defined via custom compile and render functions. */
-        static setTemplateEngine(templateEngineOptions: { compile?: Function, render?: Function }): void;
-    }
     /** An object that serves as a namespace for the methods required to perform validation. */
     export class validationEngine {
         /** Gets the default validation group. */
@@ -802,6 +787,21 @@ declare module DevExpress {
         static validateGroup(group: string | any): DevExpress.ui.dxValidationGroupResult;
         /** Validates a view model. */
         static validateModel(model: any): any;
+    }
+    /** Hides the last displayed overlay widget. */
+    export function hideTopOverlay(): boolean;
+    /** Processes the hardware back button click. */
+    export function processHardwareBackButton(): void;
+    /** An object that serves as a namespace for DevExtreme UI widgets as well as for methods implementing UI logic in DevExtreme sites/applications. */
+    export class ui {
+        /** Creates a toast message. */
+        static notify(message: string, type?: string, displayTime?: number): void;
+        /** Creates a toast message. */
+        static notify(options: any, type?: string, displayTime?: number): void;
+        /** Sets a template engine. */
+        static setTemplateEngine(templateEngineName: string): void;
+        /** Sets a custom template engine defined via custom compile and render functions. */
+        static setTemplateEngine(templateEngineOptions: { compile?: Function, render?: Function }): void;
     }
     /** An object that serves as a namespace for DevExtreme Data Visualization Widgets. */
     export class viz {
@@ -1562,6 +1562,90 @@ declare module DevExpress.framework {
     export class dxContent {
         constructor(options?: dxContentOptions)
     }
+}
+declare module DevExpress.framework.html {
+    export interface HtmlApplicationOptions {
+        /** Specifies the animation presets that are used to animate different UI elements in the current application. */
+        animationSet?: any;
+        /** Specifies where the commands that are defined in the application's views must be displayed. */
+        commandMapping?: any;
+        /** Specifies whether or not view caching is disabled. */
+        disableViewCache?: boolean;
+        /** An array of layout controllers that should be used to show application views in the current navigation context. */
+        layoutSet?: string | Array<any>;
+        /** Specifies whether the current application must behave as a mobile or web application. */
+        mode?: 'mobileApp' | 'webSite';
+        /** Specifies the object that represents a root namespace of the application. */
+        namespace?: any;
+        /** Specifies application behavior when the user navigates to a root view. */
+        navigateToRootViewMode?: 'keepHistory' | 'resetHistory';
+        /** An array of dxCommand configuration objects used to define commands available from the application's global navigation. */
+        navigation?: Array<dxCommand | dxCommandOptions>;
+        /** A custom router to be used in the application. */
+        router?: any;
+        /** A state manager to be used in the application. */
+        stateManager?: any;
+        /** Specifies the storage to be used by the application's state manager to store the application state. */
+        stateStorage?: any;
+        /** Specifies the current version of application templates. */
+        templatesVersion?: string;
+        /** Indicates whether on not to use the title of the previously displayed view as text on the Back button. */
+        useViewTitleAsBackText?: boolean;
+        /** A custom view cache to be used in the application. */
+        viewCache?: any;
+        /** Specifies a limit for the views that can be cached. */
+        viewCacheSize?: number;
+        /** Specifies options for the viewport meta tag of a mobile browser. */
+        viewPort?: any;
+    }
+    /** @deprecated #include spa-deprecated-note */
+    export class HtmlApplication {
+        constructor(options?: HtmlApplicationOptions)
+        /** Provides access to the ViewCache object. */
+        viewCache: any;
+        /** Provides access to the Router object. */
+        router: any;
+        /** An array of dxCommand components that are created based on the application's navigation option value. */
+        navigation: Array<dxCommand>;
+        /** Provides access to the StateManager object. */
+        stateManager: any;
+        /** Navigates to the URI preceding the current one in the navigation history. */
+        back(): void;
+        /** Returns a Boolean value indicating whether or not backwards navigation is currently possible. */
+        canBack(): boolean;
+        /** Calls the clearState() method of the application's StateManager object. */
+        clearState(): void;
+        /** Creates global navigation commands. */
+        createNavigation(navigationConfig: Array<any>): void;
+        /** Returns an HTML template of the specified view. */
+        getViewTemplate(viewName: string): JQuery;
+        /** Returns a configuration object used to create a dxView component for a specified view. */
+        getViewTemplateInfo(viewName: string): any;
+        /** Adds a specified HTML template to a collection of view or layout templates. */
+        loadTemplates(source: string | JQuery): Promise<void> & JQueryPromise<void>;
+        /** Navigates to the specified URI. */
+        navigate(uri?: string | any): void;
+        /** Navigates to the specified URI. */
+        navigate(uri: string | any, options: { root?: boolean, target?: string, direction?: string, modal?: boolean }): void;
+        /** Detaches all event handlers from a single event. */
+        off(eventName: string): this;
+        /** Detaches a particular event handler from a single event. */
+        off(eventName: string, eventHandler: Function): this;
+        /** Subscribes to an event. */
+        on(eventName: string, eventHandler: Function): this;
+        /** Subscribes to events. */
+        on(events: any): this;
+        /** Renders navigation commands to the navigation command containers that are located in the layouts used in the application. */
+        renderNavigation(): void;
+        /** Calls the restoreState() method of the application's StateManager object. */
+        restoreState(): void;
+        /** Calls the saveState method of the application's StateManager object. */
+        saveState(): void;
+        /** Provides access to the object that defines the current context to be considered when choosing an appropriate template for a view. */
+        templateContext(): any;
+    }
+    export var layoutSets: Array<string>;
+    export var animationSets: any;
 }
 declare module DevExpress.ui {
     export interface dxAccordionOptions extends CollectionWidgetOptions<dxAccordion> {
@@ -2462,7 +2546,9 @@ declare module DevExpress.ui {
         filterOperationDescriptions?: { between?: string, equal?: string, notEqual?: string, lessThan?: string, lessThanOrEqual?: string, greaterThan?: string, greaterThanOrEqual?: string, startsWith?: string, contains?: string, notContains?: string, endsWith?: string, isBlank?: string, isNotBlank?: string };
         /** Specifies group operation descriptions. */
         groupOperationDescriptions?: { and?: string, or?: string, notAnd?: string, notOr?: string };
+        /** Specifies a set of available group operations. */
         groupOperations?: Array<'and' | 'or' | 'notAnd' | 'notOr'>;
+        /** Specifies groups' maximum nesting level. */
         maxGroupLevel?: number;
         /** A handler for the editorPrepared event. Executed after an editor is created. */
         onEditorPrepared?: ((e: { component?: dxFilterBuilder, element?: DevExpress.core.dxElement, model?: any, value?: any, setValue?: any, editorElement?: DevExpress.core.dxElement, editorName?: string, dataField?: string, filterOperation?: string, updateValueTimeout?: number, width?: number, readOnly?: boolean, disabled?: boolean, rtlEnabled?: boolean }) => any);
@@ -4752,7 +4838,7 @@ declare module DevExpress.ui {
     }
     /** Configures a button form item. */
     export interface dxFormButtonItem {
-        /** Specifies the button's horizontal alignment. */
+        /** @deprecated Use horizontalAlignment instead. */
         alignment?: 'center' | 'left' | 'right';
         /** Configures the button. */
         buttonOptions?: dxButtonOptions;
@@ -4760,10 +4846,12 @@ declare module DevExpress.ui {
         colSpan?: number;
         /** Specifies a CSS class to be applied to the item. */
         cssClass?: string;
+        horizontalAlignment?: 'center' | 'left' | 'right';
         /** Specifies the item's type. Set it to "button" to create a button item. */
         itemType?: 'empty' | 'group' | 'simple' | 'tabbed' | 'button';
         /** Specifies the item's identifier. */
         name?: string;
+        verticalAlignment?: 'bottom' | 'center' | 'top';
         /** Specifies whether the item is visible. */
         visible?: boolean;
         /** Specifies the item's position regarding other items in a group, tab, or the whole widget. */
@@ -5335,90 +5423,6 @@ declare module DevExpress.ui {
         static ready(callback: Function): void;
     }
 }
-declare module DevExpress.framework.html {
-    export interface HtmlApplicationOptions {
-        /** Specifies the animation presets that are used to animate different UI elements in the current application. */
-        animationSet?: any;
-        /** Specifies where the commands that are defined in the application's views must be displayed. */
-        commandMapping?: any;
-        /** Specifies whether or not view caching is disabled. */
-        disableViewCache?: boolean;
-        /** An array of layout controllers that should be used to show application views in the current navigation context. */
-        layoutSet?: string | Array<any>;
-        /** Specifies whether the current application must behave as a mobile or web application. */
-        mode?: 'mobileApp' | 'webSite';
-        /** Specifies the object that represents a root namespace of the application. */
-        namespace?: any;
-        /** Specifies application behavior when the user navigates to a root view. */
-        navigateToRootViewMode?: 'keepHistory' | 'resetHistory';
-        /** An array of dxCommand configuration objects used to define commands available from the application's global navigation. */
-        navigation?: Array<dxCommand | dxCommandOptions>;
-        /** A custom router to be used in the application. */
-        router?: any;
-        /** A state manager to be used in the application. */
-        stateManager?: any;
-        /** Specifies the storage to be used by the application's state manager to store the application state. */
-        stateStorage?: any;
-        /** Specifies the current version of application templates. */
-        templatesVersion?: string;
-        /** Indicates whether on not to use the title of the previously displayed view as text on the Back button. */
-        useViewTitleAsBackText?: boolean;
-        /** A custom view cache to be used in the application. */
-        viewCache?: any;
-        /** Specifies a limit for the views that can be cached. */
-        viewCacheSize?: number;
-        /** Specifies options for the viewport meta tag of a mobile browser. */
-        viewPort?: any;
-    }
-    /** @deprecated #include spa-deprecated-note */
-    export class HtmlApplication {
-        constructor(options?: HtmlApplicationOptions)
-        /** Provides access to the ViewCache object. */
-        viewCache: any;
-        /** Provides access to the Router object. */
-        router: any;
-        /** An array of dxCommand components that are created based on the application's navigation option value. */
-        navigation: Array<dxCommand>;
-        /** Provides access to the StateManager object. */
-        stateManager: any;
-        /** Navigates to the URI preceding the current one in the navigation history. */
-        back(): void;
-        /** Returns a Boolean value indicating whether or not backwards navigation is currently possible. */
-        canBack(): boolean;
-        /** Calls the clearState() method of the application's StateManager object. */
-        clearState(): void;
-        /** Creates global navigation commands. */
-        createNavigation(navigationConfig: Array<any>): void;
-        /** Returns an HTML template of the specified view. */
-        getViewTemplate(viewName: string): JQuery;
-        /** Returns a configuration object used to create a dxView component for a specified view. */
-        getViewTemplateInfo(viewName: string): any;
-        /** Adds a specified HTML template to a collection of view or layout templates. */
-        loadTemplates(source: string | JQuery): Promise<void> & JQueryPromise<void>;
-        /** Navigates to the specified URI. */
-        navigate(uri?: string | any): void;
-        /** Navigates to the specified URI. */
-        navigate(uri: string | any, options: { root?: boolean, target?: string, direction?: string, modal?: boolean }): void;
-        /** Detaches all event handlers from a single event. */
-        off(eventName: string): this;
-        /** Detaches a particular event handler from a single event. */
-        off(eventName: string, eventHandler: Function): this;
-        /** Subscribes to an event. */
-        on(eventName: string, eventHandler: Function): this;
-        /** Subscribes to events. */
-        on(events: any): this;
-        /** Renders navigation commands to the navigation command containers that are located in the layouts used in the application. */
-        renderNavigation(): void;
-        /** Calls the restoreState() method of the application's StateManager object. */
-        restoreState(): void;
-        /** Calls the saveState method of the application's StateManager object. */
-        saveState(): void;
-        /** Provides access to the object that defines the current context to be considered when choosing an appropriate template for a view. */
-        templateContext(): any;
-    }
-    export var layoutSets: Array<string>;
-    export var animationSets: any;
-}
 declare module DevExpress.viz {
     export interface BaseWidgetOptions<T = BaseWidget> extends DOMComponentOptions<T> {
         /** Configures the exporting and printing features. */
@@ -5593,6 +5597,9 @@ declare module DevExpress.viz {
     export class dxChart extends BaseChart {
         constructor(element: Element, options?: DevExpress.viz.charts.dxChartOptions)
         constructor(element: JQuery, options?: DevExpress.viz.charts.dxChartOptions)
+        getArgumentAxis(): void;
+        getValueAxis(): void;
+        getValueAxis(name: string): void;
         /** Sets the argument axis' start and end values. */
         zoomArgument(startValue: number | Date | string, endValue: number | Date | string): void;
     }
@@ -6793,6 +6800,8 @@ declare module DevExpress.viz {
         axis: string;
         /** Returns the name of the series pane. */
         pane: string;
+        getArgumentAxis(): void;
+        getValueAxis(): void;
     }
     export interface chartPointAggregationInfoObject {
         /** Contains the length of the aggregation interval in axis units. If the interval is set in pixels, it will be converted to axis units. */
@@ -6822,6 +6831,10 @@ declare module DevExpress.viz {
         size: number | string;
         /** Gets the parameters of the point's minimum bounding rectangle (MBR). */
         getBoundingRect(): any;
+    }
+    export class chartAxisObject {
+        visualRange(): void;
+        visualRange(visualRange: Array<number | string | Date>): void;
     }
     /** This section describes the Item object, which represents a funnel item. */
     export class dxFunnelItem {
@@ -7238,13 +7251,23 @@ declare module DevExpress.viz {
 declare module DevExpress.events {
     /** Attaches an event handler to the specified elements. */
     export function on(element: Element | Array<Element>, eventName: string, selector: string, data: any, handler: Function): void;
+    export function on(element: Element | Array<Element>, eventName: string, selector: string, handler: Function): void;
+    export function on(element: Element | Array<Element>, eventName: string, data: any, handler: Function): void;
+    export function on(element: Element | Array<Element>, eventName: string, handler: Function): void;
     /** Attaches an event handler to be executed only once to the specified elements. */
     export function one(element: Element | Array<Element>, eventName: string, selector: string, data: any, handler: Function): void;
+    export function one(element: Element | Array<Element>, eventName: string, selector: string, handler: Function): void;
+    export function one(element: Element | Array<Element>, eventName: string, data: any, handler: Function): void;
+    export function one(element: Element | Array<Element>, eventName: string, handler: Function): void;
     /** Detaches an event handler from the specified elements. */
     export function off(element: Element | Array<Element>, eventName: string, selector: string, handler: Function): void;
+    export function off(element: Element | Array<Element>, eventName: string, selector: string): void;
+    export function off(element: Element | Array<Element>, eventName: string, handler: Function): void;
     /** Executes all handlers of a given event type attached to the specified elements. */
     export function trigger(element: Element | Array<Element>, event: string | event, extraParameters: any): void;
+    export function trigger(element: Element | Array<Element>, event: string | event): void;
     export function triggerHandler(element: Element | Array<Element>, event: string | event, extraParameters: any): void;
+    export function triggerHandler(element: Element | Array<Element>, event: string | event): void;
 }
 declare module DevExpress.data.utils {
     /** Compiles a getter function from a getter expression. */
@@ -7506,6 +7529,7 @@ declare module DevExpress.viz.charts {
         valueMarginsEnabled?: boolean;
         /** Makes the axis line visible. */
         visible?: boolean;
+        wholeRange?: Array<number | string | Date>;
         /** Specifies the width of the axis line in pixels. */
         width?: number;
     }


### PR DESCRIPTION
Fix for [T653840](https://www.devexpress.com/Support/Center/Question/Details/T653840/angular-node-modules-devextreme-events-directory-misses-ts-definitions)