### PR TITLE
Appointment should rendered correctly if end date appointment coincided translation oт STD(T683568)

### DIFF
--- a/js/ui/scheduler/ui.scheduler.appointments.strategy.horizontal_month_line.js
+++ b/js/ui/scheduler/ui.scheduler.appointments.strategy.horizontal_month_line.js
@@ -9,16 +9,12 @@ var HOURS_IN_DAY = 24,
 var HorizontalMonthLineRenderingStrategy = HorizontalAppointmentsStrategy.inherit({
 
     calculateAppointmentWidth: function(appointment, position, isRecurring) {
-        var startDate = new Date(this.startDate(appointment, false, position)),
-            endDate = new Date(this.endDate(appointment, position, isRecurring)),
+        var startDate = new Date(this._startDate(appointment, false, position)),
+            endDate = new Date(this._endDate(appointment, position, isRecurring)),
             cellWidth = this._defaultWidth || this.getAppointmentMinSize();
 
         startDate = dateUtils.trimTime(startDate);
-
-        var width = Math.ceil(this._getDurationInHour(startDate, endDate) / HOURS_IN_DAY) * cellWidth;
-        width = this.cropAppointmentWidth(width, cellWidth);
-
-        return width;
+        return Math.ceil(this._getDurationInHour(startDate, endDate) / HOURS_IN_DAY) * cellWidth;
     },
 
     _getDurationInHour: function(startDate, endDate) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.dstAppointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.dstAppointments.tests.js
@@ -214,3 +214,24 @@ QUnit.test("Recurrence exception should not be rendered if exception goes after 
         tzOffsetStub.restore();
     }
 });
+
+QUnit.test("Appointment should rendered correctly if end date appointment coincided translation oт STD", function(assert) {
+    this.createInstance({
+        dataSource: [{
+            text: "November 4",
+            startDate: new Date(2018, 10, 4, 18, 0),
+            endDate: new Date(2018, 10, 5, 0, 0),
+        }],
+        views: ["month"],
+        currentView: "month",
+        currentDate: new Date(2018, 10, 1),
+        firstDayOfWeek: 0,
+        cellDuration: 60,
+        height: 800
+    });
+
+    var $appointment = $(this.instance.$element()).find("." + APPOINTMENT_CLASS).first(),
+        cellWidth = this.instance.$element().find("." + DATE_TABLE_CELL_CLASS).first().outerWidth();
+
+    assert.equal($appointment.outerWidth(), cellWidth, 'Appointment width is correct after translation oт STD');
+});


### PR DESCRIPTION
…ed translation oт STD(T683568) (#6113)

* Use _adjustDurationByDaylightDiff to fix bug

* Create getDurationInHour method

* Add test

* Refactoring

* Remove integration.dstAppointments.tests

* Rename integration.DstAppointments.tests to integration.dstAppointments.tests

# Conflicts:
#	js/ui/scheduler/ui.scheduler.appointments.strategy.horizontal_month_line.js

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
