### PR TITLE
Add defaultValue option to data getters (T648641) (#5212)

### DIFF
--- a/js/core/utils/data.js
+++ b/js/core/utils/data.js
@@ -62,12 +62,24 @@ var compileGetter = function(expr) {
         return function(obj, options) {
             options = prepareOptions(options);
             var functionAsIs = options.functionsAsIs,
+                hasDefaultValue = "defaultValue" in options,
                 current = unwrap(obj, options);
 
             for(var i = 0; i < path.length; i++) {
-                if(!current) break;
+                if(!current) {
+                    if(current == null && hasDefaultValue) {
+                        return options.defaultValue;
+                    }
+                    break;
+                }
 
-                var next = unwrap(current[path[i]], options);
+                var pathPart = path[i];
+
+                if(hasDefaultValue && typeUtils.isObject(current) && !(pathPart in current)) {
+                    return options.defaultValue;
+                }
+
+                var next = unwrap(current[pathPart], options);
 
                 if(!functionAsIs && typeUtils.isFunction(next)) {
                     next = next.call(current);

--- a/js/ui/hierarchical_collection/ui.data_converter.js
+++ b/js/ui/hierarchical_collection/ui.data_converter.js
@@ -65,9 +65,9 @@ var DataConverter = Class.inherit({
         var that = this,
             node = {
                 internalFields: {
-                    disabled: that._dataAccessors.getters.disabled(item) || false,
-                    expanded: that._dataAccessors.getters.expanded(item) || false,
-                    selected: that._dataAccessors.getters.selected(item) || false,
+                    disabled: that._dataAccessors.getters.disabled(item, { defaultValue: false }),
+                    expanded: that._dataAccessors.getters.expanded(item, { defaultValue: false }),
+                    selected: that._dataAccessors.getters.selected(item, { defaultValue: false }),
                     key: that._getUniqueKey(item),
                     parentKey: typeUtils.isDefined(parentKey) ? parentKey : that._rootValue,
                     item: that._makeObjectFromPrimitive(item),

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -59,6 +59,39 @@ QUnit.test("it works", function(assert) {
     assert.equal(GETTER("c.a.a")(obj), "c.a.a");
 });
 
+QUnit.test("defaultValue", function(assert) {
+    var obj = {
+        zero: 0,
+        emptyString: "",
+        innerObj: {}
+    };
+
+    var DEFAULT_VALUE = "TEST_DEFAULT_VALUE";
+
+    assert.equal(GETTER("any")(undefined, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+    assert.equal(GETTER("any")(null, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+
+    assert.equal(GETTER("missing")(obj, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+    assert.equal(GETTER("innerObj.missing")(obj, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+
+    assert.equal(GETTER("zero")(obj, { defaultValue: DEFAULT_VALUE }), 0);
+    assert.equal(GETTER("emptyString.length")(obj, { defaultValue: DEFAULT_VALUE }), 0);
+
+    assert.deepEqual(GETTER("phantom.missing")({}, { defaultValue: { phantom: {} } }), { phantom: {} });
+
+    class Parent {
+    }
+
+    class Child extends Parent {
+    }
+
+    Parent.prototype["parentProp"] = 123;
+
+    assert.equal(GETTER("missing")(new function() {
+    }, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+    assert.equal(GETTER("parentProp")(new Child, { defaultValue: DEFAULT_VALUE }), 123);
+    assert.equal(GETTER("missing")(new Child, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
+});
 
 QUnit.test("complex getter", function(assert) {
     var original = {


### PR DESCRIPTION
Make difference between an undefined value of the property and no property in the object.

Some widgets such as the [dxCheckBox](https://js.devexpress.com/Documentation/ApiReference/UI_Widgets/dxCheckBox/Configuration/#value) may have an `undefined` value but it's default value when there is no value option specified, should be `false`