### PR TITLE
Add publicName attr to chartAxisObject

### DIFF
--- a/js/viz/docs/docObjectsDxChart.js
+++ b/js/viz/docs/docObjectsDxChart.js
@@ -109,6 +109,7 @@ var chartPointObject = {
 
 /**
 * @name chartAxisObject
+* @publicName Axis
 * @type object
 */
 var chartAxisObject = {


### PR DESCRIPTION
Without it, the root .md file for this object is called like the object.