### PR TITLE
Add missing "action" attribute to hidden event handlers

### DIFF
--- a/js/ui/box.js
+++ b/js/ui/box.js
@@ -509,6 +509,7 @@ var Box = CollectionWidget.inherit({
             */
             /**
             * @name dxBoxOptions.onSelectionChanged
+            * @action
             * @hidden
             * @inheritdoc
             */

--- a/js/ui/responsive_box.js
+++ b/js/ui/responsive_box.js
@@ -145,6 +145,7 @@ var ResponsiveBox = CollectionWidget.inherit({
             */
             /**
             * @name dxResponsiveBoxOptions.onSelectionChanged
+            * @action
             * @hidden
             * @inheritdoc
             */

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -410,18 +410,21 @@ var TagBox = SelectBox.inherit({
             /**
             * @name dxTagBoxOptions.onCopy
             * @hidden
+            * @action
             * @inheritdoc
             */
 
             /**
             * @name dxTagBoxOptions.onCut
             * @hidden
+            * @action
             * @inheritdoc
             */
 
             /**
             * @name dxTagBoxOptions.onPaste
             * @hidden
+            * @action
             * @inheritdoc
             */
 

--- a/js/ui/tooltip/tooltip.js
+++ b/js/ui/tooltip/tooltip.js
@@ -49,6 +49,7 @@ var Tooltip = Popover.inherit({
             /**
             * @name dxTooltipOptions.onTitleRendered
             * @hidden
+            * @action
             * @inheritdoc
             */
             onTitleRendered: null,


### PR DESCRIPTION
Without this attribute, only the on... event handler is hidden, but the corresponding event is still visible in the Events docs section. For instance, the Box widget doesn't have the onSelectionChanged handler, but it does have the [selectionChanged](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxBox/Events/#selectionChanged) event listed.