### PR TITLE
Don't set readonly attribute to the native date pickers (T692239)

### DIFF
--- a/js/ui/date_box/ui.date_box.base.js
+++ b/js/ui/date_box/ui.date_box.base.js
@@ -552,7 +552,7 @@ var DateBox = DropDownEditor.inherit({
     },
 
     _readOnlyPropValue: function() {
-        return this.callBase() || this._pickerType === PICKER_TYPE.rollers;
+        return this.callBase() && !this._isNativeType() || this._pickerType === PICKER_TYPE.rollers;
     },
 
     _clearButtonVisibility: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -174,6 +174,16 @@ QUnit.test("T204185 - dxDateBox input should be editable when pickerType is 'cal
     assert.ok(!$input.prop("readOnly"), "correct readOnly value");
 });
 
+QUnit.test("readonly property should not be applied to the native picker", function(assert) {
+    var $dateBox = $("#dateBox").dxDateBox({
+            pickerType: "native",
+            acceptCustomValue: false
+        }),
+        $input = $dateBox.find(".dx-texteditor-input");
+
+    assert.ok(!$input.prop("readOnly"), "correct readOnly value");
+});
+
 QUnit.test("T204179 - dxDateBox should not render dropDownButton only for generic device when pickerType is 'native'", function(assert) {
     var $dateBox = $("#dateBox").dxDateBox({
             pickerType: "native"


### PR DESCRIPTION
When the user sets `acceptCustomValue` to `false`, they wants to disable the input of a custom text to the editor. The dxDateBox adds readonly attribute to the input when `acceptCustomValue` is false.

This does not work in ios and android devices because they use native picker type. Native readonly input prevents rollers to show. This pull request removes the readonly attribute for the native picker type. The end-user still can not input custom text in the input even without readonly attribute on real devices.