### PR TITLE
Add private grouped option to the dxToolbar (T676099)

### DIFF
--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -97,7 +97,14 @@ var ToolbarBase = CollectionWidget.inherit({
     _getDefaultOptions: function() {
         return extend(this.callBase(), {
             renderAs: "topToolbar",
+
+            /**
+             * @name dxToolbarOptions.grouped
+             * @type boolean
+             * @default false
+             */
             grouped: false,
+
             useFlatButtons: false,
             useDefaultButtons: false
         });

--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -98,11 +98,6 @@ var ToolbarBase = CollectionWidget.inherit({
         return extend(this.callBase(), {
             renderAs: "topToolbar",
 
-            /**
-             * @name dxToolbarOptions.grouped
-             * @type boolean
-             * @default false
-             */
             grouped: false,
 
             useFlatButtons: false,

--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -97,6 +97,7 @@ var ToolbarBase = CollectionWidget.inherit({
     _getDefaultOptions: function() {
         return extend(this.callBase(), {
             renderAs: "topToolbar",
+            grouped: false,
             useFlatButtons: false,
             useDefaultButtons: false
         });
@@ -334,7 +335,9 @@ var ToolbarBase = CollectionWidget.inherit({
                 $container = $("<div>").addClass(TOOLBAR_GROUP_CLASS),
                 location = group.location || "center";
 
-            if(!groupItems.length) return;
+            if(!groupItems || !groupItems.length) {
+                return;
+            }
 
             each(groupItems, function(itemIndex, item) {
                 that._renderItem(itemIndex, item, $container, null);
@@ -345,7 +348,7 @@ var ToolbarBase = CollectionWidget.inherit({
     },
 
     _renderItems: function(items) {
-        var grouped = items.length && items[0].items;
+        var grouped = this.option("grouped") && items.length && items[0].items;
         grouped ? this._renderGroupedItems() : this.callBase(items);
     },
 
@@ -409,6 +412,8 @@ var ToolbarBase = CollectionWidget.inherit({
                 break;
             case "compactMode":
                 this._applyCompactMode();
+                break;
+            case "grouped":
                 break;
             default:
                 this.callBase.apply(this, arguments);

--- a/testing/tests/DevExpress.ui.widgets/toolbar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.markup.tests.js
@@ -229,7 +229,8 @@ QUnit.module("item groups", {
 }, () => {
     test("toolbar should show item groups", (assert) => {
         let $element = this.$element.dxToolbar({
-                items: this.groups
+                items: this.groups,
+                grouped: true,
             }),
             $groups = $element.find("." + TOOLBAR_GROUP_CLASS);
 
@@ -240,7 +241,8 @@ QUnit.module("item groups", {
 
     test("toolbar groups should be placed inside toolbar blocks", (assert) => {
         let $element = this.$element.dxToolbar({
-                items: this.groups
+                items: this.groups,
+                grouped: true
             }),
             $before = $element.find("." + TOOLBAR_BEFORE_CONTAINER_CLASS).eq(0),
             $center = $element.find("." + TOOLBAR_CENTER_CONTAINER_CLASS).eq(0),


### PR DESCRIPTION
This option is private because grouped items render incorrectly with the adaptive toolbar. dxDropDownMenu which is used by the adaptive toolbar doesn't support item grouping. Publishing of this option should be delayed before dxDropDownMenu grouping is implemented.