### PR TITLE
Fix TreeView parent nodes expansion after selection of rendered child (T671960)

### DIFF
--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1067,17 +1067,15 @@ var TreeViewBase = HierarchicalCollectionWidget.inherit({
         });
     },
 
-    _updateExpandedItemsUI: function(node, state, e, $currentNode) {
-        var $node = $currentNode || this._getNodeElement(node);
+    _updateExpandedItemsUI: function(node, state, e) {
+        var $node = this._getNodeElement(node),
+            isHiddenNode = !$node.length || state && $node.is(':hidden');
 
-        if(this.option("expandNodesRecursive")) {
+        if(this.option("expandNodesRecursive") && isHiddenNode) {
             var parentNode = this._getNode(node.internalFields.parentKey);
 
             if(parentNode) {
-                var $parentNode = this._getNodeElement(parentNode);
-                if(!$node.length || (state && $node.is(':hidden'))) {
-                    this._updateExpandedItemsUI(parentNode, state, e, $parentNode);
-                }
+                this._updateExpandedItemsUI(parentNode, state, e);
             }
         }
 

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1070,8 +1070,12 @@ var TreeViewBase = HierarchicalCollectionWidget.inherit({
     _updateExpandedItemsUI: function(node, state, e) {
         var $node = this._getNodeElement(node);
 
-        if(!$node.length && this.option("expandNodesRecursive")) {
-            this._updateExpandedItemsUI(this._getNode(node.internalFields.parentKey), state, e);
+        if(this.option("expandNodesRecursive")) {
+            var parentNode = this._getNode(node.internalFields.parentKey);
+
+            if(parentNode) {
+                this._updateExpandedItemsUI(parentNode, state, e);
+            }
         }
 
         var $icon = $node.children("." + TOGGLE_ITEM_VISIBILITY_CLASS);

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1067,14 +1067,17 @@ var TreeViewBase = HierarchicalCollectionWidget.inherit({
         });
     },
 
-    _updateExpandedItemsUI: function(node, state, e) {
-        var $node = this._getNodeElement(node);
+    _updateExpandedItemsUI: function(node, state, e, $currentNode) {
+        var $node = $currentNode || this._getNodeElement(node);
 
         if(this.option("expandNodesRecursive")) {
             var parentNode = this._getNode(node.internalFields.parentKey);
 
             if(parentNode) {
-                this._updateExpandedItemsUI(parentNode, state, e);
+                var $parentNode = this._getNodeElement(parentNode);
+                if(!$node.length || (state && $node.is(':hidden'))) {
+                    this._updateExpandedItemsUI(parentNode, state, e, $parentNode);
+                }
             }
         }
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
@@ -377,6 +377,36 @@ QUnit.test("expand parent items in recursive case", function(assert) {
     assert.ok(nodes[0].children[0].expanded, "child node is expanded");
 });
 
+var TREEVIEW_NODE_CONTAINER_CLASS = "dx-treeview-node-container",
+    TREEVIEW_NODE_CONTAINER_OPENED_CLASS = "dx-treeview-node-container-opened";
+
+QUnit.test("Expand parent items in markup after expand of rendered nested child (T671960)", function(assert) {
+    var items = [{
+            text: "1",
+            id: 1,
+            items: [{
+                text: "11",
+                id: 11,
+                items: [{
+                    text: "111",
+                    id: 111
+                }]
+            }]
+        }],
+        $treeView = initTree({
+            items: items
+        }),
+        treeView = $treeView.dxTreeView("instance");
+
+    treeView.expandAll();
+    treeView.collapseAll();
+    treeView.expandItem(111);
+
+    var nodeElements = $treeView.find("." + TREEVIEW_NODE_CONTAINER_CLASS);
+    assert.ok(nodeElements.eq(1).hasClass(TREEVIEW_NODE_CONTAINER_OPENED_CLASS), "item 11");
+    assert.ok(nodeElements.eq(2).hasClass(TREEVIEW_NODE_CONTAINER_OPENED_CLASS), "item 111");
+});
+
 QUnit.test("expand childless item in recursive case", function(assert) {
     var items = [{ text: "1", id: 1, items: [{ text: "11", id: 11 }] }],
         $treeView = initTree({

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
@@ -4,6 +4,9 @@ var $ = require("jquery"),
     noop = require("core/utils/common").noop,
     fx = require("animation/fx");
 
+var TREEVIEW_NODE_CONTAINER_CLASS = "dx-treeview-node-container",
+    TREEVIEW_NODE_CONTAINER_OPENED_CLASS = "dx-treeview-node-container-opened";
+
 QUnit.module("Expanded items", {
     beforeEach: function() {
         this.checkFunctionArguments = function(assert, actualArgs, expectedArgs) {
@@ -376,9 +379,6 @@ QUnit.test("expand parent items in recursive case", function(assert) {
     assert.ok(nodes[0].expanded, "root node is expanded");
     assert.ok(nodes[0].children[0].expanded, "child node is expanded");
 });
-
-var TREEVIEW_NODE_CONTAINER_CLASS = "dx-treeview-node-container",
-    TREEVIEW_NODE_CONTAINER_OPENED_CLASS = "dx-treeview-node-container-opened";
 
 QUnit.test("Expand parent items in markup after expand of rendered nested child (T671960)", function(assert) {
     var items = [{


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
