### PR TITLE
DataGrid: Fix displaying unnecessary vertical scrollbar on iOS if columnAutoWidth is enabled (T681714)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_view.js
+++ b/js/ui/grid_core/ui.grid_core.columns_view.js
@@ -103,6 +103,7 @@ exports.ColumnsView = modules.View.inherit(columnStateMixin).inherit({
         var options = extend({}, scrollingOptions, {
             direction: "both",
             bounceEnabled: false,
+            pushBackValue: 0,
             useKeyboard: false
         });
 

--- a/styles/widgets/common/scrollable.less
+++ b/styles/widgets/common/scrollable.less
@@ -62,7 +62,6 @@
 
     &.dx-scrollable-native-ios {
         .dx-scrollable-content {
-            min-height: 101%;
             .box-sizing(content-box);
         }
 

--- a/styles/widgets/ios7/scrollable.ios7.less
+++ b/styles/widgets/ios7/scrollable.ios7.less
@@ -1,9 +1,3 @@
-.dx-scrollable-native {
-    .dx-scrollable-content {
-        min-height: 101%;
-    }
-}
-
 .dx-scrollable-scroll {
     margin: 2px;
     border-radius: 2px;


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
