### PR TITLE
Don't create duplicate items in dxTreeView with search if createChildren is used (T655919)

### DIFF
--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1098,7 +1098,9 @@ var TreeViewBase = HierarchicalCollectionWidget.inherit({
         if(that._useCustomChildrenLoader()) {
             var publicNode = this._dataAdapter.getPublicNode(node);
             return that._loadChildrenByCustomLoader(publicNode).done(function(newItems) {
-                that._appendItems(newItems);
+                if(!that._areNodesExists(newItems)) {
+                    that._appendItems(newItems);
+                }
             });
         }
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/virtualMode.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/virtualMode.js
@@ -1332,6 +1332,26 @@ QUnit.test("arrow should not be rendered for item which is explicitly has 'hasIt
     assert.equal($treeView.find(".dx-treeview-toggle-item-visibility").length, 0, "arrow is not rendered");
 });
 
+QUnit.test("the 'createChildren' callback should not create duplicate items when search is used", function(assert) {
+    var $treeView = $("#treeView").dxTreeView({
+            dataStructure: "plain",
+            searchEnabled: true,
+            createChildren: function(parent) {
+                if(!parent) {
+                    return [{ id: 1, text: "Root", hasItems: true, expanded: true }];
+                } else {
+                    return [{ id: 2, text: "Child", parentId: parent.key, hasItems: false }];
+                }
+            }
+        }),
+        treeView = $treeView.dxTreeView("instance");
+
+    treeView.option("searchValue", "Ro");
+
+    assert.equal($treeView.find(".dx-treeview-item").length, 1, "only one item is rendered");
+    assert.equal($treeView.find(".dx-treeview-toggle-item-visibility").length, 0, "arrow is not rendered");
+});
+
 QUnit.test("the 'createChildren' callback should support native promises", function(assert) {
     var done = assert.async();
     var promise = new Promise(function(resolve) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
