### PR TITLE
DataSource: Fix automatic pushAggregationTimeout when reshapeOnPush is disabled

### DIFF
--- a/js/data/data_source/data_source.js
+++ b/js/data/data_source/data_source.js
@@ -733,13 +733,15 @@ var DataSource = Class.inherit({
         });
     },
 
-    _scheduleChangedCallbacks: function(deferred) {
-        var that = this;
+    _fireChanged: function(args) {
+        var date = new Date();
+        this.fireEvent("changed", args);
+        this._changedTime = new Date() - date;
+    },
 
-        deferred.done(function() {
-            var date = new Date();
-            that.fireEvent("changed");
-            that._changedTime = new Date() - date;
+    _scheduleChangedCallbacks: function(deferred) {
+        deferred.done(() => {
+            this._fireChanged();
         });
     },
 
@@ -855,7 +857,7 @@ var DataSource = Class.inherit({
             }
 
             arrayUtils.applyBatch(this.store(), items, dataSourceChanges, groupLevel, true);
-            this.fireEvent("changed", [{ changes: changes }]);
+            this._fireChanged([{ changes: changes }]);
         }
     },
 

--- a/testing/tests/DevExpress.data/dataSource.tests.js
+++ b/testing/tests/DevExpress.data/dataSource.tests.js
@@ -1752,6 +1752,33 @@ QUnit.module("live update", {
         assert.equal(this.loadSpy.callCount, 2);
     });
 
+    QUnit.test("automatic throttle depends on changed time when reshapeOnPush is disabled", function(assert) {
+        var dataSource = this.createDataSource({
+            reshapeOnPush: false
+        });
+
+        dataSource.load();
+
+        var changedSpy = sinon.spy();
+        dataSource.on("changed", (function() {
+            this.clock.tick(10);
+            changedSpy();
+        }).bind(this));
+
+        assert.equal(changedSpy.callCount, 0);
+
+        dataSource.store().push(this.changes);
+        this.clock.tick();
+        dataSource.store().push(this.changes);
+        assert.equal(changedSpy.callCount, 1);
+
+        this.clock.tick(49);
+        assert.equal(changedSpy.callCount, 1);
+
+        this.clock.tick(1);
+        assert.equal(changedSpy.callCount, 2);
+    });
+
     QUnit.test("load isn't called when reshapeOnPush is disabled", function(assert) {
         var dataSource = this.createDataSource();
         dataSource.store().push(this.changes);


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
