### PR TITLE
Introduce QUnit CI mode for gulp & style-compiler

### DIFF
--- a/build/style-compiler/LessAggregation.cs
+++ b/build/style-compiler/LessAggregation.cs
@@ -204,14 +204,20 @@ namespace StyleCompiler
 
             if (distribution.SupportedThemes != null)
             {
+                var singleSchemeMode = Utils.IsQUnitCI();
+
                 foreach (var themeName in distribution.SupportedThemes)
                 {
                     var theme = LessRegistry.KnownThemeMap[themeName];
+                    var schemes = from colorSchemeName in theme.ColorSchemeNames
+                                  from sizeSchemeName in EnumerateSizeSchemes(distributionName, themeName)
+                                  select (colorSchemeName, sizeSchemeName);
 
-                    foreach (var colorSchemeName in theme.ColorSchemeNames)
+                    foreach (var s in schemes)
                     {
-                        foreach (var sizeSchemeName in EnumerateSizeSchemes(distributionName, themeName))
-                            yield return CreateThemeItem(sourcePath, distributionName, theme, colorSchemeName, sizeSchemeName);
+                        yield return CreateThemeItem(sourcePath, distributionName, theme, s.colorSchemeName, s.sizeSchemeName);
+                        if (singleSchemeMode)
+                            break;
                     }
                 }
             }

--- a/build/style-compiler/Utils.cs
+++ b/build/style-compiler/Utils.cs
@@ -54,5 +54,9 @@ namespace StyleCompiler
         {
             return !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEVEXTREME_DOCKER_CI"));
         }
+
+        public static bool IsQUnitCI() {
+            return !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEVEXTREME_QUNIT_CI"));
+        }
     }
 }

--- a/build/style-compiler/style-compiler.csproj
+++ b/build/style-compiler/style-compiler.csproj
@@ -19,6 +19,7 @@
     <OutputPath>bin/</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>portable</DebugType>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -5,6 +5,7 @@
 trap "echo 'Interrupted!' && kill -9 0" TERM INT
 
 export DEVEXTREME_DOCKER_CI=true
+export DEVEXTREME_QUNIT_CI=true
 export NUGET_PACKAGES=$PWD/dotnet_packages
 
 function run_lint {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+/* eslint-disable no-console */
 
 var gulp = require('gulp');
 var os = require('os');
@@ -27,7 +28,7 @@ require('./build/gulp/style-compiler');
 require('./build/gulp/transpile');
 
 
-gulp.task('default', function(callback) {
+function gulpDefault(callback) {
     runSequence(
         'clean',
         'localization',
@@ -46,7 +47,27 @@ gulp.task('default', function(callback) {
         'themebuilder-npm',
         'style-compiler-generic-legacy',
         callback);
-});
+}
+
+function gulpDefault_QUnitCI(callback) {
+    runSequence(
+        'clean',
+        'localization',
+        [
+            'js-bundles-debug',
+            'vectormap',
+            'vendor'
+        ],
+        'style-compiler-themes',
+        callback);
+}
+
+if(process.env['DEVEXTREME_QUNIT_CI']) {
+    console.warn("Using QUnit CI mode for gulp default!");
+    gulp.task('default', gulpDefault_QUnitCI);
+} else {
+    gulp.task('default', gulpDefault);
+}
 
 gulp.task('dev', function(callback) {
     runSequence('bundler-config-dev', ['js-bundles-dev', 'style-compiler-themes-dev'], callback);


### PR DESCRIPTION
Closes #5162

To enable on the B-farm, we'll need to set `DEVEXTREME_QUNIT_CI` in DXBuild.QUnit.Build.xml