### PR TITLE
DataGrid: Fix continuation of group when RemoteOperations is true and SortByGroupSummaryInfo is used(T682960)

### DIFF
--- a/js/ui/data_grid/ui.data_grid.grouping.collapsed.js
+++ b/js/ui/data_grid/ui.data_grid.grouping.collapsed.js
@@ -318,7 +318,7 @@ exports.GroupingHelper = groupingCore.GroupingHelper.inherit((function() {
                 items = expandedInfo.take ? items.slice(0, expandedInfo.take) : items;
             }
             each(expandedInfo.items, function(index, item) {
-                var itemCount = item.count - (index === 0 && loadOptions.skip || 0),
+                var itemCount = item.count - (index === 0 && expandedInfo.skip || 0),
                     expandedItems = items.splice(0, itemCount);
 
                 applyContinuationToGroupItem(options, expandedInfo, groups.length - 1, index);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -7652,6 +7652,68 @@ QUnit.test("CustomStore load options when remote operations enabled and grouping
     assert.equal(items[3].key, 0, "item 3");
 });
 
+// T682960
+QUnit.test("Check second page when remote operations, paging, grouping with sort by summary info are defined", function(assert) {
+    this.options = {
+        dataSource: {
+            group: "group",
+            key: "id",
+            load: function(options) {
+                if(options.group) {
+                    return $.Deferred().resolve([
+                        { key: 'Group0', items: null, count: 6, summary: [6] },
+                        { key: 'Group1', items: null, count: 4, summary: [4] }
+                    ], {
+                        totalCount: 6
+                    });
+                } else {
+                    return $.Deferred().resolve([
+                        { id: 0, group: "Group0" },
+                        { id: 1, group: "Group0" },
+                        { id: 2, group: "Group0" },
+                        { id: 3, group: "Group0" },
+                        { id: 4, group: "Group0" },
+                        { id: 5, group: "Group0" },
+                        { id: 6, group: "Group1" },
+                        { id: 8, group: "Group1" },
+                        { id: 9, group: "Group1" },
+                        { id: 10, group: "Group1" }
+                    ]);
+                }
+            },
+            pageSize: 4
+        },
+        paging: {
+            enabled: true
+        },
+        grouping: {
+            autoExpandAll: true
+        },
+        columns: [ "id", "group" ],
+        sortByGroupSummaryInfo: [{
+            summaryItem: "count"
+        }],
+        summary: {
+            groupItems: [{
+                summaryType: "count"
+            }]
+        },
+        remoteOperations: true
+    };
+
+    // act
+    this.setupDataGridModules();
+    this.clock.tick();
+    this.dataController.pageIndex(1);
+
+    var items = this.dataController.items();
+    assert.equal(items.length, 4, "item count");
+    assert.deepEqual(items[0].key, ["Group1"]);
+    assert.equal(items[1].key, 10, "last item of Group1");
+    assert.deepEqual(items[2].key, ["Group0"]);
+    assert.equal(items[3].key, 0, "first item of Group0");
+});
+
 QUnit.test("CustomStore load options when remote operations enabled and multi-grouping with sort by summary info is defined", function(assert) {
     var storeLoadOptions;
     this.options = {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
