### PR TITLE
Disallow html in the message option of the dxDialog (T702830)

### DIFF
--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -111,7 +111,7 @@ exports.custom = function(options) {
         .appendTo(viewPortUtils.value());
 
     var $message = $("<div>").addClass(DX_DIALOG_MESSAGE_CLASSNAME)
-        .html(String(options.message));
+        .text(String(options.message));
 
     var popupToolbarItems = [];
 

--- a/testing/tests/DevExpress.ui/dialog.tests.js
+++ b/testing/tests/DevExpress.ui/dialog.tests.js
@@ -101,7 +101,7 @@ QUnit.test("dialog content", function(assert) {
     instance.show();
 
     assert.equal(this.dialog().find(".dx-popup-title").text(), this.title, "Actual title is equal to expected.");
-    assert.equal((this.dialog().find(".dx-dialog-message").html() || "").toLowerCase(), this.message.toLowerCase(), "Actual message is equal to expected.");
+    assert.equal((this.dialog().find(".dx-dialog-message").text() || "").toLowerCase(), this.message.toLowerCase(), "Actual message is equal to expected.");
     instance.hide();
 
     assert.ok(this.thereIsNoDialog(), "Dialog is not shown.");


### PR DESCRIPTION
This pull request disallows html tags in the message option of the dxDialog to prevent sequrity issue.
The type of the message option is the String in our documentation. The dxDialog is our realization of the native javascript alert that is not support html tags