### PR TITLE
Datagrid: Fix calculateFilterExpression for negative groups(T679522)

### DIFF
--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -395,13 +395,13 @@ function getFilterExpression(value, fields, customOperations, target) {
         return null;
     }
 
-    var criteria = getGroupCriteria(value);
+    var criteria = getGroupCriteria(value),
+        result = [];
 
     if(isCondition(criteria)) {
-        return getConditionFilterExpression(criteria, fields, customOperations, target) || null;
+        result = getConditionFilterExpression(criteria, fields, customOperations, target) || null;
     } else {
-        var result = [],
-            filterExpression,
+        var filterExpression,
             groupValue = getGroupValue(criteria);
         for(var i = 0; i < criteria.length; i++) {
             if(isGroup(criteria[i])) {
@@ -418,8 +418,9 @@ function getFilterExpression(value, fields, customOperations, target) {
                 }
             }
         }
-        return result.length ? result : null;
+        result = result.length ? result : null;
     }
+    return result && isNegationGroup(value) ? ["!", result] : result;
 }
 
 function getNormalizedFilter(group) {

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -1102,6 +1102,12 @@ QUnit.module("Custom filter expressions", {
         assert.deepEqual(utils.getFilterExpression(value, this.fields, []), null);
     });
 
+    QUnit.test("calculateFilterExpression for negative group with one condition", function(assert) {
+        var value = ["!", ["field", "=", 1]],
+            normalizedFields = utils.getNormalizedFields([{ dataField: "field" }]);
+        assert.deepEqual(utils.getFilterExpression(value, normalizedFields, [], "filterBuilder"), ["!", ["field", "=", 1]]);
+    });
+
     QUnit.test("calculateFilterExpression for isBlank (string field)", function(assert) {
         var value = ["field", "=", null],
             normalizedFields = utils.getNormalizedFields([{ dataField: "field" }]);
@@ -1176,6 +1182,46 @@ QUnit.module("Custom filter expressions", {
                 ],
                 "or",
                 ["field2", "=", "30"]
+            ]
+        ]);
+    });
+
+    QUnit.test("calculateFilterExpression for negative group with inner negative group", function(assert) {
+        // arrange
+        var value = [
+            ["!",
+                [
+                    ["field1", 1],
+                    "and",
+                    ["!",
+                        [
+                            ["field1", "=", 20],
+                            "or",
+                            ["field2", "30"]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        // act, assert
+        assert.deepEqual(utils.getFilterExpression(value, this.fields, []), [
+            ["!",
+                [
+                    [
+                        ["field1", "<>", 1], "or", ["field1", "=", 10]
+                    ],
+                    "and",
+                    ["!",
+                        [
+                            [
+                                ["field1", "<>", 20], "or", ["field1", "=", 10]
+                            ],
+                            "or",
+                            ["field2", "=", "30"]
+                        ]
+                    ]
+                ]
             ]
         ]);
     });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
