### PR TITLE
Allow to paste date parts or an entire text when it is exactly matches with the displayFormat

### DIFF
--- a/js/ui/date_box/ui.date_box.mask.js
+++ b/js/ui/date_box/ui.date_box.mask.js
@@ -1,5 +1,6 @@
 import eventsUtils from "../../events/utils";
 import { isFunction } from "../../core/utils/type";
+import { clipboardText } from "../../core/utils/dom";
 import { extend } from "../../core/utils/extend";
 import { fitIntoRange } from "../../core/utils/math";
 import { inRange } from "../../core/utils/math";
@@ -198,6 +199,7 @@ let DateBoxMask = DateBoxBase.inherit({
 
     _attachMaskEvents() {
         eventsEngine.on(this._input(), eventsUtils.addNamespace("dxclick", MASK_EVENT_NAMESPACE), this._maskClickHandler.bind(this));
+        eventsEngine.on(this._input(), eventsUtils.addNamespace("paste", MASK_EVENT_NAMESPACE), this._maskPasteHandler.bind(this));
         eventsEngine.on(this._input(), eventsUtils.addNamespace("drop", MASK_EVENT_NAMESPACE), (e) => {
             this._renderDisplayText(this._getDisplayedText(this._maskValue));
             this._selectNextPart(0, e);
@@ -230,8 +232,13 @@ let DateBoxMask = DateBoxBase.inherit({
 
         let index = fitIntoRange(this._activePartIndex + step, 0, this._dateParts.length - 1);
         if(this._dateParts[index].isStub) {
-            this._selectNextPart(step >= 0 ? step + 1 : step - 1, e);
-            return;
+            let isBoundaryIndex = index === 0 && step < 0 || index === this._dateParts.length - 1 && step > 0;
+            if(!isBoundaryIndex) {
+                this._selectNextPart(step >= 0 ? step + 1 : step - 1, e);
+                return;
+            } else {
+                index = this._activePartIndex;
+            }
         }
 
         this._activePartIndex = index;
@@ -314,6 +321,20 @@ let DateBoxMask = DateBoxBase.inherit({
         if(this.option("text")) {
             this._activePartIndex = getDatePartIndexByPosition(this._dateParts, this._caret().start);
             this._caret(this._getActivePartProp("caret"));
+        }
+    },
+
+    _maskPasteHandler(e) {
+        let newText = this._replaceSelectedText(this.option("text"), this._caret(), clipboardText(e));
+        let date = dateLocalization.parse(newText, this._getFormatPattern());
+
+        if(date) {
+            this._renderDateParts();
+            this._maskValue = date;
+            this._renderDisplayText(this._getDisplayedText(this._maskValue));
+            this._selectNextPart(0, e);
+        } else {
+            e.preventDefault();
         }
     },
 

--- a/js/ui/date_box/ui.date_box.mask.js
+++ b/js/ui/date_box/ui.date_box.mask.js
@@ -76,7 +76,7 @@ let DateBoxMask = DateBoxBase.inherit({
     },
 
     _getFormatPattern() {
-        var format = this.option("displayFormat"),
+        var format = this._strategy.getDisplayFormat(this.option("displayFormat")),
             isLDMLPattern = typeof format === "string" && (format.indexOf("0") >= 0 || format.indexOf("#") >= 0);
 
         if(isLDMLPattern) {
@@ -163,7 +163,7 @@ let DateBoxMask = DateBoxBase.inherit({
     },
 
     _useMaskBehavior() {
-        return this.option("useMaskBehavior") && this.option("mode") === "text" && this.option("displayFormat");
+        return this.option("useMaskBehavior") && this.option("mode") === "text";
     },
 
     _renderMask() {

--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -218,7 +218,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
 
 
         if(end - start < text.length) {
-            var editedText = this._getEditedText(text, { start: start, end: end }, ""),
+            var editedText = this._replaceSelectedText(text, { start: start, end: end }, ""),
                 noDigits = editedText.search(/[0-9]/) < 0;
 
             if(noDigits && this._isValueInRange(0)) {
@@ -289,18 +289,6 @@ var NumberBoxMask = NumberBoxBase.inherit({
         return text.replace(regExp, "");
     },
 
-    _getEditedText: function(text, selection, char) {
-        if(char === undefined) {
-            return text;
-        }
-
-        var textBefore = text.slice(0, selection.start),
-            textAfter = text.slice(selection.end),
-            edited = textBefore + char + textAfter;
-
-        return edited;
-    },
-
     _truncateToPrecision: function(value, decimalSeparator, maxPrecision) {
         if(typeUtils.isDefined(value)) {
             var strValue = value.toString(),
@@ -315,7 +303,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
     },
 
     _tryParse: function(text, selection, char) {
-        var editedText = this._getEditedText(text, selection, char),
+        var editedText = this._replaceSelectedText(text, selection, char),
             format = this._getFormatPattern(),
             isTextSelected = selection.start !== selection.end,
             parsed = this._parse(editedText, format),
@@ -548,7 +536,10 @@ var NumberBoxMask = NumberBoxBase.inherit({
     _removeMinusFromText: function(text, caret) {
         var isMinusPressed = this._lastKey === MINUS && text.charAt(caret.start - 1) === MINUS;
 
-        return isMinusPressed ? this._getEditedText(text, { start: caret.start - 1, end: caret.start }, "") : text;
+        return isMinusPressed ? this._replaceSelectedText(text, {
+            start: caret.start - 1,
+            end: caret.start
+        }, "") : text;
     },
 
     _setTextByParsedValue: function() {

--- a/js/ui/text_box/ui.text_editor.mask.js
+++ b/js/ui/text_box/ui.text_editor.mask.js
@@ -284,6 +284,18 @@ var TextEditorMask = TextEditorBase.inherit({
         this._displayMask();
     },
 
+    _replaceSelectedText: function(text, selection, char) {
+        if(char === undefined) {
+            return text;
+        }
+
+        var textBefore = text.slice(0, selection.start),
+            textAfter = text.slice(selection.end),
+            edited = textBefore + char + textAfter;
+
+        return edited;
+    },
+
     _isMaskedValueMode: function() {
         return this.option("useMaskedValue");
     },

--- a/testing/tests/DevExpress.ui.widgets.editors/dateboxMaskTests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dateboxMaskTests.js
@@ -39,10 +39,10 @@ if(devices.real().deviceType === "desktop") {
             assert.equal(this.instance.option("text"), "November 10 2012", "text is correct");
         });
 
-        QUnit.test("Masks should not be enabled when displayFormat is not specified", (assert) => {
+        QUnit.test("Masks should be enabled when displayFormat is not specified", (assert) => {
             this.instance.option("displayFormat", undefined);
             this.keyboard.press("up");
-            assert.equal(this.instance.option("text"), "10/10/2012", "mask behavior does not work");
+            assert.equal(this.instance.option("text"), "11/10/2012", "mask behavior works");
         });
 
         QUnit.test("Masks should not be enabled when mode is not text", (assert) => {

--- a/testing/tests/DevExpress.ui.widgets.editors/dateboxMaskTests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dateboxMaskTests.js
@@ -422,7 +422,7 @@ if(devices.real().deviceType === "desktop") {
         });
     });
 
-    QUnit.module("Pointer events", setupModule, () => {
+    QUnit.module("Events", setupModule, () => {
         QUnit.test("Select date part on click", (assert) => {
             this.keyboard.caret(9);
             this.$input.trigger("dxclick");
@@ -447,6 +447,15 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 6, end: 8 }, "caret is good");
         });
 
+        QUnit.test("paste should be possible when pasting data matches the format", (assert) => {
+            this.instance.option("value", null);
+
+            this.keyboard.paste("123456");
+            assert.equal(this.$input.val(), "", "pasting incorrect value is not allowed");
+
+            this.keyboard.paste("November 10 2018");
+            assert.equal(this.$input.val(), "November 10 2018", "pasting correct value is allowed");
+        });
     });
 
 


### PR DESCRIPTION
This change prevents the cursor from move out of the non-stub date part selection