### PR TITLE
Eslint - Add no-fallthrough rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,6 +47,7 @@
         "no-multi-spaces": "error",
         "no-trailing-spaces": "error",
         "no-extra-semi": "error",
+        "no-fallthrough": "error",
         "no-new-func": "error",
         "no-eval": "error",
         "no-undef": "error",

--- a/js/ui/drawer/ui.drawer.js
+++ b/js/ui/drawer/ui.drawer.js
@@ -515,6 +515,7 @@ const Drawer = Widget.inherit({
             case "position":
                 this._refreshPositionClass(args.previousValue);
                 this._invalidate();
+                break;
             case "contentTemplate":
             case "template":
                 this._invalidate();

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -756,6 +756,8 @@ var TextEditorBase = Editor.inherit({
                 break;
             case "stylingMode":
                 this._renderStylingMode();
+                this._invalidate();
+                break;
             case "valueFormat":
                 this._invalidate();
                 break;


### PR DESCRIPTION
**Info:**
https://eslint.org/docs/rules/no-fallthrough

**Cases:**
- In Drawer: we call "_invalidate()" twice for "position" case.
- In TextEditor: we call "_invalidate()" for "stylingMode" case implicitly (from "valueFormat" case)