### PR TITLE
Fix overlay wrapper height after safari address bar resizing (T653828)

### DIFF
--- a/js/ui/overlay.js
+++ b/js/ui/overlay.js
@@ -72,6 +72,7 @@ var realDevice = devices.real(),
 
     firefoxDesktop = browser.mozilla && realDevice.deviceType === "desktop",
     iOS = realDevice.platform === "ios",
+    hasSafariAddressBar = browser.safari && realDevice.deviceType !== "desktop",
     iOS7_0andBelow = iOS && compareVersions(realVersion, [7, 1]) < 0,
     android4_0nativeBrowser = realDevice.platform === "android" && compareVersions(realVersion, [4, 0], 2) === 0 && navigator.userAgent.indexOf("Chrome") === -1;
 
@@ -1199,6 +1200,12 @@ var Overlay = Widget.inherit({
         this._$wrapper.appendTo(renderContainer);
     },
 
+    _fixHeightAfterSafariAddressBarResizing: function() {
+        if(this._isWindow(this._getContainer()) && hasSafariAddressBar) {
+            this._$wrapper.css("minHeight", window.innerHeight);
+        }
+    },
+
     _renderGeometry: function() {
         if(this.option("visible") && windowUtils.hasWindow()) {
             this._renderGeometryImpl();
@@ -1209,6 +1216,7 @@ var Overlay = Widget.inherit({
         this._stopAnimation();
 
         this._normalizePosition();
+        this._fixHeightAfterSafariAddressBarResizing();
         this._renderShading();
         this._renderDimensions();
         var resultPosition = this._renderPosition();

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -866,7 +866,7 @@ QUnit.test("shading height should change after iOS address bar resize (T653828)"
         }).dxOverlay("instance");
 
     $wrapper = $(overlay.$content().parent());
-    assert.equal($wrapper.css("minHeight").replace("px", ""), window.innerHeight, "");
+    assert.equal($wrapper.css("minHeight").replace("px", ""), window.innerHeight, "overlay wrapper has right min-height style");
 });
 
 QUnit.test("shading color should be customized by option", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -854,6 +854,21 @@ QUnit.test("shading height should change after container resize (B237292)", func
     assert.strictEqual(translator.locate($wrapper).top, 0);
 });
 
+QUnit.test("shading height should change after iOS address bar resize (T653828)", function(assert) {
+    if(devices.real().platform !== "ios" || devices.real().deviceType === "desktop") {
+        assert.ok(true);
+        return;
+    }
+
+    var $wrapper,
+        overlay = $("#overlay").dxOverlay({
+            visible: true
+        }).dxOverlay("instance");
+
+    $wrapper = $(overlay.$content().parent());
+    assert.equal($wrapper.css("minHeight").replace("px", ""), window.innerHeight, "");
+});
+
 QUnit.test("shading color should be customized by option", function(assert) {
     var overlay = $("#overlay").dxOverlay({
             shading: true,


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
