### PR TITLE
Fix default handler of the HtmlEditor's button click

### DIFF
--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -7,7 +7,7 @@ import "../../select_box";
 import "../../color_box/color_view";
 
 import { each } from "../../../core/utils/iterator";
-import { isString, isObject, isDefined, isEmptyObject } from "../../../core/utils/type";
+import { isString, isObject, isDefined, isEmptyObject, isBoolean } from "../../../core/utils/type";
 import { extend } from "../../../core/utils/extend";
 import { format } from "../../../localization/message";
 import { titleize } from "../../../core/utils/inflector";
@@ -69,11 +69,12 @@ class ToolbarModule extends BaseModule {
     _getDefaultClickHandler(formatName) {
         return (e) => {
             const formats = this.quill.getFormat();
-            const value = !formats[formatName];
+            const value = formats[formatName];
+            const newValue = !(isBoolean(value) ? value : isDefined(value));
 
-            this.quill.format(formatName, value, USER_ACTION);
+            this.quill.format(formatName, newValue, USER_ACTION);
 
-            this._updateFormatWidget(formatName, value, formats);
+            this._updateFormatWidget(formatName, newValue, formats);
         };
     }
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -531,6 +531,23 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             .find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`)
             .trigger("mousedown");
     });
+
+    test("default click handler should correctly revert defined format", (assert) => {
+        this.options.items = ["bold"];
+        this.quillMock.getFormat = () => { return { bold: "" }; };
+
+        new Toolbar(this.quillMock, this.options);
+
+        const $formatButton = this.$element.find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`);
+        $formatButton.trigger("dxclick");
+
+        assert.deepEqual(
+            this.log,
+            [{
+                format: "bold",
+                value: false
+            }]);
+    });
 });
 
 QUnit.module("Active formats", simpleModuleConfig, () => {


### PR DESCRIPTION
It helps to handle toggle of a class attributor with the key-part only
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
