### PR TITLE
Restore typed text after blur in the dxSelectBox when custom value is accepted (T657550)

### DIFF
--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -108,10 +108,7 @@ var SelectBox = DropDownList.inherit({
             },
             escape: function() {
                 parent.escape.apply(this, arguments);
-                if(!this._isEditable() && this._list) {
-                    this._focusListElement(null);
-                    this._updateField(this.option("selectedItem"));
-                }
+                this._cancelEditing();
             },
             enter: function(e) {
                 if(this._input().val() === "" && this.option("value") && this.option("allowClearing")) {
@@ -303,6 +300,18 @@ var SelectBox = DropDownList.inherit({
 
     _popupWrapperClass: function() {
         return this.callBase() + " " + SELECTBOX_POPUP_WRAPPER_CLASS;
+    },
+
+    _cancelEditing: function() {
+        if(!this.option("searchEnabled") && this._list) {
+            this._focusListElement(null);
+            this._updateField(this.option("selectedItem"));
+        }
+    },
+
+    _closeOutsideDropDownHandler: function(e) {
+        this.callBase(e);
+        this._cancelEditing();
     },
 
     _renderOpenedState: function() {

--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -310,8 +310,8 @@ var SelectBox = DropDownList.inherit({
     },
 
     _closeOutsideDropDownHandler: function(e) {
-        this.callBase(e);
         this._cancelEditing();
+        return this.callBase(e);
     },
 
     _renderOpenedState: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -1540,6 +1540,38 @@ QUnit.test("Enter key press prevent default when popup is opened or acceptCustom
     assert.equal(prevented, 1, "defaults prevented on enter key when acceptCustomValue is true");
 });
 
+QUnit.test("selectBox should restore old value after outside click if custom value is accepted", function(assert) {
+    var $element = $("#selectBox").dxSelectBox({
+            items: ["item 1", "item 2"],
+            value: "item 1",
+            acceptCustomValue: true,
+            opened: true
+        }),
+        $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS)),
+        keyboard = keyboardMock($input);
+
+    keyboard.press("down");
+    $(document).trigger("dxpointerdown");
+
+    assert.equal($input.val(), "item 1", "value has been reverted");
+});
+
+QUnit.test("selectBox should restore old value after esc if custom value is accepted", function(assert) {
+    var $element = $("#selectBox").dxSelectBox({
+            items: ["item 1", "item 2"],
+            value: "item 1",
+            acceptCustomValue: true,
+            opened: true
+        }),
+        $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS)),
+        keyboard = keyboardMock($input);
+
+    keyboard.press("down");
+    keyboard.press("esc");
+
+    assert.equal($input.val(), "item 1", "value has been reverted");
+});
+
 QUnit.test("list should not be rendered on each open", function(assert) {
     var dataSourceLoadedCount = 0;
     var $selectBox = $("#selectBox").dxSelectBox({


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
