### PR TITLE
Add Word's list matchers for the RichTextEditor 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -323,6 +323,8 @@
                     "localizable",
                     "lookups",
                     "marginate",
+                    "matcher",
+                    "matchers",
                     "metadata",
                     "minify",
                     "mixin",

--- a/js/ui/rich_text_editor/matchers/wordLists.js
+++ b/js/ui/rich_text_editor/matchers/wordLists.js
@@ -1,0 +1,36 @@
+function getListType(matches) {
+    const prefix = matches[1];
+    return prefix.match(/\S+\./) ? 'ordered' : 'bullet';
+}
+
+function getIndent(node) {
+    const style = node.getAttribute('style').replace(/\n+/g, '');
+    const level = style.match(/level(\d+)/);
+
+    return level ? level[1] - 1 : 0;
+}
+
+const getMatcher = (quill) => {
+    const Delta = quill.import("delta");
+
+    return (node, delta) => {
+        let ops = delta.ops.slice();
+
+        let firstOperation = ops[0];
+        firstOperation.insert = firstOperation.insert.replace(/^\s+/, "");
+        const firstMatch = firstOperation.insert.match(/^(\S+)\s+/);
+
+        if(!firstMatch) {
+            return delta;
+        }
+
+        firstOperation.insert = firstOperation.insert.substring(firstMatch[0].length, firstOperation.insert.length);
+        const indent = getIndent(node);
+
+        ops.push({ insert: '\n', attributes: { list: getListType(firstMatch), indent } });
+
+        return new Delta(ops);
+    };
+};
+
+module.exports = getMatcher;

--- a/js/ui/rich_text_editor/matchers/wordLists.js
+++ b/js/ui/rich_text_editor/matchers/wordLists.js
@@ -10,25 +10,31 @@ function getIndent(node) {
     return level ? level[1] - 1 : 0;
 }
 
