### PR TITLE
 Fix PointerEvent detection for the latest Edge and IE11 browsers (T673292)

### DIFF
--- a/js/core/utils/support.js
+++ b/js/core/utils/support.js
@@ -47,12 +47,17 @@ var detectTouchEvents = function(window, maxTouchPoints) {
     return (window.hasProperty("ontouchstart") || !!maxTouchPoints) && !window.hasProperty("callPhantom");
 };
 
-var touchEvents = detectTouchEvents(windowUtils, navigator.maxTouchPoints),
-    pointerEvents = !!navigator.pointerEnabled || !!navigator.msPointerEnabled,
-    touchPointersPresent = !!navigator.maxTouchPoints || !!navigator.msMaxTouchPoints;
+var detectPointerEvent = function(window, navigator) {
+    return window.hasProperty("PointerEvent") || !!navigator.pointerEnabled;
+};
+
+var touchEvents = detectTouchEvents(windowUtils, navigator.maxTouchPoints);
+var pointerEvents = detectPointerEvent(windowUtils, navigator);
+var touchPointersPresent = !!navigator.maxTouchPoints || !!navigator.msMaxTouchPoints;
 
 ///#DEBUG
 exports.detectTouchEvents = detectTouchEvents;
+exports.detectPointerEvent = detectPointerEvent;
 ///#ENDDEBUG
 exports.touchEvents = touchEvents;
 exports.pointerEvents = pointerEvents;

--- a/js/events/pointer.js
+++ b/js/events/pointer.js
@@ -1,11 +1,12 @@
-var support = require("../core/utils/support"),
-    each = require("../core/utils/iterator").each,
-    devices = require("../core/devices"),
-    registerEvent = require("./core/event_registrator"),
-    TouchStrategy = require("./pointer/touch"),
-    MsPointerStrategy = require("./pointer/mspointer"),
-    MouseStrategy = require("./pointer/mouse"),
-    MouseAndTouchStrategy = require("./pointer/mouse_and_touch");
+import support from "../core/utils/support";
+import { each } from "../core/utils/iterator";
+import browser from "../core/utils/browser";
+import devices from "../core/devices";
+import registerEvent from "./core/event_registrator";
+import TouchStrategy from "./pointer/touch";
+import MsPointerStrategy from "./pointer/mspointer";
+import MouseStrategy from "./pointer/mouse";
+import MouseAndTouchStrategy from "./pointer/mouse_and_touch";
 
 /**
   * @name ui events.dxpointerdown
@@ -64,13 +65,13 @@ var support = require("../core/utils/support"),
   * @module events/pointer
 */
 
