### PR TITLE
DataGrid - Fix the "Cannot read property 'split' of undefined" error if one negative condition is specified inside another (T707084)

### DIFF
--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -399,7 +399,7 @@ function getFilterExpression(value, fields, customOperations, target) {
 
     if(isNegationGroup(value)) {
         let filterExpression = getFilterExpression(value[1], fields, customOperations, target);
-        return ["!", isCondition(filterExpression) || isNegationGroup(filterExpression) ? [filterExpression] : filterExpression];
+        return ["!", filterExpression];
     }
     let criteria = getGroupCriteria(value);
     if(isCondition(criteria)) {

--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -354,7 +354,7 @@ function convertToInnerStructure(value, customOperations) {
     if(isNegationGroup(value)) {
         return ["!", isCondition(value[1])
             ? [convertToInnerCondition(value[1], customOperations), AND_GROUP_OPERATION]
-            : isNegationGroup(value[1]) ? [convertToInnerStructure(value[1], customOperations)] : convertToInnerGroup(value[1], customOperations)];
+            : isNegationGroup(value[1]) ? [convertToInnerStructure(value[1], customOperations), AND_GROUP_OPERATION] : convertToInnerGroup(value[1], customOperations)];
     }
     return convertToInnerGroup(value, customOperations);
 }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
@@ -395,4 +395,26 @@ QUnit.module("Real dataGrid", {
         assert.equal($(".dx-popup-content .dx-filterbuilder").length, 1);
     });
 
+    // T707084
+    QUnit.test("The one negative condition is specified inside another", function(assert) {
+        // arrange, act
+        this.initDataGrid({
+            dataSource: [{ field: 1 }, { field: 2 }, { field: 3 }],
+            customizeColumns: function(columns) {
+            },
+            columns: [{
+                dataField: "field",
+                dataType: "number"
+            }],
+            filterPanel: { visible: true },
+            filterValue: ["!", ["!", ["field", "=", 1]]],
+            loadingTimeout: null
+        });
+
+        // act
+        this.dataGrid.option("filterBuilderPopup.visible", true);
+
+        // assert
+        assert.equal($(".dx-popup-content .dx-filterbuilder").length, 1);
+    });
 });

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -873,7 +873,13 @@ QUnit.module("Filter normalization", function() {
         var group = [
             "!",
             [
-                ["!", [condition1, "and"]],
+                [
+                    "!",
+                    [
+                        [condition1, "and"],
+                        "and"
+                    ]
+                ],
                 "and"
             ]
         ];
@@ -1378,26 +1384,6 @@ QUnit.module("Custom filter expressions", {
 
         // act, assert
         assert.deepEqual(utils.getFilterExpression(value, fields, []), ["field", "=", "2"]);
-    });
-
-    QUnit.test("calculateFilterExpression for negative group with inner negative group", function(assert) {
-        // arrange
-        var fields = [{
-                dataField: "field",
-                defaultCalculateFilterExpression: function() {
-                    return value;
-                }
-            }],
-            value = ["field", "=", "1"];
-
-        // act, assert
-        assert.deepEqual(utils.getFilterExpression([
-            "!",
-            ["!", value]
-        ], fields, []), [
-            "!",
-            ["!", value]
-        ]);
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -711,7 +711,8 @@ QUnit.module("Convert to inner structure", function() {
                         ],
                         "and"
                     ]
-                ]
+                ],
+                "and"
             ]
         ]);
     });

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -701,14 +701,16 @@ QUnit.module("Convert to inner structure", function() {
         assert.deepEqual(model, [
             "!",
             [
-                "!",
                 [
+                    "!",
                     [
-                        "CompanyName",
-                        "=",
-                        "Super Mart of the West"
-                    ],
-                    "and"
+                        [
+                            "CompanyName",
+                            "=",
+                            "Super Mart of the West"
+                        ],
+                        "and"
+                    ]
                 ]
             ]
         ]);
@@ -1141,7 +1143,7 @@ QUnit.module("Custom filter expressions", {
     QUnit.test("calculateFilterExpression for negative group with one condition", function(assert) {
         var value = ["!", ["field", "=", 1]],
             normalizedFields = utils.getNormalizedFields([{ dataField: "field" }]);
-        assert.deepEqual(utils.getFilterExpression(value, normalizedFields, [], "filterBuilder"), ["!", ["field", "=", 1]]);
+        assert.deepEqual(utils.getFilterExpression(value, normalizedFields, [], "filterBuilder"), ["!", [["field", "=", 1]]]);
     });
 
     QUnit.test("calculateFilterExpression for isBlank (string field)", function(assert) {
@@ -1393,7 +1395,7 @@ QUnit.module("Custom filter expressions", {
             ["!", value]
         ], fields, []), [
             "!",
-            ["!", value]
+            [["!", [value]]]
         ]);
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -1144,7 +1144,7 @@ QUnit.module("Custom filter expressions", {
     QUnit.test("calculateFilterExpression for negative group with one condition", function(assert) {
         var value = ["!", ["field", "=", 1]],
             normalizedFields = utils.getNormalizedFields([{ dataField: "field" }]);
-        assert.deepEqual(utils.getFilterExpression(value, normalizedFields, [], "filterBuilder"), ["!", [["field", "=", 1]]]);
+        assert.deepEqual(utils.getFilterExpression(value, normalizedFields, [], "filterBuilder"), ["!", ["field", "=", 1]]);
     });
 
     QUnit.test("calculateFilterExpression for isBlank (string field)", function(assert) {
@@ -1396,7 +1396,7 @@ QUnit.module("Custom filter expressions", {
             ["!", value]
         ], fields, []), [
             "!",
-            [["!", [value]]]
+            ["!", value]
         ]);
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -166,6 +166,7 @@ QUnit.module("Utils", function() {
         assert.equal(utils.getGroupValue(["!", ["column", "operation", "value"]]), "!and");
         assert.equal(utils.getGroupValue([["column", "operation", "value"]]), "and");
         assert.equal(utils.getGroupValue([["column", "operation", "value"], ["column", "operation", "value"]]), "and");
+        assert.equal(utils.getGroupValue(["!", ["!", ["column", "operation", "value"]]]), "!and");
     });
 
     QUnit.test("getItems", function(assert) {
@@ -695,6 +696,24 @@ QUnit.module("Convert to inner structure", function() {
         ]);
     });
 
+    QUnit.test("from negative group with inner negative group", function(assert) {
+        var model = utils.convertToInnerStructure(["!", ["!", condition1]], []);
+        assert.deepEqual(model, [
+            "!",
+            [
+                "!",
+                [
+                    [
+                        "CompanyName",
+                        "=",
+                        "Super Mart of the West"
+                    ],
+                    "and"
+                ]
+            ]
+        ]);
+    });
+
     QUnit.test("with custom operation", function(assert) {
         var filter = ["State", "lastWeek"],
             model = utils.convertToInnerStructure(filter, [{ name: "lastWeek" }]);
@@ -845,6 +864,23 @@ QUnit.module("Filter normalization", function() {
 
         assert.deepEqual(group, [[condition1, "and", condition2], "and", [condition3, "and", condition2]]);
         assert.equal(group[2][0], condition3);
+    });
+
+    QUnit.test("get normalized filter from negative group with inner negative group", function(assert) {
+        var group = [
+            "!",
+            [
+                ["!", [condition1, "and"]],
+                "and"
+            ]
+        ];
+
+        group = utils.getNormalizedFilter(group);
+
+        assert.deepEqual(group, [
+            "!",
+            ["!", condition1]
+        ]);
     });
 });
 
@@ -1339,6 +1375,26 @@ QUnit.module("Custom filter expressions", {
 
         // act, assert
         assert.deepEqual(utils.getFilterExpression(value, fields, []), ["field", "=", "2"]);
+    });
+
+    QUnit.test("calculateFilterExpression for negative group with inner negative group", function(assert) {
+        // arrange
+        var fields = [{
+                dataField: "field",
+                defaultCalculateFilterExpression: function() {
+                    return value;
+                }
+            }],
+            value = ["field", "=", "1"];
+
+        // act, assert
+        assert.deepEqual(utils.getFilterExpression([
+            "!",
+            ["!", value]
+        ], fields, []), [
+            "!",
+            ["!", value]
+        ]);
     });
 });
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
