### PR TITLE
Don't show ellipsis when there is no text inside the dxButton (T636219)

### DIFF
--- a/styles/widgets/common/button.less
+++ b/styles/widgets/common/button.less
@@ -19,7 +19,10 @@
 }
 
 .dx-button-content {
-    .dx-overflow();
+    .dx-button-has-text & {
+        .dx-overflow();
+    }
+
     height: 100%;
     max-height: 100%;
 


### PR DESCRIPTION
Showing ellipsis on text overflow is designed for dxButtons with long text, but there was a side effect: large icons are become ellipsis too.

This pull request disables ellipsis on text overflow when there is no text in the button