### PR TITLE
Viz - Get rid of useless escape

### DIFF
--- a/js/viz/chart.js
+++ b/js/viz/chart.js
@@ -1086,7 +1086,7 @@ var dxChart = AdvancedChart.inherit({
 
     _parseVisualRangeOption(fullName, value) {
         const that = this;
-        const name = fullName.split(/[.\[]/)[0];
+        const name = fullName.split(/[.[]/)[0];
         const index = fullName.match(/\d+/g);
 
         if(fullName.indexOf("visualRange") > 0) {

--- a/testing/tests/DevExpress.viz.renderers/SvgElement.tests.js
+++ b/testing/tests/DevExpress.viz.renderers/SvgElement.tests.js
@@ -2449,7 +2449,7 @@ function checkDashStyle(assert, elem, result, style, value) {
         rect.attr({ "clip-path": "DevExpress_34" });
 
         // assert
-        assert.strictEqual(rect.element.getAttribute("clip-path").replace(/\"/g, ""), "url(#DevExpress_34)");
+        assert.strictEqual(rect.element.getAttribute("clip-path").replace(/"/g, ""), "url(#DevExpress_34)");
     });
 
     QUnit.test("Set clip-path attribute. pathModified = true", function(assert) {
@@ -2464,7 +2464,7 @@ function checkDashStyle(assert, elem, result, style, value) {
         rect.attr({ "clip-path": "DevExpress_34" });
 
         // assert
-        assert.strictEqual(rect.element.getAttribute("clip-path").replace(/\"/g, ""), "url(" + url + "#DevExpress_34)");
+        assert.strictEqual(rect.element.getAttribute("clip-path").replace(/"/g, ""), "url(" + url + "#DevExpress_34)");
     });
 
     QUnit.test("Set clip-path = null", function(assert) {
@@ -2491,7 +2491,7 @@ function checkDashStyle(assert, elem, result, style, value) {
         rect.attr({ "filter": "DevExpress_34" });
 
         // assert
-        assert.strictEqual(rect.element.getAttribute("filter").replace(/\"/g, ""), "url(#DevExpress_34)");
+        assert.strictEqual(rect.element.getAttribute("filter").replace(/"/g, ""), "url(#DevExpress_34)");
     });
 
     QUnit.test("Set filter attribute. pathModified = true", function(assert) {
@@ -2506,7 +2506,7 @@ function checkDashStyle(assert, elem, result, style, value) {
         rect.attr({ "filter": "DevExpress_34" });
 
         // assert
-        assert.strictEqual(rect.element.getAttribute("filter").replace(/\"/g, ""), "url(" + url + "#DevExpress_34)");
+        assert.strictEqual(rect.element.getAttribute("filter").replace(/"/g, ""), "url(" + url + "#DevExpress_34)");
     });
 
     QUnit.test("Set filter = null", function(assert) {
@@ -2533,7 +2533,7 @@ function checkDashStyle(assert, elem, result, style, value) {
         rect.attr({ "fill": "DevExpress_34" });
 
         // assert
-        assert.strictEqual(rect.element.getAttribute("fill").replace(/\"/g, ""), "url(#DevExpress_34)");
+        assert.strictEqual(rect.element.getAttribute("fill").replace(/"/g, ""), "url(#DevExpress_34)");
     });
 
     QUnit.test("Set pattern as fill attribute. pathModified = true", function(assert) {
@@ -2548,7 +2548,7 @@ function checkDashStyle(assert, elem, result, style, value) {
         rect.attr({ "fill": "DevExpress_34" });
 
         // assert
-        assert.strictEqual(rect.element.getAttribute("fill").replace(/\"/g, ""), "url(" + url + "#DevExpress_34)");
+        assert.strictEqual(rect.element.getAttribute("fill").replace(/"/g, ""), "url(" + url + "#DevExpress_34)");
     });
 
     QUnit.test("Set pattern as fill attribute = null", function(assert) {
@@ -2579,7 +2579,7 @@ function checkDashStyle(assert, elem, result, style, value) {
         rect.attr({ "filter": "DevExpress_34" });
 
         // assert
-        assert.strictEqual(rect.element.getAttribute("filter").replace(/\"/g, ""), "url(" + url + "#DevExpress_34)");
+        assert.strictEqual(rect.element.getAttribute("filter").replace(/"/g, ""), "url(" + url + "#DevExpress_34)");
     });
 
     if("pushState" in history) {
@@ -2598,9 +2598,9 @@ function checkDashStyle(assert, elem, result, style, value) {
             this.refreshPaths();
 
             // assert
-            assert.strictEqual(rectWithClip.element.getAttribute("clip-path").replace(/\"/g, ""), "url(#DevExpress_12)");
-            assert.strictEqual(rectWithPattern.element.getAttribute("fill").replace(/\"/g, ""), "url(#DevExpress_13)");
-            assert.strictEqual(rectWithFilter.element.getAttribute("filter").replace(/\"/g, ""), "url(#DevExpress_14)");
+            assert.strictEqual(rectWithClip.element.getAttribute("clip-path").replace(/"/g, ""), "url(#DevExpress_12)");
+            assert.strictEqual(rectWithPattern.element.getAttribute("fill").replace(/"/g, ""), "url(#DevExpress_13)");
+            assert.strictEqual(rectWithFilter.element.getAttribute("filter").replace(/"/g, ""), "url(#DevExpress_14)");
         });
 
         QUnit.test("FixPath API. pathModified = true", function(assert) {
@@ -2620,9 +2620,9 @@ function checkDashStyle(assert, elem, result, style, value) {
             this.refreshPaths();
 
             // assert
-            assert.strictEqual(rectWithClip.element.getAttribute("clip-path").replace(/\"/g, ""), "url(" + newUrl + "#DevExpress_12)");
-            assert.strictEqual(rectWithPattern.element.getAttribute("fill").replace(/\"/g, ""), "url(" + newUrl + "#DevExpress_13)");
-            assert.strictEqual(rectWithFilter.element.getAttribute("filter").replace(/\"/g, ""), "url(" + newUrl + "#DevExpress_14)");
+            assert.strictEqual(rectWithClip.element.getAttribute("clip-path").replace(/"/g, ""), "url(" + newUrl + "#DevExpress_12)");
+            assert.strictEqual(rectWithPattern.element.getAttribute("fill").replace(/"/g, ""), "url(" + newUrl + "#DevExpress_13)");
+            assert.strictEqual(rectWithFilter.element.getAttribute("filter").replace(/"/g, ""), "url(" + newUrl + "#DevExpress_14)");
         });
 
         QUnit.test("FixPath API. do not change attribute if its value was funcIRI, but now it is not", function(assert) {


### PR DESCRIPTION
To enable the [`no-useless-escape`](https://eslint.org/docs/rules/no-useless-escape) ESLint rule in #6690.