### PR TITLE
DataGrid: Fix exception about 'anyof' operation in filterBuilder when customizeColumns is used and column.dataType is defined

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -571,6 +571,10 @@ module.exports = {
                 GROUP_LOCATION = "group",
                 COLUMN_CHOOSER_LOCATION = "columnChooser";
 
+            var setFilterOperationsAsDefaultValues = function(column) {
+                column.filterOperations = column.defaultFilterOperations;
+            };
+
             var createColumn = function(that, columnOptions, userStateColumnOptions, bandColumn) {
                 var commonColumnOptions = {},
                     calculatedColumnOptions,
@@ -583,6 +587,7 @@ module.exports = {
                         };
                     }
 
+                    let result;
                     if(columnOptions.command) {
                         isDefaultCommandColumn = that._commandColumns.some((column) => column.command === columnOptions.command);
 
@@ -590,7 +595,7 @@ module.exports = {
                             commonColumnOptions.visible = true;
                         }
 
-                        return extend(true, commonColumnOptions, columnOptions);
+                        result = extend(true, commonColumnOptions, columnOptions);
                     } else {
                         commonColumnOptions = that.getCommonSettings();
                         if(userStateColumnOptions && userStateColumnOptions.name && userStateColumnOptions.dataField) {
@@ -598,8 +603,12 @@ module.exports = {
                         }
                         calculatedColumnOptions = that._createCalculatedColumnOptions(columnOptions, bandColumn);
 
-                        return extend(true, { id: `dx-col-${globalColumnId++}` }, DEFAULT_COLUMN_OPTIONS, commonColumnOptions, calculatedColumnOptions, columnOptions, { selector: null });
+                        result = extend(true, { id: `dx-col-${globalColumnId++}` }, DEFAULT_COLUMN_OPTIONS, commonColumnOptions, calculatedColumnOptions, columnOptions, { selector: null });
                     }
+                    if(columnOptions.filterOperations === columnOptions.defaultFilterOperations) {
+                        setFilterOperationsAsDefaultValues(result);
+                    }
+                    return result;
                 }
             };
 
@@ -2130,7 +2139,7 @@ module.exports = {
                         column.customizeText = column.customizeText || getCustomizeTextByDataType(dataType);
                         column.defaultFilterOperations = column.defaultFilterOperations || !lookup && DATATYPE_OPERATIONS[dataType] || [];
                         if(!isDefined(column.filterOperations)) {
-                            column.filterOperations = column.defaultFilterOperations;
+                            setFilterOperationsAsDefaultValues(column);
                         }
                         column.defaultFilterOperation = column.filterOperations && column.filterOperations[0] || "=";
                         column.showEditorAlways = isDefined(column.showEditorAlways) ? column.showEditorAlways : (dataType === "boolean" && !column.cellTemplate);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
@@ -373,4 +373,26 @@ QUnit.module("Real dataGrid", {
         assert.equal($valueText.children().length, 3, "three children items");
     });
 
+    // T687835
+    QUnit.test("the 'any of' doesn't throw exception when customizeColumns is used and column.dataType is defined", function(assert) {
+        // arrange, act
+        this.initDataGrid({
+            dataSource: [{ field: 1 }, { field: 2 }, { field: 3 }],
+            customizeColumns: function(columns) {
+            },
+            columns: [{
+                dataField: "field",
+                dataType: "number"
+            }],
+            filterValue: ["field", "anyof", [1, 2]],
+            loadingTimeout: null
+        });
+
+        // act
+        this.dataGrid.option("filterBuilderPopup.visible", true);
+
+        // assert
+        assert.equal($(".dx-popup-content .dx-filterbuilder").length, 1);
+    });
+
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
