### PR TITLE
DataGrid - Change 'Array.findIndex' to 'for/break' because IE11 doesn't support it

### DIFF
--- a/js/client_exporter/xlsx/xlsx_file.js
+++ b/js/client_exporter/xlsx/xlsx_file.js
@@ -12,8 +12,13 @@ export default class XlsxFile {
         let result;
         const cellFormatTag = XlsxCellFormatHelper.tryCreateTag(cellFormat);
         if(typeUtils.isDefined(cellFormatTag)) {
-            result = this._cellFormatTags.findIndex(item => XlsxCellFormatHelper.areEqual(item, cellFormatTag));
-            if(result < 0) {
+            for(let i = 0; i < this._cellFormatTags.length; i++) {
+                if(XlsxCellFormatHelper.areEqual(this._cellFormatTags[i], cellFormatTag)) {
+                    result = i;
+                    break;
+                }
+            }
+            if(result === undefined) {
                 result = this._cellFormatTags.push(cellFormatTag) - 1;
             }
         }


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
