### PR TITLE
Don't trigger native focus on tabs when dxTabPanel is focused (T661209)

### DIFF
--- a/js/ui/tab_panel.js
+++ b/js/ui/tab_panel.js
@@ -381,7 +381,6 @@ var TabPanel = MultiView.inherit({
                 var newItem = value ? this._tabs._itemElements().eq(id) : value;
                 this._setTabsOption("focusedElement", getPublicElement(newItem));
                 this.callBase(args);
-                this._tabs.focus();
                 break;
             case "itemTitleTemplate":
                 this._setTabsOption("itemTemplate", this._getTemplateByOption("itemTitleTemplate"));

--- a/testing/tests/DevExpress.ui.widgets/tabPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabPanel.tests.js
@@ -437,6 +437,17 @@ QUnit.test("focusing empty tab should not cause infinite loop", function(assert)
     tabPanel.focus();
 });
 
+QUnit.test("click on dxTabPanel should not scroll page to the tabs", function(assert) {
+    var $tabPanel = $("<div>").appendTo("#qunit-fixture"),
+        tabPanel = new TabPanel($tabPanel, {
+            items: [{ title: "item 1" }]
+        }),
+        tabNativeFocus = sinon.spy(tabPanel._tabs, "focus");
+
+    $tabPanel.trigger("focusin");
+    assert.equal(tabNativeFocus.callCount, 0, "native focus should not be triggered");
+});
+
 
 QUnit.module("keyboard navigation", {
     beforeEach: function() {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
