### PR TITLE
Remove doccomment for ODataStore.load(options)

### DIFF
--- a/js/data/odata/store.js
+++ b/js/data/odata/store.js
@@ -146,15 +146,6 @@ var ODataStore = Store.inherit({
     },
 
     /**
-    * @name ODataStoreMethods.load
-    * @publicName load(options)
-    * @type function
-    * @param1 options:LoadOptions
-    * @return Promise<any>
-    * @inheritdoc
-    */
-
-    /**
     * @name ODataStoreMethods.byKey
     * @publicName byKey(key, extraOptions)
     * @param1 key:object|string|number


### PR DESCRIPTION
WHY?

The ODataStore inherits this method from the abstract store. This doccomment has been needed because the ODataStore had additional **options**, but not anymore as all the options are now declared as LoadOptions.