### PR TITLE
Hide width and height options from the documentation (T680321)

### DIFF
--- a/js/ui/context_menu/ui.context_menu.js
+++ b/js/ui/context_menu/ui.context_menu.js
@@ -184,10 +184,20 @@ var ContextMenu = MenuBase.inherit((function() {
                 target: undefined,
 
                 /**
-                * @name dxContextMenuOptions.itemHoldAction
-                * @hidden
-                * @inheritdoc
-                */
+                 * @name dxContextMenuOptions.width
+                 * @hidden
+                 */
+
+                /**
+                 * @name dxContextMenuOptions.height
+                 * @hidden
+                 */
+
+                /**
+                 * @name dxContextMenuOptions.itemHoldAction
+                 * @hidden
+                 * @inheritdoc
+                 */
 
                 /**
                 * @name dxContextMenuOptions.onItemReordered


### PR DESCRIPTION
This options should be hidden from the documentation because dxContextMenu does not support item scrolling yet. Options should be published again after menu item scrolling feature is implemented