### PR TITLE
Fix OLAP response parsing when data has empty member values (T677334)

### DIFF
--- a/js/ui/pivot_grid/xmla_store/xmla_store.js
+++ b/js/ui/pivot_grid/xmla_store/xmla_store.js
@@ -543,7 +543,7 @@ exports.XmlaStore = Class.inherit((function() {
             hash[name] = item;
         }
 
-        if(!item.value && member) {
+        if(!typeUtils.isDefined(item.value) && member) {
             item.text = member.caption;
             item.value = member.value;
             item.key = name ? name : '';


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
