### PR TITLE
DataGrid: Fix rendering of records at the bottom of the grid when the Virtual Scrolling mode is enabled

### DIFF
--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling_core.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling_core.js
@@ -19,6 +19,10 @@ var isAppendMode = function(that) {
     return that.option("scrolling.mode") === SCROLLING_MODE_INFINITE && !that._isVirtual;
 };
 
+exports.getPixelRatio = function(window) {
+    return window.devicePixelRatio || 1;
+};
+
 exports.getContentHeightLimit = function(browser) {
     if(browser.msie) {
         return 4000000;
@@ -26,7 +30,7 @@ exports.getContentHeightLimit = function(browser) {
         return 8000000;
     }
 
-    return 15000000;
+    return 15000000 / exports.getPixelRatio(window);
 };
 
 exports.subscribeToExternalScrollers = function($element, scrollChangedHandler, $targetElement) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
@@ -1,14 +1,14 @@
-require("common.css!");
-require("ui/scroll_view/ui.scrollable");
+import "common.css!";
+import "ui/scroll_view/ui.scrollable";
 
-var $ = require("jquery"),
-    memoryLeaksHelper = require("../../helpers/memoryLeaksHelper.js"),
-    virtualScrollingCore = require("ui/grid_core/ui.grid_core.virtual_scrolling_core"),
-    VirtualScrollController = virtualScrollingCore.VirtualScrollController,
-    browser = require("core/utils/browser"),
-    devices = require("core/devices"),
-    renderer = require("core/renderer"),
-    mockComponent = {
+import $ from "jquery";
+import memoryLeaksHelper from "../../helpers/memoryLeaksHelper.js";
+import virtualScrollingCore, { VirtualScrollController } from "ui/grid_core/ui.grid_core.virtual_scrolling_core";
+import browser from "core/utils/browser";
+import devices from "core/devices";
+import renderer from "core/renderer";
+
+const mockComponent = {
         option: sinon.stub()
     },
 
@@ -38,11 +38,10 @@ var $ = require("jquery"),
         onChanged: sinon.stub()
     },
 
-    CONTENT_HEIGHT_LIMIT = virtualScrollingCore.getContentHeightLimit(browser),
-
     DEFAULT_TOTAL_ITEMS_COUNT = 20000,
 
-    DEFAULT_PAGE_SIZE = 20;
+    DEFAULT_PAGE_SIZE = 20,
+    CONTENT_HEIGHT_LIMIT = virtualScrollingCore.getContentHeightLimit(browser);
 
 function resetMock(mock) {
     $.each(mock, function(_, method) {
@@ -781,4 +780,6 @@ QUnit.test("Content height limit for different browsers", function(assert) {
     assert.equal(virtualScrollingCore.getContentHeightLimit({ msie: true }), 4000000, "content height limit for ie");
     assert.equal(virtualScrollingCore.getContentHeightLimit({ mozilla: true }), 8000000, "content height limit for firefox");
     assert.equal(virtualScrollingCore.getContentHeightLimit({}), 15000000, "content height limit for other browsers");
+    virtualScrollingCore.getPixelRatio = () => 2;
+    assert.equal(virtualScrollingCore.getContentHeightLimit({}), 7500000, "content height limit depends on devicePixelRatio for other browsers"); // T692460
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
