### PR TITLE
Documentation: Extract Resizable.handles accepted values to ResizeHandle enum

### DIFF
--- a/js/docEnums.js
+++ b/js/docEnums.js
@@ -116,6 +116,11 @@
  */
 
 /**
+ * @typedef {string} Enums.ResizeHandle
+ * @enum {'bottom'|'left'|'right'|'top'|'all'}
+ */
+
+/**
  * @typedef {string} Enums.BoxDirection
  * @enum {'col'|'row'}
  */

--- a/js/ui/resizable.js
+++ b/js/ui/resizable.js
@@ -53,9 +53,8 @@ var Resizable = DOMComponent.inherit({
 
             /**
             * @name dxResizableOptions.handles
-            * @type string
+            * @type Enums.ResizeHandle
             * @default "all"
-            * @acceptValues 'top'|'bottom'|'right'|'left'|'all'
             */
             handles: "all",
 

--- a/js/ui/resizable.js
+++ b/js/ui/resizable.js
@@ -53,7 +53,7 @@ var Resizable = DOMComponent.inherit({
 
             /**
             * @name dxResizableOptions.handles
-            * @type Enums.ResizeHandle
+            * @type Enums.ResizeHandle | string
             * @default "all"
             */
             handles: "all",


### PR DESCRIPTION
**About changes:**
This PR adds the ResizeHandle enum.
The ResizeHandle enum will be used for defining the type of the [handles](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxResizable/Configuration/#handles) option of the [Resizable widget](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxResizable/).

**DevExtreme MVC Controls side:**
It helps to generate the [handles](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxResizable/Configuration/#handles) option automatically on DevExtreme MVC Controls side, like below:
```
public ResizableBuilder Handles(params ResizeHandle[] values) {
    Options["handles"] = String.Join(" ", values).ToLower();
    return this;
}
```
Also, it allows removing manually defined ResizeHandle enum in the SMDG.

**API Reference:**
Type and Accepted Values will not be affected.

**How to test:**
To check these changes, run metadata tools on the local machine and review changes in result files.