### PR TITLE
Add the ability to search in a grouped array source in drop-down editors and list (T694197, T691665)

### DIFF
--- a/js/data/store_helper.js
+++ b/js/data/store_helper.js
@@ -53,11 +53,12 @@ function queryByOptions(query, options, isCountQuery) {
 
     if(group) {
         group = normalizeSortingInfo(group);
+        group.keepInitialKeyOrder = !!options.group.keepInitialKeyOrder;
     }
 
     if(sort || group) {
         sort = normalizeSortingInfo(sort || []);
-        if(group) {
+        if(group && !group.keepInitialKeyOrder) {
             sort = arrangeSortingInfo(group, sort);
         }
         each(sort, function(index) {

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -16,7 +16,8 @@ var $ = require("../../core/renderer"),
     messageLocalization = require("../../localization/message"),
     themes = require("../themes"),
     ChildDefaultTemplate = require("../widget/child_default_template"),
-    Deferred = require("../../core/utils/deferred").Deferred;
+    Deferred = require("../../core/utils/deferred").Deferred,
+    DataConverterMixin = require("../shared/grouped_data_converter_mixin").default;
 
 var LIST_ITEM_SELECTOR = ".dx-list-item",
     LIST_ITEM_DATA_KEY = "dxListItemData",
@@ -599,6 +600,10 @@ var DropDownList = DropDownEditor.inherit({
         };
     },
 
+    _getGroupedOption: function() {
+        return this.option("grouped");
+    },
+
     _dataSourceFromUrlLoadMode: function() {
         return "raw";
     },
@@ -889,7 +894,7 @@ var DropDownList = DropDownEditor.inherit({
         }
     }
 
-}).include(DataExpressionMixin);
+}).include(DataExpressionMixin, DataConverterMixin);
 
 registerComponent("dxDropDownList", DropDownList);
 

--- a/js/ui/list/ui.list.base.js
+++ b/js/ui/list/ui.list.base.js
@@ -23,7 +23,8 @@ var $ = require("../../core/renderer"),
     deviceDependentOptions = require("../scroll_view/ui.scrollable").deviceDependentOptions,
     CollectionWidget = require("../collection/ui.collection_widget.live_update").default,
     BindableTemplate = require("../widget/bindable_template"),
-    Deferred = require("../../core/utils/deferred").Deferred;
+    Deferred = require("../../core/utils/deferred").Deferred,
+    DataConverterMixin = require("../shared/grouped_data_converter_mixin").default;
 
 var LIST_CLASS = "dx-list",
     LIST_ITEM_CLASS = "dx-list-item",
@@ -611,6 +612,10 @@ var ListBase = CollectionWidget.inherit({
         return extend(this.callBase(), {
             paginate: commonUtils.ensureDefined(scrollBottom || nextButton, true)
         });
+    },
+
+    _getGroupedOption: function() {
+        return this.option("grouped");
     },
 
     _dataSourceFromUrlLoadMode: function() {
@@ -1283,7 +1288,7 @@ var ListBase = CollectionWidget.inherit({
         this._scrollView.scrollToElement($item);
     }
 
-});
+}).include(DataConverterMixin);
 
 ListBase.ItemClass = ListItem;
 

--- a/js/ui/shared/grouped_data_converter_mixin.js
+++ b/js/ui/shared/grouped_data_converter_mixin.js
@@ -1,0 +1,51 @@
+import { isObject } from "../../core/utils/type";
+
+const isCorrectStructure = data => {
+    return Array.isArray(data) && data.every(item => {
+        const hasTwoFields = Object.keys(item).length === 2;
+        const hasCorrectFields = "key" in item && "items" in item;
+
+        return hasTwoFields && hasCorrectFields && Array.isArray(item.items);
+    });
+};
+
+export default {
+    _getSpecificDataSourceOption: function() {
+        const groupKey = "key";
+        let dataSource = this.option("dataSource");
+        let hasSimpleItems = false;
+        let data = {};
+
+        if(this._getGroupedOption() && isCorrectStructure(dataSource)) {
+            data = dataSource.reduce((accumulator, item) => {
+                const items = item.items.map(innerItem => {
+                    if(!isObject(innerItem)) {
+                        innerItem = { text: innerItem };
+                        hasSimpleItems = true;
+                    }
+
+                    if(!(groupKey in innerItem)) {
+                        innerItem[groupKey] = item.key;
+                    }
+
+                    return innerItem;
+                });
+                return accumulator.concat(items);
+            }, []);
+
+            dataSource = {
+                store: {
+                    type: "array",
+                    data
+                },
+                group: { selector: "key", keepInitialKeyOrder: true }
+            };
+
+            if(hasSimpleItems) {
+                dataSource.searchExpr = "text";
+            }
+        };
+
+        return dataSource;
+    }
+};

