### PR TITLE
Scheduler doesn't support the +30 minutes time-zones (T681124)

### DIFF
--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -12,6 +12,7 @@ var $ = require("../../core/renderer"),
     SchedulerTimezones = require("./ui.scheduler.timezones"),
     Deferred = require("../../core/utils/deferred").Deferred;
 
+var MINUTES_IN_HOUR = 60;
 var toMs = dateUtils.dateToMilliseconds;
 
 var subscribes = {
@@ -681,7 +682,9 @@ var subscribes = {
         date = new Date(dateInUTC + tzOffsets.appointment * toMs("hour"));
 
         if(typeof tzOffsets.common === "number") {
-            date = new Date(date.getTime() + ((tzOffsets.common - tzOffsets.appointment) * toMs("hour")));
+            var offset = tzOffsets.common - tzOffsets.appointment;
+            date.setHours(date.getHours() + Math.floor(offset));
+            date.setMinutes(date.getMinutes() + (offset % 1) * MINUTES_IN_HOUR);
         }
         return date;
     },
@@ -694,7 +697,9 @@ var subscribes = {
         date = new Date(dateInUTC - tzOffsets.appointment * toMs("hour"));
 
         if(typeof tzOffsets.common === "number") {
-            date = new Date(date.getTime() - ((tzOffsets.common - tzOffsets.appointment) * toMs("hour")));
+            var offset = tzOffsets.common - tzOffsets.appointment;
+            date.setHours(date.getHours() - Math.floor(offset));
+            date.setMinutes(date.getMinutes() - (offset % 1) * MINUTES_IN_HOUR);
         }
 
         return date;


### PR DESCRIPTION
Replace calculation time zone difference in ms on hour and minutes

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
