### PR TITLE
Update HtmlEditor API and options

### DIFF
--- a/js/docEnums.js
+++ b/js/docEnums.js
@@ -917,7 +917,7 @@
 
  /**
  * @typedef {string} Enums.HtmlEditorValueType
- * @enum {'HTML'|'Markdown'}
+ * @enum {'html'|'markdown'}
  */
 
  /**

--- a/js/ui/html_editor/converters/delta.js
+++ b/js/ui/html_editor/converters/delta.js
@@ -14,7 +14,6 @@ class DeltaConverter {
         }
 
         this._delta2Html = new converter();
-
         this._delta2Html.renderCustomWith(this._renderCustomFormat.bind(this));
     }
 
@@ -25,16 +24,22 @@ class DeltaConverter {
     }
 
     _parsePlaceholder(data) {
-        const startEscapedChar = ensureDefined(data.startEscapedChar, data.escapedChar);
-        const endEscapedChar = ensureDefined(data.endEscapedChar, data.escapedChar);
-        const dataString = [
-            this._addDataParam("start-char", data.startEscapedChar),
-            this._addDataParam("end-char", data.endEscapedChar),
-            this._addDataParam("esc-char", data.escapedChar),
-            this._addDataParam("value", data.value)
-        ].join(" ");
+        let startEscapeChar, endEscapeChar;
 
-        return `<span class='dx-data-placeholder'${dataString}><span>${startEscapedChar + data.value + endEscapedChar}</span></span>`;
+        if(Array.isArray(data.escapeChar)) {
+            startEscapeChar = ensureDefined(data.escapeChar[0], "");
+            endEscapeChar = ensureDefined(data.escapeChar[1], "");
+        } else {
+            startEscapeChar = endEscapeChar = data.escapeChar;
+        }
+
+        const dataString = [
+            this._addDataParam("start-esc-char", startEscapeChar),
+            this._addDataParam("end-esc-char", endEscapeChar),
+            this._addDataParam("value", data.value)
+        ].join("");
+
+        return `<span class='dx-data-placeholder'${dataString}><span>${startEscapeChar + data.value + endEscapeChar}</span></span>`;
     }
 
     _addDataParam(paramName, value) {

--- a/js/ui/html_editor/converters/delta.js
+++ b/js/ui/html_editor/converters/delta.js
@@ -18,12 +18,12 @@ class DeltaConverter {
     }
 
     _renderCustomFormat(operations, contextOperations) {
-        if(operations.insert.type === 'placeholder') {
-            return this._parsePlaceholder(operations.insert.value);
+        if(operations.insert.type === 'variable') {
+            return this._parseVariable(operations.insert.value);
         }
     }
 
-    _parsePlaceholder(data) {
+    _parseVariable(data) {
         let startEscapeChar, endEscapeChar;
 
         if(Array.isArray(data.escapeChar)) {
@@ -39,11 +39,11 @@ class DeltaConverter {
             this._addDataParam("value", data.value)
         ].join("");
 
-        return `<span class='dx-data-placeholder'${dataString}><span>${startEscapeChar + data.value + endEscapeChar}</span></span>`;
+        return `<span class='dx-variable'${dataString}><span>${startEscapeChar + data.value + endEscapeChar}</span></span>`;
     }
 
     _addDataParam(paramName, value) {
-        return value ? ` data-placeholder-${paramName}=${value}` : "";
+        return value ? ` data-var-${paramName}=${value}` : "";
     }
 
     toHtml(deltaOps) {

--- a/js/ui/html_editor/formats/placeholder.js
+++ b/js/ui/html_editor/formats/placeholder.js
@@ -10,18 +10,20 @@ const PLACEHOLDER_CLASS = "dx-data-placeholder";
 class Placeholder extends Embed {
     static create(data) {
         let node = super.create(),
-            startEscapedChar = ensureDefined(data.startEscapedChar, data.escapedChar),
-            endEscapedChar = ensureDefined(data.endEscapedChar, data.escapedChar),
+            startEscapeChar,
+            endEscapeChar,
             text = data.value;
 
-        node.innerText = startEscapedChar + text + endEscapedChar;
-        if(data.startEscapedChar) {
-            node.dataset.placeholderStartChar = data.startEscapedChar;
+        if(Array.isArray(data.escapeChar)) {
+            startEscapeChar = ensureDefined(data.escapeChar[0], "");
+            endEscapeChar = ensureDefined(data.escapeChar[1], "");
+        } else {
+            startEscapeChar = endEscapeChar = data.escapeChar;
         }
-        if(data.endEscapedChar) {
-            node.dataset.placeholderEndChar = data.endEscapedChar;
-        }
-        node.dataset.placeholderEscChar = data.escapedChar;
+
+        node.innerText = startEscapeChar + text + endEscapeChar;
+        node.dataset.placeholderStartEscChar = startEscapeChar;
+        node.dataset.placeholderEndEscChar = endEscapeChar;
         node.dataset.placeholderValue = data.value;
 
         return node;
@@ -30,9 +32,10 @@ class Placeholder extends Embed {
     static value(node) {
         return extend({}, {
             value: node.dataset.placeholderValue,
-            escapedChar: node.dataset.placeholderEscChar,
-            startEscapedChar: node.dataset.placeholderStartChar,
-            endEscapedChar: node.dataset.placeholderEndChar
+            escapeChar: [
+                node.dataset.placeholderStartEscChar || "",
+                node.dataset.placeholderEndEscChar || ""
+            ]
         });
     }
 }

--- a/js/ui/html_editor/formats/variable.js
+++ b/js/ui/html_editor/formats/variable.js
@@ -5,9 +5,9 @@ import { extend } from "../../../core/utils/extend";
 const quill = getQuill();
 const Embed = quill.import("blots/embed");
 
-const PLACEHOLDER_CLASS = "dx-data-placeholder";
+const VARIABLE_CLASS = "dx-variable";
 
-class Placeholder extends Embed {
+class Variable extends Embed {
     static create(data) {
         let node = super.create(),
             startEscapeChar,
@@ -22,26 +22,26 @@ class Placeholder extends Embed {
         }
 
         node.innerText = startEscapeChar + text + endEscapeChar;
-        node.dataset.placeholderStartEscChar = startEscapeChar;
-        node.dataset.placeholderEndEscChar = endEscapeChar;
-        node.dataset.placeholderValue = data.value;
+        node.dataset.varStartEscChar = startEscapeChar;
+        node.dataset.varEndEscChar = endEscapeChar;
+        node.dataset.varValue = data.value;
 
         return node;
     }
 
     static value(node) {
         return extend({}, {
-            value: node.dataset.placeholderValue,
+            value: node.dataset.varValue,
             escapeChar: [
-                node.dataset.placeholderStartEscChar || "",
-                node.dataset.placeholderEndEscChar || ""
+                node.dataset.varStartEscChar || "",
+                node.dataset.varEndEscChar || ""
             ]
         });
     }
 }
 
-Placeholder.blotName = "placeholder";
-Placeholder.tagName = "span";
-Placeholder.className = PLACEHOLDER_CLASS;
+Variable.blotName = "variable";
+Variable.tagName = "span";
+Variable.className = VARIABLE_CLASS;
 
-module.exports = Placeholder;
+module.exports = Variable;

--- a/js/ui/html_editor/modules/placeholder.js
+++ b/js/ui/html_editor/modules/placeholder.js
@@ -13,10 +13,7 @@ class PlaceholderModule extends PopoverModule {
         let baseConfig = super._getDefaultOptions();
 
         return extend(baseConfig, {
-            escapedChar: "",
-
-            startEscapedChar: undefined,
-            endEscapedChar: undefined
+            escapeChar: ""
         });
     }
 
@@ -79,9 +76,7 @@ class PlaceholderModule extends PopoverModule {
         const selectedItem = selectionChangedEvent.component.option("selectedItem");
         const placeholderData = extend({}, {
             value: selectedItem,
-            escapedChar: this.options.escapedChar,
-            startEscapedChar: this.options.startEscapedChar,
-            endEscapedChar: this.options.endEscapedChar
+            escapeChar: this.options.escapeChar
         });
 
         setTimeout(function() {

--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -184,7 +184,7 @@ class ToolbarModule extends BaseModule {
         each(this.options.items, (index, item) => {
             let newItem;
             if(isObject(item)) {
-                if(item.values && !item.widget) {
+                if(item.formatValues && !item.widget) {
                     const selectItemConfig = this._prepareSelectItemConfig(item);
                     newItem = this._getToolbarItem(selectItemConfig);
                 } else {
@@ -205,7 +205,7 @@ class ToolbarModule extends BaseModule {
     _prepareButtonItemConfig(formatName) {
         return {
             widget: "dxButton",
-            format: formatName,
+            formatName: formatName,
             options: {
                 text: formatName,
                 onClick: this._formatHandlers[formatName] || this._getDefaultClickHandler(formatName)
@@ -216,12 +216,12 @@ class ToolbarModule extends BaseModule {
     _prepareSelectItemConfig(item) {
         return {
             widget: "dxSelectBox",
-            format: item.format,
+            formatName: item.formatName,
             options: {
-                dataSource: item.values,
+                dataSource: item.formatValues,
                 onValueChanged: (e) => {
                     if(!this._isReset) {
-                        this.quill.format(item.format, e.value, USER_ACTION);
+                        this.quill.format(item.formatName, e.value, USER_ACTION);
                     }
                 }
             }
@@ -249,13 +249,13 @@ class ToolbarModule extends BaseModule {
             options: {
                 onInitialized: (e) => {
                     e.component.$element().addClass(TOOLBAR_FORMAT_WIDGET_CLASS);
-                    e.component.$element().toggleClass(`dx-${item.format}-format`, !!item.format);
-                    this._formats[item.format] = e.component;
+                    e.component.$element().toggleClass(`dx-${item.format}-format`, !!item.formatName);
+                    this._formats[item.formatName] = e.component;
                 }
             }
         };
 
-        return extend(true, { location: "before" }, this._getDefaultConfig(item.format), item, baseItem);
+        return extend(true, { location: "before" }, this._getDefaultConfig(item.formatName), item, baseItem);
     }
 
     _getDefaultItemsConfig() {
@@ -271,8 +271,8 @@ class ToolbarModule extends BaseModule {
         };
     }
 
-    _getDefaultConfig(format) {
-        return this._getDefaultItemsConfig()[format];
+    _getDefaultConfig(formatName) {
+        return this._getDefaultItemsConfig()[formatName];
     }
 
     updateFormatWidgets() {

--- a/js/ui/html_editor/modules/variables.js
+++ b/js/ui/html_editor/modules/variables.js
@@ -1,14 +1,14 @@
 import { getQuill } from "../quill_importer";
 
 import PopoverModule from "./popover";
-import Placeholder from "../formats/placeholder";
+import Variable from "../formats/variable";
 
 import { extend } from "../../../core/utils/extend";
 
 getQuill()
-    .register({ "formats/placeholder": Placeholder }, true);
+    .register({ "formats/variable": Variable }, true);
 
-class PlaceholderModule extends PopoverModule {
+class VariableModule extends PopoverModule {
     _getDefaultOptions() {
         let baseConfig = super._getDefaultOptions();
 
@@ -22,7 +22,7 @@ class PlaceholderModule extends PopoverModule {
 
         const toolbar = quill.getModule('toolbar');
         if(toolbar) {
-            toolbar.addClickHandler('placeholder', this.showPopover.bind(this));
+            toolbar.addClickHandler('variable', this.showPopover.bind(this));
         }
 
         quill.keyboard.addBinding({
@@ -74,16 +74,16 @@ class PlaceholderModule extends PopoverModule {
     insertEmbedContent(selectionChangedEvent) {
         const caretPosition = this.getPosition();
         const selectedItem = selectionChangedEvent.component.option("selectedItem");
-        const placeholderData = extend({}, {
+        const variableData = extend({}, {
             value: selectedItem,
             escapeChar: this.options.escapeChar
         });
 
         setTimeout(function() {
-            this.quill.insertEmbed(caretPosition, "placeholder", placeholderData);
+            this.quill.insertEmbed(caretPosition, "variable", variableData);
             this.quill.setSelection(caretPosition + 1);
         }.bind(this));
     }
 }
 
-module.exports = PlaceholderModule;
+module.exports = VariableModule;

--- a/js/ui/html_editor/quill_registrator.js
+++ b/js/ui/html_editor/quill_registrator.js
@@ -13,7 +13,7 @@ class QuillRegistrator {
         const Link = require("./formats/link");
         const Toolbar = require("./modules/toolbar");
         const DropImage = require("./modules/dropImage");
-        const Placeholder = require("./modules/placeholder");
+        const Variables = require("./modules/variables");
 
         const DirectionStyle = quill.import("attributors/style/direction");
         const AlignStyle = quill.import("attributors/style/align");
@@ -32,7 +32,7 @@ class QuillRegistrator {
 
             "modules/toolbar": Toolbar,
             "modules/dropImage": DropImage,
-            "modules/placeholder": Placeholder,
+            "modules/variables": Variables,
 
             "themes/basic": BaseTheme
         },

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -116,16 +116,6 @@ const HtmlEditor = Editor.inherit({
             * @type string|Array<string>
             * @default ""
             */
