### PR TITLE
DataGrid: Fix syncing of not-equals operation in filter row for column with lookup (T662699) 

### DIFF
--- a/js/ui/grid_core/ui.grid_core.filter_sync.js
+++ b/js/ui/grid_core/ui.grid_core.filter_sync.js
@@ -101,8 +101,11 @@ var FilterSyncController = modules.Controller.inherit((function() {
 
     var updateFilterRowCondition = function(columnsController, column, condition) {
         var filterRowOptions,
-            selectedFilterOperation = condition && condition[1];
-        if(FILTER_ROW_OPERATIONS.indexOf(selectedFilterOperation) >= 0) {
+            selectedFilterOperation = condition && condition[1],
+            filterOperations = column.filterOperations || column.defaultFilterOperations;
+
+        if((!filterOperations || filterOperations.indexOf(selectedFilterOperation) >= 0 || selectedFilterOperation === column.defaultFilterOperation)
+            && FILTER_ROW_OPERATIONS.indexOf(selectedFilterOperation) >= 0) {
             if(selectedFilterOperation === column.defaultFilterOperation && !isDefined(column.selectedFilterOperation)) {
                 selectedFilterOperation = column.selectedFilterOperation;
             }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
@@ -279,6 +279,37 @@ QUnit.module("Sync with FilterValue", {
         // assert
         assert.deepEqual(this.option("filterValue"), [["field", "anyof", ["2", "3"]], "and", ["field2", "=", "1"]]);
     });
+
+    // T662699
+    QUnit.test("filterRow clears value if column.filterOperations do not contain selectedFilterOperation", function(assert) {
+        this.setupDataGrid({
+            columns: [{
+                dataField: "field",
+                dataType: "number",
+                filterOperations: []
+            }],
+            filterValue: ["field", ">", 1]
+        });
+
+        assert.equal(this.columnOption("field", "filterValue"), undefined);
+        assert.equal(this.columnOption("field", "selectedFilterOperation"), undefined);
+    });
+
+    QUnit.test("filterRow does not clear value if selectedFilterOperations equals defaultFilterOperation", function(assert) {
+        this.setupDataGrid({
+            columns: [{
+                dataField: "field",
+                dataType: "number",
+                defaultFilterOperation: "=",
+                selectedFilterOperation: "=",
+                filterOperations: []
+            }],
+            filterValue: ["field", "=", 1]
+        });
+
+        assert.equal(this.columnOption("field", "filterValue"), 1);
+        assert.equal(this.columnOption("field", "selectedFilterOperation"), "=");
+    });
 });
 
 QUnit.module("getCombinedFilter", {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
