### PR TITLE
Remove inheritdoc from Toast.displayTime

### DIFF
--- a/js/ui/toast.js
+++ b/js/ui/toast.js
@@ -325,7 +325,6 @@ var Toast = Overlay.inherit({
                     /**
                     * @name dxToastOptions.displayTime
                     * @default 4000 @for Material
-                    * @inheritdoc
                     */
                     displayTime: 4000
                 }


### PR DESCRIPTION
The attribute was erroneously left from the old doccomment for the `animation` option.