### PR TITLE
Export - Get rid of useless escape

### DIFF
--- a/js/exporter/image_creator.js
+++ b/js/exporter/image_creator.js
@@ -216,7 +216,7 @@ function parseStyles(element, options) {
 }
 
 function parseUrl(urlString) {
-    var matches = urlString && urlString.match(/url\(.*\#(.*?)["']?\)/i);
+    var matches = urlString && urlString.match(/url\(.*#(.*?)["']?\)/i);
     return matches && matches[1];
 }
 

--- a/testing/tests/DevExpress.exporter/imageCreator.tests.js
+++ b/testing/tests/DevExpress.exporter/imageCreator.tests.js
@@ -1254,7 +1254,7 @@ QUnit.test("Text with big amount of spaces", function(assert) {
 QUnit.test("Stroke text", function(assert) {
     var that = this,
         done = assert.async(),
-        markup = testingMarkupStart + "<text x=\"50\" y=\"50\" text-anchor=\"start\" stroke-width=\"5\" style=\"fill:#222; font-family:\'Trebuchet MS\', Verdana; stroke: #F2f2f2; stroke-width: 5px;\"><tspan style=\"font-weight: bold; font-style: italic; \" stroke-opacity=\"0.7\">Age</tspan></text>" + testingMarkupEnd,
+        markup = testingMarkupStart + "<text x=\"50\" y=\"50\" text-anchor=\"start\" stroke-width=\"5\" style=\"fill:#222; font-family:'Trebuchet MS', Verdana; stroke: #F2f2f2; stroke-width: 5px;\"><tspan style=\"font-weight: bold; font-style: italic; \" stroke-opacity=\"0.7\">Age</tspan></text>" + testingMarkupEnd,
         imageBlob = getData(markup);
 
     assert.expect(14);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.export.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.export.tests.js
@@ -635,7 +635,7 @@ QUnit.test("Columns - date with format as function", function(assert) { // T5736
 
 QUnit.test("Columns - datetime", function(assert) {
     const styles = helper.STYLESHEET_HEADER_XML +
-        '<numFmts count="1"><numFmt numFmtId="165" formatCode="[$-9]M\\/d\\/yyyy\, H:mm AM/PM" /></numFmts>' +
+        '<numFmts count="1"><numFmt numFmtId="165" formatCode="[$-9]M\\/d\\/yyyy, H:mm AM/PM" /></numFmts>' +
         helper.BASE_STYLE_XML +
         '<cellXfs count="5">' +
         helper.STYLESHEET_STANDARDSTYLES +


### PR DESCRIPTION
To enable the [`no-useless-escape`](https://eslint.org/docs/rules/no-useless-escape) ESLint rule in #6690.