### PR TITLE
Parse dates formatted with escaped pattern chars

### DIFF
--- a/js/localization/ldml/date.parser.js
+++ b/js/localization/ldml/date.parser.js
@@ -166,7 +166,7 @@ var getRegExpInfo = function(format, dateParts) {
 
     var addPreviousStub = function() {
         if(stubText) {
-            patterns.push(stubText);
+            patterns.push("'" + stubText + "'");
             regexpText += escapeRegExp(stubText) + ")";
             stubText = "";
         }
@@ -237,7 +237,11 @@ var setPatternPartFromNow = function(date, pattern, now) {
 
 var getShortPatterns = function(fullPatterns) {
     return fullPatterns.map(function(pattern) {
-        return pattern[0] === "H" ? "h" : pattern[0];
+        if(pattern[0] === "'") {
+            return "";
+        } else {
+            return pattern[0] === "H" ? "h" : pattern[0];
+        }
     });
 };
 
@@ -271,7 +275,9 @@ var getParser = function(format, dateParts) {
                 orderedFormatPatterns = getOrderedFormatPatterns(formatPatterns);
 
             orderedFormatPatterns.forEach(function(pattern, index) {
-                if(index < ORDERED_PATTERNS.length && index > maxPatternIndex) return;
+                if(!pattern || (index < ORDERED_PATTERNS.length && index > maxPatternIndex)) {
+                    return;
+                }
 
                 var patternIndex = formatPatterns.indexOf(pattern);
                 if(patternIndex >= 0) {

--- a/js/ui/date_box/ui.date_box.mask.parts.js
+++ b/js/ui/date_box/ui.date_box.mask.parts.js
@@ -79,7 +79,7 @@ const renderDateParts = (text, regExpInfo) => {
         start = end;
         end = start + result[i].length;
 
-        let pattern = regExpInfo.patterns[i - 1],
+        let pattern = regExpInfo.patterns[i - 1].replace(/^'|'$/g, ""),
             getter = getPatternGetter(pattern[0]);
 
         sections.push({

--- a/testing/tests/DevExpress.localization/ldml.tests.js
+++ b/testing/tests/DevExpress.localization/ldml.tests.js
@@ -19,6 +19,13 @@ QUnit.test("parse with escaped chars", function(assert) {
     assert.deepEqual(parser("Monday, 12. November 2018 um 14:15:16"), date, "parse correct date string");
 });
 
+QUnit.test("parse with escaped pattern chars", function(assert) {
+    var date = new Date(2018, 0, 1, 0, 0, 0),
+        parser = getDateParser("'dd' yyyy", dateParts);
+
+    assert.deepEqual(parser("dd 2018"), date, "parse correct date string");
+});
+
 QUnit.test("parse dd/MM/yyyy format", function(assert) {
     var parser = getDateParser("dd/MM/yyyy"),
         date = new Date(2017, 8, 22);
@@ -305,6 +312,6 @@ QUnit.module("getRegExpInfo method");
 QUnit.test("getRegExpInfo should return correct pattern set when stub is in the end", function(assert) {
     var regExpInfo = getRegExpInfo("EEE, MMMM, dd, HH:mm:ss '(stub)'", dateParts);
     assert.deepEqual(regExpInfo.patterns, [
-        "EEE", ", ", "MMMM", ", ", "dd", ", ", "HH", ":", "mm", ":", "ss", " (stub)"
+        "EEE", "', '", "MMMM", "', '", "dd", "', '", "HH", "':'", "mm", "':'", "ss", "' (stub)'"
     ]);
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
@@ -235,6 +235,14 @@ if(devices.real().deviceType === "desktop") {
                 text: ":"
             });
         });
+
+        QUnit.test("Pattern stub", (assert) => {
+            const parts = renderDateParts("dd 2016", dateParser.getRegExpInfo("'dd' yyyy", dateLocalization));
+
+            assert.equal(parts.length, 2, "there are 2 parts rendered");
+            assert.ok(parts[0].isStub, "first part is the stub");
+            assert.notOk(parts[1].isStub, "second part is not the stub");
+        });
     });
 
     QUnit.module("Date parts find", setupModule, () => {


### PR DESCRIPTION
This PR fixes an issue with devextreme-intl.
When the user uses format `'dd' yyyy` and text `dd 2016`, the parser returned an invalid date.
After this changes, the dates with special LDML chars in the format will be parsed correctly