### PR TITLE
DataGrid: Fix the Between filter if a column uses calculateCellValue and the dataField property is not defined (T663887)

### DIFF
--- a/js/ui/shared/filtering.js
+++ b/js/ui/shared/filtering.js
@@ -31,22 +31,22 @@ module.exports = (function() {
         });
     };
 
-    var getFilterExpressionByRange = function(filterValue) {
+    var getFilterExpressionByRange = function(filterValue, target) {
         var column = this,
             endFilterValue,
             startFilterExpression,
             endFilterExpression,
-            dataField = column.dataField;
+            selector = getFilterSelector(column, target);
 
         if(Array.isArray(filterValue) && typeUtils.isDefined(filterValue[0]) && typeUtils.isDefined(filterValue[1])) {
-            startFilterExpression = [dataField, ">=", filterValue[0]];
-            endFilterExpression = [dataField, "<=", filterValue[1]];
+            startFilterExpression = [selector, ">=", filterValue[0]];
+            endFilterExpression = [selector, "<=", filterValue[1]];
 
             if(isDateType(column.dataType)) {
                 if(isZeroTime(filterValue[1])) {
                     endFilterValue = new Date(filterValue[1].getTime());
                     endFilterValue.setDate(filterValue[1].getDate() + 1);
-                    endFilterExpression = [dataField, "<", endFilterValue];
+                    endFilterExpression = [selector, "<", endFilterValue];
                 }
             }
 
@@ -152,7 +152,7 @@ module.exports = (function() {
             } else if(dataType === "string" && (!column.lookup || isSearchByDisplayValue)) {
                 filter = [selector, selectedFilterOperation || "contains", filterValue];
             } else if(selectedFilterOperation === "between") {
-                return getFilterExpressionByRange.apply(column, arguments);
+                return getFilterExpressionByRange.apply(column, [filterValue, target]);
             } else if(isDateType(dataType) && typeUtils.isDefined(filterValue)) {
                 return getFilterExpressionForDate.apply(column, arguments);
             } else if(dataType === "number") {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
@@ -2086,6 +2086,31 @@ QUnit.test("Filter by range when column with customizeText and filter value is a
     assert.equal(that.dataController.items().length, 1, "count item");
 });
 
+// T663887
+QUnit.test("Filter by range when column with calculateCellValue and filter value is array", function(assert) {
+    this.options.columns = [{
+        dataType: "date",
+        selectedFilterOperation: "between",
+        allowFiltering: true,
+        filterValue: [new Date(1992, 7, 6), new Date(1992, 7, 8)],
+        calculateCellValue: function(data) {
+            return new Date(data.OrderDate);
+        }
+    }];
+
+    setupDataGridModules(this, ["data", "columns", "filterRow"], {
+        initViews: true
+    });
+
+    // act
+    var filter = this.dataController.getCombinedFilter();
+
+    // assert
+    assert.equal(filter.length, 3, "has filter range content");
+    assert.equal(typeof filter[0][0], "function", "has selector");
+    assert.equal(typeof filter[2][0], "function", "has selector");
+});
+
 QUnit.test("Rows view is not rendered when value is entered to editor of the filter row (applyFilter mode is onClick)", function(assert) {
     // arrange
     var $testElement = $('#container'),


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