+function removeNewLineChar(operations) {
+    let newLineOperation = operations[operations.length - 1];
+    newLineOperation.insert = newLineOperation.insert.trim();
+}
+
 const getMatcher = (quill) => {
     const Delta = quill.import("delta");
 
     return (node, delta) => {
         let ops = delta.ops.slice();
 
-        let firstOperation = ops[0];
-        firstOperation.insert = firstOperation.insert.replace(/^\s+/, "");
-        const firstMatch = firstOperation.insert.match(/^(\S+)\s+/);
+        let insertOperation = ops[0];
+        insertOperation.insert = insertOperation.insert.replace(/^\s+/, "");
+        const listDecoratorMatches = insertOperation.insert.match(/^(\S+)\s+/);
 
-        if(!firstMatch) {
+        if(!listDecoratorMatches) {
             return delta;
         }
 
-        firstOperation.insert = firstOperation.insert.substring(firstMatch[0].length, firstOperation.insert.length);
+        insertOperation.insert = insertOperation.insert.substring(listDecoratorMatches[0].length, insertOperation.insert.length);
         const indent = getIndent(node);
 
-        ops.push({ insert: '\n', attributes: { list: getListType(firstMatch), indent } });
+        removeNewLineChar(ops);
 
+        ops.push({ insert: '\n', attributes: { list: getListType(listDecoratorMatches), indent } });
         return new Delta(ops);
     };
 };

--- a/js/ui/rich_text_editor/ui.rich_text_editor.js
+++ b/js/ui/rich_text_editor/ui.rich_text_editor.js
@@ -229,8 +229,8 @@ const RichTextEditor = Editor.inherit({
                     delete this._isEditorUpdating;
                 } else {
                     const updatedValue = this._isMarkdownValue() ? this._updateValueByType("HTML", args.value) : args.value;
+                    const newDelta = this._quillInstance.clipboard.convert(updatedValue);
 
-                    let newDelta = this._quillInstance.clipboard.convert(updatedValue);
                     this._quillInstance.setContents(newDelta);
                 }
                 this.callBase(args);

--- a/js/ui/rich_text_editor/ui.rich_text_editor.js
+++ b/js/ui/rich_text_editor/ui.rich_text_editor.js
@@ -10,6 +10,7 @@ import Errors from "../widget/ui.errors";
 import QuillRegistrator from "./quill_registrator";
 import "./converters/delta";
 import ConverterController from "./converterController";
+import getWordMatcher from "./matchers/wordLists";
 
 const RICH_TEXT_EDITOR_CLASS = "dx-richtexteditor";
 const QUILL_CONTAINER_CLASS = "dx-quill-container";
@@ -129,11 +130,19 @@ const RichTextEditor = Editor.inherit({
     },
 
     _getModulesConfig: function() {
+        const wordListMatcher = getWordMatcher(this._quillRegistrator.getQuill());
         let modulesConfig = {
             mention: this._getModuleConfigByOption("mention"),
             toolbar: this._getToolbarConfig(),
             dataPlaceholders: this._getModuleConfigByOption("dataPlaceholders"),
-            dropImage: this._getBaseModuleConfig()
+            dropImage: this._getBaseModuleConfig(),
+            clipboard: {
+                matchers: [
+                    ['p.MsoListParagraphCxSpFirst', wordListMatcher],
+                    ['p.MsoListParagraphCxSpMiddle', wordListMatcher],
+                    ['p.MsoListParagraphCxSpLast', wordListMatcher]
+                ]
+            }
         };
 
         if(this.option("allowImageResizing")) {

--- a/testing/tests/DevExpress.ui.widgets.editors/richTextEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/richTextEditor.tests.js
@@ -14,3 +14,4 @@ import "./richTextEditorParts/markup.tests.js";
 import "./richTextEditorParts/valueRendering.tests.js";
 import "./richTextEditorParts/toolbarModule.tests.js";
 import "./richTextEditorParts/dropImageModule.tests.js";
+import "./richTextEditorParts/paste.tests.js";

--- a/testing/tests/DevExpress.ui.widgets.editors/richTextEditorParts/paste.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/richTextEditorParts/paste.tests.js
@@ -1,0 +1,66 @@
+import $ from "jquery";
+
+import "ui/rich_text_editor";
+
+const MS_BULLET_LIST = "<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l1 level1 lfo1'><![if !supportLists]><span" +
+"><span style='mso-list:Ignore'>·<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" +
+"</span></span></span><![endif]><span lang=EN-US style='mso-ansi-language:EN-US'>1</span><o:p></o:p></p>" +
+"<p class=MsoListParagraphCxSpMiddle style='margin-left:72.0pt;mso-add-space:" +
+"auto;text-indent:-18.0pt;mso-list:l1 level2 lfo1'><![if !supportLists]><span><span" +
+"style='mso-list:Ignore'>o<span>&nbsp;&nbsp;</span></span></span><![endif]><span lang=EN-US style='mso-ansi-language:EN-US'>2</span><o:p></o:p></p>" +
+"<p class=MsoListParagraphCxSpMiddle style='margin-left:108.0pt;mso-add-space:" +
+"auto;text-indent:-18.0pt;mso-list:l1 level3 lfo1'><![if !supportLists]><span" +
+"><span style='mso-list:Ignore'>§<span>&nbsp;" +
+"</span></span></span><![endif]><span lang=EN-US style='mso-ansi-language:EN-US'>3</span><o:p></o:p></p>";
+
+const MS_ORDERED_LIST = "<p class=MsoListParagraphCxSpMiddle style='text-indent:-18.0pt;mso-list:l0 level1 lfo2'><![if !supportLists]><span" +
+"lang=EN-US style='mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin;" +
+"mso-ansi-language:EN-US'><span style='mso-list:Ignore'>1.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span" +
+"lang=EN-US style='mso-ansi-language:EN-US'>1<o:p></o:p></span></p>" +
+"<p class=MsoListParagraphCxSpMiddle style='margin-left:72.0pt;mso-add-space:" +
+"auto;text-indent:-18.0pt;mso-list:l0 level2 lfo2'><![if !supportLists]><span" +
+"lang=EN-US style='mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin;" +
+"mso-ansi-language:EN-US'><span style='mso-list:Ignore'>a.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span" +
+"lang=EN-US style='mso-ansi-language:EN-US'>2<o:p></o:p></span></p>" +
+"<p class=MsoListParagraphCxSpLast style='margin-left:108.0pt;mso-add-space:" +
+"auto;text-indent:-108.0pt;mso-text-indent-alt:-9.0pt;mso-list:l0 level3 lfo2'><![if !supportLists]><span" +
+"lang=EN-US style='mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin;" +
+"mso-ansi-language:EN-US'><span style='mso-list:Ignore'><span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" +
+"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" +
+"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" +
+"</span>i.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" +
+"</span></span></span><![endif]><span lang=EN-US style='mso-ansi-language:EN-US'>3<o:p></o:p></span></p>";
+
+const { test } = QUnit;
+
+QUnit.module("Paste MS lists", () => {
+    test("paste bullet list with indent", (assert) => {
+        const done = assert.async();
+        const instance = $("#richTextEditor")
+            .dxRichTextEditor({
+                onValueChanged: (e) => {
+                    assert.equal(e.value, "<ul><li>1<ul><li>2<ul><li>3</li></ul></li></ul></li></ul>");
+                    done();
+                }
+            })
+            .dxRichTextEditor("instance");
+
+        const newDelta = instance._quillInstance.clipboard.convert(MS_BULLET_LIST);
+        instance._quillInstance.setContents(newDelta);
+    });
+
+    test("paste ordered list with indent", (assert) => {
+        const done = assert.async();
+        const instance = $("#richTextEditor")
+            .dxRichTextEditor({
+                onValueChanged: (e) => {
+                    assert.equal(e.value, "<ol><li>1<ol><li>2<ol><li>3</li></ol></li></ol></li></ol>");
+                    done();
+                }
+            })
+            .dxRichTextEditor("instance");
+
+        const newDelta = instance._quillInstance.clipboard.convert(MS_ORDERED_LIST);
+        instance._quillInstance.setContents(newDelta);
+    });
+});


### PR DESCRIPTION
It allows pasting ordered or bulleted lists from Word with a nesting preserving
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
