### PR TITLE
dxTreeList: Fix the expand button that disappears after clicking it if another cell is edited (T690119)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -208,7 +208,7 @@ var EditingController = modules.ViewController.inherit((function() {
             that._updateEditButtons();
         },
 
-        _closeEditItem: function($targetElement) {
+        _needToCloseEditableCell: function($targetElement) {
             var isDataRow = $targetElement.closest("." + DATA_ROW_CLASS).length,
                 $targetCell = $targetElement.closest("." + ROW_CLASS + "> td"),
                 columnIndex = $targetCell[0] && $targetCell[0].cellIndex,
@@ -217,7 +217,11 @@ var EditingController = modules.ViewController.inherit((function() {
                 // TODO jsdmitry: Move this code to _rowClick method of rowsView
                 allowEditing = visibleColumns[columnIndex] && visibleColumns[columnIndex].allowEditing;
 
-            if(this.isEditing() && (!isDataRow || (isDataRow && !allowEditing && !this.isEditCell(rowIndex, columnIndex)))) {
+            return this.isEditing() && (!isDataRow || (isDataRow && !allowEditing && !this.isEditCell(rowIndex, columnIndex)));
+        },
+
+        _closeEditItem: function($targetElement) {
+            if(this._needToCloseEditableCell($targetElement)) {
                 this.closeEditCell();
             }
         },

--- a/js/ui/tree_list/ui.tree_list.editing.js
+++ b/js/ui/tree_list/ui.tree_list.editing.js
@@ -118,6 +118,10 @@ var EditingController = editingModule.controllers.editing.inherit((function() {
             parentIdSetter(options.data, parentKey);
 
             this.callBase.apply(this, arguments);
+        },
+
+        _needToCloseEditableCell: function($targetElement) {
+            return this.callBase.apply(this, arguments) || $targetElement.closest("." + TREELIST_EXPAND_ICON_CONTAINER_CLASS).length && this.isEditing();
         }
     };
 })());

--- a/testing/tests/DevExpress.ui.widgets.treeList/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/editing.tests.js
@@ -702,3 +702,36 @@ QUnit.test("Add row when 'keyExpr' and 'parentIdExpr' options are specified as f
     assert.ok($rowElements.first().hasClass("dx-row-inserted"), "insert row");
     assert.strictEqual(this.getVisibleRows()[0].data.parentId, 0, "parentId of an inserted row");
 });
+
+// T690119
+QUnit.test("Edit cell - The editable cell should be closed after click on expand button", function(assert) {
+    // arrange
+    var $testElement = $('#treeList');
+
+    this.options.editing = {
+        mode: "cell",
+        allowUpdating: true
+    };
+    this.options.loadingTimeout = 0;
+    this.options.dataSource = [
+        { id: 1, field1: 'test1', field2: 1, field3: new Date(2001, 0, 1) },
+        { id: 2, field1: 'test2', field2: 2, field3: new Date(2002, 1, 2) },
+        { id: 3, parentId: 2, field1: 'test3', field2: 3, field3: new Date(2003, 2, 3) }
+    ];
+    this.setupTreeList();
+    this.clock.tick();
+    this.rowsView.render($testElement);
+
+    this.editCell(0, 0);
+    this.clock.tick();
+
+    // assert
+    assert.strictEqual($(this.getCellElement(0, 0)).find(".dx-texteditor").length, 1, "has editor");
+
+    // act
+    $(this.getCellElement(1, 0)).find(".dx-treelist-collapsed").trigger("dxclick");
+    this.clock.tick();
+
+    // assert
+    assert.strictEqual($(this.getCellElement(0, 0)).find(".dx-texteditor").length, 0, "hasn't editor");
+});


### PR DESCRIPTION
See https://devexpress.com/issue=T690119