### PR TITLE
dxDataGrid: Fix the "Maximum call stack size exceeded" error occurs if DevExtreme AMD modules are used and the scrolling mode is set to "standard" (T690340)

### DIFF
--- a/js/ui/data_grid/ui.data_grid.grouping.js
+++ b/js/ui/data_grid/ui.data_grid.grouping.js
@@ -45,7 +45,7 @@ var GroupingDataSourceAdapterExtender = (function() {
             return (totalCount > 0 && that._dataSource.group() && that._dataSource.requireTotalCount()) ? totalCount + that._grouping.totalCountCorrection() : totalCount;
         },
         itemsCount: function() {
-            return this._dataSource.group() ? (this._grouping.itemsCount() || 0) : this.callBase();
+            return this._dataSource.group() ? (this._grouping.itemsCount() || 0) : this.callBase.apply(this, arguments);
         },
         allowCollapseAll: function() {
             return this._grouping.allowCollapseAll();


### PR DESCRIPTION
See https://devexpress.com/issue=T690340