### PR TITLE
Trigger 'dxresize' event for dxMultiView item when the item is shown (T675662)

### DIFF
--- a/js/ui/multi_view.js
+++ b/js/ui/multi_view.js
@@ -4,6 +4,7 @@ var $ = require("../core/renderer"),
     mathUtils = require("../core/utils/math"),
     extend = require("../core/utils/extend").extend,
     noop = require("../core/utils/common").noop,
+    domUtils = require("../core/utils/dom"),
     isDefined = require("../core/utils/type").isDefined,
     devices = require("../core/devices"),
     getPublicElement = require("../core/utils/dom").getPublicElement,
@@ -284,10 +285,12 @@ var MultiView = CollectionWidget.inherit({
     },
 
     _renderSpecificItem: function(index) {
-        var hasItemContent = this._itemElements().eq(index).find(this._itemContentClass()).length > 0;
+        var $item = this._itemElements().eq(index),
+            hasItemContent = $item.find(this._itemContentClass()).length > 0;
 
         if(isDefined(index) && !hasItemContent) {
             this._deferredItems[index].resolve();
+            domUtils.triggerResizeEvent($item);
         }
     },
 

--- a/testing/tests/DevExpress.ui.widgets/multiView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/multiView.tests.js
@@ -127,6 +127,22 @@ QUnit.test("height should be correctly updated on dxshown event", function(asser
     }
 });
 
+QUnit.test("multiView should trigger resize event for item content after item visibility changed", function(assert) {
+    var resizeHandler = sinon.spy();
+
+    $("#customMultiView").dxMultiView({
+        items: [{
+            template: () => {
+                return $("<div>", { class: "dx-visibility-change-handler" }).on("dxresize", resizeHandler);
+            }
+        }, { template: 'template2' }],
+        selectedIndex: 0,
+        height: 'auto'
+    });
+
+    assert.ok(resizeHandler.called, "event has been triggered");
+});
+
 QUnit.test("item content should be rendered correctly when template was changed (T585645)", function(assert) {
     var $multiView = $("#customMultiViewWithTemplate").dxMultiView({
             items: [{ template: $("#template1") }, { template: $("#template1") }],


### PR DESCRIPTION
This change is required for cases when there are some other widgets inside of the dxMultiview. Other widgets may require to recalculate it's dimensions when the multiview item is shown.