### PR TITLE
dxTreeList/dxDataGrid: Fix wrong command column position when there are fixed columns (T695370)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -1370,7 +1370,10 @@ module.exports = {
                 return rowCount;
             };
 
-            var getFixedPosition = function(column) {
+            var getFixedPosition = function(that, column) {
+                if(column.command && !isCustomCommandColumn(that, column)) {
+                    return column.visibleIndex < 0 ? "left" : "right";
+                }
                 return !column.fixedPosition ? "left" : column.fixedPosition;
             };
 
@@ -1828,7 +1831,7 @@ module.exports = {
                                     if(!isDefined(transparentColumnIndex)) {
                                         transparentColumnIndex = j;
                                     }
-                                } else if(prevColumn && prevColumn.fixed && getFixedPosition(prevColumn) !== getFixedPosition(column)) {
+                                } else if(prevColumn && prevColumn.fixed && getFixedPosition(that, prevColumn) !== getFixedPosition(that, column)) {
                                     if(!isDefined(transparentColumnIndex)) {
                                         transparentColumnIndex = j;
                                     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -8591,6 +8591,32 @@ QUnit.module("Customization of the command columns", {
         assert.notOk(visibleColumns[1].allowReordering, "allowReordering of the second grouped column");
         assert.notOk(visibleColumns[1].allowFixing, "allowFixing of the second grouped column");
     });
+
+    // T695370
+    QUnit.test("Change the command column position via columnOption method when there are fixed columns", function(assert) {
+        // arrange
+        this.applyOptions({
+            editing: {
+                mode: "row",
+                allowUpdating: true,
+                allowDeleting: true
+            },
+            columns: [
+                { dataField: 'TestField3', caption: 'Custom Title 3', fixed: true },
+                { dataField: 'TestField4', caption: 'Custom Title 4' }
+            ]
+        });
+
+        // act
+        this.columnOption("command:edit", { visibleIndex: -1 });
+
+        // assert
+        var fixedColumns = this.columnsController.getFixedColumns();
+        assert.strictEqual(fixedColumns.length, 3, "fixed column count");
+        assert.strictEqual(fixedColumns[0].type, "buttons", "command column");
+        assert.strictEqual(fixedColumns[1].dataField, "TestField3", "fixed column");
+        assert.strictEqual(fixedColumns[2].command, "transparent", "transparent column");
+    });
 });
 
 // T622771


### PR DESCRIPTION
See https://devexpress.com/issue=T695370