-var EventStrategy = (function() {
-    if(support.pointerEvents) {
+const getStrategy = (support, device, browser) => {
+    if(support.pointerEvents && browser.msie) {
         return MsPointerStrategy;
     }
 
-    var device = devices.real();
-    if(support.touch && !(device.tablet || device.phone)) {
+    const { tablet, phone } = device;
+    if(support.touch && !(tablet || phone)) {
         return MouseAndTouchStrategy;
     }
 
@@ -79,13 +80,15 @@ var EventStrategy = (function() {
     }
 
     return MouseStrategy;
-})();
+};
 
-each(EventStrategy.map, function(pointerEvent, originalEvents) {
+const EventStrategy = getStrategy(support, devices.real(), browser);
+
+each(EventStrategy.map, (pointerEvent, originalEvents) => {
     registerEvent(pointerEvent, new EventStrategy(pointerEvent, originalEvents));
 });
 
-module.exports = {
+const pointer = {
     down: "dxpointerdown",
     up: "dxpointerup",
     move: "dxpointermove",
@@ -95,3 +98,9 @@ module.exports = {
     over: "dxpointerover",
     out: "dxpointerout"
 };
+
+///#DEBUG
+pointer.getStrategy = getStrategy;
+///#ENDDEBUG
+
+module.exports = pointer;

--- a/js/events/pointer/mspointer.js
+++ b/js/events/pointer/mspointer.js
@@ -1,18 +1,16 @@
 var BaseStrategy = require("./base"),
     Observer = require("./observer"),
-    windowUtils = require("../../core/utils/window"),
-    extend = require("../../core/utils/extend").extend,
-    onlyMSPointerSupport = !windowUtils.hasProperty("PointerEvent") && windowUtils.hasProperty("MSPointerEvent");
+    extend = require("../../core/utils/extend").extend;
 
 var eventMap = {
-    "dxpointerdown": onlyMSPointerSupport ? "MSPointerDown" : "pointerdown",
-    "dxpointermove": onlyMSPointerSupport ? "MSPointerMove" : "pointermove",
-    "dxpointerup": onlyMSPointerSupport ? "MSPointerUp" : "pointerup",
-    "dxpointercancel": onlyMSPointerSupport ? "MSPointerCancel" : "pointercancel",
-    "dxpointerover": onlyMSPointerSupport ? "MSPointerOver" : "pointerover",
-    "dxpointerout": onlyMSPointerSupport ? "MSPointerOut" : "pointerout",
-    "dxpointerenter": onlyMSPointerSupport ? "mouseenter" : "pointerenter",
-    "dxpointerleave": onlyMSPointerSupport ? "mouseleave" : "pointerleave"
+    "dxpointerdown": "pointerdown",
+    "dxpointermove": "pointermove",
+    "dxpointerup": "pointerup",
+    "dxpointercancel": "pointercancel",
+    "dxpointerover": "pointerover",
+    "dxpointerout": "pointerout",
+    "dxpointerenter": "pointerenter",
+    "dxpointerleave": "pointerleave"
 };
 
 var observer;

--- a/styles/widgets/common/list.less
+++ b/styles/widgets/common/list.less
@@ -172,7 +172,7 @@
         background-repeat: no-repeat;
         background-size: 75% 75%;
         background-position: center;
-        touch-action: pinch-zoom;
+        touch-action: manipulation;
 
         .dx-state-disabled & {
             cursor: default;

--- a/testing/helpers/nativePointerMock.js
+++ b/testing/helpers/nativePointerMock.js
@@ -52,17 +52,9 @@
                 "contextmenu": 1
             },
 
-            MS_POINTER_EVENTS = {
-                MSPointerOver: 1,
-                MSPointerOut: 1,
-                MSPointerDown: 1,
-                MSPointerUp: 1,
-                MSPointerMove: 1
-            },
-
             POINTER_EVENTS = {
                 "pointerover": 1,
-                "pointerOut": 1,
+                "pointerout": 1,
                 "pointerdown": 1,
                 "pointerup": 1,
                 "pointermove": 1
@@ -210,7 +202,7 @@
 
 
             if(isString(type)) {
-                if(!MOUSE_EVENTS[type.toLowerCase()] && !MS_POINTER_EVENTS[type] && !POINTER_EVENTS[type]) {
+                if(!MOUSE_EVENTS[type.toLowerCase()] && !POINTER_EVENTS[type]) {
                     throw Error("Event type '" + type + "' not supported.");
                 }
             } else {
@@ -515,7 +507,7 @@
         return function(target, type, options) {
             options = options || {};
 
-            if(MOUSE_EVENTS[type] || MS_POINTER_EVENTS[type] || POINTER_EVENTS[type]) {
+            if(MOUSE_EVENTS[type] || POINTER_EVENTS[type]) {
                 simulateMouseEvent(target, type, options.bubbles,
                     options.cancelable, options.view, options.detail, options.screenX,
                     options.screenY, options.clientX, options.clientY, options.ctrlKey,
@@ -554,29 +546,16 @@
         };
     })();
 
-    var pointerEventsSupport = navigator.pointerEnabled,
-        msPointerEventsSupport = !!window.MSPointerEvent && !pointerEventsSupport;
+    var pointerEventsSupport = !!window.PointerEvent;
 
     var simulatePointerEvent = function($element, type, options) {
         options = $.extend({
-            canBubble: true,
+            bubbles: true,
             cancelable: true,
             type: type
         }, options);
 
-        var event = document.createEvent(msPointerEventsSupport ? "MSPointerEvent" : "pointerEvent");
-
-        var args = [];
-        $.each(["type", "canBubble", "cancelable", "view", "detail", "screenX", "screenY", "clientX", "clientY", "ctrlKey", "altKey",
-            "shiftKey", "metaKey", "button", "relatedTarget", "offsetX", "offsetY", "width", "height", "pressure", "rotation", "tiltX",
-            "tiltY", "pointerId", "pointerType", "hwTimestamp", "isPrimary"], function(i, name) {
-            if(name in options) {
-                args.push(options[name]);
-            } else {
-                args.push(event[name]);
-            }
-        });
-        event.initPointerEvent.apply(event, args);
+        var event = new PointerEvent(type, options);
 
         $element[0].dispatchEvent(event);
     };
@@ -832,7 +811,7 @@
             },
 
             pointerDown: function() {
-                var eventName = msPointerEventsSupport ? "MSPointerDown" : "pointerdown";
+                var eventName = "pointerdown";
                 try {
                     simulatePointerEvent($element, eventName, { clientX: _x, clientY: _y, pointerType: "mouse", pointerId: 1 });
                 } catch(e) {
@@ -842,7 +821,7 @@
             },
 
             pointerMove: function(deltaX, deltaY) {
-                var eventName = msPointerEventsSupport ? "MSPointerMove" : "pointermove";
+                var eventName = "pointermove";
 
                 _x += deltaX || 0;
                 _y += deltaY || 0;
@@ -855,7 +834,7 @@
             },
 
             pointerUp: function() {
-                var eventName = msPointerEventsSupport ? "MSPointerUp" : "pointerup";
+                var eventName = "pointerup";
                 try {
                     simulatePointerEvent($element, eventName, { clientX: _x, clientY: _y, pointerType: "mouse", pointerId: 1 });
                 } catch(e) {
@@ -865,7 +844,7 @@
             },
 
             pointerCancel: function() {
-                var eventName = msPointerEventsSupport ? "MSPointerCancel" : "pointercancel";
+                var eventName = "pointercancel";
                 try {
                     simulatePointerEvent($element, eventName, { clientX: _x, clientY: _y, pointerType: "mouse", pointerId: 1 });
                 } catch(e) {
@@ -914,7 +893,7 @@
             down: function(x, y) {
                 _x = x || _x;
                 _y = y || _y;
-                pointerEventsSupport || msPointerEventsSupport ? this.pointerDown() : this.touchStart();
+                pointerEventsSupport ? this.pointerDown() : this.touchStart();
                 this.mouseDown();
                 return this;
             },
@@ -923,14 +902,14 @@
                 if($.isArray(x)) {
                     this.move.apply(this, x);
                 } else {
-                    pointerEventsSupport || msPointerEventsSupport ? this.pointerMove(x, y) : this.touchMove(x, y);
+                    pointerEventsSupport ? this.pointerMove(x, y) : this.touchMove(x, y);
                     this.mouseMove();
                 }
                 return this;
             },
 
             up: function() {
-                pointerEventsSupport || msPointerEventsSupport ? this.pointerUp() : this.touchEnd();
+                pointerEventsSupport ? this.pointerUp() : this.touchEnd();
                 this.mouseUp();
                 this.click(true);
                 return this;

--- a/testing/tests/DevExpress.ui.events/pointer.tests.js
+++ b/testing/tests/DevExpress.ui.events/pointer.tests.js
@@ -14,3 +14,4 @@ require("./pointerParts/mouseTests.js");
 require("./pointerParts/touchTests.js");
 require("./pointerParts/mouseAndTouchTests.js");
 require("./pointerParts/msPointerTests.js");
+require("./pointerParts/strategySelectionTests.js");

--- a/testing/tests/DevExpress.ui.events/pointerParts/msPointerTests.js
+++ b/testing/tests/DevExpress.ui.events/pointerParts/msPointerTests.js
@@ -1,23 +1,25 @@
-var $ = require("jquery"),
-    MsPointerStrategy = require("events/pointer/mspointer"),
-    registerEvent = require("events/core/event_registrator"),
-    support = require("core/utils/support"),
-    nativePointerMock = require("../../../helpers/nativePointerMock.js"),
-    special = require("../../../helpers/eventHelper.js").special,
-    onlyMSPointerSupport = !window.PointerEvent && window.MSPointerEvent,
-    POINTER_DOWN_EVENT_NAME = onlyMSPointerSupport ? "MSPointerDown" : "pointerdown",
-    POINTER_UP_EVENT_NAME = onlyMSPointerSupport ? "MSPointerUp" : "pointerup",
-    POINTER_MOVE_EVENT_NAME = onlyMSPointerSupport ? "MSPointerMove" : "pointermove",
-    POINTER_OVER_EVENT_NAME = onlyMSPointerSupport ? "MSPointerOver" : "pointerover",
-    POINTER_OUT_EVENT_NAME = onlyMSPointerSupport ? "MSPointerOut" : "pointerout",
-    POINTER_ENTER_EVENT_NAME = onlyMSPointerSupport ? "mouseenter" : "pointerenter",
-    POINTER_LEAVE_EVENT_NAME = onlyMSPointerSupport ? "mouseleave" : "pointerleave";
+import $ from "jquery";
+import MsPointerStrategy from "events/pointer/mspointer";
+import registerEvent from "events/core/event_registrator";
+import { pointerEvents as isPointerEventsSupported } from "core/utils/support";
+import nativePointerMock from "../../../helpers/nativePointerMock.js";
+import { special } from "../../../helpers/eventHelper.js";
+
+const POINTER_DOWN_EVENT_NAME = "pointerdown";
+const POINTER_UP_EVENT_NAME = "pointerup";
+const POINTER_MOVE_EVENT_NAME = "pointermove";
+const POINTER_OVER_EVENT_NAME = "pointerover";
+const POINTER_OUT_EVENT_NAME = "pointerout";
+const POINTER_ENTER_EVENT_NAME = "pointerenter";
+const POINTER_LEAVE_EVENT_NAME = "pointerleave";
+
+const { test } = QUnit;
 
 QUnit.module("mspointer events", {
-    beforeEach: function() {
+    beforeEach: () => {
         this.clock = sinon.useFakeTimers();
 
-        $.each(MsPointerStrategy.map, function(pointerEvent, originalEvents) {
+        $.each(MsPointerStrategy.map, (pointerEvent, originalEvents) => {
             if(special[pointerEvent]) {
                 special[pointerEvent].dispose.apply(undefined);
             }
@@ -27,232 +29,205 @@ QUnit.module("mspointer events", {
         this.$element = $("#element");
     },
 
-    afterEach: function() {
+    afterEach: () => {
         MsPointerStrategy.resetObserver();
         this.clock.restore();
     }
+}, () => {
+    test("pointer event should not trigger twice on real devices", (assert) => {
+        const stubHandler = sinon.stub();
+        const $container = $("#container").on("dxpointerdown", stubHandler);
+        const $element = this.$element.on("dxpointerdown", stubHandler);
+
+        nativePointerMock($element)
+            .start()
+            .pointerDown()
+            .mouseDown();
+
+        assert.strictEqual(stubHandler.callCount, 2);
+
+        nativePointerMock($container)
+            .start()
+            .pointerDown()
+            .mouseDown();
+
+        assert.strictEqual(stubHandler.callCount, 3);
+    });
+
+    test("dxpointerup triggers twice on real devices", (assert) => {
+        const stubHandler = sinon.stub();
+
+        this.$element.on("dxpointerup", stubHandler);
+
+        const pointer = nativePointerMock(this.$element)
+            .start()
+            .pointerDown()
+            .pointerUp();
+
+        this.clock.tick(300);
+
+        pointer
+            .mouseDown()
+            .mouseUp();
+
+        assert.strictEqual(stubHandler.callCount, 1);
+    });
+
+    $.each({
+        "dxpointerdown": POINTER_DOWN_EVENT_NAME,
+        "dxpointermove": POINTER_MOVE_EVENT_NAME,
+        "dxpointerup": POINTER_UP_EVENT_NAME,
+        "dxpointerover": POINTER_OVER_EVENT_NAME,
+        "dxpointerout": POINTER_OUT_EVENT_NAME,
+        "dxpointerenter": POINTER_ENTER_EVENT_NAME,
+        "dxpointerleave": POINTER_LEAVE_EVENT_NAME
+    }, (eventName, triggerEvent) => {
+        test("'" + eventName + "' has pointerType = 'mouse' if it was triggered by mouse event", (assert) => {
+            this.$element.on(eventName, (e) => {
+                assert.strictEqual(e.pointerType, "mouse");
+            });
+
+            this.$element.trigger({
+                type: triggerEvent,
+                pointerType: "mouse"
+            });
+        });
+    });
+
+    $.each({
+        "dxpointerdown": "pointerdown",
+        "dxpointermove": "pointermove",
+        "dxpointerup": "pointerup",
+        "dxpointerover": "pointerover",
+        "dxpointerout": "pointerout",
+        "dxpointerenter": "pointerenter",
+        "dxpointerleave": "pointerleave"
+    }, (eventName, triggerEvent) => {
+        test("'" + eventName + "' was triggered once", (assert) => {
+            const stubHandler = sinon.stub();
+            this.$element.on(eventName, stubHandler);
+
+            this.$element.trigger(triggerEvent);
+
+            assert.strictEqual(stubHandler.callCount, 1);
+        });
+    });
+
+    $.each({
+        "dxpointerdown": POINTER_DOWN_EVENT_NAME,
+        "dxpointermove": POINTER_MOVE_EVENT_NAME,
+        "dxpointerup": POINTER_UP_EVENT_NAME,
+        "dxpointerover": POINTER_OVER_EVENT_NAME,
+        "dxpointerout": POINTER_OUT_EVENT_NAME,
+        "dxpointerenter": POINTER_ENTER_EVENT_NAME,
+        "dxpointerleave": POINTER_LEAVE_EVENT_NAME
+    }, (eventName, triggerEvent) => {
+        test(`'${eventName}' has pointerType = 'touch' if it was triggered by touch event`, (assert) => {
+            this.$element.on(eventName, (e) => {
+                assert.strictEqual(e.pointerType, "touch");
+            });
+
+            this.$element.trigger({
+                type: triggerEvent,
+                pointerType: "touch"
+            });
+        });
+    });
+
+    $.each({
+        "dxpointerdown": POINTER_DOWN_EVENT_NAME,
+        "dxpointermove": POINTER_MOVE_EVENT_NAME,
+        "dxpointerup": POINTER_UP_EVENT_NAME,
+        "dxpointerover": POINTER_OVER_EVENT_NAME,
+        "dxpointerout": POINTER_OUT_EVENT_NAME,
+        "dxpointerenter": POINTER_ENTER_EVENT_NAME,
+        "dxpointerleave": POINTER_LEAVE_EVENT_NAME
+    }, (eventName, triggerEvent) => {
+        test(`'${eventName}' event should have correct pointerId`, (assert) => {
+            this.$element.on(eventName, (e) => {
+                assert.strictEqual(e.pointerId, 17);
+            });
+
+            this.$element.trigger({
+                type: triggerEvent,
+                pointerType: "touch",
+                pointerId: 17
+            });
+        });
+    });
+
+    if(isPointerEventsSupported) {
+        const simulatePointerEvent = ($element, type, options) => {
+            options = $.extend({
+                bubbles: true,
+                cancelable: true,
+                type: type
+            }, options);
+
+            const event = new PointerEvent(type, options);
+
+            $element[0].dispatchEvent(event);
+        };
+
+        QUnit.test("dxpointer events should have all touches in pointer array", (assert) => {
+            simulatePointerEvent(this.$element, "pointerdown", { pointerType: "touch", pointerId: 17 });
+
+            this.$element.on("dxpointerdown", (e) => {
+                const pointers = e.pointers;
+                assert.strictEqual(pointers[0].pointerId, 17);
+                assert.strictEqual(pointers[1].pointerId, 18);
+            });
+
+            simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 18 });
+
+            this.$element.on("dxpointerup", (e) => {
+                const pointers = e.pointers;
+                assert.strictEqual(pointers.length, 1);
+                assert.strictEqual(pointers[0].pointerId, 18);
+            });
+
+            simulatePointerEvent(this.$element, POINTER_UP_EVENT_NAME, { pointerType: "touch", pointerId: 17 });
+        });
+
+        QUnit.test("active touches should be reset if primary pointer is added", (assert) => {
+            simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 17, isPrimary: false });
+
+            this.$element.on("dxpointerdown", (e) => {
+                const pointers = e.pointers;
+                assert.strictEqual(pointers.length, 1);
+                assert.strictEqual(pointers[0].pointerId, 18);
+            });
+
+            simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 18, isPrimary: true });
+        });
+
+        QUnit.test("pointers in dxpointer events should be updated on mouse move", (assert) => {
+            simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 17, clientX: 0 });
+            simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 18, clientX: 100 });
+
+            this.$element.one("dxpointermove", (e) => {
+                const pointers = e.pointers;
+
+                assert.strictEqual(pointers[0].pageX, 0);
+                assert.strictEqual(pointers[1].pageX, 50);
+            });
+            simulatePointerEvent(this.$element, POINTER_MOVE_EVENT_NAME, { pointerType: "touch", pointerId: 18, clientX: 50 });
+
+            this.$element.one("dxpointermove", (e) => {
+                const pointers = e.pointers;
+
+                assert.strictEqual(pointers[0].pageX, 20);
+                assert.strictEqual(pointers[1].pageX, 50);
+            });
+            simulatePointerEvent(this.$element, POINTER_MOVE_EVENT_NAME, { pointerType: "touch", pointerId: 17, clientX: 20 });
+        });
+
+        QUnit.test("two pointers with same pointerid should not be present in pointers array", (assert) => {
+            this.$element.on("dxpointerdown", (e) => {
+                assert.strictEqual(e.pointers.length, 1);
+            });
+            simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "mouse", pointerId: 1 });
+            simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "mouse", pointerId: 1 });
+        });
+    }
 });
-
-QUnit.test("pointer event should not trigger twice on real devices", function(assert) {
-    var handlerTriggerCount = 0;
-
-    var $container = $("#container").on("dxpointerdown", function() {
-        handlerTriggerCount++;
-    });
-
-    var $element = this.$element.on("dxpointerdown", function() {
-        handlerTriggerCount++;
-    });
-
-    nativePointerMock($element)
-        .start()
-        .pointerDown()
-        .mouseDown();
-
-    assert.equal(handlerTriggerCount, 2);
-
-    nativePointerMock($container)
-        .start()
-        .pointerDown()
-        .mouseDown();
-
-    assert.equal(handlerTriggerCount, 3);
-});
-
-QUnit.test("dxpointerup triggers twice on real devices", function(assert) {
-    var triggered = 0;
-
-    this.$element.on("dxpointerup", function() {
-        triggered++;
-    });
-
-    var pointer = nativePointerMock(this.$element)
-        .start()
-        .pointerDown()
-        .pointerUp();
-
-    this.clock.tick(300);
-
-    pointer
-        .mouseDown()
-        .mouseUp();
-
-    assert.equal(triggered, 1);
-});
-
-$.each({
-    "dxpointerdown": POINTER_DOWN_EVENT_NAME,
-    "dxpointermove": POINTER_MOVE_EVENT_NAME,
-    "dxpointerup": POINTER_UP_EVENT_NAME,
-    "dxpointerover": POINTER_OVER_EVENT_NAME,
-    "dxpointerout": POINTER_OUT_EVENT_NAME,
-    "dxpointerenter": POINTER_ENTER_EVENT_NAME,
-    "dxpointerleave": POINTER_LEAVE_EVENT_NAME
-}, function(eventName, triggerEvent) {
-    QUnit.test("'" + eventName + "' has pointerType = 'mouse' if it was triggered by mouse event", function(assert) {
-        this.$element.on(eventName, function(e) {
-            assert.equal(e.pointerType, "mouse");
-        });
-
-        this.$element.trigger({
-            type: triggerEvent,
-            pointerType: "mouse"
-        });
-    });
-});
-
-$.each({
-    "dxpointerdown": ["MSPointerDown", "pointerdown"],
-    "dxpointermove": ["MSPointerMove", "pointermove"],
-    "dxpointerup": ["MSPointerUp", "pointerup"],
-    "dxpointerover": ["MSPointerOver", "pointerover"],
-    "dxpointerout": ["MSPointerOut", "pointerout"],
-    "dxpointerenter": ["mouseenter", "pointerenter"],
-    "dxpointerleave": ["mouseleave", "pointerleave"]
-}, function(eventName, triggerEvents) {
-    QUnit.test("'" + eventName + "' was triggered once", function(assert) {
-        var triggered = 0;
-        this.$element.on(eventName, function(e) {
-            triggered++;
-        });
-
-        this.$element.trigger(triggerEvents[0]);
-        this.$element.trigger(triggerEvents[1]);
-
-        assert.equal(triggered, 1);
-    });
-});
-
-$.each({
-    "dxpointerdown": POINTER_DOWN_EVENT_NAME,
-    "dxpointermove": POINTER_MOVE_EVENT_NAME,
-    "dxpointerup": POINTER_UP_EVENT_NAME,
-    "dxpointerover": POINTER_OVER_EVENT_NAME,
-    "dxpointerout": POINTER_OUT_EVENT_NAME,
-    "dxpointerenter": POINTER_ENTER_EVENT_NAME,
-    "dxpointerleave": POINTER_LEAVE_EVENT_NAME
-}, function(eventName, triggerEvent) {
-    QUnit.test("'" + eventName + "' has pointerType = 'touch' if it was triggered by touch event", function(assert) {
-        this.$element.on(eventName, function(e) {
-            assert.equal(e.pointerType, "touch");
-        });
-
-        this.$element.trigger({
-            type: triggerEvent,
-            pointerType: "touch"
-        });
-    });
-});
-
-
-$.each({
-    "dxpointerdown": POINTER_DOWN_EVENT_NAME,
-    "dxpointermove": POINTER_MOVE_EVENT_NAME,
-    "dxpointerup": POINTER_UP_EVENT_NAME,
-    "dxpointerover": POINTER_OVER_EVENT_NAME,
-    "dxpointerout": POINTER_OUT_EVENT_NAME,
-    "dxpointerenter": POINTER_ENTER_EVENT_NAME,
-    "dxpointerleave": POINTER_LEAVE_EVENT_NAME
-}, function(eventName, triggerEvent) {
-    QUnit.test("'" + eventName + "' event should have correct pointerId", function(assert) {
-        this.$element.on(eventName, function(e) {
-            assert.equal(e.pointerId, 17);
-        });
-
-        this.$element.trigger({
-            type: triggerEvent,
-            pointerType: "touch",
-            pointerId: 17
-        });
-    });
-});
-
-
-if(support.pointerEvents) {
-    var msPointerEnabled = window.navigator.msPointerEnabled;
-
-    var simulatePointerEvent = function($element, type, options) {
-        options = $.extend({
-            canBubble: true,
-            cancelable: true,
-            type: type
-        }, options);
-
-        var event = document.createEvent(msPointerEnabled ? "MSPointerEvent" : "pointerEvent");
-
-        var args = [];
-        $.each(["type", "canBubble", "cancelable", "view", "detail", "screenX", "screenY", "clientX", "clientY", "ctrlKey", "altKey",
-            "shiftKey", "metaKey", "button", "relatedTarget", "offsetX", "offsetY", "width", "height", "pressure", "rotation", "tiltX",
-            "tiltY", "pointerId", "pointerType", "hwTimestamp", "isPrimary"], function(i, name) {
-            if(name in options) {
-                args.push(options[name]);
-            } else {
-                args.push(event[name]);
-            }
-        });
-        event.initPointerEvent.apply(event, args);
-
-        $element[0].dispatchEvent(event);
-    };
-
-    QUnit.test("dxpointer events should have all touches in pointer array", function(assert) {
-        simulatePointerEvent(this.$element, "pointerdown", { pointerType: "touch", pointerId: 17 });
-
-        this.$element.on("dxpointerdown", function(e) {
-            var pointers = e.pointers;
-            assert.equal(pointers[0].pointerId, 17);
-            assert.equal(pointers[1].pointerId, 18);
-        });
-
-        simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 18 });
-
-        this.$element.on("dxpointerup", function(e) {
-            var pointers = e.pointers;
-            assert.equal(pointers.length, 1);
-            assert.equal(pointers[0].pointerId, 18);
-        });
-
-        simulatePointerEvent(this.$element, POINTER_UP_EVENT_NAME, { pointerType: "touch", pointerId: 17 });
-    });
-
-    QUnit.test("active touches should be reset if primary pointer is added", function(assert) {
-        simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 17, isPrimary: false });
-
-        this.$element.on("dxpointerdown", function(e) {
-            var pointers = e.pointers;
-            assert.equal(pointers.length, 1);
-            assert.equal(pointers[0].pointerId, 18);
-        });
-
-        simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 18, isPrimary: true });
-    });
-
-    QUnit.test("pointers in dxpointer events should be updated on mouse move", function(assert) {
-        simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 17, clientX: 0 });
-        simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "touch", pointerId: 18, clientX: 100 });
-
-        this.$element.one("dxpointermove", function(e) {
-            var pointers = e.pointers;
-
-            assert.equal(pointers[0].pageX, 0);
-            assert.equal(pointers[1].pageX, 50);
-        });
-        simulatePointerEvent(this.$element, POINTER_MOVE_EVENT_NAME, { pointerType: "touch", pointerId: 18, clientX: 50 });
-
-        this.$element.one("dxpointermove", function(e) {
-            var pointers = e.pointers;
-
-            assert.equal(pointers[0].pageX, 20);
-            assert.equal(pointers[1].pageX, 50);
-        });
-        simulatePointerEvent(this.$element, POINTER_MOVE_EVENT_NAME, { pointerType: "touch", pointerId: 17, clientX: 20 });
-    });
-
-    QUnit.test("two pointers with same pointerid should not be present in pointers array", function(assert) {
-        this.$element.on("dxpointerdown", function(e) {
-            assert.equal(e.pointers.length, 1);
-        });
-        simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "mouse", pointerId: 1 });
-        simulatePointerEvent(this.$element, POINTER_DOWN_EVENT_NAME, { pointerType: "mouse", pointerId: 1 });
-    });
-}

