### PR TITLE
Make it possible to prevent selection of dxTreeView item on itemClick handler

### DIFF
--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1434,7 +1434,7 @@ var TreeViewBase = HierarchicalCollectionWidget.inherit({
 
         this._itemDXEventHandler(e, "onItemClick", { node: this._dataAdapter.getPublicNode(node) });
 
-        if(this.option("selectByClick")) {
+        if(this.option("selectByClick") && !e.isDefaultPrevented()) {
             this._updateItemSelection(!node.internalFields.selected, itemData, e);
         }
     },

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/selection.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/selection.js
@@ -262,6 +262,23 @@ QUnit.test("selectByClick option should unselect item  by second click", functio
     assert.notOk(items[0].selected, "item was unselected");
 });
 
+QUnit.test("selection can be prevented on itemClick", function(assert) {
+    var items = [{ text: "item 1" }, { text: "item 2" }],
+        $treeview = initTree({
+            items: items,
+            selectByClick: true,
+            selectionMode: "single",
+            onItemClick: function(e) {
+                e.event.preventDefault();
+            }
+        }),
+        $item = $treeview.find(".dx-treeview-item").eq(0);
+
+    $item.trigger("dxclick");
+
+    assert.notOk(items[0].selected, "item selection has been prevented");
+});
+
 QUnit.test("selectNodesRecursive should be ignored when single selection is enabled", function(assert) {
     var $treeview = initTree({
             items: [{ text: "Item 1", expanded: true, items: [{ text: "Item 11" }] }],


### PR DESCRIPTION
This change is useful in case when the dxTreeView is a navigation widget. If you are using a slideOut menu with the dxTreeView inside it, you don't expected non-leaf item selected on click but expected it just expanded.