### PR TITLE
Eslint - Enable eslint:recommended preset

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
         "module": true,
         "exports": true
     },
+    "extends": "eslint:recommended",
     "rules": {
         "block-spacing": "error",
         "comma-spacing": "error",
@@ -43,29 +44,15 @@
             }
         ],
         "no-multiple-empty-lines": [ "error", { "max": 2 } ],
-        "no-irregular-whitespace": "error",
         "no-multi-spaces": "error",
         "no-trailing-spaces": "error",
-        "no-duplicate-case": "error",
-        "no-case-declarations": "error",
         "no-empty": ["error", { "allowEmptyCatch": true }],
-        "no-inner-declarations": "error",
-        "no-mixed-spaces-and-tabs": "error",
-        "no-extra-semi": "error",
-        "no-fallthrough": "error",
         "no-new-func": "error",
-        "no-redeclare": "error",
         "no-eval": "error",
-        "no-undef": "error",
         "no-undef-init": "error",
-        "no-unused-expressions": "off",
         "no-unused-vars": ["error", { "args": "none" }],
-        "no-constant-condition": "error",
-        "no-self-assign": "error",
         "no-extend-native": "error",
         "no-alert": "error",
-        "no-useless-escape": "error",
-        "no-unsafe-finally": "error",
         "no-whitespace-before-property": "error",
         "object-curly-spacing": [ "error", "always" ],
         "semi-spacing": "error",
@@ -96,8 +83,6 @@
                 }
             }
         ],
-        "no-console": "error",
-        "no-debugger": "error",
         "spellcheck/spell-checker": [
             "error",
             {

--- a/js/core/utils/date_serialization.js
+++ b/js/core/utils/date_serialization.js
@@ -71,7 +71,7 @@ var parseISO8601String = function(text) {
         },
         millisecond = parseMilliseconds(parts[11]);
 
-    if(!!parts[12]) {
+    if(parts[12]) {
         return new Date(Date.UTC(year, month, day, hour, minute, second, millisecond));
     }
 

--- a/js/ui/data_grid/ui.data_grid.export.js
+++ b/js/ui/data_grid/ui.data_grid.export.js
@@ -53,7 +53,7 @@ exports.DataProvider = Class.inherit({
         this._options = {
             columns: exportController._getColumns(this._initialColumnWidthsByColumnIndex),
             groupColumns: groupColumns,
-            items: !!exportController._selectionOnly ? exportController._getSelectedItems() : exportController._getAllItems(),
+            items: exportController._selectionOnly ? exportController._getSelectedItems() : exportController._getAllItems(),
             getVisibleIndex: exportController._columnsController.getVisibleIndex.bind(exportController._columnsController),
             isHeadersVisible: exportController.option("showColumnHeaders"),
             summaryTexts: exportController.option("summary.texts"),

--- a/js/ui/form/ui.form.layout_manager.js
+++ b/js/ui/form/ui.form.layout_manager.js
@@ -446,7 +446,7 @@ var LayoutManager = Widget.inherit({
         }
 
         if(colCount === "auto") {
-            if(!!this._cashedColCount) {
+            if(this._cashedColCount) {
                 return this._cashedColCount;
             }
 

--- a/js/ui/hierarchical_collection/ui.data_adapter.js
+++ b/js/ui/hierarchical_collection/ui.data_adapter.js
@@ -90,7 +90,7 @@ var DataAdapter = Class.inherit({
                 return;
             }
 
-            if(!!node.internalFields[property]) {
+            if(node.internalFields[property]) {
                 if(property === EXPANDED || that.options.multipleSelection) {
                     array.push(node.internalFields.key);
                 } else {

--- a/js/ui/menu/ui.menu.js
+++ b/js/ui/menu/ui.menu.js
@@ -438,7 +438,7 @@ var Menu = MenuBase.inherit({
             }).bind(this),
             height: "auto",
             closeOnOutsideClick: function(e) {
-                return !(!!$(e.target).closest("." + DX_ADAPTIVE_HAMBURGER_BUTTON_CLASS).length);
+                return !($(e.target).closest("." + DX_ADAPTIVE_HAMBURGER_BUTTON_CLASS).length);
             },
             position: {
                 collision: "flipfit",

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -1172,7 +1172,7 @@ var Scheduler = Widget.inherit({
                 break;
             case "views":
                 this._processCurrentView();
-                if(!!this._getCurrentViewOptions()) {
+                if(this._getCurrentViewOptions()) {
                     this.repaint();
                 } else {
                     this._header.option(name, value);
@@ -1677,7 +1677,7 @@ var Scheduler = Widget.inherit({
         }
 
         each(fields, (function(name, expr) {
-            if(!!expr) {
+            if(expr) {
 
                 var getter = dataCoreUtils.compileGetter(expr),
                     setter = dataCoreUtils.compileSetter(expr);

--- a/js/ui/scheduler/ui.scheduler.work_space_week.js
+++ b/js/ui/scheduler/ui.scheduler.work_space_week.js
@@ -75,7 +75,7 @@ var SchedulerWorkSpaceWeek = SchedulerWorkSpace.inherit({
 
         $cells = $(result).slice(newFirstIndex, newLastIndex + 1);
 
-        if(!!this._getGroupCount()) {
+        if(this._getGroupCount()) {
             var arr = [],
                 focusedGroupIndex = this._getGroupIndexByCell($first);
             each($cells, (function(_, cell) {

--- a/js/viz/core/renderers/renderer.js
+++ b/js/viz/core/renderers/renderer.js
@@ -1476,7 +1476,7 @@ extend(TextSvgElement.prototype, {
 function updateIndexes(items, k) {
     var i,
         item;
-    for(i = k; !!(item = items[i]); ++i) {
+    for(i = k; (item = items[i]); ++i) {
         item._link.i = i;
     }
 }

--- a/js/viz/tree_map/plain_data_source.js
+++ b/js/viz/tree_map/plain_data_source.js
@@ -20,7 +20,7 @@ proto._processDataSourceItems = function(items) {
     for(i = 0; i < items.length; i++) {
         currentItem = items[i];
         parentId = currentItem[parentField];
-        if(!!parentId) {
+        if(parentId) {
             struct[parentId] = struct[parentId] || { items: [] };
             tmpItems = struct[parentId].items;
         } else {


### PR DESCRIPTION
In previous PRs (see this list in https://github.com/DevExpress/DevExtreme/pull/6697#issue-247902914), we fixed incompatibilities in our code with rules from `eslint:recommended` preset.

This PR fixes a last portion of issues and enables this preset.