### PR TITLE
Don't recalculate dxMenu item width on each window resize event (T672827)

### DIFF
--- a/js/ui/menu/ui.menu.js
+++ b/js/ui/menu/ui.menu.js
@@ -311,6 +311,9 @@ var Menu = MenuBase.inherit({
 
     _visibilityChanged: function(visible) {
         if(visible) {
+            if(!this._menuItemsWidth) {
+                this._updateItemsWidthCache();
+            }
             this._dimensionChanged();
         }
     },
@@ -319,16 +322,23 @@ var Menu = MenuBase.inherit({
         return this.option("adaptivityEnabled") && this.option("orientation") === "horizontal";
     },
 
+    _updateItemsWidthCache: function() {
+        var $menuItems = this.$element().find("ul").first().children("li").children("." + DX_MENU_ITEM_CLASS);
+        this._menuItemsWidth = this._getSummaryItemsWidth($menuItems, true);
+    },
+
     _dimensionChanged: function() {
         if(!this._isAdaptivityEnabled()) {
             return;
         }
 
-        var $menuItems = this.$element().find("ul").first().children("li").children("." + DX_MENU_ITEM_CLASS),
-            menuItemsWidth = this._getSummaryItemsWidth($menuItems, true),
-            containerWidth = this.$element().outerWidth();
+        var containerWidth = this.$element().outerWidth();
+        this._toggleAdaptiveMode(this._menuItemsWidth > containerWidth);
+    },
 
-        this._toggleAdaptiveMode(menuItemsWidth > containerWidth);
+    _renderItems: function(items) {
+        this.callBase(items);
+        this._updateItemsWidthCache();
     },
 
     _init: function() {

--- a/js/ui/menu/ui.menu.js
+++ b/js/ui/menu/ui.menu.js
@@ -336,11 +336,6 @@ var Menu = MenuBase.inherit({
         this._toggleAdaptiveMode(this._menuItemsWidth > containerWidth);
     },
 
-    _renderItems: function(items) {
-        this.callBase(items);
-        this._updateItemsWidthCache();
-    },
-
     _init: function() {
         this.callBase();
         this._submenus = [];
@@ -508,6 +503,7 @@ var Menu = MenuBase.inherit({
 
         this.$element().append(this._$adaptiveContainer);
 
+        this._updateItemsWidthCache();
         this._dimensionChanged();
     },
 

--- a/testing/tests/DevExpress.ui.widgets/menu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menu.tests.js
@@ -1,6 +1,7 @@
 var $ = require("jquery"),
     devices = require("core/devices"),
     fx = require("animation/fx"),
+    renderer = require("core/renderer"),
     viewPort = require("core/utils/view_port").value,
     isRenderer = require("core/utils/type").isRenderer,
     config = require("core/config"),
@@ -2361,6 +2362,24 @@ QUnit.test("Menu should toggle it's view between adaptive and non adaptive on vi
     menu.option("visible", true);
 
     assert.notOk($itemsContainer.is(":visible"), "non adaptive container should be hidden");
+});
+
+QUnit.test("Adaptive menu should not flick when the window has been resized with jQuery 3.3.1", function(assert) {
+    var outerWidth = sinon.spy(renderer.fn, "outerWidth");
+
+    try {
+        new Menu(this.$element, {
+            items: [{ text: "item 1" }, { text: "item 2" }],
+            adaptivityEnabled: true
+        });
+
+        assert.equal(outerWidth.callCount, 3, "itemWidth has been called for each item and container on render");
+
+        resizeCallbacks.fire();
+        assert.equal(outerWidth.callCount, 4, "itemWidth has been called just for container on dimension change");
+    } finally {
+        outerWidth.restore();
+    }
 });
 
 QUnit.test("Adaptive mode should depend on summary item width but not on item container width", function(assert) {


### PR DESCRIPTION
This change has been made to prevent dxMenu from flicking during window resize when jQuery 3.3.1 is used