### PR TITLE
dxDataGrid: Fix the onContentReady event which isn't triggering when datasource is null and stateStoring is enabled (T689294)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.state_storing.js
+++ b/js/ui/grid_core/ui.grid_core.state_storing.js
@@ -133,6 +133,7 @@ module.exports = {
                             that.renderNoDataText();
                             var columnHeadersView = that.component.getView("columnHeadersView");
                             columnHeadersView && columnHeadersView.render();
+                            that.component._fireContentReadyAction();
                         }
                     });
                 }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -8004,6 +8004,30 @@ QUnit.test("change editing.allowAdding with onCellPrepared and dataSource option
     assert.strictEqual($addRowButton.length, 1, "add row button is rendered");
 });
 
+// T689294
+QUnit.test("onContentReady when there is no dataSource and stateStoring is enabled", function(assert) {
+    // arrange
+    var contentReadyCallCount = 0;
+
+    // act
+    createDataGrid({
+        stateStoring: {
+            enabled: true,
+            type: "custom",
+            customLoad: function() {
+                return {};
+            }
+        },
+        onContentReady: function() {
+            contentReadyCallCount++;
+        }
+    });
+    this.clock.tick();
+
+    // assert
+    assert.equal(contentReadyCallCount, 1);
+});
+
 QUnit.module("API methods", {
     beforeEach: function() {
         this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
See https://devexpress.com/issue=T689294