### PR TITLE
DataGrid tests: Firefox on Linux needs more height to display scrollbar

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/gridView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/gridView.tests.js
@@ -541,7 +541,7 @@ function createGridView(options, userOptions) {
             }),
             $container = $('#container');
 
-        $container.height(100).width(1000);
+        $container.height(110).width(1000);
         gridView.render($container, $.extend(this.options, {
             scrolling: {},
             showColumnHeaders: true,


### PR DESCRIPTION
Another prerequisite for making QUnit tests compatible with Firefox on Linux.

The gif below shows what happens in `qunit-fixture`.
Seems related: https://bugzilla.mozilla.org/show_bug.cgi?id=292284

---

![](https://user-images.githubusercontent.com/4426185/48553326-502f4080-e8ec-11e8-9840-ee0fe1aa1346.gif)
