### PR TITLE
More care for OData error.code

### DIFF
--- a/js/data/odata/utils.js
+++ b/js/data/odata/utils.js
@@ -302,8 +302,10 @@ var errorFromResponse = function(obj, textStatus, ajaxOptions) {
         if(httpStatus === 200) {
             httpStatus = 500;
         }
-        if(errorObj.code) {
-            httpStatus = Number(errorObj.code);
+
+        var customCode = Number(errorObj.code);
+        if(isFinite(customCode) && customCode >= 400) {
+            httpStatus = customCode;
         }
     }
 


### PR DESCRIPTION
A follow-up to #5062.

According to [the spec](http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091):

> The value for the code name/value pair is a language-independent string. Its value is a service-defined error code. This code serves as a sub-status for the HTTP error code specified in the response.

However, we've been treating it as a numeric HTTP status override. Not changing this, but adding additional checks to ensure that it's a number and falls in the valid HTTP status range.