### PR TITLE
Fix HtmlEditor focus behavior (fixes T685852)

### DIFF
--- a/js/ui/html_editor/modules/dropImage.js
+++ b/js/ui/html_editor/modules/dropImage.js
@@ -1,7 +1,7 @@
 import { getQuill } from "../quill_importer";
 
 import eventsEngine from "../../../events/core/events_engine";
-import eventUtils from "../../../events/utils";
+import { addNamespace } from "../../../events/utils";
 import { each } from "../../../core/utils/iterator";
 import browser from "../../../core/utils/browser";
 
@@ -14,9 +14,9 @@ class DropImageModule extends BaseModule {
         this.editorInstance = options.editorInstance;
         const widgetName = this.editorInstance.NAME;
 
-        eventsEngine.on(this.quill.root, eventUtils.addNamespace("dragover", widgetName), this._dragOverHandler.bind(this));
-        eventsEngine.on(this.quill.root, eventUtils.addNamespace("drop", widgetName), this._dropHandler.bind(this));
-        eventsEngine.on(this.quill.root, eventUtils.addNamespace("paste", widgetName), this._pasteHandler.bind(this));
+        eventsEngine.on(this.quill.root, addNamespace("dragover", widgetName), this._dragOverHandler.bind(this));
+        eventsEngine.on(this.quill.root, addNamespace("drop", widgetName), this._dropHandler.bind(this));
+        eventsEngine.on(this.quill.root, addNamespace("paste", widgetName), this._pasteHandler.bind(this));
     }
 
     _dragOverHandler(e) {

--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -12,6 +12,9 @@ import { extend } from "../../../core/utils/extend";
 import { format } from "../../../localization/message";
 import { titleize } from "../../../core/utils/inflector";
 
+import eventsEngine from "../../../events/core/events_engine";
+import { addNamespace } from "../../../events/utils";
+
 const BaseModule = getQuill().import("core/module");
 
 const TOOLBAR_WRAPPER_CLASS = "dx-htmleditor-toolbar-wrapper";
@@ -172,6 +175,10 @@ class ToolbarModule extends BaseModule {
                     this.quill.format("link", formData, USER_ACTION);
                 }
             });
+
+            promise.fail(() => {
+                this.quill.focus();
+            });
         };
     }
 
@@ -229,13 +236,16 @@ class ToolbarModule extends BaseModule {
 
     _renderToolbar() {
         const container = this.options.container || this._getContainer();
-        const $container = $(container);
+        const $container = $(container).addClass(TOOLBAR_WRAPPER_CLASS);
         const toolbarItems = this._prepareToolbarItems();
         const $toolbar = $("<div>")
             .addClass(TOOLBAR_CLASS)
             .appendTo(container);
 
-        $container.addClass(TOOLBAR_WRAPPER_CLASS);
+        eventsEngine.on($toolbar, addNamespace("mousedown", this._editorInstance.NAME), (e) => {
+            e.preventDefault();
+        });
+
         this.toolbarInstance = this._editorInstance._createComponent($toolbar, Toolbar, { dataSource: toolbarItems });
 
         this._editorInstance.on("disposing", () => {
@@ -345,6 +355,9 @@ class ToolbarModule extends BaseModule {
 
             promise.done((formData) => {
                 this.quill.format(formatName, formData[formatName], USER_ACTION);
+            });
+            promise.fail(() => {
+                this.quill.focus();
             });
         };
     }

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -567,7 +567,13 @@ const HtmlEditor = Editor.inherit({
 
     formDialogOption: function(optionName, optionValue) {
         return this._formDialog.popupOption.apply(this._formDialog, arguments);
-    }
+    },
+
+    focus: function() {
+        this.callBase();
+
+        this._applyQuillMethod("focus");
+    },
 });
 
 registerComponent("dxHtmlEditor", HtmlEditor);

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -573,7 +573,7 @@ const HtmlEditor = Editor.inherit({
         this.callBase();
 
         this._applyQuillMethod("focus");
-    },
+    }
 });
 
 registerComponent("dxHtmlEditor", HtmlEditor);

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
@@ -158,4 +158,12 @@ QUnit.module("API", moduleConfig, () => {
         assert.ok(testModule);
         assert.equal(testModule.getEditor(), this.instance);
     });
+
+    test("'focus' method should call the quill's focus", (assert) => {
+        const focusSpy = sinon.spy(this.instance.getQuillInstance(), "focus");
+
+        this.instance.focus();
+
+        assert.ok(focusSpy.calledOnce, "Quill focus() should triggered on the editor's focus()");
+    });
 });


### PR DESCRIPTION
* Fix focus restoring on color or link dialog hiding
* Editor's `focus` should trigger quill instance `focus()`
* Fix formatting via toolbar in IE11