### PR TITLE
Don't close dxSelectBox after the search when focus state is disabled (T659551)

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -756,7 +756,7 @@ var DropDownList = DropDownEditor.inherit({
         var resultAmount = resultItems.length;
         var isMinSearchLengthExceeded = this._needPassDataSourceToList();
 
-        return isMinSearchLengthExceeded && resultAmount;
+        return !!(isMinSearchLengthExceeded && resultAmount);
     },
 
     _clearSearchTimer: function() {

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -756,7 +756,7 @@ var DropDownList = DropDownEditor.inherit({
         var resultAmount = resultItems.length;
         var isMinSearchLengthExceeded = this._needPassDataSourceToList();
 
-        return isMinSearchLengthExceeded && resultAmount && this._hasFocusClass();
+        return isMinSearchLengthExceeded && resultAmount;
     },
 
     _clearSearchTimer: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -2423,6 +2423,21 @@ QUnit.test("Widget should works correctly after setting dataSource to null", fun
     assert.equal($list.dxList("option", "noDataText"), "No data to display", "SelectBox works correctly");
 });
 
+QUnit.test("search should stay opened after the search when focus state is disabled", function(assert) {
+    var $selectBox = $("#selectBox").dxSelectBox({
+            items: ["item 1"],
+            focusStateEnabled: false,
+            searchEnabled: true,
+            searchTimeout: 0
+        }),
+        selectBox = $selectBox.dxSelectBox("instance"),
+        $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)),
+        keyboard = keyboardMock($input);
+
+    keyboard.type("item");
+    assert.ok(selectBox.option("opened"), "selectBox should be opened");
+});
+
 QUnit.testInActiveWindow("Value should be null after input is cleared and enter key is tapped", function(assert) {
     var items = [1, 2],
         $selectBox = $("#selectBox").dxSelectBox({


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
