### PR TITLE
Add defaultValue option to data getters (T648641)

### DIFF
--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -70,7 +70,7 @@ var compileGetter = function(expr) {
                     break;
                 }
 
-                var useDefaultValue = defaultValueExists && !(path[i] in current),
+                var useDefaultValue = defaultValueExists && typeUtils.isPlainObject(current) && !(path[i] in current),
                     nextValue = useDefaultValue ? options.defaultValue : current[path[i]],
                     next = unwrap(nextValue, options);
 

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -66,9 +66,12 @@ var compileGetter = function(expr) {
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
-                if(!current) break;
+                if(!current) {
+                    current = defaultValueExists ? options.defaultValue : current;
+                    break;
+                }
 
-                var useDefaultValue = defaultValueExists && !path[i] in current,
+                var useDefaultValue = defaultValueExists && !(path[i] in current),
                     nextValue = useDefaultValue ? options.defaultValue : current[path[i]],
                     next = unwrap(nextValue, options);
 

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -67,13 +67,15 @@ var compileGetter = function(expr) {
 
             for(var i = 0; i < path.length; i++) {
                 if(!current) {
-                    return hasDefaultValue ? options.defaultValue : current;
+                    if(current == null && hasDefaultValue) {
+                        return options.defaultValue;
+                    }
+                    break;
                 }
 
-                var pathPart = path[i],
-                    useDefaultValue = hasDefaultValue && typeUtils.isObject(current) && !(pathPart in current);
+                var pathPart = path[i];
 
-                if(useDefaultValue) {
+                if(hasDefaultValue && typeUtils.isObject(current) && !(pathPart in current)) {
                     return options.defaultValue;
                 }
 

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -62,16 +62,15 @@ var compileGetter = function(expr) {
         return function(obj, options) {
             options = prepareOptions(options);
             var functionAsIs = options.functionsAsIs,
-                defaultValueExists = "defaultValue" in options,
+                hasDefaultValue = "defaultValue" in options,
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
                 if(!current) break;
 
                 var pathPart = path[i],
-                    useDefaultValue = defaultValueExists && typeUtils.isObject(current) && !(pathPart in current),
-                    nextValue = useDefaultValue ? options.defaultValue : current[pathPart],
-                    next = unwrap(nextValue, options);
+                    useDefaultValue = hasDefaultValue && typeUtils.isObject(current) && !(pathPart in current),
+                    next = unwrap(useDefaultValue ? options.defaultValue : current[pathPart], options);
 
                 if(!functionAsIs && typeUtils.isFunction(next)) {
                     next = next.call(current);

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -62,12 +62,13 @@ var compileGetter = function(expr) {
         return function(obj, options) {
             options = prepareOptions(options);
             var functionAsIs = options.functionsAsIs,
+                defaultValueExists = "defaultValue" in options,
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
                 if(!current) break;
 
-                var useDefaultValue = options.hasOwnProperty("defaultValue") && !current.hasOwnProperty(path[i]) && typeUtils.isPlainObject(current),
+                var useDefaultValue = defaultValueExists && !path[i] in current,
                     nextValue = useDefaultValue ? options.defaultValue : current[path[i]],
                     next = unwrap(nextValue, options);
 

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -67,7 +67,6 @@ var compileGetter = function(expr) {
 
             for(var i = 0; i < path.length; i++) {
                 if(!current) {
-                    current = defaultValueExists ? options.defaultValue : current;
                     break;
                 }
 

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -66,10 +66,15 @@ var compileGetter = function(expr) {
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
-                var pathPart = path[i];
+                if(!current) {
+                    return hasDefaultValue ? options.defaultValue : current;
+                }
 
-                if(!current || typeUtils.isObject(current) && !(pathPart in current)) {
-                    return hasDefaultValue ? options.defaultValue : undefined;
+                var pathPart = path[i],
+                    useDefaultValue = hasDefaultValue && typeUtils.isObject(current) && !(pathPart in current);
+
+                if(useDefaultValue) {
+                    return options.defaultValue;
                 }
 
                 var next = unwrap(current[pathPart], options);

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -66,11 +66,22 @@ var compileGetter = function(expr) {
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
-                if(!current) break;
+                if(!current) {
+                    if(hasDefaultValue) {
+                        return options.defaultValue;
+                    }
+
+                    break;
+                }
 
                 var pathPart = path[i],
-                    useDefaultValue = hasDefaultValue && typeUtils.isObject(current) && !(pathPart in current),
-                    next = unwrap(useDefaultValue ? options.defaultValue : current[pathPart], options);
+                    useDefaultValue = hasDefaultValue && typeUtils.isObject(current) && !(pathPart in current);
+
+                if(useDefaultValue) {
+                    return options.defaultValue;
+                }
+
+                var next = unwrap(current[pathPart], options);
 
                 if(!functionAsIs && typeUtils.isFunction(next)) {
                     next = next.call(current);

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -66,9 +66,7 @@ var compileGetter = function(expr) {
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
-                if(!current) {
-                    break;
-                }
+                if(!current) break;
 
                 var pathPart = path[i],
                     useDefaultValue = defaultValueExists && typeUtils.isObject(current) && !(pathPart in current),

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -68,7 +68,7 @@ var compileGetter = function(expr) {
             for(var i = 0; i < path.length; i++) {
                 if(!current) break;
 
-                var nextValue = current.hasOwnProperty(path[i]) ? current[path[i]] : defaultValue,
+                var nextValue = current[path[i]] || current.hasOwnProperty(path[i]) ? current[path[i]] : defaultValue,
                     next = unwrap(nextValue, options);
 
                 if(!functionAsIs && typeUtils.isFunction(next)) {

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -66,19 +66,10 @@ var compileGetter = function(expr) {
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
-                if(!current) {
-                    if(hasDefaultValue) {
-                        return options.defaultValue;
-                    }
+                var pathPart = path[i];
 
-                    break;
-                }
-
-                var pathPart = path[i],
-                    useDefaultValue = hasDefaultValue && typeUtils.isObject(current) && !(pathPart in current);
-
-                if(useDefaultValue) {
-                    return options.defaultValue;
+                if(!current || typeUtils.isObject(current) && !(pathPart in current)) {
+                    return hasDefaultValue ? options.defaultValue : undefined;
                 }
 
                 var next = unwrap(current[pathPart], options);

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -68,7 +68,8 @@ var compileGetter = function(expr) {
             for(var i = 0; i < path.length; i++) {
                 if(!current) break;
 
-                var nextValue = current[path[i]] || current.hasOwnProperty(path[i]) ? current[path[i]] : defaultValue,
+                var useDefaultValue = typeUtils.isPlainObject(current) && !current.hasOwnProperty(path[i]),
+                    nextValue = useDefaultValue ? defaultValue : current[path[i]],
                     next = unwrap(nextValue, options);
 
                 if(!functionAsIs && typeUtils.isFunction(next)) {

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -70,8 +70,9 @@ var compileGetter = function(expr) {
                     break;
                 }
 
-                var useDefaultValue = defaultValueExists && typeUtils.isPlainObject(current) && !(path[i] in current),
-                    nextValue = useDefaultValue ? options.defaultValue : current[path[i]],
+                var pathPart = path[i],
+                    useDefaultValue = defaultValueExists && typeUtils.isObject(current) && !(pathPart in current),
+                    nextValue = useDefaultValue ? options.defaultValue : current[pathPart],
                     next = unwrap(nextValue, options);
 
                 if(!functionAsIs && typeUtils.isFunction(next)) {

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -62,14 +62,13 @@ var compileGetter = function(expr) {
         return function(obj, options) {
             options = prepareOptions(options);
             var functionAsIs = options.functionsAsIs,
-                defaultValue = options.defaultValue,
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
                 if(!current) break;
 
-                var useDefaultValue = typeUtils.isPlainObject(current) && !current.hasOwnProperty(path[i]),
-                    nextValue = useDefaultValue ? defaultValue : current[path[i]],
+                var useDefaultValue = options.hasOwnProperty("defaultValue") && !current.hasOwnProperty(path[i]) && typeUtils.isPlainObject(current),
+                    nextValue = useDefaultValue ? options.defaultValue : current[path[i]],
                     next = unwrap(nextValue, options);
 
                 if(!functionAsIs && typeUtils.isFunction(next)) {

--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -62,12 +62,14 @@ var compileGetter = function(expr) {
         return function(obj, options) {
             options = prepareOptions(options);
             var functionAsIs = options.functionsAsIs,
+                defaultValue = options.defaultValue,
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
                 if(!current) break;
 
-                var next = unwrap(current[path[i]], options);
+                var nextValue = current.hasOwnProperty(path[i]) ? current[path[i]] : defaultValue,
+                    next = unwrap(nextValue, options);
 
                 if(!functionAsIs && typeUtils.isFunction(next)) {
                     next = next.call(current);

--- a/js/ui/hierarchical_collection/ui.data_converter.js
+++ b/js/ui/hierarchical_collection/ui.data_converter.js
@@ -63,12 +63,12 @@ var DataConverter = Class.inherit({
         item.visible !== false && this._visibleItemsCount++;
 
         var that = this,
-            isNodeSelected = that._dataAccessors.getters.selected(item, { defaultValue: null }),
+            isNodeSelected = that._dataAccessors.getters.selected(item, { defaultValue: false }),
             node = {
                 internalFields: {
                     disabled: that._dataAccessors.getters.disabled(item) || false,
                     expanded: that._dataAccessors.getters.expanded(item) || false,
-                    selected: isNodeSelected !== null ? isNodeSelected : false,
+                    selected: isNodeSelected,
                     key: that._getUniqueKey(item),
                     parentKey: typeUtils.isDefined(parentKey) ? parentKey : that._rootValue,
                     item: that._makeObjectFromPrimitive(item),

--- a/js/ui/hierarchical_collection/ui.data_converter.js
+++ b/js/ui/hierarchical_collection/ui.data_converter.js
@@ -63,11 +63,12 @@ var DataConverter = Class.inherit({
         item.visible !== false && this._visibleItemsCount++;
 
         var that = this,
+            isNodeSelected = that._dataAccessors.getters.selected(item, { defaultValue: null }),
             node = {
                 internalFields: {
                     disabled: that._dataAccessors.getters.disabled(item) || false,
                     expanded: that._dataAccessors.getters.expanded(item) || false,
-                    selected: that._dataAccessors.getters.selected(item) || false,
+                    selected: isNodeSelected !== null ? isNodeSelected : false,
                     key: that._getUniqueKey(item),
                     parentKey: typeUtils.isDefined(parentKey) ? parentKey : that._rootValue,
                     item: that._makeObjectFromPrimitive(item),

--- a/js/ui/hierarchical_collection/ui.data_converter.js
+++ b/js/ui/hierarchical_collection/ui.data_converter.js
@@ -63,12 +63,11 @@ var DataConverter = Class.inherit({
         item.visible !== false && this._visibleItemsCount++;
 
         var that = this,
-            isNodeSelected = that._dataAccessors.getters.selected(item, { defaultValue: false }),
             node = {
                 internalFields: {
-                    disabled: that._dataAccessors.getters.disabled(item) || false,
-                    expanded: that._dataAccessors.getters.expanded(item) || false,
-                    selected: isNodeSelected,
+                    disabled: that._dataAccessors.getters.disabled(item, { defaultValue: false }),
+                    expanded: that._dataAccessors.getters.expanded(item, { defaultValue: false }),
+                    selected: that._dataAccessors.getters.selected(item, { defaultValue: false }),
                     key: that._getUniqueKey(item),
                     parentKey: typeUtils.isDefined(parentKey) ? parentKey : that._rootValue,
                     item: that._makeObjectFromPrimitive(item),

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -56,10 +56,11 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("d.a")(obj), "d().a");
     assert.equal(GETTER("e.z")(obj), undefined);
     assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);
-    assert.equal(GETTER("a")(null, { defaultValue: 1 }), null);
+    assert.equal(GETTER("a")(null, { defaultValue: 1 }), 1);
     assert.equal(GETTER("a")(null), null);
     assert.equal(GETTER("z.z.z")(obj), undefined);
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
+    assert.deepEqual(GETTER("a.b.c")({}, { defaultValue: { b: 1 } }), { b: 1 });
 });
 
 QUnit.test("inheritance", function(assert) {

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -59,6 +59,16 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("a")(null), null);
     assert.equal(GETTER("z.z.z")(obj), undefined);
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
+});
+
+QUnit.test("default values", function(assert) {
+    var obj = {
+        a: "a",
+        c: {
+            a: 1
+        },
+        f: 0
+    };
 
     assert.equal(GETTER("a")(null, { defaultValue: 1 }), 1);
     assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -55,11 +55,12 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
     assert.equal(GETTER("d.a")(obj), "d().a");
     assert.equal(GETTER("e.z")(obj), undefined);
-    assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);
-    assert.equal(GETTER("a")(null, { defaultValue: 1 }), 1);
     assert.equal(GETTER("a")(null), null);
     assert.equal(GETTER("z.z.z")(obj), undefined);
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
+
+    assert.equal(GETTER("a")(null, { defaultValue: 1 }), 1);
+    assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);
     assert.deepEqual(GETTER("a.b.c")({}, { defaultValue: { b: 1 } }), { b: 1 });
 });
 

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -56,10 +56,25 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("d.a")(obj), "d().a");
     assert.equal(GETTER("e.z")(obj), undefined);
     assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);
+    assert.equal(GETTER("a")(null, { defaultValue: 1 }), 1);
+    assert.equal(GETTER("a")(null), null);
     assert.equal(GETTER("z.z.z")(obj), undefined);
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
 });
 
+QUnit.test("inheritance", function(assert) {
+    class Parent {
+    };
+
+    class Child extends Parent {
+    };
+
+    Parent.prototype["a"] = 123;
+    let obj = new Child();
+
+    assert.equal(obj.a, 123, "object has property");
+    assert.equal(GETTER("a")(obj, { defaultValue: false }), 123);
+});
 
 QUnit.test("complex getter", function(assert) {
     var original = {

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -46,7 +46,6 @@ QUnit.test("it works", function(assert) {
         d: function() {
             return { a: "d().a" };
         },
-        e: null,
         f: 0
     };
     assert.equal(GETTER()(obj), obj);

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -46,7 +46,8 @@ QUnit.test("it works", function(assert) {
         d: function() {
             return { a: "d().a" };
         },
-        e: null
+        e: null,
+        f: 0
     };
     assert.equal(GETTER()(obj), obj);
     assert.equal(GETTER("this")(obj), obj);
@@ -62,6 +63,8 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("a")(null, { defaultValue: 1 }), 1);
     assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);
     assert.deepEqual(GETTER("a.b.c")({}, { defaultValue: { b: 1 } }), { b: 1 });
+    assert.strictEqual(GETTER("f")(obj, { defaultValue: 1 }), 0);
+    assert.strictEqual(GETTER("f.x")(obj, { defaultValue: 1 }), 1);
 });
 
 QUnit.test("inheritance", function(assert) {

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -68,6 +68,7 @@ QUnit.test("defaultValue", function(assert) {
 
     var DEFAULT_VALUE = "TEST_DEFAULT_VALUE";
 
+    assert.equal(GETTER("any")(undefined, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
     assert.equal(GETTER("any")(null, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
 
     assert.equal(GETTER("missing")(obj, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
@@ -77,21 +78,14 @@ QUnit.test("defaultValue", function(assert) {
     assert.equal(GETTER("emptyString.length")(obj, { defaultValue: DEFAULT_VALUE }), 0);
 
     assert.deepEqual(GETTER("phantom.missing")({}, { defaultValue: { phantom: {} } }), { phantom: {} });
-});
 
-QUnit.test("inheritance", function(assert) {
-    class Parent {
-    };
+    class Parent { }
+    class Child extends Parent { }
+    Parent.prototype["parentProp"] = 123;
 
-    class Child extends Parent {
-    };
-
-    Parent.prototype["a"] = 123;
-    let obj = new Child();
-
-    assert.equal(obj.a, 123, "object has property");
-    assert.equal(GETTER("a")(obj, { defaultValue: false }), 123);
-    assert.equal(GETTER("b")(obj, { defaultValue: 1 }), 1);
+    assert.equal(GETTER("missing")(new function() {}, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+    assert.equal(GETTER("parentProp")(new Child, { defaultValue: DEFAULT_VALUE }), 123);
+    assert.equal(GETTER("missing")(new Child, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
 });
 
 QUnit.test("complex getter", function(assert) {

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -46,7 +46,7 @@ QUnit.test("it works", function(assert) {
         d: function() {
             return { a: "d().a" };
         },
-        f: 0
+        e: null
     };
     assert.equal(GETTER()(obj), obj);
     assert.equal(GETTER("this")(obj), obj);

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -74,6 +74,7 @@ QUnit.test("inheritance", function(assert) {
 
     assert.equal(obj.a, 123, "object has property");
     assert.equal(GETTER("a")(obj, { defaultValue: false }), 123);
+    assert.equal(GETTER("b")(obj, { defaultValue: 1 }), 1);
 });
 
 QUnit.test("complex getter", function(assert) {

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -56,25 +56,28 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
     assert.equal(GETTER("d.a")(obj), "d().a");
     assert.equal(GETTER("e.z")(obj), undefined);
-    assert.equal(GETTER("a")(null), null);
     assert.equal(GETTER("z.z.z")(obj), undefined);
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
 });
 
-QUnit.test("default values", function(assert) {
+QUnit.test("defaultValue", function(assert) {
     var obj = {
-        a: "a",
-        c: {
-            a: 1
-        },
-        f: 0
+        zero: 0,
+        emptyString: "",
+        innerObj: {}
     };
 
-    assert.equal(GETTER("a")(null, { defaultValue: 1 }), 1);
-    assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);
-    assert.deepEqual(GETTER("a.b.c")({}, { defaultValue: { b: 1 } }), { b: 1 });
-    assert.strictEqual(GETTER("f")(obj, { defaultValue: 1 }), 0);
-    assert.strictEqual(GETTER("f.x")(obj, { defaultValue: 1 }), 1);
+    var DEFAULT_VALUE = "TEST_DEFAULT_VALUE";
+
+    assert.equal(GETTER("any")(null, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+
+    assert.equal(GETTER("missing")(obj, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+    assert.equal(GETTER("innerObj.missing")(obj, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+
+    assert.equal(GETTER("zero")(obj, { defaultValue: DEFAULT_VALUE }), 0);
+    assert.equal(GETTER("emptyString.length")(obj, { defaultValue: DEFAULT_VALUE }), 0);
+
+    assert.deepEqual(GETTER("phantom.missing")({}, { defaultValue: { phantom: {} } }), { phantom: {} });
 });
 
 QUnit.test("inheritance", function(assert) {

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -56,7 +56,7 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("d.a")(obj), "d().a");
     assert.equal(GETTER("e.z")(obj), undefined);
     assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);
-    assert.equal(GETTER("a")(null, { defaultValue: 1 }), 1);
+    assert.equal(GETTER("a")(null, { defaultValue: 1 }), null);
     assert.equal(GETTER("a")(null), null);
     assert.equal(GETTER("z.z.z")(obj), undefined);
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -55,6 +55,7 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
     assert.equal(GETTER("d.a")(obj), "d().a");
     assert.equal(GETTER("e.z")(obj), undefined);
+    assert.equal(GETTER("c.b")(obj, { defaultValue: 1 }), 1);
     assert.equal(GETTER("z.z.z")(obj), undefined);
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
 });


### PR DESCRIPTION
Make difference between an undefined value of the property and no property in the object.

Some widgets such as the [dxCheckBox](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxCheckBox/Configuration/#value) may have an `undefined` value but it's default value when there is no value option specified, should be `false`