### PR TITLE
DataGrid: Call saveEditData manually after set cellValue (T661354) 

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1411,10 +1411,10 @@ var EditingController = modules.ViewController.inherit((function() {
                 that._addEditData(params, options.row);
                 that._updateEditButtons();
 
-                if(options.column.showEditorAlways) {
+                if(options.column.showEditorAlways && !forceUpdateRow) {
                     if(editMode === EDIT_MODE_CELL && options.row && !options.row.inserted) {
                         return that.saveEditData();
-                    } else if(editMode === EDIT_MODE_BATCH && !forceUpdateRow) {
+                    } else if(editMode === EDIT_MODE_BATCH) {
                         columns = that._columnsController.getVisibleColumns();
                         forceUpdateRow = columns.some((column) => column.calculateCellValue !== column.defaultCalculateCellValue);
                     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -5842,7 +5842,9 @@ QUnit.test("repaintRows should be skipped on saving", function(assert) {
     });
 
     // act
-    this.cellValue(0, "selected", true);
+    var checkboxInstance = testElement.find(".dx-checkbox").eq(0).dxCheckBox("instance");
+    checkboxInstance.option("value", true);
+    this.saveEditData();
     this.repaintRows([0]);
 
     // assert
@@ -5853,6 +5855,33 @@ QUnit.test("repaintRows should be skipped on saving", function(assert) {
 
     // assert
     assert.strictEqual(changeCount, 1, "data is changed once");
+});
+
+// T661354
+QUnit.test("saveEditData is not called automatically after call cellValue", function(assert) {
+    var testElement = $('#container'),
+        onRowUpdatingSpy = sinon.spy();
+
+    this.options.editing = {
+        allowUpdating: true,
+        mode: 'cell'
+    };
+
+    this.options.onRowUpdating = onRowUpdatingSpy;
+
+    this.columns.push({ dataField: "selected", dataType: "boolean" });
+
+    this.columnsController.init();
+
+    this.rowsView.render(testElement);
+    this.editingController.optionChanged({ name: "onRowUpdating" });
+
+    this.cellValue(0, "selected", true);
+    this.cellValue(1, "selected", true);
+    assert.strictEqual(onRowUpdatingSpy.callCount, 0);
+
+    this.saveEditData();
+    assert.strictEqual(onRowUpdatingSpy.callCount, 2);
 });
 
 // T607746


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
