### PR TITLE
PivotGrid - Get rid of useless escape in tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.export.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.export.tests.js
@@ -198,7 +198,7 @@ QUnit.test("Export [string x string x number] with row grand totals", function(a
 
 QUnit.test("Export [string x string x number] with 'format: currency'", function(assert) {
     const styles = helper.STYLESHEET_HEADER_XML +
-        '<numFmts count=\"1\"><numFmt numFmtId=\"165\" formatCode=\"$#,##0_);\\($#,##0\\)\" /></numFmts>' +
+        '<numFmts count="1"><numFmt numFmtId="165" formatCode="$#,##0_);\\($#,##0\\)" /></numFmts>' +
         helper.BASE_STYLE_XML +
         '<cellXfs count="3">' +
         '<xf xfId="0" applyAlignment="1" fontId="0" applyNumberFormat="0" numFmtId="0"><alignment vertical="top" wrapText="0" horizontal="center" /></xf>' +

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/sortable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/sortable.tests.js
@@ -786,7 +786,7 @@ QUnit.test("dragging to empty group", function(assert) {
                                         </div>');
 
     $("#sortable").append('<div group="group2" class="group">\
-                                            <div class="test-container" style="height: 30px;">\</div>\
+                                            <div class="test-container" style="height: 30px;"></div>\
                                         </div>');
 
     var indicator,
@@ -990,13 +990,13 @@ QUnit.test("drag without source element", function(assert) {
 
 QUnit.test("Indicator should not be shown on dragging to the same item at another sortable", function(assert) {
     $("#sortable").css("display", "none");
-    $("<div id='sortable1'><div id='second-group' group='groupFilter' class='group horizontal' style='height: 150px'><div class='test-container'><div class='test-item'>1</div><div class='test-item'>2</div><div class='test-item'>3</div>\</div></div>")
+    $("<div id='sortable1'><div id='second-group' group='groupFilter' class='group horizontal' style='height: 150px'><div class='test-container'><div class='test-item'>1</div><div class='test-item'>2</div><div class='test-item'>3</div></div></div>")
         .insertAfter("#sortable")
         .css({
             width: "3000px",
             height: "200px"
         });
-    $("<div id='sortable2'><div id='second-group' group='groupFilter' class='group horizontal' style='height: 150px'><div class='test-container'><div class='test-item'>1</div><div class='test-item'>2</div><div class='test-item'>3</div>\</div></div>")
+    $("<div id='sortable2'><div id='second-group' group='groupFilter' class='group horizontal' style='height: 150px'><div class='test-container'><div class='test-item'>1</div><div class='test-item'>2</div><div class='test-item'>3</div></div></div>")
         .insertAfter("#sortable1")
         .css({
             width: "3000px",
@@ -1385,7 +1385,7 @@ QUnit.test("dragging between different sortables by groupFilter callback to non-
 });
 
 QUnit.test("dragging between different sortables positioned one on another", function(assert) {
-    $("<div id='sortable1'><div id='second-group' group='groupFilter' class='group horizontal' style='height: 150px'><div class='test-container'><div class='test-item'>1</div><div class='test-item'>2</div>\</div></div>")
+    $("<div id='sortable1'><div id='second-group' group='groupFilter' class='group horizontal' style='height: 150px'><div class='test-container'><div class='test-item'>1</div><div class='test-item'>2</div></div></div>")
         .insertAfter("#sortable")
         .css({
             position: "absolute",

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/store.xmla.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/store.xmla.tests.js
@@ -828,7 +828,7 @@ define(function(require) {
             var deferred = $.Deferred();
             send.apply(this, arguments)
                 .then(function() {
-                    arguments[0] = arguments[0].replace(/\<MEMBER_VALUE xsi\:type=\"xsd\:short\"\>2001\<\/MEMBER_VALUE\>/g, "<MEMBER_VALUE/>");
+                    arguments[0] = arguments[0].replace(/<MEMBER_VALUE xsi:type="xsd:short">2001<\/MEMBER_VALUE>/g, "<MEMBER_VALUE/>");
                     deferred.resolve.apply(deferred, arguments);
                 })
                 .fail(deferred.reject);


### PR DESCRIPTION
To enable the [`no-useless-escape`](https://eslint.org/docs/rules/no-useless-escape) ESLint rule in #6690.