### PR TITLE
Fix toolbar interaction issue for the HtmlEditor with readOnly state (T701863)

### DIFF
--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -247,23 +247,23 @@ class ToolbarModule extends BaseModule {
             e.preventDefault();
         });
 
-        this.toolbarInstance = this._editorInstance._createComponent($toolbar, Toolbar, this._prepareToolbarConfig());
+        this.toolbarInstance = this._editorInstance._createComponent($toolbar, Toolbar, this.toolbarConfig);
 
-        this._editorInstance.on("optionChanged", (args) => {
-            if(args.name === "readOnly" || args.name === "disabled") {
-                this.toolbarInstance.option("disabled", this._isInteractionDisabled());
+        this._editorInstance.on("optionChanged", ({ name }) => {
+            if(name === "readOnly" || name === "disabled") {
+                this.toolbarInstance.option("disabled", this.isInteractionDisabled);
             }
         });
     }
 
-    _prepareToolbarConfig() {
+    get toolbarConfig() {
         return {
             dataSource: this._prepareToolbarItems(),
-            disabled: this._isInteractionDisabled()
+            disabled: this.isInteractionDisabled
         };
     }
 
-    _isInteractionDisabled() {
+    get isInteractionDisabled() {
         return this._editorInstance.option("readOnly") || this._editorInstance.option("disabled");
     }
 

--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -237,7 +237,6 @@ class ToolbarModule extends BaseModule {
 
     _renderToolbar() {
         const container = this.options.container || this._getContainer();
-        const toolbarItems = this._prepareToolbarItems();
         const $toolbar = $("<div>")
             .addClass(TOOLBAR_CLASS)
             .appendTo(container);
@@ -248,7 +247,24 @@ class ToolbarModule extends BaseModule {
             e.preventDefault();
         });
 
-        this.toolbarInstance = this._editorInstance._createComponent($toolbar, Toolbar, { dataSource: toolbarItems });
+        this.toolbarInstance = this._editorInstance._createComponent($toolbar, Toolbar, this._prepareToolbarConfig());
+
+        this._editorInstance.on("optionChanged", (args) => {
+            if(args.name === "readOnly" || args.name === "disabled") {
+                this.toolbarInstance.option("disabled", this._isInteractionDisabled());
+            }
+        });
+    }
+
+    _prepareToolbarConfig() {
+        return {
+            dataSource: this._prepareToolbarItems(),
+            disabled: this._isInteractionDisabled()
+        };
+    }
+
+    _isInteractionDisabled() {
+        return this._editorInstance.option("readOnly") || this._editorInstance.option("disabled");
     }
 
     clean() {

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarIntegration.tests.js
@@ -8,6 +8,7 @@ const TOOLBAR_FORMAT_WIDGET_CLASS = "dx-htmleditor-toolbar-format";
 const DROPDOWNMENU_CLASS = "dx-dropdownmenu-button";
 const BUTTON_CONTENT_CLASS = "dx-button-content";
 const QUILL_CONTAINER_CLASS = "dx-quill-container";
+const STATE_DISABLED_CLASS = "dx-state-disabled";
 
 const { test } = QUnit;
 
@@ -122,5 +123,43 @@ QUnit.module("Toolbar integration", {
 
         assert.ok($toolbarContainer.hasClass(TOOLBAR_WRAPPER_CLASS), "Container has wrapper class");
         assert.equal($toolbarContainer.find(`.${TOOLBAR_CLASS}`).length, 1, "Toolbar container contains the htmlEditor's toolbar");
+    });
+
+    test("Toolbar should be disabled once editor is read only", (assert) => {
+        $("#htmlEditor").dxHtmlEditor({
+            readOnly: true,
+            toolbar: { items: ["bold"] }
+        });
+
+        const isToolbarDisabled = $(`.${TOOLBAR_CLASS}`).hasClass(STATE_DISABLED_CLASS);
+        assert.ok(isToolbarDisabled);
+    });
+
+    test("Toolbar should be disabled once editor is disabled", (assert) => {
+        $("#htmlEditor").dxHtmlEditor({
+            disabled: true,
+            toolbar: { items: ["bold"] }
+        });
+
+        const isToolbarDisabled = $(`.${TOOLBAR_CLASS}`).hasClass(STATE_DISABLED_CLASS);
+        assert.ok(isToolbarDisabled);
+    });
+
+    test("Toolbar should correctly update disabled state on the option changed", (assert) => {
+        const editor = $("#htmlEditor").dxHtmlEditor({
+            disabled: true,
+            readOnly: true,
+            toolbar: { items: ["bold"] }
+        }).dxHtmlEditor("instance");
+        const $toolbar = $(`.${TOOLBAR_CLASS}`);
+
+        editor.option("disabled", false);
+        assert.ok($toolbar.hasClass(STATE_DISABLED_CLASS));
+
+        editor.option("readOnly", false);
+        assert.notOk($toolbar.hasClass(STATE_DISABLED_CLASS));
+
+        editor.option("disabled", true);
+        assert.ok($toolbar.hasClass(STATE_DISABLED_CLASS));
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -71,6 +71,7 @@ const simpleModuleConfig = {
                 _createComponent: ($element, widget, options) => {
                     return new widget($element, options);
                 },
+                option: noop,
                 on: noop
             }
         };
@@ -117,6 +118,7 @@ const dialogModuleConfig = {
                     return new widget($element, options);
                 },
                 on: noop,
+                option: noop,
                 formDialogOption: this.formDialogOptionStub,
                 showFormDialog: (formConfig) => {
                     return this.formDialog.show(formConfig);


### PR DESCRIPTION
The toolbar shouldn't be interactive if editor's `disabled` and/or `readOnly` options are true.
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
