### PR TITLE
fix themebuilder not using custom items without swatch (T703972)

### DIFF
--- a/themebuilder/modules/less-template-loader.js
+++ b/themebuilder/modules/less-template-loader.js
@@ -14,8 +14,9 @@ const createModifyVars = modifyVars => {
 };
 
 const addSwatchClass = (less, swatchSelector, modifyVars) => {
-    if(!swatchSelector) return less + createModifyVars(modifyVars);
-    return swatchSelector + "{" + less + createModifyVars(modifyVars) + "}";
+    const lessWithVars = less + createModifyVars(modifyVars);
+    if(!swatchSelector) return lessWithVars;
+    return swatchSelector + "{" + lessWithVars + "}";
 };
 
 class LessFontPlugin {

--- a/themebuilder/modules/less-template-loader.js
+++ b/themebuilder/modules/less-template-loader.js
@@ -14,7 +14,7 @@ const createModifyVars = modifyVars => {
 };
 
 const addSwatchClass = (less, swatchSelector, modifyVars) => {
-    if(!swatchSelector) return less;
+    if(!swatchSelector) return less + createModifyVars(modifyVars);
     return swatchSelector + "{" + less + createModifyVars(modifyVars) + "}";
 };
 


### PR DESCRIPTION
Fix for https://www.devexpress.com/Support/Center/Question/Details/T703972/devextreme-cli-themebuilder-not-using-custom-settings-unless-using-swatch-selector