--- a/js/ui/slide_out.js
+++ b/js/ui/slide_out.js
@@ -9,7 +9,8 @@ var $ = require("../core/renderer"),
     CollectionWidget = require("./collection/ui.collection_widget.edit"),
     List = require("./list"),
     ChildDefaultTemplate = require("./widget/child_default_template"),
-    EmptyTemplate = require("./widget/empty_template");
+    EmptyTemplate = require("./widget/empty_template"),
+    DataConverterMixin = require("./shared/grouped_data_converter_mixin").default;
 
 var SLIDEOUT_CLASS = "dx-slideout",
     SLIDEOUT_ITEM_CONTAINER_CLASS = "dx-slideout-item-container",
@@ -264,12 +265,11 @@ var SlideOut = CollectionWidget.inherit({
         this._list = this._createComponent($list, List, {
             itemTemplateProperty: "menuTemplate",
             selectionMode: this.option("selectionMode"),
-            selectedIndex: this.option("selectedIndex"),
             selectionRequired: this.option("selectionRequired"),
             indicateLoading: false,
             onItemClick: this._listItemClickHandler.bind(this),
             items: this.option("items"),
-            dataSource: this.option("dataSource"),
+            dataSource: this._dataSource,
             itemTemplate: this._getTemplateByOption("menuItemTemplate"),
             grouped: this.option("menuGrouped"),
             groupTemplate: this._getTemplateByOption("menuGroupTemplate"),
@@ -277,6 +277,12 @@ var SlideOut = CollectionWidget.inherit({
             onGroupRendered: this.option("onMenuGroupRendered"),
             onContentReady: this._updateSlideOutView.bind(this)
         });
+
+        this._list.option("selectedIndex", this.option("selectedIndex"));
+    },
+
+    _getGroupedOption: function() {
+        return this.option("menuGrouped");
     },
 
     _updateSlideOutView: function() {
@@ -459,7 +465,7 @@ var SlideOut = CollectionWidget.inherit({
     * @hidden
     * @inheritdoc
     */
-});
+}).include(DataConverterMixin);
 
 registerComponent("dxSlideOut", SlideOut);
 

--- a/testing/tests/DevExpress.data/storeArray.tests.js
+++ b/testing/tests/DevExpress.data/storeArray.tests.js
@@ -351,6 +351,32 @@ QUnit.test("sort/group by function (regression)", assert => {
 
 });
 
+QUnit.test("turn off sort in grouping", assert => {
+    const done = assert.async();
+
+    new ArrayStore([
+        { key: "c", text: "c1" },
+        { key: "a", text: "a1" }
+    ])
+        .load({
+            group: { selector: "key", keepInitialKeyOrder: true }
+        })
+        .done(data => {
+            assert.deepEqual(data, [
+                {
+                    key: "c",
+                    items: [{ key: "c", text: "c1" }]
+                },
+                {
+                    key: "a",
+                    items: [ { key: "a", text: "a1" }]
+                }
+            ]);
+
+            done();
+        });
+});
+
 QUnit.test("byKey", assert => {
     const done = assert.async();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -592,6 +592,26 @@ QUnit.test("dropDownList should search for a pasted value", function(assert) {
     assert.equal(searchSpy.callCount, 1, "widget searched for a suitable values");
 });
 
+QUnit.test("dropDownList should search in grouped DataSource", function(assert) {
+    var $element = $("#dropDownList").dxDropDownList({
+            grouped: true,
+            searchEnabled: true,
+            valueExpr: "name",
+            displayExpr: "name",
+            searchExpr: "name",
+            dataSource: [{ key: "a", items: [{ name: "1" }] }, { key: "b", items: [{ name: "2" }] }]
+        }),
+        instance = $element.dxDropDownList("instance"),
+        $input = $element.find("input"),
+        kb = keyboardMock($input),
+        expectedValue = { key: "b", items: [{ name: "2", key: "b" }] };
+
+    kb.type("2");
+    this.clock.tick(500);
+
+    assert.deepEqual(instance.option("items")[0], expectedValue, "widget searched for a suitable values");
+});
+
 QUnit.test("valueExpr should not be passed to the list if it is 'this'", function(assert) {
     // note: selection can not work with this and function as keyExpr.
     // Allowing of this breaks the case when store key is specified and deferred datasource is used

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -2285,8 +2285,8 @@ QUnit.test("list option bouncing", function(assert) {
 });
 
 QUnit.test("group options bouncing", function(assert) {
-    var dataSource = [{ key: "header", items: ["1", "2"] },
-            { key: "header", items: ["1", "2"] }],
+    var dataSource = [{ key: "header1", items: ["1", "2"] },
+            { key: "header2", items: ["1", "2"] }],
         $lookup = $("#lookupOptions").dxLookup({
             dataSource: dataSource,
             grouped: true,

--- a/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
@@ -2706,6 +2706,41 @@ QUnit.test("Search when searchMode is specified", function(assert) {
     assert.strictEqual(instance.getDataSource().searchOperation(), "startswith", "search operation");
 });
 
+QUnit.test("Search in items of grouped dataSource", function(assert) {
+    var $element = $("#list").dxList({
+            dataSource: [{ key: "a", items: [{ name: "1" }] }, { key: "b", items: [{ name: "2" }] }],
+            grouped: true,
+            searchEnabled: true,
+            searchExpr: "name"
+        }),
+        instance = $element.dxList("instance"),
+        expectedValue = { key: "a", items: [{ name: "1", key: "a" }] };
+
+    assert.equal(instance.getDataSource().searchExpr(), "name", "dataSource has correct searchExpr");
+
+    instance.option("searchValue", "1");
+
+    assert.deepEqual(instance.option("items")[0], expectedValue, "items");
+});
+
+QUnit.test("Search in items of grouped dataSource with simple items", function(assert) {
+    var $element = $("#list").dxList({
+            dataSource: [{ key: "a", items: ["1", "2"] }],
+            grouped: true,
+            searchEnabled: true
+        }),
+        instance = $element.dxList("instance"),
+        expectedItems = [{ key: "a", items: [ { text: "1", key: "a" }, { text: "2", key: "a" }] }],
+        expectedValue = { key: "a", items: [ { text: "1", key: "a" }] };
+
+    assert.deepEqual(instance.option("items"), expectedItems, "items have correct structure");
+    assert.equal(instance.getDataSource().searchExpr(), "text", "dataSource has correct searchExpr");
+
+    instance.option("searchValue", "1");
+
+    assert.deepEqual(instance.option("items")[0], expectedValue, "items");
+});
+
 // T582179
 QUnit.test("Selection should not be cleared after searching", function(assert) {
     var $element = $("#list").dxList({

--- a/testing/tests/DevExpress.ui.widgets/slideOut.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/slideOut.tests.js
@@ -381,7 +381,7 @@ QUnit.test("First slideout item content should be loaded when deferred data sour
             }
         });
 
-        clock.tick(100);
+        clock.tick(200);
 
         assert.equal(this.$element.find(".dx-list-item-selected").text(), "Item 2", "item is selected");
         assert.equal(this.$element.find(".dx-slideout-item-content").text(), "Item 2", "content was loaded");


### PR DESCRIPTION

The repeat of solution #6417 except _group.keepInitialKeyOrder_ option. It allows to not sort data after "ungrouping".