### PR TITLE
DataGrid: Fix the filter row editor loses its focus when a filter is applied and the filter panel is visible (T657041)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.filter_sync.js
+++ b/js/ui/grid_core/ui.grid_core.filter_sync.js
@@ -103,6 +103,9 @@ var FilterSyncController = modules.Controller.inherit((function() {
         var filterRowOptions,
             selectedFilterOperation = condition && condition[1];
         if(FILTER_ROW_OPERATIONS.indexOf(selectedFilterOperation) >= 0) {
+            if(selectedFilterOperation === column.defaultFilterOperation && !isDefined(column.selectedFilterOperation)) {
+                selectedFilterOperation = column.selectedFilterOperation;
+            }
             filterRowOptions = {
                 filterValue: condition[2],
                 selectedFilterOperation: selectedFilterOperation

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
@@ -117,6 +117,43 @@ QUnit.module("Sync with FilterValue", {
         assert.deepEqual(this.columnsController.columnOption("field", "selectedFilterOperation"), "<>");
     });
 
+    // T657041
+    QUnit.test("selectedFilterOperation is set as undefined if it equals defaultFilterOperation and 'reset' operation is selected", function(assert) {
+        // arrange, act
+        this.setupDataGrid({
+            filterValue: ["field", "=", 2],
+            columns: [{ dataField: "field", dataType: "number" }],
+        });
+
+        // assert
+        assert.deepEqual(this.columnsController.columnOption("field", "filterValue"), 2);
+        assert.deepEqual(this.columnsController.columnOption("field", "selectedFilterOperation"), undefined);
+    });
+
+    QUnit.test("selectedFilterOperation is set if it equals defaultFilterOperation and defaultFilterOperation operation is selected", function(assert) {
+        // arrange, act
+        this.setupDataGrid({
+            filterValue: ["field", "=", 2],
+            columns: [{ dataField: "field", dataType: "number", selectedFilterOperation: "=" }],
+        });
+
+        // assert
+        assert.deepEqual(this.columnsController.columnOption("field", "filterValue"), 2);
+        assert.deepEqual(this.columnsController.columnOption("field", "selectedFilterOperation"), "=");
+    });
+
+    QUnit.test("selectedFilterOperation is set if it does not equal defaultFilterOperation and 'reset' operation is selected", function(assert) {
+        // arrange, act
+        this.setupDataGrid({
+            filterValue: ["field", "<>", 2],
+            columns: [{ dataField: "field", dataType: "number" }],
+        });
+
+        // assert
+        assert.deepEqual(this.columnsController.columnOption("field", "filterValue"), 2);
+        assert.deepEqual(this.columnsController.columnOption("field", "selectedFilterOperation"), "<>");
+    });
+
     QUnit.test("skip header filter for equal operation if it has groupInterval", function(assert) {
         // arrange, act
         this.setupDataGrid({
@@ -128,7 +165,7 @@ QUnit.module("Sync with FilterValue", {
         assert.deepEqual(this.option("filterValue"), ["field", "=", 2]);
         assert.deepEqual(this.columnsController.columnOption("field", "filterValues"), undefined);
         assert.deepEqual(this.columnsController.columnOption("field", "filterValue"), 2);
-        assert.deepEqual(this.columnsController.columnOption("field", "selectedFilterOperation"), "=");
+        assert.deepEqual(this.columnsController.columnOption("field", "selectedFilterOperation"), undefined);
     });
 
     QUnit.test("skip header filter for equal operation if it has dataSource", function(assert) {
@@ -142,7 +179,7 @@ QUnit.module("Sync with FilterValue", {
         assert.deepEqual(this.option("filterValue"), ["field", "=", 2]);
         assert.deepEqual(this.columnsController.columnOption("field", "filterValues"), undefined);
         assert.deepEqual(this.columnsController.columnOption("field", "filterValue"), 2);
-        assert.deepEqual(this.columnsController.columnOption("field", "selectedFilterOperation"), "=");
+        assert.deepEqual(this.columnsController.columnOption("field", "selectedFilterOperation"), undefined);
     });
 
     QUnit.test("sync header filter & filterrow on initialization if filterValue = null", function(assert) {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
