### PR TITLE
queryByOptions: don't take grouping into account for totalCount calculation

### DIFF
--- a/js/data/store_helper.js
+++ b/js/data/store_helper.js
@@ -50,30 +50,30 @@ function queryByOptions(query, options, isCountQuery) {
         group = normalizeSortingInfo(group);
     }
 
-    if(!isCountQuery) {
-        if(sort || group) {
-            sort = normalizeSortingInfo(sort || []);
-            if(group) {
-                sort = arrangeSortingInfo(group, sort);
-            }
-            each(sort, function(index) {
-                query = query[index ? "thenBy" : "sortBy"](this.selector, this.desc, this.compare);
-            });
-        }
+    if(isCountQuery) {
+        return query;
+    }
 
-        if(select) {
-            query = query.select(select);
+    if(sort || group) {
+        sort = normalizeSortingInfo(sort || []);
+        if(group) {
+            sort = arrangeSortingInfo(group, sort);
         }
+        each(sort, function(index) {
+            query = query[index ? "thenBy" : "sortBy"](this.selector, this.desc, this.compare);
+        });
+    }
+
+    if(select) {
+        query = query.select(select);
     }
 
     if(group) {
         query = multiLevelGroup(query, group);
     }
 
-    if(!isCountQuery) {
-        if(take || skip) {
-            query = query.slice(skip || 0, take);
-        }
+    if(take || skip) {
+        query = query.slice(skip || 0, take);
     }
 
     return query;

--- a/js/data/store_helper.js
+++ b/js/data/store_helper.js
@@ -35,23 +35,24 @@ function arrangeSortingInfo(groupInfo, sortInfo) {
 function queryByOptions(query, options, isCountQuery) {
     options = options || {};
 
-    var filter = options.filter,
-        sort = options.sort,
-        select = options.select,
-        group = options.group,
-        skip = options.skip,
-        take = options.take;
+    var filter = options.filter;
 
     if(filter) {
         query = query.filter(filter);
     }
 
-    if(group) {
-        group = normalizeSortingInfo(group);
-    }
-
     if(isCountQuery) {
         return query;
+    }
+
+    var sort = options.sort,
+        select = options.select,
+        group = options.group,
+        skip = options.skip,
+        take = options.take;
+
+    if(group) {
+        group = normalizeSortingInfo(group);
     }
 
     if(sort || group) {

--- a/testing/tests/DevExpress.data/storeArray.tests.js
+++ b/testing/tests/DevExpress.data/storeArray.tests.js
@@ -34,7 +34,7 @@ QUnit.test("totalCount", assert => {
 
         })
         .done(r => {
-            assert.equal(r, 3);
+            assert.equal(r, 5);
             done();
         });
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataSource.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataSource.tests.js
@@ -5,6 +5,7 @@ var $ = require("jquery"),
     CustomStore = require("data/custom_store"),
     ODataStore = require("data/odata/store"),
     dataQuery = require("data/query"),
+    queryByOptions = require("data/store_helper").queryByOptions,
     gridCore = require("ui/data_grid/ui.data_grid.core"),
     dataGridMocks = require("../../helpers/dataGridMocks.js"),
     setupDataGridModules = dataGridMocks.setupDataGridModules,
@@ -2550,8 +2551,11 @@ function createDataSourceWithRemoteGrouping(options, remoteGroupPaging, brokeOpt
                             extra.totalCount = totalCount;
                         }
                         if(loadOptions.requireGroupCount && !brokeOptions.skipGroupCount) {
-                            arrayStore._loadImpl({ filter: loadOptions.filter, group: loadOptions.group }).done(function(allData) {
-                                extra.groupCount = allData.length;
+                            queryByOptions(arrayStore.createQuery(), {
+                                filter: loadOptions.filter,
+                                group: loadOptions.group
+                            }).count().done(function(groupCount) {
+                                extra.groupCount = groupCount;
                             });
                         }
                         if(brokeOptions.useNativePromise) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataSource.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataSource.tests.js
@@ -2550,7 +2550,9 @@ function createDataSourceWithRemoteGrouping(options, remoteGroupPaging, brokeOpt
                             extra.totalCount = totalCount;
                         }
                         if(loadOptions.requireGroupCount && !brokeOptions.skipGroupCount) {
-                            extra.groupCount = totalCount;
+                            arrayStore._loadImpl({ filter: loadOptions.filter, group: loadOptions.group }).done(function(allData) {
+                                extra.groupCount = allData.length;
+                            });
                         }
                         if(brokeOptions.useNativePromise) {
                             d.resolve($.extend({ data: data }, extra));


### PR DESCRIPTION
fix [T694728](https://devexpress.com/issue=T694728)
