### PR TITLE
ThemeBuilder - Get rid of useless escape

### DIFF
--- a/testing/tests/DevExpress.ui/themes.tests.js
+++ b/testing/tests/DevExpress.ui/themes.tests.js
@@ -30,10 +30,10 @@ require("style-compiler-test-server/known-css-files");
         selectorText = selectorText.replace(/\[.*?\]/gi, "");
 
         // strip :not(), :nth-child(n), ::after, etc
-        selectorText = selectorText.replace(/::?[w-]+((.*?))?/gi, "");
+        selectorText = selectorText.replace(/::?[\w-]+(\(.*?\))?/gi, "");
 
         // strip tag names when qualified by class/id
-        selectorText = selectorText.replace(/(^|[^w.#-])[a-z]+([.#][w-]+)/gi, "$1$2");
+        selectorText = selectorText.replace(/(^|[^\w.#-])[a-z]+([.#][\w-]+)/gi, "$1$2");
 
         // strip precedence/descendance qualifiers
         selectorText = selectorText.replace(/[+~>]/g, "");

--- a/testing/tests/DevExpress.ui/themes.tests.js
+++ b/testing/tests/DevExpress.ui/themes.tests.js
@@ -30,10 +30,10 @@ require("style-compiler-test-server/known-css-files");
         selectorText = selectorText.replace(/\[.*?\]/gi, "");
 
         // strip :not(), :nth-child(n), ::after, etc
-        selectorText = selectorText.replace(/\:\:?[\w-]+(\(.*?\))?/gi, "");
+        selectorText = selectorText.replace(/::?[w-]+((.*?))?/gi, "");
 
         // strip tag names when qualified by class/id
-        selectorText = selectorText.replace(/(^|[^\w.#-])[a-z]+([.#][\w-]+)/gi, "$1$2");
+        selectorText = selectorText.replace(/(^|[^w.#-])[a-z]+([.#][w-]+)/gi, "$1$2");
 
         // strip precedence/descendance qualifiers
         selectorText = selectorText.replace(/[+~>]/g, "");

--- a/themebuilder/modules/less-template-loader.js
+++ b/themebuilder/modules/less-template-loader.js
@@ -65,7 +65,7 @@ class LessMetadataPostCompilerPlugin {
         if(this.swatchSelector) {
             const escapedSelector = this.swatchSelector.replace(".", "\\.");
 
-            const customStylesDuplicateRegex = new RegExp(`\\s+${escapedSelector}\\s+\.dx-theme-.*?-typography\\s+\.dx-theme-.*?{[\\s\\S]*?}[\\r\\n]*?`, "g");
+            const customStylesDuplicateRegex = new RegExp(`\\s+${escapedSelector}\\s+.dx-theme-.*?-typography\\s+.dx-theme-.*?{[\\s\\S]*?}[\\r\\n]*?`, "g");
             const swatchOrderRegex = new RegExp(`([ \\t]*)([\\w\\.#:\\*][\\w\\.#:\\*\\->()\\s]*)(${escapedSelector}\\s)([^,{+~]*)`, "gm");
             const themeMarkerRegex = /(\.dx-theme-marker\s*{\s*font-family:\s*['"]dx\..*?\.)(.*)(['"])/g;
 

--- a/themebuilder/modules/less-template-loader.js
+++ b/themebuilder/modules/less-template-loader.js
@@ -65,7 +65,7 @@ class LessMetadataPostCompilerPlugin {
         if(this.swatchSelector) {
             const escapedSelector = this.swatchSelector.replace(".", "\\.");
 
-            const customStylesDuplicateRegex = new RegExp(`\\s+${escapedSelector}\\s+.dx-theme-.*?-typography\\s+.dx-theme-.*?{[\\s\\S]*?}[\\r\\n]*?`, "g");
+            const customStylesDuplicateRegex = new RegExp(`\\s+${escapedSelector}\\s+\\.dx-theme-.*?-typography\\s+\\.dx-theme-.*?{[\\s\\S]*?}[\\r\\n]*?`, "g");
             const swatchOrderRegex = new RegExp(`([ \\t]*)([\\w\\.#:\\*][\\w\\.#:\\*\\->()\\s]*)(${escapedSelector}\\s)([^,{+~]*)`, "gm");
             const themeMarkerRegex = /(\.dx-theme-marker\s*{\s*font-family:\s*['"]dx\..*?\.)(.*)(['"])/g;
 

--- a/themebuilder/tests/less-template-loader-spec.js
+++ b/themebuilder/tests/less-template-loader-spec.js
@@ -62,7 +62,7 @@ describe("LessTemplateLoader", () => {
             lessFileContent,
             config.bootstrapVersion).then(data => {
             assert.equal(data.compiledMetadata["@base-bg"], "#000");
-            assert.equal(data.compiledMetadata["@base-font-family"], "\'default\'");
+            assert.equal(data.compiledMetadata["@base-font-family"], "'default'");
             assert.equal(data.compiledMetadata["@base-text-color"], "#0f0");
             assert.equal(data.css, "div {\n  color: #000;\n}\n");
         });
@@ -104,7 +104,7 @@ describe("LessTemplateLoader", () => {
             sassFileContent,
             config.bootstrapVersion).then((data) => {
             assert.equal(data.compiledMetadata["@base-bg"], "#000");
-            assert.equal(data.compiledMetadata["@base-font-family"], "\'default\'");
+            assert.equal(data.compiledMetadata["@base-font-family"], "'default'");
             assert.equal(data.compiledMetadata["@base-text-color"], "#212529");
             assert.equal(data.css, "div {\n  color: #000;\n  background: #212529;\n}\n");
         });
@@ -130,7 +130,7 @@ describe("LessTemplateLoader", () => {
             metadata,
             [{ key: "@base-bg", value: "green" }]).then(data => {
             assert.equal(data.compiledMetadata["@base-bg"], "green");
-            assert.equal(data.compiledMetadata["@base-font-family"], "\'default\'");
+            assert.equal(data.compiledMetadata["@base-font-family"], "'default'");
             assert.equal(data.compiledMetadata["@base-text-color"], "#0f0");
             assert.equal(data.css, "div {\n  color: green;\n}\n");
         });


### PR DESCRIPTION
To enable the [`no-useless-escape`](https://eslint.org/docs/rules/no-useless-escape) ESLint rule in #6690.