### PR TITLE
DataGrid - Get rid of useless escape in tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -19,7 +19,7 @@ QUnit.testStart(function() {
             <div data-options="dxTemplate: { name: \'test\' }">Template Content</div>\
             <div data-options="dxTemplate: { name: \'test2\' }">Template Content2</div>\
             <table data-options="dxTemplate: { name: \'testRow\' }"><tr class="dx-row dx-data-row test"><td colspan="2">Row Content</td></tr></table>\
-            <table data-options="dxTemplate: { name: \'testRowWithExpand\' }"><tr class="dx-row"><td colspan="2">Row Content <em class=\"dx-command-expand dx-datagrid-expand\">More info</em></td></tr></table>\
+            <table data-options="dxTemplate: { name: \'testRowWithExpand\' }"><tr class="dx-row"><td colspan="2">Row Content <em class="dx-command-expand dx-datagrid-expand">More info</em></td></tr></table>\
             <div data-options="dxTemplate: { name: \'testDetail\' }"><p>Test Details</p></div>\
         </div>\
 \

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
@@ -667,7 +667,7 @@ QUnit.test('Highlight searchText for a cell template (T656969)', function(assert
     assert.equal(getNormalizeMarkup(cells.eq(2)), '1/01/2001', 'cell 2');
 });
 function getNormalizeMarkup($element) {
-    var quoteRE = new RegExp('\"', 'g'),
+    var quoteRE = new RegExp('"', 'g'),
         spanRE = new RegExp('span', 'gi');
     return $element.html().replace(quoteRE, '').replace(spanRE, "span");
 }


### PR DESCRIPTION
To enable the [`no-useless-escape`](https://eslint.org/docs/rules/no-useless-escape) ESLint rule in #6690.