### PR TITLE
Scheduler doesn't support the +30 minutes time-zones. Re fix bug. (T681124)

### DIFF
--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -679,7 +679,7 @@ var subscribes = {
 
         var tzOffsets = this._subscribes.getComplexOffsets(this, date, appointmentTimezone);
         date = this._subscribes.translateDateToAppointmentTimeZone(date, tzOffsets);
-        date = this._subscribes.translateDateToCommonTimeZoneIfRequired(date, tzOffsets);
+        date = this._subscribes.translateDateToCommonTimeZone(date, tzOffsets);
 
         return date;
     },
@@ -689,7 +689,7 @@ var subscribes = {
 
         var tzOffsets = this._subscribes.getComplexOffsets(this, date, appointmentTimezone);
         date = this._subscribes.translateDateToAppointmentTimeZone(date, tzOffsets, true);
-        date = this._subscribes.translateDateToCommonTimeZoneIfRequired(date, tzOffsets, true);
+        date = this._subscribes.translateDateToCommonTimeZone(date, tzOffsets, true);
 
         return date;
     },
@@ -700,7 +700,7 @@ var subscribes = {
         return new Date(dateInUTC + operation * offsets.appointment * toMs("hour"));
     },
 
-    translateDateToCommonTimeZoneIfRequired: function(date, offsets, back) {
+    translateDateToCommonTimeZone: function(date, offsets, back) {
         var operation = back ? -1 : 1;
         if(typeof offsets.common === "number") {
             var offset = offsets.common - offsets.appointment,

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -703,7 +703,6 @@ var subscribes = {
     translateDateToCommonTimeZoneIfRequired: function(date, offsets, back) {
         var operation = back ? -1 : 1;
         if(typeof offsets.common === "number") {
-            date = new Date(date);
             var offset = offsets.common - offsets.appointment,
                 hoursOffset = Math.floor(offset),
                 minutesOffset = offset % 1;

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -12,6 +12,7 @@ var $ = require("../../core/renderer"),
     SchedulerTimezones = require("./ui.scheduler.timezones"),
     Deferred = require("../../core/utils/deferred").Deferred;
 
+var MINUTES_IN_HOUR = 60;
 var toMs = dateUtils.dateToMilliseconds;
 
 var subscribes = {
@@ -681,7 +682,9 @@ var subscribes = {
         date = new Date(dateInUTC + tzOffsets.appointment * toMs("hour"));
 
         if(typeof tzOffsets.common === "number") {
-            date = new Date(date.getTime() + ((tzOffsets.common - tzOffsets.appointment) * toMs("hour")));
+            var offset = tzOffsets.common - tzOffsets.appointment;
+            date.setHours(date.getHours() + Math.floor(offset));
+            date.setMinutes(date.getMinutes() + (offset % 1) * MINUTES_IN_HOUR);
         }
         return date;
     },
@@ -694,7 +697,9 @@ var subscribes = {
         date = new Date(dateInUTC - tzOffsets.appointment * toMs("hour"));
 
         if(typeof tzOffsets.common === "number") {
-            date = new Date(date.getTime() - ((tzOffsets.common - tzOffsets.appointment) * toMs("hour")));
+            var offset = tzOffsets.common - tzOffsets.appointment;
+            date.setHours(date.getHours() - Math.floor(offset));
+            date.setMinutes(date.getMinutes() - (offset % 1) * MINUTES_IN_HOUR);
         }
 
         return date;

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -678,8 +678,8 @@ var subscribes = {
         date = new Date(date);
 
         var tzOffsets = this._subscribes.getComplexOffsets(this, date, appointmentTimezone);
-        this._subscribes.translateDateToAppointmentTimeZone(date, tzOffsets);
-        this._subscribes.translateDateToCommonTimeZoneIfRequired(date, tzOffsets);
+        date = this._subscribes.translateDateToAppointmentTimeZone(date, tzOffsets);
+        date = this._subscribes.translateDateToCommonTimeZoneIfRequired(date, tzOffsets);
 
         return date;
     },
@@ -688,8 +688,8 @@ var subscribes = {
         date = new Date(date);
 
         var tzOffsets = this._subscribes.getComplexOffsets(this, date, appointmentTimezone);
-        this._subscribes.translateDateToAppointmentTimeZone(date, tzOffsets, true);
-        this._subscribes.translateDateToCommonTimeZoneIfRequired(date, tzOffsets, true);
+        date = this._subscribes.translateDateToAppointmentTimeZone(date, tzOffsets, true);
+        date = this._subscribes.translateDateToCommonTimeZoneIfRequired(date, tzOffsets, true);
 
         return date;
     },
@@ -697,18 +697,20 @@ var subscribes = {
     translateDateToAppointmentTimeZone: function(date, offsets, back) {
         var operation = back ? -1 : 1;
         var dateInUTC = date.getTime() - operation * offsets.client * toMs("hour");
-        date = new Date(dateInUTC + operation * offsets.appointment * toMs("hour"));
+        return new Date(dateInUTC + operation * offsets.appointment * toMs("hour"));
     },
 
     translateDateToCommonTimeZoneIfRequired: function(date, offsets, back) {
         var operation = back ? -1 : 1;
         if(typeof offsets.common === "number") {
+            date = new Date(date);
             var offset = offsets.common - offsets.appointment,
                 hoursOffset = Math.floor(offset),
                 minutesOffset = offset % 1;
             date.setHours(date.getHours() + operation * hoursOffset);
             date.setMinutes(date.getMinutes() + operation * minutesOffset * MINUTES_IN_HOUR);
         }
+        return date;
     },
 
     getComplexOffsets: function(scheduler, date, appointmentTimezone) {


### PR DESCRIPTION
Replace calculation time zone difference in ms on hour and minutes

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
