### PR TITLE
Add possibility to customize inner overlay options for editors

### DIFF
--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -141,7 +141,7 @@ exports.custom = function(options) {
         });
     });
 
-    var popupInstance = new Popup($element, {
+    var popupInstance = new Popup($element, extend({
         title: options.title || exports.title,
         showTitle: function() {
             var isTitle = options.showTitle === undefined ? true : options.showTitle;
@@ -203,7 +203,7 @@ exports.custom = function(options) {
         },
         rtlEnabled: config().rtlEnabled,
         boundaryOffset: { h: 10, v: 0 }
-    });
+    }, options.popupOptions));
 
     popupInstance._wrapper().addClass(DX_DIALOG_WRAPPER_CLASSNAME);
 

--- a/js/ui/drop_down_box.js
+++ b/js/ui/drop_down_box.js
@@ -86,7 +86,6 @@ var DropDownBox = DropDownEditor.inherit({
              * @type dxPopupOptions
              * @default {}
              */
-            dropDownOptions: {},
 
             /**
              * @name dxDropDownBoxOptions.fieldTemplate
@@ -264,11 +263,6 @@ var DropDownBox = DropDownEditor.inherit({
 
     _renderPopup: function(e) {
         this.callBase();
-        this._options.dropDownOptions = extend({}, this._popup.option());
-
-        this._popup.on("optionChanged", function(e) {
-            this.option("dropDownOptions" + "." + e.fullName, e.value);
-        }.bind(this));
 
         if(this.option("focusStateEnabled")) {
             this._popup._keyboardProcessor.push(new KeyboardProcessor({
@@ -291,30 +285,13 @@ var DropDownBox = DropDownEditor.inherit({
             maxHeight: function() {
                 return getElementMaxHeightByWindow(this.$element());
             }.bind(this)
-        }, this.option("dropDownOptions"));
+        });
     },
 
     _popupShownHandler: function() {
         this.callBase();
         var $firstElement = this._getTabbableElements().first();
         eventsEngine.trigger($firstElement, "focus");
-    },
-
-    _popupOptionChanged: function(args) {
-        var options = {};
-
-        if(args.name === args.fullName) {
-            options = args.value;
-        } else {
-            var option = args.fullName.split(".").pop();
-            options[option] = args.value;
-        }
-
-        this._setPopupOption(options);
-
-        if(Object.keys(options).indexOf("width") !== -1 && options["width"] === undefined) {
-            this._updatePopupWidth();
-        }
     },
 
     _setCollectionWidgetOption: commonUtils.noop,
@@ -325,9 +302,6 @@ var DropDownBox = DropDownEditor.inherit({
             case "width":
                 this.callBase(args);
                 this._updatePopupWidth();
-                break;
-            case "dropDownOptions":
-                this._popupOptionChanged(args);
                 break;
             case "dataSource":
                 this._renderInputValue();

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -532,10 +532,6 @@ var DropDownEditor = TextBox.inherit({
         this._renderPopupContent();
     },
 
-    _refreshDropDownOptions: function() {
-        this._options.dropDownOptions = extend({}, this._popup.option());
-    },
-
     _renderPopup: function() {
         this._popup = this._createComponent(this._$popup, Popup, extend(this._popupConfig(), this.option("dropDownOptions")));
 
@@ -552,10 +548,7 @@ var DropDownEditor = TextBox.inherit({
         this._popupContentId = "dx-" + new Guid();
         this.setAria("id", this._popupContentId, this._popup.$content());
 
-        this._refreshDropDownOptions();
-        this._popup.on("optionChanged", function(e) {
-            this._refreshDropDownOptions();
-        }.bind(this));
+        this._bindInnerWidgetOptions(this._popup, "dropDownOptions");
     },
 
     _contentReadyHandler: commonUtils.noop,
@@ -667,7 +660,6 @@ var DropDownEditor = TextBox.inherit({
     _clean: function() {
         delete this._$dropDownButton;
         delete this._openOnFieldClickAction;
-        delete this._options.dropDownOptions;
 
         if(this._$popup) {
             this._$popup.remove();
@@ -781,7 +773,7 @@ var DropDownEditor = TextBox.inherit({
     _updatePopupWidth: commonUtils.noop,
 
     _popupOptionChanged: function(args) {
-        var options = this._getInnerChangedOptions(args);
+        var options = this._getOptionsFromContainer(args);
 
         this._setPopupOption(options);
 

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -660,6 +660,7 @@ var DropDownEditor = TextBox.inherit({
     _clean: function() {
         delete this._$dropDownButton;
         delete this._openOnFieldClickAction;
+        delete this._options.dropDownOptions;
 
         if(this._$popup) {
             this._$popup.remove();

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -532,6 +532,10 @@ var DropDownEditor = TextBox.inherit({
         this._renderPopupContent();
     },
 
+    _refreshDropDownOptions: function() {
+        this._options.dropDownOptions = extend({}, this._popup.option());
+    },
+
     _renderPopup: function() {
         this._popup = this._createComponent(this._$popup, Popup, extend(this._popupConfig(), this.option("dropDownOptions")));
 
@@ -548,10 +552,9 @@ var DropDownEditor = TextBox.inherit({
         this._popupContentId = "dx-" + new Guid();
         this.setAria("id", this._popupContentId, this._popup.$content());
 
-        // Breaking code
-        this._options.dropDownOptions = extend({}, this._popup.option());
+        this._refreshDropDownOptions();
         this._popup.on("optionChanged", function(e) {
-            this.option("dropDownOptions" + "." + e.fullName, e.value);
+            this._refreshDropDownOptions();
         }.bind(this));
     },
 

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -781,14 +781,7 @@ var DropDownEditor = TextBox.inherit({
     _updatePopupWidth: commonUtils.noop,
 
     _popupOptionChanged: function(args) {
-        var options = {};
-
-        if(args.name === args.fullName) {
-            options = args.value;
-        } else {
-            var option = args.fullName.split(".").pop();
-            options[option] = args.value;
-        }
+        var options = this._getInnerChangedOptions(args);
 
         this._setPopupOption(options);
 

--- a/js/ui/editor/editor.js
+++ b/js/ui/editor/editor.js
@@ -173,7 +173,7 @@ var Editor = Widget.inherit({
 
     _bindInnerWidgetOptions: function(innerWidget, optionsContainer) {
         this._options[optionsContainer] = extend({}, innerWidget.option());
-        this._validationMessage.on("optionChanged", function(e) {
+        innerWidget.on("optionChanged", function(e) {
             this._options[optionsContainer] = extend({}, e.component.option());
         }.bind(this));
     },
@@ -293,7 +293,7 @@ var Editor = Widget.inherit({
         return null;
     },
 
-    _getInnerChangedOptions: function(args) {
+    _getOptionsFromContainer: function(args) {
         var options = {};
 
         if(args.name === args.fullName) {
@@ -322,7 +322,7 @@ var Editor = Widget.inherit({
                 this._renderValidationState();
                 break;
             case "validationOverlayOptions":
-                this._setValidationOverlayOptions(this._getInnerChangedOptions(args));
+                this._setValidationOverlayOptions(this._getOptionsFromContainer(args));
                 break;
             case "readOnly":
                 this._toggleReadOnlyState();

--- a/js/ui/editor/editor.js
+++ b/js/ui/editor/editor.js
@@ -104,7 +104,7 @@ var Editor = Widget.inherit({
 
             validationMessageOffset: { h: 0, v: 0 },
 
-            validationOverlayOptions: {}
+            validationTooltipOptions: {}
         });
     },
 
@@ -216,14 +216,14 @@ var Editor = Widget.inherit({
                 visible: true,
                 propagateOutsideClick: true,
                 _checkParentVisibility: false
-            }, this.option("validationOverlayOptions")));
+            }, this.option("validationTooltipOptions")));
 
             this._$validationMessage
                 .toggleClass(INVALID_MESSAGE_AUTO, validationMessageMode === "auto")
                 .toggleClass(INVALID_MESSAGE_ALWAYS, validationMessageMode === "always");
 
             this._setValidationMessageMaxWidth();
-            this._bindInnerWidgetOptions(this._validationMessage, "validationOverlayOptions");
+            this._bindInnerWidgetOptions(this._validationMessage, "validationTooltipOptions");
         }
     },
 
@@ -306,7 +306,7 @@ var Editor = Widget.inherit({
         return options;
     },
 
-    _setValidationOverlayOptions: function(optionName, value) {
+    _setValidationTooltipOptions: function(optionName, value) {
         this._setWidgetOption("_validationMessage", arguments);
     },
 
@@ -321,8 +321,8 @@ var Editor = Widget.inherit({
             case "validationMessageMode":
                 this._renderValidationState();
                 break;
-            case "validationOverlayOptions":
-                this._setValidationOverlayOptions(this._getOptionsFromContainer(args));
+            case "validationTooltipOptions":
+                this._setValidationTooltipOptions(this._getOptionsFromContainer(args));
                 break;
             case "readOnly":
                 this._toggleReadOnlyState();

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -303,6 +303,63 @@ QUnit.test("field method returning overlay content", function(assert) {
     assert.ok($field.hasClass("dx-texteditor-input"), "field has class dx-texteditor-input");
 });
 
+QUnit.module("dropDownOptions");
+
+QUnit.test("dropDownOptions should work on init", function(assert) {
+    var instance = $("#dropDownEditorLazy").dxDropDownEditor({
+        opened: true,
+        dropDownOptions: { customOption: "Test" }
+    }).dxDropDownEditor("instance");
+
+    assert.equal(instance._popup.option("customOption"), "Test", "Option has been passed to the popup");
+});
+
+QUnit.test("dropDownOptions should redefine built-in values", function(assert) {
+    var instance = $("#dropDownEditorLazy").dxDropDownEditor({
+        opened: true,
+        dropDownOptions: { showTitle: true }
+    }).dxDropDownEditor("instance");
+
+    assert.strictEqual(instance._popup.option("showTitle"), true, "Option has been redefined");
+});
+
+QUnit.test("dropDownOptions should be prior than built-in public options", function(assert) {
+    var instance = $("#dropDownEditorLazy").dxDropDownEditor({
+        opened: true,
+        showPopupTitle: false,
+        dropDownOptions: { showTitle: true }
+    }).dxDropDownEditor("instance");
+
+    assert.strictEqual(instance._popup.option("showTitle"), true, "Option has been redefined");
+});
+
+QUnit.test("dropDownOptions should be updated when popup option changed", function(assert) {
+    var instance = $("#dropDownEditorLazy").dxDropDownEditor({
+            opened: true
+        }).dxDropDownEditor("instance"),
+        popup = instance._popup;
+
+    assert.equal(popup.option("width"), instance.option("dropDownOptions.width"), "dropDownOptions has been updated on init");
+
+    popup.option("width", 400);
+    assert.equal(instance.option("dropDownOptions.width"), 400, "dropDownOptions has been updated on popup's option changed");
+});
+
+QUnit.test("it should be possible to set part of the dropDownOptions without full object changing", function(assert) {
+    var instance = $("#dropDownEditorLazy").dxDropDownEditor({
+            opened: true
+        }).dxDropDownEditor("instance"),
+        popup = instance._popup;
+
+    instance.option("dropDownOptions.width", 300);
+    assert.equal(popup.option("width"), 300, "popup's width has been changed");
+
+    instance.option("dropDownOptions", { height: 200 });
+    assert.equal(popup.option("width"), 300, "popup's width has not been changed");
+    assert.equal(popup.option("height"), 200, "popup's height has been changed");
+    assert.equal(instance.option("dropDownOptions.width"), 300, "dropDownOptions object has not been rewrited");
+});
+
 
 QUnit.module("focus policy");
 

--- a/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
@@ -590,7 +590,7 @@ var Fixture = Class.inherit({
             validationError: {
                 message: "Error message"
             },
-            validationOverlayOptions: {
+            validationTooltipOptions: {
                 width: 200,
                 customOption: "Test"
             },
@@ -613,15 +613,15 @@ var Fixture = Class.inherit({
                 isValid: false
             });
 
-        assert.equal(instance.option("validationOverlayOptions.width"), "auto", "options are readable on init");
+        assert.equal(instance.option("validationTooltipOptions.width"), "auto", "options are readable on init");
 
         var overlay = instance._validationMessage;
 
         overlay.option("width", 150);
-        assert.equal(instance.option("validationOverlayOptions.width"), 150, "option has ben changed");
+        assert.equal(instance.option("validationTooltipOptions.width"), 150, "option has ben changed");
     });
 
-    QUnit.test("it should be possible to set validationOverlayOptions dynamically", function(assert) {
+    QUnit.test("it should be possible to set validationTooltipOptions dynamically", function(assert) {
         var $element = this.fixture.createOnlyElement(),
             instance = new Editor($element, {
                 validationMessageMode: "always",
@@ -632,13 +632,13 @@ var Fixture = Class.inherit({
             }),
             overlay = instance._validationMessage;
 
-        instance.option("validationOverlayOptions.width", 130);
+        instance.option("validationTooltipOptions.width", 130);
         assert.equal(overlay.option("width"), 130, "option has ben changed");
 
-        instance.option("validationOverlayOptions", { height: 50 });
+        instance.option("validationTooltipOptions", { height: 50 });
         assert.equal(overlay.option("height"), 50, "option has ben changed");
-        assert.equal(instance.option("validationOverlayOptions.width"), 130, "redefined object's fields was not changed");
-        assert.equal(instance.option("validationOverlayOptions.shading"), false, "default object's fields was not changed");
+        assert.equal(instance.option("validationTooltipOptions.width"), 130, "redefined object's fields was not changed");
+        assert.equal(instance.option("validationTooltipOptions.shading"), false, "default object's fields was not changed");
     });
 })("Validation Events");
 

--- a/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
@@ -572,6 +572,76 @@ var Fixture = Class.inherit({
     });
 })("Validation - UI");
 
+(function() {
+    QUnit.module("Validation overlay options", {
+        beforeEach: function() {
+            this.fixture = new Fixture();
+        },
+        afterEach: function() {
+            this.fixture.teardown();
+        }
+    });
+
+    QUnit.test("it should be possible to redefine validation overlay options", function(assert) {
+        var $element = this.fixture.createOnlyElement();
+
+        new Editor($element, {
+            validationMessageMode: "always",
+            validationError: {
+                message: "Error message"
+            },
+            validationOverlayOptions: {
+                width: 200,
+                customOption: "Test"
+            },
+            isValid: false
+        });
+
+        var overlay = $element.find(".dx-invalid-message.dx-widget").dxOverlay("instance");
+
+        assert.equal(overlay.option("customOption"), "Test", "a custom option has been created");
+        assert.equal(overlay.option("width"), 200, "a default option has been redefined");
+    });
+
+    QUnit.test("editor's overlay options should be changed when validation overlay's options changed", function(assert) {
+        var $element = this.fixture.createOnlyElement(),
+            instance = new Editor($element, {
+                validationMessageMode: "always",
+                validationError: {
+                    message: "Error message"
+                },
+                isValid: false
+            });
+
+        assert.equal(instance.option("validationOverlayOptions.width"), "auto", "options are readable on init");
+
+        var overlay = instance._validationMessage;
+
+        overlay.option("width", 150);
+        assert.equal(instance.option("validationOverlayOptions.width"), 150, "option has ben changed");
+    });
+
+    QUnit.test("it should be possible to set validationOverlayOptions dynamically", function(assert) {
+        var $element = this.fixture.createOnlyElement(),
+            instance = new Editor($element, {
+                validationMessageMode: "always",
+                validationError: {
+                    message: "Error message"
+                },
+                isValid: false
+            }),
+            overlay = instance._validationMessage;
+
+        instance.option("validationOverlayOptions.width", 130);
+        assert.equal(overlay.option("width"), 130, "option has ben changed");
+
+        instance.option("validationOverlayOptions", { height: 50 });
+        assert.equal(overlay.option("height"), 50, "option has ben changed");
+        assert.equal(instance.option("validationOverlayOptions.width"), 130, "redefined object's fields was not changed");
+        assert.equal(instance.option("validationOverlayOptions.shading"), false, "default object's fields was not changed");
+    });
+})("Validation Events");
+
 
 (function() {
     QUnit.module("Validation Events", {

--- a/testing/tests/DevExpress.ui/dialog.tests.js
+++ b/testing/tests/DevExpress.ui/dialog.tests.js
@@ -240,3 +240,20 @@ QUnit.test("dialog should reset active element on showing", function(assert) {
         domUtils.resetActiveElement = originalResetActiveElement;
     }
 });
+
+QUnit.test("it should be possible to redefine popup option in the dialog", function(assert) {
+    dialog.custom({
+        title: "Test Title",
+        popupOptions: {
+            customOption: "Test",
+            title: "Popup title",
+            height: 300
+        }
+    }).show();
+
+    var popup = $(".dx-popup").dxPopup("instance");
+
+    assert.equal(popup.option("customOption"), "Test", "custom option is defined");
+    assert.equal(popup.option("title"), "Popup title", "user option is redefined");
+    assert.equal(popup.option("height"), 300, "default option is redefined");
+});


### PR DESCRIPTION
This feature was requested from the dashboards team. There are no possibilities to set custom container option for overlays that are built-in in more complex widgets