### PR TITLE
DataGrid - Change 'Object.assign' to 'extend' because IE11 doesn't support it

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.export.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.export.tests.js
@@ -6,6 +6,7 @@ import $ from "jquery";
 import { excel as excelCreator } from "client_exporter";
 import excel_creator from "client_exporter/excel_creator";
 import JSZipMock from "../../helpers/jszipMock.js";
+import { extend } from "core/utils/extend";
 
 QUnit.testStart(function() {
     var markup = '<div id="dataGrid"></div>';
@@ -1049,7 +1050,7 @@ QUnit.test("customizeXlsxCell - set alignment: null for all xlsx cells", functio
             columns: [{ dataField: "field1" }],
             dataSource: [{ field1: 'str1_1' }],
             export: {
-                customizeXlsxCell: e => Object.assign(e.xlsxCell.style, { alignment: null })
+                customizeXlsxCell: e => extend(true, e.xlsxCell, { style: { alignment: null } }),
             }
         },
         { styles, worksheet, sharedStrings }

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.export.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.export.tests.js
@@ -9,6 +9,7 @@ import $ from "jquery";
 import { __internals as internals } from "client_exporter/excel_creator";
 import excel_creator from "client_exporter/excel_creator";
 import JSZipMock from "../../helpers/jszipMock.js";
+import { extend } from "core/utils/extend";
 
 const SHARED_STRINGS_HEADER_XML = internals.XML_TAG + '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"';
 const STYLESHEET_HEADER_XML = internals.XML_TAG + '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">';
@@ -324,7 +325,7 @@ QUnit.test("customizeXlsxCell - set alignment: null for all xlsx cells", functio
         assert,
         {
             export: {
-                customizeXlsxCell: e => Object.assign(e.xlsxCell.style, { alignment: null })
+                customizeXlsxCell: e => extend(true, e.xlsxCell, { style: { alignment: null } }),
             }
         },
         { styles, worksheet, sharedStrings }


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