--- a/testing/tests/DevExpress.ui.events/pointerParts/strategySelectionTests.js
+++ b/testing/tests/DevExpress.ui.events/pointerParts/strategySelectionTests.js
@@ -1,0 +1,34 @@
+import { getStrategy } from "events/pointer";
+import TouchStrategy from "events/pointer/touch";
+import MsPointerStrategy from "events/pointer/mspointer";
+import MouseStrategy from "events/pointer/mouse";
+import MouseAndTouchStrategy from "events/pointer/mouse_and_touch";
+
+
+const { test } = QUnit;
+
+QUnit.module("Strategy selection", () => {
+    test("Use the Mouse strategy by default", (assert) => {
+        const strategy = getStrategy({}, {}, {});
+
+        assert.strictEqual(strategy, MouseStrategy);
+    });
+
+    test("Use the MouseAndTouch strategy when touch supported and device isn't a tablet or phone", (assert) => {
+        const strategyDesktop = getStrategy({ touch: true }, { desktop: true }, {});
+        const strategyPhone = getStrategy({ touch: true }, { tablet: true }, {});
+        const strategyTablet = getStrategy({ touch: true }, { phone: true }, {});
+
+        assert.strictEqual(strategyDesktop, MouseAndTouchStrategy);
+        assert.strictEqual(strategyPhone, TouchStrategy);
+        assert.strictEqual(strategyTablet, TouchStrategy);
+    });
+
+    test("Use the MsPointer strategy when PointerEvent supported and the Edge or IE11 browser using", (assert) => {
+        const strategyMsie = getStrategy({ pointerEvents: true }, {}, { msie: true });
+        const strategyWebkit = getStrategy({ pointerEvents: true }, {}, { webkit: true });
+
+        assert.strictEqual(strategyMsie, MsPointerStrategy);
+        assert.strictEqual(strategyWebkit, MouseStrategy, "default strategy");
+    });
+});

