### PR TITLE
Remove unnecessary style mixins

### DIFF
--- a/styles/mixins.less
+++ b/styles/mixins.less
@@ -13,356 +13,40 @@
 
 .gradient-linear(@options) {
     background-repeat: no-repeat;
-    background-image: -webkit-linear-gradient(@options);
-    background-image:    -moz-linear-gradient(@options);
-    background-image:      -o-linear-gradient(@options);
-    background-image:      linear-gradient(@options);
-}
-
-.double-gradient-linear(@options1, @options2) {
-    background-image: -webkit-linear-gradient(@options1), -webkit-linear-gradient(@options2);
-    background-image:    -moz-linear-gradient(@options1), -moz-linear-gradient(@options2);
-    background-image:      -o-linear-gradient(@options1), -o-linear-gradient(@options2);
-    background-image:         linear-gradient(@options1), linear-gradient(@options2);
-}
-
-.gradient-radial(@value) {
-    background: -webkit-gradient(@value);
-    background: -webkit-radial-gradient(@value);
-    background:    -moz-radial-gradient(@value);
-    background:      -o-radial-gradient(@value);
-    background:         radial-gradient(@value);
-}
-
-.gradient-radial(@startColor, @endColor) {
-    background: @startColor;
-    background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(0%, @startColor), color-stop(100%,  @endColor)); /* Chrome,Safari4+ */
-    background: -webkit-radial-gradient(center, ellipse cover, @startColor 0%, @endColor 100%); /* Chrome10+, Safari5.1+ */
-    background:    -moz-radial-gradient(center, ellipse cover, @startColor 0%, @endColor 100%); /* FF3.6+ */
-    background:      -o-radial-gradient(center, ellipse cover, @startColor 0%, @endColor 100%); /* Opera 12+ */
-    background:         radial-gradient(ellipse at center,     @startColor 0%, @endColor 100%); /* W3C */
+    background-image: linear-gradient(@options);
 }
 
 .gradient-radial-circle2(@startColor, @startPosition, @middleColor, @middlePosition, @endColor, @endPosition) {
     background: @startColor;
-    background: -webkit-radial-gradient(circle closest-side, @startColor @startPosition, @middleColor @middlePosition, @endColor @endPosition);
-    background:    -moz-radial-gradient(circle closest-side, @startColor @startPosition, @middleColor @middlePosition, @endColor @endPosition);
-    background:      -o-radial-gradient(circle closest-side, @startColor @startPosition, @middleColor @middlePosition, @endColor @endPosition);
-    background:         radial-gradient(circle closest-side at center, @startColor @startPosition, @middleColor @middlePosition, @endColor @endPosition);
+    background: radial-gradient(circle closest-side at center, @startColor @startPosition, @middleColor @middlePosition, @endColor @endPosition);
 }
 
 .gradient-radial-circle(@startColor, @startPosition, @endColor, @endPosition) {
     background: @startColor;
-    background: -webkit-radial-gradient(circle closest-side, @startColor @startPosition, @endColor @endPosition); /* Chrome10+, Safari5.1+ */
-    background:    -moz-radial-gradient(circle closest-side, @startColor @startPosition, @endColor @endPosition); /* FF3.6+ */
-    background:      -o-radial-gradient(circle closest-side, @startColor @startPosition, @endColor @endPosition); /* Opera 12+ */
-    background:         radial-gradient(circle closest-side at center,    @startColor @startPosition, @endColor @endPosition); /* W3C */
+    background: radial-gradient(circle closest-side at center, @startColor @startPosition, @endColor @endPosition);
 }
 
-.background-size(@x: 100%, @y: 100%) {
-    -webkit-background-size: @x @y;
-       -moz-background-size: @x @y;
-            background-size: @x @y;
-}
-
-.background-size-prop(@property: cover) {
-    -webkit-background-size: @property;
-       -moz-background-size: @property;
-            background-size: @property;
-}
-
-.box-shadow(@value) {
-    -webkit-box-shadow: @value;
-       -moz-box-shadow: @value;
-            box-shadow: @value;
-}
-
-.box-shadow(@value1, @value2) {
-    -webkit-box-shadow: @value1, @value2;
-       -moz-box-shadow: @value1, @value2;
-            box-shadow: @value1, @value2;
-}
-
-.box-shadow(@value1, @value2, @value3) {
-    -webkit-box-shadow: @value1, @value2, @value3;
-       -moz-box-shadow: @value1, @value2, @value3;
-            box-shadow: @value1, @value2, @value3;
-}
-
-.text-shadow(@value) {
-    text-shadow: @value;
-}
-
-.box-sizing(@value: border-box) {
-    -webkit-box-sizing: @value;
-       -moz-box-sizing: @value;
-            box-sizing: @value;
-}
-
-.background-clip(@value: border-box) {
-    -moz-background-clip: @value;
-    -webkit-background-clip: @value;
-    background-clip: @value;
-}
-
-/* border radius */
-.border-radius(@radius: 10px) {
-    -webkit-border-radius: @radius;
-       -moz-border-radius: @radius;
-         -o-border-radius: @radius;
-            border-radius: @radius;
-}
-.border-radius-top-left(@radius: 10px) {
-    -webkit-border-top-left-radius: @radius;
-       -moz-border-top-left-radius: @radius;
-            border-top-left-radius: @radius;
-}
-.border-radius-top-right(@radius: 10px) {
-    -webkit-border-top-right-radius: @radius;
-       -moz-border-top-right-radius: @radius;
-            border-top-right-radius: @radius;
-}
-.border-radius-bottom-left(@radius: 10px) {
-    -webkit-border-bottom-left-radius: @radius;
-       -moz-border-bottom-left-radius: @radius;
-            border-bottom-left-radius: @radius;
-}
-.border-radius-bottom-right(@radius: 10px) {
-    -webkit-border-bottom-right-radius: @radius;
-       -moz-border-bottom-right-radius: @radius;
-            border-bottom-right-radius: @radius;
-}
-.border-radius-right(@radius: 10px) {
-    -webkit-border-bottom-right-radius: @radius;
-       -moz-border-bottom-right-radius: @radius;
-            border-bottom-right-radius: @radius;
-    -webkit-border-top-right-radius: @radius;
-       -moz-border-top-right-radius: @radius;
-            border-top-right-radius: @radius;
-}
-.border-radius-left(@radius: 10px) {
-    -webkit-border-bottom-left-radius: @radius;
-       -moz-border-bottom-left-radius: @radius;
-            border-bottom-left-radius: @radius;
-    -webkit-border-top-left-radius: @radius;
-       -moz-border-top-left-radius: @radius;
-            border-top-left-radius: @radius;
-}
-.border-radius-custom(@radius-top-left: 10px, @radius-top-right: 10px, @radius-bottom-right: 10px, @radius-bottom-left: 10px) {
-    -webkit-border-radius:@radius-top-left @radius-top-right @radius-bottom-right @radius-bottom-left;
-       -moz-border-radius:@radius-top-left @radius-top-right @radius-bottom-right @radius-bottom-left;
-            border-radius:@radius-top-left @radius-top-right @radius-bottom-right @radius-bottom-left;
-}
 /* flex */
 .flex-container(@direction: row, @wrap: wrap) {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-flex;
     display: flex;
-
-    -webkit-flex-flow: @direction @wrap;
-    -moz-flex-flow: @direction @wrap;
     flex-flow: @direction @wrap;
 }
 
-.flex-item(@grow: 1, @shrink: 1, @basis: auto) {
-    -webkit-box-flex:@grow;
-    -webkit-flex:@grow @shrink @basis;
-    -moz-flex:@grow @shrink @basis;
-    flex:@grow @shrink @basis;
-}
-
-.transition-transform(@time: 1s, @ease: linear) {
-    -webkit-transition: -webkit-transform @time @ease;
-       -moz-transition: -moz-transform @time @ease;
-         -o-transition: -o-transform @time @ease;
-            transition: transform @time @ease;
-}
-
-.transition(@transition) {
-    -webkit-transition: @transition;
-       -moz-transition: @transition;
-         -o-transition: @transition;
-            transition: @transition;
-}
-
-.transition-property(@arguments: all) {
-    webkit-transition-property: @arguments;
-    moz-transition-property: @arguments;
-    o-transition-property: @arguments;
-    transition-property: @arguments;
-}
-
-.transition-duration(@arguments: 1s) {
-    webkit-transition-duration: @arguments;
-    moz-transition-duration: @arguments;
-    o-transition-duration: @arguments;
-    transition-duration: @arguments;
-}
-
-.transition-timing-function(@arguments: linear) {
-    webkit-transition-timing-function: @arguments;
-    moz-transition-timing-function: @arguments;
-    o-transition-timing-function: @arguments;
-    transition-timing-function: @arguments;
-}
-
-.transition-delay(@arguments: 0s) {
-    webkit-transition-delay: @arguments;
-    moz-transition-delay: @arguments;
-    o-transition-delay: @arguments;
-    transition-delay: @arguments;
-}
-
 .user-select(@value: text) {
-    -webkit-user-select: @value;
-     -khtml-user-select: @value;
-       -moz-user-select: @value;
-        -ms-user-select: @value;
-         -o-user-select: @value;
-            user-select: @value;
+    user-select: @value;
 }
 .user-select(@value) when (@value = none) {
     -webkit-touch-callout: none;
 }
 
-.user-drag(@value: text) {
-    -webkit-user-drag: @value;
-       -moz-user-drag: @value;
-        -ms-user-drag: @value;
-         -o-user-drag: @value;
-            user-drag: @value;
-}
-
-.transform(@string){
-    -webkit-transform: @string;
-       -moz-transform: @string;
-         -o-transform: @string;
-            transform: @string;
-}
-
-.scale(@factor) {
-    -webkit-transform: scale(@factor);
-       -moz-transform: scale(@factor);
-         -o-transform: scale(@factor);
-            transform: scale(@factor);
-}
-
-.rotate(@deg) {
-    -webkit-transform: rotate(@deg);
-       -moz-transform: rotate(@deg);
-         -o-transform: rotate(@deg);
-            transform: rotate(@deg);
-}
-
-.rotate3d(@x, @y, @z, @deg) {
-    -webkit-transform: rotate3d(@x, @y, @z, @deg);
-       -moz-transform: rotate3d(@x, @y, @z, @deg);
-         -o-transform: rotate3d(@x, @y, @z, @deg);
-            transform: rotate3d(@x, @y, @z, @deg);
-}
-
-.translate(@x, @y:0) {
-    -webkit-transform: translate(@x, @y);
-       -moz-transform: translate(@x, @y);
-         -o-transform: translate(@x, @y);
-             transform: translate(@x, @y);
-}
-
-.scale3d(@x, @y: 0, @z: 0) {
-    -webkit-transform: scale3d(@x, @y, @z);
-       -moz-transform: scale3d(@x, @y, @z);
-         -o-transform: scale3d(@x, @y, @z);
-            transform: scale3d(@x, @y, @z);
-}
-
-.translate3d(@x, @y: 0, @z: 0) {
-    -webkit-transform: translate3d(@x, @y, @z);
-       -moz-transform: translate3d(@x, @y, @z);
-         -o-transform: translate3d(@x, @y, @z);
-            transform: translate3d(@x, @y, @z);
-}
-
 .dx-overflow(@x: hidden) {
     overflow: @x;
-    -o-text-overflow: ellipsis;
-    -ms-text-overflow: ellipsis;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.transform-origin(@prop) {
-    -webkit-transform-origin: @prop;
-       -moz-transform-origin: @prop;
-         -o-transform-origin: @prop;
-            transform-origin: @prop;
-}
-
-.animation(@prop) {
-    -webkit-animation: @prop;
-       -moz-animation: @prop;
-         -o-animation: @prop;
-            animation: @prop;
-}
-
-.animation-name(@prop) {
-    -webkit-animation-name: @prop;
-       -moz-animation-name: @prop;
-         -o-animation-name: @prop;
-            animation-name: @prop;
-}
-
-.animation-duration(@prop) {
-    -webkit-animation-duration: @prop;
-       -moz-animation-duration: @prop;
-         -o-animation-duration: @prop;
-            animation-duration: @prop;
-}
-
-.animation-iteration-count(@prop) {
-    -webkit-animation-iteration-count: @prop;
-       -moz-animation-iteration-count: @prop;
-         -o-animation-iteration-count: @prop;
-            animation-iteration-count: @prop;
-}
-
-.animation-delay(@prop) {
-    -webkit-animation-delay: @prop;
-       -moz-animation-delay: @prop;
-         -o-animation-delay: @prop;
-            animation-delay: @prop;
-}
-
-.animation-timing(@prop) {
--webkit-animation-timing-function: @prop;
-   -moz-animation-timing-function: @prop;
-     -o-animation-timing-function: @prop;
-        animation-timing-function: @prop;
-}
-
-.animation-fill-mode(@prop: both) {
--webkit-animation-fill-mode: @prop;
-   -moz-animation-fill-mode: @prop;
-    -ms-animation-fill-mode: @prop;
-        animation-fill-mode: @prop;
-}
-
-.backface-visibility(@prop: hidden) {
-    -webkit-backface-visibility: @prop;
-    -moz-backface-visibility: @prop;
-    -ms-backface-visibility: @prop;
-    backface-visibility: @prop;
-}
-
 .flip-horizontally() {
-    -moz-transform: scaleX(-1);
-    -o-transform: scaleX(-1);
-    -webkit-transform: scaleX(-1);
     transform: scaleX(-1);
-}
-
-.touch-action(@value) {
-    touch-action: @value;
 }
 
 .vertical-middle() {
@@ -391,29 +75,20 @@
     }
 }
 
