### PR TITLE
Fix the max date of min-max range when a value is the last day of the month (T669145)

### DIFF
--- a/js/core/utils/date.js
+++ b/js/core/utils/date.js
@@ -321,7 +321,8 @@ var getViewMinBoundaryDate = function(viewType, date) {
 };
 
 var getViewMaxBoundaryDate = function(viewType, date) {
-    var resultDate = new Date(date.getFullYear(), date.getMonth(), getLastMonthDay(date));
+    var resultDate = new Date(date);
+    resultDate.setDate(getLastMonthDay(date));
 
     if(viewType === "month") {
         return resultDate;

--- a/testing/tests/DevExpress.core/utils.date.tests.js
+++ b/testing/tests/DevExpress.core/utils.date.tests.js
@@ -570,3 +570,9 @@ QUnit.test("getViewMaxBoundaryDate", function(assert) {
     resultDate = dateUtils.getViewMaxBoundaryDate("century", initialDate);
     assert.deepEqual(resultDate, new Date(2099, 11, 31), "last decade, last year, last month and last day are set for century");
 });
+
+QUnit.test("the getViewMaxBoundaryDate method is should be return value with corrected time", function(assert) {
+    var initialDate = new Date(2018, 7, 31, 12, 13, 23);
+    var resultDate = dateUtils.getViewMaxBoundaryDate("month", initialDate);
+    assert.deepEqual(resultDate, new Date(initialDate), "last day of a month should be equal to an initial date and a time");
+});


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
