### PR TITLE
Fix syntax of jshint predef

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,9 +17,9 @@
     "-W069": true,
     "-W079": true,
 
-    "predef": [
-        "require",
-        "module",
-        "exports"
-    ]
+    "predef": {
+        "require": true,
+        "module": true,
+        "exports": true
+    }
 }

--- a/testing/.jshintrc
+++ b/testing/.jshintrc
@@ -3,12 +3,12 @@
 
   "multistr": true,
 
-  "predef": [
-    "define",
-    "Promise",
-    "SystemJS",
-    "DevExpress",
-    "QUnit",
-    "sinon"
-  ]
+  "predef": {
+    "define": true,
+    "Promise": true,
+    "SystemJS": true,
+    "DevExpress": true,
+    "QUnit": true,
+    "sinon": true
+  }
 }


### PR DESCRIPTION
Starting with v2.9.6 jshint stopped merging array's values in `.jshint` configuration files