--- a/testing/tests/DevExpress.utils/utils.support.tests.js
+++ b/testing/tests/DevExpress.utils/utils.support.tests.js
@@ -1,4 +1,4 @@
-import { detectTouchEvents } from "core/utils/support";
+import { detectTouchEvents, detectPointerEvent } from "core/utils/support";
 
 const createWindowMock = (...properties) => { return { hasProperty: name => properties.indexOf(name) > -1 }; };
 
@@ -33,20 +33,20 @@ QUnit.module("Pointer event detection", () => {
         const windowMock = createWindowMock("PointerEvent");
         const navigatorMock = {};
 
-        assert.ok(detectTouchEvents(windowMock, navigatorMock), "PointerEvent detected");
+        assert.ok(detectPointerEvent(windowMock, navigatorMock), "PointerEvent detected");
     });
 
     QUnit.test("pointerEvent = true when 'pointerEnabled' exists (surface with old IE11)", assert => {
         const windowMock = createWindowMock();
         const navigatorMock = { pointerEnabled: true };
 
-        assert.ok(detectTouchEvents(windowMock, navigatorMock), "PointerEvent detected");
+        assert.ok(detectPointerEvent(windowMock, navigatorMock), "PointerEvent detected");
     });
 
     QUnit.test("pointerEvent = false when 'pointerEnabled' or 'PointerEvent' not exists", assert => {
         const windowMock = createWindowMock();
 
-        assert.notOk(detectTouchEvents(windowMock, {}), "PointerEvent isn't detected");
+        assert.notOk(detectPointerEvent(windowMock, {}), "PointerEvent isn't detected");
     });
 });
 

