### PR TITLE
DataGrid: Fix resetting of pageIndex after dataSource was reloaded (T646491)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -214,6 +214,7 @@ var VirtualScrollingDataSourceAdapterExtender = (function() {
                     that.pageIndex(0);
                     dataSource.pageIndex(0);
                     storeLoadOptions.pageIndex = 0;
+                    options.pageIndex = 0;
                     storeLoadOptions.skip = 0;
                 } else {
                     dataSource.pageIndex(that.pageIndex());

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -10114,6 +10114,9 @@ QUnit.test("reload reset pageIndex in infinite scrolling mode", function(assert)
     assert.equal(this.dataController.totalItemsCount(), 5);
     assert.equal(this.dataController.items().length, 5);
 
+    var spy = sinon.spy();
+    this.dataSource.on("customizeStoreLoadOptions", spy);
+
     // act
     this.dataSource.reload(true);
     this.clock.tick();
@@ -10123,6 +10126,8 @@ QUnit.test("reload reset pageIndex in infinite scrolling mode", function(assert)
     assert.equal(this.dataController.items().length, 3);
     assert.equal(this.dataController.pageIndex(), 0);
     assert.equal(this.dataSource.pageIndex(), 0);
+    assert.equal(spy.getCall(0).args[0].pageIndex, 0); // T646491
+    assert.equal(spy.getCall(0).args[0].storeLoadOptions.pageIndex, 0);
 });
 
 QUnit.test("Grouping not reset after change option autoExpandAll", function(assert) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
