### PR TITLE
Core - Get rid of useless escape

### DIFF
--- a/build/gulp/npm.js
+++ b/build/gulp/npm.js
@@ -188,7 +188,7 @@ gulp.task('npm-dts-check', ['npm-dts-generator'], function() {
 
             var uniqueIdentifier = moduleMeta.name
                 .replace(/\./g, '_')
-                .split('\/')
+                .split('/')
                 .concat([name])
                 .join('__');
 

--- a/js/animation/fx.js
+++ b/js/animation/fx.js
@@ -316,7 +316,7 @@ var FrameAnimationStrategy = {
     _parseTransform: function(transformString) {
         var result = {};
 
-        iteratorUtils.each(transformString.match(/(\w|\d)+\([^\)]*\)\s*/g), function(i, part) {
+        iteratorUtils.each(transformString.match(/(\w|\d)+\([^)]*\)\s*/g), function(i, part) {
             var translateData = translator.parseTranslate(part),
                 scaleData = part.match(/scale\((.+?)\)/),
                 rotateData = part.match(/(rotate.)\((.+)deg\)/);

--- a/js/core/component.js
+++ b/js/core/component.js
@@ -363,7 +363,7 @@ var Component = Class.inherit({
             for(var i = 0; i < optionNames.length; i++) {
                 var name = optionNames[i],
                     args = {
-                        name: name.split(/[.\[]/)[0],
+                        name: name.split(/[.[]/)[0],
                         fullName: name,
                         value: value,
                         previousValue: previousValue
@@ -628,7 +628,7 @@ var Component = Class.inherit({
                 cachedSetters[name] = coreDataUtils.compileSetter(name);
             }
 
-            var path = name.split(/[.\[]/);
+            var path = name.split(/[.[]/);
 
             cachedSetters[name](that._options, value, {
                 functionsAsIs: true,

--- a/js/core/renderer_base.js
+++ b/js/core/renderer_base.js
@@ -497,7 +497,7 @@ initRender.prototype.find = function(selector) {
                 }
                 queryId = "[id='" + queryId + "'] ";
 
-                var querySelector = queryId + selector.replace(/([^\\])(\,)/g, "$1, " + queryId);
+                var querySelector = queryId + selector.replace(/([^\\])(,)/g, "$1, " + queryId);
                 nodes.push.apply(nodes, domAdapter.querySelectorAll(element, querySelector));
                 setAttributeValue(element, "id", elementId);
             } else if(domAdapter.isDocument(element)) {

--- a/js/core/utils/browser.js
+++ b/js/core/utils/browser.js
@@ -2,10 +2,10 @@ var extend = require("./extend").extend,
     windowUtils = require("./window"),
     navigator = windowUtils.getNavigator();
 
-var webkitRegExp = /(webkit)[ \/]([\w.]+)/,
+var webkitRegExp = /(webkit)[ /]([\w.]+)/,
     ieRegExp = /(msie) (\d{1,2}\.\d)/,
     ie11RegExp = /(trident).*rv:(\d{1,2}\.\d)/,
-    msEdge = /(edge)\/((\d+)?[\w\.]+)/,
+    msEdge = /(edge)\/((\d+)?[\w.]+)/,
     safari = /(safari)/i,
     mozillaRegExp = /(mozilla)(?:.*? rv:([\w.]+))/;
 

--- a/js/core/utils/date_serialization.js
+++ b/js/core/utils/date_serialization.js
@@ -10,7 +10,7 @@ var NUMBER_SERIALIZATION_FORMAT = "number",
     DATE_SERIALIZATION_FORMAT = "yyyy/MM/dd",
     DATETIME_SERIALIZATION_FORMAT = "yyyy/MM/dd HH:mm:ss";
 
-var ISO8601_PATTERN = /^(\d{4,})(-)?(\d{2})(-)?(\d{2})(?:T(\d{2})(:)?(\d{2})?(:)?(\d{2}(?:\.(\d{1,3})\d*)?)?)?(Z|([\+\-])(\d{2})(:)?(\d{2})?)?$/;
+var ISO8601_PATTERN = /^(\d{4,})(-)?(\d{2})(-)?(\d{2})(?:T(\d{2})(:)?(\d{2})?(:)?(\d{2}(?:\.(\d{1,3})\d*)?)?)?(Z|([+-])(\d{2})(:)?(\d{2})?)?$/;
 var ISO8601_TIME_PATTERN = /^(\d{2}):(\d{2})(:(\d{2}))?$/;
 var ISO8601_PATTERN_PARTS = ["", "yyyy", "", "MM", "", "dd", "THH", "", "mm", "", "ss", ".SSS"];
 

--- a/js/core/utils/html_parser.js
+++ b/js/core/utils/html_parser.js
@@ -1,7 +1,7 @@
 var merge = require("./array").merge,
     domAdapter = require("../dom_adapter");
 
-var isTagName = (/<([a-z][^\/\0>\x20\t\r\n\f]+)/i);
+var isTagName = (/<([a-z][^/\0>\x20\t\r\n\f]+)/i);
 
 var tagWrappers = {
     default: {

--- a/js/core/utils/string.js
+++ b/js/core/utils/string.js
@@ -80,7 +80,7 @@ var stringFormat = function() {
 
 var replaceAll = (function() {
     var quote = function(str) {
-        return (str + "").replace(/([\+\*\?\\\.\[\^\]\$\(\)\{\}\><\|\=\!\:])/g, "\\$1");
+        return (str + "").replace(/([+*?.[^\]$(){}><|=!:])/g, "\\$1");
     };
 
     return function(text, searchToken, replacementToken) {

--- a/js/data/utils.js
+++ b/js/data/utils.js
@@ -150,7 +150,7 @@ function isDisjunctiveOperator(condition) {
 }
 
 function isConjunctiveOperator(condition) {
-    return /^(and|\&\&|\&)$/i.test(condition);
+    return /^(and|&&|&)$/i.test(condition);
 }
 
 var keysEqual = function(keyExpr, key1, key2) {

--- a/js/framework/router.js
+++ b/js/framework/router.js
@@ -10,7 +10,7 @@ var JSON_URI_PREFIX = encodeURIComponent("json:");
 
 var Route = Class.inherit({
     _trimSeparators: function(str) {
-        return str.replace(/^[\/.]+|\/+$/g, "");
+        return str.replace(/^[/.]+|\/+$/g, "");
     },
     _escapeRe: function(str) {
         return str.replace(/[^-\w]/g, "\\$1");
@@ -41,7 +41,7 @@ var Route = Class.inherit({
         this._segments = [];
         this._separators = [];
 
-        this._pattern.replace(/[^\/]+/g, function(segment, index) {
+        this._pattern.replace(/[^/]+/g, function(segment, index) {
             that._segments.push(segment);
             if(index) {
                 that._separators.push(that._pattern.substr(index - 1, 1));
@@ -216,7 +216,7 @@ var Router = Class.inherit({
     },
 
     _trimSeparators: function(str) {
-        return str.replace(/^[\/.]+|\/+$/g, "");
+        return str.replace(/^[/.]+|\/+$/g, "");
     },
 
     _createRoute: function(pattern, defaults, constraints) {

--- a/js/localization/number.js
+++ b/js/localization/number.js
@@ -234,7 +234,7 @@ var numberLocalization = dependencyInjector({
     },
 
     getSign: function(text, format) {
-        if(text.replace(/[^0-9\-]/g, "").charAt(0) === "-") {
+        if(text.replace(/[^0-9-]/g, "").charAt(0) === "-") {
             return -1;
         }
         if(!format) {

--- a/testing/helpers/qunitExtensions.js
+++ b/testing/helpers/qunitExtensions.js
@@ -539,7 +539,7 @@
             if(!timerInfo || !timerInfo.callback) {
                 return false;
             }
-            var callback = String(timerInfo.callback).replace(/\s|\"use strict\";/g, "");
+            var callback = String(timerInfo.callback).replace(/\s|"use strict";/g, "");
 
             if(timerInfo.timerType === "animationFrames" &&
                 [

--- a/testing/helpers/ssrEmulator.js
+++ b/testing/helpers/ssrEmulator.js
@@ -171,7 +171,7 @@ var serverSideDOMAdapter = require("./serverSideDOMAdapterPatch.js");
     Element.prototype.matches = function(selector) {
         var selectorParts = selector.split(/\s|>/);
         var lastSelectorPart = selectorParts[selectorParts.length - 1];
-        if(/^\.[\w|\-]+$/.test(lastSelectorPart)) {
+        if(/^\.[\w|-]+$/.test(lastSelectorPart)) {
             lastSelectorPart = lastSelectorPart.substr(1);
             var index = this.className.indexOf(lastSelectorPart);
             var l = this.className[index + lastSelectorPart.length];

--- a/testing/tests/DevExpress.angular/componentRegistration.tests.js
+++ b/testing/tests/DevExpress.angular/componentRegistration.tests.js
@@ -1536,7 +1536,7 @@ QUnit.test("dynamic templates should be supported by angular", function(assert) 
         $scope.text = "Test";
         $scope.vm = {
             template() {
-                return $("<script type=\"text/html\" id=\"scriptTemplate\"><div>{{text}}</div><\/script>");
+                return $("<script type=\"text/html\" id=\"scriptTemplate\"><div>{{text}}</div></script>");
             }
         };
     });

--- a/testing/tests/DevExpress.framework/routing.tests.js
+++ b/testing/tests/DevExpress.framework/routing.tests.js
@@ -351,7 +351,7 @@ QUnit.test("format should compare values which don't exist in segments", functio
     });
     assert.equal(uri, "View2/hi/1", "View2/hi/1");
 });
-QUnit.test("B236385 '\' symbol in route arguments", function(assert) {
+QUnit.test("B236385 '\\' symbol in route arguments", function(assert) {
     var router = new Router(),
         uri;
     router.register(":view/:item", { view: 'View1', item: undefined });

--- a/testing/tests/DevExpress.jquery/template.tests.js
+++ b/testing/tests/DevExpress.jquery/template.tests.js
@@ -139,7 +139,7 @@ define(function(require) {
     QUnit.test("custom user template engine for script template", function(assert) {
         setTemplateEngine(customUserTemplate);
 
-        var template = new Template($("<script type='text/html'>Text: <b>$text$</b><\/script>"));
+        var template = new Template($("<script type='text/html'>Text: <b>$text$</b></script>"));
         var container = $('<div>');
 
         // act


### PR DESCRIPTION
To enable the [`no-useless-escape`](https://eslint.org/docs/rules/no-useless-escape) ESLint rule in #6690.