-.printable-background() {
-    -webkit-print-color-adjust: exact;
-    color-adjust: exact;
-}
-
 .flexible-scrollable() {
     & > .dx-scrollable,
     & > .dx-treeview,
     & > .dx-treeview > .dx-scrollable {
         display: -webkit-flex;
         display: flex;
-        -webkit-flex-grow: 1;
         flex-grow: 1;
-        -webkit-flex-direction: column;
         flex-direction: column;
         height: 0;
 
         & > .dx-scrollable-wrapper {
             display: -webkit-flex;
             display:  flex;
-            -webkit-flex-grow: 1;
             flex-grow: 1;
-            -webkit-flex-direction: column;
             flex-direction: column;
             height: 0;
 

--- a/styles/widgets/android5/actionSheet.android5.less
+++ b/styles/widgets/android5/actionSheet.android5.less
@@ -77,7 +77,7 @@
         text-align: left;
         height: @ANDROID5_ACTIONSHEET_BUTTON_HEIGHT;
         font-size: @ANDROID5_ACTIONSHEET_FONTSIZE;
-        .border-radius(0);
+        border-radius: 0;
     }
 }
 

--- a/styles/widgets/android5/button.android5.less
+++ b/styles/widgets/android5/button.android5.less
@@ -20,7 +20,7 @@
     color: @ANDROID5_BUTTON_TEXT;
     background-color: @ANDROID5_BUTTON_DISABLED_BACKGROUND;
     opacity: @ANDROID5_BUTTON_DISABLE_OPACITY;
-    .box-shadow(none);
+    box-shadow: none;
 }
 
 .dx-state-disabled {
@@ -34,7 +34,7 @@
     background-color: @ANDROID5_BUTTON_BACKGROUND;
     min-width: @ANDROID5_BUTTON_MIN_WIDTH;
     min-height: @ANDROID5_BUTTON_MIN_HEIGHT;
-    .border-radius(@ANDROID5_BUTTON_RADIUS);
+    border-radius: @ANDROID5_BUTTON_RADIUS;
     .shadow-transition();
     .shadow-z1();
 
@@ -66,7 +66,7 @@
     line-height: 0;
     min-height: @ANDROID5_BUTTON_MIN_HEIGHT;
     padding: @ANDROID5_TEXT_BUTTON_CONTENT_PADDING_VERTICAL @ANDROID5_BUTTON_CONTENT_PADDING_HORIZONTAL_RAISED;
-    .border-radius(@ANDROID5_BUTTON_RADIUS);
+    border-radius: @ANDROID5_BUTTON_RADIUS;
 }
 
 .dx-button-text {
@@ -85,7 +85,7 @@
 .dx-button-default {
     color: @ANDROID5_BUTTON_DEFAULT_TEXT;
     background-color: @ANDROID5_BUTTON_DEFAULT_BACKGROUND;
-    .box-shadow(@ANDROID5_BUTTON_CUSTOM_BOX_SHADOW);
+    box-shadow: @ANDROID5_BUTTON_CUSTOM_BOX_SHADOW;
 
     &.dx-state-hover,
     &.dx-state-focused {
@@ -100,7 +100,7 @@
 .dx-button-danger {
     color: @ANDROID5_BUTTON_DANGER_TEXT;
     background-color: @ANDROID5_BUTTON_DANGER_BACKGROUND;
-    .box-shadow(@ANDROID5_BUTTON_CUSTOM_BOX_SHADOW);
+    box-shadow: @ANDROID5_BUTTON_CUSTOM_BOX_SHADOW;
 
     &.dx-state-hover,
     &.dx-state-focused {
@@ -115,7 +115,7 @@
 .dx-button-success {
     color: @ANDROID5_BUTTON_SUCCESS_TEXT;
     background-color: @ANDROID5_BUTTON_SUCCESS_BACKGROUND;
-    .box-shadow(@ANDROID5_BUTTON_CUSTOM_BOX_SHADOW);
+    box-shadow: @ANDROID5_BUTTON_CUSTOM_BOX_SHADOW;
 
     &.dx-state-hover,
     &.dx-state-focused {
@@ -129,7 +129,7 @@
 
 .flat-button(@noHoverFocus) when (@noHoverFocus = true) {
     background-color: @ANDROID5_BUTTON_FLAT_BACKGROUND_COLOR;
-    .box-shadow(none);
+    box-shadow: none;
 
     .dx-button-content {
         padding-right: @ANDROID5_BUTTON_CONTENT_PADDING_HORIZONTAL;

--- a/styles/widgets/android5/calendar.android5.less
+++ b/styles/widgets/android5/calendar.android5.less
@@ -197,7 +197,7 @@
     .dx-calendar-cell {
         span {
             border: 1px solid transparent;
-            .border-radius(10px);
+            border-radius: 10px;
             display: inline-block;
         }
     }

--- a/styles/widgets/android5/checkBox.android5.less
+++ b/styles/widgets/android5/checkBox.android5.less
@@ -35,9 +35,9 @@
     width: @ANDROID5_CHECKBOX_SIZE;
     height: @ANDROID5_CHECKBOX_SIZE;
     border: 2px solid @ANDROID5_CHECKBOX_BACKGROUND;
-    .border-radius(@ANDROID5_CHECKBOX_BORDER_RADIUS);
+    border-radius: @ANDROID5_CHECKBOX_BORDER_RADIUS;
     background-color: transparent;
-    .transition(~"background-color .14s linear, border-color .14s linear");
+    transition: background-color .14s linear, border-color .14s linear;
 }
 
 .dx-checkbox-checked {
@@ -51,9 +51,9 @@
             border-bottom: 2px solid #fff;
             border-right: 2px solid #fff;
             position: absolute;
-            .rotate(45deg);
-            .animation(checkbox-icon-extension 140ms ease-out forwards);
-            .box-sizing(content-box);
+            transform: rotate(45deg);
+            animation: checkbox-icon-extension 140ms ease-out forwards;
+            box-sizing: content-box;
             width: 35%;
             height: 70%;
             top: -1px;
@@ -69,7 +69,7 @@
 .dx-checkbox-indeterminate {
     .dx-checkbox-icon {
         border-color: @ANDROID5_CHECKBOX_CHECKED_BACKGROUND;
-        .box-shadow(inset 0px 0px 0px 2px @ANDROID5_CHECKBOX_CHECKED_BACKGROUND);
+        box-shadow: inset 0px 0px 0px 2px @ANDROID5_CHECKBOX_CHECKED_BACKGROUND;
     }
 
     &.dx-state-focused, &.dx-state-active {
@@ -94,7 +94,7 @@
 
         &.dx-checkbox-indeterminate {
             .dx-checkbox-icon {
-                .box-shadow(inset 0px 0px 0px 2px @ANDROID5_CHECKBOX_DISABLED_BACKGROUND);
+                box-shadow: inset 0px 0px 0px 2px @ANDROID5_CHECKBOX_DISABLED_BACKGROUND;
             }
         }
     }

--- a/styles/widgets/android5/common.android5.less
+++ b/styles/widgets/android5/common.android5.less
@@ -82,23 +82,23 @@
 }
 
 .shadow-z1() {
-    .box-shadow(0 1px 4px 0 rgba(0, 0, 0, 0.37));
+    box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.37);
 }
 
 .shadow-z2() {
-    .box-shadow(0 4px 13px 0 rgba(0, 0, 0, 0.3), 0 2px 2px 0 rgba(0, 0, 0, 0.2));
+    box-shadow: 0 4px 13px 0 rgba(0, 0, 0, 0.3), 0 2px 2px 0 rgba(0, 0, 0, 0.2);
 }
 
 .shadow-z3() {
-    .box-shadow(0 3px 25px 0 rgba(0, 0, 0, 0.3), 0 11px 7px 0 rgba(0, 0, 0, 0.19));
+    box-shadow: 0 3px 25px 0 rgba(0, 0, 0, 0.3), 0 11px 7px 0 rgba(0, 0, 0, 0.19);
 }
 
 .shadow-z4() {
-    .box-shadow(0 7px 40px 0 rgba(0, 0, 0, 0.3), 0 14px 12px 0 rgba(0, 0, 0, 0.17));
+    box-shadow: 0 7px 40px 0 rgba(0, 0, 0, 0.3), 0 14px 12px 0 rgba(0, 0, 0, 0.17);
 }
 
 .shadow-z5() {
-    .box-shadow(0 27px 55px 0 rgba(0, 0, 0, 0.3), 0 17px 17px 0 rgba(0, 0, 0, 0.15));
+    box-shadow: 0 27px 55px 0 rgba(0, 0, 0, 0.3), 0 17px 17px 0 rgba(0, 0, 0, 0.15);
 }
 
 .dx-content-background {

--- a/styles/widgets/android5/dataGrid.android5.less
+++ b/styles/widgets/android5/dataGrid.android5.less
@@ -3,7 +3,7 @@
 .dx-datagrid-group-panel {
     margin-bottom: @datagrid-header-panel-margin-bottom;
     font-size: @ANDROID5_BASE_FONT_SIZE;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 
     .dx-group-panel-message {
         color: @datagrid-headers-color;

--- a/styles/widgets/android5/datePicker.android5.less
+++ b/styles/widgets/android5/datePicker.android5.less
@@ -51,7 +51,7 @@
     margin: 0 10%;
 
     &:before, &:after {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
         content: "";
         display: block;
         width: 100%;
@@ -91,7 +91,7 @@
     z-index: 2;
 
     &:after {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
         width: 0;
         margin: auto;
         content: "";

--- a/styles/widgets/android5/dateView.android5.less
+++ b/styles/widgets/android5/dateView.android5.less
@@ -54,7 +54,7 @@
     margin: 0 10%;
 
     &:before, &:after {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
         content: "";
         display: block;
         width: 100%;

--- a/styles/widgets/android5/dropDownMenu.android5.less
+++ b/styles/widgets/android5/dropDownMenu.android5.less
@@ -1,7 +1,7 @@
 .dx-dropdownmenu-popup-wrapper {
     .dx-overlay-content {
-        .transform-origin(100% 0 0);
-        .box-shadow(1px 1px 6px rgba(0,0,0,.5));
+        transform-origin: 100% 0 0;
+        box-shadow: 1px 1px 6px rgba(0, 0, 0, .5);
     }
 
     .dx-popup-content {
@@ -34,14 +34,14 @@
     }
 
     &.dx-popover-flipped-vertical .dx-overlay-content {
-        .transform-origin(100% 100% 0);
+        transform-origin: 100% 100% 0;
     }
 
     &.dx-popover-flipped-horizontal .dx-overlay-content {
-        .transform-origin(0 0 0);
+        transform-origin: 0 0 0;
     }
 
     &.dx-popover-flipped-vertical.dx-popover-flipped-horizontal .dx-overlay-content {
-        .transform-origin(0 100% 0);
+        transform-origin: 0 100% 0;
     }
 }

--- a/styles/widgets/android5/gallery.android5.less
+++ b/styles/widgets/android5/gallery.android5.less
@@ -19,7 +19,7 @@
 .dx-gallery-nav-button-prev,
 .dx-gallery-nav-button-next {
     .dx-icon-font-centered-sizing(36px);
-    .border-radius(20%);
+    border-radius: 20%;
     color: @ANDROID5_LIGHT_ICON_COLOR;
     background-color: @ANDROID5_GALLERY_NAV_BUTTON_BACKGROUND_COLOR;
 
@@ -37,7 +37,7 @@
     width: 8px;
     height: 8px;
     background: @ANDROID5_GALLERY_INDICATOR_ITEM_BACKGROUND;
-    .border-radius(@ANDROID5_GALLERY_INDICATOR_ITEM_RADIUS);
+    border-radius: @ANDROID5_GALLERY_INDICATOR_ITEM_RADIUS;
     border: 1px solid @ANDROID5_GALLERY_INDICATOR_ITEM_SELECTED_BACKGROUND;
 }
 

--- a/styles/widgets/android5/gridBase.android5.less
+++ b/styles/widgets/android5/gridBase.android5.less
@@ -197,7 +197,7 @@
     .dx-@{widgetName}-filter-range-overlay .dx-overlay-content {
         border: ~"@{@{widgetName}-border}";
         overflow: inherit;
-        .box-shadow(2px 2px 3px fade(black, 15%));
+        box-shadow: 2px 2px 3px fade(black, 15%);
 
         .dx-editor-container.dx-highlight-outline::after {
             border-color: ~"@{@{widgetName}-data-modified-color}";
@@ -272,7 +272,7 @@
                 background-color: ~"@{@{widgetName}-headers-background-color}";
                 border: ~"@{@{widgetName}-border}";
                 padding: @GRID_BASE_CELL_PADDING;
-                .box-shadow(0px 1px 3px -1px rgba(0, 0, 0, 0.2));
+                box-shadow: 0px 1px 3px -1px rgba(0, 0, 0, 0.2);
 
                 .dx-treeview-item-content {
                     color: ~"@{@{widgetName}-headers-color}";
@@ -290,7 +290,7 @@
     }
 
     .dx-@{widgetName}-drag-header {
-        .box-shadow(@GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @GRID_BASE_DRAG_HEADER_SECOND_SHADOW);
+        box-shadow: @GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @GRID_BASE_DRAG_HEADER_SECOND_SHADOW;
         padding: @GRID_BASE_CELL_PADDING;
         line-height: normal;
         border: ~"@{@{widgetName}-drag-header-border}";
@@ -339,7 +339,7 @@
 
     .dx-@{widgetName}-headers {
         color: ~"@{@{widgetName}-headers-color}";
-        .touch-action(pinch-zoom);
+        touch-action: pinch-zoom;
 
         .dx-texteditor-input, .dx-placeholder::before {
            padding: @GRID_BASE_CELL_PADDING;
@@ -549,7 +549,7 @@
             .dx-invalid-message {
                 .dx-overlay-content {
                     padding: 14px 17px 12px;
-                    .border-radius(0px);
+                    border-radius: 0px;
                 }
             }
 

--- a/styles/widgets/android5/list.android5.less
+++ b/styles/widgets/android5/list.android5.less
@@ -56,7 +56,7 @@
 
     .dx-icon-toggle-delete {
         background-image: @ANDROID5_LIST_DELETE_SWITCH_BACKGROUND;
-        .background-size-prop(100%);
+        background-size: 100%;
     }
 
     &.dx-state-focused,
@@ -120,7 +120,7 @@
     .dx-list-toggle-delete-switch {
         border: none;
         background-color: transparent;
-        .box-shadow(none);
+        box-shadow: none;
     }
 
     .dx-button-content:before {
@@ -229,7 +229,7 @@
 
 .dx-list-context-menucontent {
     background-color: @ANDROID5_POPUP_CONTENT_BACKGROUND;
-    .box-shadow(~"0 3px 4px rgba(0,0,0,.15)");
+    box-shadow: 0 3px 4px rgba(0,0,0,.15);
 
     .dx-scrollable-container {
         border: none;

--- a/styles/widgets/android5/loadIndicator.android5.less
+++ b/styles/widgets/android5/loadIndicator.android5.less
@@ -1,14 +1,14 @@
 .dx-loadindicator-content {
     height: 100%;
     width: 100%;
-    .animation(content-rotation 1568ms linear infinite);
+    animation: content-rotation 1568ms linear infinite;
 }
 
 .dx-loadindicator-image {
     background-image: @ANDROID5_LOADINDICATOR_BACKGROUND;
 
     .dx-loadindicator-content {
-        .animation(none);
+        animation: none;
     }
 }
 
@@ -16,7 +16,7 @@
     position: absolute;
     height: 100%;
     width: 100%;
-    .animation(icon-rotation 5332ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both);
+    animation: icon-rotation 5332ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;
 }
 
 .dx-loadindicator-segment {
@@ -32,8 +32,8 @@
     border-width: 0.12em;
     border-style: solid;
     border-bottom-color: transparent;
-    .animation(none);
-    .border-radius(50%);
+    animation: none;
+    border-radius: 50%;
 }
 
 .dx-loadindicator-segment2, .dx-loadindicator-segment0 {
@@ -51,8 +51,8 @@
 .dx-loadindicator-segment2 {
     .dx-loadindicator-segment-inner {
         border-right-color: transparent;
-        .transform(rotate(-129deg));
-        .animation(left-segment-rotation 1333ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both);
+        transform: rotate(-129deg);
+        animation: left-segment-rotation 1333ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;
     }
 }
 
@@ -60,8 +60,8 @@
     .dx-loadindicator-segment-inner {
         left: -100%;
         border-left-color: transparent;
-        .transform(rotate(129deg));
-        .animation(right-segment-rotation 1333ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both);
+        transform: rotate(129deg);
+        animation: right-segment-rotation 1333ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;
     }
 }
 
@@ -72,7 +72,7 @@
     width: 10%;
     height: 100%;
     overflow: hidden;
-    .box-sizing(border-box);
+    box-sizing: border-box;
 
     .dx-loadindicator-segment-inner {
         width: 1000%;

--- a/styles/widgets/android5/loadPanel.android5.less
+++ b/styles/widgets/android5/loadPanel.android5.less
@@ -1,5 +1,5 @@
 .dx-loadpanel-content {
     background: @ANDROID5_LOAD_INDICATOR_BACKGROUND;
-    .box-shadow(@ANDROID5_POPUP_CONTENT_SHADOW);
-    .border-radius(0);
+    box-shadow: @ANDROID5_POPUP_CONTENT_SHADOW;
+    border-radius: 0;
 }

--- a/styles/widgets/android5/lookup.android5.less
+++ b/styles/widgets/android5/lookup.android5.less
@@ -58,7 +58,7 @@
         &:before {
             right: auto;
             left: -3px;
-            .rotate(180deg);
+            transform: rotate(180deg);
         }
     }
 }

--- a/styles/widgets/android5/navBar.android5.less
+++ b/styles/widgets/android5/navBar.android5.less
@@ -4,11 +4,11 @@
     }
 
     .dx-tab-selected {
-        .box-shadow(~"inset 0px 3px 0px" @ANDROID5_ACCENT_COLOR);
+        box-shadow: inset 0px 3px 0px @ANDROID5_ACCENT_COLOR;
     }
 
     .dx-state-active.dx-tab:before {
-        .scale(1.8);
+        transform: scale(1.8);
     }
 
     .dx-tab-content {

--- a/styles/widgets/android5/overlay.android5.less
+++ b/styles/widgets/android5/overlay.android5.less
@@ -1,5 +1,5 @@
 .dx-overlay-wrapper {
-    .transition(~"background-color .4s ease");
+    transition: background-color .4s ease;
     .dx-base-typography();
 }
 

--- a/styles/widgets/android5/pivotTabs.android5.less
+++ b/styles/widgets/android5/pivotTabs.android5.less
@@ -14,7 +14,7 @@
 }
 
 .dx-pivottabs-tab-selected {
-    .box-shadow(@ANDROID5_PIVOTTABS_SELECTED_BORDER_SHADOW);
+    box-shadow: @ANDROID5_PIVOTTABS_SELECTED_BORDER_SHADOW;
 }
 
 .dx-pivottabs-tab-content {

--- a/styles/widgets/android5/popup.android5.less
+++ b/styles/widgets/android5/popup.android5.less
@@ -29,7 +29,7 @@
         background: none;
         height: @ANDROID5_POPUP_TITLE_TOOLBAR_HEIGHT;
         padding: @ANDROID5_POPUP_TITLE_PADDING_TOP @ANDROID5_POPUP_TITLE_PADDING_BASE 0;
-        .box-shadow(none);
+        box-shadow: none;
 
         &,
         .dx-toolbar-label,
@@ -45,7 +45,7 @@
             }
 
         .dx-button-content {
-            .border-radius(@ANDROID5_BUTTON_RADIUS);
+            border-radius: @ANDROID5_BUTTON_RADIUS;
         }
 
         .dx-toolbar-label {
@@ -61,16 +61,16 @@
     padding-right: @ANDROID5_POPUP_BOTTOM_TOOLBAR_PADDING_AFTER;
     padding-left: @ANDROID5_POPUP_BOTTOM_TOOLBAR_PADDING_BEFORE;
     background: none;
-    .box-shadow(none);
+    box-shadow: none;
 
     .dx-button {
         min-width: @ANDROID5_POPUP_BOTTOM_BUTTONS_MIN_WIDTH;
-        .border-radius(@ANDROID5_BUTTON_RADIUS);
+        border-radius: @ANDROID5_BUTTON_RADIUS;
     }
 
     .dx-button-content {
         padding: @ANDROID5_BUTTON_CONTENT_PADDING_TOP @ANDROID5_BUTTON_CONTENT_PADDING_HORIZONTAL @ANDROID5_BUTTON_CONTENT_PADDING_BOTTOM;
-        .border-radius(@ANDROID5_BUTTON_RADIUS);
+        border-radius: @ANDROID5_BUTTON_RADIUS;
     }
 
     .dx-button-text {

--- a/styles/widgets/android5/progressBar.android5.less
+++ b/styles/widgets/android5/progressBar.android5.less
@@ -26,18 +26,18 @@
     height: @ANDROID5_PROGRESSBAR_HEIGHT;
     background-color: @ANDROID5_PROGRESSBAR_RANGE_COLOR;
     opacity: 1;
-    .animation(loader 1.5s infinite);
-    .animation-timing(cubic-bezier(.30, 1, .15, .80));
-    .animation-fill-mode();
+    animation: loader 1.5s infinite;
+    animation-timing-function: cubic-bezier(.30, 1, .15, .80);
+    animation-fill-mode: both;
 }
 
 .dx-progressbar-animating-segment-1 {
     opacity: 0;
-    .animation-delay(0.75s);
+    animation-delay: 0.75s;
 }
 
 .dx-progressbar-animating-segment-2 {
-    .animation-delay(0);
+    animation-delay: 0;
 }
 
 .dx-state-disabled {
@@ -59,38 +59,38 @@
     .dx-progressbar-animating-segment {
         left: auto;
         right: -10px;
-        .animation-name(loader-rtl);
-        .animation-duration(1.5s);
-        .animation-iteration-count(infinite);
-        .animation-timing(cubic-bezier(.30, 1, .15, .80));
-        .animation-fill-mode();
+        animation-name: loader-rtl;
+        animation-duration: 1.5s;
+        animation-iteration-count: infinite;
+        animation-timing-function: cubic-bezier(.30, 1, .15, .80);
+        animation-fill-mode: both;
     }
 
     .dx-progressbar-animating-segment-1 {
         opacity: 0;
-        .animation-delay(0.75s);
+        animation-delay: 0.75s;
     }
 
     .dx-progressbar-animating-segment-2 {
-        .animation-delay(0);
+        animation-delay: 0;
     }
 }
 
 @-webkit-keyframes loader {
     0% {
         left: -15%;
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     15% {
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     100% {
         left: 105%;
-        .scale(~"0.1, 1");
+        transform: scale(0.1, 1);
         opacity: 0.1;
     }
 }
@@ -98,18 +98,18 @@
 @-moz-keyframes loader {
     0% {
         left: -15%;
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     15% {
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     100% {
         left: 105%;
-        .scale(~"0.1, 1");
+        transform: scale(0.1, 1);
         opacity: 0.1;
     }
 }
@@ -117,18 +117,18 @@
 @keyframes loader {
     0% {
         left: -15%;
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     15% {
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     100% {
         left: 105%;
-        .scale(~"0.1, 1");
+        transform: scale(0.1, 1);
         opacity: 0.1;
     }
 }
@@ -136,18 +136,18 @@
 @-webkit-keyframes loader-rtl {
     0% {
         right: -15%;
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     15% {
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     100% {
         right: 105%;
-        .scale(~"0.1, 1");
+        transform: scale(0.1, 1);
         opacity: 0.1;
     }
 }
@@ -155,18 +155,18 @@
 @-moz-keyframes loader-rtl {
     0% {
         right: -15%;
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     15% {
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     100% {
         right: 105%;
-        .scale(~"0.1, 1");
+        transform: scale(0.1, 1);
         opacity: 0.1;
     }
 }
@@ -174,18 +174,18 @@
 @keyframes loader-rtl {
     0% {
         right: -15%;
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     15% {
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     100% {
         right: 105%;
-        .scale(~"0.1, 1");
+        transform: scale(0.1, 1);
         opacity: 0.1;
     }
 }

--- a/styles/widgets/android5/radioButton.android5.less
+++ b/styles/widgets/android5/radioButton.android5.less
@@ -13,8 +13,8 @@
     width: @ANDROID5_RADIOBUTTON_SIZE;
     height: @ANDROID5_RADIOBUTTON_SIZE;
     position: relative;
-    .transition(~"border-color .14s");
-    .border-radius(50%);
+    transition: border-color .14s;
+    border-radius: 50%;
 }
 
 .dx-radiobutton-icon-dot {
@@ -24,15 +24,15 @@
     width: 10px;
     height: 10px;
     background-color: @ANDROID5_RADIOBUTTON_CHECKED_BACKGROUND;
-    .border-radius(50%);
-    .scale(0);
-    .transition(~"transform .14s");
+    border-radius: 50%;
+    transform: scale(0);
+    transition: transform .14s;
 }
 
 .dx-radiobutton-icon-checked {
     border-color: @ANDROID5_RADIOBUTTON_CHECKED_BACKGROUND;
     .dx-radiobutton-icon-dot {
-        .scale(1);
+        transform: scale(1);
     }
 }
 

--- a/styles/widgets/android5/slideOutView.android5.less
+++ b/styles/widgets/android5/slideOutView.android5.less
@@ -13,8 +13,8 @@
 }
 
 .dx-slideoutview-content {
-    .box-sizing(content-box);
-    .background-clip(content-box);
+    box-sizing: content-box;
+    background-clip: content-box;
     background-color: @ANDROID5_SLIDEOUTVIEW_CONTENT_BACKGROUND;
     margin-left:-@ANDROID_SLIDEOUTVIEW_BORDER_WIDTH;
     border-left: @ANDROID_SLIDEOUTVIEW_BORDER_WIDTH solid @ANDROID_SLIDEOUTVIEW_BORDER_COLOR;

--- a/styles/widgets/android5/slider.android5.less
+++ b/styles/widgets/android5/slider.android5.less
@@ -35,7 +35,7 @@
     margin-right: -@ANDROID5_SLIDER_HANDLE_SIZE / 2;
     width: @ANDROID5_SLIDER_HANDLE_SIZE;
     height: @ANDROID5_SLIDER_HANDLE_SIZE;
-    .border-radius(@ANDROID5_SLIDER_RADIUS);
+    border-radius: @ANDROID5_SLIDER_RADIUS;
 
     &:after {
         position: absolute;
@@ -48,7 +48,7 @@
         height: @ANDROID5_SLIDER_HANDLE_INNER_SIZE;
         background: @ANDROID5_SLIDER_BACKGROUND;
         content: "";
-        .border-radius(@ANDROID5_SLIDER_RADIUS);
+        border-radius: @ANDROID5_SLIDER_RADIUS;
     }
 
     .dx-tooltip-wrapper .dx-popup-content {
@@ -109,7 +109,7 @@
 }
 
 .dx-state-active.dx-slider-handle:after {
-    .transform(scale(1.3));
+    transform: scale(1.3);
 }
 
 .dx-rtl {

--- a/styles/widgets/android5/switch.android5.less
+++ b/styles/widgets/android5/switch.android5.less
@@ -32,7 +32,7 @@
         content: '';
         width: 100%;
         height: 14px;
-        .border-radius(500px);
+        border-radius: 500px;
         background-color: @ANDROID5_SWITCH_OFF_TRACK_COLOR;
         margin: 3px 0;
     }
@@ -72,7 +72,7 @@
     width: @ANDROID5_SWITCH_HEIGHT;
     height: @ANDROID5_SWITCH_HEIGHT;
     background-color: @ANDROID5_SWITCH_OFF_HANDLE_COLOR;
-    .border-radius(50%);
+    border-radius: 50%;
     .shadow-z1();
 
     &:after {
@@ -83,7 +83,7 @@
         left: 0;
         display: block;
         content: '';
-        .border-radius(50%);
+        border-radius: 50%;
     }
 
     .dx-inkripple-wave {

--- a/styles/widgets/android5/tabs.android5.less
+++ b/styles/widgets/android5/tabs.android5.less
@@ -25,7 +25,7 @@
 
 .dx-tabs-nav-button {
     background-color: @ANDROID5_TABS_BACKGROUND;
-    .box-shadow(none);
+    box-shadow: none;
 
     .dx-icon {
         margin: auto;
@@ -33,7 +33,7 @@
     }
 
     &.dx-button {
-        .border-radius(0);
+        border-radius: 0;
     }
 
     &.dx-state-hover {
@@ -81,7 +81,7 @@
 
     &.dx-tabs-nav-button {
         background-color: fade(@ANDROID5_TABS_SELECTED_COLOR, 54%);
-        .box-shadow(none);
+        box-shadow: none;
     }
 }
 
@@ -98,7 +98,7 @@
 }
 
 .dx-tab-selected {
-    .box-shadow(@ANDROID5_TABS_SELECTED_BOX_SHADOW);
+    box-shadow: @ANDROID5_TABS_SELECTED_BOX_SHADOW;
 
     .dx-tab-text {
         color: @ANDROID5_TABS_SELECTED_TEXT_COLOR;

--- a/styles/widgets/android5/textEditor.android5.less
+++ b/styles/widgets/android5/textEditor.android5.less
@@ -21,7 +21,7 @@
     top: @ANDROID5_TEXTEDITOR_ICON_TOP;
     width: @ANDROID5_TEXTEDITOR_INVALID_BADGE_WIDTH;
     height: @ANDROID5_TEXTEDITOR_INVALID_BADGE_WIDTH;
-    .border-radius(@radius: @ANDROID5_TEXTEDITOR_INVALID_BADGE_WIDTH / 2);
+    border-radius: @ANDROID5_TEXTEDITOR_INVALID_BADGE_WIDTH / 2;
     text-align: center;
     line-height: @ANDROID5_TEXTEDITOR_INVALID_BADGE_WIDTH;
 }
@@ -67,9 +67,9 @@
         &.dx-state-focused {
             .dx-texteditor-container {
                 &:before {
-                    .transform(scale(1));
+                    transform: scale(1);
                     background-color: @ANDROID5_INVALID_COLOR;
-                    .transition-transform(0.3s, cubic-bezier(0.2, 0, 0.03, 1));
+                    transition: transform 0.3s cubic-bezier(0.2, 0, 0.03, 1);
                 }
             }
         }
@@ -92,7 +92,7 @@
     color: @ANDROID5_TEXTEDITOR_COLOR;
     font-size: @ANDROID5_TEXTEDITOR_FONT_SIZE;
     &:-moz-ui-invalid:not(output) {
-        .box-shadow(none);
+        box-shadow: none;
     }
 }
 
@@ -111,7 +111,7 @@
         bottom: -1px;
         height: 2px;
         width: 100%;
-        .transform(scale(0, 2));
+        transform: scale(0, 2);
     }
 }
 
@@ -140,9 +140,9 @@
 .dx-state-focused.dx-texteditor {
     .dx-texteditor-container {
         &:before {
-            .transform(scale(1));
+            transform: scale(1);
             background-color: @ANDROID5_TEXTEDITOR_FOCUSED_BORDER_COLOR;
-            .transition-transform(0.3s, cubic-bezier(0.2, 0, 0.03, 1));
+            transition: transform 0.3s cubic-bezier(0.2, 0, 0.03, 1);
         }
     }
 }

--- a/styles/widgets/android5/toast.android5.less
+++ b/styles/widgets/android5/toast.android5.less
@@ -1,7 +1,7 @@
 @ANDROID5_TOAST_RADIUS: 2px;
 
 .dx-toast-content {
-    .box-shadow(none);
+    box-shadow: none;
 }
 
 .dx-toast-wrapper .dx-overlay-content {
@@ -15,14 +15,14 @@
     .dx-toast-wrapper .dx-overlay-content {
         min-width: 288px;
         max-width: 568px;
-        .border-radius(@ANDROID5_TOAST_RADIUS);
+        border-radius: @ANDROID5_TOAST_RADIUS;
     }
 }
 
 .dx-device-phone {
     .dx-toast-wrapper .dx-overlay-content {
         width: 100%;
-        .border-radius(0);
+        border-radius: 0;
     }
 }
 

--- a/styles/widgets/android5/toolbar.android5.less
+++ b/styles/widgets/android5/toolbar.android5.less
@@ -29,8 +29,8 @@
         overflow: hidden;
         border: none;
         background: @ANDROID5_TOOLBAR_BUTTON_BACKGROUND;
-        .box-shadow(@ANDROID5_TOOLBAR_BUTTON_SHADOW);
-        .border-radius(0);
+        box-shadow: @ANDROID5_TOOLBAR_BUTTON_SHADOW;
+        border-radius: 0;
 
         .dx-icon {
             .dx-icon-sizing(@ANDROID_BASE_ICON_SIZE);

--- a/styles/widgets/android5/tooltip.android5.less
+++ b/styles/widgets/android5/tooltip.android5.less
@@ -7,11 +7,11 @@
 
     .dx-overlay-content {
         padding: 5px 7px;
-        .border-radius(2px);
+        border-radius: 2px;
         background-color: fade(#616161, 90%);
         border: 1px solid transparent;
         color: #ffffff;
-        .box-shadow(none);
+        box-shadow: none;
 
         .dx-popup-content {
             padding: 0;

--- a/styles/widgets/base/colorView.less
+++ b/styles/widgets/base/colorView.less
@@ -1,14 +1,14 @@
 .dx-colorview-palette-handle {
-    .gradient-radial(~"transparent 5px, " @COLORVIEW_HANDLE_BORDER_COLOR ~"6px, " @COLORVIEW_HANDLE_COLOR ~"7px, " @COLORVIEW_HANDLE_COLOR ~"12px, " @COLORVIEW_HANDLE_BORDER_COLOR ~"13px");
-    .box-shadow(~"0 1px 1px 0" @COLORVIEW_HANDLE_BORDER_COLOR);
+    background: radial-gradient(transparent 5px, @COLORVIEW_HANDLE_BORDER_COLOR 6px, @COLORVIEW_HANDLE_COLOR 7px, @COLORVIEW_HANDLE_COLOR 12px, @COLORVIEW_HANDLE_BORDER_COLOR 13px);
+    box-shadow: 0 1px 1px 0 @COLORVIEW_HANDLE_BORDER_COLOR;
 }
 
 .dx-colorview-hue-scale-handle {
     border: 1px solid @COLORVIEW_HANDLE_BORDER_COLOR;
-    .box-shadow( ~"inset -5px 0px 0px 3px" @COLORVIEW_HANDLE_COLOR ~", inset 5px 0px 0px 3px" @COLORVIEW_HANDLE_COLOR ~", inset -6px 0px 1px 4px" @COLORVIEW_HANDLE_BORDER_COLOR ~", inset 6px 0px 1px 4px" @COLORVIEW_HANDLE_BORDER_COLOR );
+    box-shadow: inset -5px 0px 0px 3px @COLORVIEW_HANDLE_COLOR, inset 5px 0px 0px 3px @COLORVIEW_HANDLE_COLOR, inset -6px 0px 1px 4px @COLORVIEW_HANDLE_BORDER_COLOR, inset 6px 0px 1px 4px @COLORVIEW_HANDLE_BORDER_COLOR;
 }
 
 .dx-colorview-alpha-channel-handle {
     border: 1px solid @COLORVIEW_HANDLE_BORDER_COLOR;
-    .box-shadow( ~"  inset 0px -5px 0px 3px" @COLORVIEW_HANDLE_COLOR ~", inset 0px 5px 0px 3px" @COLORVIEW_HANDLE_COLOR ~", inset 0px -6px 1px 4px" @COLORVIEW_HANDLE_BORDER_COLOR ~", inset 0px 6px 1px 4px" @COLORVIEW_HANDLE_BORDER_COLOR );
+    box-shadow: inset 0px -5px 0px 3px @COLORVIEW_HANDLE_COLOR, inset 0px 5px 0px 3px @COLORVIEW_HANDLE_COLOR, inset 0px -6px 1px 4px @COLORVIEW_HANDLE_BORDER_COLOR, inset 0px 6px 1px 4px @COLORVIEW_HANDLE_BORDER_COLOR;
 }

--- a/styles/widgets/base/dataGrid.less
+++ b/styles/widgets/base/dataGrid.less
@@ -186,7 +186,7 @@
                 }
 
                 &[style*="text-align: left"]:before {
-                    .scale(1);
+                    transform: scale(1);
                 }
             }
         }

--- a/styles/widgets/base/icons.less
+++ b/styles/widgets/base/icons.less
@@ -9,7 +9,7 @@
 
     // Icon as background sizing
     background-position: @icon_padding @icon_padding;
-    .background-size(@icon_size, @icon_size);
+    background-size: @icon_size @icon_size;
 
     // Icon as img src sizing
     padding: @icon_padding;

--- a/styles/widgets/base/pivotGrid.less
+++ b/styles/widgets/base/pivotGrid.less
@@ -69,7 +69,7 @@
         opacity: 0.8;
 
         .dx-area-field.dx-area-box {
-                .box-shadow(@PIVOTGRID_DRAG_HEADER_FIRST_SHADOW, @PIVOTGRID_DRAG_HEADER_SECOND_SHADOW);
+                box-shadow: @PIVOTGRID_DRAG_HEADER_FIRST_SHADOW, @PIVOTGRID_DRAG_HEADER_SECOND_SHADOW;
                 border: @PIVOTGRID_DRAG_HEADER_BORDER;
             }
     }

--- a/styles/widgets/base/scheduler.less
+++ b/styles/widgets/base/scheduler.less
@@ -458,7 +458,7 @@
 
 .dx-scheduler-appointment-focused-mixin() {
     &.dx-state-focused {
-        .box-shadow(none);
+        box-shadow: none;
 
         &:before {
             pointer-events: none;
@@ -635,7 +635,7 @@
             background-color:  @SCHEDULER_TIME_INDICATOR_COLOR;
             position: absolute;
             pointer-events: none;
-            .box-shadow(@SCHEDULER_TIME_INDICATOR_SHADOW);
+            box-shadow: @SCHEDULER_TIME_INDICATOR_SHADOW;
 
             &:before {
                 font-size: @SCHEDULER_TIME_INDICATOR_FONT_SIZE;
@@ -644,7 +644,7 @@
                 z-index: 1000;
                 margin-top: -@SCHEDULER_TIME_INDICATOR_TOP;
                 margin-left: -@SCHEDULER_TIME_INDICATOR_LEFT;
-                .text-shadow(@SCHEDULER_TIME_INDICATOR_TEXT_SHADOW);
+                text-shadow: @SCHEDULER_TIME_INDICATOR_TEXT_SHADOW;
             }
     }
 
@@ -778,7 +778,7 @@
 
         .dx-scheduler-header-panel-cell.dx-scheduler-header-panel-current-time-cell {
             border-bottom: 2px solid @SCHEDULER_TIME_INDICATOR_COLOR;
-            .box-shadow(none);
+            box-shadow: none;
             &:before {
                 content: none;
             }
@@ -1783,23 +1783,23 @@
         .user-select(none);
         background-color: @SCHEDULER_APPOINTMENT_BASE_COLOR;
         color: @SCHEDULER_APPOINTMENT_TEXT_COLOR;
-        .box-shadow(@SCHEDULER_VERTICAL_APPOINTMENT_SHADOW);
+        box-shadow: @SCHEDULER_VERTICAL_APPOINTMENT_SHADOW;
         left: 0;
 
         min-width: @SCHEDULER_APPOINTMENT_MIN_SIZE;
         min-height: @SCHEDULER_APPOINTMENT_MIN_SIZE;
     
         &.dx-state-active, &.dx-resizable-resizing {
-            .box-shadow(@SCHEDULER_VERTICAL_APPOINTMENT_RESIZING_SHADOW);
+            box-shadow: @SCHEDULER_VERTICAL_APPOINTMENT_RESIZING_SHADOW;
         }
 
         .dx-scheduler-appointment-focused-mixin;
 
         &.dx-state-hover {
-            .box-shadow(@SCHEDULER_VERTICAL_APPOINTMENT_HOVERING_SHADOW);
+            box-shadow: @SCHEDULER_VERTICAL_APPOINTMENT_HOVERING_SHADOW;
 
             &.dx-resizable {
-                .box-shadow(@SCHEDULER_VERTICAL_APPOINTMENT_RESIZABLE_HOVERING_SHADOW);
+                box-shadow: @SCHEDULER_VERTICAL_APPOINTMENT_RESIZABLE_HOVERING_SHADOW;
             }
 
             .dx-resizable-handle-top {
@@ -1812,7 +1812,7 @@
         }
 
         &.dx-draggable-dragging {
-            .box-shadow(@SCHEDULER_APPOINTMENT_DRAGGING_SHADOW, @SCHEDULER_VERTICAL_APPOINTMENT_RESIZING_SHADOW);
+            box-shadow: @SCHEDULER_APPOINTMENT_DRAGGING_SHADOW, @SCHEDULER_VERTICAL_APPOINTMENT_RESIZING_SHADOW;
         }
 
         &.dx-resizable-resizing,
@@ -1875,36 +1875,36 @@
     .dx-scheduler-timeline .dx-scheduler-appointment,
     .dx-scheduler-work-space-month .dx-scheduler-appointment,
     .dx-scheduler-all-day-appointment {
-        .box-shadow(@SCHEDULER_HORIZONTAL_APPOINTMENT_SHADOW);
+        box-shadow: @SCHEDULER_HORIZONTAL_APPOINTMENT_SHADOW;
 
         .dx-rtl & {
-            .box-shadow(@SCHEDULER_HORIZONTAL_APPOINTMENT_SHADOW_RTL);
+            box-shadow: @SCHEDULER_HORIZONTAL_APPOINTMENT_SHADOW_RTL;
         }
 
         &.dx-state-active, &.dx-resizable-resizing {
-            .box-shadow(@SCHEDULER_HORIZONTAL_APPOINTMENT_RESIZING_SHADOW);
+            box-shadow: @SCHEDULER_HORIZONTAL_APPOINTMENT_RESIZING_SHADOW;
         }
 
         .dx-scheduler-appointment-focused-mixin;
 
         &.dx-state-hover {
-            .box-shadow(@SCHEDULER_HORIZONTAL_APPOINTMENT_HOVERING_SHADOW);
+            box-shadow: @SCHEDULER_HORIZONTAL_APPOINTMENT_HOVERING_SHADOW;
 
             &.dx-resizable {
-                .box-shadow(@SCHEDULER_HORIZONTAL_APPOINTMENT_RESIZABLE_HOVERING_SHADOW);
+                box-shadow: @SCHEDULER_HORIZONTAL_APPOINTMENT_RESIZABLE_HOVERING_SHADOW;
             }
 
             .dx-rtl & {
-                .box-shadow(@SCHEDULER_HORIZONTAL_APPOINTMENT_HOVERING_SHADOW_RTL);
+                box-shadow: @SCHEDULER_HORIZONTAL_APPOINTMENT_HOVERING_SHADOW_RTL;
 
                 &.dx-resizable {
-                    .box-shadow(@SCHEDULER_HORIZONTAL_APPOINTMENT_RESIZABLE_HOVERING_SHADOW_RTL);
+                    box-shadow: @SCHEDULER_HORIZONTAL_APPOINTMENT_RESIZABLE_HOVERING_SHADOW_RTL;
                 }
             }
         }
 
         &.dx-draggable-dragging {
-            .box-shadow(@SCHEDULER_HORIZONTAL_APPOINTMENT_RESIZING_SHADOW, @SCHEDULER_APPOINTMENT_DRAGGING_SHADOW);
+            box-shadow: @SCHEDULER_HORIZONTAL_APPOINTMENT_RESIZING_SHADOW, @SCHEDULER_APPOINTMENT_DRAGGING_SHADOW;
         }
     }
 
@@ -2124,7 +2124,7 @@
             background-color: @SCHEDULER_APPOINTMENT_BASE_COLOR;
             color: @SCHEDULER_APPOINTMENT_TEXT_COLOR;
             border: none;
-            .box-shadow(none);
+            box-shadow: none;
 
             .dx-button-content {
                 line-height: inherit;
@@ -2191,7 +2191,7 @@
 
         .dx-scheduler-appointment {
             position: relative;
-            .box-shadow(none);
+            box-shadow: none;
         }
 
         .dx-scheduler-time-panel {

--- a/styles/widgets/base/treeList.less
+++ b/styles/widgets/base/treeList.less
@@ -201,7 +201,7 @@
                 }
 
                 &[style*="text-align: left"]:before {
-                    .scale(1);
+                    transform: scale(1);
                 }
             }
         }

--- a/styles/widgets/common/actionSheet.less
+++ b/styles/widgets/common/actionSheet.less
@@ -2,7 +2,7 @@
     .dx-overlay-content {
         padding-top: 0;
         padding-bottom: 0;
-        .user-drag(none);
+        user-drag: none;
     }
 }
 .dx-actionsheet-popup-wrapper,

--- a/styles/widgets/common/badge.less
+++ b/styles/widgets/common/badge.less
@@ -1,6 +1,6 @@
 .dx-badge {
     padding: 0px 5px;
-    .border-radius(14px);
+    border-radius: 14px;
     color: white;
     font-size: 13px;
     line-height: 1;

--- a/styles/widgets/common/button.less
+++ b/styles/widgets/common/button.less
@@ -9,10 +9,10 @@
     vertical-align: middle;
     max-width: 100%;
     .user-select(none);
-    .user-drag(none);
+    user-drag: none;
 
     .dx-icon {
-        .user-drag(none);
+        user-drag: none;
         display: inline-block;
         vertical-align: middle;
     }

--- a/styles/widgets/common/buttonGroup.less
+++ b/styles/widgets/common/buttonGroup.less
@@ -7,13 +7,13 @@
 }
 
 .dx-buttongroup-item {
-    .flex-item(0, 1, auto);
+    flex: 0 1 auto;
 
     &.dx-button-mode-outlined, &.dx-button-mode-contained {
         border-left-width: 0;
 
         &.dx-button {
-            .border-radius(0);
+            border-radius: 0;
         }
     }
 
@@ -23,7 +23,7 @@
 }
 
 .dx-buttongroup-item-has-width {
-    .flex-item();
+    flex: 1 1 auto;
     width: 100%;
 }
 

--- a/styles/widgets/common/calendar.less
+++ b/styles/widgets/common/calendar.less
@@ -59,7 +59,7 @@
 
     td {
         cursor: pointer;
-        .box-sizing(content-box);
+        box-sizing: content-box;
     }
 
     thead th {

--- a/styles/widgets/common/checkBox.less
+++ b/styles/widgets/common/checkBox.less
@@ -2,7 +2,7 @@
     display: inline-block;
     cursor: pointer;
     line-height: 0;
-    .user-drag(none);
+    user-drag: none;
     .user-select(none);
 
     &.dx-state-readonly {

--- a/styles/widgets/common/colorView.less
+++ b/styles/widgets/common/colorView.less
@@ -113,7 +113,7 @@
 .dx-colorview-color-preview-container-inner,
 .dx-colorview-alpha-channel-wrapper,
 .dx-colorbox-input-container::after {
-    .double-gradient-linear( ~"45deg," @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR ~"25%, transparent 25%, transparent 74%, " @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR ~"75%," @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR, ~"45deg," @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR ~"25%, transparent 25%, transparent 74%, " @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR ~"75%," @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR );
+    background-image: linear-gradient(45deg, @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR 25%, transparent 25%, transparent 74%, @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR 75%, @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR), linear-gradient(45deg, @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR 25%, transparent 25%, transparent 74%, @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR 75%, @COLORVIEW_TRANSPARENT_BACKGROUND_COLOR);
     background-size: 16px 16px;
     background-position: 0 0, 8px 8px;
 }

--- a/styles/widgets/common/dataGrid.less
+++ b/styles/widgets/common/dataGrid.less
@@ -16,7 +16,7 @@
     display: inline-block;
     white-space: nowrap;
     width: 100%;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 
     .dx-group-panel-message {
         .dx-overflow();

--- a/styles/widgets/common/dateView.less
+++ b/styles/widgets/common/dateView.less
@@ -11,7 +11,7 @@
     position: relative;
     vertical-align: top;
     cursor: pointer;
-    .flex-item();
+    flex: 1 1 auto;
 }
 
 .dx-dateview-item-selected-frame {

--- a/styles/widgets/common/drawer.less
+++ b/styles/widgets/common/drawer.less
@@ -2,7 +2,7 @@
     height: 100%;
     width: 100%;
     
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 }
 
 .dx-drawer-wrapper {

--- a/styles/widgets/common/fieldset.less
+++ b/styles/widgets/common/fieldset.less
@@ -6,7 +6,7 @@
     }
 
     &, * {
-        .box-sizing(border-box);
+        box-sizing: border-box;
     }
 }
 

--- a/styles/widgets/common/gallery.less
+++ b/styles/widgets/common/gallery.less
@@ -2,7 +2,7 @@
     width: 100%;
     height: 100%;
     .user-select(none);
-    .touch-action(pinch-zoom pan-y);
+    touch-action: pinch-zoom pan-y;
 }
 .dx-gallery-wrapper {
     position: relative;
@@ -16,7 +16,7 @@
         position: absolute;
         width: 100%;
         top: 50%;
-        .transform(~"translateY(-50%)");
+        transform: translateY(-50%);
     }
 }
 
@@ -67,7 +67,7 @@
     top: 50%;
     cursor: pointer;
     .user-select(none);
-    .background-size();
+    background-size: 100% 100%;
 }
 
 .dx-gallery-nav-button-prev {
@@ -123,19 +123,19 @@
         .dx-gallery-indicator,
         .dx-gallery-nav-button-prev,
         .dx-gallery-nav-button-next {
-            .backface-visibility(visible);
+            backface-visibility: visible;
         }
 
         .dx-gallery-active .dx-gallery-item,
         .dx-gallery-active .dx-gallery-indicator,
         .dx-gallery-active .dx-gallery-nav-button-prev,
         .dx-gallery-active .dx-gallery-nav-button-next {
-            .backface-visibility(hidden);
+            backface-visibility: hidden;
         }
     }
 
     .dx-gallery-item {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
     }
 }
 
@@ -145,6 +145,6 @@
     .dx-gallery-indicator,
     .dx-gallery-nav-button-prev,
     .dx-gallery-nav-button-next {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
     }
 }

--- a/styles/widgets/common/gridBase.less
+++ b/styles/widgets/common/gridBase.less
@@ -185,12 +185,12 @@
                 .dx-column-chooser-item {
                     opacity: 0.5;
                     margin-bottom: 10px;
-                    .box-shadow(0px 1px 3px -1px rgba(0, 0, 0, 0.2));
+                    box-shadow: 0px 1px 3px -1px rgba(0, 0, 0, 0.2);
 
                     &.dx-@{widgetName}-drag-action {
                         opacity: 1;
                         cursor: pointer;
-                        .touch-action(pinch-zoom);
+                        touch-action: pinch-zoom;
                     }
                 }
             }
@@ -229,7 +229,7 @@
         cursor: pointer;
         z-index: 10000;
         // T105728
-        .box-sizing(content-box);
+        box-sizing: content-box;
 
         &.dx-drag-command-cell {
             padding: 0px;
@@ -910,7 +910,7 @@
         &.dx-popover-wrapper {
             .dx-overlay-content {
                 border: none;
-                .box-shadow(none);
+                box-shadow: none;
 
                 .dx-popup-content {
                     padding: 0;

--- a/styles/widgets/common/htmlEditor.less
+++ b/styles/widgets/common/htmlEditor.less
@@ -92,7 +92,7 @@
     .dx-variable {
         & > span {
             padding: 3px 6px;
-            .border-radius(8px);
+            border-radius: 8px;
         }
     }
 

--- a/styles/widgets/common/list.less
+++ b/styles/widgets/common/list.less
@@ -105,7 +105,7 @@
     width: 8px;
     margin-left: -6px;
 
-    .rotate(135deg);
+    transform: rotate(135deg);
 
     border-width: 2px 0 0 2px;
     border-style: solid;
@@ -116,14 +116,14 @@
         margin-left: auto;
         margin-right: -6px;
 
-        .rotate(-45deg);
+        transform: rotate(-45deg);
     }
 }
 
 
 .dx-list-item-response-wait {
     opacity: 0.5;
-    .transition(~"opacity .2s linear");
+    transition: opacity .2s linear;
 }
 
 .dx-list-slide-menu-content {
@@ -148,12 +148,12 @@
     }
 
     .dx-icon-toggle-delete {
-        .transition(~"all .1s linear");
+        transition: all .1s linear;
     }
 
     .dx-list-select-checkbox {
         float: left;
-        .transition(~"all .1s linear");
+        transition: all .1s linear;
     }
 }
 
@@ -170,9 +170,9 @@
     .dx-list-reorder-handle {
         cursor: move;
         background-repeat: no-repeat;
-        .background-size(75%, 75%);
+        background-size: 75% 75%;
         background-position: center;
-        .touch-action(pinch-zoom);
+        touch-action: pinch-zoom;
 
         .dx-state-disabled & {
             cursor: default;
@@ -253,7 +253,7 @@
 
 .dx-list-switchable-delete-ready {
     .dx-icon-toggle-delete {
-        .rotate(-90deg);
+        transform: rotate(-90deg);
     }
 }
 

--- a/styles/widgets/common/loadIndicator.less
+++ b/styles/widgets/common/loadIndicator.less
@@ -18,8 +18,8 @@
 }
 
 .dx-loadindicator-image {
-    .background-size-prop(contain);
-    .transform-origin(50% 50%);
+    background-size: contain;
+    transform-origin: 50% 50%;
     background-position: 50%;
     background-repeat: no-repeat;
 }
@@ -32,9 +32,9 @@
     position: relative;
     width: 100%;
     height: 100%;
-    .background-size();
-    .transform-origin(50% 50%);
-    .animation(dx-loadindicator-icon-custom-rotate 1.5s infinite linear);
+    background-size: 100% 100%;
+    transform-origin: 50% 50%;
+    animation: dx-loadindicator-icon-custom-rotate 1.5s infinite linear;
 
     @-webkit-keyframes dx-loadindicator-icon-custom-rotate {
         from {

--- a/styles/widgets/common/loadPanel.less
+++ b/styles/widgets/common/loadPanel.less
@@ -4,8 +4,8 @@
     background: #fefefe;
     text-align: center;
     .user-select(none);
-    .user-drag(none);
-    .border-radius(5px);
+    user-drag: none;
+    border-radius: 5px;
 
     &:before {
         display: inline-block;
@@ -26,7 +26,7 @@
 }
 
 .dx-loadpanel-content.dx-loadpanel-pane-hidden {
-    .box-shadow(none);
+    box-shadow: none;
     border: none;
     background: none;
 }

--- a/styles/widgets/common/menu.less
+++ b/styles/widgets/common/menu.less
@@ -88,7 +88,7 @@
         .dx-treeview {
             height: auto;
 
-            .flex-item();
+            flex: 1 1 auto;
         }
     }
 }

--- a/styles/widgets/common/multiView.less
+++ b/styles/widgets/common/multiView.less
@@ -2,7 +2,7 @@
     overflow: hidden;
     width: 100%;
     height: 100%;
-    .touch-action(pinch-zoom pan-y);
+    touch-action: pinch-zoom pan-y;
 }
 
 .dx-multiview-item-container {

--- a/styles/widgets/common/overlay.less
+++ b/styles/widgets/common/overlay.less
@@ -6,7 +6,7 @@
     z-index: @OVERLAY_ZINDEX;
 
     &, *, &:before, &:after, *:before, *:after {
-        .box-sizing(border-box);
+        box-sizing: border-box;
     }
 }
 
@@ -33,12 +33,12 @@
 
 .dx-device-android {
     .dx-overlay-content {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
     }
 
     .dx-scrollable-native {
         .dx-overlay-content {
-            .backface-visibility(visible);
+            backface-visibility: visible;
         }
     }
 }

--- a/styles/widgets/common/pager.less
+++ b/styles/widgets/common/pager.less
@@ -43,7 +43,7 @@
             display: inline-block;
             vertical-align: top;
             padding: @PAGER_PADDINGS - 1px 13px;
-            .box-sizing(content-box);
+            box-sizing: content-box;
 
             &.dx-button-disable {
                 opacity: .3;
@@ -78,7 +78,8 @@
     .dx-pages, .dx-page-sizes {
         .dx-selection {
             cursor: inherit;
-            .text-shadow(none);
+            text-shadow: none;
+
         }
     }
 

--- a/styles/widgets/common/panorama.less
+++ b/styles/widgets/common/panorama.less
@@ -3,8 +3,8 @@
 
     background-position-y: 0;
     background-repeat: repeat-x;
-    .background-size(auto, 100%);
-    .touch-action(pinch-zoom);
+    background-size: auto 75%;
+    touch-action: pinch-zoom;
 }
 
 .dx-panorama-wrapper {

--- a/styles/widgets/common/pivot.less
+++ b/styles/widgets/common/pivot.less
@@ -1,6 +1,6 @@
 .dx-pivot {
     height: 100%;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 }
 
 .dx-pivot-wrapper {

--- a/styles/widgets/common/pivotGrid.less
+++ b/styles/widgets/common/pivotGrid.less
@@ -62,12 +62,12 @@
 
     td {
         vertical-align: top;
-        .box-sizing(content-box);
+        box-sizing: content-box;
     }
 
     .dx-area-description-cell {
         position: relative;
-        .background-clip(padding-box);  // T379462
+        background-clip: padding-box;  // T379462
         .dx-pivotgrid-fields-area {
             position: absolute;
             bottom: 0;
@@ -243,5 +243,5 @@
 }
 
 .dx-pivotgrid-drag-action {
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 }

--- a/styles/widgets/common/popover.less
+++ b/styles/widgets/common/popover.less
@@ -39,7 +39,7 @@
         display: block;
         overflow: hidden;
         content: " ";
-        .rotate(-45deg);
+        transform: rotate(-45deg);
     }
 }
 
@@ -47,25 +47,25 @@
     &.dx-position-top .dx-popover-arrow:after {
         top: 0;
         left: 0;
-        .transform-origin(~"top left");
+        transform-origin: top left;
     }
 
     &.dx-position-bottom .dx-popover-arrow:after {
         right: 0;
         bottom: 0;
-        .transform-origin(~"bottom right");
+        transform-origin: bottom right;
     }
 
     &.dx-position-left .dx-popover-arrow:after {
         bottom: 0;
         left: 0;
-        .transform-origin(~"bottom left");
+        transform-origin: bottom left;
     }
 
     &.dx-position-right .dx-popover-arrow:after {
         top: 0;
         right: 0;
-        .transform-origin(~"top right");
+        transform-origin: top right;
     }
 
     .dx-overlay-content {

--- a/styles/widgets/common/popup.less
+++ b/styles/widgets/common/popup.less
@@ -1,14 +1,14 @@
 .dx-popup-title {
     padding: 10px;
     min-height: 19px;
-    .user-drag(none);
+    user-drag: none;
     .user-select(none);
     white-space: normal;
 }
 
 .dx-popup-draggable .dx-popup-title {
     cursor: move;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 }
 
 .dx-overlay-content {
@@ -25,7 +25,7 @@
 
 .dx-popup-content {
     padding: 10px;
-    .user-drag(none);
+    user-drag: none;
 
     &.dx-dialog-content {
         padding: 0;

--- a/styles/widgets/common/progressBar.less
+++ b/styles/widgets/common/progressBar.less
@@ -59,7 +59,7 @@
 .dx-progressbar-range {
     height: 100%;
     .user-select(none);
-    .user-drag(none);
+    user-drag: none;
 }
 
 .dx-progressbar-status {

--- a/styles/widgets/common/resizable.less
+++ b/styles/widgets/common/resizable.less
@@ -68,7 +68,7 @@
     top: -@HANDLE_OFFSET;
 
     cursor: se-resize;
-    .border-radius-bottom-right(~"100%");
+    border-bottom-right-radius: 100%;
 }
 
 .dx-resizable-handle-corner-top-right {
@@ -76,7 +76,7 @@
     top: -@HANDLE_OFFSET;
 
     cursor: ne-resize;
-    .border-radius-bottom-left(~"100%");
+    border-bottom-left-radius: 100%;
 }
 
 :not(.dx-rtl){
@@ -88,7 +88,7 @@
         bottom: -@HANDLE_OFFSET;
 
         cursor: se-resize;
-        .border-radius-top-left(~"100%");
+        border-top-left-radius: 100%;
 
         background-position: @BOTTOM_CORNER_ICON_POSITION @BOTTOM_CORNER_ICON_POSITION;
     }
@@ -98,14 +98,14 @@
         bottom: -@HANDLE_OFFSET;
 
         cursor: ne-resize;
-        .border-radius-top-right(~"100%");
+        border-top-right-radius: 100%;
     }
 
 }
 
 .dx-rtl {
     .dx-resizable-handle-corner-bottom-left {
-        .rotate(90deg);
+        transform: rotate(90deg);
 
         width: @BOTTOM_CORNER_HANDLE_SIZE;
         height: @BOTTOM_CORNER_HANDLE_SIZE;
@@ -114,7 +114,7 @@
         bottom: -@HANDLE_OFFSET;
 
         cursor: ne-resize;
-        .border-radius-top-left(~"100%");
+        border-top-left-radius: 100%;
 
         background-position: @BOTTOM_CORNER_ICON_POSITION @BOTTOM_CORNER_ICON_POSITION;
     }
@@ -124,6 +124,6 @@
         bottom: -@HANDLE_OFFSET;
 
         cursor: se-resize;
-        .border-radius-top-left(~"100%");
+        border-top-left-radius: 100%;
     }
 }

--- a/styles/widgets/common/scheduler.less
+++ b/styles/widgets/common/scheduler.less
@@ -39,14 +39,14 @@
     
     &.dx-state-hover {
         &:before {
-            .border-radius(@SCHEDULER_DROP_DOWN_BUTTON_HEIGHT);
+            border-radius: @SCHEDULER_DROP_DOWN_BUTTON_HEIGHT;
         }
     }
 
     &.dx-button {
         padding: 0;
         max-width: none;
-        .border-radius(@SCHEDULER_DROP_DOWN_BUTTON_HEIGHT);
+        border-radius: @SCHEDULER_DROP_DOWN_BUTTON_HEIGHT;
     }
 }
 

--- a/styles/widgets/common/scrollView.less
+++ b/styles/widgets/common/scrollView.less
@@ -26,10 +26,10 @@
             left: -50%;
             margin-left: -20px;
             padding: 0;
-            .border-radius(50%);
+            border-radius: 50%;
 
             &.dx-scrollview-pull-down-loading {
-                .transition-transform(100ms);
+                transition: transform 100ms linear;
             }
 
             .dx-scrollview-pull-down-indicator {
@@ -40,7 +40,7 @@
                 height: 100%;
                 width: 100%;
                 float: left;
-                .box-sizing(border-box);
+                box-sizing: border-box;
 
                 .dx-loadindicator {
                     float: left;
@@ -53,12 +53,12 @@
             height: 100%;
             padding: 8px;
             font-size: 24px;
-            .box-sizing(border-box);
-            .transition(~"opacity .2s");
+            box-sizing: border-box;
+            transition: opacity .2s;
         }
 
         .dx-scrollview-pull-down-loading.dx-scrollview-pull-down {
-            .transition(~"top .2s ease-out 0s");
+            transition: top .2s ease-out 0s;
         }
 
         .dx-scrollview-pull-down-image {
@@ -69,7 +69,7 @@
             top: 0;
             left: 0;
             background-size: contain;
-            .transition(~"opacity .2s ease 0s");
+            transition: opacity .2s ease 0s;
         }
 
         .dx-scrollview-pull-down-loading .dx-icon-pulldown {
@@ -83,13 +83,13 @@
             left: 0;
             width: 100%;
             overflow-y: auto;
-            .transition-transform(400ms, ease);
-            .transform(~"translate(0px, 0px)");
+            transition: transform 400ms ease;
+            transform: translate(0px, 0px);
         }
 
         .dx-scrollview-content {
-            .transition-transform(400ms, ease);
-            .transform(~"none");
+            transition: transform 400ms ease;
+            transform: none;
         }
     }
 
@@ -140,9 +140,9 @@
     padding: @PULLDOWN_PADDING 0;
     top: -(@PULLDOWN_HEIGHT + @PULLDOWN_PADDING*2);
     overflow: hidden;
-    .transform(~"translate(0px, 0px)");
-    .user-drag(none);
-    .box-sizing(content-box);
+    transform: translate(0px, 0px);
+    user-drag: none;
+    box-sizing: content-box;
 }
 
 .dx-scrollview-pull-down-container {
@@ -159,7 +159,7 @@
     display: inline-block;
     margin: -15px 20px 0 15px;
     width: 20px;
-    .user-drag(none);
+    user-drag: none;
 }
 
 .dx-scrollview-pull-down-image {
@@ -169,10 +169,10 @@
     width: 20px;
     height: 50px;
     background-size: contain;
-    .user-drag(none);
+    user-drag: none;
     // B231062
-    .transform(~"translate(0,0) rotate(0deg)");
-    .transition-transform(.2s, linear);
+    transform: translate(0,0) rotate(0deg);
+    transition: transform .2s linear;
 }
 
 .dx-scrollview-pull-down-text {
@@ -180,7 +180,7 @@
     vertical-align: middle;
     position: relative;
     overflow: visible;
-    .user-drag(none);
+    user-drag: none;
 
     div {
         position: absolute;
@@ -199,7 +199,7 @@
 .dx-scrollview-pull-down-ready {
     .dx-scrollview-pull-down-image {
         // B231062
-        .transform(~"translate(0,0) rotate(-180deg)");
+        transform: translate(0,0) rotate(-180deg);
     }
 }
 
@@ -218,7 +218,7 @@
     padding: 10px 0;
     overflow: hidden;
     text-align: center;
-    .transform(~"translate(0,0)");
+    transform: translate(0,0);
 
     &:before {
         content: '';
@@ -231,14 +231,14 @@
 .dx-scrollview-scrollbottom-indicator {
     display: inline-block;
     margin: 0 10px 0 0;
-    .user-drag(none);
+    user-drag: none;
 }
 
 .dx-scrollview-scrollbottom-text {
     display: inline-block;
     margin-top: -20px;
     vertical-align: middle;
-    .user-drag(none);
+    user-drag: none;
 }
 
 .dx-scrollview-scrollbottom-end {

--- a/styles/widgets/common/scrollable.less
+++ b/styles/widgets/common/scrollable.less
@@ -28,14 +28,14 @@
 
     &.dx-scrollable-vertical,
     &.dx-scrollable-vertical .dx-scrollable-container {
-        .touch-action(pan-y);
+        touch-action: pan-y;
         overflow-x: hidden;
         overflow-y: auto;
     }
 
     &.dx-scrollable-horizontal,
     &.dx-scrollable-horizontal .dx-scrollable-container {
-        .touch-action(pan-x);
+        touch-action: pan-x;
         float: none;
         overflow-x: auto;
         overflow-y: hidden;
@@ -43,7 +43,7 @@
 
     &.dx-scrollable-both,
     &.dx-scrollable-both .dx-scrollable-container {
-        .touch-action(e("pan-y pan-x"));
+        touch-action: pan-y pan-x;
         float: none;
         overflow-x: auto;
         overflow-y: auto;
@@ -51,7 +51,7 @@
 
     &.dx-scrollable-disabled,
     &.dx-scrollable-disabled .dx-scrollable-container {
-        .touch-action(auto);
+        touch-action: auto;
     }
 
     &.dx-scrollable-scrollbars-hidden {
@@ -63,7 +63,7 @@
     &.dx-scrollable-native-ios {
         .dx-scrollable-content {
             min-height: 101%;
-            .box-sizing(content-box);
+            box-sizing: content-box;
         }
 
         &.dx-scrollable-horizontal {
@@ -84,7 +84,7 @@
     }
 
     &.dx-scrollable-native-android .dx-scrollable-content {
-        .transform(none);
+        transform: none;
         z-index: 0;
     }
 }
@@ -117,7 +117,7 @@
 .dx-scrollable-content {
     position: relative;
     min-height: 100%;
-    .box-sizing();
+    box-sizing: border-box;
     .dx-clearfix;
 }
 
@@ -158,13 +158,13 @@
     background-color: #888; /* NOTE: fallback for rgba non-supporting*/
     background-color: rgba(0, 0, 0, .5);
     -webkit-transform: translate(0px, 0px);
-    .transition(~"background-color 0s linear");
+    transition: background-color 0s linear;
 
     &.dx-state-invisible {
         display: block !important;
         background-color: transparent; /* NOTE: fallback for rgba non-supporting */
         background-color: rgba(0, 0, 0, 0);
-        .transition(~"background-color .5s linear 1s");
+        transition: background-color .5s linear 1s;
     }
 }
 
@@ -192,7 +192,7 @@
 
 .dx-device-ios-6 {
     .dx-scrollable-content {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
     }
 }
 

--- a/styles/widgets/common/slideOut.less
+++ b/styles/widgets/common/slideOut.less
@@ -13,7 +13,7 @@
             margin-right: 15px;
             width: 24px;
             height: 24px;
-            .background-size(100%, 100%);
+            background-size: 100% 100%;
         }
     }
 }

--- a/styles/widgets/common/slideOutView.less
+++ b/styles/widgets/common/slideOutView.less
@@ -1,7 +1,7 @@
 .dx-slideoutview {
     height: 100%;
     width: 100%;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 }
 
 .dx-slideoutview-wrapper {
@@ -42,5 +42,5 @@
 }
 
 .dx-device-android .dx-slideoutview-content {
-    .backface-visibility(hidden);
+    backface-visibility: hidden;
 }

--- a/styles/widgets/common/slider.less
+++ b/styles/widgets/common/slider.less
@@ -70,7 +70,7 @@
     top: 0;
     height: 100%;
     pointer-events: none;
-    .user-drag(none);
+    user-drag: none;
 }
 
 .dx-slider-handle {
@@ -78,7 +78,7 @@
     top: 0;
     right: 0;
     pointer-events: auto;
-    .user-drag(none);
+    user-drag: none;
 
     .dx-tooltip-wrapper .dx-popup-content {
         line-height: 0;

--- a/styles/widgets/common/switch.less
+++ b/styles/widgets/common/switch.less
@@ -2,7 +2,7 @@
     display: inline-block;
     cursor: pointer;
     .user-select(none);
-    .user-drag(none);
+    user-drag: none;
 }
 
 .dx-switch-wrapper {
@@ -38,20 +38,20 @@
 }
 
 .dx-switch-inner {
-    .transform(~"translateX(-50%)");
+    transform: translateX(-50%);
 }
 
 .dx-switch-handle {
-    .transform(~"translateX(0%)");
+    transform: translateX(0%);
 }
 
 .dx-switch-on-value {
     .dx-switch-inner {
-        .transform(~"translateX(0%)");
+        transform: translateX(0%);
     }
 
     .dx-switch-handle {
-        .transform(~"translateX(-100%)");
+        transform: translateX(-100%);
     }
 }
 .dx-rtl {
@@ -60,16 +60,16 @@
     }
 
     .dx-switch-inner {
-        .transform(~"translateX(50%)");
+        transform: translateX(50%);
     }
 
     .dx-switch-handle {
-        .transform(~"translateX(-100%)");
+        transform: translateX(-100%);
     }
 
     &.dx-switch-on-value {
         .dx-switch-handle {
-            .transform(~"translateX(0%)");
+            transform: translateX(0%);
         }
     }
 }

--- a/styles/widgets/common/tabs.less
+++ b/styles/widgets/common/tabs.less
@@ -98,7 +98,7 @@
         height: @icon_size;
         display: block;
         margin: 0 auto;
-        .user-drag(none);
+        user-drag: none;
     }
 }
 
@@ -112,7 +112,7 @@
     margin: 0 auto;
     text-align: center;
     max-width: 100%;
-    .user-drag(none);
+    user-drag: none;
     .dx-overflow;
 }
 

--- a/styles/widgets/common/tagBox.less
+++ b/styles/widgets/common/tagBox.less
@@ -75,7 +75,7 @@
         position: absolute;
         top: 50%;
         content: "";
-        .rotate(45deg);
+        transform: rotate(45deg);
     }
 }
 

--- a/styles/widgets/common/textBox.less
+++ b/styles/widgets/common/textBox.less
@@ -10,7 +10,7 @@
             display: inline-block;
             overflow: hidden;
             text-indent: -9999px;
-            .box-sizing(content-box);
+            box-sizing: content-box;
         }
     }
 }

--- a/styles/widgets/common/textEditor.less
+++ b/styles/widgets/common/textEditor.less
@@ -77,7 +77,7 @@
     .dx-icon-clear {
         position: absolute;
         display: inline-block;
-        .background-size-prop(contain);
+        background-size: contain;
     }
 }
 

--- a/styles/widgets/common/tileView.less
+++ b/styles/widgets/common/tileView.less
@@ -9,8 +9,8 @@
     text-align: center;
 
     &.dx-state-active {
-        .scale(0.96);
-        .transition-transform(100ms, linear);
+        transform: scale(0.96);
+        transition: transform 100ms linear;
     }
 }
 
@@ -27,6 +27,6 @@
 
 .dx-device-ios-6 {
     .dx-tile {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
     }
 }

--- a/styles/widgets/common/timeView.less
+++ b/styles/widgets/common/timeView.less
@@ -22,7 +22,7 @@
     margin-left: -15px;
     background-position: bottom;
     background-repeat: no-repeat;
-    .transform-origin(50% 100%);
+    transform-origin: 50% 100%;
     -webkit-backface-visibility: hidden;
 }
 

--- a/styles/widgets/common/toolbar.less
+++ b/styles/widgets/common/toolbar.less
@@ -7,7 +7,7 @@
 }
 
 .dx-toolbar .dx-button .dx-icon {
-    .box-sizing(content-box);
+    box-sizing: content-box;
 }
 
 .dx-toolbar-items-container {
@@ -21,7 +21,7 @@
     display: table-cell;
     padding: 0 5px;
     vertical-align: middle;
-    .box-sizing(content-box);
+    box-sizing: content-box;
 
     .dx-tabs {
         table-layout: auto;
@@ -59,7 +59,7 @@
 
 .dx-toolbar-label {
     white-space: nowrap;
-    .user-drag(none);
+    user-drag: none;
 
     .dx-toolbar-item-content > div {
         .dx-overflow();

--- a/styles/widgets/common/treeView.less
+++ b/styles/widgets/common/treeView.less
@@ -55,7 +55,7 @@
     list-style-type: none;
     position: relative;
     .user-select(none);
-    .user-drag(none);
+    user-drag: none;
 
     a {
         text-decoration: none;
@@ -77,7 +77,7 @@
         height: @TREE_VIEW_ICON_SIZE;
         vertical-align: middle;
         margin-right: 5px;
-        .background-size(@TREE_VIEW_ICON_SIZE, @TREE_VIEW_ICON_SIZE);
+        background-size: @TREE_VIEW_ICON_SIZE @TREE_VIEW_ICON_SIZE;
     }
 
     .dx-treeview-item-content {

--- a/styles/widgets/common/widget.less
+++ b/styles/widgets/common/widget.less
@@ -10,10 +10,10 @@
     -webkit-touch-callout: none;
     padding: 0;
     outline: 0;
-    .printable-background();
+    color-adjust: exact;
 
     &, &:before, &:after, *, *:before, *:after {
-        .box-sizing();
+        box-sizing: border-box;
     }
 }
 

--- a/styles/widgets/generic/button.generic.less
+++ b/styles/widgets/generic/button.generic.less
@@ -106,7 +106,7 @@
 }
 
 .dx-button-styling() {
-    .border-radius(@button-border-radius);
+    border-radius: @button-border-radius;
     border-width: @GENERIC_BUTTON_BORDER_WEIGHT;
     border-style: solid;
 

--- a/styles/widgets/generic/buttonGroup.generic.less
+++ b/styles/widgets/generic/buttonGroup.generic.less
@@ -4,7 +4,7 @@
         padding-right: 1px;
 
         &.dx-state-hover .dx-button-content {
-            .border-radius(0);
+            border-radius: 0;
         }
     }
 
@@ -13,8 +13,8 @@
         border-left-width: @GENERIC_BUTTON_BORDER_WEIGHT;
 
         &.dx-button, &.dx-state-hover .dx-button-content {
-            .border-radius-top-left(@button-border-radius);
-            .border-radius-bottom-left(@button-border-radius);
+            border-top-left-radius: @button-border-radius;
+            border-bottom-left-radius: @button-border-radius;
         }
     }
 
@@ -22,8 +22,8 @@
         padding-right: 0;
 
         &.dx-button, &.dx-state-hover .dx-button-content {
-            .border-radius-top-right(@button-border-radius);
-            .border-radius-bottom-right(@button-border-radius);
+            border-top-right-radius: @button-border-radius;
+            border-bottom-right-radius: @button-border-radius;
         }
     }
 }
@@ -86,7 +86,7 @@
             padding-right: 0;
 
             &.dx-button, &.dx-state-hover .dx-button-content {
-                .border-radius-custom(0, @button-border-radius, @button-border-radius, 0);
+                border-radius: 0 @button-border-radius @button-border-radius 0;
             }
         }
 
@@ -96,7 +96,7 @@
             padding-left: 0;
 
             &.dx-button, &.dx-state-hover .dx-button-content {
-                .border-radius-custom(@button-border-radius, 0, 0, @button-border-radius);
+                border-radius: @button-border-radius 0 0 @button-border-radius;
             }
         }
     }

--- a/styles/widgets/generic/calendar.generic.less
+++ b/styles/widgets/generic/calendar.generic.less
@@ -75,7 +75,7 @@
 
     .dx-button {
         height: 100%;
-        .border-radius(0);
+        border-radius: 0;
         display: table-cell;
         border-color: @calendar-navigator-border-color;
 
@@ -161,7 +161,7 @@
     left: 0px;
 
     &.dx-button {
-        .border-radius-custom(@calendar-navigator-border-radius, 0, 0, @calendar-navigator-border-radius);
+        border-radius: @calendar-navigator-border-radius 0 0 @calendar-navigator-border-radius;
 
         .dx-icon {
             color: @calendar-shevron-icon-color;
@@ -174,7 +174,7 @@
     right: 0px;
 
     &.dx-button {
-        .border-radius-custom(0, @calendar-navigator-border-radius, @calendar-navigator-border-radius, 0);
+        border-radius: 0 @calendar-navigator-border-radius @calendar-navigator-border-radius 0;
 
         .dx-icon {
             color: @calendar-shevron-icon-color;
@@ -196,7 +196,7 @@
             padding-bottom: 10px;
 
             th {
-                .box-shadow(inset 0px -1px 0px @calendar-border-color);
+                box-shadow: inset 0px -1px 0px @calendar-border-color;
                 color: @calendar-header-color;
             }
         }
@@ -221,14 +221,14 @@
     font-size: @GENERIC_CALENDAR_CELL_FONT_SIZE;
     border: 1px double transparent;
     width: 39px;
-    .border-radius(@calendar-cell-contoured-border-radius);
+    border-radius: @calendar-cell-contoured-border-radius;
 
     &.dx-calendar-today {
         font-weight: bold;
     }
 
     &.dx-state-hover {
-        .box-shadow(inset 0px -1px 0px 1000px @calendar-hover-bg);
+        box-shadow: inset 0px -1px 0px 1000px @calendar-hover-bg;
         color: @calendar-cell-hover-color;
     }
 
@@ -247,26 +247,26 @@
         background: @calendar-cell-empty-bg;
 
         &.dx-state-hover {
-            .box-shadow(none);
+            box-shadow: none;
         }
     }
 
     &.dx-state-active {
         &:not(.dx-calendar-empty-cell) {
             &:not(.dx-calendar-selected-date) {
-                .box-shadow(inset 0px -1px 0px 1000px @calendar-cell-active-bg);
+                box-shadow: inset 0px -1px 0px 1000px @calendar-cell-active-bg;
             }
         }
     }
 
     &.dx-calendar-contoured-date {
-        .box-shadow(inset 0px 0px 0px 1px @calendar-cell-contoured-border-color);
+        box-shadow: inset 0px 0px 0px 1px @calendar-cell-contoured-border-color;
     }
 
     &.dx-calendar-selected-date {
         &, &.dx-calendar-today {
             color: @base-selected-text-color;
-            .box-shadow(inset 0px 0px 0px 1000px @calendar-cell-selected-bg);
+            box-shadow: inset 0px 0px 0px 1000px @calendar-cell-selected-bg;
             font-weight: normal;
 
             &.dx-calendar-contoured-date {

--- a/styles/widgets/generic/card.generic.less
+++ b/styles/widgets/generic/card.generic.less
@@ -1,5 +1,5 @@
 .dx-card {
     border: 1px solid @base-border-color;
-    .border-radius(@base-border-radius);
+    border-radius: @base-border-radius;
     background-color: @base-bg;
 }

--- a/styles/widgets/generic/checkBox.generic.less
+++ b/styles/widgets/generic/checkBox.generic.less
@@ -48,7 +48,7 @@
 .dx-checkbox-icon {
     width: @GENERIC_CHECKBOX_SIZE;
     height: @GENERIC_CHECKBOX_SIZE;
-    .border-radius(@checkbox-icon-border-radius);
+    border-radius: @checkbox-icon-border-radius;
     border: 1px solid @checkbox-border-color;
     background-color: @checkbox-bg;
 

--- a/styles/widgets/generic/common.generic.less
+++ b/styles/widgets/generic/common.generic.less
@@ -95,7 +95,7 @@
     margin-top: -@GENERIC_INVALID_BADGE_SIZE/2;
     width: @GENERIC_INVALID_BADGE_SIZE;
     height: @GENERIC_INVALID_BADGE_SIZE;
-    .border-radius(@radius: ~"50%");
+    border-radius: 50%;
     text-align: center;
     line-height: @GENERIC_INVALID_BADGE_SIZE;
     font-size: @GENERIC_BASE_FONT_SIZE - 1px;

--- a/styles/widgets/generic/contextMenu.generic.less
+++ b/styles/widgets/generic/contextMenu.generic.less
@@ -6,7 +6,7 @@
     .dx-submenu {
         background-color: @menu-popup-bg;
         border: @GENERIC_MENU_POPUP_BORDER;
-        .box-shadow(0 2px 2px @menu-container-shadow-color);
+        box-shadow: 0 2px 2px @menu-container-shadow-color;
     }
 
     .dx-menu-item-popout {

--- a/styles/widgets/generic/dataGrid.generic.less
+++ b/styles/widgets/generic/dataGrid.generic.less
@@ -2,7 +2,7 @@
 
 .dx-datagrid-group-panel {
     font-size: @GENERIC_BASE_FONT_SIZE;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 
     .dx-group-panel-message {
         color: @datagrid-columnchooser-item-color;

--- a/styles/widgets/generic/dateView.generic.less
+++ b/styles/widgets/generic/dateView.generic.less
@@ -19,7 +19,7 @@
 
 .dx-dateviewroller-current {
     .dx-dateview-item {
-        .transition(~"font-size .2s ease-out");
+        transition: font-size .2s ease-out;
     }
 }
 
@@ -107,7 +107,7 @@
     width: 100%;
 
     &:before, &:after {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
         content: "";
         display: block;
         width: 100%;

--- a/styles/widgets/generic/dropDownEditor.generic.less
+++ b/styles/widgets/generic/dropDownEditor.generic.less
@@ -28,7 +28,7 @@
     width: @GENERIC_DROPDOWNEDITOR_BUTTON_SIZE;
     height: 100%;
     .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
-    .border-radius(@dropdowneditor-icon-border-radius);
+    border-radius: @dropdowneditor-icon-border-radius;
 }
 
 .dx-dropdowneditor-button {

--- a/styles/widgets/generic/dropDownMenu.generic.less
+++ b/styles/widgets/generic/dropDownMenu.generic.less
@@ -6,7 +6,7 @@
     }
 
     .dx-dropdownmenu-list {
-        .border-radius(8px);
+        border-radius: 8px;
     }
 
     .dx-list-item {

--- a/styles/widgets/generic/fileUploader.generic.less
+++ b/styles/widgets/generic/fileUploader.generic.less
@@ -50,7 +50,7 @@
         padding: @GENERIC_FILEUPLOADER_VERTICAL_PADDING*2 @GENERIC_FILEUPLOADER_FILE_WRAPPER_BORDER_SIZE;
         // NOTE: height of the widget should be the same in default and drag over states
         margin-bottom: 1px;
-        .box-sizing(content-box);
+        box-sizing: content-box;
     }
 
     .dx-fileuploader-input-label {

--- a/styles/widgets/generic/gallery.generic.less
+++ b/styles/widgets/generic/gallery.generic.less
@@ -34,7 +34,7 @@
             position: absolute;
             width: 32px;
             height: 100%;
-            .border-radius(@gallery-navbutton-border-radius);
+            border-radius: @gallery-navbutton-border-radius;
         }
 
         &:before {
@@ -81,8 +81,8 @@
 }
 
 .dx-gallery-indicator-item {
-    .border-radius(50%);
-    .box-sizing(border-box);
+    border-radius: 50%;
+    box-sizing: border-box;
     border: 1px solid @gallery-indicator-item-border-color;
     pointer-events: auto;
 

--- a/styles/widgets/generic/gridBase.generic.less
+++ b/styles/widgets/generic/gridBase.generic.less
@@ -342,8 +342,8 @@
 
         .dx-overlay-content {
             background-color: ~"@{@{widgetName}-columnchooser-bg}";
-            .border-radius(~"@{@{widgetName}-columnchooser-overlay-border-radius}");
-            .box-shadow(0px 1px 3px ~"@{@{widgetName}-columnchooser-shadow-color}");
+            border-radius: ~"@{@{widgetName}-columnchooser-overlay-border-radius}";
+            box-shadow: 0px 1px 3px ~"@{@{widgetName}-columnchooser-shadow-color}";
 
             .dx-popup-title {
                 padding-top: 7px;
@@ -359,14 +359,14 @@
                     font-weight: ~"@{@{widgetName}-columnchooser-font-weight}";
                     border: ~"@{@{widgetName}-border}";
                     padding: @GENERIC_GRID_BASE_CELL_PADDING;
-                    .box-shadow(0px 1px 3px -1px ~"@{@{widgetName}-columnchooser-shadow-color}");
+                    box-shadow: 0px 1px 3px -1px ~"@{@{widgetName}-columnchooser-shadow-color}";
                 }
             }
         }
     }
 
     .dx-@{widgetName}-drag-header {
-        .box-shadow(@GENERIC_GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @GENERIC_GRID_BASE_DRAG_HEADER_SECOND_SHADOW);
+        box-shadow: @GENERIC_GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @GENERIC_GRID_BASE_DRAG_HEADER_SECOND_SHADOW;
         color: ~"@{@{widgetName}-columnchooser-item-color}";
         font-weight: ~"@{@{widgetName}-columnchooser-font-weight}";
         padding: @GENERIC_GRID_BASE_CELL_PADDING;
@@ -443,7 +443,7 @@
     .dx-@{widgetName}-headers {
         color: ~"@{@{widgetName}-columnchooser-item-color}";
         font-weight: ~"@{@{widgetName}-columnchooser-font-weight}";
-        .touch-action(pinch-zoom);
+        touch-action: pinch-zoom;
         border-bottom: ~"@{@{widgetName}-border}";
 
         .dx-@{widgetName}-content {
@@ -517,7 +517,7 @@
         .dx-overlay-content {
             border: ~"@{@{widgetName}-border}";
             overflow: inherit;
-            .box-shadow(2px 2px 3px ~"@{@{widgetName}-overlay-content-shadow-color}");
+            box-shadow: 2px 2px 3px ~"@{@{widgetName}-overlay-content-shadow-color}";
 
             .dx-editor-container.dx-highlight-outline::after {
                 border-color: ~"@{@{widgetName}-cell-modified-border-color}";
@@ -720,7 +720,7 @@
         }
 
         .dx-item-modified {
-            .border-radius(@base-border-radius);
+            border-radius: @base-border-radius;
             border: 2px solid ~"@{@{widgetName}-cell-modified-border-color}";
 
             &.dx-adaptive-item-text {

--- a/styles/widgets/generic/icons.generic.less
+++ b/styles/widgets/generic/icons.generic.less
@@ -3,7 +3,7 @@
 .dx-tab {
     .dx-icon,
     &.dx-tab-selected .dx-icon {
-        .background-size();
+        background-size: 100% 100%;
         background-position: 50% 50%;
     }
 }

--- a/styles/widgets/generic/list.generic.less
+++ b/styles/widgets/generic/list.generic.less
@@ -40,12 +40,12 @@
 
 
 .dx-list-item-chevron {
-    .rotate(0);
+    transform: rotate(0);
     border: none;
     opacity: 1;
 
     .dx-rtl & {
-        .rotate(0);
+        transform: rotate(0);
     }
 
     .dx-icon-chevronnext;
@@ -182,7 +182,7 @@
 
         .dx-icon-toggle-delete {
             background-image: @list-item-icon-toggle-delete-bg;
-            .background-size-prop(100%);
+            background-size: 100%;
         }
 
         &.dx-list-item-ghost-reordering {
@@ -192,7 +192,7 @@
                     background: @list-item-ghost-bg;
                     border-top: 1px solid fade(@list-item-ghost-border-color, 50%);
                     border-bottom: 1px solid fade(@list-item-ghost-border-color, 50%);
-                    .box-shadow(0px 0px 1px fade(@list-item-ghost-shadow-color, 10%), 0px 1px 3px fade(@list-item-ghost-shadow-color, 20%));
+                    box-shadow: 0px 0px 1px fade(@list-item-ghost-shadow-color, 10%), 0px 1px 3px fade(@list-item-ghost-shadow-color, 20%);
                 }
             }
         }
@@ -243,7 +243,7 @@
         .dx-button.dx-list-toggle-delete-switch {
             border: none;
             background: transparent;
-            .box-shadow(none);
+            box-shadow: none;
 
             .dx-button-content {
                 padding: 0;
@@ -323,8 +323,8 @@
     .dx-list-context-menucontent {
         background-color: @list-holdmenu-bg;
         border: 1px solid @list-holdmenu-border-color;
-        .border-radius(0);
-        .box-shadow(0px 3px 10px @list-holdmenu-shadow-color);
+        border-radius: 0;
+        box-shadow: 0px 3px 10px @list-holdmenu-shadow-color;
     }
 
     .dx-state-disabled {

--- a/styles/widgets/generic/loadIndicator.generic.less
+++ b/styles/widgets/generic/loadIndicator.generic.less
@@ -22,11 +22,11 @@
         top: 37%;
         opacity: 0;
         background: @loadindicator-bg;
-        .border-radius(50%);
-        .border-radius-top-left(10%);
-        .border-radius-top-right(10%);
-        .box-shadow(0 0 3px @loadindicator-segment-shadow-color);
-        .animation(dx-generic-loadindicator-opacity 1s linear infinite);
+        border-radius: 50%;
+        border-top-left-radius: 10%;
+        border-top-right-radius: 10%;
+        box-shadow: 0 0 3px @loadindicator-segment-shadow-color;
+        animation: dx-generic-loadindicator-opacity 1s linear infinite;
     }
 
     @-webkit-keyframes dx-generic-loadindicator-opacity {
@@ -70,43 +70,43 @@
     }
 
     .dx-loadindicator-segment0 {
-        .transform(rotate(0deg) translate(0, -142%));
-        .animation-delay(0s);
+        transform: rotate(0deg) translate(0, -142%);
+        animation-delay: 0s;
     }
 
     .dx-loadindicator-segment1 {
-        .transform(rotate(45deg) translate(0, -142%));
-        .animation-delay(-0.875s);
+        transform: rotate(45deg) translate(0, -142%);
+        animation-delay: -0.875s;
     }
 
     .dx-loadindicator-segment2 {
-        .transform(rotate(90deg) translate(0, -142%));
-        .animation-delay(-0.75s);
+        transform: rotate(90deg) translate(0, -142%);
+        animation-delay: -0.75s;
     }
 
     .dx-loadindicator-segment3 {
-        .transform(rotate(135deg) translate(0, -142%));
-        .animation-delay(-0.625s);
+        transform: rotate(135deg) translate(0, -142%);
+        animation-delay: -0.625s;
     }
 
     .dx-loadindicator-segment4 {
-        .transform(rotate(180deg) translate(0, -142%));
-        .animation-delay(-0.5s);
+        transform: rotate(180deg) translate(0, -142%);
+        animation-delay: -0.5s;
     }
 
     .dx-loadindicator-segment5 {
-        .transform(rotate(225deg) translate(0, -142%));
-        .animation-delay(-0.375s);
+        transform: rotate(225deg) translate(0, -142%);
+        animation-delay: -0.375s;
     }
 
     .dx-loadindicator-segment6 {
-        .transform(rotate(270deg) translate(0, -142%));
-        .animation-delay(-0.25s);
+        transform: rotate(270deg) translate(0, -142%);
+        animation-delay: -0.25s;
     }
 
     .dx-loadindicator-segment7 {
-        .transform(rotate(315deg) translate(0, -142%));
-        .animation-delay(-0.125s);
+        transform: rotate(315deg) translate(0, -142%);
+        animation-delay: -0.125s;
     }
 
     .dx-loadindicator-segment8,

--- a/styles/widgets/generic/loadPanel.generic.less
+++ b/styles/widgets/generic/loadPanel.generic.less
@@ -1,6 +1,6 @@
 .dx-loadpanel-content {
     border: 1px solid @loadpanel-border-color;
     background: @loadpanel-content-bg;
-    .border-radius(@loadpanel-content-border-radius);
-    .box-shadow(0px 6px 12px @loadpanel-content-shadow-color);
+    border-radius: @loadpanel-content-border-radius;
+    box-shadow: 0px 6px 12px @loadpanel-content-shadow-color;
 }

--- a/styles/widgets/generic/menu.generic.less
+++ b/styles/widgets/generic/menu.generic.less
@@ -2,7 +2,7 @@
 {
 	background-color: transparent;
 	border: @GENERIC_MENU_POPUP_BORDER;
-	.box-shadow(0px 1px 1px @menu-container-shadow-color);
+	box-shadow: 0px 1px 1px @menu-container-shadow-color;
 }
 
 .dx-context-menu-content-delimiter {
@@ -80,10 +80,10 @@
 
     .dx-treeview {
         border: 1px solid @menu-popup-border-color;
-        .border-radius(@base-border-radius);
+        border-radius: @base-border-radius;
 
         &, &.dx-state-focused {
-            .box-shadow(0px 3px 10px fade(@base-shadow-color, 10%));
+            box-shadow: 0px 3px 10px fade(@base-shadow-color, 10%);
         }
     }
 

--- a/styles/widgets/generic/navBar.generic.less
+++ b/styles/widgets/generic/navBar.generic.less
@@ -39,11 +39,11 @@
 
     &.dx-state-active {
         border: none;
-        .box-shadow(none);
+        box-shadow: none;
     }
 
     &.dx-state-focused {
-        .box-shadow(@GENERIC_NAVBAR_FOCUSED_ITEM_SHADOW);
+        box-shadow: @GENERIC_NAVBAR_FOCUSED_ITEM_SHADOW;
     }
 
     &.dx-state-disabled{

--- a/styles/widgets/generic/numberBox.generic.less
+++ b/styles/widgets/generic/numberBox.generic.less
@@ -15,7 +15,7 @@
 .dx-numberbox-spin-container {
     overflow: hidden;
     width: @GENERIC_NUMBERBOX_SPIN_CONTAINER_WIDTH;
-    .border-radius(@numberbox-spin-container-border-radius);
+    border-radius: @numberbox-spin-container-border-radius;
 }
 
 .dx-numberbox-spin-up-icon {
@@ -31,7 +31,7 @@
 .dx-numberbox-spin-up-icon,
 .dx-numberbox-spin-down-icon {
     .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
-    .border-radius(@numberbox-spin-icon-border-radius);
+    border-radius: @numberbox-spin-icon-border-radius;
 }
 
 .dx-numberbox-spin.dx-show-clear-button .dx-texteditor-input {

--- a/styles/widgets/generic/pager.generic.less
+++ b/styles/widgets/generic/pager.generic.less
@@ -70,7 +70,7 @@
     }
 
     .dx-page, .dx-page-size {
-        .border-radius(@pager-page-border-radius);
+        border-radius: @pager-page-border-radius;
         border-style: solid;
         border-width: 1px;
         border-color: transparent;

--- a/styles/widgets/generic/popup.generic.less
+++ b/styles/widgets/generic/popup.generic.less
@@ -37,12 +37,12 @@
     & > .dx-overlay-content {
         border: 1px solid @overlay-border-color;
         background: @overlay-content-bg;
-        .box-shadow(0 6px 12px @overlay-content-shadow-color);
-        .border-radius(@popup-border-radius);
+        box-shadow: 0 6px 12px @overlay-content-shadow-color;
+        border-radius: @popup-border-radius;
     }
 
     & > .dx-popup-fullscreen {
-        .border-radius(0);
+        border-radius: 0;
     }
 }
 
@@ -56,7 +56,7 @@
 
     &.dx-toolbar {
         .dx-toolbar-sizing(@GENERIC_POPUP_TOOLBAR_HEIGHT, @GENERIC_POPUP_TOOLBARTOP_PADDING, @GENERIC_POPUP_TOOLBAR_LABEL_FONT_SIZE, @GENERIC_POPUP_TOOLBAR_ITEM_SPACING );
-        .box-shadow(none);
+        box-shadow: none;
     }
 
     .dx-closebutton {
@@ -67,7 +67,7 @@
         }
 
         .dx-icon {
-            .box-sizing(border-box);
+            box-sizing: border-box;
         }
 
         .dx-button-styling();

--- a/styles/widgets/generic/progressBar.generic.less
+++ b/styles/widgets/generic/progressBar.generic.less
@@ -8,7 +8,7 @@
     height: @GENERIC_BAR_HEIGHT;
     border: @GENERIC_PROGRESS_BAR_BORDER;
     background-color: @progressbar-bg;
-    .border-radius(@GENERIC_PROGRESSBAR_BORDER_RADIUS);
+    border-radius: @GENERIC_PROGRESSBAR_BORDER_RADIUS;
 }
 
 .dx-progressbar-range {
@@ -17,9 +17,9 @@
     background-color: @progressbar-range-bg;
     margin-top: -1px;
 
-    .box-sizing(content-box);
-    .border-radius-top-left(@GENERIC_PROGRESSBAR_BORDER_RADIUS);
-    .border-radius-bottom-left(@GENERIC_PROGRESSBAR_BORDER_RADIUS);
+    box-sizing: content-box;
+    border-top-left-radius: @GENERIC_PROGRESSBAR_BORDER_RADIUS;
+    border-bottom-left-radius: @GENERIC_PROGRESSBAR_BORDER_RADIUS;
 }
 
 .dx-progressbar-animating-container {
@@ -28,9 +28,9 @@
     background-size: @GENERIC_BACKGROUND_WIDTH 5px;
     border: @GENERIC_PROGRESS_BAR_BORDER;
 
-    .border-radius(@GENERIC_PROGRESSBAR_BORDER_RADIUS);
+    border-radius: @GENERIC_PROGRESSBAR_BORDER_RADIUS;
 
-    .animation(loader 2s linear infinite);
+    animation: loader 2s linear infinite;
     .gradient-linear(@GENERIC_PROGRESSBAR_INTERDETERMINATE_STATE_GRADIENT);
     background-repeat: repeat;
 }
@@ -41,7 +41,7 @@
     }
 
     .dx-progressbar-animating-container {
-        .animation(none);
+        animation: none;
         background-position-x: @GENERIC_BACKGROUND_WIDTH / 2;
     }
 }
@@ -49,7 +49,7 @@
 .dx-rtl {
     .dx-progressbar, &.dx-progressbar {
         .dx-progressbar-animating-container {
-            .animation(loader-rtl 2s linear infinite);
+            animation: loader-rtl 2s linear infinite;
             .gradient-linear(@GENERIC_PROGRESSBAR_INTERDETERMINATE_STATE_GRADIENT);
             background-repeat: repeat;
         }

--- a/styles/widgets/generic/radioButton.generic.less
+++ b/styles/widgets/generic/radioButton.generic.less
@@ -23,8 +23,8 @@
     border: @GENERIC_RADIOBUTTON_BORDER_WIDTH solid @radiogroup-border-color;
     background-color: @radiogroup-bg;
     content: "";
-    .border-radius(@GENERIC_RADIOBUTTON_SIZE / 2);
-    .box-sizing(content-box);
+    border-radius: @GENERIC_RADIOBUTTON_SIZE / 2;
+    box-sizing: content-box;
 }
 
 .dx-radiobutton-icon-checked .dx-radiobutton-icon-dot {
@@ -35,7 +35,7 @@
     height: @GENERIC_RADIOBUTTON_DOT_SIZE;
     background: @radiogroup-checked-bg;
     content: "";
-    .border-radius(@GENERIC_RADIOBUTTON_DOT_SIZE / 2);
+    border-radius: @GENERIC_RADIOBUTTON_DOT_SIZE / 2;
 }
 
 .dx-radiobutton {

--- a/styles/widgets/generic/scrollView.generic.less
+++ b/styles/widgets/generic/scrollView.generic.less
@@ -5,7 +5,7 @@
 
 .dx-scrollable-native.dx-scrollable-native-android .dx-scrollview-pull-down {
     background-color: @scrollable-bg;
-    .box-shadow(0 1px 4px 0 @scrollview-shadow-color);
+    box-shadow: 0 1px 4px 0 @scrollview-shadow-color;
 }
 
 .dx-scrollview-scrollbottom-loading {

--- a/styles/widgets/generic/scrollable.generic.less
+++ b/styles/widgets/generic/scrollable.generic.less
@@ -10,12 +10,12 @@
     background-color: transparent;
     opacity: 1;
     overflow: hidden;
-    .transition(~"opacity 0s linear");
+    transition: opacity 0s linear;
 }
 
 .dx-scrollable-scroll.dx-state-invisible {
     opacity: 0;
-    .transition(~"opacity .5s linear 1s");
+    transition: opacity .5s linear 1s;
 }
 
 .dx-scrollable-scroll-content {
@@ -55,20 +55,20 @@
 
     &.dx-scrollbar-hoverable {
         width: @SCROLLBAR_SIZE_THIN;
-        .transition(~"width .2s linear .15s, background-color .2s linear .15s");
+        transition: width .2s linear .15s, background-color .2s linear .15s;
 
         .dx-scrollable-scroll {
-            .transition(~"background-color .5s linear 1s, width .2s linear 150ms");
+            transition: background-color .5s linear 1s, width .2s linear 150ms;
 
             .dx-scrollable-scroll-content {
-                .transition(~"box-shadow .15s linear .15s, background-color .15s linear .15s");
+                transition: box-shadow .15s linear .15s, background-color .15s linear .15s;
             }
 
             &.dx-state-invisible {
-                .transition(~"background-color .5s linear 1s, width .2s linear .15s");
+                transition: background-color .5s linear 1s, width .2s linear .15s;
 
                 .dx-scrollable-scroll-content {
-                    .transition(~"box-shadow .5s linear 1s, background-color .5s linear 1s");
+                    transition: box-shadow .5s linear 1s, background-color .5s linear 1s;
                 }
             }
         }
@@ -90,20 +90,20 @@
 
     &.dx-scrollbar-hoverable {
         height: @SCROLLBAR_SIZE_THIN;
-        .transition(~"height .2s linear .15s, background-color .2s linear .15s");
+        transition: height .2s linear .15s, background-color .2s linear .15s;
 
         .dx-scrollable-scroll {
-            .transition(~"background-color .5s linear 1s, height .2s linear .15s");
+            transition: background-color .5s linear 1s, height .2s linear .15s;
 
             .dx-scrollable-scroll-content {
-                .transition(~"box-shadow .15s linear .15s, background-color .15s linear .15s");
+                transition: box-shadow .15s linear .15s, background-color .15s linear .15s;
             }
 
             &.dx-state-invisible {
-                .transition(~"background-color .5s linear 1s, height .2s linear .15s");
+                transition: background-color .5s linear 1s, height .2s linear .15s;
 
                 .dx-scrollable-scroll-content {
-                    .transition(~"box-shadow .5s linear 1s, background-color .5s linear 1s");
+                    transition: box-shadow .5s linear 1s, background-color .5s linear 1s;
                 }
             }
         }

--- a/styles/widgets/generic/selectBox.generic.less
+++ b/styles/widgets/generic/selectBox.generic.less
@@ -1,6 +1,6 @@
 .dx-selectbox-popup-wrapper {
     .dx-overlay-content {
-        .box-shadow(0px 6px 12px @selectbox-shadow-color);
+        box-shadow: 0px 6px 12px @selectbox-shadow-color;
     }
 
     .dx-list {

--- a/styles/widgets/generic/slideOutView.generic.less
+++ b/styles/widgets/generic/slideOutView.generic.less
@@ -13,7 +13,7 @@
 
 .dx-slideout-sizing() {
     .dx-slideoutview-content {
-        .box-sizing(content-box);
+        box-sizing: content-box;
         margin-left: -@GENERIC_SLIDEOUTVIEW_BORDER_WIDTH;
         border-style: solid;
         border-width: 0 @GENERIC_SLIDEOUTVIEW_BORDER_WIDTH;

--- a/styles/widgets/generic/slider.generic.less
+++ b/styles/widgets/generic/slider.generic.less
@@ -15,7 +15,7 @@
 .dx-slider {
     .dx-tooltip-wrapper {
         .dx-overlay-content {
-            .box-shadow(none);
+            box-shadow: none;
         }
     }
 }
@@ -28,18 +28,18 @@
     margin: @GENERIC_SLIDER_HEIGHT/2 @GENERIC_SLIDER_WIDTH / 2;
     height: @GENERIC_SLIDER_TRACK_HEIGHT;
     background: @slider-bar-bg;
-    .border-radius(@GENERIC_SLIDER_RADIUS);
+    border-radius: @GENERIC_SLIDER_RADIUS;
 }
 
 .dx-slider-range {
     border: 1px solid transparent;
     height: @GENERIC_SLIDER_TRACK_HEIGHT - 2px;
-    .box-sizing(content-box);
+    box-sizing: content-box;
 
     &.dx-slider-range-visible {
         border: 1px solid @slider-range-border-color;
         background: @slider-range-bg;
-        .border-radius(@GENERIC_SLIDER_RADIUS);
+        border-radius: @GENERIC_SLIDER_RADIUS;
     }
 }
 
@@ -63,8 +63,8 @@
     height: @GENERIC_SLIDER_HEIGHT;
     border: 1px solid @slider-handle-border-color;
     background-color: @slider-handle-bg;
-    .border-radius(@slider-handle-border-radius);
-    .box-sizing(content-box);
+    border-radius: @slider-handle-border-radius;
+    box-sizing: content-box;
 }
 
 .dx-state-disabled .dx-slider,

--- a/styles/widgets/generic/switch.generic.less
+++ b/styles/widgets/generic/switch.generic.less
@@ -78,7 +78,7 @@
     height: @GENERIC_SWITCH_HEIGHT;
     border: @GENERIC_SWITCH_BORDER_WEIGHT solid @switch-border-color;
     background: @switch-bg;
-    .border-radius(@switch-border-radius);
+    border-radius: @switch-border-radius;
 }
 
 .dx-switch-inner {
@@ -97,7 +97,7 @@
     font-size: @GENERIC_SWITCH_FONT_SIZE;
     font-weight: 600;
     .dx-overflow();
-    .box-sizing();
+    box-sizing: border-box;
 }
 
 .dx-switch-off {
@@ -117,7 +117,7 @@
     width: @GENERIC_SWITCH_HANDLE_WIDTH;
     height: @GENERIC_SWITCH_INNER_SIZE - @GENERIC_SWITCH_HANDLE_OFFSET*2;
     margin-top: @GENERIC_SWITCH_HANDLE_OFFSET;
-    .box-sizing();
+    box-sizing: border-box;
 
     &:before {
         display: block;
@@ -125,7 +125,7 @@
         width: 100%;
         height: 100%;
         background-color: @switch-handle-off-bg;
-        .border-radius(@switch-handle-border-radius);
+        border-radius: @switch-handle-border-radius;
     }
 }
 

--- a/styles/widgets/generic/tabs.generic.less
+++ b/styles/widgets/generic/tabs.generic.less
@@ -58,8 +58,8 @@
 .dx-tabs-nav-button {
     border: none;
     background-color: @tabs-tab-bg;
-    .border-radius(0);
-    .box-shadow(none);
+    border-radius: 0;
+    box-shadow: none;
 
     .dx-button-content {
         padding: 0;

--- a/styles/widgets/generic/toast.generic.less
+++ b/styles/widgets/generic/toast.generic.less
@@ -18,8 +18,8 @@
     font-weight: 600;
     line-height: @GENERIC_TOAST_LINE_HEIGHT;
     padding: @GENERIC_TOAST_CONTENT_PADDING;
-    .box-shadow(@GENERIC_TOAST_SHADOW);
-    .border-radius(@toast-border-radius);
+    box-shadow: @GENERIC_TOAST_SHADOW;
+    border-radius: @toast-border-radius;
 }
 
 .dx-toast-icon {

--- a/styles/widgets/generic/tooltip.generic.less
+++ b/styles/widgets/generic/tooltip.generic.less
@@ -3,8 +3,8 @@
         border: 1px solid @tooltip-border-color;
         background-color: @tooltip-bg;
         color: @tooltip-color;
-        .box-shadow(0 2px 4px @tooltip-shadow-color);
-        .border-radius(@tooltip-border-radius);
+        box-shadow: 0 2px 4px @tooltip-shadow-color;
+        border-radius: @tooltip-border-radius;
     }
 
     &.dx-popover-wrapper .dx-popover-arrow {

--- a/styles/widgets/generic/validation.generic.less
+++ b/styles/widgets/generic/validation.generic.less
@@ -1,6 +1,6 @@
 .dx-invalid-message > .dx-overlay-content {
-    .border-radius(@validation-overlay-border-radius);
+    border-radius: @validation-overlay-border-radius;
     .dx-editor-underlined & {
-        .border-radius(0);
+        border-radius: 0;
     }
 }

--- a/styles/widgets/ios7/actionSheet.ios7.less
+++ b/styles/widgets/ios7/actionSheet.ios7.less
@@ -1,6 +1,6 @@
 .dx-actionsheet-without-title {
     .dx-actionsheet-container {
-        .border-radius-custom(6px, 6px, 6px, 6px);
+        border-radius: 6px 6px 6px 6px;
     }
 }
 
@@ -16,7 +16,7 @@
         background: @IOS7_ACTIONSHEET_BACKGROUND;
         color: @IOS7_ACTIONSHEET_TITLE;
         font-size: 14px;
-        .border-radius-custom(6px, 6px, 0, 0);
+        border-radius: 6px 6px 0 0;
         font-weight: normal;
 
         &.dx-toolbar {
@@ -27,12 +27,12 @@
 
     .dx-popup-content {
         padding: 0;
-        .border-radius(0);
+        border-radius: 0;
     }
 
     .dx-actionsheet-cancel {
         margin: 0 0 8px 0;
-        .border-radius(6px);
+        border-radius: 6px;
         border-top: none;
         background: @IOS7_ACTIONSHEET_CANCEL_BACKGROUND;
 
@@ -81,7 +81,7 @@
 
 .dx-actionsheet-container {
     overflow: hidden;
-    .border-radius-custom(0, 0, 6px, 6px);
+    border-radius: 0 0 6px 6px;
     margin-bottom: 8px;
 
     .dx-popover-wrapper & {
@@ -89,7 +89,7 @@
     }
 
     .dx-button {
-        .border-radius-custom(0, 0, 0, 0);
+        border-radius: 0 0 0 0;
 
         &.dx-state-disabled .dx-button-text {
             color: @IOS7_ACTIONSHEET_BUTTON_DISABLE;

--- a/styles/widgets/ios7/autocomplete.ios7.less
+++ b/styles/widgets/ios7/autocomplete.ios7.less
@@ -1,7 +1,7 @@
 .dx-autocomplete-popup-wrapper {
 
     .dx-overlay-content {
-        .box-shadow(@IOS7_AUTOCOMPLETE_SHADOW);
+        box-shadow: @IOS7_AUTOCOMPLETE_SHADOW;
     }
 
     .dx-popup-content {

--- a/styles/widgets/ios7/button.ios7.less
+++ b/styles/widgets/ios7/button.ios7.less
@@ -18,7 +18,7 @@
     width: 100%;
     border: 0;
     text-align: center;
-    .transition(~"opacity .15s linear");
+    transition: opacity .15s linear;
 }
 
 .dx-button-text {
@@ -64,7 +64,7 @@
 .dx-state-active {
     &.dx-button .dx-button-content {
         opacity: .35;
-        .transition(~"opacity 0s");
+        transition: opacity 0s;
     }
 }
 

--- a/styles/widgets/ios7/calendar.ios7.less
+++ b/styles/widgets/ios7/calendar.ios7.less
@@ -168,7 +168,7 @@
     .dx-calendar-cell {
         span {
             border: 1px solid transparent;
-            .border-radius(10px);
+            border-radius: 10px;
             display: inline-block;
         }
     }

--- a/styles/widgets/ios7/checkBox.ios7.less
+++ b/styles/widgets/ios7/checkBox.ios7.less
@@ -27,8 +27,8 @@
     outline: 1px solid transparent;
     border: 1px solid @IOS7_CHECKBOX_BORDER;
     background-color: @IOS7_CHECKBOX_BACKGROUND_COLOR;
-    .background-size-prop(100%);
-    .border-radius(@IOS7_CHECKBOX_BORDER_RADIUS_ICON_SIZE);
+    background-size: 100%;
+    border-radius: @IOS7_CHECKBOX_BORDER_RADIUS_ICON_SIZE;
 
     .dx-checkbox-checked & {
         .dx-icon-check;
@@ -42,7 +42,7 @@
             width: 15px;
             height: 15px;
             background-color: @IOS7_CHECKBOX_BACKGROUND_COLOR;
-            .border-radius(@IOS7_CHECKBOX_BORDER_RADIUS_ICON_SIZE);
+            border-radius: @IOS7_CHECKBOX_BORDER_RADIUS_ICON_SIZE;
             position: absolute;
             left: 4px;
             top: 4px;

--- a/styles/widgets/ios7/colorBox.ios7.less
+++ b/styles/widgets/ios7/colorBox.ios7.less
@@ -17,8 +17,8 @@
 }
 
 .dx-colorbox-overlay {
-    .border-radius(.5em);
-    .box-shadow(@IOS7_AUTOCOMPLETE_SHADOW);
+    border-radius: .5em;
+    box-shadow: @IOS7_AUTOCOMPLETE_SHADOW;
     background-color: @IOS7_COLOR_VIEW_OVERLAY_BACKGROUND_COLOR;
 
     .dx-popup-content {

--- a/styles/widgets/ios7/contextMenu.ios7.less
+++ b/styles/widgets/ios7/contextMenu.ios7.less
@@ -11,8 +11,8 @@
 
     .dx-submenu > .dx-menu-items-container {
         background-color: @IOS7_MENU_POPUP_BACKGROUND;
-        .border-radius(@IOS7_MENU_POPUP_BORDER_RADIUS);
-        .box-shadow(0px 1px 11px 1px rgba(0, 0, 0, 0.15));
+        border-radius: @IOS7_MENU_POPUP_BORDER_RADIUS;
+        box-shadow: 0px 1px 11px 1px rgba(0, 0, 0, 0.15);
         margin-left: -5px;
     }
 
@@ -25,8 +25,8 @@
 
         &:first-child {
             & > .dx-menu-item {
-                .border-radius-top-left(@IOS7_MENU_POPUP_BORDER_RADIUS);
-                .border-radius-top-right(@IOS7_MENU_POPUP_BORDER_RADIUS);
+                border-top-left-radius: @IOS7_MENU_POPUP_BORDER_RADIUS;
+                border-top-right-radius: @IOS7_MENU_POPUP_BORDER_RADIUS;
             }
         }
 
@@ -35,8 +35,8 @@
 
             & > .dx-menu-item {
                 border-bottom: none;
-                .border-radius-bottom-left(@IOS7_MENU_POPUP_BORDER_RADIUS);
-                .border-radius-bottom-right(@IOS7_MENU_POPUP_BORDER_RADIUS);
+                border-bottom-left-radius: @IOS7_MENU_POPUP_BORDER_RADIUS;
+                border-bottom-right-radius: @IOS7_MENU_POPUP_BORDER_RADIUS;
             }
         }
     }

--- a/styles/widgets/ios7/dataGrid.ios7.less
+++ b/styles/widgets/ios7/dataGrid.ios7.less
@@ -8,7 +8,7 @@
 .dx-datagrid-group-panel {
     font-size: @IOS7_BASE_FONT_SIZE;
     vertical-align: middle;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 
     .dx-group-panel-message {
         color: @datagrid-headers-color;

--- a/styles/widgets/ios7/dateBox.ios7.less
+++ b/styles/widgets/ios7/dateBox.ios7.less
@@ -41,8 +41,8 @@
 
 .dx-datebox-wrapper-calendar {
     .dx-overlay-content {
-        .border-radius(.5em);
-        .box-shadow(@IOS7_AUTOCOMPLETE_SHADOW);
+        border-radius: .5em;
+        box-shadow: @IOS7_AUTOCOMPLETE_SHADOW;
         background-color: @IOS7_COLOR_VIEW_OVERLAY_BACKGROUND_COLOR;
         border: 1px solid @IOS7_COLOR_VIEW_OVERLAY_BORDER_COLOR;
     }

--- a/styles/widgets/ios7/dropDownEditor.ios7.less
+++ b/styles/widgets/ios7/dropDownEditor.ios7.less
@@ -15,8 +15,8 @@
 
 .dx-dropdowneditor-button-visible {
     .dx-texteditor-input {
-        .border-radius-top-right(0);
-        .border-radius-bottom-right(0);
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
     }
 }
 

--- a/styles/widgets/ios7/dropDownMenu.ios7.less
+++ b/styles/widgets/ios7/dropDownMenu.ios7.less
@@ -1,18 +1,18 @@
 .dx-dropdownmenu-popup-wrapper {
     .dx-overlay-content {
-        .border-radius(.5em);
+        border-radius: .5em;
     }
 
     .dx-popup-content {
         padding: 0px;
         background-color: @IOS7_DROPDOWNMENU_BACKGROUND;
-        .border-radius(.5em);
+        border-radius: .5em;
     }
 
     .dx-scrollview-content {
         position: static;
         overflow: hidden;
-        .border-radius(.4em);
+        border-radius: .4em;
     }
 
     .dx-list-item {

--- a/styles/widgets/ios7/fieldset.ios7.less
+++ b/styles/widgets/ios7/fieldset.ios7.less
@@ -155,7 +155,7 @@
         margin-bottom: -3px;
         height: 100%;
         text-align: left;
-        .box-sizing(content-box);
+        box-sizing: content-box;
 
         .dx-lookup-field {
             padding: 8px 40px 8px 8px;
@@ -173,7 +173,7 @@
     .dx-tagbox-single-line
      {
         border: none;
-        .box-shadow(none);
+        box-shadow: none;
     }
 
     &.dx-textarea {
@@ -261,7 +261,7 @@
         }
 
         & > .dx-lookup {
-            .box-sizing(content-box);
+            box-sizing: content-box;
             padding-right: 10px;
             margin-right: -10px;
             min-height: 39px;
@@ -410,7 +410,7 @@
     .dx-field-value {
         &:not(.dx-widget) {
             & > .dx-lookup {
-                .box-sizing(content-box);
+                box-sizing: content-box;
                 padding-right: 10px;
                 margin-right: -10px;
                 min-height: 41px;

--- a/styles/widgets/ios7/gallery.ios7.less
+++ b/styles/widgets/ios7/gallery.ios7.less
@@ -33,7 +33,7 @@
     width: 8px;
     height: 8px;
     background: @IOS7_GALLERY_INDICATOR_BACKGROUND;
-    .border-radius(@IOS7_GALLERY_INDICATOR_RADIUS);
+    border-radius: @IOS7_GALLERY_INDICATOR_RADIUS;
     border: solid 1px @IOS7_GALLERY_INDICATOR_SELECTED_BACKGROUND;
 }
 

--- a/styles/widgets/ios7/gridBase.ios7.less
+++ b/styles/widgets/ios7/gridBase.ios7.less
@@ -133,7 +133,7 @@
                 }
 
                 .dx-texteditor-input {
-                    .border-radius(0px);
+                    border-radius: 0px;
                     border-width: 0px;
                     background: ~"@{@{widgetName}-editor-background}";
                 }
@@ -160,7 +160,7 @@
             }
 
             .dx-dropdowneditor-icon {
-                .box-shadow(none);
+                box-shadow: none;
             }
         }
 
@@ -209,14 +209,14 @@
     .dx-@{widgetName}-filter-range-overlay .dx-overlay-content {
         border: ~"@{@{widgetName}-border}";
         overflow: inherit;
-        .box-shadow(2px 2px 3px fade(black, 15%));
+        box-shadow: 2px 2px 3px fade(black, 15%);
 
         .dx-texteditor-container {
             border: none;
         }
 
         &, .dx-texteditor-container {
-            .border-radius(0px);
+            border-radius: 0px;
         }
 
         .dx-editor-container.dx-highlight-outline::after {
@@ -318,8 +318,8 @@
         }
 
         .dx-overlay-content {
-            .border-radius(0px);
-            .box-shadow(0px 1px 3px rgba(0, 0, 0, 0.2));
+            border-radius: 0px;
+            box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
 
             .dx-popup-content {
                 .dx-list-item-content::after {
@@ -329,7 +329,7 @@
                 .dx-column-chooser-item {
                     padding: 0px;
                     border: ~"@{@{widgetName}-border}";
-                    .box-shadow(0px 1px 3px -1px rgba(0, 0, 0, 0.2));
+                    box-shadow: 0px 1px 3px -1px rgba(0, 0, 0, 0.2);
                     background-color: ~"@{@{widgetName}-headers-background-color}";
 
                     .dx-treeview-item-content {
@@ -349,7 +349,7 @@
     }
 
     .dx-@{widgetName}-drag-header {
-        .box-shadow(@GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @GRID_BASE_DRAG_HEADER_SECOND_SHADOW);
+        box-shadow: @GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @GRID_BASE_DRAG_HEADER_SECOND_SHADOW;
         text-transform: uppercase;
         font-size: 0.9em;
         font-weight: bold;
@@ -405,7 +405,7 @@
 
     .dx-@{widgetName}-headers {
         color: ~"@{@{widgetName}-headers-color}";
-        .touch-action(pinch-zoom);
+        touch-action: pinch-zoom;
 
         .dx-@{widgetName}-table {
             .dx-row {
@@ -550,7 +550,7 @@
             .dx-invalid-message {
                 .dx-overlay-content {
                     padding: 10px 17px 9px;
-                    .border-radius(0px);
+                    border-radius: 0px;
                 }
             }
 
@@ -573,7 +573,7 @@
 
         .dx-adaptive-detail-row {
             .dx-@{widgetName}-invalid {
-                .border-radius(6px);
+                border-radius: 6px;
                 border: 1px solid ~"@{@{widgetName}-data-invalid-color}";
 
                 &.dx-adaptive-item-text {
@@ -585,7 +585,7 @@
         }
 
         .dx-item-modified {
-            .border-radius(6px);
+            border-radius: 6px;
             border: 2px solid ~"@{@{widgetName}-data-modified-color}";
 
             &.dx-adaptive-item-text {
@@ -676,7 +676,7 @@
             min-width: 32px;
 
             .dx-popup-content{
-                .border-radius(4px);
+                border-radius: 4px;
             }
         }
 

--- a/styles/widgets/ios7/list.ios7.less
+++ b/styles/widgets/ios7/list.ios7.less
@@ -149,7 +149,7 @@
         width: 25px;
         height: 25px;
         background-image: @IOS7_LIST_DELETE_SWITCH_BACKGROUND;
-        .background-size-prop(100%);
+        background-size: 100%;
     }
 
     .dx-list-select-checkbox,
@@ -295,8 +295,8 @@
 }
 
 .dx-list-context-menucontent {
-    .box-shadow(@IOS7_HOLDMENU_SHADOW);
-    .border-radius(.5em);
+    box-shadow: @IOS7_HOLDMENU_SHADOW;
+    border-radius: .5em;
     border: 1px solid @IOS7_HOLDMENU_BORDERCOLOR;
     background-color: @IOS7_HOLDMENU_BACKGROUND;
 

--- a/styles/widgets/ios7/loadIndicator.ios7.less
+++ b/styles/widgets/ios7/loadIndicator.ios7.less
@@ -17,8 +17,8 @@
         top: 37%;
         opacity: 0;
         background: @IOS7_LOAD_INDICATOR_SEGMENT;
-        .border-radius(80%);
-        .animation(dx-ios-loadindicator-opacity 1s linear infinite);
+        border-radius: 80%;
+        animation: dx-ios-loadindicator-opacity 1s linear infinite;
     }
 
     @-webkit-keyframes dx-ios-loadindicator-opacity {
@@ -62,63 +62,63 @@
     }
 
     .dx-loadindicator-segment0 {
-        .transform(rotate(0deg) translate(0, -142%));
-        .animation-delay(0s);
+        transform: rotate(0deg) translate(0, -142%);
+        animation-delay: 0s;
     }
 
     .dx-loadindicator-segment1 {
-        .transform(rotate(30deg) translate(0, -142%));
-        .animation-delay(-0.9167s);
+        transform: rotate(30deg) translate(0, -142%);
+        animation-delay: -0.9167s;
     }
 
     .dx-loadindicator-segment2 {
-        .transform(rotate(60deg) translate(0, -142%));
-        .animation-delay(-0.833s);
+        transform: rotate(60deg) translate(0, -142%);
+        animation-delay: -0.833s;
     }
 
     .dx-loadindicator-segment3 {
-        .transform(rotate(90deg) translate(0, -142%));
-        .animation-delay(-0.75s);
+        transform: rotate(90deg) translate(0, -142%);
+        animation-delay: -0.75s;
     }
 
     .dx-loadindicator-segment4 {
-        .transform(rotate(120deg) translate(0, -142%));
-        .animation-delay(-0.667s);
+        transform: rotate(120deg) translate(0, -142%);
+        animation-delay: -0.667s;
     }
 
     .dx-loadindicator-segment5 {
-        .transform(rotate(150deg) translate(0, -142%));
-        .animation-delay(-0.5833s);
+        transform: rotate(150deg) translate(0, -142%);
+        animation-delay: -0.5833s;
     }
 
     .dx-loadindicator-segment6 {
-        .transform(rotate(180deg) translate(0, -142%));
-        .animation-delay(-0.5s);
+        transform: rotate(180deg) translate(0, -142%);
+        animation-delay: -0.5s;
     }
 
     .dx-loadindicator-segment7 {
-        .transform(rotate(210deg) translate(0, -142%));
-        .animation-delay(-0.41667s);
+        transform: rotate(210deg) translate(0, -142%);
+        animation-delay: -0.41667s;
     }
 
     .dx-loadindicator-segment8 {
-        .transform(rotate(240deg) translate(0, -142%));
-        .animation-delay(-0.333s);
+        transform: rotate(240deg) translate(0, -142%);
+        animation-delay: -0.333s;
     }
 
     .dx-loadindicator-segment9 {
-        .transform(rotate(270deg) translate(0, -142%));
-        .animation-delay(-0.25s);
+        transform: rotate(270deg) translate(0, -142%);
+        animation-delay: -0.25s;
     }
 
     .dx-loadindicator-segment10 {
-        .transform(rotate(300deg) translate(0, -142%));
-        .animation-delay(-0.1667s);
+        transform: rotate(300deg) translate(0, -142%);
+        animation-delay: -0.1667s;
     }
 
     .dx-loadindicator-segment11 {
-        .transform(rotate(330deg) translate(0, -142%));
-        .animation-delay(-0.0833s);
+        transform: rotate(330deg) translate(0, -142%);
+        animation-delay: -0.0833s;
     }
 
     .dx-loadindicator-segment12,

--- a/styles/widgets/ios7/menu.ios7.less
+++ b/styles/widgets/ios7/menu.ios7.less
@@ -34,8 +34,8 @@
     &.dx-overlay-content {
         background-color: @IOS7_MENU_POPUP_BACKGROUND;
         border: 1px solid @IOS7_MENU_ITEM_BORDER_COLOR;
-        .border-radius(7px);
-        .box-shadow(0px 1px 11px 1px rgba(0, 0, 0, 0.15));
+        border-radius: 7px;
+        box-shadow: 0px 1px 11px 1px rgba(0, 0, 0, 0.15);
     }
 
     .dx-treeview-node {

--- a/styles/widgets/ios7/navBar.ios7.less
+++ b/styles/widgets/ios7/navBar.ios7.less
@@ -7,7 +7,7 @@
     border-top: 1px solid @IOS7_NAVBAR_BORDER;
     background: @IOS7_NAVBAR_BACKGROUND;
     table-layout: fixed;
-    .border-radius(0);
+    border-radius: 0;
 
     .dx-hairlines & {
         border-top-width: .5px;
@@ -20,11 +20,11 @@
         height: 100%;
         border: none;
         background: transparent;
-        .border-radius(0);
+        border-radius: 0;
 
         &:first-child, &:last-child {
             border: none;
-            .border-radius(0);
+            border-radius: 0;
         }
 
         .dx-icon {

--- a/styles/widgets/ios7/overlay.ios7.less
+++ b/styles/widgets/ios7/overlay.ios7.less
@@ -1,5 +1,5 @@
 .dx-overlay-wrapper {
-    .transition(~"background-color .4s ease");
+    transition: background-color .4s ease;
     .dx-base-typography();
 }
 

--- a/styles/widgets/ios7/popup.ios7.less
+++ b/styles/widgets/ios7/popup.ios7.less
@@ -4,7 +4,7 @@
     & > .dx-overlay-content {
         border: @IOS7_POPUP_BORDER;
         background: @IOS7_DIALOG_BACKGROUND;
-        .border-radius(@IOS7_POPUP_BORDER_RADIUS);
+        border-radius: @IOS7_POPUP_BORDER_RADIUS;
 
         .dx-hairlines & {
             border-width: .5px;
@@ -27,12 +27,12 @@
 }
 
 .dx-popup-content {
-    .border-radius(@IOS7_POPUP_BORDER_RADIUS);
+    border-radius: @IOS7_POPUP_BORDER_RADIUS;
 }
 
 .dx-popup-fullscreen {
     border: none;
-    .border-radius(0px);
+    border-radius: 0px;;
 }
 
 .dx-popup-title {
@@ -41,7 +41,7 @@
     color: @IOS7_POPUP_TITLE_TEXT;
     text-align: center;
     font-weight: bold;
-    .border-radius-custom(@IOS7_POPUP_BORDER_RADIUS, @IOS7_POPUP_BORDER_RADIUS, 0, 0);
+    border-radius: @IOS7_POPUP_BORDER_RADIUS @IOS7_POPUP_BORDER_RADIUS 0 0;
     font-weight: bold;
 
     .dx-hairlines & {
@@ -49,7 +49,7 @@
     }
 
     & + .dx-popup-content {
-        .border-radius-custom(0, 0, @IOS7_POPUP_BORDER_RADIUS, @IOS7_POPUP_BORDER_RADIUS);
+        border-radius: 0 0 @IOS7_POPUP_BORDER_RADIUS @IOS7_POPUP_BORDER_RADIUS;
     }
 
     &.dx-toolbar {
@@ -86,7 +86,7 @@
 
 .dx-dialog-root {
     .dx-overlay-content, .dx-popup-content {
-        .border-radius(@IOS7_DIALOG_BORDER_RADIUS);
+        border-radius: @IOS7_DIALOG_BORDER_RADIUS;
     }
 
     .dx-popup-title {

--- a/styles/widgets/ios7/progressBar.ios7.less
+++ b/styles/widgets/ios7/progressBar.ios7.less
@@ -30,7 +30,7 @@
     height: @IOS7_BAR_HEIGHT;
     background-color: @IOS7_PROGRESSBAR_RANGE_COLOR;
     background-size: @IOS7_BACKGROUND_WIDTH @IOS7_BAR_HEIGHT;
-    .animation(loader 2s linear infinite);
+    animation: loader 2s linear infinite;
     .gradient-linear(@IOS7_PROGRESSBAR_INTERDETERMINATE_STATE_GRADIENT);
     background-repeat: repeat;
 }
@@ -45,7 +45,7 @@
     }
 
     .dx-progressbar-animating-container {
-        .animation(none);
+        animation: none;
         .gradient-linear(@IOS7_PROGRESSBAR_DISABLED_STATE_INTERDETERMINATE_STATE_GRADIENT);
         background-repeat: repeat;
         background-color: @IOS7_PROGRESSBAR_CONTAINER_COLOR;
@@ -56,7 +56,7 @@
 .dx-rtl {
     .dx-progressbar, &.dx-progressbar {
         .dx-progressbar-animating-container {
-            .animation(loader-rtl 1s linear infinite);
+            animation: loader-rtl 1s linear infinite;
             .gradient-linear(@IOS7_PROGRESSBAR_INTERDETERMINATE_STATE_GRADIENT);
             background-repeat: repeat;
         }

--- a/styles/widgets/ios7/radioButton.ios7.less
+++ b/styles/widgets/ios7/radioButton.ios7.less
@@ -13,13 +13,13 @@
             left: @IOS7_RADIONBUTTON_ICON_SIZE/4;
             top: @IOS7_RADIONBUTTON_ICON_SIZE/4;
             background: @IOS7_RADIOGROUP_BACKGROUND_COLOR;
-            .box-shadow(~"0 1px 1px rgba(0, 0, 0, 0.1)");
-            .border-radius(50%);
+            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+            border-radius: 50%;
         }
 
         &:before {
             background: @IOS7_RADIOGROUP_CHECK_BACKGROUND_COLOR;
-            .box-shadow(none);
+            box-shadow: none;
         }
     }
 
@@ -30,8 +30,8 @@
         width: 100%;
         height: 100%;
         background-color: @IOS7_RADIOGROUP_BACKGROUND_COLOR;
-        .box-shadow(0 0 2px rgba(170,170,170,.6) inset);
-        .border-radius(50%);
+        box-shadow: 0 0 2px rgba(170,170,170,.6) inset;
+        border-radius: 50%;
     }
 
     .dx-state-disabled & {

--- a/styles/widgets/ios7/selectBox.ios7.less
+++ b/styles/widgets/ios7/selectBox.ios7.less
@@ -1,6 +1,6 @@
 .dx-selectbox-popup-wrapper {
     .dx-overlay-content {
-        .box-shadow(@IOS7_SELECTBOX_SHADOW);
+        box-shadow: @IOS7_SELECTBOX_SHADOW;
     }
 
     .dx-list {

--- a/styles/widgets/ios7/slideOutView.ios7.less
+++ b/styles/widgets/ios7/slideOutView.ios7.less
@@ -1,5 +1,5 @@
 .dx-slideoutview-content {
-    .box-sizing(content-box);
+    box-sizing: content-box;
     background-color: @IOS7_BACKGROUND;
     margin-left: -@IOS7_SLIDEOUTVIEW_BORDER_WIDTH;
     border-left: @IOS7_SLIDEOUTVIEW_BORDER_WIDTH solid @IOS7_SLIDEOUTVIEW_BORDER_COLOR;

--- a/styles/widgets/ios7/slider.ios7.less
+++ b/styles/widgets/ios7/slider.ios7.less
@@ -11,7 +11,7 @@
     margin: 13px (@IOS7_SLIDER_HANDLE_SIZE + 1px) / 2;
     height: @IOS7_SLIDER_BAR_HEIGHT;
     background: @IOS7_SLIDER_BAR_BACKGROUND;
-    .border-radius(3px);
+    border-radius: 3px;
 }
 
 .dx-slider-range {
@@ -29,8 +29,8 @@
     height: @IOS7_SLIDER_HANDLE_SIZE;
     border: @IOS7_SLIDER_HANDLE_BORDER;
     background: @IOS7_SLIDER_HANDLE_BACKGROUND;
-    .box-shadow(@IOS7_SLIDER_HANDLE_SHADOW);
-    .border-radius(50%);
+    box-shadow: @IOS7_SLIDER_HANDLE_SHADOW;
+    border-radius: 50%;
 
     .dx-hairlines & {
         border-width: .5px;

--- a/styles/widgets/ios7/switch.ios7.less
+++ b/styles/widgets/ios7/switch.ios7.less
@@ -27,9 +27,9 @@
     min-width: @IOS7_SWITCH_WIDTH;
     width: 100%;
     height: @IOS7_SWITCH_HEIGHT;
-    .border-radius(@IOS7_SWITCH_RADIUS);
+    border-radius: @IOS7_SWITCH_RADIUS;
     background: @IOS7_SWITCH_OFF_BACKGROUND;
-    .transition(~"all .24s ease");
+    transition: all .24s ease;
 
     &:before {
         position: absolute;
@@ -39,9 +39,9 @@
         bottom: @IOS7_SWITCH_BORDER_WIDTH;
         left: @IOS7_SWITCH_BORDER_WIDTH;
         content: " ";
-        .border-radius(@IOS7_SWITCH_RADIUS);
+        border-radius: @IOS7_SWITCH_RADIUS;
         background: @IOS7_SWITCH_OFF_INNER_BACKGROUND;
-        .transition(~"all .24s ease");
+        transition: all .24s ease;
     }
 }
 
@@ -55,10 +55,10 @@
     left: 50%;
     margin-left: @IOS7_SWITCH_BORDER_WIDTH;
     bottom: @IOS7_SWITCH_BORDER_WIDTH;
-    .border-radius(@IOS7_SWITCH_RADIUS);
+    border-radius: @IOS7_SWITCH_RADIUS;
     background: @IOS7_SWITCH_HANDLE_BACKGROUND;
     box-shadow: 0 1px 2px rgba(0,0,0,.4), 0 4px 5px rgba(0,0,0,.2);
-    .transition(~"margin-left .24s ease 0s, left .24s ease 0s, width .14s ease .1s, transform .14s ease .1s");
+    transition: margin-left .24s ease 0s, left .24s ease 0s, width .14s ease .1s, transform .14s ease .1s;
 
     .dx-state-active & {
         width: @IOS7_SWITCH_ACTIVE_HANDLE_SIZE;
@@ -74,7 +74,7 @@
             right: 50%;
             bottom: 50%;
             left: 50%;
-            .transition(~"all .06s ease");
+            transition: all .06s ease;
         }
     }
 
@@ -82,7 +82,7 @@
         margin-left: 0 - @IOS7_SWITCH_BORDER_WIDTH;
 
         .dx-state-active& {
-            .translate(@IOS7_SWITCH_HANDLE_SIZE - @IOS7_SWITCH_ACTIVE_HANDLE_SIZE);
+            transform: translate(@IOS7_SWITCH_HANDLE_SIZE - @IOS7_SWITCH_ACTIVE_HANDLE_SIZE, 0);
         }
     }
 }
@@ -94,10 +94,10 @@
         left: auto;
         right: 50%;
         margin-right: -@IOS7_SWITCH_HANDLE_SIZE;
-        .transition(~"margin-right .24s ease 0s, right .24s ease 0s, width .14s ease .1s, transform .14s ease .1s");
+        transition: margin-right .24s ease 0s, right .24s ease 0s, width .14s ease .1s, transform .14s ease .1s;
 
         .dx-state-active& {
-            .translate(0);
+            transform: translate(0, 0);
         }
     }
 
@@ -107,7 +107,7 @@
             margin-right: 0 - @IOS7_SWITCH_BORDER_WIDTH - @IOS7_SWITCH_HANDLE_SIZE;
 
             .dx-state-active& {
-                .translate(@IOS7_SWITCH_ACTIVE_HANDLE_SIZE - @IOS7_SWITCH_HANDLE_SIZE);
+                transform: translate(@IOS7_SWITCH_ACTIVE_HANDLE_SIZE - @IOS7_SWITCH_HANDLE_SIZE, 0);
             }
         }
     }

--- a/styles/widgets/ios7/tabs.ios7.less
+++ b/styles/widgets/ios7/tabs.ios7.less
@@ -1,7 +1,7 @@
 .dx-tabs {
     border: 0;
     background: @IOS7_TABS_BACKGROUND;
-    .border-radius(6px);
+    border-radius: 6px;
 
     .dx-tabs-nav-button {
         width: 30px;
@@ -20,11 +20,11 @@
 .dx-tabs-nav-buttons {
     .dx-tab {
         &:first-child {
-            .border-radius(0);
+            border-radius: 0;
         }
 
         &:last-child {
-            .border-radius(0);
+            border-radius: 0;
         }
     }
 }
@@ -38,11 +38,11 @@
 }
 
 .dx-tabs-nav-button-left {
-    .border-radius-custom(6px, 0, 0, 6px);
+    border-radius: 6px 0 0 6px;
 }
 
 .dx-tabs-nav-button-right {
-    .border-radius-custom(0, 6px, 6px, 0);
+    border-radius:0 6px 6px 0;
 }
 
 .dx-tab {
@@ -63,12 +63,12 @@
     }
 
     &:first-child {
-        .border-radius-custom(6px, 0, 0, 6px);
+        border-radius: 6px 0 0 6px;
     }
 
     &:last-child {
         border-right: 1px solid @IOS7_TABS_TAB_BORDER;
-        .border-radius-custom(0, 6px, 6px, 0);
+        border-radius: 0 6px 6px 0;
     }
 }
 
@@ -114,11 +114,11 @@
 .dx-rtl .dx-tab {
     &:first-child {
         border-right: 1px solid @IOS7_TABS_TAB_BORDER;
-        .border-radius-custom(0, 6px, 6px, 0);
+        border-radius:0 6px 6px 0;
     }
 
     &:last-child {
         border-right: none;
-        .border-radius-custom(6px, 0, 0, 6px);
+        border-radius: 6px 0 0 6px;
     }
 }

--- a/styles/widgets/ios7/tagBox.ios7.less
+++ b/styles/widgets/ios7/tagBox.ios7.less
@@ -55,7 +55,7 @@
     color: #fff;
     font-size: 1em;
     background-color: @IOS7_TAGBOX_TAG_ITEM_BACKGROUND_COLOR;
-    .border-radius(10px);
+    border-radius: 10px;
 }
 
 .dx-tag-remove-button {

--- a/styles/widgets/ios7/textBox.ios7.less
+++ b/styles/widgets/ios7/textBox.ios7.less
@@ -35,7 +35,7 @@
         height: @SEARCH_ICON_SIZE;
         background-image: @ICON_SEARCH_PATH;
         background-repeat: no-repeat;
-        .background-size-prop(contain);
+        background-size: contain;
     }
 
     .dx-texteditor-input {
@@ -46,10 +46,10 @@
     &.dx-state-focused {
         .dx-placeholder {
             text-align: left;
-            .transform(translate(@SEARCH_ICON_OFFSET / 2, 0));
+            transform: translate(@SEARCH_ICON_OFFSET / 2, 0);
 
             &:before {
-                .transform(translate(0, 0));
+                transform: translate(0, 0);
             }
         }
     }
@@ -72,8 +72,8 @@
 
 .ios-search-placeholder() {
     width: 100%;
-    .transform(translate(50%, 0));
-    .transition(transform @ANIMATION_DURATION ease);
+    transform: translate(50%, 0);
+    transition: transform @ANIMATION_DURATION ease;
 
     &:before {
         overflow: visible;
@@ -85,14 +85,14 @@
         padding-left: @SEARCH_ICON_SIZE + @SEARCH_ICON_OFFSET;
         min-height: @SEARCH_ICON_SIZE + @SEARCH_ICON_OFFSET;
         background-repeat: no-repeat;
-        .background-size(@SEARCH_ICON_SIZE, @SEARCH_ICON_SIZE);
-        .transform(translate(-50%, 0));
-        .transition(transform @ANIMATION_DURATION ease);
+        background-size: @SEARCH_ICON_SIZE @SEARCH_ICON_SIZE;
+        transform: translate(-50%, 0);
+        transition: transform @ANIMATION_DURATION ease;
     }
 }
 
 .ios-search-placeholder-rtl() {
-    .transform(translate(-50%, 0));
+    transform: translate(-50%, 0);
 
     &:before {
         display: inline-block;
@@ -100,7 +100,7 @@
         margin-right: @SEARCH_ICON_OFFSET / 2;
         margin-left: 0;
         padding-right: @SEARCH_ICON_SIZE + @SEARCH_ICON_OFFSET;
-        .transform(translate(50%, 0));
+        transform: translate(50%, 0);
     }
 }
 
@@ -115,10 +115,10 @@
         &.dx-state-focused {
             .dx-placeholder {
                 text-align: right;
-                .transform(translate(-@SEARCH_ICON_OFFSET / 2, 0));
+                transform: translate(-@SEARCH_ICON_OFFSET / 2, 0);
 
                 &:before {
-                    .transform(translate(0, 0));
+                    transform: translate(0, 0);
                 }
             }
         }

--- a/styles/widgets/ios7/textEditor.ios7.less
+++ b/styles/widgets/ios7/textEditor.ios7.less
@@ -48,7 +48,7 @@
 
 .dx-texteditor-container {
     border: @TEXTEDITOR_BORDER;
-    .border-radius(@TEXTEDITOR_BORDER_RADIUS);
+    border-radius: @TEXTEDITOR_BORDER_RADIUS;
     overflow: hidden;
 
     .dx-hairlines &{
@@ -76,7 +76,7 @@
     font-family: @IOS7_FONT;
 
     &:invalid {
-        .box-shadow(none);
+        box-shadow: none;
     }
 }
 
@@ -132,7 +132,7 @@
     margin-top: -@TEXTEDITOR_INVALID_BADGE_WIDTH/2;
     width: @TEXTEDITOR_INVALID_BADGE_WIDTH;
     height: @TEXTEDITOR_INVALID_BADGE_WIDTH;
-    .border-radius(@radius: 11px);
+    border-radius: 11px;
     text-align: center;
     line-height: @TEXTEDITOR_INVALID_BADGE_WIDTH - 3px;
 }

--- a/styles/widgets/ios7/toast.ios7.less
+++ b/styles/widgets/ios7/toast.ios7.less
@@ -1,11 +1,11 @@
 .dx-toast-content {
     color: white;
-    .border-radius(5px);
-    .text-shadow(~"0px 1px 0px rgba(0, 0, 0, 0.18)");
+    border-radius: 5px;
+    text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.18);
 }
 
 .dx-toast-icon {
-    .background-size(contain);
+    background-size: contain;
 }
 
 .dx-toast-info {

--- a/styles/widgets/ios7/validation.ios7.less
+++ b/styles/widgets/ios7/validation.ios7.less
@@ -1,3 +1,3 @@
 .dx-invalid-message > .dx-overlay-content {
-    .border-radius(@IOS7_POPUP_BORDER_RADIUS);
+    border-radius: @IOS7_POPUP_BORDER_RADIUS;
 }

--- a/styles/widgets/material/accordion.material.less
+++ b/styles/widgets/material/accordion.material.less
@@ -23,7 +23,7 @@
 
 .dx-accordion-item {
     background-color: @accordion-item-bg;
-    .box-shadow(0 3px 1px -2px rgba(0,0,0,.2), 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12));
+    box-shadow: 0 3px 1px -2px rgba(0, 0, 0, .2), 0 2px 2px 0 rgba(0, 0, 0, .14), 0 1px 5px 0 rgba(0, 0, 0, .12);
     transition: margin 200ms cubic-bezier(0.4, 0, 0.2, 1);
     will-change: margin, height;
 

--- a/styles/widgets/material/button.material.less
+++ b/styles/widgets/material/button.material.less
@@ -81,8 +81,8 @@
 .dx-button {
     &.dx-button-has-icon:not(.dx-button-has-text) {
         &:not(.dx-shape-standard) {
-            .border-radius(50%);
-            .box-shadow(none);
+            border-radius: 50%;
+            box-shadow: none;
         }
     }
 }
@@ -103,7 +103,7 @@
 ) {
     background-color: @background-color;
     color: @text-color;
-    .box-shadow(@shadow-color);
+    box-shadow: @shadow-color;
 
     .dx-icon {
         color: @icon-color;
@@ -111,22 +111,22 @@
 
     &.dx-state-hover {
         background-color: @hover-background-color;
-        .box-shadow(@hover-shadow-color);
+        box-shadow: @hover-shadow-color;
     }
 
     &.dx-state-focused {
         background-color: @focused-background-color;
-        .box-shadow(@focused-shadow-color);
+        box-shadow: @focused-shadow-color;
     }
 
     &.dx-state-active {
         background-color: @active-background-color;
-        .box-shadow(@active-shadow-color);
+        box-shadow: @active-shadow-color;
     }
 
     &.dx-state-disabled {
         background: @disabled-background-color;
-        .box-shadow(none);
+        box-shadow: none;
 
         .dx-icon {
             opacity: @button-disabled-icon-opacity;
@@ -146,7 +146,7 @@
     @button-bg, @button-color, @button-hover-bg,
     @button-focused-bg, @button-active-bg, @button-icon-color
 ) {
-    .border-radius(@button-border-radius);
+    border-radius: @button-border-radius;
 
     .dx-button-styling-variant(
         @button-bg,
@@ -197,7 +197,7 @@
 }
 
 .dx-button-styling-clear() {
-    .box-shadow(none);
+    box-shadow: none;
     background: transparent;
     border-color: transparent;
 }
@@ -258,7 +258,7 @@
 
     &.dx-button-back {
         .dx-button-flat-color-styling(@button-flat-color);
-        .border-radius(50%);
+        border-radius: 50%;
         .dx-button-onlyicon-sizing();
         .dx-button-text {
             display: none;

--- a/styles/widgets/material/buttonGroup.material.less
+++ b/styles/widgets/material/buttonGroup.material.less
@@ -20,7 +20,7 @@
 
 .dx-button-mode-text {
     &.dx-button.dx-buttongroup-item {
-        .border-radius(@button-border-radius);
+        border-radius: @button-border-radius;
     }
 
     &.dx-buttongroup-first-item {
@@ -30,13 +30,13 @@
 
 .dx-button-mode-outlined, .dx-button-mode-contained {
     &.dx-button.dx-buttongroup-first-item {
-        .border-radius-top-left(@button-border-radius);
-        .border-radius-bottom-left(@button-border-radius);
+        border-top-left-radius: @button-border-radius;
+        border-bottom-left-radius: @button-border-radius;
     }
 
     &.dx-button.dx-buttongroup-last-item {
-        .border-radius-top-right(@button-border-radius);
-        .border-radius-bottom-right(@button-border-radius);
+        border-top-right-radius: @button-border-radius;
+        border-bottom-right-radius: @button-border-radius;
     }
 }
 
@@ -73,11 +73,11 @@
 .dx-rtl {
     &.dx-button-mode-outlined, &.dx-button-mode-contained {
         &.dx-button.dx-buttongroup-first-item {
-            .border-radius-custom(0, @button-border-radius, @button-border-radius, 0);
+            border-radius: 0 @button-border-radius @button-border-radius 0;
         }
 
         &.dx-button.dx-buttongroup-last-item {
-            .border-radius-custom(@button-border-radius, 0, 0, @button-border-radius);
+            border-radius: @button-border-radius 0 0 @button-border-radius;
         }
     }
 

--- a/styles/widgets/material/calendar.material.less
+++ b/styles/widgets/material/calendar.material.less
@@ -150,7 +150,7 @@
     left: 0px;
 
     &.dx-button {
-        .border-radius-custom(@calendar-navigator-border-radius, 0, 0, @calendar-navigator-border-radius);
+        border-radius: @calendar-navigator-border-radius 0 0 @calendar-navigator-border-radius;
 
         .dx-icon{
             color: @calendar-shevron-icon-color;
@@ -163,7 +163,7 @@
     right: 0px;
 
     &.dx-button {
-        .border-radius-custom(0, @calendar-navigator-border-radius, @calendar-navigator-border-radius, 0);
+        border-radius: 0 @calendar-navigator-border-radius @calendar-navigator-border-radius 0;
 
         .dx-icon{
             color: @calendar-shevron-icon-color;
@@ -202,7 +202,7 @@
     color: @calendar-color;
     font-size: @MATERIAL_CALENDAR_CELL_FONT_SIZE;
     width: 39px;
-    .border-radius(@calendar-cell-contoured-border-radius);
+    border-radius: @calendar-cell-contoured-border-radius;
 
     .dx-calendar-view-decade &,
     .dx-calendar-view-year & {

--- a/styles/widgets/material/card.material.less
+++ b/styles/widgets/material/card.material.less
@@ -1,6 +1,6 @@
 .dx-card {
-    .box-shadow(0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24));
-    .border-radius(@base-border-radius);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    border-radius: @base-border-radius;
     background-color: @base-bg;
     margin: 2px 2px 3px;
 }

--- a/styles/widgets/material/checkBox.material.less
+++ b/styles/widgets/material/checkBox.material.less
@@ -29,7 +29,7 @@
     &.dx-state-active {
         .dx-checkbox-icon:after {
             background-color: fade(@checkbox-border-color, 10%);
-            .scale(1);
+            transform: scale(1);
         }
     }
 
@@ -39,7 +39,7 @@
         &.dx-state-active {
             .dx-checkbox-icon:after {
                 background-color: fade(@checkbox-bg, 10%);
-                .scale(1);
+                transform: scale(1);
             }
         }
 
@@ -58,7 +58,7 @@
     &.dx-state-readonly.dx-state-focused {
         .dx-checkbox-icon:after {
             background-color: fade(@checkbox-border-color, 10%);
-            .scale(1);
+            transform: scale(1);
         }
     }
 }
@@ -67,7 +67,7 @@
     width: @MATERIAL_CHECKBOX_SIZE;
     height: @MATERIAL_CHECKBOX_SIZE;
     border: 2px solid @checkbox-border-color;
-    .border-radius(@checkbox-icon-border-radius);
+    border-radius: @checkbox-icon-border-radius;
 
     &:after {
         content: "";
@@ -81,8 +81,8 @@
         display: block;
         position: absolute;
         z-index: 1;
-        .scale(0.5);
-        .transition(@MATERIAL_CHECKBOX_RIPPLE_TRANSITION);
+        transform: scale(0.5);
+        transition: @MATERIAL_CHECKBOX_RIPPLE_TRANSITION;
     }
 
     &:before {
@@ -127,7 +127,7 @@
     &.dx-state-focused {
         .dx-checkbox-icon:after {
             background-color: fade(@checkbox-invalid-focused-border-color, 10%);
-            .scale(1);
+            transform: scale(1);
         }
     }
 }

--- a/styles/widgets/material/common.material.less
+++ b/styles/widgets/material/common.material.less
@@ -95,7 +95,7 @@
     margin-top: -@MATERIAL_INVALID_BADGE_SIZE/2;
     width: @MATERIAL_INVALID_BADGE_SIZE;
     height: @MATERIAL_INVALID_BADGE_SIZE;
-    .border-radius(@radius: ~"50%");
+    border-radius: 50%;
     text-align: center;
     line-height: @MATERIAL_INVALID_BADGE_SIZE + 1;
     font-size: @MATERIAL_BASE_FONT_SIZE;

--- a/styles/widgets/material/contextMenu.material.less
+++ b/styles/widgets/material/contextMenu.material.less
@@ -40,13 +40,13 @@
     }
 
     &.dx-overlay-content.dx-state-focused {
-        .box-shadow(none);
+        box-shadow: none;
     }
 
     .dx-submenu {
         background-color: @menu-popup-bg;
         border-radius: @base-border-radius;
-        .box-shadow(0 2px 7px @menu-container-shadow-color);
+        box-shadow: 0 2px 7px @menu-container-shadow-color;
     }
 
     .dx-menu-separator {

--- a/styles/widgets/material/dataGrid.material.less
+++ b/styles/widgets/material/dataGrid.material.less
@@ -2,7 +2,7 @@
 
 .dx-datagrid-group-panel {
     font-size: @MATERIAL_BASE_FONT_SIZE;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 
     .dx-group-panel-message {
         color: @datagrid-columnchooser-item-color;

--- a/styles/widgets/material/dateView.material.less
+++ b/styles/widgets/material/dateView.material.less
@@ -19,7 +19,7 @@
 
 .dx-dateviewroller-current {
     .dx-dateview-item {
-        .transition(~"font-size .2s ease-out");
+        transition: font-size .2s ease-out;
     }
 }
 
@@ -108,7 +108,7 @@
     width: 100%;
 
     &:before, &:after {
-        .backface-visibility(hidden);
+        backface-visibility: hidden;
         content: "";
         display: block;
         width: 100%;

--- a/styles/widgets/material/dropDownEditor.material.less
+++ b/styles/widgets/material/dropDownEditor.material.less
@@ -227,6 +227,6 @@
 
 .dx-dropdowneditor-overlay.dx-popup-wrapper {
     .dx-overlay-content {
-        .box-shadow(@dropdown-widgets-shadow);
+        box-shadow: @dropdown-widgets-shadow;
     }
 }

--- a/styles/widgets/material/dropDownList.material.less
+++ b/styles/widgets/material/dropDownList.material.less
@@ -2,7 +2,7 @@
     height: 100%;
 
     &.dx-popup-wrapper .dx-overlay-content {
-        .box-shadow(@dropdown-widgets-shadow);
+        box-shadow: @dropdown-widgets-shadow;
         border-top-width: 0;
         border-bottom-width: 1px;
         &.dx-dropdowneditor-overlay-flipped {

--- a/styles/widgets/material/dropDownMenu.material.less
+++ b/styles/widgets/material/dropDownMenu.material.less
@@ -1,13 +1,13 @@
 .dx-dropdownmenu-popup-wrapper {
     .dx-overlay-content {
-        .box-shadow(@dropdown-widgets-shadow);
+        box-shadow: @dropdown-widgets-shadow;
         .dx-popup-content {
             padding: 1px;
         }
     }
 
     .dx-dropdownmenu-list {
-        .border-radius(8px);
+        border-radius: 8px;
     }
 
     .dx-list-item {

--- a/styles/widgets/material/fileUploader.material.less
+++ b/styles/widgets/material/fileUploader.material.less
@@ -50,7 +50,7 @@
         padding: @MATERIAL_FILEUPLOADER_VERTICAL_PADDING*2 @MATERIAL_FILEUPLOADER_FILE_WRAPPER_BORDER_SIZE;
         //NOTE: height of the widget should be the same in default and drag over states
         margin-bottom: 1px;
-        .box-sizing(content-box);
+        box-sizing: content-box;
     }
 
     .dx-fileuploader-input-label {
@@ -90,7 +90,7 @@
     }
 
     .dx-fileuploader-file-container {
-        .box-shadow(0 1px 3px 0px rgba(0, 0, 0, 0.1));
+        box-shadow: 0 1px 3px 0px rgba(0, 0, 0, 0.1);
         padding: 5px 8px;
         margin-bottom: 4px;
 

--- a/styles/widgets/material/filterBuilder.material.less
+++ b/styles/widgets/material/filterBuilder.material.less
@@ -34,7 +34,7 @@
 .dx-filterbuilder-overlay {
 
     &.dx-popup-wrapper > .dx-overlay-content {
-        .box-shadow(@dropdown-widgets-shadow);
+        box-shadow: @dropdown-widgets-shadow;
     }
 
     &.dx-filterbuilder-operations {

--- a/styles/widgets/material/gallery.material.less
+++ b/styles/widgets/material/gallery.material.less
@@ -35,7 +35,7 @@
             width: 32px;
             height: 32px;
             background: @gallery-navbutton-color;
-            .border-radius(50%);
+            border-radius: 50%;
             top: 50%;
             margin-top: -16px;
         }
@@ -84,8 +84,8 @@
 }
 
 .dx-gallery-indicator-item {
-    .border-radius(50%);
-    .box-sizing(border-box);
+    border-radius: 50%;
+    box-sizing: border-box;
     border: 1px solid @gallery-indicator-item-border-color;
     pointer-events: auto;
 

--- a/styles/widgets/material/gridBase.material.less
+++ b/styles/widgets/material/gridBase.material.less
@@ -481,14 +481,14 @@
                     font-size: @MATERIAL_GRID_BASE_HEADER_CELL_FONT_SIZE;
                     padding: @MATERIAL_GRID_BASE_CELL_VERTICAL_PADDING;
                     line-height: @MATERIAL_GRID_BASE_HEADER_LINE_HEIGHT;
-                    .box-shadow(@MATERIAL_GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @MATERIAL_GRID_BASE_DRAG_HEADER_SECOND_SHADOW);
+                    box-shadow: @MATERIAL_GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @MATERIAL_GRID_BASE_DRAG_HEADER_SECOND_SHADOW;
                 }
             }
         }
     }
 
     .dx-@{widgetName}-drag-header {
-        .box-shadow(@MATERIAL_GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @MATERIAL_GRID_BASE_DRAG_HEADER_SECOND_SHADOW);
+        box-shadow: @MATERIAL_GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @MATERIAL_GRID_BASE_DRAG_HEADER_SECOND_SHADOW;
         color: ~"@{@{widgetName}-columnchooser-item-color}";
         font-weight: ~"@{@{widgetName}-columnchooser-font-weight}";
         padding: @MATERIAL_GRID_BASE_HEADER_CELL_VERTICAL_PADDING;
@@ -555,7 +555,7 @@
 
     .dx-@{widgetName}-headers {
         color: ~"@{@{widgetName}-columnchooser-item-color}";
-        .touch-action(pinch-zoom);
+        touch-action: pinch-zoom;
         border-bottom: ~"@{@{widgetName}-border}";
 
         .dx-@{widgetName}-content {
@@ -653,7 +653,7 @@
         .dx-overlay-content {
             overflow: inherit;
             background-color: ~"@{@{widgetName}-filter-row-background-color}";
-            .box-shadow(@MATERIAL_GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @MATERIAL_GRID_BASE_DRAG_HEADER_SECOND_SHADOW);
+            box-shadow: @MATERIAL_GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @MATERIAL_GRID_BASE_DRAG_HEADER_SECOND_SHADOW;
 
             .dx-texteditor {
                 &.dx-state-focused:after,
@@ -696,7 +696,7 @@
         }
 
         .dx-toolbar-text-auto-hide .dx-button.dx-button-has-icon {
-            .border-radius(50%);
+            border-radius: 50%;
         }
 
         .dx-@{widgetName}-toolbar-button {
@@ -846,7 +846,7 @@
             }
 
             .dx-texteditor.dx-editor-outlined {
-                .box-shadow(none);
+                box-shadow: none;
             }
         }
 
@@ -962,7 +962,7 @@
             min-width: inherit;
 
             &.dx-button-has-icon:not(.dx-button-has-text) {
-                .border-radius(2px);
+                border-radius: 2px;
             }
 
             &.dx-state-hover {

--- a/styles/widgets/material/icons.material.less
+++ b/styles/widgets/material/icons.material.less
@@ -11,7 +11,7 @@
 .dx-tab {
     .dx-icon,
     &.dx-tab-selected .dx-icon {
-        .background-size();
+        background-size: 100% 100%;
         background-position: 50% 50%;
     }
 }

--- a/styles/widgets/material/list.material.less
+++ b/styles/widgets/material/list.material.less
@@ -39,12 +39,12 @@
 @MATERIAL_LIST_ITEM_BORDER: @MATERIAL_LIST_ITEM_BORDER_WIDTH solid @list-border-color;
 
 .dx-list-item-chevron {
-    .rotate(0);
+    transform: rotate(0);
     border: none;
     opacity: 1;
 
     .dx-rtl & {
-        .rotate(0);
+        transform: rotate(0);
     }
 
     .dx-icon-chevronnext;
@@ -151,13 +151,13 @@
                     .dx-checkbox {
                         .dx-checkbox-icon:after {
                             background-color: fade(@checkbox-border-color, 10%);
-                            .scale(1);
+                            transform: scale(1);
                         }
                         &.dx-checkbox-checked,
                         &.dx-checkbox-indeterminate {
                             .dx-checkbox-icon:after {
                                 background-color: fade(@checkbox-bg, 10%);
-                                .scale(1);
+                                transform: scale(1);
                             }
                         }
                     }
@@ -267,7 +267,7 @@
 
         .dx-icon-toggle-delete {
             background-image: @list-item-icon-toggle-delete-bg;
-            .background-size-prop(100%);
+            background-size: 100%;
         }
 
         &.dx-list-item-ghost-reordering {
@@ -277,7 +277,7 @@
                     background: @list-item-ghost-bg;
                     border-top: 1px solid fade(@list-item-ghost-border-color, 50%);
                     border-bottom: 1px solid fade(@list-item-ghost-border-color, 50%);
-                    .box-shadow(0px 0px 1px fade(@list-item-ghost-shadow-color, 10%), 0px 1px 3px fade(@list-item-ghost-shadow-color, 20%));
+                    box-shadow: 0px 0px 1px fade(@list-item-ghost-shadow-color, 10%), 0px 1px 3px fade(@list-item-ghost-shadow-color, 20%);
                 }
             }
         }
@@ -345,7 +345,7 @@
             width:  24px;
             margin-left: @item_horizontal_padding - 1px;
 
-            .box-shadow(none);
+            box-shadow: none;
 
             .dx-button-content {
                 padding: 0;
@@ -471,8 +471,8 @@
     .dx-list-context-menucontent {
         background-color: @list-holdmenu-bg;
         border: 1px solid @list-holdmenu-border-color;
-        .border-radius(0);
-        .box-shadow(0px 3px 10px @list-holdmenu-shadow-color);
+        border-radius: 0;
+        box-shadow: 0px 3px 10px @list-holdmenu-shadow-color;
     }
 
     .dx-state-disabled {

--- a/styles/widgets/material/loadIndicator.material.less
+++ b/styles/widgets/material/loadIndicator.material.less
@@ -6,14 +6,14 @@
 .dx-loadindicator-content {
     height: 100%;
     width: 100%;
-    .animation(content-rotation 1568ms linear infinite);
+    animation: content-rotation 1568ms linear infinite;
 }
 
 .dx-loadindicator-image {
     background-image: @loadindicator-background-image;
 
     .dx-loadindicator-content {
-        .animation(none);
+        animation: none;
     }
 }
 
@@ -21,7 +21,7 @@
     position: absolute;
     height: 100%;
     width: 100%;
-    .animation(icon-rotation 5332ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both);
+    animation: icon-rotation 5332ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;
 }
 
 .dx-loadindicator-segment {
@@ -37,8 +37,8 @@
     border-width: 0.12em;
     border-style: solid;
     border-bottom-color: transparent;
-    .animation(none);
-    .border-radius(50%);
+    animation: none;
+    border-radius: 50%;
 }
 
 .dx-loadindicator-segment2, .dx-loadindicator-segment0 {
@@ -56,8 +56,8 @@
 .dx-loadindicator-segment2 {
     .dx-loadindicator-segment-inner {
         border-right-color: transparent;
-        .transform(rotate(-129deg));
-        .animation(left-segment-rotation 1333ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both);
+        transform: rotate(-129deg);
+        animation: left-segment-rotation 1333ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;
     }
 }
 
@@ -65,8 +65,8 @@
     .dx-loadindicator-segment-inner {
         left: -100%;
         border-left-color: transparent;
-        .transform(rotate(129deg));
-        .animation(right-segment-rotation 1333ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both);
+        transform: rotate(129deg);
+        animation: right-segment-rotation 1333ms cubic-bezier(0.4, 0.0, 0.2, 1) infinite both;
     }
 }
 
@@ -77,7 +77,7 @@
     width: 10%;
     height: 100%;
     overflow: hidden;
-    .box-sizing(border-box);
+    box-sizing: border-box;
 
     .dx-loadindicator-segment-inner {
         width: 1000%;

--- a/styles/widgets/material/loadPanel.material.less
+++ b/styles/widgets/material/loadPanel.material.less
@@ -2,8 +2,8 @@
     border: 1px solid @loadpanel-border-color;
     background: @loadpanel-content-bg;
     padding: 13px;
-    .border-radius(50%);
-    .box-shadow(0px 6px 12px @loadpanel-content-shadow-color);
+    border-radius: 50%;
+    box-shadow: 0px 6px 12px @loadpanel-content-shadow-color;
 }
 
 .dx-loadpanel-message {

--- a/styles/widgets/material/menu.material.less
+++ b/styles/widgets/material/menu.material.less
@@ -52,10 +52,10 @@
 
     .dx-treeview {
         border: 1px solid @menu-popup-border-color;
-        .border-radius(@base-border-radius);
+        border-radius: @base-border-radius;
 
         &, &.dx-state-focused {
-            .box-shadow(0px 3px 10px fade(@base-shadow-color, 10%));
+            box-shadow: 0px 3px 10px fade(@base-shadow-color, 10%);
         }
     }
 

--- a/styles/widgets/material/navBar.material.less
+++ b/styles/widgets/material/navBar.material.less
@@ -39,11 +39,11 @@
 
     &.dx-state-active {
         border: none;
-        .box-shadow(none);
+        box-shadow: none;
     }
 
     &.dx-state-focused {
-        .box-shadow(@MATERIAL_NAVBAR_FOCUSED_ITEM_SHADOW);
+        box-shadow: @MATERIAL_NAVBAR_FOCUSED_ITEM_SHADOW;
     }
 
     &.dx-state-disabled{

--- a/styles/widgets/material/pager.material.less
+++ b/styles/widgets/material/pager.material.less
@@ -71,7 +71,7 @@
         &:hover {
             background-color: @pager-page-hovered-bg;
         }
-        .border-radius(20px);
+        border-radius: 20px;
     }
 
     .dx-page-sizes .dx-page-size {

--- a/styles/widgets/material/pivotGrid.material.less
+++ b/styles/widgets/material/pivotGrid.material.less
@@ -11,7 +11,7 @@
         .dx-area-field.dx-area-box {
             background-color: fade(@pivotgrid-field-area-box-background-color, 90%);
             border: none;
-            .box-shadow(@MATERIAL_PIVOTGRID_DRAG_HEADER_SHADOW);
+            box-shadow: @MATERIAL_PIVOTGRID_DRAG_HEADER_SHADOW;
         }
     }
 

--- a/styles/widgets/material/popup.material.less
+++ b/styles/widgets/material/popup.material.less
@@ -17,12 +17,12 @@
 .dx-popup-wrapper {
     & > .dx-overlay-content {
         background: @overlay-content-bg;
-        .box-shadow(0px 11px 15px -7px fade(@base-shadow-color, 20%), 0px 24px 38px 3px fade(@base-shadow-color, 14%), 0px 9px 46px 8px fade(@base-shadow-color, 12%));
-        .border-radius(@popup-border-radius);
+        box-shadow: 0px 11px 15px -7px fade(@base-shadow-color, 20%), 0px 24px 38px 3px fade(@base-shadow-color, 14%), 0px 9px 46px 8px fade(@base-shadow-color, 12%);
+        border-radius: @popup-border-radius;
     }
 
     & > .dx-popup-fullscreen {
-        .border-radius(0);
+        border-radius: 0;
     }
 
     .dx-button {
@@ -45,7 +45,7 @@
 
     &.dx-toolbar {
         .dx-toolbar-sizing(@MATERIAL_TOOLBAR_HEIGHT, @MATERIAL_POPUP_TOOLBARTOP_PADDING, @MATERIAL_POPUP_TOOLBAR_LABEL_FONT_SIZE, @MATERIAL_POPUP_TOOLBAR_ITEM_SPACING );
-        .box-shadow(none);
+        box-shadow: none;
 
         .dx-button.dx-closebutton {
             display: block;

--- a/styles/widgets/material/progressBar.material.less
+++ b/styles/widgets/material/progressBar.material.less
@@ -12,7 +12,7 @@
     background-color: @progressbar-range-bg;
     margin-top: -1px;
 
-    .box-sizing(content-box);
+    box-sizing: content-box;
 }
 
 .dx-progressbar-animating-container {
@@ -20,7 +20,7 @@
     background-color: @progressbar-bg;
     background-size: @MATERIAL_BACKGROUND_WIDTH 5px;
 
-    .animation(loader 2s linear infinite);
+    animation: loader 2s linear infinite;
     .gradient-linear(@MATERIAL_PROGRESSBAR_INTERDETERMINATE_STATE_GRADIENT);
     background-repeat: repeat;
 }
@@ -31,7 +31,7 @@
     }
 
     .dx-progressbar-animating-container {
-        .animation(none);
+        animation: none;
         background-position-x: @MATERIAL_BACKGROUND_WIDTH / 2;
     }
 }
@@ -48,7 +48,7 @@
 .dx-rtl {
     .dx-progressbar, &.dx-progressbar {
         .dx-progressbar-animating-container {
-            .animation(loader-rtl 2s linear infinite);
+            animation: loader-rtl 2s linear infinite;
             .gradient-linear(@MATERIAL_PROGRESSBAR_INTERDETERMINATE_STATE_GRADIENT);
             background-repeat: repeat;
         }

--- a/styles/widgets/material/radioButton.material.less
+++ b/styles/widgets/material/radioButton.material.less
@@ -32,8 +32,8 @@
         display: block;
         position: absolute;
         z-index: 1;
-        .scale(0.5);
-        .transition(@MATERIAL_RADIOBUTTON_RIPPLE_TRANSITION);
+        transform: scale(0.5);
+        transition: @MATERIAL_RADIOBUTTON_RIPPLE_TRANSITION;
     }
 
     &:before {
@@ -43,8 +43,8 @@
         border: @MATERIAL_RADIOBUTTON_BORDER_WIDTH solid @radiogroup-border-color;
         background-color: @radiogroup-bg;
         content: "";
-        .border-radius(@MATERIAL_RADIOBUTTON_SIZE / 2);
-        .box-sizing(content-box);
+        border-radius: @MATERIAL_RADIOBUTTON_SIZE / 2;
+        box-sizing: content-box;
     }
 }
 
@@ -61,7 +61,7 @@
         height: @MATERIAL_RADIOBUTTON_DOT_SIZE;
         background: @radiogroup-checked-bg;
         content: "";
-        .border-radius(@MATERIAL_RADIOBUTTON_DOT_SIZE / 2);
+        border-radius: @MATERIAL_RADIOBUTTON_DOT_SIZE / 2;
     }
 }
 
@@ -72,7 +72,7 @@
     &.dx-state-focused {
         .dx-radiobutton-icon:after {
             background-color: fade(@base-text-color, 10%);
-            .scale(1);
+            transform: scale(1);
         }
     }
 
@@ -81,7 +81,7 @@
         &.dx-state-focused {
             .dx-radiobutton-icon-checked:after {
                 background-color: fade(@radiogroup-checked-bg, 10%);
-                .scale(1);
+                transform: scale(1);
             }
         }
     }
@@ -124,7 +124,7 @@
 
             .dx-radiobutton-icon:after {
                 background-color: fade(@radiobutton-invalid-focused-border-color, 10%);
-                .scale(1);
+                transform: scale(1);
             }
         }
     }

--- a/styles/widgets/material/scheduler.material.less
+++ b/styles/widgets/material/scheduler.material.less
@@ -370,7 +370,7 @@
     }
     .dx-overlay-content {
         border: none;
-        .box-shadow(0 7px 25px rgba(0, 0, 0, 0.25));
+        box-shadow: 0 7px 25px rgba(0, 0, 0, 0.25);
         .dx-popup-content.dx-scheduler-appointment-tooltip {
             width:  @MATERIAL_SCHEDULER_APPOINTMENT_TOOLTIP_WIDTH;
             padding: 0;
@@ -524,7 +524,7 @@
     z-index: 1;
 
     &.dx-button-has-icon:not(.dx-button-has-text) {
-        .border-radius(2px);
+        border-radius: 2px;
     }
 }
 
@@ -537,7 +537,7 @@
     padding-right: @MATERIAL_SCHEDULER_NAVIGATOR_HEIGHT + 14;
     z-index: 0;
     background-color: rgba(0,0,0,0.05);
-    .border-radius(@base-border-radius);
+    border-radius: @base-border-radius;
 
     .dx-rtl & {
         left: @MATERIAL_SCHEDULER_SWITCHER_LABEL_OFFSET;
@@ -667,7 +667,7 @@
     }
 
     &.dx-scheduler-focused-cell {
-        .box-shadow(none);
+        box-shadow: none;
     }
 }
 
@@ -780,17 +780,17 @@
             color: @scheduler-appointment-focus-color;
         }
 
-        .box-shadow(none);
+        box-shadow: none;
 
         &.dx-state-active,
         &.dx-resizable-resizing,
         &.dx-draggable-dragging,
         &.dx-state-hover,
         &.dx-state-hover.dx-resizable {
-            .box-shadow(none);
+            box-shadow: none;
         }
 
-        .border-radius(2px);
+        border-radius: 2px;
     }
 }
 

--- a/styles/widgets/material/scrollView.material.less
+++ b/styles/widgets/material/scrollView.material.less
@@ -2,7 +2,7 @@
 
 .dx-scrollable-native.dx-scrollable-native-android .dx-scrollview-pull-down {
     background-color: @scrollable-bg;
-    .box-shadow(0 1px 4px 0 @scrollview-shadow-color);
+    box-shadow: 0 1px 4px 0 @scrollview-shadow-color;
 }
 
 .dx-scrollview-scrollbottom-loading {

--- a/styles/widgets/material/scrollable.material.less
+++ b/styles/widgets/material/scrollable.material.less
@@ -10,7 +10,7 @@
     background-color: transparent;
     opacity: 1;
     overflow: hidden;
-    .transition(~"opacity 0s linear");
+    transition: opacity 0s linear;
 
     .dx-rtl & {
         padding-left: 0;
@@ -20,7 +20,7 @@
 
 .dx-scrollable-scroll.dx-state-invisible {
     opacity: 0;
-    .transition(~"opacity .5s linear 1s");
+    transition: opacity .5s linear 1s;
 }
 
 .dx-scrollable-scroll-content {
@@ -51,20 +51,20 @@
 
     &.dx-scrollbar-hoverable {
         width: @SCROLLBAR_SIZE_THIN;
-        .transition(~"width .2s linear .15s, background-color .2s linear .15s");
+        transition: width .2s linear .15s, background-color .2s linear .15s;
 
         .dx-scrollable-scroll {
-            .transition(~"background-color .5s linear 1s, width .2s linear 150ms");
+            transition: background-color .5s linear 1s, width .2s linear 150ms;
 
             .dx-scrollable-scroll-content {
-                .transition(~"box-shadow .15s linear .15s, background-color .15s linear .15s");
+                transition: box-shadow .15s linear .15s, background-color .15s linear .15s;
             }
 
             &.dx-state-invisible {
-                .transition(~"background-color .5s linear 1s, width .2s linear .15s");
+                transition: background-color .5s linear 1s, width .2s linear .15s;
 
                 .dx-scrollable-scroll-content {
-                    .transition(~"box-shadow .5s linear 1s, background-color .5s linear 1s");
+                    transition: box-shadow .5s linear 1s, background-color .5s linear 1s;
                 }
             }
         }
@@ -86,20 +86,20 @@
 
     &.dx-scrollbar-hoverable {
         height: @SCROLLBAR_SIZE_THIN;
-        .transition(~"height .2s linear .15s, background-color .2s linear .15s");
+        transition: height .2s linear .15s, background-color .2s linear .15s;
 
         .dx-scrollable-scroll {
-            .transition(~"background-color .5s linear 1s, height .2s linear .15s");
+            transition: background-color .5s linear 1s, height .2s linear .15s;
 
             .dx-scrollable-scroll-content {
-                .transition(~"box-shadow .15s linear .15s, background-color .15s linear .15s");
+                transition: box-shadow .15s linear .15s, background-color .15s linear .15s;
             }
 
             &.dx-state-invisible {
-                .transition(~"background-color .5s linear 1s, height .2s linear .15s");
+                transition: background-color .5s linear 1s, height .2s linear .15s;
 
                 .dx-scrollable-scroll-content {
-                    .transition(~"box-shadow .5s linear 1s, background-color .5s linear 1s");
+                    transition: box-shadow .5s linear 1s, background-color .5s linear 1s;
                 }
             }
         }

--- a/styles/widgets/material/selectBox.material.less
+++ b/styles/widgets/material/selectBox.material.less
@@ -1,6 +1,6 @@
 .dx-selectbox-popup-wrapper {
     .dx-overlay-content {
-        .box-shadow(@dropdown-widgets-shadow);
+        box-shadow: @dropdown-widgets-shadow;
     }
 
     .dx-popup-content {

--- a/styles/widgets/material/slideOutView.material.less
+++ b/styles/widgets/material/slideOutView.material.less
@@ -13,7 +13,7 @@
 
 .dx-slideout-sizing() {
     .dx-slideoutview-content {
-        .box-sizing(content-box);
+        box-sizing: content-box;
         margin-left: -@MATERIAL_SLIDEOUTVIEW_BORDER_WIDTH;
         border-style: solid;
         border-width: 0 @MATERIAL_SLIDEOUTVIEW_BORDER_WIDTH;

--- a/styles/widgets/material/slider.material.less
+++ b/styles/widgets/material/slider.material.less
@@ -47,7 +47,7 @@
     margin-right: -@MATERIAL_SLIDER_HANDLE_SIZE / 2;
     width: @MATERIAL_SLIDER_HANDLE_SIZE;
     height: @MATERIAL_SLIDER_HANDLE_SIZE;
-    .border-radius(@MATERIAL_SLIDER_RADIUS);
+    border-radius: @MATERIAL_SLIDER_RADIUS;
 
     &:after {
         position: absolute;
@@ -60,7 +60,7 @@
         height: @MATERIAL_SLIDER_HANDLE_INNER_SIZE;
         background: @material-slider-bg;
         content: "";
-        .border-radius(@MATERIAL_SLIDER_RADIUS);
+        border-radius: @MATERIAL_SLIDER_RADIUS;
     }
 
     .dx-tooltip-wrapper {

--- a/styles/widgets/material/switch.material.less
+++ b/styles/widgets/material/switch.material.less
@@ -52,8 +52,8 @@
     &.dx-state-active,
     &.dx-state-focused {
         .dx-switch-handle:before {
-            .box-shadow(@MATERIAL_SWITCH_SHADOW);
-            .border-radius(50%)
+            box-shadow: @MATERIAL_SWITCH_SHADOW;
+            border-radius: 50%;
         }
     }
 }
@@ -62,8 +62,8 @@
 .dx-switch {
     &.dx-state-readonly.dx-state-focused {
         .dx-switch-handle:before {
-            .box-shadow(@MATERIAL_SWITCH_SHADOW);
-            .border-radius(50%)
+            box-shadow: @MATERIAL_SWITCH_SHADOW;
+            border-radius: 50%;
         }
     }
 }
@@ -78,7 +78,7 @@
         content: '';
         width: 100%;
         height: 14px;
-        .border-radius(500px);
+        border-radius: 500px;
         background-color: @switch-bg;
         margin: 3px 0;
     }
@@ -120,8 +120,8 @@
     width: @MATERIAL_SWITCH_HEIGHT;
     height: @MATERIAL_SWITCH_HEIGHT;
     background-color: @switch-handle-off-bg;
-    .box-shadow(@MATERIAL_SWITCH_HANDLE_SHADOW);
-    .border-radius(@switch-handle-border-radius);
+    box-shadow: @MATERIAL_SWITCH_HANDLE_SHADOW;
+    border-radius: @switch-handle-border-radius;
 
     &:before {
         display: block;
@@ -129,8 +129,8 @@
         width: 100%;
         height: 100%;
         background-color: @switch-handle-off-bg;
-        .border-radius(@switch-handle-border-radius);
-        .transition(@MATERIAL_SWITCH_TRANSITION);
+        border-radius: @switch-handle-border-radius;
+        transition: @MATERIAL_SWITCH_TRANSITION;
     }
 }
 
@@ -146,8 +146,8 @@
     &.dx-state-active,
     &.dx-state-focused {
         .dx-switch-handle:before {
-            .box-shadow(@MATERIAL_ON_VALUE_SWITCH_SHADOW);
-            .border-radius(50%)
+            box-shadow: @MATERIAL_ON_VALUE_SWITCH_SHADOW;
+            border-radius: 50%;
         }
     }
 }

--- a/styles/widgets/material/tabs.material.less
+++ b/styles/widgets/material/tabs.material.less
@@ -28,12 +28,12 @@
     position: absolute;
     height: @MATERIAL_TAB_HEIGHT;
 
-    .border-radius(0);
-    .box-shadow(none);
+    border-radius: 0;
+    box-shadow: none;
 
     &.dx-button.dx-tabs-nav-button.dx-button-has-icon:not(.dx-button-has-text) {
         .dx-button-flat-color-styling(@base-icon-color);
-        .border-radius(0);
+        border-radius: 0;
     }
 
     .dx-button-content {

--- a/styles/widgets/material/tagBox.material.less
+++ b/styles/widgets/material/tagBox.material.less
@@ -88,7 +88,7 @@
     min-width: 40px;
     background-color: @tagbox-tag-bg;
     color: @tagbox-tag-color;
-    .border-radius(@tagbox-tag-border-radius);
+    border-radius: @tagbox-tag-border-radius;
 }
 
 .dx-tag-remove-button {
@@ -113,8 +113,8 @@
         line-height: 16px;
         color: @tagbox-tag-button-remove-color;
         background-color: @tagbox-tag-button-remove-bg;
-        .border-radius(50%);
-        .transform(none);
+        border-radius: 50%;
+        transform: none;
     }
 }
 

--- a/styles/widgets/material/textEditor.material.less
+++ b/styles/widgets/material/textEditor.material.less
@@ -71,7 +71,7 @@
     &:before {
         .dx-texteditor-borders-position();
         z-index: 2;
-        .scale(0);
+        transform: scale(0);
     }
 
     &:after {
@@ -83,8 +83,8 @@
 
         &:before {
             border-bottom: 2px solid @texteditor-focused-border-color;
-            .scale(1);
-            .transition-transform(0.6s, cubic-bezier(0.4, 0, 0.02, 1));
+            transform: scale(1);
+            transition: transform 0.6s cubic-bezier(0.4, 0, 0.02, 1);
         }
     }
 
@@ -248,7 +248,7 @@
     .dx-icon-clear {
         color: @texteditor-button-clear-icon-color;
         background-color: @texteditor-button-clear-icon-color-bg;
-        .border-radius(50%);
+        border-radius: 50%;
         .dx-texteditor-icon();
         .dx-icon-font-centered-sizing(@MATERIAL_TEXTEDITOR_CLEAR_ICON_SIZE);
     }

--- a/styles/widgets/material/toast.material.less
+++ b/styles/widgets/material/toast.material.less
@@ -10,8 +10,8 @@
     font-size: @MATERIAL_BASE_FONT_SIZE;
     font-weight: 400;
     padding: @MATERIAL_TOAST_CONTENT_PADDING;
-    .border-radius(@toast-border-radius);
-    .box-shadow(0 2px 3px rgba(0, 0 ,0 ,0.25));
+    border-radius: @toast-border-radius;
+    box-shadow: 0 2px 3px rgba(0, 0 ,0 ,0.25);
 
     min-height: 48px;
     display: flex;

--- a/styles/widgets/material/toolbar.material.less
+++ b/styles/widgets/material/toolbar.material.less
@@ -170,12 +170,12 @@
     .dx-button-onlyicon-sizing();
 
     &.dx-button-has-icon.dx-button-has-text {
-        .border-radius(50%);
+        border-radius: 50%;
     }
 }
 
 .dx-toolbar-menu-action .dx-button.dx-button-has-icon:not(.dx-button-has-text) {
-    .border-radius(0);
+    border-radius: 0;
 }
 
 .dx-toolbar .dx-tab {

--- a/styles/widgets/material/tooltip.material.less
+++ b/styles/widgets/material/tooltip.material.less
@@ -2,8 +2,8 @@
     .dx-overlay-content {
         background-color: @tooltip-bg;
         color: @tooltip-color;
-        .box-shadow(none);
-        .border-radius(@tooltip-border-radius);
+        box-shadow: none;
+        border-radius: @tooltip-border-radius;
         .dx-popup-content {
             padding: 6px 8px;
             font-size: 12px;

--- a/styles/widgets/ui.less
+++ b/styles/widgets/ui.less
@@ -3,7 +3,7 @@
 }
 
 .dx-translate-disabled {
-    .transform(e("none !important"));
+    transform: none !important;
 }
 
 .dx-hidden-input {
@@ -23,7 +23,7 @@
 }
 
 .dx-gesture-cover {
-    .transform(e("translate3d(0,0,0)"));
+    transform: translate3d(0, 0, 0);
     position: fixed;
     top: 0;
     right: 0;
@@ -267,32 +267,32 @@
 .dx-win-pop-animation {
 
     &.dx-enter.dx-forward {
-        .scale(0.5);
+        transform: scale(0.5);
         opacity: 0;
     }
 
     &.dx-enter.dx-enter-active.dx-forward {
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     &.dx-leave.dx-leave-active.dx-forward {
-        .scale(1.5);
+        transform: scale(1.5);
         opacity: 0;
     }
 
     &.dx-enter.dx-backward {
-        .scale(1.5);
+        transform: scale(1.5);
         opacity: 0;
     }
 
     &.dx-enter.dx-enter-active.dx-backward {
-        .scale(1);
+        transform: scale(1);
         opacity: 1;
     }
 
     &.dx-leave.dx-leave-active.dx-backward {
-        .scale(0.5);
+        transform: scale(0.5);
         opacity: 0;
     }
 }

--- a/styles/widgets/win10/actionSheet.win10.less
+++ b/styles/widgets/win10/actionSheet.win10.less
@@ -40,7 +40,7 @@
 .dx-actionsheet-popup-wrapper {
     .dx-overlay-content {
         border: none;
-        .box-shadow(none);
+        box-shadow: none;
     }
 }
 

--- a/styles/widgets/win10/dataGrid.win10.less
+++ b/styles/widgets/win10/dataGrid.win10.less
@@ -11,7 +11,7 @@
     margin-top: 8px;
     vertical-align: middle;
     font-size: @WIN10_BASE_FONT_SIZE;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 
     .dx-group-panel-message {
         color: @datagrid-headers-color;

--- a/styles/widgets/win10/dropDownEditor.win10.less
+++ b/styles/widgets/win10/dropDownEditor.win10.less
@@ -92,6 +92,6 @@
     .dx-overlay-content {
         background-color: @WIN10_DROPDOWNEDITOR_POPUP_BACKGROUND_COLOR;
         border: none;
-        .box-shadow(none);
+        box-shadow: none;
     }
 }

--- a/styles/widgets/win10/gridBase.win10.less
+++ b/styles/widgets/win10/gridBase.win10.less
@@ -275,7 +275,7 @@
 
     .dx-@{widgetName}-column-chooser {
         .dx-overlay-content {
-            .box-shadow(0px 1px 3px rgba(0, 0, 0, 0.2));
+            box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
 
             .dx-popup-content {
                 margin: 0px;
@@ -289,7 +289,7 @@
                     border: ~"@{@{widgetName}-headers-border}";
                     padding: @GRID_BASE_CELL_PADDING;
                     background-color: @WIN10_BACKGROUND_COLOR;
-                    .box-shadow(0px 1px 3px -1px rgba(0, 0, 0, 0.2));
+                    box-shadow: 0px 1px 3px -1px rgba(0, 0, 0, 0.2);
                 }
             }
 
@@ -317,7 +317,7 @@
     }
 
     .dx-@{widgetName}-drag-header {
-        .box-shadow(@GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @GRID_BASE_DRAG_HEADER_SECOND_SHADOW);
+        box-shadow: @GRID_BASE_DRAG_HEADER_FIRST_SHADOW, @GRID_BASE_DRAG_HEADER_SECOND_SHADOW;
         font-size: 12pt;
         padding: @GRID_BASE_CELL_PADDING;
         color: @WIN10_LIGHT_COLOR;
@@ -346,7 +346,7 @@
     .dx-data-row.dx-state-hover {
         &:not(.dx-selection):not(.dx-row-inserted):not(.dx-row-removed):not(.dx-edit-row) {
             & > td:not(.dx-focused) {
-                .text-shadow(none);
+                text-shadow: none;
                 background-color: ~"@{@{widgetName}-hover-background}";
                 color: ~"@{@{widgetName}-hover-color}";
 
@@ -357,7 +357,7 @@
 
             & > .dx-@{widgetName}-readonly:not(.dx-focused) .dx-texteditor {
                 .dx-texteditor-input {
-                    .text-shadow(none);
+                    text-shadow: none;
                     background-color: ~"@{@{widgetName}-hover-background}";
                     color: ~"@{@{widgetName}-hover-color}";
                 }
@@ -379,7 +379,7 @@
 
     .dx-@{widgetName}-headers {
         color: ~"@{@{widgetName}-headers-color}";
-        .touch-action(pinch-zoom);
+        touch-action: pinch-zoom;
 
         .dx-@{widgetName}-table {
             .dx-row {
@@ -561,7 +561,7 @@
         }
 
         .dx-selection.dx-row, .dx-selection.dx-row:hover {
-            .text-shadow(none);
+            text-shadow: none;
             color: ~"@{@{widgetName}-selection-color}";
 
             & > td, & > tr > td {
@@ -613,7 +613,7 @@
     }
 
     .dx-@{widgetName}-search-text {
-        .text-shadow(none);
+        text-shadow: none;
         color: ~"@{@{widgetName}-search-text-color}";
         background-color: ~"@{@{widgetName}-search-text-background}";
     }

--- a/styles/widgets/win10/loadIndicator.win10.less
+++ b/styles/widgets/win10/loadIndicator.win10.less
@@ -10,8 +10,8 @@
     width: 100%;
     height: 100%;
     opacity: 0;
-    .transform(rotate(180deg));
-    .animation(dx-win-loadindicator-orbit 5s infinite);
+    transform: rotate(180deg);
+    animation: dx-win-loadindicator-orbit 5s infinite;
 
     &:before {
         content: "";
@@ -21,23 +21,23 @@
         background: @WIN10_LOADINDICATOR_ACCENT_COLOR;
         top: 0;
         left: 0;
-        .border-radius(100%);
+        border-radius: 100%;
     }
 
     &.dx-loadindicator-segment1 {
-        .animation-delay(240ms);
+        animation-delay: 240ms;
     }
 
     &.dx-loadindicator-segment2 {
-        .animation-delay(480ms);
+        animation-delay: 480ms;
     }
 
     &.dx-loadindicator-segment3 {
-        .animation-delay(720ms);
+        animation-delay: 720ms;
     }
 
     &.dx-loadindicator-segment4 {
-        .animation-delay(960ms);
+        animation-delay: 960ms;
     }
 
     @-webkit-keyframes dx-win-loadindicator-orbit {

--- a/styles/widgets/win10/loadPanel.win10.less
+++ b/styles/widgets/win10/loadPanel.win10.less
@@ -1,5 +1,5 @@
 .dx-loadpanel-content {
     border: 1px solid @WIN10_LOADPANEL_BORDER_COLOR;
     background-color: @WIN10_LOADPANEL_BACKGROUND_COLOR;
-    .border-radius(0);
+    border-radius: 0;
 }

--- a/styles/widgets/win10/lookup.win10.less
+++ b/styles/widgets/win10/lookup.win10.less
@@ -111,7 +111,7 @@
     &.dx-popup-wrapper {
         .dx-overlay-content {
             border: 1px solid @WIN10_POPUP_BORDER_COLOR;
-            .box-shadow(0 5px 25px 0 @WIN10_POPUP_SHADOW_COLOR);
+            box-shadow: 0 5px 25px 0 @WIN10_POPUP_SHADOW_COLOR;
         }
     }
 

--- a/styles/widgets/win10/popup.win10.less
+++ b/styles/widgets/win10/popup.win10.less
@@ -9,7 +9,7 @@
     & > .dx-overlay-content {
         background-color: @WIN10_POPUP_BACKGROUND_COLOR;
         border: 1px solid @WIN10_POPUP_BORDER_COLOR;
-        .box-shadow(0 5px 25px 0 @WIN10_POPUP_SHADOW_COLOR);
+        box-shadow: 0 5px 25px 0 @WIN10_POPUP_SHADOW_COLOR;
     }
 }
 

--- a/styles/widgets/win10/progressBar.win10.less
+++ b/styles/widgets/win10/progressBar.win10.less
@@ -15,11 +15,11 @@
     height: 4px;
     width: 4px;
     background-color: @WIN10_PROGRESSBAR_ACCENT_COLOR;
-    .border-radius(50%);
+    border-radius: 50%;
 
-    .animation(loader 4s infinite);
-    .animation-timing(cubic-bezier(0.030, 0.615, 0.995, 0.415));
-    .animation-fill-mode();
+    animation: loader 4s infinite;
+    animation-timing-function: cubic-bezier(0.030, 0.615, 0.995, 0.415);
+    animation-fill-mode: both;
 }
 
 .dx-state-disabled.dx-progressbar {
@@ -30,7 +30,7 @@
     }
 
     .dx-progressbar-animating-segment {
-        .animation(none);
+        animation: none;
         background-color: @WIN10_PROGRESSBAR_ACCENT_COLOR;
     }
 
@@ -60,28 +60,28 @@
     .dx-progressbar-animating-segment {
         left: auto;
         right: 0;
-        .animation-name(loader-rtl);
+        animation-name: loader-rtl;
     }
 }
 
 .dx-progressbar-animating-segment-1 {
-    .animation-delay(1s);
+    animation-delay: 1s;
 }
 
 .dx-progressbar-animating-segment-2 {
-    .animation-delay(0.8s);
+    animation-delay: 0.8s;
 }
 
 .dx-progressbar-animating-segment-3 {
-    .animation-delay(0.6s);
+    animation-delay: 0.6s;
 }
 
 .dx-progressbar-animating-segment-4 {
-    .animation-delay(0.4s);
+    animation-delay: 0.4s;
 }
 
 .dx-progressbar-animating-segment-5 {
-    .animation-delay(0.2s);
+    animation-delay: 0.2s;
 }
 
 @-webkit-keyframes loader {

--- a/styles/widgets/win10/switch.win10.less
+++ b/styles/widgets/win10/switch.win10.less
@@ -13,7 +13,7 @@
     background-color: @WIN10_SWITCH_OFF_ALTERNATE_COLOR;
     padding: @WIN10_SWITCH_CONTAINER_PADDING;
     margin-top: -5px;
-    .border-radius(@WIN10_SWITCH_CONTAINER_BORDER_RADIUS);
+    border-radius: @WIN10_SWITCH_CONTAINER_BORDER_RADIUS;
 }
 
 .dx-switch-inner {
@@ -48,7 +48,7 @@
         height: @WIN10_SWITCH_HANDLE_SIZE;
         width: @WIN10_SWITCH_HANDLE_SIZE;
         background-color: @WIN10_SWITCH_OFF_COLOR;
-        .border-radius(50%);
+        border-radius: 50%;
     }
 }
 

--- a/styles/widgets/win10/tabs.win10.less
+++ b/styles/widgets/win10/tabs.win10.less
@@ -53,7 +53,7 @@
         display: inline-block;
         vertical-align: middle;
         font-size: 16px;
-        .border-radius(50%);
+        border-radius: 50%;
     }
 
     &.dx-state-hover, &.dx-state-focused {

--- a/styles/widgets/win10/tagBox.win10.less
+++ b/styles/widgets/win10/tagBox.win10.less
@@ -79,7 +79,7 @@
     line-height: 16px;
 
     &:before {
-        .transform(none);
+        transform: none;
     }
 
     &:after {

--- a/styles/widgets/win10/toast.win10.less
+++ b/styles/widgets/win10/toast.win10.less
@@ -12,7 +12,7 @@
 .dx-toast-icon {
     width: 25px;
     height: 25px;
-    .background-size-prop(contain);
+    background-size: contain;
 }
 
 .dx-toast-info {

--- a/styles/widgets/win10/tooltip.win10.less
+++ b/styles/widgets/win10/tooltip.win10.less
@@ -5,7 +5,7 @@
     .dx-overlay-content {
         background-color: @WIN10_TOOLTIP_BACKGROUND_COLOR;
         border-color: @WIN10_TOOLTIP_BORDER_COLOR;
-        .box-shadow(none);
+        box-shadow: none;
 
         .dx-popup-content {
             font-size: @WIN10_TOOLTIP_FONT_SIZE;

--- a/styles/widgets/win8/actionSheet.win8.less
+++ b/styles/widgets/win8/actionSheet.win8.less
@@ -8,14 +8,14 @@
             background: transparent;
             color: @WIN8_BASE_TEXT;
             text-align: left;
-            .backface-visibility(hidden);
-            .transition-duration(100ms);
+            backface-visibility: hidden;
+            transition-duration: 100ms;
             .dx-theme-win8-typography.dx-font-s;
-            .transition-property(transform);
+            transition-property: transform;
             line-height: 1.7;
 
             &.dx-state-active {
-                .translate(2px, 2px);
+                transform: translate(2px, 2px);
             }
         }
 

--- a/styles/widgets/win8/calendar.win8.less
+++ b/styles/widgets/win8/calendar.win8.less
@@ -84,7 +84,7 @@
     }
 
     .dx-button:before {
-        .box-sizing(content-box);
+        box-sizing: content-box;
     }
 }
 

--- a/styles/widgets/win8/colorView.win8.less
+++ b/styles/widgets/win8/colorView.win8.less
@@ -12,7 +12,7 @@
 .dx-colorview-container {
     label {
         input {
-            .border-radius(0);
+            border-radius: 0;
         }
     }
 }

--- a/styles/widgets/win8/dataGrid.win8.less
+++ b/styles/widgets/win8/dataGrid.win8.less
@@ -270,7 +270,7 @@
 
 .dx-datagrid-column-chooser {
     .dx-overlay-content {
-        .box-shadow(0px 1px 3px rgba(0, 0, 0, 0.2));
+        box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2);
 
         .dx-popup-content {
             margin: 0px;
@@ -282,7 +282,7 @@
                 border: @WIN8_DATAGRID_HEADERS_BORDER;
                 padding: @WIN8_DATAGRID_CELL_PADDING;
                 background-color: @WIN8_BASE_BACKGROUND;
-                .box-shadow(0px 1px 3px -1px rgba(0, 0, 0, 0.2));
+                box-shadow: 0px 1px 3px -1px rgba(0, 0, 0, 0.2);
             }
         }
 
@@ -296,7 +296,7 @@
 }
 
 .dx-datagrid-drag-header {
-    .box-shadow(@WIN8_DATAGRID_DRAG_HEADER_FIRST_SHADOW, @WIN8_DATAGRID_DRAG_HEADER_SECOND_SHADOW);
+    box-shadow: @WIN8_DATAGRID_DRAG_HEADER_FIRST_SHADOW, @WIN8_DATAGRID_DRAG_HEADER_SECOND_SHADOW;
     .dx-datagrid-header-text;
     padding: @WIN8_DATAGRID_CELL_PADDING;
     color: @WIN8_WHITE_COLOR;
@@ -325,7 +325,7 @@
 .dx-data-row.dx-state-hover {
     &:not(.dx-selection):not(.dx-row-inserted):not(.dx-row-removed):not(.dx-edit-row) {
         & > td:not(.dx-focused) {
-            .text-shadow(none);
+            text-shadow: none;
             background-color: @WIN8_DATAGRID_HOVER_BACKGROUND;
             color: @WIN8_DATAGRID_HOVER_COLOR;
 
@@ -336,7 +336,7 @@
 
         & > .dx-datagrid-readonly:not(.dx-focused) .dx-texteditor {
             .dx-texteditor-input {
-                .text-shadow(none);
+                text-shadow: none;
                 background-color: @WIN8_DATAGRID_HOVER_BACKGROUND;
                 color: @WIN8_DATAGRID_HOVER_COLOR;
             }
@@ -358,7 +358,7 @@
 
 .dx-datagrid-headers {
     color: @WIN8_DATAGRID_HEADERS_COLOR;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 
     .dx-datagrid-table {
         .dx-row {
@@ -493,7 +493,7 @@
 
 .dx-datagrid-group-panel {
     margin-bottom: @WIN8_DATAGRID_HEADER_PANEL_MARGIN_BOTTOM;
-    .touch-action(pinch-zoom);
+    touch-action: pinch-zoom;
 
     .dx-group-panel-message {
         color: @WIN8_DATAGRID_HEADERS_COLOR;
@@ -591,7 +591,7 @@
     }
 
     .dx-selection.dx-row, .dx-selection.dx-row:hover {
-        .text-shadow(none);
+        text-shadow: none;
         color: @WIN8_DATAGRID_SELECTION_COLOR;
 
         & > td, & > tr > td {
@@ -641,7 +641,7 @@
 }
 
 .dx-datagrid-search-text {
-    .text-shadow(none);
+    text-shadow: none;
     color: @WIN8_DATAGRID_SEARCH_TEXT_COLOR;
     background-color: @WIN8_DATAGRID_SEARCH_TEXT_BACKGROUND;
 }

--- a/styles/widgets/win8/dateBox.win8.less
+++ b/styles/widgets/win8/dateBox.win8.less
@@ -59,7 +59,7 @@
                 min-width: 0;
                 width: @BOTTOM_BUTTON_WIDTH;
                 height: @BOTTOM_BUTTON_HEIGHT;
-                .border-radius(@BOTTOM_BUTTON_BORDER_RADIUS);
+                border-radius: @BOTTOM_BUTTON_BORDER_RADIUS;
 
                 .dx-button-text {
                     display: none;

--- a/styles/widgets/win8/dateView.win8.less
+++ b/styles/widgets/win8/dateView.win8.less
@@ -15,7 +15,7 @@
 
 .dx-dateviewroller {
     height: @ROLLER_HEIGHT;
-    .flex-item(0, 1, auto);
+    flex: 0 1 auto;
 
     .dx-scrollable-content:before,
     .dx-scrollable-content:after {

--- a/styles/widgets/win8/dropDownList.win8.less
+++ b/styles/widgets/win8/dropDownList.win8.less
@@ -70,7 +70,7 @@
         .dx-list-item {
 
             &.dx-state-active .dx-list-item-content {
-                .translate(3px, 1px);
+                transform: translate(3px, 1px);
             }
         }
     }

--- a/styles/widgets/win8/gallery.win8.less
+++ b/styles/widgets/win8/gallery.win8.less
@@ -17,7 +17,7 @@
 .dx-gallery-nav-button-prev,
 .dx-gallery-nav-button-next {
     .dx-icon-font-centered-sizing(36px);
-    .border-radius(50%);
+    border-radius: 50%;
     border: @WIN8_GALLERY_NAV_BUTTON_BORDER;
     color: @WIN8_GALLERY_NAV_BUTTON_COLOR;
 
@@ -35,7 +35,7 @@
     width: 15px;
     height: 6px;
     background: @WIN8_WHITE_COLOR;
-    .box-shadow(~"0 0 1px 1px rgba(50,50,50,.3)");
+    box-shadow: 0 0 1px 1px rgba(50,50,50,.3);
 }
 
 .dx-gallery-indicator-item-selected {

--- a/styles/widgets/win8/list.win8.less
+++ b/styles/widgets/win8/list.win8.less
@@ -45,10 +45,10 @@
     .dx-theme-win8-typography.dx-font-s;
 
     &.dx-state-active .dx-list-item-content {
-        .translate(5px, 1px);
+        transform: translate(5px, 1px);
 
         .dx-rtl & {
-            .translate(-5px, 1px);
+            transform: translate(-5px, 1px);
         }
     }
 }
@@ -91,7 +91,7 @@
         background-image: @WIN8_LIST_DELETE_SWITCH_BACKGROUND;
         background-position: center;
         background-repeat: no-repeat;
-        .background-size-prop(100%);
+        background-size: 100%;
     }
 
     .dx-list-select-checkbox,

--- a/styles/widgets/win8/loadIndicator.win8.less
+++ b/styles/widgets/win8/loadIndicator.win8.less
@@ -10,8 +10,8 @@
     width: 100%;
     height: 100%;
     opacity: 0;
-    .transform(rotate(180deg));
-    .animation(dx-win-loadindicator-orbit 4.95s infinite);
+    transform: rotate(180deg);
+    animation: dx-win-loadindicator-orbit 4.95s infinite;
 
     &:before {
         content: "";
@@ -21,27 +21,27 @@
         background: @WIN8_BASE_TEXT;
         top: 0;
         left: 0;
-        .border-radius(100%);
+        border-radius: 100%;
     }
 
     &.dx-loadindicator-segment0 {
-        .animation-delay(1.08s);
+        animation-delay: 1.08s;
     }
 
     &.dx-loadindicator-segment1 {
-        .animation-delay(0.22s);
+        animation-delay: 0.22s;
     }
 
     &.dx-loadindicator-segment2 {
-        .animation-delay(0.43s);
+        animation-delay: 0.43s;
     }
 
     &.dx-loadindicator-segment3 {
-        .animation-delay(0.65s);
+        animation-delay: 0.65s;
     }
 
     &.dx-loadindicator-segment4 {
-        .animation-delay(0.86s);
+        animation-delay: 0.86s;
     }
 
     @-webkit-keyframes dx-win-loadindicator-orbit {

--- a/styles/widgets/win8/loadPanel.win8.less
+++ b/styles/widgets/win8/loadPanel.win8.less
@@ -1,5 +1,5 @@
 .dx-loadpanel-content {
     background: @WIN8_LOAD_INDICATOR_BACKGROUND;
     border: 0;
-    .border-radius(0);
+    border-radius: 0;
 }

--- a/styles/widgets/win8/progressBar.win8.less
+++ b/styles/widgets/win8/progressBar.win8.less
@@ -20,10 +20,10 @@
     height: 5px;
     background-color: @WIN8_PROGRESSBAR_RANGE_COLOR;
     opacity: 0;
-    .border-radius(100%);
-    .animation(loader 4s infinite);
-    .animation-timing(cubic-bezier(0.030, 0.615, 0.995, 0.415));
-    .animation-fill-mode();
+    border-radius: 100%;
+    animation: loader 4s infinite;
+    animation-timing-function: cubic-bezier(0.030, 0.615, 0.995, 0.415);
+    animation-fill-mode: both;
 }
 
 .dx-state-disabled.dx-progressbar {
@@ -34,7 +34,7 @@
     }
 
     .dx-progressbar-animating-segment {
-        .animation(none);
+        animation: none;
         opacity: 1;
         background-color: @WIN8_PROGRESSBAR_DISABLED_STATE_RANGE_COLOR;
     }
@@ -65,32 +65,32 @@
     .dx-progressbar-animating-segment {
         left: auto;
         right: 0px;
-        .animation-name(loader-rtl);
-        .animation-duration(4s);
-        .animation-iteration-count(infinite);
-        .animation-timing(cubic-bezier(0.030, 0.615, 0.995, 0.415));
-        .animation-fill-mode();
+        animation-name: loader-rtl;
+        animation-duration: 4s;
+        animation-iteration-count: infinite;
+        animation-timing-function: cubic-bezier(0.030, 0.615, 0.995, 0.415);
+        animation-fill-mode: both;
     }
 }
 
 .dx-progressbar-animating-segment-1 {
-    .animation-delay(1s);
+    animation-delay: 1s;
 }
 
 .dx-progressbar-animating-segment-2 {
-    .animation-delay(0.8s);
+    animation-delay: 0.8s;
 }
 
 .dx-progressbar-animating-segment-3 {
-    .animation-delay(0.6s);
+    animation-delay: 0.6s;
 }
 
 .dx-progressbar-animating-segment-4 {
-    .animation-delay(0.4s);
+    animation-delay: 0.4s;
 }
 
 .dx-progressbar-animating-segment-5 {
-    .animation-delay(0.2s);
+    animation-delay: 0.2s;
 }
 
 @-webkit-keyframes loader {

--- a/styles/widgets/win8/radioButton.win8.less
+++ b/styles/widgets/win8/radioButton.win8.less
@@ -12,7 +12,7 @@
         height: 16px;
         background-color: @WIN8_TEXTEDITOR_BACKGROUND;
         content: "";
-        .border-radius(8px);
+        border-radius: 8px;
     }
 }
 
@@ -21,7 +21,7 @@
     width: 8px;
     height: 8px;
     background: @WIN8_BLACK_COLOR;
-    .border-radius(4px);
+    border-radius: 4px;
 }
 
 .dx-radio-value-container {
@@ -31,21 +31,21 @@
 .dx-state-focused {
     &.dx-radiobutton .dx-radiobutton-icon:before {
         background-color: @WIN8_RADIOBUTTON_FOCUS_BACKGROUND;
-        .box-shadow(@WIN8_RADIOGROUP_SHADOW);
+        box-shadow: @WIN8_RADIOGROUP_SHADOW;
     }
 }
 
 .dx-state-hover {
     &.dx-radiobutton .dx-radiobutton-icon:before {
         background-color: @WIN8_RADIOBUTTON_HOVER_BACKGROUND;
-        .box-shadow(@WIN8_RADIOGROUP_SHADOW);
+        box-shadow: @WIN8_RADIOGROUP_SHADOW;
     }
 }
 
 .dx-state-active {
     &.dx-radiobutton .dx-radiobutton-icon:before {
         background-color: @WIN8_RADIOBUTTON_ACTIVE_BACKGROUND;
-        .box-shadow(@WIN8_RADIOGROUP_SHADOW);
+        box-shadow: @WIN8_RADIOGROUP_SHADOW;
     }
 }
 

--- a/styles/widgets/win8/tabs.win8.less
+++ b/styles/widgets/win8/tabs.win8.less
@@ -58,7 +58,7 @@
         .dx-icon-sizing(@WIN8_TAB_ICON_SIZE * @WIN8_TAB_ICON_PART, @WIN8_TAB_ICON_SIZE, @WIN8_TAB_ICON_BORDER_WIDTH);
         border: @WIN8_TABS_IMG_BORDER;
         margin: 0 5px 0 0;
-        .border-radius(50%);
+        border-radius: 50%;
         color: @WIN8_TABS_ICON_COLOR;
     }
 }

--- a/styles/widgets/win8/toast.win8.less
+++ b/styles/widgets/win8/toast.win8.less
@@ -8,7 +8,7 @@
 .dx-toast-icon {
     width: 25px;
     height: 25px;
-    .background-size-prop(contain);
+    background-size: contain;
 }
 
 .dx-toast-default-color {

--- a/styles/widgets/win8/toolbar.win8.less
+++ b/styles/widgets/win8/toolbar.win8.less
@@ -96,10 +96,10 @@
     padding: @WIN8_TOOLBAR_BUTTON_PADDING;
 
     .dx-icon {
-        .box-sizing();
+        box-sizing: border-box;
         .dx-icon-sizing(@WIN8_TOOLBAR_BUTTON_ICON_SIZE, @WIN8_TOOLBAR_BUTTON_ICON_CONTAINER_SIZE, @WIN8_TOOLBAR_BUTTON_ICON_BORDER_WIDTH);
         border: 2px solid @WIN8_BASE_TEXT;
-        .border-radius(50%);
+        border-radius: 50%;
     }
 
     .dx-button-has-icon {
@@ -210,7 +210,7 @@
 }
 
 .dx-toolbar .dx-toolbar-button .dx-icon {
-    .box-sizing();
+    box-sizing: border-box;
 }
 
 .dx-toolbar-menu-section {


### PR DESCRIPTION
@AntonSermyazhko added CSS autoprefixer in the #5148. So we can remove the most part of mixins.
This PR resolves #6403 