--- a/testing/tests/DevExpress.utils/utils.support.tests.js
+++ b/testing/tests/DevExpress.utils/utils.support.tests.js
@@ -27,3 +27,26 @@ QUnit.module("Touch events detection", () => {
         assert.notOk(detectTouchEvents(windowMock, 0), "touch events are not detected");
     });
 });
+
+QUnit.module("Pointer event detection", () => {
+    QUnit.test("pointerEvent = true when 'PointerEvent' exists (Surface pro, edge 17+, latest IE11)", assert => {
+        const windowMock = createWindowMock("PointerEvent");
+        const navigatorMock = {};
+
+        assert.ok(detectTouchEvents(windowMock, navigatorMock), "PointerEvent detected");
+    });
+
+    QUnit.test("pointerEvent = true when 'pointerEnabled' exists (surface with old IE11)", assert => {
+        const windowMock = createWindowMock();
+        const navigatorMock = { pointerEnabled: true };
+
+        assert.ok(detectTouchEvents(windowMock, navigatorMock), "PointerEvent detected");
+    });
+
+    QUnit.test("pointerEvent = false when 'pointerEnabled' or 'PointerEvent' not exists", assert => {
+        const windowMock = createWindowMock();
+
+        assert.notOk(detectTouchEvents(windowMock, {}), "PointerEvent isn't detected");
+    });
+});
+


### PR DESCRIPTION
This PR fixes IE11\Edge issues (List items reordering, ScrollView's content scrolling) related to the using touch monitor on desktop and tablet devices.

1. Fixes detection of the PointerEvent
2. Removes using of the deprecated API from the msPointerEvent strategy
3. Improves tests coverage (pointer strategy selection)