### PR TITLE
Scheduler doesn't support the +30 minutes time-zones (T681124)

### DIFF
--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -335,7 +335,7 @@ var subscribes = {
             "DATE": function() {
                 var dateTimeFormat = "monthAndDay",
                     startDateString = dateLocalization.format(startDate, dateTimeFormat),
-                    isDurationMoreThanDay = (endDate.getTime() - startDate.getTime()) > 24 * 3600000;
+                    isDurationMoreThanDay = (endDate.getTime() - startDate.getTime()) > toMs("day");
 
                 var endDateString = (isDurationMoreThanDay || endDate.getDate() !== startDate.getDate()) ?
                     " - " + dateLocalization.format(endDate, dateTimeFormat) :
@@ -640,50 +640,44 @@ var subscribes = {
 
     convertDateByTimezone: function(date, appointmentTimezone) {
         date = new Date(date);
+        var tzOffsets = this._subscribes.getComplexOffsets(this, date, appointmentTimezone);
 
-        var clientTzOffset = -(this._subscribes["getClientTimezoneOffset"](date) / 3600000);
+        var dateInUTC = date.getTime() - tzOffsets.client * toMs("hour");
+        date = new Date(dateInUTC + tzOffsets.appointment * toMs("hour"));
 
-        var commonTimezoneOffset = this._getTimezoneOffsetByOption(date);
-
-        var appointmentTimezoneOffset = this._calculateTimezoneByValue(appointmentTimezone, date);
-
-        if(typeof appointmentTimezoneOffset !== "number") {
-            appointmentTimezoneOffset = clientTzOffset;
+        if(typeof tzOffsets.common === "number") {
+            date = new Date(date.getTime() + ((tzOffsets.common - tzOffsets.appointment) * toMs("hour")));
         }
-
-        var dateInUTC = date.getTime() - clientTzOffset * 3600000;
-
-        date = new Date(dateInUTC + appointmentTimezoneOffset * 3600000);
-
-        if(typeof commonTimezoneOffset === "number") {
-            date = new Date(date.setHours(date.getHours() + (commonTimezoneOffset - appointmentTimezoneOffset)));
-        }
-
         return date;
     },
 
     convertDateByTimezoneBack: function(date, appointmentTimezone) {
         date = new Date(date);
+        var tzOffsets = this._subscribes.getComplexOffsets(this, date, appointmentTimezone);
 
-        var clientTzOffset = -(this._subscribes["getClientTimezoneOffset"](date) / 3600000);
+        var dateInUTC = date.getTime() + tzOffsets.client * toMs("hour");
+        date = new Date(dateInUTC - tzOffsets.appointment * toMs("hour"));
 
-        var commonTimezoneOffset = this._getTimezoneOffsetByOption(date);
-
-        var appointmentTimezoneOffset = this._calculateTimezoneByValue(appointmentTimezone, date);
-
-        if(typeof appointmentTimezoneOffset !== "number") {
-            appointmentTimezoneOffset = clientTzOffset;
-        }
-
-        var dateInUTC = date.getTime() + clientTzOffset * 3600000;
-
-        date = new Date(dateInUTC - appointmentTimezoneOffset * 3600000);
-
-        if(typeof commonTimezoneOffset === "number") {
-            date = new Date(date.setHours(date.getHours() - (commonTimezoneOffset - appointmentTimezoneOffset)));
+        if(typeof tzOffsets.common === "number") {
+            date = new Date(date.getTime() - ((tzOffsets.common - tzOffsets.appointment) * toMs("hour")));
         }
 
         return date;
+    },
+    getComplexOffsets: function(scheduler, date, appointmentTimezone) {
+        var clientTimezoneOffset = -this.getClientTimezoneOffset(date) / toMs("hour");
+        var commonTimezoneOffset = scheduler._getTimezoneOffsetByOption(date);
+        var appointmentTimezoneOffset = scheduler._calculateTimezoneByValue(appointmentTimezone, date);
+
+        if(typeof appointmentTimezoneOffset !== "number") {
+            appointmentTimezoneOffset = clientTimezoneOffset;
+        }
+
+        return {
+            client: clientTimezoneOffset,
+            common: commonTimezoneOffset,
+            appointment: appointmentTimezoneOffset
+        };
     },
 
     getDaylightOffset: function(startDate, endDate) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/subscribes.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/subscribes.tests.js
@@ -10,6 +10,11 @@ var $ = require("jquery"),
     dateUtils = require("core/utils/date"),
     config = require("core/config");
 
+
+function getTimezoneDifference(date, timeZone) {
+    return date.getTimezoneOffset() * dateUtils.dateToMilliseconds("minute") + timeZone * dateUtils.dateToMilliseconds("hour");
+}
+
 QUnit.testStart(function() {
     $("#qunit-fixture").html('<div id="scheduler"></div>');
 });
@@ -808,7 +813,7 @@ QUnit.test("'convertDateByTimezone' should return date according to the custom t
     });
 
     var date = new Date(2015, 6, 3, 3),
-        timezoneDifference = date.getTimezoneOffset() * 60000 + timezoneValue * 3600000;
+        timezoneDifference = getTimezoneDifference(date, timezoneValue);
 
     var convertedDate = this.instance.fire("convertDateByTimezone", date);
 
@@ -816,7 +821,6 @@ QUnit.test("'convertDateByTimezone' should return date according to the custom t
 });
 
 QUnit.test("'convertDateByTimezone' should return date according to the custom timeZone as string", function(assert) {
-
     var timezone = { id: "Asia/Ashkhabad", value: 5 };
     this.createInstance();
 
@@ -825,7 +829,23 @@ QUnit.test("'convertDateByTimezone' should return date according to the custom t
     });
 
     var date = new Date(2015, 6, 3, 3),
-        timezoneDifference = date.getTimezoneOffset() * 60000 + timezone.value * 3600000;
+        timezoneDifference = getTimezoneDifference(date, timezone.value);
+
+    var convertedDate = this.instance.fire("convertDateByTimezone", date);
+
+    assert.deepEqual(convertedDate, new Date(date.getTime() + timezoneDifference), "'convertDateByTimezone' works fine");
+});
+
+QUnit.test("'convertDateByTimezone' should return date according to the custom timeZone with non-integer number", function(assert) {
+    var timezone = { id: "Australia/Broken_Hill", value: 9.5 };
+    this.createInstance();
+
+    this.instance.option({
+        timeZone: timezone.id
+    });
+
+    var date = new Date(2015, 6, 3, 3),
+        timezoneDifference = getTimezoneDifference(date, timezone.value);
 
     var convertedDate = this.instance.fire("convertDateByTimezone", date);
 


### PR DESCRIPTION
* T681124

* T681124, add test

* re-fix T681124.

* Push fix in convertDateByTimezoneBack

* Refactoring: move the common part to a separate method

* Remove magic constant

* for test

* Refactoring: rename method

* Refactoring: invalid context

* Replace commonTimezoneOffset on tzOffsets.common

* T681124

* T681124, add test

* re-fix T681124.

* Push fix in convertDateByTimezoneBack

* Refactoring: move the common part to a separate method

* Remove magic constant

* for test

* Refactoring: rename method

* Refactoring: invalid context

* Replace commonTimezoneOffset on tzOffsets.common

* Refactoring tests,
Add toMs('day')

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
