### PR TITLE
Fix nested radio group. Root group should not affect on nested group (T680199) 

### DIFF
--- a/js/ui/radio_group/radio_group.js
+++ b/js/ui/radio_group/radio_group.js
@@ -18,6 +18,7 @@ var RADIO_GROUP_CLASS = "dx-radiogroup",
     RADIO_BUTTON_ICON_DOT_CLASS = "dx-radiobutton-icon-dot",
     RADIO_VALUE_CONTAINER_CLASS = "dx-radio-value-container",
     RADIO_BUTTON_CHECKED_CLASS = "dx-radiobutton-checked",
+    RADIO_BUTTON_ICON_CHECKED_CLASS = "dx-radiobutton-icon-checked",
     ITEM_DATA_KEY = "dxItemData",
     RADIO_FEEDBACK_HIDE_TIMEOUT = 100;
 
@@ -275,8 +276,10 @@ var RadioGroup = Editor.inherit({
     },
 
     _itemClickHandler: function(e) {
-        this._saveValueChangeEvent(e.event);
-        this.option("value", this._getItemValue(e.itemData));
+        if(this.itemElements().is(e.itemElement)) {
+            this._saveValueChangeEvent(e.event);
+            this.option("value", this._getItemValue(e.itemData));
+        }
     },
 
     _getItemValue: function(item) {
@@ -284,7 +287,8 @@ var RadioGroup = Editor.inherit({
     },
 
     itemElements: function() {
-        return this._radios.itemElements();
+        var result = this._radios.itemElements();
+        return result.not(result.find(this._radios._itemSelector()));
     },
 
     _renderLayout: function() {
@@ -299,7 +303,12 @@ var RadioGroup = Editor.inherit({
         this.itemElements().each((function(_, item) {
             var $item = $(item);
             var itemValue = this._valueGetter($item.data(ITEM_DATA_KEY));
-            $item.toggleClass(RADIO_BUTTON_CHECKED_CLASS, this._isValueEquals(itemValue, selectedValue));
+            var isValueEquals = this._isValueEquals(itemValue, selectedValue);
+            $item
+                .toggleClass(RADIO_BUTTON_CHECKED_CLASS, isValueEquals)
+                .find("." + RADIO_BUTTON_ICON_CLASS)
+                .first()
+                .toggleClass(RADIO_BUTTON_ICON_CHECKED_CLASS, isValueEquals);
 
             this.setAria("checked", this._isValueEquals(itemValue, selectedValue), $item);
         }).bind(this));

--- a/styles/widgets/android5/radioButton.android5.less
+++ b/styles/widgets/android5/radioButton.android5.less
@@ -29,11 +29,8 @@
     .transition(~"transform .14s");
 }
 
-.dx-radiobutton-checked {
-    .dx-radiobutton-icon {
-        border-color: @ANDROID5_RADIOBUTTON_CHECKED_BACKGROUND;
-    }
-
+.dx-radiobutton-icon-checked {
+    border-color: @ANDROID5_RADIOBUTTON_CHECKED_BACKGROUND;
     .dx-radiobutton-icon-dot {
         .scale(1);
     }
@@ -44,10 +41,8 @@
         border-color: @ANDROID5_RADIOBUTTON_DISABLED_BACKGROUND;
     }
 
-    .dx-radiobutton-checked {
-        .dx-radiobutton-icon:after {
-            background-color: @ANDROID5_RADIOBUTTON_DISABLED_BACKGROUND;
-        }
+    .dx-radiobutton-icon-checked:after {
+        background-color: @ANDROID5_RADIOBUTTON_DISABLED_BACKGROUND;
     }
 }
 

--- a/styles/widgets/generic/radioButton.generic.less
+++ b/styles/widgets/generic/radioButton.generic.less
@@ -27,7 +27,7 @@
     .box-sizing(content-box);
 }
 
-.dx-radiobutton-checked .dx-radiobutton-icon-dot {
+.dx-radiobutton-icon-checked .dx-radiobutton-icon-dot {
     display: block;
     margin-top: -@GENERIC_RADIOBUTTON_SIZE / 2 - @GENERIC_RADIOBUTTON_DOT_SIZE / 2;
     margin-left: @GENERIC_RADIOBUTTON_SIZE / 2 - @GENERIC_RADIOBUTTON_DOT_SIZE / 2;

--- a/styles/widgets/material/radioButton.material.less
+++ b/styles/widgets/material/radioButton.material.less
@@ -48,8 +48,8 @@
     }
 }
 
-.dx-radiobutton-checked  {
-    .dx-radiobutton-icon:before {
+.dx-radiobutton-icon-checked  {
+    &:before {
         border-color: @radiogroup-checked-bg;
     }
 
@@ -79,7 +79,7 @@
     &.dx-radiobutton-checked {
         &.dx-state-active,
         &.dx-state-focused {
-            .dx-radiobutton-icon:after {
+            .dx-radiobutton-icon-checked:after {
                 background-color: fade(@radiogroup-checked-bg, 10%);
                 .scale(1);
             }

--- a/styles/widgets/win10/radioButton.win10.less
+++ b/styles/widgets/win10/radioButton.win10.less
@@ -6,10 +6,8 @@
     background-color: @WIN10_RADIOBUTTON_BACKGROUND_COLOR;
 }
 
-.dx-radiobutton-checked {
-    .dx-radiobutton-icon {
-        border-color: @WIN10_RADIOBUTTON_CHECKED_BORDER_COLOR;
-    }
+.dx-radiobutton-icon-checked {
+    border-color: @WIN10_RADIOBUTTON_CHECKED_BORDER_COLOR;
 
     .dx-radiobutton-icon-dot {
         height: 10px;
@@ -27,10 +25,8 @@
 }
 
 .dx-state-hover, .dx-state-focused {
-    &.dx-radiobutton-checked {
-        .dx-radiobutton-icon {
-            border-color: @WIN10_RADIOBUTTON_CHECKED_BORDER_COLOR;
-        }
+    .dx-radiobutton-icon-checked {
+        border-color: @WIN10_RADIOBUTTON_CHECKED_BORDER_COLOR;
 
         .dx-radiobutton-icon-dot {
             background-color: @WIN10_RADIOBUTTON_HOVER_STATE_COLOR;
@@ -43,7 +39,7 @@
     background-color: @WIN10_RADIOBUTTON_ACTIVE_BACKGROUND_COLOR;
 }
 
-.dx-state-active.dx-radiobutton-checked .dx-radiobutton-icon-dot {
+.dx-state-active.dx-radiobutton .dx-radiobutton-icon-checked .dx-radiobutton-icon-dot {
     background-color: @WIN10_RADIOBUTTON_ACTIVE_COLOR;
 }
 

--- a/styles/widgets/win8/radioButton.win8.less
+++ b/styles/widgets/win8/radioButton.win8.less
@@ -16,7 +16,7 @@
     }
 }
 
-.dx-radiobutton-checked .dx-radiobutton-icon .dx-radiobutton-icon-dot {
+.dx-radiobutton-icon-checked .dx-radiobutton-icon-dot {
     margin: -12px 0 0 4px;
     width: 8px;
     height: 8px;

--- a/testing/tests/DevExpress.ui.widgets.editors/radioGroup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/radioGroup.tests.js
@@ -35,6 +35,68 @@ var moduleConfig = {
     }
 };
 
+QUnit.module("nested radio group", moduleConfig, function() {
+    QUnit.test("T680199 - click on nested radio group in template should not affect on contaier parent radio group", function(assert) {
+        var $nestedRadioGroup;
+
+        var $radioGroup = $("#radioGroup").dxRadioGroup({
+            items: [{
+                template: function(itemData, itemIndex, element) {
+                    $nestedRadioGroup = $("<div/>").dxRadioGroup({
+                        items: [1, 2]
+                    }).appendTo(element);
+
+                    $("<div/>").dxRadioGroup({
+                        items: [1, 2]
+                    }).appendTo(element);
+                }
+            }]
+        });
+
+        var parentRadioGroup = $radioGroup.dxRadioGroup("instance");
+        var parentItemElement = $(parentRadioGroup.itemElements()).first();
+        parentItemElement.trigger("dxclick");
+        assert.ok(parentItemElement.hasClass(RADIO_BUTTON_CHECKED_CLASS), "item of parent radio group is checked");
+
+        var nestedRadioGroup = $nestedRadioGroup.dxRadioGroup("instance");
+        var nestedItemElement = $(nestedRadioGroup.itemElements()).first();
+        nestedItemElement.trigger("dxclick");
+        assert.ok(nestedItemElement.hasClass(RADIO_BUTTON_CHECKED_CLASS), "item of nested radio group is checked");
+
+        assert.ok(parentItemElement.hasClass(RADIO_BUTTON_CHECKED_CLASS), "item of parent radio group is not changed");
+    });
+    QUnit.test("T680199 - click on one nested radio group doesn't change another nested group", function(assert) {
+        var $nestedRadioGroup1,
+            $nestedRadioGroup2;
+
+        $("#radioGroup").dxRadioGroup({
+            items: [{
+                template: function(itemData, itemIndex, element) {
+                    $nestedRadioGroup1 = $("<div/>").dxRadioGroup({
+                        items: [1, 2]
+                    }).appendTo(element);
+
+                    $nestedRadioGroup2 = $("<div/>").dxRadioGroup({
+                        items: [1, 2]
+                    }).appendTo(element);
+                }
+            }]
+        });
+
+        var nestedRadioGroup1 = $nestedRadioGroup1.dxRadioGroup("instance");
+        var nestedRadioGroup2 = $nestedRadioGroup2.dxRadioGroup("instance");
+
+        var firstNestedItemElement1 = $(nestedRadioGroup1.itemElements()).first();
+        firstNestedItemElement1.trigger("dxclick");
+        assert.ok(firstNestedItemElement1.hasClass(RADIO_BUTTON_CHECKED_CLASS), "item of first nested radio group is checked");
+
+        var firstNestedItemElement2 = $(nestedRadioGroup2.itemElements()).first();
+        assert.notOk(firstNestedItemElement2.hasClass(RADIO_BUTTON_CHECKED_CLASS), "item of second nested radio group is not changed");
+    });
+});
+
+
+QUnit.module("buttons group rendering");
 
 QUnit.module("buttons group rendering");
 


### PR DESCRIPTION
…(T680199) (#5919)

* T680199

* Fix he setting value when clicking on the inner radio group.
Fix active state style in generic.

* Refactoring: Move first level nesting selector from collection_base to radio_group

* tests

* fix warning in test

* Remove preventing click event.
Refactoring selector

* Add new class name dx-radiobutton-icon-checked

* Refactoring _refreshSelected: chain operation on new line

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
