### PR TITLE
Fix the form's height when the scrollView is contained inside the tabbed item (T686135)

### DIFF
--- a/styles/widgets/common/form.less
+++ b/styles/widgets/common/form.less
@@ -104,6 +104,17 @@
     }
 }
 
+.dx-layout-manager, .dx-field-item-content, .dx-form-group-content, .dx-field-item,
+.dx-form-group-with-caption, .dx-form-group-content, .dx-form-group {
+    height: 100%;
+}
+
+.dx-field-item-content {
+    .dx-tabpanel {
+        height: 100%;
+    }
+}
+
 .dx-field-item-label-location-top{
     display: block;
 }

--- a/testing/tests/DevExpress.ui.widgets.form/form.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.tests.js
@@ -815,6 +815,41 @@ QUnit.test("Update editorOptions of an editor inside the tab", function(assert) 
     assert.equal(form.getEditor("firstName").option("disabled"), false, "'disabled' option was successfully changed");
 });
 
+QUnit.test("The form's height is changed when the scrollView is contained inside the tabbed item", function(assert) {
+    var formHeight = 300;
+    var $form = $("#form").dxForm({
+        height: formHeight,
+        items: [{
+            itemType: "group",
+            caption: "Contact Information",
+            items: [{
+                itemType: "group",
+                items: [{
+                    itemType: "tabbed",
+                    cssClass: "test",
+                    tabs: [{
+                        title: "Phone",
+                        items: [{
+                            template: function(data, container) {
+                                var scrollView = $("<div>").css({
+                                        "height": "100%",
+                                        "width": "100%"
+                                    }),
+                                    content = $("<div style=\"height: 900px; width: 100%;\" />");
+
+                                content.appendTo(scrollView);
+                                scrollView.appendTo(container);
+                            }
+                        }]
+                    }]
+                }]
+            }]
+        }]
+    });
+
+    assert.ok($form.find(".test").height() <= formHeight, "height of tabbed item");
+});
+
 
 QUnit.module("Align labels", {
     beforeEach: function() {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
