### PR TITLE
Fix HtmlEditor toolbar dialog width in the IE11 (T702531)

### DIFF
--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -23,6 +23,7 @@ const TOOLBAR_FORMAT_WIDGET_CLASS = "dx-htmleditor-toolbar-format";
 const TOOLBAR_SEPARATOR_CLASS = "dx-htmleditor-toolbar-separator";
 const TOOLBAR_MENU_SEPARATOR_CLASS = "dx-htmleditor-toolbar-menu-separator";
 const ACTIVE_FORMAT_CLASS = "dx-format-active";
+const BOX_ITEM_CONTENT_CLASS = "dx-box-item-content";
 
 const ICON_CLASS = "dx-icon";
 
@@ -365,6 +366,11 @@ class ToolbarModule extends BaseModule {
                     dataField: formatName,
                     editorType: "dxColorView",
                     editorOptions: {
+                        onContentReady: (e) => {
+                            $(e.element)
+                                .closest(`.${BOX_ITEM_CONTENT_CLASS}`)
+                                .css("flexBasis", "auto"); // WA for the T590137
+                        },
                         focusStateEnabled: false
                     },
                     label: { visible: false }

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -34,6 +34,7 @@ const COLOR_VIEW_HEX_FIELD_CLASS = "dx-colorview-label-hex";
 const TEXTEDITOR_INPUT_CLASS = "dx-texteditor-input";
 const DROPDOWNEDITOR_ICON_CLASS = "dx-dropdowneditor-icon";
 const LIST_ITEM_CLASS = "dx-list-item";
+const BOX_ITEM_CONTENT_CLASS = "dx-box-item-content";
 
 const BOLD_FORMAT_CLASS = "dx-bold-format";
 const ITALIC_FORMAT_CLASS = "dx-italic-format";
@@ -719,10 +720,12 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         const $form = $(`.${FORM_CLASS}`);
         const $colorView = $form.find(`.${COLORVIEW_CLASS}`);
         const $hexValueInput = $colorView.find(`.${COLOR_VIEW_HEX_FIELD_CLASS} .${TEXTEDITOR_INPUT_CLASS}`);
+        const $boxItemContent = $colorView.closest(`.${BOX_ITEM_CONTENT_CLASS}`);
 
-        assert.equal($form.length, 1, "Form shown");
-        assert.equal($colorView.length, 1, "Form contains ColorView");
-        assert.equal($hexValueInput.val(), "000000", "Base value");
+        assert.strictEqual($form.length, 1, "Form shown");
+        assert.strictEqual($colorView.length, 1, "Form contains ColorView");
+        assert.strictEqual($hexValueInput.val(), "000000", "Base value");
+        assert.strictEqual($boxItemContent.css("flexBasis"), "auto", "Box item content flex-basis is 'auto'");
     });
 
     test("show color dialog when formatted text selected", (assert) => {


### PR DESCRIPTION
It is duplicate of the [T590137](https://isc.devexpress.com/Thread/WorkplaceDetails/T590137). Issue is related to the incorrect rendering of the flex element(dxForm) nested into an absolutely positioned container(dxPopup). I suggest to use WA from **T590137** to fix the **T702531**