### PR TITLE
Make it possible to use keyboard navigation in dxList with selection controls (T673845)

### DIFF
--- a/js/ui/list/ui.list.edit.decorator.selection.js
+++ b/js/ui/list/ui.list.edit.decorator.selection.js
@@ -101,7 +101,7 @@ registerDecorator(
                 this._selectAllCheckBox.$element().addClass(FOCUSED_STATE_CLASS);
                 return true;
             } else {
-                this._selectAllCheckBox.$element().removeClass(FOCUSED_STATE_CLASS);
+                this._$selectAll && this._selectAllCheckBox.$element().removeClass(FOCUSED_STATE_CLASS);
                 this._list.focusListItem(itemIndex);
                 return false;
             }
@@ -112,7 +112,7 @@ registerDecorator(
         },
 
         handleEnterPressing: function() {
-            if(this._selectAllCheckBox.$element().hasClass(FOCUSED_STATE_CLASS)) {
+            if(this._$selectAll && this._selectAllCheckBox.$element().hasClass(FOCUSED_STATE_CLASS)) {
                 this._selectAllCheckBox.option("value", !this._selectAllCheckBox.option("value"));
                 return true;
             }

--- a/testing/tests/DevExpress.ui.widgets/listParts/editingUITests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/editingUITests.js
@@ -11,6 +11,7 @@ var $ = require("jquery"),
     config = require("core/config"),
     pointerMock = require("../../../helpers/pointerMock.js"),
     contextMenuEvent = require("events/contextmenu"),
+    keyboardMock = require("../../../helpers/keyboardMock.js"),
     decoratorRegistry = require("ui/list/ui.list.edit.decorator_registry"),
     SwitchableEditDecorator = require("ui/list/ui.list.edit.decorator.switchable"),
     SwitchableButtonEditDecorator = require("ui/list/ui.list.edit.decorator.switchable.button"),
@@ -2505,6 +2506,22 @@ QUnit.test("item click changes radio button state only to true in single selecti
     var radioButton = $item.children(toSelector(LIST_ITEM_BEFORE_BAG_CLASS)).children(toSelector(SELECT_RADIO_BUTTON_CLASS)).dxRadioButton("instance");
 
     assert.equal(radioButton.option("value"), true, "item selected");
+});
+
+QUnit.test("keyboard navigation should work with without selectAll checkbox", function(assert) {
+    var $list = $($("#templated-list").dxList({
+            items: ["0", "1"],
+            showSelectionControls: true,
+            selectionMode: 'single'
+        })),
+        instance = $list.dxList("instance"),
+        keyboard = keyboardMock($list);
+
+    keyboard
+        .press("down")
+        .press("enter");
+
+    assert.deepEqual(instance.option("selectedItems"), ["1"], "selection is correct");
 });
 
 


### PR DESCRIPTION
dxSelectBox uses dxList with single selection mode and without selectAll checkbox. This case leads to an exception during the keyboard navigation. This pull request fixes a problem