-            /**
-            * @name dxHtmlEditorVariables.startEscapedChar
-            * @type string
-            * @default undefined
-            */
-            /**
-            * @name dxHtmlEditorVariables.endEscapedChar
-            * @type string
-            * @default undefined
-            */
         });
     },
 

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -68,11 +68,11 @@ const HtmlEditor = Editor.inherit({
             */
             toolbar: null,
             /**
-            * @name dxHtmlEditorOptions.dataPlaceholder
-            * @type dxHtmlEditorDataPlaceholder
+            * @name dxHtmlEditorOptions.variables
+            * @type dxHtmlEditorVariables
             * @default null
             */
-            dataPlaceholder: null,
+            variables: null,
 
             formDialogOptions: null
 
@@ -103,26 +103,26 @@ const HtmlEditor = Editor.inherit({
             */
 
             /**
-            * @name dxHtmlEditorDataPlaceholder
+            * @name dxHtmlEditorVariables
             * @type object
             */
             /**
-            * @name dxHtmlEditorDataPlaceholder.dataSource
+            * @name dxHtmlEditorVariables.dataSource
             * @type string|Array<string>|DataSource|DataSourceOptions
             * @default null
             */
             /**
-            * @name dxHtmlEditorDataPlaceholder.escapeChar
+            * @name dxHtmlEditorVariables.escapeChar
             * @type string|Array<string>
             * @default ""
             */
             /**
-            * @name dxHtmlEditorDataPlaceholder.startEscapedChar
+            * @name dxHtmlEditorVariables.startEscapedChar
             * @type string
             * @default undefined
             */
             /**
-            * @name dxHtmlEditorDataPlaceholder.endEscapedChar
+            * @name dxHtmlEditorVariables.endEscapedChar
             * @type string
             * @default undefined
             */
@@ -224,7 +224,7 @@ const HtmlEditor = Editor.inherit({
         const wordListMatcher = getWordMatcher(this._quillRegistrator.getQuill());
         let modulesConfig = {
             toolbar: this._getModuleConfigByOption("toolbar"),
-            placeholder: this._getModuleConfigByOption("dataPlaceholder"),
+            variables: this._getModuleConfigByOption("variables"),
             dropImage: this._getBaseModuleConfig(),
             clipboard: {
                 matchers: [
@@ -316,7 +316,7 @@ const HtmlEditor = Editor.inherit({
                 this.callBase(args);
                 break;
             case "placeholder":
-            case "dataPlaceholder":
+            case "variables":
             case "toolbar":
                 this._invalidate();
                 break;

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -16,6 +16,8 @@ import FormDialog from "./ui/formDialog";
 const HTML_EDITOR_CLASS = "dx-htmleditor";
 const QUILL_CONTAINER_CLASS = "dx-quill-container";
 
+const MARKDOWN_VALUE_TYPE = "markdown";
+
 const ANONYMOUS_TEMPLATE_NAME = "content";
 
 const HtmlEditor = Editor.inherit({
@@ -50,9 +52,9 @@ const HtmlEditor = Editor.inherit({
             /**
             * @name dxHtmlEditorOptions.valueType
             * @type Enums.HtmlEditorValueType
-            * @default "HTML"
+            * @default "html"
             */
-            valueType: "HTML",
+            valueType: "html",
             /**
             * @name dxHtmlEditorOptions.placeholder
             * @type string
@@ -92,11 +94,11 @@ const HtmlEditor = Editor.inherit({
             * @inherits dxToolbarItemTemplate
             */
             /**
-            * @name dxHtmlEditorToolbarItem.format
+            * @name dxHtmlEditorToolbarItem.formatName
             * @type string
             */
             /**
-            * @name dxHtmlEditorToolbarItem.values
+            * @name dxHtmlEditorToolbarItem.formatValues
             * @type Array<string,number,boolean>
             */
 
@@ -110,8 +112,8 @@ const HtmlEditor = Editor.inherit({
             * @default null
             */
             /**
-            * @name dxHtmlEditorDataPlaceholder.escapedChar
-            * @type string
+            * @name dxHtmlEditorDataPlaceholder.escapeChar
+            * @type string|Array<string>
             * @default ""
             */
             /**
@@ -145,7 +147,7 @@ const HtmlEditor = Editor.inherit({
             }
         }
 
-        if(this.option("valueType") === "Markdown" && !this._markdownConverter) {
+        if(this.option("valueType") === MARKDOWN_VALUE_TYPE && !this._markdownConverter) {
             const MarkdownConverter = ConverterController.getConverter("markdown");
 
             if(MarkdownConverter) {
@@ -256,7 +258,7 @@ const HtmlEditor = Editor.inherit({
 
         this._isEditorUpdating = true;
 
-        const value = this._isMarkdownValue() ? this._updateValueByType("Markdown", htmlMarkup) : htmlMarkup;
+        const value = this._isMarkdownValue() ? this._updateValueByType(MARKDOWN_VALUE_TYPE, htmlMarkup) : htmlMarkup;
 
         this.option("value", value);
     },
@@ -270,11 +272,11 @@ const HtmlEditor = Editor.inherit({
 
         const currentValue = value || this.option("value");
 
-        return valueType === "Markdown" ? converter.toMarkdown(currentValue) : converter.toHtml(currentValue);
+        return valueType === MARKDOWN_VALUE_TYPE ? converter.toMarkdown(currentValue) : converter.toHtml(currentValue);
     },
 
     _isMarkdownValue: function() {
-        return this.option("valueType") === "Markdown";
+        return this.option("valueType") === MARKDOWN_VALUE_TYPE;
     },
 
     _resetEnabledState: function() {
@@ -507,12 +509,12 @@ const HtmlEditor = Editor.inherit({
     },
 
     /**
-    * @name dxHtmlEditorMethods.deleteContent
-    * @publicName deleteContent(index, length)
+    * @name dxHtmlEditorMethods.delete
+    * @publicName delete(index, length)
     * @param1 index:number
     * @param2 length:number
     */
-    deleteContent: function(index, length) {
+    delete: function(index, length) {
         this._applyQuillMethod("deleteText", arguments);
     },
 

--- a/styles/widgets/base/icons.less
+++ b/styles/widgets/base/icons.less
@@ -268,7 +268,7 @@
     .dx-icon-link { .dx-font-icon("\f08e"); }
     .dx-icon-video { .dx-font-icon("\f08f"); }
     .dx-icon-mention { .dx-font-icon("\f090"); }
-    .dx-icon-placeholder { .dx-font-icon("\f091"); }
+    .dx-icon-variable { .dx-font-icon("\f091"); }
     .dx-icon-clearformat { .dx-font-icon("\f092"); }
     .dx-icon-undo { 
         .dx-font-icon("\f04c");

--- a/styles/widgets/common/htmlEditor.less
+++ b/styles/widgets/common/htmlEditor.less
@@ -81,6 +81,16 @@
     white-space: pre-wrap;
     word-wrap: break-word;
 
+    .dx-variable {
+        background: lightgray;
+        padding: 3px 0;
+        .border-radius(8px);
+    
+        & > span {
+            margin: 0 3px;   
+        }
+    }
+
     > * {
         cursor: text;
     }
@@ -201,16 +211,6 @@
 .dx-suggestion-list {
     .dx-list-item {
         display: block;
-    }
-}
-
-.dx-data-placeholder {
-    background: lightgray;
-    padding: 3px 0;
-    .border-radius(8px);
-
-    & > span {
-        margin: 0 3px;   
     }
 }
 

--- a/styles/widgets/common/icons.less
+++ b/styles/widgets/common/icons.less
@@ -10,7 +10,7 @@
 .dx-icon-fontsize, .dx-icon-growfont, .dx-icon-shrinkfont, .dx-icon-color, .dx-icon-background, .dx-icon-superscript, 
 .dx-icon-subscript, .dx-icon-header, .dx-icon-blockquote, .dx-icon-formula, .dx-icon-codeblock, .dx-icon-orderedlist,
 .dx-icon-bulletlist, .dx-icon-increaseindent, .dx-icon-decreaseindent, .dx-icon-alignleft, .dx-icon-alignright, 
-.dx-icon-aligncenter, .dx-icon-alignjustify, .dx-icon-link, .dx-icon-video, .dx-icon-mention, .dx-icon-placeholder,
+.dx-icon-aligncenter, .dx-icon-alignjustify, .dx-icon-link, .dx-icon-video, .dx-icon-mention, .dx-icon-variable,
 .dx-icon-clearformat, .dx-icon-undo, .dx-icon-redo {
     background-position: 0 0;
     background-repeat: no-repeat;

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditor.tests.js
@@ -15,7 +15,7 @@ import "./htmlEditorParts/valueRendering.tests.js";
 import "./htmlEditorParts/toolbarModule.tests.js";
 import "./htmlEditorParts/dropImageModule.tests.js";
 import "./htmlEditorParts/popoverModule.tests.js";
-import "./htmlEditorParts/placeholderModule.tests.js";
+import "./htmlEditorParts/variablesModule.tests.js";
 import "./htmlEditorParts/api.tests.js";
 import "./htmlEditorParts/formDialog.tests.js";
 import "./htmlEditorParts/paste.tests.js";

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
@@ -89,8 +89,8 @@ QUnit.module("API", moduleConfig, () => {
         assert.equal(length, LINE_WIDTH * 3, "correct format");
     });
 
-    test("deleteContent", (assert) => {
-        this.instance.deleteContent(1, 7);
+    test("delete", (assert) => {
+        this.instance.delete(1, 7);
 
         assert.equal(this.instance.option("value"), "<p>Test 2<br/>Test 3</p>", "custom range removed");
     });
@@ -103,9 +103,9 @@ QUnit.module("API", moduleConfig, () => {
     });
 
     test("insertEmbed", (assert) => {
-        const expected = "<p>T<span class='dx-data-placeholder'   data-placeholder-esc-char=#  data-placeholder-value=template><span>#template#</span>" +
-            "</span>est 1<br/>Test 2<br/>Test 3</p>";
-        this.instance.insertEmbed(1, "placeholder", { value: "template", escapedChar: "#" });
+        const expected = "<p>T<span class='dx-data-placeholder' data-placeholder-start-esc-char=# data-placeholder-end-esc-char=#" +
+            " data-placeholder-value=template><span>#template#</span></span>est 1<br/>Test 2<br/>Test 3</p>";
+        this.instance.insertEmbed(1, "placeholder", { value: "template", escapeChar: "#" });
 
         assert.equal(this.instance.option("value"), expected, "insert embed");
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
@@ -103,9 +103,9 @@ QUnit.module("API", moduleConfig, () => {
     });
 
     test("insertEmbed", (assert) => {
-        const expected = "<p>T<span class='dx-data-placeholder' data-placeholder-start-esc-char=# data-placeholder-end-esc-char=#" +
-            " data-placeholder-value=template><span>#template#</span></span>est 1<br/>Test 2<br/>Test 3</p>";
-        this.instance.insertEmbed(1, "placeholder", { value: "template", escapeChar: "#" });
+        const expected = "<p>T<span class='dx-variable' data-var-start-esc-char=# data-var-end-esc-char=#" +
+            " data-var-value=template><span>#template#</span></span>est 1<br/>Test 2<br/>Test 3</p>";
+        this.instance.insertEmbed(1, "variable", { value: "template", escapeChar: "#" });
 
         assert.equal(this.instance.option("value"), expected, "insert embed");
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/converterController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/converterController.tests.js
@@ -25,7 +25,7 @@ QUnit.module("Converter controller", () => {
 QUnit.module("Unknown converter", () => {
     test("Editor throw an error if cannot find a converter", (assert) => {
         assert.throws(
-            function() { $("#htmlEditor").dxHtmlEditor({ valueType: "Markdown" }); },
+            function() { $("#htmlEditor").dxHtmlEditor({ valueType: "markdown" }); },
             function(e) {
                 return /E1050/.test(e.message);
             },

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/placeholderModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/placeholderModule.tests.js
@@ -54,89 +54,80 @@ QUnit.module("Placeholder format", () => {
     test("Create an element by data", (assert) => {
         const data = {
             value: "TEST_NAME",
-            escapedChar: "@"
+            escapeChar: "@"
         };
         const element = PlaceholderFormat.create(data);
 
-        assert.equal(element.dataset.placeholderEscChar, "@", "correct escaped char");
+        assert.equal(element.dataset.placeholderStartEscChar, "@", "correct start escape char");
+        assert.equal(element.dataset.placeholderEndEscChar, "@", "correct end escape char");
         assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
-        assert.notOk(element.dataset.placeholderStartChar, "There is no start char");
-        assert.notOk(element.dataset.placeholderEndChar, "There is no end char");
         assert.equal(element.innerText, "@TEST_NAME@", "correct inner text");
     });
 
-    test("Create an element with default escaped char", (assert) => {
+    test("Create an element with default escape char", (assert) => {
         const data = {
             value: "TEST_NAME",
-            escapedChar: ""
+            escapeChar: ""
         };
         const element = PlaceholderFormat.create(data);
 
-        assert.equal(element.dataset.placeholderEscChar, "", "correct escaped char");
+        assert.equal(element.dataset.placeholderStartEscChar, "", "correct start escape char");
+        assert.equal(element.dataset.placeholderEndEscChar, "", "correct end escape char");
         assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
-        assert.notOk(element.dataset.placeholderStartChar, "There is no start char");
-        assert.notOk(element.dataset.placeholderEndChar, "There is no end char");
         assert.equal(element.innerText, "TEST_NAME", "correct inner text");
     });
 
     test("Create an element with start escaping char", (assert) => {
         const data = {
             value: "TEST_NAME",
-            escapedChar: "",
-            startEscapedChar: "{"
+            escapeChar: ["{", ""],
         };
         const element = PlaceholderFormat.create(data);
 
-        assert.equal(element.dataset.placeholderEscChar, "", "correct escaped char");
         assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
-        assert.equal(element.dataset.placeholderStartChar, "{", "There is no start char");
-        assert.notOk(element.dataset.placeholderEndChar, "There is no end char");
+        assert.equal(element.dataset.placeholderStartEscChar, "{", "There is no start char");
+        assert.notOk(element.dataset.placeholderEndEscChar, "There is no end char");
         assert.equal(element.innerText, "{TEST_NAME", "correct inner text");
     });
 
     test("Create an element with end escaping char", (assert) => {
         const data = {
             value: "TEST_NAME",
-            escapedChar: "",
-            endEscapedChar: "}"
+            escapeChar: ["", "}"],
         };
         const element = PlaceholderFormat.create(data);
 
-        assert.equal(element.dataset.placeholderEscChar, "", "correct escaped char");
         assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
-        assert.notOk(element.dataset.placeholderStartChar, "There is no start char");
-        assert.equal(element.dataset.placeholderEndChar, "}", "There is no end char");
+        assert.notOk(element.dataset.placeholderStartEscChar, "There is no start char");
+        assert.equal(element.dataset.placeholderEndEscChar, "}", "There is no end char");
         assert.equal(element.innerText, "TEST_NAME}", "correct inner text");
     });
 
     test("Create an element with start, end and default escaping char", (assert) => {
         const data = {
             value: "TEST_NAME",
-            startEscapedChar: "{",
-            endEscapedChar: "}",
-            escapedChar: "@"
+            escapeChar: ["{", "}"]
         };
         const element = PlaceholderFormat.create(data);
 
-        assert.equal(element.dataset.placeholderEscChar, "@", "correct escaped char");
         assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
-        assert.equal(element.dataset.placeholderStartChar, "{", "There is no start char");
-        assert.equal(element.dataset.placeholderEndChar, "}", "There is no end char");
+        assert.equal(element.dataset.placeholderStartEscChar, "{", "There is no start char");
+        assert.equal(element.dataset.placeholderEndEscChar, "}", "There is no end char");
         assert.equal(element.innerText, "{TEST_NAME}", "correct inner text");
     });
 
     test("Get data from element", (assert) => {
-        const markup = "<span class='dx-data-placeholder' data-placeholder-esc-char=## data-placeholder-value=TEST_NAME><span>##TEST_NAME##</span></span>";
+        const markup = "<span class='dx-data-placeholder' data-placeholder-start-esc-char=## data-placeholder-value=TEST_NAME><span>##TEST_NAME##</span></span>";
         const element = $(markup).get(0);
         const data = PlaceholderFormat.value(element);
 
-        assert.deepEqual(data, { value: "TEST_NAME", escapedChar: "##" }, "Correct data");
+        assert.deepEqual(data, { value: "TEST_NAME", escapeChar: ["##", ""] }, "Correct data");
     });
 });
 
 QUnit.module("Placeholder module", moduleConfig, () => {
     test("Render toolbar without any options", (assert) => {
-        this.options.escapedChar = "#";
+        this.options.escapeChar = "#";
         const dataPlaceholder = new DataPlaceholder(this.quillMock, this.options);
 
         dataPlaceholder.showPopover();
@@ -148,7 +139,7 @@ QUnit.module("Placeholder module", moduleConfig, () => {
             format: "placeholder",
             position: 0,
             value: {
-                escapedChar: "#",
+                escapeChar: "#",
                 value: "TEST_NAME"
             }
         }], "Correct formatting");

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -133,7 +133,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             return { bold: false };
         };
         this.options.items = ["bold", {
-            format: "strike",
+            formatName: "strike",
             widget: "dxButton",
             options: {
                 onClick: () => {
@@ -154,7 +154,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
     });
 
     test("Render toolbar with enum format", (assert) => {
-        this.options.items = [{ format: "header", values: [1, 2, 3, false] }];
+        this.options.items = [{ formatName: "header", formatValues: [1, 2, 3, false] }];
 
         new Toolbar(this.quillMock, this.options);
         const $formatWidget = this.$element.find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`);

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/valueRendering.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/valueRendering.tests.js
@@ -54,10 +54,10 @@ QUnit.module("Value as HTML markup", () => {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
-                valueType: "Markdown",
+                valueType: "markdown",
                 value: "Hi! **Test.**",
                 onValueChanged: (e) => {
-                    if(e.component.option("valueType") === "HTML") {
+                    if(e.component.option("valueType") === "html") {
                         assert.equal(e.value, "<p>Hi! <strong>Test.</strong></p>");
                         done();
                     }
@@ -65,7 +65,7 @@ QUnit.module("Value as HTML markup", () => {
             })
             .dxHtmlEditor("instance");
 
-        instance.option("valueType", "HTML");
+        instance.option("valueType", "html");
     });
 });
 
@@ -74,7 +74,7 @@ QUnit.module("Value as Markdown markup", () => {
     test("render default value", (assert) => {
         const instance = $("#htmlEditor").dxHtmlEditor({
                 value: "Hi!\nIt's a **test**!",
-                valueType: "Markdown"
+                valueType: "markdown"
             }).dxHtmlEditor("instance"),
             $element = instance.$element(),
             markup = $element.find(getSelector(CONTENT_CLASS)).html();
@@ -87,7 +87,7 @@ QUnit.module("Value as Markdown markup", () => {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
-                valueType: "Markdown",
+                valueType: "markdown",
                 onValueChanged: (e) => {
                     assert.equal(e.value, "Hi! **Test.**");
                     done();
@@ -107,7 +107,7 @@ QUnit.module("Value as Markdown markup", () => {
             .dxHtmlEditor({
                 value: "<p>Hi! <strong>Test.</strong></p>",
                 onValueChanged: (e) => {
-                    if(e.component.option("valueType") === "Markdown") {
+                    if(e.component.option("valueType") === "markdown") {
                         assert.equal(e.value, "Hi! **Test.**");
                         done();
                     }
@@ -115,6 +115,6 @@ QUnit.module("Value as Markdown markup", () => {
             })
             .dxHtmlEditor("instance");
 
-        instance.option("valueType", "Markdown");
+        instance.option("valueType", "markdown");
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/variablesModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/variablesModule.tests.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 
-import PlaceholderFormat from "ui/html_editor/formats/placeholder";
-import DataPlaceholder from "ui/html_editor/modules/placeholder";
+import VariableFormat from "ui/html_editor/formats/variable";
+import Variables from "ui/html_editor/modules/variables";
 import { noop } from "core/utils/common";
 
 const SUGGESTION_LIST_CLASS = "dx-suggestion-list";
@@ -50,17 +50,17 @@ const moduleConfig = {
 
 const { test } = QUnit;
 
-QUnit.module("Placeholder format", () => {
+QUnit.module("Variable format", () => {
     test("Create an element by data", (assert) => {
         const data = {
             value: "TEST_NAME",
             escapeChar: "@"
         };
-        const element = PlaceholderFormat.create(data);
+        const element = VariableFormat.create(data);
 
-        assert.equal(element.dataset.placeholderStartEscChar, "@", "correct start escape char");
-        assert.equal(element.dataset.placeholderEndEscChar, "@", "correct end escape char");
-        assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
+        assert.equal(element.dataset.varStartEscChar, "@", "correct start escape char");
+        assert.equal(element.dataset.varEndEscChar, "@", "correct end escape char");
+        assert.equal(element.dataset.varValue, "TEST_NAME", "correct inner text");
         assert.equal(element.innerText, "@TEST_NAME@", "correct inner text");
     });
 
@@ -69,11 +69,11 @@ QUnit.module("Placeholder format", () => {
             value: "TEST_NAME",
             escapeChar: ""
         };
-        const element = PlaceholderFormat.create(data);
+        const element = VariableFormat.create(data);
 
-        assert.equal(element.dataset.placeholderStartEscChar, "", "correct start escape char");
-        assert.equal(element.dataset.placeholderEndEscChar, "", "correct end escape char");
-        assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
+        assert.equal(element.dataset.varStartEscChar, "", "correct start escape char");
+        assert.equal(element.dataset.varEndEscChar, "", "correct end escape char");
+        assert.equal(element.dataset.varValue, "TEST_NAME", "correct inner text");
         assert.equal(element.innerText, "TEST_NAME", "correct inner text");
     });
 
@@ -82,11 +82,11 @@ QUnit.module("Placeholder format", () => {
             value: "TEST_NAME",
             escapeChar: ["{", ""],
         };
-        const element = PlaceholderFormat.create(data);
+        const element = VariableFormat.create(data);
 
-        assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
-        assert.equal(element.dataset.placeholderStartEscChar, "{", "There is no start char");
-        assert.notOk(element.dataset.placeholderEndEscChar, "There is no end char");
+        assert.equal(element.dataset.varValue, "TEST_NAME", "correct inner text");
+        assert.equal(element.dataset.varStartEscChar, "{", "There is no start char");
+        assert.notOk(element.dataset.varEndEscChar, "There is no end char");
         assert.equal(element.innerText, "{TEST_NAME", "correct inner text");
     });
 
@@ -95,11 +95,11 @@ QUnit.module("Placeholder format", () => {
             value: "TEST_NAME",
             escapeChar: ["", "}"],
         };
-        const element = PlaceholderFormat.create(data);
+        const element = VariableFormat.create(data);
 
-        assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
-        assert.notOk(element.dataset.placeholderStartEscChar, "There is no start char");
-        assert.equal(element.dataset.placeholderEndEscChar, "}", "There is no end char");
+        assert.equal(element.dataset.varValue, "TEST_NAME", "correct inner text");
+        assert.notOk(element.dataset.varStartEscChar, "There is no start char");
+        assert.equal(element.dataset.varEndEscChar, "}", "There is no end char");
         assert.equal(element.innerText, "TEST_NAME}", "correct inner text");
     });
 
@@ -108,35 +108,35 @@ QUnit.module("Placeholder format", () => {
             value: "TEST_NAME",
             escapeChar: ["{", "}"]
         };
-        const element = PlaceholderFormat.create(data);
+        const element = VariableFormat.create(data);
 
-        assert.equal(element.dataset.placeholderValue, "TEST_NAME", "correct inner text");
-        assert.equal(element.dataset.placeholderStartEscChar, "{", "There is no start char");
-        assert.equal(element.dataset.placeholderEndEscChar, "}", "There is no end char");
+        assert.equal(element.dataset.varValue, "TEST_NAME", "correct inner text");
+        assert.equal(element.dataset.varStartEscChar, "{", "There is no start char");
+        assert.equal(element.dataset.varEndEscChar, "}", "There is no end char");
         assert.equal(element.innerText, "{TEST_NAME}", "correct inner text");
     });
 
     test("Get data from element", (assert) => {
-        const markup = "<span class='dx-data-placeholder' data-placeholder-start-esc-char=## data-placeholder-value=TEST_NAME><span>##TEST_NAME##</span></span>";
+        const markup = "<span class='dx-variable' data-var-start-esc-char=## data-var-value=TEST_NAME><span>##TEST_NAME##</span></span>";
         const element = $(markup).get(0);
-        const data = PlaceholderFormat.value(element);
+        const data = VariableFormat.value(element);
 
         assert.deepEqual(data, { value: "TEST_NAME", escapeChar: ["##", ""] }, "Correct data");
     });
 });
 
-QUnit.module("Placeholder module", moduleConfig, () => {
+QUnit.module("Variables module", moduleConfig, () => {
     test("Render toolbar without any options", (assert) => {
         this.options.escapeChar = "#";
-        const dataPlaceholder = new DataPlaceholder(this.quillMock, this.options);
+        const variables = new Variables(this.quillMock, this.options);
 
-        dataPlaceholder.showPopover();
+        variables.showPopover();
         $(`.${SUGGESTION_LIST_CLASS} .dx-item`).first().trigger("dxclick");
 
         this.clock.tick();
 
         assert.deepEqual(this.log, [{
-            format: "placeholder",
+            format: "variable",
             position: 0,
             value: {
                 escapeChar: "#",

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2807,14 +2807,14 @@ declare module DevExpress.ui {
         dataPlaceholder?: dxHtmlEditorDataPlaceholder;
         placeholder?: string;
         toolbar?: dxHtmlEditorToolbar;
-        valueType?: 'HTML' | 'Markdown';
+        valueType?: 'html' | 'markdown';
     }
     /** A base class for editors. */
     export class dxHtmlEditor extends Editor {
         constructor(element: Element, options?: dxHtmlEditorOptions)
         constructor(element: JQuery, options?: dxHtmlEditorOptions)
         clearHistory(): void;
-        deleteContent(index: number, length: number): void;
+        delete(index: number, length: number): void;
         format(name: string, value: any): void;
         formatLine(index: number, length: number, formatName: string, formatValue: any): void;
         formatLine(index: number, length: number, formats: any): void;
@@ -5241,9 +5241,7 @@ declare module DevExpress.ui {
     }
     export interface dxHtmlEditorDataPlaceholder {
         dataSource?: string | Array<string> | DevExpress.data.DataSource | DevExpress.data.DataSourceOptions;
-        endEscapedChar?: string;
-        escapedChar?: string;
-        startEscapedChar?: string;
+        escapeChar?: string | Array<string>;
     }
     /** This section lists the data source fields that are used in a default template for list items. */
     export interface dxListItemTemplate extends CollectionWidgetItemTemplate {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2804,7 +2804,7 @@ declare module DevExpress.ui {
         imageSrc?: string;
     }
     export interface dxHtmlEditorOptions extends EditorOptions<dxHtmlEditor> {
-        dataPlaceholder?: dxHtmlEditorDataPlaceholder;
+        variables?: dxHtmlEditorVariables;
         placeholder?: string;
         toolbar?: dxHtmlEditorToolbar;
         valueType?: 'html' | 'markdown';
@@ -5239,7 +5239,7 @@ declare module DevExpress.ui {
         format?: string;
         values?: Array<string | number | boolean>;
     }
-    export interface dxHtmlEditorDataPlaceholder {
+    export interface dxHtmlEditorVariables {
         dataSource?: string | Array<string> | DevExpress.data.DataSource | DevExpress.data.DataSourceOptions;
         escapeChar?: string | Array<string>;
     }


### PR DESCRIPTION
1. `valueType` option values -> to lower case
2. ToolbarModule items: `values` -> `formatValues`, `format` -> `formatName`
3. `deleteContent`  -> `delete`
4. `dataPlaceholder` -> `variables`
remove `variables.startEscapedChar` and `variables.endEscapedChar`
`escapedChar`->`escapeChar`