### PR TITLE
Don't use jQuery template engines when 'transclude' flag is true

### DIFF
--- a/js/ui/widget/jquery.template.js
+++ b/js/ui/widget/jquery.template.js
@@ -11,7 +11,7 @@ var registerTemplateEngine = function(name, templateEngine) {
 
 registerTemplateEngine("default", {
     compile: (element) => domUtils.normalizeTemplateElement(element),
-    render: (template, model, index, transclude) => transclude ? template : template.clone()
+    render: (template, model, index) => template.clone()
 });
 
 registerTemplateEngine("jquery-tmpl", {
@@ -105,13 +105,16 @@ var Template = TemplateBase.inherit({
 
     ctor: function(element) {
         this._element = element;
-
-        this._compiledTemplate = currentTemplateEngine.compile(element);
     },
 
     _renderCore: function(options) {
+        const transclude = options.transclude;
+        if(!transclude && !this._compiledTemplate) {
+            this._compiledTemplate = currentTemplateEngine.compile(this._element);
+        }
+
         return $("<div>").append(
-            currentTemplateEngine.render(this._compiledTemplate, options.model, options.index, options.transclude)
+            transclude ? this._element : currentTemplateEngine.render(this._compiledTemplate, options.model, options.index)
         ).contents();
     },
 

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -316,4 +316,39 @@
             "<script>alert(1)</script>"
         );
     });
+
+    QUnit.test("Transcluded content (T691770, T693379)", function(assert) {
+        aspnet.setTemplateEngine();
+        try {
+            window.testCounters = {
+                innerEval: 0,
+                innerClick: 0
+            };
+
+            $("#qunit-fixture").html("\
+                <div id=test-button>\
+                    <div id=test-button-inner></div>\
+                    <script>\
+                        testCounters.innerEval++;\
+                        $('#test-button-inner')\
+                            .append('test-button-inner-text')\
+                            .click(function() {\
+                                testCounters.innerClick++;\
+                            });\
+                    </script>\
+                </div>\
+            ");
+
+            $("#test-button").dxButton();
+            $("#test-button-inner").trigger("click");
+
+            assert.equal(window.testCounters.innerEval, 1);
+            assert.equal(window.testCounters.innerClick, 1);
+            assert.equal($("#test-button-inner").html(), "test-button-inner-text");
+        } finally {
+            setTemplateEngine("default");
+            delete window.testCounters;
+        }
+    });
+
 }));

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -177,7 +177,7 @@
                     </div>\
                     </script>\
                     \
-                    <div id="buttonWithInnerTemplate"><script>// DevExpress.aspnet.setTemplateEngine();</script><script type="text/html">BUTTON_CONTENT</script></div>'
+                    <div id="buttonWithInnerTemplate"><script>// DevExpress.aspnet.setTemplateEngine();</script>BUTTON_CONTENT</div>'
                 );
 
                 if(!window.DevExpress || !window.DevExpress.aspnet) {
@@ -239,6 +239,7 @@
 
             QUnit.test("Inner template is rendered correctly when another script tags exist", function(assert) {
                 var $buttonElement = $("#buttonWithInnerTemplate").dxButton();
+                $buttonElement.find("script").remove();
                 assert.equal($buttonElement.text(), "BUTTON_CONTENT");
             });
         }


### PR DESCRIPTION
Effectively, this makes all template engines (including the one used in our ASP.NET integration) compatible with the `transclude` flag.

Related tickets:
- https://devexpress.com/issue=T691770
- https://devexpress.com/issue=T694614
- https://devexpress.com/issue=T693379