### PR TITLE
 Mark extension widgets and widgets with transluded content

### DIFF
--- a/js/ui/resizable.js
+++ b/js/ui/resizable.js
@@ -43,6 +43,7 @@ var SIDE_BORDER_WIDTH_STYLES = {
 /**
 * @name dxResizable
 * @inherits DOMComponent
+* @hasTranscludedContent
 * @module ui/resizable
 * @export default
 */

--- a/js/ui/scroll_view.js
+++ b/js/ui/scroll_view.js
@@ -3,6 +3,7 @@
 /**
 * @name dxScrollView
 * @inherits dxScrollable
+* @hasTranscludedContent
 * @module ui/scroll_view
 * @export default
 */

--- a/js/ui/validation_group.js
+++ b/js/ui/validation_group.js
@@ -11,6 +11,7 @@ var VALIDATION_ENGINE_CLASS = "dx-validationgroup";
 /**
  * @name dxValidationGroup
  * @inherits DOMComponent
+ * @hasTranscludedContent
  * @module ui/validation_group
  * @export default
  */

--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -16,6 +16,7 @@ var VALIDATOR_CLASS = "dx-validator";
 /**
 * @name dxValidator
 * @inherits DOMComponent
+* @extension
 * @module ui/validator
 * @export default
 */


### PR DESCRIPTION
Use `@extension` doc-comment for components, that should be used as an extension to another DevExtreme widget.
```
$(function() {
    $("#textBox1").dxTextBox({ })
        .dxValidator({
            validationRules: [
                // ...
            ]
        });
});
```

Use `@hasTranscludedContent` doc-comment for components, that have a transcluded content.
```html
<div id="scrollView">
    <span>Some transcluded content<span>    
</div>
```