### PR TITLE
Fix multi-slot transclusion in AngularJS templates

### DIFF
--- a/js/integration/angular/component_registrator.js
+++ b/js/integration/angular/component_registrator.js
@@ -1,35 +1,36 @@
-var $ = require("../../core/renderer"),
-    eventsEngine = require("../../events/core/events_engine"),
-    Config = require("../../core/config"),
-    registerComponentCallbacks = require("../../core/component_registrator_callbacks"),
-    Class = require("../../core/class"),
-    Callbacks = require("../../core/utils/callbacks"),
-    typeUtils = require("../../core/utils/type"),
-    each = require("../../core/utils/iterator").each,
-    inArray = require("../../core/utils/array").inArray,
-    Locker = require("../../core/utils/locker"),
-    Widget = require("../../ui/widget/ui.widget"),
-    Editor = require("../../ui/editor/editor"),
-    NgTemplate = require("./template"),
-    ngModule = require("./module"),
-    CollectionWidget = require("../../ui/collection/ui.collection_widget.edit"),
-    compileSetter = require("../../core/utils/data").compileSetter,
-    compileGetter = require("../../core/utils/data").compileGetter,
-    extendFromObject = require("../../core/utils/extend").extendFromObject,
-    inflector = require("../../core/utils/inflector"),
-    errors = require("../../core/errors");
+import $ from "../../core/renderer";
+import eventsEngine from "../../events/core/events_engine";
+import Config from "../../core/config";
+import registerComponentCallbacks from "../../core/component_registrator_callbacks";
+import Class from "../../core/class";
+import Callbacks from "../../core/utils/callbacks";
+import typeUtils from "../../core/utils/type";
+import iterator from "../../core/utils/iterator";
+const each = iterator.each;
+import arrayUtils from "../../core/utils/array";
+const inArray = arrayUtils.inArray;
+import Locker from "../../core/utils/locker";
+import Widget from "../../ui/widget/ui.widget";
+import Editor from "../../ui/editor/editor";
+import NgTemplate from "./template";
+import ngModule from "./module";
+import CollectionWidget from "../../ui/collection/ui.collection_widget.edit";
+import dataUtils from "../../core/utils/data";
+const compileSetter = dataUtils.compileSetter;
+const compileGetter = dataUtils.compileGetter;
+import extendUtils from "../../core/utils/extend";
+const extendFromObject = extendUtils.extendFromObject;
+import inflector from "../../core/utils/inflector";
+import errors from "../../core/errors";
+const ITEM_ALIAS_ATTRIBUTE_NAME = "dxItemAlias";
+const SKIP_APPLY_ACTION_CATEGORIES = ["rendering"];
+const NG_MODEL_OPTION = "value";
 
