### PR TITLE
Add 'bin' section to devextreme-themebuilder package to allow run through npx

### DIFF
--- a/themebuilder/package.json
+++ b/themebuilder/package.json
@@ -25,5 +25,8 @@
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "mock-require": "^3.0.2"
+  },
+  "bin": {
+    "devextreme-themebuilder": "cli/index.js"
   }
 }


### PR DESCRIPTION
We have to add 'bin' section. Npx searches bin scripts only.
