### PR TITLE
Template Engine: Use only first child non-executable script tag as a widget template

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -8,7 +8,8 @@
                 require("./ui/widget/ui.template_base").renderedCallbacks,
                 require("./core/guid"),
                 require("./ui/validation_engine"),
-                require("./core/utils/iterator")
+                require("./core/utils/iterator"),
+                require("./core/utils/dom").extractTemplateMarkup
             );
         });
     } else {
@@ -20,10 +21,11 @@
             ui && ui.templateRendered,
             DevExpress.data.Guid,
             DevExpress.validationEngine,
-            DevExpress.utils.iterator
+            DevExpress.utils.iterator,
+            DevExpress.utils.dom.extractTemplateMarkup
         );
     }
-})(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils) {
+})(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils, extractTemplateMarkup) {
     var templateCompiler = createTemplateCompiler();
 
     function createTemplateCompiler() {
@@ -84,21 +86,9 @@
 
     function createTemplateEngine() {
 
-        function outerHtml(element) {
-            element = $(element);
-
-            var templateTag = element.length && element[0].nodeName.toLowerCase();
-            if(templateTag === "script") {
-                return element.html();
-            } else {
-                element = $("<div>").append(element);
-                return element.html();
-            }
-        }
-
         return {
             compile: function(element) {
-                return templateCompiler(outerHtml(element));
+                return templateCompiler(extractTemplateMarkup(element));
             },
             render: function(template, data) {
                 return template(data);

--- a/js/core/utils/dom.js
+++ b/js/core/utils/dom.js
@@ -135,7 +135,7 @@ var extractTemplateMarkup = function(element) {
 
     var templateTag = element.length && element.filter(function isNotExecutableScript() {
         var $node = $(this);
-        return $node.is("script[type]") && !(/\/(java|ecma)script/i.test($node.attr("type")));
+        return $node.is("script[type]") && ($node.attr("type").indexOf("script") < 0);
     });
 
     if(templateTag.length) {

--- a/js/core/utils/dom.js
+++ b/js/core/utils/dom.js
@@ -133,7 +133,11 @@ var createMarkupFromString = function(str) {
 var extractTemplateMarkup = function(element) {
     element = $(element);
 
-    var templateTag = element.length && element.filter("script[type='text/html']");
+    var templateTag = element.length && element.filter(function isNotExecutableScript() {
+        var $node = $(this);
+        return $node.is("script[type]") && !(/\/(java|ecma)script/i.test($node.attr("type")));
+    });
+
     if(templateTag.length) {
         return templateTag.eq(0).html();
     } else {

--- a/js/core/utils/dom.js
+++ b/js/core/utils/dom.js
@@ -130,6 +130,17 @@ var createMarkupFromString = function(str) {
     return tempElement.contents();
 };
 
+var extractTemplateMarkup = function(element) {
+    element = $(element);
+
+    var templateTag = element.length && element.filter("script[type='text/html']");
+    if(templateTag.length) {
+        return templateTag.eq(0).html();
+    } else {
+        element = $("<div>").append(element);
+        return element.html();
+    }
+};
 
 var normalizeTemplateElement = function(element) {
     var $element = isDefined(element) && (element.nodeType || isRenderer(element))
@@ -191,6 +202,7 @@ exports.triggerHidingEvent = triggerVisibilityChangeEvent("dxhiding");
 exports.triggerResizeEvent = triggerVisibilityChangeEvent("dxresize");
 exports.getElementOptions = getElementOptions;
 exports.createComponents = createComponents;
+exports.extractTemplateMarkup = extractTemplateMarkup;
 exports.normalizeTemplateElement = normalizeTemplateElement;
 exports.clearSelection = clearSelection;
 exports.uniqueId = uniqueId;

--- a/js/ui/widget/jquery.template.js
+++ b/js/ui/widget/jquery.template.js
@@ -9,18 +9,6 @@ var registerTemplateEngine = function(name, templateEngine) {
     templateEngines[name] = templateEngine;
 };
 
-var outerHtml = function(element) {
-    element = $(element);
-
-    var templateTag = element.length && element[0].nodeName.toLowerCase();
-    if(templateTag === "script") {
-        return element.html();
-    } else {
-        element = $("<div>").append(element);
-        return element.html();
-    }
-};
-
 registerTemplateEngine("default", {
     compile: (element) => domUtils.normalizeTemplateElement(element),
     render: (template, model, index, transclude) => transclude ? template : template.clone()
@@ -28,7 +16,7 @@ registerTemplateEngine("default", {
 
 registerTemplateEngine("jquery-tmpl", {
     compile: function(element) {
-        return outerHtml(element);
+        return domUtils.extractTemplateMarkup(element);
     },
     render: function(template, data) {
         /* global jQuery */
@@ -40,7 +28,7 @@ registerTemplateEngine("jsrender", {
     compile: function(element) {
         /* global jQuery */
         /* global jsrender */
-        return (jQuery ? jQuery : jsrender).templates(outerHtml(element));
+        return (jQuery ? jQuery : jsrender).templates(domUtils.extractTemplateMarkup(element));
     },
     render: function(template, data) {
         return template.render(data);
@@ -50,7 +38,7 @@ registerTemplateEngine("jsrender", {
 registerTemplateEngine("mustache", {
     compile: function(element) {
         /* global Mustache */
-        return outerHtml(element);
+        return domUtils.extractTemplateMarkup(element);
     },
     render: function(template, data) {
         return Mustache.render(template, data);
@@ -60,7 +48,7 @@ registerTemplateEngine("mustache", {
 registerTemplateEngine("hogan", {
     compile: function(element) {
         /* global Hogan */
-        return Hogan.compile(outerHtml(element));
+        return Hogan.compile(domUtils.extractTemplateMarkup(element));
     },
     render: function(template, data) {
         return template.render(data);
@@ -70,7 +58,7 @@ registerTemplateEngine("hogan", {
 registerTemplateEngine("underscore", {
     compile: function(element) {
         /* global _ */
-        return _.template(outerHtml(element));
+        return _.template(domUtils.extractTemplateMarkup(element));
     },
     render: function(template, data) {
         return template(data);
@@ -80,7 +68,7 @@ registerTemplateEngine("underscore", {
 registerTemplateEngine("handlebars", {
     compile: function(element) {
         /* global Handlebars */
-        return Handlebars.compile(outerHtml(element));
+        return Handlebars.compile(domUtils.extractTemplateMarkup(element));
     },
     render: function(template, data) {
         return template(data);
@@ -90,7 +78,7 @@ registerTemplateEngine("handlebars", {
 registerTemplateEngine("doT", {
     compile: function(element) {
         /* global doT */
-        return doT.template(outerHtml(element));
+        return doT.template(domUtils.extractTemplateMarkup(element));
     },
     render: function(template, data) {
         return template(data);

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -175,7 +175,9 @@
                     <div id="templateContent">\
                         <%= DevExpress.aspnet.renderComponent("dxTextBox", { }, "test-id", { validationGroup: "my-group" }) %>\
                     </div>\
-                    </script>'
+                    </script>\
+                    \
+                    <div id="buttonWithInnerTemplate"><script>// DevExpress.aspnet.setTemplateEngine();</script><script type="text/html">BUTTON_CONTENT</script></div>'
                 );
 
                 if(!window.DevExpress || !window.DevExpress.aspnet) {
@@ -233,6 +235,11 @@
             QUnit.test("Exotic characters in component ID should be escaped (T531137)", function(assert) {
                 var $result = renderTemplate("#templateWithExoticId");
                 assert.ok($result.dxButton("instance"));
+            });
+
+            QUnit.test("Inner template is rendered correctly when another script tags exist", function(assert) {
+                var $buttonElement = $("#buttonWithInnerTemplate").dxButton();
+                assert.equal($buttonElement.text(), "BUTTON_CONTENT");
             });
         }
     );


### PR DESCRIPTION
Fixes widget rendering when it's placed in another widget content, for example:

    @Html.DevExtreme().Popup().Content(@<text>
        @Html.DevExtreme().Button()
    </text>)

See [this client-side example](https://codepen.io/anon/pen/RBPKEO?editors=1000) to reproduce the issue.