-var ITEM_ALIAS_ATTRIBUTE_NAME = "dxItemAlias",
-    SKIP_APPLY_ACTION_CATEGORIES = ["rendering"],
-    NG_MODEL_OPTION = "value";
-
-var safeApply = function(func, scope) {
+const safeApply = (func, scope) => {
     if(scope.$root.$$phase) {
         return func(scope);
     } else {
-        return scope.$apply(function() {
-            return func(scope);
-        });
+        return scope.$apply(() => func(scope));
     }
 };
 
@@ -39,9 +40,9 @@ var safeApply = function(func, scope) {
  * @default {}
  */
 
-var ComponentBuilder = Class.inherit({
+let ComponentBuilder = Class.inherit({
 
-    ctor: function(options) {
+    ctor(options) {
         this._componentDisposing = Callbacks();
         this._optionChangedCallbacks = Callbacks();
         this._ngLocker = new Locker();
@@ -66,88 +67,82 @@ var ComponentBuilder = Class.inherit({
         }
     },
 
-    _addOptionsStringWatcher: function(optionsString) {
-        var that = this;
-
-        var clearOptionsStringWatcher = that._scope.$watch(optionsString, function(newOptions) {
+    _addOptionsStringWatcher(optionsString) {
+        const clearOptionsStringWatcher = this._scope.$watch(optionsString, newOptions => {
             if(!newOptions) {
                 return;
             }
 
             clearOptionsStringWatcher();
 
-            that._normalizeOptions(newOptions);
+            this._normalizeOptions(newOptions);
 
-            that._initComponentBindings();
-            that._component.option(that._evalOptions(that._scope));
+            this._initComponentBindings();
+            this._component.option(this._evalOptions(this._scope));
         });
 
-        that._componentDisposing.add(clearOptionsStringWatcher);
+        this._componentDisposing.add(clearOptionsStringWatcher);
     },
 
-    _normalizeOptions: function(options) {
-        var that = this;
-
-        that._ngOptions = extendFromObject({}, options);
+    _normalizeOptions(options) {
+        this._ngOptions = extendFromObject({}, options);
 
         if(!options) {
             return;
         }
 
         if(!options.hasOwnProperty('bindingOptions') && options.bindingOptions) {
-            that._ngOptions.bindingOptions = options.bindingOptions;
+            this._ngOptions.bindingOptions = options.bindingOptions;
         }
 
         if(options.bindingOptions) {
-            each(options.bindingOptions, function(key, value) {
+            each(options.bindingOptions, (key, value) => {
                 if(typeUtils.type(value) === 'string') {
-                    that._ngOptions.bindingOptions[key] = { dataPath: value };
+                    this._ngOptions.bindingOptions[key] = { dataPath: value };
                 }
             });
         }
     },
 
-    _initComponent: function(scope) {
+    _initComponent(scope) {
         this._component = new this._componentClass(this._$element, this._evalOptions(scope));
         this._component._isHidden = true;
         this._handleDigestPhase();
     },
 
-    _handleDigestPhase: function() {
-        var that = this,
-            beginUpdate = function() {
-                that._component.beginUpdate();
-            },
-            endUpdate = function() {
-                that._component.endUpdate();
-            };
+    _handleDigestPhase() {
+        const beginUpdate = () => {
+            this._component.beginUpdate();
+        };
 
-        that._digestCallbacks.begin.add(beginUpdate);
-        that._digestCallbacks.end.add(endUpdate);
+        const endUpdate = () => {
+            this._component.endUpdate();
+        };
 
-        that._componentDisposing.add(function() {
-            that._digestCallbacks.begin.remove(beginUpdate);
-            that._digestCallbacks.end.remove(endUpdate);
+        this._digestCallbacks.begin.add(beginUpdate);
+        this._digestCallbacks.end.add(endUpdate);
+
+        this._componentDisposing.add(() => {
+            this._digestCallbacks.begin.remove(beginUpdate);
+            this._digestCallbacks.end.remove(endUpdate);
         });
-
     },
 
-    _initComponentBindings: function() {
-        var that = this,
-            optionDependencies = {};
+    _initComponentBindings() {
+        const optionDependencies = {};
 
-        if(!that._ngOptions.bindingOptions) {
+        if(!this._ngOptions.bindingOptions) {
             return;
         }
 
-        each(that._ngOptions.bindingOptions, function(optionPath, value) {
-            var separatorIndex = optionPath.search(/\[|\./),
-                optionForSubscribe = separatorIndex > -1 ? optionPath.substring(0, separatorIndex) : optionPath,
-                prevWatchMethod,
-                clearWatcher,
-                valuePath = value.dataPath,
-                deepWatch = true,
-                forcePlainWatchMethod = false;
+        each(this._ngOptions.bindingOptions, (optionPath, value) => {
+            const separatorIndex = optionPath.search(/\[|\./);
+            const optionForSubscribe = separatorIndex > -1 ? optionPath.substring(0, separatorIndex) : optionPath;
+            let prevWatchMethod;
+            let clearWatcher;
+            const valuePath = value.dataPath;
+            let deepWatch = true;
+            let forcePlainWatchMethod = false;
 
             if(value.deep !== undefined) {
                 forcePlainWatchMethod = deepWatch = !!value.deep;
@@ -159,44 +154,44 @@ var ComponentBuilder = Class.inherit({
 
             optionDependencies[optionForSubscribe][optionPath] = valuePath;
 
-            var watchCallback = function(newValue, oldValue) {
-                if(that._ngLocker.locked(optionPath)) {
+            const watchCallback = (newValue, oldValue) => {
+                if(this._ngLocker.locked(optionPath)) {
                     return;
                 }
 
-                that._ngLocker.obtain(optionPath);
-                that._component.option(optionPath, newValue);
+                this._ngLocker.obtain(optionPath);
+                this._component.option(optionPath, newValue);
                 updateWatcher();
 
-                if(that._component._optionValuesEqual(optionPath, oldValue, newValue) && that._ngLocker.locked(optionPath)) {
-                    that._ngLocker.release(optionPath);
+                if(this._component._optionValuesEqual(optionPath, oldValue, newValue) && this._ngLocker.locked(optionPath)) {
+                    this._ngLocker.release(optionPath);
                 }
             };
 
-            var updateWatcher = function() {
-                var watchMethod = Array.isArray(that._scope.$eval(valuePath)) && !forcePlainWatchMethod ? "$watchCollection" : "$watch";
+            var updateWatcher = () => {
+                const watchMethod = Array.isArray(this._scope.$eval(valuePath)) && !forcePlainWatchMethod ? "$watchCollection" : "$watch";
 
                 if(prevWatchMethod !== watchMethod) {
                     if(clearWatcher) {
                         clearWatcher();
                     }
-                    clearWatcher = that._scope[watchMethod](valuePath, watchCallback, deepWatch);
+                    clearWatcher = this._scope[watchMethod](valuePath, watchCallback, deepWatch);
                     prevWatchMethod = watchMethod;
                 }
             };
 
             updateWatcher();
 
-            that._componentDisposing.add(clearWatcher);
+            this._componentDisposing.add(clearWatcher);
         });
 
-        that._optionChangedCallbacks.add(function(args) {
-            var optionName = args.name,
-                fullName = args.fullName,
-                component = args.component;
+        this._optionChangedCallbacks.add(args => {
+            const optionName = args.name;
+            const fullName = args.fullName;
+            const component = args.component;
 
-            if(that._ngLocker.locked(fullName)) {
-                that._ngLocker.release(fullName);
+            if(this._ngLocker.locked(fullName)) {
+                this._ngLocker.release(fullName);
                 return;
             }
 
@@ -204,55 +199,55 @@ var ComponentBuilder = Class.inherit({
                 return;
             }
 
-            var isActivePhase = that._scope.$root.$$phase;
-            var obtainOption = function() {
-                that._ngLocker.obtain(fullName);
+            const isActivePhase = this._scope.$root.$$phase;
+            const obtainOption = () => {
+                this._ngLocker.obtain(fullName);
             };
 
             if(isActivePhase) {
-                that._digestCallbacks.begin.add(obtainOption);
+                this._digestCallbacks.begin.add(obtainOption);
             } else {
                 obtainOption();
             }
 
-            safeApply(function() {
-                each(optionDependencies[optionName], function(optionPath, valuePath) {
-                    if(!that._optionsAreLinked(fullName, optionPath)) {
+            safeApply(() => {
+                each(optionDependencies[optionName], (optionPath, valuePath) => {
+                    if(!this._optionsAreLinked(fullName, optionPath)) {
                         return;
                     }
 
-                    var value = component.option(optionPath);
-                    that._parse(valuePath).assign(that._scope, value);
+                    const value = component.option(optionPath);
+                    this._parse(valuePath).assign(this._scope, value);
 
-                    var scopeValue = that._parse(valuePath)(that._scope);
+                    const scopeValue = this._parse(valuePath)(this._scope);
                     if(scopeValue !== value) {
                         args.component.option(optionPath, scopeValue);
                     }
                 });
-            }, that._scope);
+            }, this._scope);
 
-            var releaseOption = function() {
-                if(that._ngLocker.locked(fullName)) {
-                    that._ngLocker.release(fullName);
+            const releaseOption = () => {
+                if(this._ngLocker.locked(fullName)) {
+                    this._ngLocker.release(fullName);
                 }
-                that._digestCallbacks.begin.remove(obtainOption);
-                that._digestCallbacks.end.remove(releaseOption);
+                this._digestCallbacks.begin.remove(obtainOption);
+                this._digestCallbacks.end.remove(releaseOption);
             };
 
             if(isActivePhase) {
-                that._digestCallbacks.end.addPrioritized(releaseOption);
+                this._digestCallbacks.end.addPrioritized(releaseOption);
             } else {
                 releaseOption();
             }
         });
     },
 
-    _optionsAreNested: function(optionPath1, optionPath2) {
-        var parentSeparator = optionPath1[optionPath2.length];
+    _optionsAreNested(optionPath1, optionPath2) {
+        const parentSeparator = optionPath1[optionPath2.length];
         return optionPath1.indexOf(optionPath2) === 0 && (parentSeparator === "." || parentSeparator === "[");
     },
 
-    _optionsAreLinked: function(optionPath1, optionPath2) {
+    _optionsAreLinked(optionPath1, optionPath2) {
         if(optionPath1 === optionPath2) return true;
 
         return optionPath1.length > optionPath2.length
@@ -260,24 +255,23 @@ var ComponentBuilder = Class.inherit({
             : this._optionsAreNested(optionPath2, optionPath1);
     },
 
-    _compilerByTemplate: function(template) {
-        var that = this,
-            scopeItemsPath = this._getScopeItemsPath();
+    _compilerByTemplate(template) {
+        const scopeItemsPath = this._getScopeItemsPath();
 
-        return function(options) {
-            var $resultMarkup = $(template).clone(),
-                dataIsScope = options.model && options.model.constructor === that._scope.$root.constructor,
-                templateScope = dataIsScope ? options.model : (options.noModel ? that._scope : that._createScopeWithData(options));
+        return options => {
+            const $resultMarkup = $(template).clone();
+            const dataIsScope = options.model && options.model.constructor === this._scope.$root.constructor;
+            const templateScope = dataIsScope ? options.model : (options.noModel ? this._scope : this._createScopeWithData(options));
 
             if(scopeItemsPath) {
-                that._synchronizeScopes(templateScope, scopeItemsPath, options.index);
+                this._synchronizeScopes(templateScope, scopeItemsPath, options.index);
             }
 
             $resultMarkup.appendTo(options.container);
 
             if(!options.noModel) {
-                eventsEngine.on($resultMarkup, "$destroy", function() {
-                    var destroyAlreadyCalled = !templateScope.$parent;
+                eventsEngine.on($resultMarkup, "$destroy", () => {
+                    const destroyAlreadyCalled = !templateScope.$parent;
 
                     if(destroyAlreadyCalled) {
                         return;
@@ -287,37 +281,35 @@ var ComponentBuilder = Class.inherit({
                 });
             }
 
-            that._applyAsync(that._compile($resultMarkup, that._transcludeFn), templateScope);
+            this._applyAsync(this._compile($resultMarkup, this._transcludeFn), templateScope);
 
             return $resultMarkup;
         };
     },
 
-    _applyAsync: function(func, scope) {
-        var that = this;
-
+    _applyAsync(func, scope) {
         func(scope);
         if(!scope.$root.$$phase) {
-            if(!that._renderingTimer) {
-                that._renderingTimer = setTimeout(function() {
+            if(!this._renderingTimer) {
+                this._renderingTimer = setTimeout(() => {
                     scope.$apply();
-                    that._renderingTimer = null;
+                    this._renderingTimer = null;
                 });
             }
-            that._componentDisposing.add(function() {
-                clearTimeout(that._renderingTimer);
+            this._componentDisposing.add(() => {
+                clearTimeout(this._renderingTimer);
             });
         }
     },
 
-    _getScopeItemsPath: function() {
+    _getScopeItemsPath() {
         if(this._componentClass.subclassOf(CollectionWidget) && this._ngOptions.bindingOptions && this._ngOptions.bindingOptions.items) {
             return this._ngOptions.bindingOptions.items.dataPath;
         }
     },
 
-    _createScopeWithData: function(options) {
-        var newScope = this._scope.$new();
+    _createScopeWithData(options) {
+        const newScope = this._scope.$new();
 
         if(this._itemAlias) {
             newScope[this._itemAlias] = options.model;
@@ -330,29 +322,28 @@ var ComponentBuilder = Class.inherit({
         return newScope;
     },
 
-    _synchronizeScopes: function(itemScope, parentPrefix, itemIndex) {
+    _synchronizeScopes(itemScope, parentPrefix, itemIndex) {
         if(this._itemAlias && typeof (itemScope[this._itemAlias]) !== "object") {
             this._synchronizeScopeField({
                 parentScope: this._scope,
                 childScope: itemScope,
                 fieldPath: this._itemAlias,
-                parentPrefix: parentPrefix,
-                itemIndex: itemIndex
+                parentPrefix,
+                itemIndex
             });
         }
     },
 
-    _synchronizeScopeField: function(args) {
-        var parentScope = args.parentScope,
-            childScope = args.childScope,
-            fieldPath = args.fieldPath,
-            parentPrefix = args.parentPrefix,
-            itemIndex = args.itemIndex;
-
-        var innerPathSuffix = fieldPath === this._itemAlias ? "" : "." + fieldPath,
-            collectionField = itemIndex !== undefined,
-            optionOuterBag = [parentPrefix],
-            optionOuterPath;
+    _synchronizeScopeField(args) {
+        const parentScope = args.parentScope;
+        const childScope = args.childScope;
+        const fieldPath = args.fieldPath;
+        const parentPrefix = args.parentPrefix;
+        const itemIndex = args.itemIndex;
+        const innerPathSuffix = fieldPath === this._itemAlias ? "" : "." + fieldPath;
+        const collectionField = itemIndex !== undefined;
+        const optionOuterBag = [parentPrefix];
+        let optionOuterPath;
 
         if(collectionField) {
             if(!typeUtils.isNumeric(itemIndex)) return;
@@ -363,13 +354,13 @@ var ComponentBuilder = Class.inherit({
         optionOuterBag.push(innerPathSuffix);
         optionOuterPath = optionOuterBag.join("");
 
-        var clearParentWatcher = parentScope.$watch(optionOuterPath, function(newValue, oldValue) {
+        const clearParentWatcher = parentScope.$watch(optionOuterPath, (newValue, oldValue) => {
             if(newValue !== oldValue) {
                 compileSetter(fieldPath)(childScope, newValue);
             }
         });
 
-        var clearItemWatcher = childScope.$watch(fieldPath, function(newValue, oldValue) {
+        const clearItemWatcher = childScope.$watch(fieldPath, (newValue, oldValue) => {
             if(newValue !== oldValue) {
                 if(collectionField && !compileGetter(parentPrefix)(parentScope)[itemIndex]) {
                     clearItemWatcher();
@@ -382,76 +373,69 @@ var ComponentBuilder = Class.inherit({
         this._componentDisposing.add([clearParentWatcher, clearItemWatcher]); // TODO: test
     },
 
-    _evalOptions: function(scope) {
-        var result = extendFromObject({}, this._ngOptions);
+    _evalOptions(scope) {
+        const result = extendFromObject({}, this._ngOptions);
 
         delete result.bindingOptions;
 
         if(this._ngOptions.bindingOptions) {
-            each(this._ngOptions.bindingOptions, function(key, value) {
+            each(this._ngOptions.bindingOptions, (key, value) => {
                 result[key] = scope.$eval(value.dataPath);
             });
         }
 
         result._optionChangedCallbacks = this._optionChangedCallbacks;
         result._disposingCallbacks = this._componentDisposing;
-        result.onActionCreated = function(component, action, config) {
+        result.onActionCreated = (component, action, config) => {
             if(config && inArray(config.category, SKIP_APPLY_ACTION_CATEGORIES) > -1) {
                 return action;
             }
 
-            var wrappedAction = function() {
-                var that = this,
-                    args = arguments;
+            const wrappedAction = function() {
+                const args = arguments;
 
                 if(!scope || !scope.$root || scope.$root.$$phase) {
-                    return action.apply(that, args);
+                    return action.apply(this, args);
                 }
 
-                return safeApply(function() {
-                    return action.apply(that, args);
-                }, scope);
+                return safeApply(() => action.apply(this, args), scope);
             };
 
             return wrappedAction;
         };
         result.beforeActionExecute = result.onActionCreated;
-        result.nestedComponentOptions = function(component) {
-            return {
-                templatesRenderAsynchronously: component.option("templatesRenderAsynchronously"),
-                forceApplyBindings: component.option("forceApplyBindings"),
-                modelByElement: component.option("modelByElement"),
-                onActionCreated: component.option("onActionCreated"),
-                beforeActionExecute: component.option("beforeActionExecute"),
-                nestedComponentOptions: component.option("nestedComponentOptions")
-            };
-        };
+        result.nestedComponentOptions = component => ({
+            templatesRenderAsynchronously: component.option("templatesRenderAsynchronously"),
+            forceApplyBindings: component.option("forceApplyBindings"),
+            modelByElement: component.option("modelByElement"),
+            onActionCreated: component.option("onActionCreated"),
+            beforeActionExecute: component.option("beforeActionExecute"),
+            nestedComponentOptions: component.option("nestedComponentOptions")
+        });
 
         result.templatesRenderAsynchronously = true;
 
         if(Config().wrapActionsBeforeExecute) {
-            result.forceApplyBindings = function() {
-                safeApply(function() {}, scope);
+            result.forceApplyBindings = () => {
+                safeApply(() => {}, scope);
             };
         }
 
         result.integrationOptions = {
-            createTemplate: function(element) {
-                return new NgTemplate(element, this._compilerByTemplate.bind(this));
-            }.bind(this),
-            watchMethod: function(fn, callback, options) {
+            createTemplate: element => new NgTemplate(element, this._compilerByTemplate.bind(this)),
+            watchMethod: (fn, callback, options) => {
                 options = options || {};
 
-                var immediateValue;
-                var skipCallback = options.skipImmediate;
-                var disposeWatcher = scope.$watch(function() {
-                    var value = fn();
+                let immediateValue;
+                let skipCallback = options.skipImmediate;
+                const disposeWatcher = scope.$watch(() => {
+                    let value = fn();
                     if(value instanceof Date) {
                         value = value.valueOf();
                     }
                     return value;
-                }, function(newValue) {
-                    var isSameValue = immediateValue === newValue;
+                }, newValue => {
+                    const isSameValue = immediateValue === newValue;
                     if(!skipCallback && (!isSameValue || isSameValue && options.deep)) {
                         callback(newValue);
                     }
@@ -464,40 +448,38 @@ var ComponentBuilder = Class.inherit({
                 }
 
                 if(Config().wrapActionsBeforeExecute) {
-                    this._applyAsync(function() {}, scope);
+                    this._applyAsync(() => {}, scope);
                 }
 
                 return disposeWatcher;
-            }.bind(this),
+            },
             templates: {
                 "dx-polymorph-widget": {
-                    render: function(options) {
-                        var widgetName = options.model.widget;
+                    render: options => {
+                        let widgetName = options.model.widget;
                         if(!widgetName) {
                             return;
                         }
 
                         if(widgetName === "button" || widgetName === "tabs" || widgetName === "dropDownMenu") {
-                            var deprecatedName = widgetName;
+                            const deprecatedName = widgetName;
                             widgetName = inflector.camelize("dx-" + widgetName);
                             errors.log("W0001", "dxToolbar - 'widget' item field", deprecatedName, "16.1", "Use: '" + widgetName + "' instead");
                         }
 
-                        var markup = $("<div>").attr(inflector.dasherize(widgetName), "options").get(0);
+                        const markup = $("<div>").attr(inflector.dasherize(widgetName), "options").get(0);
 
-                        var newScope = this._scope.$new();
+                        const newScope = this._scope.$new();
                         newScope.options = options.model.options;
 
                         options.container.append(markup);
                         this._compile(markup)(newScope);
-                    }.bind(this)
+                    }
                 }
             }
         };
 
-        result.modelByElement = function() {
-            return scope;
-        };
+        result.modelByElement = () => scope;
 
         return result;
     }
@@ -505,33 +487,31 @@ var ComponentBuilder = Class.inherit({
 
 ComponentBuilder = ComponentBuilder.inherit({
 
-    ctor: function(options) {
+    ctor(options) {
         this._componentName = options.componentName;
         this._ngModel = options.ngModel;
         this._ngModelController = options.ngModelController;
 
-        this.callBase.apply(this, arguments);
+        this.callBase(...arguments);
     },
 
-    _isNgModelRequired: function() {
+    _isNgModelRequired() {
         return this._componentClass.subclassOf(Editor) && this._ngModel;
     },
 
-    _initComponentBindings: function() {
-        this.callBase.apply(this, arguments);
+    _initComponentBindings(...args) {
+        this.callBase(...args);
 
         this._initNgModelBinding();
     },
 
-    _initNgModelBinding: function() {
+    _initNgModelBinding() {
         if(!this._isNgModelRequired()) {
             return;
         }
 
-        var that = this;
-
-        var clearNgModelWatcher = this._scope.$watch(this._ngModel, function(newValue, oldValue) {
-            if(that._ngLocker.locked(NG_MODEL_OPTION)) {
+        const clearNgModelWatcher = this._scope.$watch(this._ngModel, (newValue, oldValue) => {
+            if(this._ngLocker.locked(NG_MODEL_OPTION)) {
                 return;
             }
 
@@ -539,20 +519,20 @@ ComponentBuilder = ComponentBuilder.inherit({
                 return;
             }
 
-            that._component.option(NG_MODEL_OPTION, newValue);
+            this._component.option(NG_MODEL_OPTION, newValue);
         });
 
-        that._optionChangedCallbacks.add(function(args) {
-            that._ngLocker.obtain(NG_MODEL_OPTION);
+        this._optionChangedCallbacks.add(args => {
+            this._ngLocker.obtain(NG_MODEL_OPTION);
             try {
                 if(args.name !== NG_MODEL_OPTION) {
                     return;
                 }
 
-                that._ngModelController.$setViewValue(args.value);
+                this._ngModelController.$setViewValue(args.value);
             } finally {
-                if(that._ngLocker.locked(NG_MODEL_OPTION)) {
-                    that._ngLocker.release(NG_MODEL_OPTION);
+                if(this._ngLocker.locked(NG_MODEL_OPTION)) {
+                    this._ngLocker.release(NG_MODEL_OPTION);
                 }
             }
         });
@@ -560,58 +540,56 @@ ComponentBuilder = ComponentBuilder.inherit({
         this._componentDisposing.add(clearNgModelWatcher);
     },
 
-    _evalOptions: function() {
+    _evalOptions(...args) {
         if(!this._isNgModelRequired()) {
-            return this.callBase.apply(this, arguments);
+            return this.callBase(...args);
         }
 
-        var result = this.callBase.apply(this, arguments);
+        const result = this.callBase(...args);
         result[NG_MODEL_OPTION] = this._parse(this._ngModel)(this._scope);
         return result;
     }
-
 });
 
-var registeredComponents = {};
+const registeredComponents = {};
 
-var registerComponentDirective = function(name) {
-    var priority = name !== "dxValidator" ? 1 : 10;
-    ngModule.directive(name, ["$compile", "$parse", "dxDigestCallbacks", function($compile, $parse, dxDigestCallbacks) {
-        return {
-            restrict: "A",
-            require: "^?ngModel",
-            priority: priority,
-            compile: function($element) {
-                var componentClass = registeredComponents[name],
-                    $content = componentClass.subclassOf(Widget) ? $element.contents().detach() : null;
+const registerComponentDirective = name => {
+    const priority = name !== "dxValidator" ? 1 : 10;
+    ngModule.directive(name, ["$compile", "$parse", "dxDigestCallbacks", ($compile, $parse, dxDigestCallbacks) => ({
+        restrict: "A",
+        require: "^?ngModel",
+        priority,
 
-                return function(scope, $element, attrs, ngModelController, transcludeFn) {
-                    $element.append($content);
+        compile($element) {
+            const componentClass = registeredComponents[name];
+            const $content = componentClass.subclassOf(Widget) ? $element.contents().detach() : null;
 
-                    safeApply(function() {
-                        new ComponentBuilder({
-                            componentClass: componentClass,
-                            componentName: name,
-                            compile: $compile,
-                            parse: $parse,
-                            $element: $element,
-                            scope: scope,
-                            ngOptionsString: attrs[name],
-                            ngOptions: attrs[name] ? scope.$eval(attrs[name]) : {},
-                            ngModel: attrs.ngModel,
-                            ngModelController: ngModelController,
-                            transcludeFn: transcludeFn,
-                            itemAlias: attrs[ITEM_ALIAS_ATTRIBUTE_NAME],
-                            dxDigestCallbacks: dxDigestCallbacks
-                        });
-                    }, scope);
-                };
-            }
-        };
-    }]);
+            return (scope, $element, attrs, ngModelController, transcludeFn) => {
+                $element.append($content);
+
+                safeApply(() => {
+                    new ComponentBuilder({
+                        componentClass,
+                        componentName: name,
+                        compile: $compile,
+                        parse: $parse,
+                        $element,
+                        scope,
+                        ngOptionsString: attrs[name],
+                        ngOptions: attrs[name] ? scope.$eval(attrs[name]) : {},
+                        ngModel: attrs.ngModel,
+                        ngModelController,
+                        transcludeFn,
+                        itemAlias: attrs[ITEM_ALIAS_ATTRIBUTE_NAME],
+                        dxDigestCallbacks
+                    });
+                }, scope);
+            };
+        }
+    })]);
 };
 
-registerComponentCallbacks.add(function(name, componentClass) {
+registerComponentCallbacks.add((name, componentClass) => {
 
     if(!registeredComponents[name]) {
         registerComponentDirective(name);

--- a/js/integration/angular/component_registrator.js
+++ b/js/integration/angular/component_registrator.js
@@ -281,7 +281,10 @@ let ComponentBuilder = Class.inherit({
                 });
             }
 
-            this._applyAsync(this._compile($resultMarkup, this._transcludeFn), templateScope);
+            const ngTemplate = this._compile($resultMarkup, this._transcludeFn);
+            this._applyAsync(scope => {
+                ngTemplate(scope, null, { parentBoundTranscludeFn: this._transcludeFn });
+            }, templateScope);
 
             return $resultMarkup;
         };

--- a/testing/tests/DevExpress.angular/componentRegistration.tests.js
+++ b/testing/tests/DevExpress.angular/componentRegistration.tests.js
@@ -1,37 +1,36 @@
-var $ = require("jquery"),
-    config = require("core/config"),
-    noop = require("core/utils/common").noop,
-    domUtils = require("core/utils/dom"),
-    angular = require("angular"),
-    registerComponent = require("core/component_registrator"),
-    DOMComponent = require("core/dom_component"),
-    Widget = require("ui/widget/ui.widget"),
-    NgTemplate = require("integration/angular/template"),
-    CollectionWidget = require("ui/collection/ui.collection_widget.edit");
+import $ from "jquery";
+import config from "core/config";
+import commonUtils from "core/utils/common";
+const noop = commonUtils.noop;
+import domUtils from "core/utils/dom";
+import angular from "angular";
+import registerComponent from "core/component_registrator";
+import DOMComponent from "core/dom_component";
+import Widget from "ui/widget/ui.widget";
+import NgTemplate from "integration/angular/template";
+import CollectionWidget from "ui/collection/ui.collection_widget.edit";
 
-require("integration/angular");
+import "integration/angular";
 
-require("ui/list");
-require("ui/button");
+import "ui/list";
+import "ui/button";
 
-var FIXTURE_ELEMENT = function() { return $("#qunit-fixture"); };
+const FIXTURE_ELEMENT = () => $("#qunit-fixture");
 
-var ignoreAngularBrowserDeferTimer = function(args) {
-    return args.timerType === "timeouts" && (args.callback.toString().indexOf("delete pendingDeferIds[timeoutId];") > -1 || args.callback.toString().indexOf("delete F[c];e(a)}") > -1);
-};
+const ignoreAngularBrowserDeferTimer = args => args.timerType === "timeouts" && (args.callback.toString().indexOf("delete pendingDeferIds[timeoutId];") > -1 || args.callback.toString().indexOf("delete F[c];e(a)}") > -1);
 
 QUnit.module("simple component tests", {
-    beforeEach: function() {
-        var componentRendered = $.Callbacks();
-        var TestComponent = DOMComponent.inherit({
-            _render: function() {
+    beforeEach() {
+        const componentRendered = $.Callbacks();
+        const TestComponent = DOMComponent.inherit({
+            _render(...args) {
                 componentRendered.fire();
-                return this.callBase.apply(this, arguments);
+                return this.callBase(...args);
             },
-            _optionChanged: function() {
+            _optionChanged() {
                 this._invalidate();
             },
-            _getDefaultOptions: function() {
+            _getDefaultOptions() {
                 return { text: "", array: [], obj: null };
             }
         });
@@ -47,22 +46,22 @@ QUnit.module("simple component tests", {
 
         QUnit.timerIgnoringCheckers.register(ignoreAngularBrowserDeferTimer);
     },
-    afterEach: function() {
+    afterEach() {
         QUnit.timerIgnoringCheckers.unregister(ignoreAngularBrowserDeferTimer);
     }
 });
 
 QUnit.test("simple component init", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
         .attr("dx-test", "{ text: 'my text' }")
         .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function() { });
+    this.testApp.controller("my-controller", () => { });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
@@ -72,11 +71,11 @@ QUnit.test("simple component init", function(assert) {
 });
 
 QUnit.test("component options from scope", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "options")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.options = {
             text: "my text"
         };
@@ -84,12 +83,12 @@ QUnit.test("component options from scope", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.options.text = "change1";
     });
     assert.equal(instance.option("text"), "my text");
@@ -103,11 +102,11 @@ QUnit.test("component options from scope", function(assert) {
 });
 
 QUnit.test("component option fields from scope", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ text: vm.text }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             text: "my text"
         };
@@ -115,12 +114,12 @@ QUnit.test("component option fields from scope", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.text = "change1";
     });
     assert.equal(instance.option("text"), "my text");
@@ -134,11 +133,11 @@ QUnit.test("component option fields from scope", function(assert) {
 });
 
 QUnit.test("component with bindingOptions", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { text: 'vm.text' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             text: "my text"
         };
@@ -146,12 +145,12 @@ QUnit.test("component with bindingOptions", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.text = "change1";
     });
     assert.equal(instance.option("text"), "change1");
@@ -168,11 +167,11 @@ QUnit.test("component with bindingOptions", function(assert) {
 });
 
 QUnit.test("component with bindingOptions and computed binding", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { text: 'vm[field]' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             text: "my text"
         };
@@ -181,12 +180,12 @@ QUnit.test("component with bindingOptions and computed binding", function(assert
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.text = "change1";
     });
     assert.equal(instance.option("text"), "change1");
@@ -196,11 +195,11 @@ QUnit.test("component with bindingOptions and computed binding", function(assert
 });
 
 QUnit.test("component with bindingOptions for nested option", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ obj: { }, bindingOptions: { 'obj.text': 'vm.caption' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             caption: "my text"
         };
@@ -208,12 +207,12 @@ QUnit.test("component with bindingOptions for nested option", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("obj.text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.caption = "change1";
     });
     assert.equal(instance.option("obj.text"), "change1");
@@ -223,11 +222,11 @@ QUnit.test("component with bindingOptions for nested option", function(assert) {
 });
 
 QUnit.test("component with bindingOptions from scope", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: defs }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             text: "my text"
         };
@@ -239,12 +238,12 @@ QUnit.test("component with bindingOptions from scope", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.text = "change1";
     });
     assert.equal(instance.option("text"), "change1");
@@ -261,15 +260,15 @@ QUnit.test("component with bindingOptions from scope", function(assert) {
 });
 
 QUnit.test("component with bindingOptions from scope inside sync action (T302197)", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ onInitialized: inited, bindingOptions: defs }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             text: "my text"
         };
-        $scope.inited = function() {
+        $scope.inited = () => {
             $scope.vm.text = "new text";
         };
 
@@ -280,14 +279,14 @@ QUnit.test("component with bindingOptions from scope inside sync action (T302197
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance");
+    const instance = $markup.dxTest("instance");
 
     assert.equal(instance.option("text"), "new text");
 });
 
 QUnit.test("component with bindingOptions from scope when invalid value for widget was set (T403775)", function(assert) {
-    var TestComponent = DOMComponent.inherit({
-        _optionChanged: function(args) {
+    const TestComponent = DOMComponent.inherit({
+        _optionChanged(args) {
             this._invalidate();
             if(args.name === "width" && args.value < 0) {
                 this.option("width", 0);
@@ -297,23 +296,23 @@ QUnit.test("component with bindingOptions from scope when invalid value for widg
 
     registerComponent("dxTestWithValidatedOption", TestComponent);
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test-with-validated-option", "{ bindingOptions: { width: 'width' }}")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.width = 10;
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTestWithValidatedOption("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTestWithValidatedOption("instance");
+    const scope = $markup.scope();
 
     assert.equal(scope.width, 10);
     assert.equal(instance.option("width"), 10);
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.width = -1;
     });
 
@@ -322,11 +321,11 @@ QUnit.test("component with bindingOptions from scope when invalid value for widg
 });
 
 QUnit.test("bindingOptions can be inherited inside options object (T426046)", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "config")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         function baseOption() { }
 
         baseOption.prototype.bindingOptions = {
@@ -339,8 +338,8 @@ QUnit.test("bindingOptions can be inherited inside options object (T426046)", fu
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
@@ -349,11 +348,11 @@ QUnit.test("bindingOptions can be inherited inside options object (T426046)", fu
 });
 
 QUnit.test("bindingOptions fields can be inherited", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "config")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         function baseOption() { }
 
         baseOption.prototype.text = 'text';
@@ -366,8 +365,8 @@ QUnit.test("bindingOptions fields can be inherited", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
@@ -376,8 +375,8 @@ QUnit.test("bindingOptions fields can be inherited", function(assert) {
 });
 
 QUnit.test("repeat binding", function(assert) {
-    var $markup = $("<div/>").appendTo(this.$controller),
-        scope;
+    const $markup = $("<div/>").appendTo(this.$controller);
+    let scope;
 
     $markup.append($(
         "<div ng-repeat='item in vm.items'>" +
@@ -385,7 +384,7 @@ QUnit.test("repeat binding", function(assert) {
         "</div>"
     ));
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         scope = $scope;
 
         $scope.vm = {
@@ -400,22 +399,22 @@ QUnit.test("repeat binding", function(assert) {
 
     assert.equal($markup.children().eq(1).children().dxTest("option", "text"), "1");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.items.push({ text: "2" });
     });
     assert.equal($markup.children().eq(2).children().dxTest("option", "text"), "2");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.items.splice(1, 1);
     });
     assert.equal($markup.children().length, 2);
 
-    var $firstElement = $markup.children().eq(1).children(),
-        $secondElement = $markup.children().eq(1).children(),
-        firstScope = $firstElement.scope(),
-        secondScope = $secondElement.scope();
+    const $firstElement = $markup.children().eq(1).children();
+    const $secondElement = $markup.children().eq(1).children();
+    const firstScope = $firstElement.scope();
+    const secondScope = $secondElement.scope();
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         $markup.remove();
     });
 
@@ -426,7 +425,7 @@ QUnit.test("repeat binding", function(assert) {
 });
 
 QUnit.test("DOMComponent does not control descendant bindings", function(assert) {
-    var $markup = $("<div/>").appendTo(this.$controller);
+    const $markup = $("<div/>").appendTo(this.$controller);
 
     $markup.append($(
         "<div dx-test>" +
@@ -436,7 +435,7 @@ QUnit.test("DOMComponent does not control descendant bindings", function(assert)
         "</div>"
     ));
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             items: [1, 2, 3]
         };
@@ -444,18 +443,19 @@ QUnit.test("DOMComponent does not control descendant bindings", function(assert)
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var listItems = $markup.find("ul").children();
+    const listItems = $markup.find("ul").children();
     assert.equal(listItems.length, 3);
     assert.equal(listItems.text(), "123");
 });
 
 QUnit.test("changing a field of bound object changes component option", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { obj: 'obj' } }")
-            .appendTo(this.$controller),
-        optionChanged = false;
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let optionChanged = false;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.obj = {
             a: 42
         };
@@ -463,15 +463,15 @@ QUnit.test("changing a field of bound object changes component option", function
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.ok(!optionChanged);
 
-    instance.on("optionChanged", function() {
+    instance.on("optionChanged", () => {
         optionChanged = true;
     });
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.obj.a = 43;
     });
 
@@ -479,12 +479,13 @@ QUnit.test("changing a field of bound object changes component option", function
 });
 
 QUnit.test("binding options with deep=true for array option", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { items: { deep: true, dataPath: 'dataItems' } } }")
-            .appendTo(this.$controller),
-        optionChanged = false;
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let optionChanged = false;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.dataItems = [
             { value: 1 },
             { value: 2 },
@@ -494,16 +495,16 @@ QUnit.test("binding options with deep=true for array option", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.ok(!optionChanged);
 
-    instance.on("optionChanged", function() {
+    instance.on("optionChanged", () => {
         optionChanged = true;
     });
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.dataItems[0].value = 42;
     });
 
@@ -512,12 +513,13 @@ QUnit.test("binding options with deep=true for array option", function(assert) {
 });
 
 QUnit.test("binding options with deep=false for array option", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { items: { deep: false, dataPath: 'dataItems' } } }")
-            .appendTo(this.$controller),
-        optionChanged = false;
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let optionChanged = false;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.dataItems = [
             { value: 1 },
             { value: 2 },
@@ -527,16 +529,16 @@ QUnit.test("binding options with deep=false for array option", function(assert) 
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.ok(!optionChanged);
 
-    instance.on("optionChanged", function() {
+    instance.on("optionChanged", () => {
         optionChanged = true;
     });
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.dataItems[0].value = 42;
     });
 
@@ -545,27 +547,28 @@ QUnit.test("binding options with deep=false for array option", function(assert) 
 });
 
 QUnit.test("binding options with deep=true for not array option", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { option: { deep: true, dataPath: 'dataValue' } } }")
-            .appendTo(this.$controller),
-        optionChanged = false;
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let optionChanged = false;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.dataValue = { value: 1 };
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.ok(!optionChanged);
 
-    instance.on("optionChanged", function() {
+    instance.on("optionChanged", () => {
         optionChanged = true;
     });
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.dataValue.value = 42;
     });
 
@@ -574,25 +577,26 @@ QUnit.test("binding options with deep=true for not array option", function(asser
 });
 
 QUnit.test("binding options with deep=false for not array option", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { text: { deep: false, dataPath: 'dataValue' } } }")
-            .appendTo(this.$controller),
-        optionChanged = false;
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let optionChanged = false;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.dataValue = { value: 1 };
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
-    instance.on("optionChanged", function() {
+    instance.on("optionChanged", () => {
         optionChanged = true;
     });
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.dataValue.value = 42;
     });
 
@@ -605,20 +609,20 @@ QUnit.test("binding should fired once when option is a plain object", function(a
         return;
     }
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { testOption: 'dataValue' }, onOptionChanged: optionChangedHandler }")
             .appendTo(this.$controller);
 
-    var spy = sinon.spy();
+    const spy = sinon.spy();
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.optionChangedHandler = spy;
         $scope.dataValue = { value: 1 };
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance");
+    const instance = $markup.dxTest("instance");
 
     spy.reset();
     instance.option("testOption", { value: 2 });
@@ -632,24 +636,24 @@ QUnit.test("dependence options changed when option is a plain object", function(
         return;
     }
 
-    var $widget = $("<div>")
+    const $widget = $("<div>")
             .attr("dx-test", "{testOption: testOption, bindingOptions: {'testOption.value': 'testOption.value', 'testOption.dependenceValue': 'testOption.dependenceValue' }}")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.testOption = {
             value: { value: 1 },
             dependenceValue: 0
         };
 
-        $scope.$watch("testOption.value", function() {
+        $scope.$watch("testOption.value", () => {
             $scope.testOption.dependenceValue++;
         });
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var widget = $widget.dxTest("instance");
+    const widget = $widget.dxTest("instance");
     widget.option("testOption.value", { value: 2 });
 
     assert.equal(widget.option("testOption.dependenceValue"), 2, "dependence option was changed");
@@ -661,25 +665,25 @@ QUnit.test("option changed fired after value was set in the same value(plain obj
         return;
     }
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { testOption: 'dataValue' }, onOptionChanged: optionChangedHandler }")
             .appendTo(this.$controller);
-    var spy = sinon.spy();
-    var value = { value: 1 };
-    this.testApp.controller("my-controller", function($scope) {
+    const spy = sinon.spy();
+    const value = { value: 1 };
+    this.testApp.controller("my-controller", $scope => {
         $scope.optionChangedHandler = spy;
         $scope.dataValue = value;
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
-    var instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
 
     instance.option("testOption", value);
 
     spy.reset();
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.dataValue.value = 3;
     });
 
@@ -687,26 +691,26 @@ QUnit.test("option changed fired after value was set in the same value(plain obj
 });
 
 QUnit.test("Variable from scope not re-assign after change the corresponding widget options (T373260)", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { option1_widget: 'option1_scope', option2_widget: 'option2_scope' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller('my-controller', function($scope) {
+    this.testApp.controller('my-controller', $scope => {
 
         Object.defineProperty($scope, "option1_scope", {
-            get: function() {
+            get() {
                 return $scope.option1;
             },
-            set: function(value) {
+            set(value) {
                 $scope.option1 = value;
                 $scope.option2 = false;
             }
         });
         Object.defineProperty($scope, "option2_scope", {
-            get: function() {
+            get() {
                 return $scope.option2;
             },
-            set: function(value) {
+            set(value) {
                 assert.ok(false, "this method should not be called");
             }
         });
@@ -718,8 +722,8 @@ QUnit.test("Variable from scope not re-assign after change the corresponding wid
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
-    var instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
 
     instance.option("option1_widget", 2);
 
@@ -728,29 +732,29 @@ QUnit.test("Variable from scope not re-assign after change the corresponding wid
 });
 
 QUnit.test("Lockers works correctly when widget options changed using action (T381596)", function(assert) {
-    var MyComponent = DOMComponent.inherit({
-        _getDefaultOptions: function() {
+    const MyComponent = DOMComponent.inherit({
+        _getDefaultOptions() {
             return $.extend(this.callBase(), {
-                onClick: function(e) {
+                onClick(e) {
                     e.component.option("testOption", false);
                 }
             });
         },
-        emulateAction: function() {
+        emulateAction() {
             this._createActionByOption("onClick")();
         }
     });
     registerComponent("dxMyComponent", MyComponent);
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-my-component", "{ bindingOptions: { testOption: 'testOption' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.testOption = true;
 
-        $scope.changeScopeValue = function() {
-            scope.$apply(function() {
+        $scope.changeScopeValue = () => {
+            scope.$apply(() => {
                 $scope.testOption = true;
             });
         };
@@ -759,7 +763,7 @@ QUnit.test("Lockers works correctly when widget options changed using action (T3
     angular.bootstrap(this.$container, ["testApp"]);
 
     var scope = $markup.scope();
-    var instance = $markup.dxMyComponent("instance");
+    const instance = $markup.dxMyComponent("instance");
 
     assert.equal(instance.option("testOption"), true, "binding worked");
 
@@ -772,42 +776,42 @@ QUnit.test("Lockers works correctly when widget options changed using action (T3
 
 // Note: Needed for dxFilterBuilder
 QUnit.test("The component should not be rendered more times than it needed", function(assert) {
-    var rendered = sinon.stub();
-    var MyComponent = DOMComponent.inherit({
-        _getDefaultOptions: function() {
+    const rendered = sinon.stub();
+    const MyComponent = DOMComponent.inherit({
+        _getDefaultOptions() {
             return $.extend(this.callBase(), {
-                onClick: function(e) {
+                onClick(e) {
                     e.component.skipInvalidation = true;
                     e.component.option("testOption", [ 3, 2, 1 ]);
                 }
             });
         },
-        _optionChanged: function() {
+        _optionChanged(...args) {
             if(this.skipInvalidation) {
                 this.skipInvalidation = false;
             } else {
                 rendered();
-                return this.callBase.apply(this, arguments);
+                return this.callBase(...args);
             }
         },
-        emulateAction: function() {
+        emulateAction() {
             this._createActionByOption("onClick")();
         }
     });
 
     registerComponent("dxMyComponent", MyComponent);
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-my-component", "{ bindingOptions: { testOption: 'testOption' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.testOption = [ 1, 2, 3 ];
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxMyComponent("instance");
+    const instance = $markup.dxMyComponent("instance");
 
     assert.equal(rendered.callCount, 1);
 
@@ -816,61 +820,61 @@ QUnit.test("The component should not be rendered more times than it needed", fun
 });
 
 QUnit.test("WrappedAction should return function result (T388034)", function(assert) {
-    var MyComponent = DOMComponent.inherit({
-        _getDefaultOptions: function() {
+    const MyComponent = DOMComponent.inherit({
+        _getDefaultOptions() {
             return $.extend(this.callBase(), {
-                onTestAction: function(value) {
+                onTestAction(value) {
                     return value.text;
                 }
             });
         },
-        emulateAction: function() {
-            var testAction = this._createActionByOption("onTestAction");
+        emulateAction() {
+            const testAction = this._createActionByOption("onTestAction");
             return testAction({ text: "testText" });
         }
     });
     registerComponent("dxMyComponent", MyComponent);
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-my-component", "{ }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function() { });
+    this.testApp.controller("my-controller", () => { });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxMyComponent("instance");
+    const instance = $markup.dxMyComponent("instance");
 
-    var result = instance.emulateAction();
+    const result = instance.emulateAction();
     assert.equal(result, "testText", "action return function result");
 });
 
 QUnit.test("Empty action doesn't call scope.$apply if config.wrapActionsBeforeExecute == true (T514528)", function(assert) {
-    var originFlag = config().wrapActionsBeforeExecute;
+    const originFlag = config().wrapActionsBeforeExecute;
     config({ wrapActionsBeforeExecute: true });
 
-    var TestDOMComponent = DOMComponent.inherit();
+    const TestDOMComponent = DOMComponent.inherit();
     registerComponent("dxMyComponent", TestDOMComponent);
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-my-component", "{ }")
             .appendTo(this.$controller);
 
-    var applyCount = 0;
+    let applyCount = 0;
 
-    this.testApp.controller("my-controller", function() { });
+    this.testApp.controller("my-controller", () => { });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
-    var originApply = scope.$apply;
+    const scope = $markup.scope();
+    const originApply = scope.$apply;
 
-    scope.$apply = function(fn) {
+    scope.$apply = fn => {
         applyCount++;
         originApply.bind(fn, scope);
     };
 
-    var instance = $markup.dxMyComponent("instance");
+    const instance = $markup.dxMyComponent("instance");
     instance._createActionByOption("onTestAction")();
     assert.equal(applyCount, 0);
 
@@ -884,18 +888,18 @@ QUnit.test("Empty action doesn't call scope.$apply if config.wrapActionsBeforeEx
 });
 
 QUnit.test("The option should be changed if changes occur before scope.$apply calling", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { text: 'text' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.text = "initial text";
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance");
-    var scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "initial text");
     assert.equal(scope.text, "initial text");
@@ -924,10 +928,10 @@ QUnit.test("The option should be changed if changes occur before scope.$apply ca
 });
 
 QUnit.test("The 'release' method shouldn't be called for an unlocked Lock object (T400093)", function(assert) {
-    var MyComponent = DOMComponent.inherit({
-        _getDefaultOptions: function() {
+    const MyComponent = DOMComponent.inherit({
+        _getDefaultOptions() {
             return $.extend(this.callBase(), {
-                onTestAction: function(args) {
+                onTestAction(args) {
                     args.instance.option("text", "second");
                     args.instance.option("text", "third");
                     args.instance.option("obj.text", "second");
@@ -935,26 +939,26 @@ QUnit.test("The 'release' method shouldn't be called for an unlocked Lock object
                 }
             });
         },
-        emulateAction: function() {
-            var testAction = this._createActionByOption("onTestAction");
+        emulateAction() {
+            const testAction = this._createActionByOption("onTestAction");
             testAction({ instance: this });
         }
     });
     registerComponent("dxMyComponentWithWrappedAction", MyComponent);
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-my-component-with-wrapped-action", "{ bindingOptions: { text: 'text', obj: 'obj' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.text = "first";
         $scope.obj = { text: "first" };
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxMyComponentWithWrappedAction("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxMyComponentWithWrappedAction("instance");
+    const scope = $markup.scope();
 
     try {
         instance.emulateAction();
@@ -969,20 +973,20 @@ QUnit.test("The 'release' method shouldn't be called for an unlocked Lock object
 });
 
 QUnit.test("Lockers works correctly when method _optionChangedCallbacks occur in external apply phase (T386467)", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
         .attr("dx-test", "{ bindingOptions: {text: 'myText'} }")
         .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.myText = "";
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         try {
             instance.option("text", "testText");
             assert.ok(true, "the error is not thrown");
@@ -993,26 +997,26 @@ QUnit.test("Lockers works correctly when method _optionChangedCallbacks occur in
 });
 
 QUnit.test("Lockers works correctly for composite option (T382985)", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ testOption: testOption, bindingOptions: { 'testOption.text': 'testOption.text' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller('my-controller', function($scope) {
+    this.testApp.controller('my-controller', $scope => {
         $scope.testOption = {};
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
-    var instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.testOption.text = "testText";
     });
 
     assert.equal(instance.option("testOption").text, "testText", "binding worked");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.testOption.text = "";
     });
 
@@ -1020,18 +1024,18 @@ QUnit.test("Lockers works correctly for composite option (T382985)", function(as
 });
 
 QUnit.test("Lockers works correctly for defineProperty (T396622)", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "{ bindingOptions: { text: 'publicText' } }")
             .appendTo(this.$controller);
 
-    this.testApp.controller('my-controller', function($scope) {
+    this.testApp.controller('my-controller', $scope => {
         $scope.privateText = "test";
 
         Object.defineProperty($scope, "publicText", {
-            get: function() {
+            get() {
                 return $scope.privateText;
             },
-            set: function(value) {
+            set(value) {
                 $scope.privateText = "calculatedText";
             }
         });
@@ -1039,8 +1043,8 @@ QUnit.test("Lockers works correctly for defineProperty (T396622)", function(asse
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
-    var instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
 
     assert.equal(instance.option("text"), "test", "binding worked");
     assert.equal(scope.publicText, "test", "binding worked");
@@ -1052,20 +1056,20 @@ QUnit.test("Lockers works correctly for defineProperty (T396622)", function(asse
 });
 
 QUnit.test("Binding works if options config object added to $scope after bootstrap (T314032)", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
         .attr("dx-test", "testSettings")
         .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.myText = "testText";
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTest("instance");
+    const scope = $markup.scope();
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.testSettings = {
             bindingOptions: { text: "myText" }
         };
@@ -1079,12 +1083,13 @@ QUnit.test("Binding works if options config object added to $scope after bootstr
 });
 
 QUnit.test("changing several options causes single render", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "testSettings")
-            .appendTo(this.$controller),
-        renderedCount = 0;
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let renderedCount = 0;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.myText = "testText";
         $scope.myObj = { a: 1 };
         $scope.testSettings = {
@@ -1094,13 +1099,13 @@ QUnit.test("changing several options causes single render", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
+    const scope = $markup.scope();
 
-    this.componentRendered.add(function() {
+    this.componentRendered.add(() => {
         renderedCount++;
     });
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.myText = "testText 2";
         scope.myObj = { b: 2 };
     });
@@ -1109,15 +1114,15 @@ QUnit.test("changing several options causes single render", function(assert) {
 });
 
 QUnit.test("beginUpdate and endUpdate must be called in pairs (T373299)", function(assert) {
-    var beginWithoutEnd = 0,
-        endWithoutBegin = 0;
+    let beginWithoutEnd = 0;
+    let endWithoutBegin = 0;
 
-    var myComponent = DOMComponent.inherit({
-        beginUpdate: function() {
+    const myComponent = DOMComponent.inherit({
+        beginUpdate() {
             beginWithoutEnd++;
             this.callBase();
         },
-        endUpdate: function() {
+        endUpdate() {
             if(beginWithoutEnd === 0) {
                 endWithoutBegin++;
             } else {
@@ -1129,17 +1134,17 @@ QUnit.test("beginUpdate and endUpdate must be called in pairs (T373299)", functi
 
     registerComponent("dxMytest", myComponent);
 
-    var $markup = $("<div dx-mytest='settings'></div>");
+    const $markup = $("<div dx-mytest='settings'></div>");
     $markup.appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.myText = "testText";
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
-    scope.$apply(function() {
+    const scope = $markup.scope();
+    scope.$apply(() => {
         scope.settings = {
             bindingOptions: {
                 text: 'myText'
@@ -1152,15 +1157,15 @@ QUnit.test("beginUpdate and endUpdate must be called in pairs (T373299)", functi
 });
 
 QUnit.test("beginUpdate and endUpdate shouldn't fire only once for each apply", function(assert) {
-    var beginUpdate = 0,
-        endUpdate = 0;
+    let beginUpdate = 0;
+    let endUpdate = 0;
 
-    var myComponent = DOMComponent.inherit({
-        beginUpdate: function() {
+    const myComponent = DOMComponent.inherit({
+        beginUpdate() {
             beginUpdate++;
             this.callBase();
         },
-        endUpdate: function() {
+        endUpdate() {
             endUpdate++;
             this.callBase();
         }
@@ -1168,20 +1173,20 @@ QUnit.test("beginUpdate and endUpdate shouldn't fire only once for each apply", 
 
     registerComponent("dxMytest", myComponent);
 
-    var $markup = $("<div ng-repeat='item in items'><div dx-mytest='settings' ></div></div>");
+    const $markup = $("<div ng-repeat='item in items'><div dx-mytest='settings' ></div></div>");
     $markup.appendTo(this.$controller);
 
-    var scope;
-    this.testApp.controller("my-controller", function($scope) {
+    let scope;
+    this.testApp.controller("my-controller", $scope => {
         scope = $scope;
         $scope.items = [1];
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var expectedUpdate = 2 * beginUpdate + 1;
+    const expectedUpdate = 2 * beginUpdate + 1;
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.items.push(2);
     });
 
@@ -1190,17 +1195,17 @@ QUnit.test("beginUpdate and endUpdate shouldn't fire only once for each apply", 
 });
 
 QUnit.test("Angular component should have 'templatesRenderAsynchronously' option (T351071)", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "options")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.options = {};
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance");
+    const instance = $markup.dxTest("instance");
 
     assert.ok(instance.option("templatesRenderAsynchronously"), "option should exist");
 });
@@ -1208,19 +1213,19 @@ QUnit.test("Angular component should have 'templatesRenderAsynchronously' option
 QUnit.test("Angular component should not fire 'triggerResizeEvent' on 'contentReady' event (T351071)", function(assert) {
     this.clock = sinon.useFakeTimers();
 
-    var resizeEventSpy = sinon.spy(domUtils, "triggerResizeEvent");
+    const resizeEventSpy = sinon.spy(domUtils, "triggerResizeEvent");
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test", "options")
             .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.options = {};
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance");
+    const instance = $markup.dxTest("instance");
     instance.fireEvent("contentReady", {});
 
     this.clock.tick();
@@ -1231,11 +1236,11 @@ QUnit.test("Angular component should not fire 'triggerResizeEvent' on 'contentRe
 });
 
 QUnit.test("options with undefined value should be passed correctly", function(assert) {
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
         .attr("dx-test", "options")
         .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.options = {
             text: undefined
         };
@@ -1243,13 +1248,13 @@ QUnit.test("options with undefined value should be passed correctly", function(a
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTest("instance");
+    const instance = $markup.dxTest("instance");
     assert.equal(instance.option("text"), undefined, "option is passed correctly");
 });
 
 QUnit.test("Binding with several nested options with same parent should work correctly", function(assert) {
-    var TestComponentWithDeprecated = DOMComponent.inherit({
-        _setDeprecatedOptions: function() {
+    const TestComponentWithDeprecated = DOMComponent.inherit({
+        _setDeprecatedOptions() {
             this.callBase();
 
             this._deprecatedOptions['root.deprecated'] = { alias: 'root.child1' };
@@ -1257,20 +1262,20 @@ QUnit.test("Binding with several nested options with same parent should work cor
     });
     registerComponent("dxTestWithDeprecated", TestComponentWithDeprecated);
 
-    var $markup = $("<div>")
+    const $markup = $("<div>")
         .attr("dx-test-with-deprecated", "{ root: { }, bindingOptions: { 'root.child1': 'prop', 'root.child2': 'prop' } }")
         .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.prop = true;
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var instance = $markup.dxTestWithDeprecated("instance"),
-        scope = $markup.scope();
+    const instance = $markup.dxTestWithDeprecated("instance");
+    const scope = $markup.scope();
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.prop = false;
     });
 
@@ -1279,35 +1284,35 @@ QUnit.test("Binding with several nested options with same parent should work cor
 });
 
 QUnit.test("Components should not affect on eachother lock engines", function(assert) {
-    var needUpdating;
-    var TestComponentWithEndUpdateAction = DOMComponent.inherit({
-        endUpdate: function() {
+    let needUpdating;
+    const TestComponentWithEndUpdateAction = DOMComponent.inherit({
+        endUpdate(...args) {
             if(needUpdating) {
                 needUpdating = false;
                 this._createActionByOption("onUpdate")();
             }
-            this.callBase.apply(this, arguments);
+            this.callBase(...args);
         }
     });
 
     registerComponent("dxTestWithAction", TestComponentWithEndUpdateAction);
 
-    var $testElement = $("<div>").attr("dx-test", "{ bindingOptions: { text: 'prop' } }"),
-        $badNeighbor = $("<div>").attr("dx-test-with-action", "{ onUpdate: onUpdate }");
+    const $testElement = $("<div>").attr("dx-test", "{ bindingOptions: { text: 'prop' } }");
+    const $badNeighbor = $("<div>").attr("dx-test-with-action", "{ onUpdate: onUpdate }");
 
     this.$controller.append($badNeighbor).append($testElement);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.prop = "value 1";
-        $scope.onUpdate = function() {};
+        $scope.onUpdate = () => {};
     });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = this.$controller.scope(),
-        instance = $testElement.dxTest("instance");
+    const scope = this.$controller.scope();
+    const instance = $testElement.dxTest("instance");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         instance.option("text", "value 2");
         needUpdating = true;
     });
@@ -1318,17 +1323,17 @@ QUnit.test("Components should not affect on eachother lock engines", function(as
 });
 
 QUnit.module("nested Widget with templates enabled", {
-    beforeEach: function() {
-        var TestContainer = Widget.inherit({
+    beforeEach() {
+        const TestContainer = Widget.inherit({
 
-            _getDefaultOptions: function() {
+            _getDefaultOptions() {
                 return $.extend(this.callBase(), {
                     text: ""
                 });
             },
 
-            _render: function() {
-                var content = $("<div />")
+            _render() {
+                const content = $("<div />")
                         .addClass("dx-content")
                         .appendTo(this.$element());
 
@@ -1336,7 +1341,7 @@ QUnit.module("nested Widget with templates enabled", {
                     container: content
                 });
 
-                var text = this.option("text");
+                const text = this.option("text");
                 if(text) {
                     content.append($("<span />").addClass("text-by-option").text(text));
                 }
@@ -1344,35 +1349,35 @@ QUnit.module("nested Widget with templates enabled", {
 
             _renderContentImpl: noop,
 
-            _clean: function() {
+            _clean() {
                 this.$element().empty();
             },
 
-            _optionChanged: function() {
+            _optionChanged() {
                 this._invalidate();
             }
 
         });
 
-        var TestWidget = Widget.inherit({
+        const TestWidget = Widget.inherit({
 
-            _getDefaultOptions: function() {
+            _getDefaultOptions() {
                 return $.extend(this.callBase(), {
                     text: ""
                 });
             },
 
-            _render: function() {
+            _render() {
                 this.$element().append($("<span />").text(this.option("text")));
             },
 
             _renderContentImpl: noop,
 
-            _clean: function() {
+            _clean() {
                 this.$element().empty();
             },
 
-            _optionChanged: function() {
+            _optionChanged() {
                 this._invalidate();
             }
         });
@@ -1389,13 +1394,13 @@ QUnit.module("nested Widget with templates enabled", {
 
         QUnit.timerIgnoringCheckers.register(ignoreAngularBrowserDeferTimer);
     },
-    afterEach: function() {
+    afterEach() {
         QUnit.timerIgnoringCheckers.unregister(ignoreAngularBrowserDeferTimer);
     }
 });
 
 QUnit.test("two nested containers", function(assert) {
-    var $markup = $(
+    const $markup = $(
         "<div class='outerWidget' dx-test-container>" +
             "   <div data-options='dxTemplate: { name: \"template\" }' class='outer-template'>" +
             "       <span ng-bind='vm.outerText'></span>" +
@@ -1408,7 +1413,7 @@ QUnit.test("two nested containers", function(assert) {
             "</div>"
     ).appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             outerText: "outer",
             innerText: "inner"
@@ -1417,20 +1422,20 @@ QUnit.test("two nested containers", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var outerWidget = $markup;
+    const outerWidget = $markup;
     assert.equal(outerWidget.length, 1);
 
-    var outerContent = outerWidget.children().children().children();
+    const outerContent = outerWidget.children().children().children();
     assert.equal(outerContent.length, 2);
     assert.equal(outerContent.filter("span").text(), "outer");
 
-    var innerWidget = outerContent.filter(".innerWidget");
+    const innerWidget = outerContent.filter(".innerWidget");
     assert.equal(innerWidget.length, 1);
     assert.equal(innerWidget.find("span").text(), "inner");
 });
 
 QUnit.test("Dispose nested containers", function(assert) {
-    var $markup = $(
+    const $markup = $(
         "<div class='container'>" +
                 "<div class='outer' dx-test-container>" +
                     "<div data-options='dxTemplate: { name: \"template\" }'>" +
@@ -1440,21 +1445,20 @@ QUnit.test("Dispose nested containers", function(assert) {
             "</div>"
         ).appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) { });
+    this.testApp.controller("my-controller", $scope => { });
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var outer = $markup.find(".outer").dxTestContainer("instance"),
-        inner = $markup.find(".inner").dxTestContainer("instance");
+    const outer = $markup.find(".outer").dxTestContainer("instance");
+    const inner = $markup.find(".inner").dxTestContainer("instance");
+    let outerDisposed = false;
+    let innerDisposed = false;
 
-    var outerDisposed = false,
-        innerDisposed = false;
-
-    outer.on("disposing", function() {
+    outer.on("disposing", () => {
         outerDisposed = true;
     });
 
-    inner.on("disposing", function() {
+    inner.on("disposing", () => {
         innerDisposed = true;
     });
 
@@ -1465,7 +1469,7 @@ QUnit.test("Dispose nested containers", function(assert) {
 
 
 QUnit.test("widget inside two nested containers", function(assert) {
-    var $markup = $(
+    const $markup = $(
         "<div dx-test-container='{ bindingOptions: { text: \"vm.outerText\" } }'>" +
             "   <div class='middle' dx-test-container='{ bindingOptions: { text: \"vm.middleText\" } }'>" +
             "       <div class='inner' dx-test-widget='{ bindingOptions: { text: \"vm.innerText\" } }'></div>" +
@@ -1473,7 +1477,7 @@ QUnit.test("widget inside two nested containers", function(assert) {
             "</div>"
         ).appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             outerText: "outerText",
             middleText: "middleText",
@@ -1483,26 +1487,26 @@ QUnit.test("widget inside two nested containers", function(assert) {
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
+    const scope = $markup.scope();
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.outerText = "new outerText";
         scope.vm.middleText = "new middleText";
         scope.vm.innerText = "new innerText";
     });
 
-    var outer = $markup;
+    const outer = $markup;
     assert.equal($.trim(outer.find(".dx-content:first > span").text()), "new outerText");
 
-    var middle = $markup.find(".middle");
+    const middle = $markup.find(".middle");
     assert.equal($.trim(middle.find(".dx-content:first > span").text()), "new middleText");
 
-    var inner = $markup.find(".inner");
+    const inner = $markup.find(".inner");
     assert.equal($.trim(inner.find("span").text()), "new innerText");
 });
 
-QUnit.test("angular integration don't breaks defaultOptions", function(assert) {
-    var TestDOMComponent = DOMComponent.inherit();
+QUnit.test("angular integration don't breaks defaultOptions", assert => {
+    const TestDOMComponent = DOMComponent.inherit();
 
     registerComponent("dxTestDOMComponent", TestDOMComponent);
 
@@ -1516,8 +1520,8 @@ QUnit.test("angular integration don't breaks defaultOptions", function(assert) {
 });
 
 QUnit.test("dynamic templates should be supported by angular", function(assert) {
-    var TestContainer = Widget.inherit({
-        _renderContentImpl: function(template) {
+    const TestContainer = Widget.inherit({
+        _renderContentImpl(template) {
             this._getTemplateByOption("template").render({
                 container: this.$element()
             });
@@ -1526,12 +1530,12 @@ QUnit.test("dynamic templates should be supported by angular", function(assert) 
 
     registerComponent("dxTestContainerEmpty", TestContainer);
 
-    var $markup = $("<div dx-test-container-empty='{ bindingOptions: { template: \"vm.template\" } }'></div>").appendTo(this.$controller);
+    const $markup = $("<div dx-test-container-empty='{ bindingOptions: { template: \"vm.template\" } }'></div>").appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         $scope.text = "Test";
         $scope.vm = {
-            template: function() {
+            template() {
                 return $("<script type=\"text/html\" id=\"scriptTemplate\"><div>{{text}}</div><\/script>");
             }
         };
@@ -1541,44 +1545,41 @@ QUnit.test("dynamic templates should be supported by angular", function(assert) 
     assert.equal($.trim($markup.text()), "Test");
 });
 
-if(angular.version.minor > 2) {
-    QUnit.test("Transclude inside dxComponent template (T318690). Since angularjs 1.3", function(assert) {
-        assert.expect(1);
-        this.testApp.directive('testDirective', function() {
-            return {
-                restrict: 'E',
-                transclude: true,
-                template: "<div dx-test-container>" +
-                        "<div data-options='dxTemplate: { name: \"template\" }'>" +
-                            "<div ng-transclude></div>" +
-                        "</div>" +
-                    "</div>"
-            };
-        });
+QUnit.test("Transclude inside dxComponent template (T318690). Since angularjs 1.3", function(assert) {
+    assert.expect(1);
+    this.testApp.directive('testDirective', () => ({
+        restrict: 'E',
+        transclude: true,
 
-        var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-            $markup = $("<test-directive><div class='transcluded-content'></div></test-directive>").appendTo($container);
+        template: "<div dx-test-container>" +
+                "<div data-options='dxTemplate: { name: \"template\" }'>" +
+                    "<div ng-transclude></div>" +
+                "</div>" +
+            "</div>"
+    }));
 
-        angular.bootstrap($container, ["testApp"]);
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+    const $markup = $("<test-directive><div class='transcluded-content'></div></test-directive>").appendTo($container);
 
-        assert.equal($markup.children('[dx-test-container]').find(".transcluded-content").length, 1);
-    });
-}
+    angular.bootstrap($container, ["testApp"]);
+
+    assert.equal($markup.children('[dx-test-container]').find(".transcluded-content").length, 1);
+});
 
 QUnit.module("Widget & CollectionWidget with templates enabled", {
-    beforeEach: function() {
+    beforeEach() {
         this.testApp = angular.module("testApp", ["dx"]);
 
         QUnit.timerIgnoringCheckers.register(ignoreAngularBrowserDeferTimer);
     },
-    afterEach: function() {
+    afterEach() {
         QUnit.timerIgnoringCheckers.unregister(ignoreAngularBrowserDeferTimer);
     }
 });
 
-QUnit.test("default NG template is not retrieved for widgets created with angular", function(assert) {
-    var TestContainer = Widget.inherit({
-        _renderContentImpl: function(template) {
+QUnit.test("default NG template is not retrieved for widgets created with angular", assert => {
+    const TestContainer = Widget.inherit({
+        _renderContentImpl(template) {
             template = template || this.option("integrationOptions.templates").template;
             if(template) {
                 template.render({
@@ -1590,10 +1591,10 @@ QUnit.test("default NG template is not retrieved for widgets created with angula
 
     registerComponent("dxTestContainerEmpty", TestContainer);
 
-    var $markup,
-        instance,
-        template,
-        $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+    let $markup;
+    let instance;
+    let template;
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
     // angular scenario
     $markup = $("<div dx-test-container-empty></div>").appendTo($container);
@@ -1612,9 +1613,9 @@ QUnit.test("default NG template is not retrieved for widgets created with angula
     assert.ok(!(template instanceof NgTemplate), "default NG template not retrieved");
 });
 
-QUnit.test("retrieving default NG template for collection widgets created with angular", function(assert) {
-    var TestContainer = CollectionWidget.inherit({
-        _renderContentImpl: function(template) {
+QUnit.test("retrieving default NG template for collection widgets created with angular", assert => {
+    const TestContainer = CollectionWidget.inherit({
+        _renderContentImpl(template) {
             template = template || this.option("integrationOptions.templates").template;
             if(template) {
                 template.render({
@@ -1626,10 +1627,10 @@ QUnit.test("retrieving default NG template for collection widgets created with a
 
     registerComponent("dxTestContainerEmpty", TestContainer);
 
-    var $markup,
-        instance,
-        template,
-        $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+    let $markup;
+    let instance;
+    let template;
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
     // angular scenario
     $markup = $("<div dx-test-container-empty></div>").appendTo($container);
@@ -1649,14 +1650,14 @@ QUnit.test("retrieving default NG template for collection widgets created with a
 });
 
 QUnit.test("creates anonymous template from its contents", function(assert) {
-    var TestContainer = Widget.inherit({
-        _getDefaultOptions: function() {
+    const TestContainer = Widget.inherit({
+        _getDefaultOptions() {
             return $.extend(this.callBase(), {
                 items: null
             });
         },
 
-        _render: function() {
+        _render() {
             this.option("integrationOptions.templates")["template"].render({
                 container: this.$element()
             });
@@ -1664,26 +1665,28 @@ QUnit.test("creates anonymous template from its contents", function(assert) {
 
         _renderContentImpl: noop,
 
-        _clean: function() {
+        _clean() {
             this.$element().empty();
         }
     });
 
     registerComponent("dxTestContainerAnonymousTemplate", TestContainer);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div/>")
-            .attr("ng-controller", "my-controller")
-            .appendTo($container),
-        $markup = $(
-            "<div dx-test-container-anonymous-template='{ bindingOptions: { items: \"vm.items\" } }'>" +
-            "   <ul>" +
-            "       <li ng-repeat='item in vm.items' ng-bind='item'></li>" +
-            "   </ul>" +
-            "</div>"
-        ).appendTo($controller);
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
-    this.testApp.controller("my-controller", function($scope) {
+    const $controller = $("<div/>")
+        .attr("ng-controller", "my-controller")
+        .appendTo($container);
+
+    const $markup = $(
+        "<div dx-test-container-anonymous-template='{ bindingOptions: { items: \"vm.items\" } }'>" +
+        "   <ul>" +
+        "       <li ng-repeat='item in vm.items' ng-bind='item'></li>" +
+        "   </ul>" +
+        "</div>"
+    ).appendTo($controller);
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             items: [1, 2, 3]
         };
@@ -1691,29 +1694,29 @@ QUnit.test("creates anonymous template from its contents", function(assert) {
 
     angular.bootstrap($container, ["testApp"]);
 
-    var instance = $markup.dxTestContainerAnonymousTemplate("instance");
+    const instance = $markup.dxTestContainerAnonymousTemplate("instance");
 
     assert.ok(instance.option("integrationOptions.templates"));
     assert.ok(instance.option("integrationOptions.templates")["template"]);
 
-    var list = $markup.find("ul");
+    const list = $markup.find("ul");
     assert.equal(list.length, 1);
 
-    var listItems = list.children();
+    const listItems = list.children();
     assert.equal(listItems.length, 3);
     assert.equal(listItems.text(), "123");
 });
 
 
 QUnit.test("correct scope as model for template", function(assert) {
-    var TestContainer = Widget.inherit({
-        _getDefaultOptions: function() {
+    const TestContainer = Widget.inherit({
+        _getDefaultOptions() {
             return $.extend(this.callBase(), {
                 items: null
             });
         },
 
-        _render: function() {
+        _render() {
             this.option("integrationOptions.templates")["template"].render({
                 container: this.$element()
             });
@@ -1721,24 +1724,26 @@ QUnit.test("correct scope as model for template", function(assert) {
 
         _renderContentImpl: noop,
 
-        _clean: function() {
+        _clean() {
             this.$element().empty();
         }
     });
 
     registerComponent("dxTestContainerDataTemplate", TestContainer);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div/>")
-            .attr("ng-controller", "my-controller")
-            .appendTo($container),
-        $markup = $(
-            "<div dx-test-container-data-template>" +
-            "   <div>{{vm.text}}</div>" +
-            "</div>"
-        ).appendTo($controller);
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
-    this.testApp.controller("my-controller", function($scope) {
+    const $controller = $("<div/>")
+        .attr("ng-controller", "my-controller")
+        .appendTo($container);
+
+    const $markup = $(
+        "<div dx-test-container-data-template>" +
+        "   <div>{{vm.text}}</div>" +
+        "</div>"
+    ).appendTo($controller);
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
             text: "My text"
         };
@@ -1748,17 +1753,17 @@ QUnit.test("correct scope as model for template", function(assert) {
 
     assert.equal($.trim($markup.text()), "My text");
 
-    var parentScope = $markup.scope(),
-        childScope = $markup.children().scope();
+    const parentScope = $markup.scope();
+    const childScope = $markup.children().scope();
 
-    parentScope.$apply(function() {
+    parentScope.$apply(() => {
         parentScope.vm.text = "New text";
     });
 
     assert.equal(childScope.vm.text, "New text");
     assert.equal($.trim($markup.text()), "New text");
 
-    childScope.$apply(function() {
+    childScope.$apply(() => {
         childScope.vm.text = "New text 2";
     });
 
@@ -1766,26 +1771,28 @@ QUnit.test("correct scope as model for template", function(assert) {
 });
 
 QUnit.test("two-way binding works correct for inner component (T577900)", function(assert) {
-    var MyComponent = DOMComponent.inherit({
-        emulateAction: function() {
+    const MyComponent = DOMComponent.inherit({
+        emulateAction() {
             this._createActionByOption("onClick")();
         }
     });
     registerComponent("dxComponentWithInnerComponent", MyComponent);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div/>")
-            .attr("ng-controller", "my-controller as $ctrl")
-            .appendTo($container);
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+
+    const $controller = $("<div/>")
+        .attr("ng-controller", "my-controller as $ctrl")
+        .appendTo($container);
+
     $("<inner-component></inner-component>").appendTo($controller);
 
-    this.testApp.controller("my-controller", function() {});
+    this.testApp.controller("my-controller", () => {});
 
     angular.module('testApp').component('innerComponent', {
-        controller: function() {
+        controller() {
             this.widgetSettings = {
-                onClick: function(args) {
-                    var prevText = args.component.option("text");
+                onClick(args) {
+                    const prevText = args.component.option("text");
                     args.component.option("text", prevText + "1");
                 },
                 bindingOptions: {
@@ -1800,8 +1807,8 @@ QUnit.test("two-way binding works correct for inner component (T577900)", functi
 
     angular.bootstrap($container, ["testApp"]);
 
-    var testField = $("#test"),
-        instance = $("#widget").dxComponentWithInnerComponent("instance");
+    const testField = $("#test");
+    const instance = $("#widget").dxComponentWithInnerComponent("instance");
 
     assert.equal(testField.text(), "");
     assert.equal(instance.option("text"), undefined);
@@ -1819,32 +1826,31 @@ QUnit.test("two-way binding works correct for inner component (T577900)", functi
 
 QUnit.test("Directive is in DOM on linking (T306481)", function(assert) {
     assert.expect(1);
-    var TestContainer = Widget.inherit({
-        _render: function() {
+    const TestContainer = Widget.inherit({
+        _render() {
             this.option("integrationOptions.templates")["template"].render({
                 container: this.$element()
             });
         },
         _renderContentImpl: noop,
-        _clean: function() {
+        _clean() {
             this.$element().empty();
         }
     });
 
     registerComponent("dxTestContainerWidget", TestContainer);
 
-    this.testApp.directive('customDirective', function() {
-        return {
-            restrict: 'E',
-            replace: true,
-            template: '<div>InnerContent</div>',
-            link: function(scope, element) {
-                assert.equal($(element).parent().length, 1, "T306481");
-            }
-        };
-    });
+    this.testApp.directive('customDirective', () => ({
+        restrict: 'E',
+        replace: true,
+        template: '<div>InnerContent</div>',
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+        link(scope, element) {
+            assert.equal($(element).parent().length, 1, "T306481");
+        }
+    }));
+
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
     $(
         "<div dx-test-container-widget='{}'>" +
@@ -1856,8 +1862,8 @@ QUnit.test("Directive is in DOM on linking (T306481)", function(assert) {
 });
 
 QUnit.test("Widget options does not override scope properties", function(assert) {
-    var TestContainer = Widget.inherit({
-        _renderContentImpl: function(template) {
+    const TestContainer = Widget.inherit({
+        _renderContentImpl(template) {
             template = template || this.option("integrationOptions.templates").template;
             if(template) {
                 template.render({
@@ -1871,17 +1877,19 @@ QUnit.test("Widget options does not override scope properties", function(assert)
     registerComponent("dxTestContainer1", TestContainer);
 
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div/>")
-            .attr("ng-controller", "my-controller")
-            .appendTo($container),
-        $markup = $(
-            "<div dx-test-container1='{ }'>" +
-            "   <div>{{text}}</div>" +
-            "</div>"
-        ).appendTo($controller);
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
-    this.testApp.controller("my-controller", function($scope) {
+    const $controller = $("<div/>")
+        .attr("ng-controller", "my-controller")
+        .appendTo($container);
+
+    const $markup = $(
+        "<div dx-test-container1='{ }'>" +
+        "   <div>{{text}}</div>" +
+        "</div>"
+    ).appendTo($controller);
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.text = "Controller model";
     });
 
@@ -1891,37 +1899,37 @@ QUnit.test("Widget options does not override scope properties", function(assert)
 });
 
 QUnit.module("ui.collectionWidget", {
-    beforeEach: function() {
+    beforeEach() {
         QUnit.timerIgnoringCheckers.register(ignoreAngularBrowserDeferTimer);
     },
-    afterEach: function() {
+    afterEach() {
         QUnit.timerIgnoringCheckers.unregister(ignoreAngularBrowserDeferTimer);
     }
 });
 
-var initMarkup = function($markup, controller) {
-    var TestCollectionContainer = CollectionWidget.inherit({
-        _itemClass: function() {
+const initMarkup = ($markup, controller) => {
+    const TestCollectionContainer = CollectionWidget.inherit({
+        _itemClass() {
             return "dx-test-item";
         },
 
-        _itemDataKey: function() {
+        _itemDataKey() {
             return "dxTestItemData";
         }
     });
 
-    var TestWidget = Widget.inherit({
-        _getDefaultOptions: function() {
+    const TestWidget = Widget.inherit({
+        _getDefaultOptions() {
             return $.extend(this.callBase(), {
                 text: ""
             });
         },
 
-        _render: function() {
+        _render() {
             this.$element().append($("<span />").text(this.option("text")));
         },
 
-        _clean: function() {
+        _clean() {
             this.$element().empty();
         }
     });
@@ -1929,7 +1937,7 @@ var initMarkup = function($markup, controller) {
     registerComponent("dxTestCollectionContainer", TestCollectionContainer);
     registerComponent("dxTestWidget", TestWidget);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
     $("<div/>")
         .attr("ng-controller", "my-controller")
@@ -1943,24 +1951,26 @@ var initMarkup = function($markup, controller) {
     return $markup;
 };
 
-QUnit.test("collection container item value escalates to scope", function(assert) {
-    var controller = function($scope) {
-            $scope.collection = [
-            { widgetText: "my text" }
-            ];
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"item\">" +
-            "   <div data-options='dxTemplate: { name: \"item\" }' dx-test-widget='{ bindingOptions: { text: \"item.widgetText\" } }'>" +
-            "   </div>" +
-            "</div>"
-        ), controller),
-        scope = $markup.scope();
+QUnit.test("collection container item value escalates to scope", assert => {
+    const controller = $scope => {
+        $scope.collection = [
+        { widgetText: "my text" }
+        ];
+    };
 
-    var $item = $markup.children().children().eq(0);
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"item\">" +
+        "   <div data-options='dxTemplate: { name: \"item\" }' dx-test-widget='{ bindingOptions: { text: \"item.widgetText\" } }'>" +
+        "   </div>" +
+        "</div>"
+    ), controller);
+
+    const scope = $markup.scope();
+
+    const $item = $markup.children().children().eq(0);
     assert.equal($item.dxTestWidget("instance").option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.collection[0].widgetText = "new text";
     });
     assert.equal($item.dxTestWidget("instance").option("text"), "new text");
@@ -1970,22 +1980,24 @@ QUnit.test("collection container item value escalates to scope", function(assert
     assert.equal(scope.collection[0].widgetText, "own text");
 });
 
-QUnit.test("collection container primitive item value escalates to scope", function(assert) {
-    var controller = function($scope) {
-            $scope.collection = ["my text"];
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"item\">" +
-            "   <div data-options='dxTemplate: { name: \"item\" }' dx-test-widget='{ bindingOptions: { text: \"item\" } }'>" +
-            "   </div>" +
-            "</div>"
-        ), controller),
-        scope = $markup.scope();
+QUnit.test("collection container primitive item value escalates to scope", assert => {
+    const controller = $scope => {
+        $scope.collection = ["my text"];
+    };
 
-    var $item = $markup.children().children().eq(0);
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"item\">" +
+        "   <div data-options='dxTemplate: { name: \"item\" }' dx-test-widget='{ bindingOptions: { text: \"item\" } }'>" +
+        "   </div>" +
+        "</div>"
+    ), controller);
+
+    const scope = $markup.scope();
+
+    let $item = $markup.children().children().eq(0);
     assert.equal($item.dxTestWidget("instance").option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.collection[0] = "new text";
     });
     $item = $markup.children().children().eq(0);
@@ -1996,26 +2008,28 @@ QUnit.test("collection container primitive item value escalates to scope", funct
     assert.equal(scope.collection[0], "own text");
 });
 
-QUnit.test("collection container item value escalates to scope: complex paths", function(assert) {
-    var controller = function($scope) {
-            $scope.vm = {
-                collection: [
+QUnit.test("collection container item value escalates to scope: complex paths", assert => {
+    const controller = $scope => {
+        $scope.vm = {
+            collection: [
                 { data: { widgetText: "my text" } }
-                ]
-            };
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'vm.collection' } }\" dx-item-alias=\"item\">" +
-            "   <div data-options='dxTemplate: { name: \"item\" }' dx-test-widget='{ bindingOptions: { text: \"item.data.widgetText\" } }'>" +
-            "   </div>" +
-            "</div>"
-        ), controller),
-        scope = $markup.scope();
+            ]
+        };
+    };
 
-    var $item = $markup.children().children().eq(0);
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'vm.collection' } }\" dx-item-alias=\"item\">" +
+        "   <div data-options='dxTemplate: { name: \"item\" }' dx-test-widget='{ bindingOptions: { text: \"item.data.widgetText\" } }'>" +
+        "   </div>" +
+        "</div>"
+    ), controller);
+
+    const scope = $markup.scope();
+
+    const $item = $markup.children().children().eq(0);
     assert.equal($item.dxTestWidget("instance").option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.vm.collection[0].data.widgetText = "new text";
     });
     assert.equal($item.dxTestWidget("instance").option("text"), "new text");
@@ -2025,8 +2039,8 @@ QUnit.test("collection container item value escalates to scope: complex paths", 
     assert.equal(scope.vm.collection[0].data.widgetText, "own text");
 });
 
-QUnit.test("Bootstrap should not fail if container component changes element markup on init (Problem after updating Angular to 1.2.16)", function(assert) {
-    var controller = function($scope) {
+QUnit.test("Bootstrap should not fail if container component changes element markup on init (Problem after updating Angular to 1.2.16)", assert => {
+    const controller = $scope => {
         $scope.vm = {
             items: [
                 { text: "0" },
@@ -2055,23 +2069,24 @@ QUnit.test("Bootstrap should not fail if container component changes element mar
 QUnit.test("Global scope properties are accessible from item template", function(assert) {
     this.clock = sinon.useFakeTimers();
 
-    var controller = function($scope) {
-            $scope.collection = [
+    const controller = $scope => {
+        $scope.collection = [
             { itemText: "Item text" }
-            ];
+        ];
 
-            $scope.globalText = "Global text";
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"item\">" +
-            "   <div data-options='dxTemplate: { name: \"item\" }'>" +
-            "       <div ng-bind='item.itemText' class='item-text'>" +
-            "       </div>" +
-            "       <div ng-bind='globalText' class='global-text'>" +
-            "       </div>" +
-            "   </div>" +
-            "</div>"
-        ), controller);
+        $scope.globalText = "Global text";
+    };
+
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"item\">" +
+        "   <div data-options='dxTemplate: { name: \"item\" }'>" +
+        "       <div ng-bind='item.itemText' class='item-text'>" +
+        "       </div>" +
+        "       <div ng-bind='globalText' class='global-text'>" +
+        "       </div>" +
+        "   </div>" +
+        "</div>"
+    ), controller);
 
     this.clock.tick();
 
@@ -2081,82 +2096,89 @@ QUnit.test("Global scope properties are accessible from item template", function
     this.clock.restore();
 });
 
-QUnit.test("binding to circular data (T144697)", function(assert) {
-    var controller = function($scope) {
-            $scope.collection = [];
-            $scope.collection.push({
-                text: "Item text",
-                parent: $scope.collection
-            });
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\"></div>"
-        ), controller),
-        scope = $markup.scope();
+QUnit.test("binding to circular data (T144697)", assert => {
+    const controller = $scope => {
+        $scope.collection = [];
+        $scope.collection.push({
+            text: "Item text",
+            parent: $scope.collection
+        });
+    };
+
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\"></div>"
+    ), controller);
+
+    const scope = $markup.scope();
 
     assert.equal($.trim($markup.text()), "Item text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.collection[0].text = "New text";
     });
 
     assert.equal($.trim($markup.text()), "New text");
 });
 
-QUnit.test("watcher type changed (T145604)", function(assert) {
-    var data = [],
-        controller = function($scope) {
-            $scope.collection = undefined;// Important!!!
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\"></div>"
-        ), controller),
-        scope = $markup.scope();
+QUnit.test("watcher type changed (T145604)", assert => {
+    const data = [];
+
+    const controller = $scope => {
+        $scope.collection = undefined;// Important!!!
+    };
+
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\"></div>"
+    ), controller);
+
+    const scope = $markup.scope();
 
 
-    for(var i = 0; i < 100; i++) {
+    for(let i = 0; i < 100; i++) {
         data.push({
             text: "Item text " + i
         });
     }
 
     // render items can take some time
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.collection = data;
     });
 
     // change item's property shouldn't recompare the whole collection
-    var $watchOld = scope["$watch"],
-        watchLog = [];
+    const $watchOld = scope["$watch"];
 
-    scope["$watch"] = function() {
-        watchLog.push(arguments);
-        return $watchOld.apply(arguments, this);
+    const watchLog = [];
+
+    scope["$watch"] = function(...args) {
+        watchLog.push(args);
+        return $watchOld.apply(args, this);
     };
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.collection[0].text = "New text";
     });
     assert.equal(watchLog.length, 0, "$watch shouldn't be used");
-
 });
 
-QUnit.test("Defining item data alias by 'itemAlias' with custom template for all items", function(assert) {
-    var controller = function($scope) {
-            $scope.collection = [1, 2, 3];
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"item\">" +
-            "   <div data-options='dxTemplate: { name: \"item\" }'>" +
-            "       <div dx-test-widget=\"{ bindingOptions: { text: 'item' } }\" class=\"test-widget\"></div>" +
-            "   </div>" +
-            "</div>"
-        ), controller),
-        scope = $markup.scope();
+QUnit.test("Defining item data alias by 'itemAlias' with custom template for all items", assert => {
+    const controller = $scope => {
+        $scope.collection = [1, 2, 3];
+    };
 
-    var $item = $markup.find(".test-widget").eq(0);
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"item\">" +
+        "   <div data-options='dxTemplate: { name: \"item\" }'>" +
+        "       <div dx-test-widget=\"{ bindingOptions: { text: 'item' } }\" class=\"test-widget\"></div>" +
+        "   </div>" +
+        "</div>"
+    ), controller);
+
+    const scope = $markup.scope();
+
+    let $item = $markup.find(".test-widget").eq(0);
     assert.equal($item.dxTestWidget("option", "text"), "1");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.collection[0] = "new text";
     });
 
@@ -2169,30 +2191,33 @@ QUnit.test("Defining item data alias by 'itemAlias' with custom template for all
 
 QUnit.test("Defining item data alias by 'itemAlias' with custom template for some items", function(assert) {
     this.clock = sinon.useFakeTimers();
-    var controller = function($scope) {
-            $scope.collection = [{ name: "0", template: "customWidget" }, { name: "1", template: "custom" }, { text: "2" }, "3"];
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"user\">" +
-            "   <div data-options='dxTemplate: { name: \"customWidget\" }'>" +
-            "       <div dx-test-widget=\"{ bindingOptions: { text: 'user.name' } }\" class=\"test-widget\"></div>" +
-            "   </div>" +
-            "   <div data-options='dxTemplate: { name: \"custom\" }'>" +
-            "       {{user.name}}" +
-            "   </div>" +
-            "</div>"
-        ), controller),
-        scope = $markup.scope();
+
+    const controller = $scope => {
+        $scope.collection = [{ name: "0", template: "customWidget" }, { name: "1", template: "custom" }, { text: "2" }, "3"];
+    };
+
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'collection' } }\" dx-item-alias=\"user\">" +
+        "   <div data-options='dxTemplate: { name: \"customWidget\" }'>" +
+        "       <div dx-test-widget=\"{ bindingOptions: { text: 'user.name' } }\" class=\"test-widget\"></div>" +
+        "   </div>" +
+        "   <div data-options='dxTemplate: { name: \"custom\" }'>" +
+        "       {{user.name}}" +
+        "   </div>" +
+        "</div>"
+    ), controller);
+
+    const scope = $markup.scope();
 
     this.clock.tick();
 
-    var $items = $markup.children();
+    let $items = $markup.children();
     assert.equal($items.eq(0).find(".test-widget").dxTestWidget("option", "text"), "0");
     assert.equal($.trim($items.eq(1).text()), "1");
     assert.equal($.trim($items.eq(2).text()), "2");
     assert.equal($.trim($items.eq(3).text()), "3");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.collection[0].name = "new text 0";
         scope.collection[1].name = "new text 1";
         scope.collection[2].text = "new text 2";
@@ -2213,70 +2238,72 @@ QUnit.test("Defining item data alias by 'itemAlias' with custom template for som
     this.clock.restore();
 });
 
-QUnit.test("$index is available in markup (T542335)", function(assert) {
-    var controller = function($scope) {
-            $scope.items = [
+QUnit.test("$index is available in markup (T542335)", assert => {
+    const controller = $scope => {
+        $scope.items = [
                 { text: "text1" },
                 { text: "text2" }
-            ];
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ bindingOptions: { items: 'items' } }\" dx-item-alias=\"item\">" +
-            "   <div data-options='dxTemplate: { name: \"item\" }'>" +
-            "       <div dx-test-widget=\"{ bindingOptions: { text: '$index' } }\" class=\"test-widget\"></div>" +
-            "   </div>" +
-            "</div>"
-        ), controller);
+        ];
+    };
 
-    var $items = $markup.find(".test-widget");
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ bindingOptions: { items: 'items' } }\" dx-item-alias=\"item\">" +
+        "   <div data-options='dxTemplate: { name: \"item\" }'>" +
+        "       <div dx-test-widget=\"{ bindingOptions: { text: '$index' } }\" class=\"test-widget\"></div>" +
+        "   </div>" +
+        "</div>"
+    ), controller);
+
+    const $items = $markup.find(".test-widget");
 
     assert.equal($items.eq(0).dxTestWidget("option", "text"), "0");
     assert.equal($items.eq(1).dxTestWidget("option", "text"), "1");
 });
 
-QUnit.test("$id in item model not caused exception", function(assert) {
-    var controller = function($scope) {
-            $scope.collection = [
+QUnit.test("$id in item model not caused exception", assert => {
+    const controller = $scope => {
+        $scope.collection = [
                 { text: "my text", $id: 1 }
-            ];
-        },
-        $markup = initMarkup($(
-            "<div dx-test-collection-container=\"{ items: collection }\">" +
-            "</div>"
-        ), controller);
+        ];
+    };
+
+    const $markup = initMarkup($(
+        "<div dx-test-collection-container=\"{ items: collection }\">" +
+        "</div>"
+    ), controller);
 
     assert.equal($markup.text(), "my text");
 });
 
 QUnit.module("misc and regressions", {
-    beforeEach: function() {
+    beforeEach() {
         this.testApp = angular.module("testApp", ["dx"]);
         QUnit.timerIgnoringCheckers.register(ignoreAngularBrowserDeferTimer);
     },
-    afterEach: function() {
+    afterEach() {
         QUnit.timerIgnoringCheckers.unregister(ignoreAngularBrowserDeferTimer);
     }
 });
 
-QUnit.test("template.render() - data parameter is Scope", function(assert) {
-    var TestContainer = Widget.inherit({
+QUnit.test("template.render() - data parameter is Scope", assert => {
+    const TestContainer = Widget.inherit({
 
-        _getDefaultOptions: function() {
+        _getDefaultOptions() {
             return $.extend(this.callBase(), {
                 text: "default"
             });
         },
 
-        _init: function() {
-            this.callBase.apply(this, arguments);
+        _init(...args) {
+            this.callBase(...args);
 
-            var element = this.$element().get(0);
+            const element = this.$element().get(0);
             this.scope = angular.element(element).scope().$new();
             this.scope.text = this.option("text");
         },
 
-        _render: function() {
-            var content = $("<div />")
+        _render() {
+            const content = $("<div />")
                     .addClass("dx-content")
                     .appendTo(this.$element());
 
@@ -2288,11 +2315,11 @@ QUnit.test("template.render() - data parameter is Scope", function(assert) {
 
         _renderContentImpl: noop,
 
-        _optionChanged: function(args) {
+        _optionChanged(args) {
             if(args.name === "text") {
-                var that = this;
+                const that = this;
 
-                that.scope.$apply(function() {
+                that.scope.$apply(() => {
                     that.scope.text = args.value;
                 });
             } else {
@@ -2304,47 +2331,51 @@ QUnit.test("template.render() - data parameter is Scope", function(assert) {
 
     registerComponent("dxTestContainerScope", TestContainer);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $markup = $(
-            "<div dx-test-container-scope='{ text: \"my text\" }'>" +
-            "   <div class='text' ng-bind='text'></div>" +
-            "</div>"
-        ).appendTo($container);
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+
+    const $markup = $(
+        "<div dx-test-container-scope='{ text: \"my text\" }'>" +
+        "   <div class='text' ng-bind='text'></div>" +
+        "</div>"
+    ).appendTo($container);
 
 
     angular.bootstrap($container, ["testApp"]);
 
     assert.equal($markup.find(".text").text(), "my text");
-    var instance = $markup.dxTestContainerScope("instance");
+    const instance = $markup.dxTestContainerScope("instance");
 
     instance.option("text", "new text");
     assert.equal($markup.find(".text").text(), "new text");
 });
 
 QUnit.test("binding for item of array option", function(assert) {
-    var TestCollectionContainer = CollectionWidget.inherit({
-        _itemClass: function() {
+    const TestCollectionContainer = CollectionWidget.inherit({
+        _itemClass() {
             return "dx-test-item";
         },
 
-        _itemDataKey: function() {
+        _itemDataKey() {
             return "dxTestItemData";
         }
     });
 
     registerComponent("dxTestCollectionContainer", TestCollectionContainer);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div/>")
-                    .attr("ng-controller", "my-controller")
-                    .appendTo($container),
-        $markup = $(
-            "<div dx-test-collection-container=\"{ items: [ { text: 'value 1'}, { }, { } ], bindingOptions: { 'items[1].text': 'item2', 'items[2].text': 'vm.item3' } }\">" +
-                    "</div>"
-            ).appendTo($controller),
-        scope;
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
-    this.testApp.controller("my-controller", function($scope) {
+    const $controller = $("<div/>")
+                .attr("ng-controller", "my-controller")
+                .appendTo($container);
+
+    const $markup = $(
+        "<div dx-test-collection-container=\"{ items: [ { text: 'value 1'}, { }, { } ], bindingOptions: { 'items[1].text': 'item2', 'items[2].text': 'vm.item3' } }\">" +
+                "</div>"
+        ).appendTo($controller);
+
+    let scope;
+
+    this.testApp.controller("my-controller", $scope => {
         scope = $scope;
 
         $scope.item2 = "value 2";
@@ -2357,14 +2388,14 @@ QUnit.test("binding for item of array option", function(assert) {
 
     assert.equal($markup.children().eq(1).text(), "value 2");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.item2 = "new value 2";
         scope.vm.item3 = "new value 3";
     });
     assert.equal($markup.children().eq(1).text(), "new value 2");
     assert.equal($markup.children().eq(2).text(), "new value 3");
 
-    var instance = $markup.dxTestCollectionContainer("instance");
+    const instance = $markup.dxTestCollectionContainer("instance");
     instance.option("items", [{ text: 'value 4' }, { text: 'value 5' }, { text: 'value 6' }]);
 
     assert.equal(scope.item2, "value 5");
@@ -2374,13 +2405,15 @@ QUnit.test("binding for item of array option", function(assert) {
 QUnit.test("all values should be correct displayed in collection widget (T425426)", function(assert) {
     registerComponent("dxTestCollection", CollectionWidget);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div/>")
-                .attr("ng-controller", "my-controller")
-                .appendTo($container),
-        $markup = $("<div dx-test-collection=\"{ items: [ 0, 1, null, '', undefined, {} ] }\"></div>").appendTo($controller);
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
 
-    this.testApp.controller("my-controller", function() { });
+    const $controller = $("<div/>")
+            .attr("ng-controller", "my-controller")
+            .appendTo($container);
+
+    const $markup = $("<div dx-test-collection=\"{ items: [ 0, 1, null, '', undefined, {} ] }\"></div>").appendTo($controller);
+
+    this.testApp.controller("my-controller", () => { });
 
     angular.bootstrap($container, ["testApp"]);
 
@@ -2392,9 +2425,9 @@ QUnit.test("all values should be correct displayed in collection widget (T425426
     assert.equal($markup.children().eq(5).text(), "");
 });
 
-QUnit.test("child collection widget should be rendered correctly when template provider is specified", function(assert) {
-    var ChildWidget = Widget.inherit({
-        _render: function() {
+QUnit.test("child collection widget should be rendered correctly when template provider is specified", assert => {
+    const ChildWidget = Widget.inherit({
+        _render() {
             this.callBase();
             this.$element().addClass("child-widget");
         }
@@ -2402,18 +2435,18 @@ QUnit.test("child collection widget should be rendered correctly when template p
 
     registerComponent("dxChildWidget", ChildWidget);
 
-    var ParentWidget = Widget.inherit({
-        _render: function() {
+    const ParentWidget = Widget.inherit({
+        _render() {
             this.callBase();
-            var $childWidget = $("<div>").appendTo(this.$element());
+            const $childWidget = $("<div>").appendTo(this.$element());
             this._createComponent($childWidget, "dxChildWidget");
         }
     });
 
     registerComponent("dxParentWidget", ParentWidget);
 
-    var $container = $("<div>").appendTo(FIXTURE_ELEMENT());
-    var $markup = $("<div dx-parent-widget='{}'></div>")
+    const $container = $("<div>").appendTo(FIXTURE_ELEMENT());
+    const $markup = $("<div dx-parent-widget='{}'></div>")
         .appendTo($container);
 
     angular.bootstrap($container, ["testApp"]);
@@ -2423,28 +2456,30 @@ QUnit.test("child collection widget should be rendered correctly when template p
 
 
 QUnit.test("memory leaks in CollectionWidget", function(assert) {
-    var TestCollectionContainer = CollectionWidget.inherit({
-        _itemClass: function() {
+    const TestCollectionContainer = CollectionWidget.inherit({
+        _itemClass() {
             return "dx-test-item";
         },
 
-        _itemDataKey: function() {
+        _itemDataKey() {
             return "dxTestItemData";
         }
     });
 
     registerComponent("dxLeakTestCollectionContainer", TestCollectionContainer);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div/>")
-            .attr("ng-controller", "my-controller")
-            .appendTo($container),
-        scope;
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+
+    const $controller = $("<div/>")
+        .attr("ng-controller", "my-controller")
+        .appendTo($container);
+
+    let scope;
 
     $("<div dx-leak-test-collection-container=\"{ bindingOptions: { items: 'items' } }\" dx-item-alias=\"item\"><span></span></div>")
         .appendTo($controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         scope = $scope;
 
         $scope.items = [
@@ -2455,8 +2490,8 @@ QUnit.test("memory leaks in CollectionWidget", function(assert) {
 
     angular.bootstrap($container, ["testApp"]);
 
-    var calcSiblings = function(sibling) {
-        var result = 0;
+    const calcSiblings = sibling => {
+        let result = 0;
 
         while(sibling) {
             result++;
@@ -2468,7 +2503,7 @@ QUnit.test("memory leaks in CollectionWidget", function(assert) {
 
     assert.equal(calcSiblings(scope.$$childHead), 2);
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.items.pop();
     });
 
@@ -2476,26 +2511,28 @@ QUnit.test("memory leaks in CollectionWidget", function(assert) {
 });
 
 QUnit.test("binding inside ng-repeat (T137200)", function(assert) {
-    var TestComponent = DOMComponent.inherit({
-        _getDefaultOptions: function() {
+    const TestComponent = DOMComponent.inherit({
+        _getDefaultOptions() {
             return { text: "", array: [], obj: null };
         }
     });
 
     registerComponent("dxRepeatTest", TestComponent);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div></div>")
-            .attr("ng-controller", "my-controller")
-            .appendTo($container),
-        scope;
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+
+    const $controller = $("<div></div>")
+        .attr("ng-controller", "my-controller")
+        .appendTo($container);
+
+    let scope;
 
     $("<div ng-repeat=\"vm in items\">"
         + "    <div dx-repeat-test=\"{ bindingOptions: { text: 'vm.text' } }\"></div>"
         + "</div>")
         .appendTo($controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         scope = $scope;
 
         $scope.items = [
@@ -2507,19 +2544,19 @@ QUnit.test("binding inside ng-repeat (T137200)", function(assert) {
 
     angular.bootstrap($container, ["testApp"]);
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.items[0].text = "new text";
     });
 
-    var $elements = $("[dx-repeat-test]", $container);
+    const $elements = $("[dx-repeat-test]", $container);
 
     assert.equal($elements.first().dxRepeatTest("option", "text"), "new text");
     assert.equal($elements.last().dxRepeatTest("option", "text"), "my text 3");
 });
 
 QUnit.test("component should notify view model if option changed on ctor after initialization (T219862)", function(assert) {
-    var ComponentClass = DOMComponent.inherit({
-        _render: function() {
+    const ComponentClass = DOMComponent.inherit({
+        _render() {
             this.callBase();
             this.option("a", 2);
         }
@@ -2527,15 +2564,17 @@ QUnit.test("component should notify view model if option changed on ctor after i
 
     registerComponent("test", ComponentClass);
 
-    var $container = $("<div/>").appendTo(FIXTURE_ELEMENT()),
-        $controller = $("<div></div>")
-            .attr("ng-controller", "my-controller")
-            .appendTo($container),
-        scope;
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+
+    const $controller = $("<div></div>")
+        .attr("ng-controller", "my-controller")
+        .appendTo($container);
+
+    let scope;
 
     $("<div test=\"{ bindingOptions: { a: 'a'} }\"></div>").appendTo($controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         scope = $scope;
         $scope.a = 1;
     });
@@ -2545,40 +2584,40 @@ QUnit.test("component should notify view model if option changed on ctor after i
     assert.equal(scope.a, 2);
 });
 
-QUnit.test("Watchers executed after component initialization (T334273)", function(assert) {
-    var exceptionFired = false,
-        app = angular.module('app', ["ng", 'dx']).factory('$exceptionHandler', function() {
-            return function(exception, cause) {
-                exceptionFired = true;
-            };
-        });
+QUnit.test("Watchers executed after component initialization (T334273)", assert => {
+    let exceptionFired = false;
 
-    var TestComponent = DOMComponent.inherit({});
+    const app = angular.module('app', ["ng", 'dx']).factory('$exceptionHandler', () => (exception, cause) => {
+        exceptionFired = true;
+    });
+
+    const TestComponent = DOMComponent.inherit({});
 
     registerComponent("dxTest", TestComponent);
 
     app.directive('customDirective', [
-        function() {
-            return {
-                restrict: 'A',
-                template: '<div>' +
-                                '<div dx-test="{ bindingOptions: { width: \'w\' }, height: \'0\' }"></div>' +
-                            '</div>',
-                replace: true,
-                compile: function(tElem, tAttrs) {
-                    return {
-                        "pre": function(scope, iElem, iAttrs, controller) {
-                            scope.w = 0;
-                        }
-                    };
-                }
-            };
-        }]);
+        () => ({
+            restrict: 'A',
 
-    var element = $('<div custom-directive></div>').appendTo(FIXTURE_ELEMENT());
+            template: '<div>' +
+                            '<div dx-test="{ bindingOptions: { width: \'w\' }, height: \'0\' }"></div>' +
+                        '</div>',
+
+            replace: true,
+
+            compile(tElem, tAttrs) {
+                return {
+                    "pre": function(scope, iElem, iAttrs, controller) {
+                        scope.w = 0;
+                    }
+                };
+            }
+        })]);
+
+    const element = $('<div custom-directive></div>').appendTo(FIXTURE_ELEMENT());
 
 
-    angular.injector(['app']).invoke(function($rootScope, $compile) {
+    angular.injector(['app']).invoke(($rootScope, $compile) => {
         $compile(element)($rootScope);
     });
 
@@ -2586,22 +2625,22 @@ QUnit.test("Watchers executed after component initialization (T334273)", functio
 });
 
 QUnit.module("component action context", {
-    beforeEach: function() {
-        var TestComponent = DOMComponent.inherit({
-            _getDefaultOptions: function() {
+    beforeEach() {
+        const TestComponent = DOMComponent.inherit({
+            _getDefaultOptions() {
                 return $.extend(this.callBase(), {
                     onHandler: noop,
                     value: null
                 });
             },
 
-            trigger: function(e) {
+            trigger(e) {
                 this._createAction(this.option("onHandler"))(e);
             },
-            triggerByOption: function(e) {
+            triggerByOption(e) {
                 this._createActionByOption("onHandler")(e);
             },
-            triggerByOptionCategoryRendering: function(e) {
+            triggerByOptionCategoryRendering(e) {
                 this._createActionByOption("onHandler", { category: "rendering" })(e);
             }
         });
@@ -2616,25 +2655,26 @@ QUnit.module("component action context", {
 
         QUnit.timerIgnoringCheckers.register(ignoreAngularBrowserDeferTimer);
     },
-    afterEach: function() {
+    afterEach() {
         QUnit.timerIgnoringCheckers.unregister(ignoreAngularBrowserDeferTimer);
     }
 });
 
 QUnit.test("component action created by option calls scope.$apply", function(assert) {
-    var $markup = $("<div dx-action-test='{ onHandler: vm.handler }'></div>")
-            .appendTo(this.$controller),
-        valueChanged = false;
+    const $markup = $("<div dx-action-test='{ onHandler: vm.handler }'></div>")
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let valueChanged = false;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
-            handler: function(e) {
+            handler(e) {
                 $scope.vm.value = "new value";
             },
             value: "old value"
         };
 
-        $scope.$watch("vm.value", function(newValue, oldValue) {
+        $scope.$watch("vm.value", (newValue, oldValue) => {
             if(newValue !== oldValue) {
                 valueChanged = true;
             }
@@ -2649,19 +2689,20 @@ QUnit.test("component action created by option calls scope.$apply", function(ass
 });
 
 QUnit.test("component internal action does not calls scope.$apply", function(assert) {
-    var $markup = $("<div dx-action-test='{ onHandler: vm.handler }'></div>")
-            .appendTo(this.$controller),
-        valueChanged = false;
+    const $markup = $("<div dx-action-test='{ onHandler: vm.handler }'></div>")
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let valueChanged = false;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
-            handler: function(e) {
+            handler(e) {
                 $scope.vm.value = "new value";
             },
             value: "old value"
         };
 
-        $scope.$watch("vm.value", function(newValue, oldValue) {
+        $scope.$watch("vm.value", (newValue, oldValue) => {
             if(newValue !== oldValue) {
                 valueChanged = true;
             }
@@ -2676,19 +2717,20 @@ QUnit.test("component internal action does not calls scope.$apply", function(ass
 });
 
 QUnit.test("component created by option with category 'rendering' does not calls scope.$apply", function(assert) {
-    var $markup = $("<div dx-action-test='{ onHandler: vm.handler }'></div>")
-            .appendTo(this.$controller),
-        valueChanged = false;
+    const $markup = $("<div dx-action-test='{ onHandler: vm.handler }'></div>")
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let valueChanged = false;
+
+    this.testApp.controller("my-controller", $scope => {
         $scope.vm = {
-            handler: function(e) {
+            handler(e) {
                 $scope.vm.value = "new value";
             },
             value: "old value"
         };
 
-        $scope.$watch("vm.value", function(newValue, oldValue) {
+        $scope.$watch("vm.value", (newValue, oldValue) => {
             if(newValue !== oldValue) {
                 valueChanged = true;
             }
@@ -2704,15 +2746,16 @@ QUnit.test("component created by option with category 'rendering' does not calls
 
 // related with Q566857
 QUnit.test("change option in component action handler (phase $apply) ", function(assert) {
-    var $markup = $("<div dx-action-test=\"{ onHandler: vm.handler,  bindingOptions: { value: 'vm.value' }}\"></div>")
-            .appendTo(this.$controller),
-        scope;
+    const $markup = $("<div dx-action-test=\"{ onHandler: vm.handler,  bindingOptions: { value: 'vm.value' }}\"></div>")
+            .appendTo(this.$controller);
+
+    let scope;
 
 
-    this.testApp.controller("my-controller", function($scope) {
+    this.testApp.controller("my-controller", $scope => {
         scope = $scope;
         $scope.vm = {
-            handler: function(e) {
+            handler(e) {
                 $markup.dxActionTest("option", "value", "new value");
             },
             value: "old value"
@@ -2727,27 +2770,28 @@ QUnit.test("change option in component action handler (phase $apply) ", function
 });
 
 QUnit.test("component action context is component", function(assert) {
-    var context;
-    var handler = function(e) {
+    let context;
+    const handler = function(e) {
         context = this;
     };
 
-    var $markup = $("<div></div>").appendTo(this.$container);
+    const $markup = $("<div></div>").appendTo(this.$container);
     $markup.dxActionTest({ onHandler: handler });
 
-    var component = $markup.dxActionTest("instance");
+    const component = $markup.dxActionTest("instance");
     component.triggerByOption();
 
     assert.equal(context, component);
 });
 
 QUnit.test("Using ng-expressions in dx syntax", function(assert) {
-    var $markup = $("<div/>")
+    const $markup = $("<div/>")
             .attr("dx-action-test", "{ onHandler: 'vm.value = \"new value\"' }")
-            .appendTo(this.$controller),
-        scope;
+            .appendTo(this.$controller);
 
-    this.testApp.controller("my-controller", function($scope) {
+    let scope;
+
+    this.testApp.controller("my-controller", $scope => {
         scope = $scope;
         $scope.vm = {
             value: "old value"
@@ -2762,8 +2806,8 @@ QUnit.test("Using ng-expressions in dx syntax", function(assert) {
 });
 
 QUnit.module("dxComponent as a template", {
-    beforeEach: function() {
-        var TemplateComponent = Widget.inherit({});
+    beforeEach() {
+        const TemplateComponent = Widget.inherit({});
 
         this.testApp = angular.module("testApp", ["dx"]);
         this.$container = $("<div/>").appendTo(FIXTURE_ELEMENT());
@@ -2772,45 +2816,44 @@ QUnit.module("dxComponent as a template", {
 
         QUnit.timerIgnoringCheckers.register(ignoreAngularBrowserDeferTimer);
     },
-    afterEach: function() {
+    afterEach() {
         QUnit.timerIgnoringCheckers.unregister(ignoreAngularBrowserDeferTimer);
     }
 });
 
 QUnit.test("Parent directive scope value goes to template component option object", function(assert) {
-    var initialWatchersCount;
+    let initialWatchersCount;
 
     $("<custom-directive/>").appendTo(this.$container);
 
-    this.testApp.directive('customDirective', function() {
-        return {
-            restrict: 'E',
-            replace: true,
-            template: '<div dx-template-component="config"></div>',
-            link: function(scope) {
-                // NOTE: One uncleared watcher created for dxDigestCallbacks service
-                initialWatchersCount = scope.$$watchers.length;
+    this.testApp.directive('customDirective', () => ({
+        restrict: 'E',
+        replace: true,
+        template: '<div dx-template-component="config"></div>',
 
-                scope.boundOption = 'default value';
-                scope.config = {
-                    text: "my text",
-                    bindingOptions: {
-                        boundOption: 'boundOption'
-                    }
-                };
-            }
-        };
-    });
+        link(scope) {
+            // NOTE: One uncleared watcher created for dxDigestCallbacks service
+            initialWatchersCount = scope.$$watchers.length;
+
+            scope.boundOption = 'default value';
+            scope.config = {
+                text: "my text",
+                bindingOptions: {
+                    boundOption: 'boundOption'
+                }
+            };
+        }
+    }));
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var $markup = this.$container.children(),
-        instance = $markup.dxTemplateComponent("instance"),
-        scope = $markup.scope();
+    const $markup = this.$container.children();
+    const instance = $markup.dxTemplateComponent("instance");
+    const scope = $markup.scope();
 
     assert.equal(instance.option("text"), "my text");
 
-    scope.$apply(function() {
+    scope.$apply(() => {
         scope.boundOption = "new value";
     });
 
@@ -2821,21 +2864,18 @@ QUnit.test("Parent directive scope value goes to template component option objec
 QUnit.test("No watchers on disposing", function(assert) {
     $("<custom-directive/>").appendTo(this.$container);
 
-    this.testApp.directive('customDirective', function() {
-
-        return {
-            restrict: 'E',
-            replace: true,
-            template: '<div dx-template-component="config"></div>',
-            link: function(scope) { }
-        };
-    });
+    this.testApp.directive('customDirective', () => ({
+        restrict: 'E',
+        replace: true,
+        template: '<div dx-template-component="config"></div>',
+        link(scope) { }
+    }));
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var $markup = this.$container.children(),
-        instance = $markup.dxTemplateComponent("instance"),
-        scope = $markup.scope();
+    const $markup = this.$container.children();
+    const instance = $markup.dxTemplateComponent("instance");
+    const scope = $markup.scope();
 
     $markup.remove();
 
@@ -2845,34 +2885,34 @@ QUnit.test("No watchers on disposing", function(assert) {
 
 
 QUnit.test("Component shouldn't watch digest callback after dispose", function(assert) {
-    var beginCounter = 0,
-        endCounter = 0;
+    let beginCounter = 0;
+    let endCounter = 0;
 
-    var TestComponent = DOMComponent.inherit({
-        beginUpdate: function(args) {
+    const TestComponent = DOMComponent.inherit({
+        beginUpdate(args) {
             beginCounter++;
-            this.callBase.apply(this, arguments);
+            this.callBase(...arguments);
         },
-        endUpdate: function() {
+        endUpdate(...args) {
             endCounter++;
-            this.callBase.apply(this, arguments);
+            this.callBase(...args);
         }
     });
 
     registerComponent("dxTestWidget", TestComponent);
 
-    var $markup = $("<div></div>")
+    const $markup = $("<div></div>")
             .attr("dx-test-widget", "{}")
             .appendTo(this.$container);
 
     angular.bootstrap(this.$container, ["testApp"]);
 
-    var scope = $markup.scope();
+    const scope = $markup.scope();
     $markup.remove();
 
     beginCounter = 0;
     endCounter = 0;
-    scope.$apply(function() {});
+    scope.$apply(() => {});
 
     assert.equal(beginCounter, 0);
     assert.equal(endCounter, 0);

--- a/testing/tests/DevExpress.angular/componentRegistration.tests.js
+++ b/testing/tests/DevExpress.angular/componentRegistration.tests.js
@@ -1566,6 +1566,41 @@ QUnit.test("Transclude inside dxComponent template (T318690). Since angularjs 1.
     assert.equal($markup.children('[dx-test-container]').find(".transcluded-content").length, 1);
 });
 
+QUnit.test("Multi-slot transclusion should work with dx temapltes", function(assert) {
+    const TestContainer = Widget.inherit({
+        _renderContentImpl(template) {
+            template = template || this.option("integrationOptions.templates").template;
+            if(template) {
+                template.render({
+                    container: this.$element()
+                });
+            }
+        }
+    });
+
+    registerComponent("dxTestTranscluded", TestContainer);
+    this.testApp.directive("testMultiTransclude", () => ({
+        restrict: "E",
+        transclude: {
+            "content": '?content',
+        },
+        template: `<div dx-test-transcluded="{}">
+                    <div data-options="dxTemplate: { name: 'template'}">
+                        <div ng-transclude="content"></div>
+                    </div>
+                </div>`
+    }));
+
+    const $container = $("<div/>").appendTo(FIXTURE_ELEMENT());
+    $(`<test-multi-transclude>
+        <content>Test content</content>
+    </test-multi-transclude>`).appendTo($container);
+
+    angular.bootstrap($container, ["testApp"]);
+
+    assert.equal($container.find("[dx-test-transcluded] content").text(), "Test content");
+});
+
 QUnit.module("Widget & CollectionWidget with templates enabled", {
     beforeEach() {
         this.testApp = angular.module("testApp", ["dx"]);


### PR DESCRIPTION
Fixes [T654943](https://www.devexpress.com/Support/Center/Question/Details/T654943/popup-the-multi-slot-transclusion-causes-the-compile-noslot-error).