### PR TITLE
Prevent browser to clear the dxDateBox selection when up key pressed (T710547)

### DIFF
--- a/js/ui/date_box/ui.date_box.mask.js
+++ b/js/ui/date_box/ui.date_box.mask.js
@@ -234,7 +234,7 @@ let DateBoxMask = DateBoxBase.inherit({
 
     _onMouseWheel(e) {
         if(this._useMaskBehavior()) {
-            this._partIncrease(e.delta > 0 ? FORWARD : BACKWARD);
+            this._partIncrease(e.delta > 0 ? FORWARD : BACKWARD, e);
         }
     },
 
@@ -327,7 +327,7 @@ let DateBoxMask = DateBoxBase.inherit({
         }
     },
 
-    _partIncrease(step) {
+    _partIncrease(step, e) {
         this._setNewDateIfEmpty();
 
         let limits = this._getActivePartLimits(),
@@ -337,6 +337,8 @@ let DateBoxMask = DateBoxBase.inherit({
         newValue = newValue < limits.min ? limits.max : newValue;
 
         this._setActivePartValue(newValue);
+
+        e && e.preventDefault();
     },
 
     _maskClickHandler() {

--- a/js/ui/date_box/ui.date_box.mask.js
+++ b/js/ui/date_box/ui.date_box.mask.js
@@ -22,44 +22,42 @@ let DateBoxMask = DateBoxBase.inherit({
             return this.callBase(e);
         }
 
-        let that = this;
-
         return extend(this.callBase(e), {
             del: (e) => {
-                that._revertPart(FORWARD);
+                this._revertPart(FORWARD);
                 this._isAllSelected() || e.preventDefault();
             },
             backspace: (e) => {
-                that._revertPart(BACKWARD);
+                this._revertPart(BACKWARD);
                 this._isAllSelected() || e.preventDefault();
             },
             home: (e) => {
-                that._selectFirstPart();
+                this._selectFirstPart();
                 e.preventDefault();
             },
             end: (e) => {
-                that._selectLastPart();
+                this._selectLastPart();
                 e.preventDefault();
             },
             escape: (e) => {
-                that._revertChanges();
+                this._revertChanges();
                 e.preventDefault();
             },
-            enter: that._enterHandler.bind(that),
+            enter: this._enterHandler,
             leftArrow: (e) => {
-                that._selectNextPart(BACKWARD);
+                this._selectNextPart(BACKWARD);
                 e.preventDefault();
             },
             rightArrow: (e) => {
-                that._selectNextPart(FORWARD);
+                this._selectNextPart(FORWARD);
                 e.preventDefault();
             },
             upArrow: (e) => {
-                that._partIncrease(FORWARD);
+                this._partIncrease(FORWARD);
                 e.preventDefault();
             },
             downArrow: (e) => {
-                that._partIncrease(BACKWARD);
+                this._partIncrease(BACKWARD);
                 e.preventDefault();
             },
         });

--- a/js/ui/date_box/ui.date_box.mask.js
+++ b/js/ui/date_box/ui.date_box.mask.js
@@ -25,16 +25,43 @@ let DateBoxMask = DateBoxBase.inherit({
         let that = this;
 
         return extend(this.callBase(e), {
-            del: that._revertPart.bind(that, FORWARD),
-            backspace: that._revertPart.bind(that, BACKWARD),
-            home: that._selectFirstPart.bind(that),
-            end: that._selectLastPart.bind(that),
-            escape: that._revertChanges.bind(that),
+            del: (e) => {
+                that._revertPart(FORWARD);
+                this._isAllSelected() || e.preventDefault();
+            },
+            backspace: (e) => {
+                that._revertPart(BACKWARD);
+                this._isAllSelected() || e.preventDefault();
+            },
+            home: (e) => {
+                that._selectFirstPart();
+                e.preventDefault();
+            },
+            end: (e) => {
+                that._selectLastPart();
+                e.preventDefault();
+            },
+            escape: (e) => {
+                that._revertChanges();
+                e.preventDefault();
+            },
             enter: that._enterHandler.bind(that),
-            leftArrow: that._selectNextPart.bind(that, BACKWARD),
-            rightArrow: that._selectNextPart.bind(that, FORWARD),
-            upArrow: that._partIncrease.bind(that, FORWARD),
-            downArrow: that._partIncrease.bind(that, BACKWARD)
+            leftArrow: (e) => {
+                that._selectNextPart(BACKWARD);
+                e.preventDefault();
+            },
+            rightArrow: (e) => {
+                that._selectNextPart(FORWARD);
+                e.preventDefault();
+            },
+            upArrow: (e) => {
+                that._partIncrease(FORWARD);
+                e.preventDefault();
+            },
+            downArrow: (e) => {
+                that._partIncrease(BACKWARD);
+                e.preventDefault();
+            },
         });
     },
 
@@ -159,12 +186,12 @@ let DateBoxMask = DateBoxBase.inherit({
         this._searchValue = "";
     },
 
-    _revertPart: function(direction, e) {
+    _revertPart: function(direction) {
         if(!this._isAllSelected()) {
             const actual = this._getActivePartValue(this.option("emptyDateValue"));
             this._setActivePartValue(actual);
 
-            this._selectNextPart(direction, e);
+            this._selectNextPart(direction);
         }
         this._clearSearchValue();
     },
@@ -218,17 +245,17 @@ let DateBoxMask = DateBoxBase.inherit({
         });
     },
 
-    _selectLastPart(e) {
+    _selectLastPart() {
         if(this.option("text")) {
             this._activePartIndex = this._dateParts.length;
-            this._selectNextPart(BACKWARD, e);
+            this._selectNextPart(BACKWARD);
         }
     },
 
-    _selectFirstPart(e) {
+    _selectFirstPart() {
         if(this.option("text")) {
             this._activePartIndex = -1;
-            this._selectNextPart(FORWARD, e);
+            this._selectNextPart(FORWARD);
         }
     },
 
@@ -238,7 +265,7 @@ let DateBoxMask = DateBoxBase.inherit({
         }
     },
 
-    _selectNextPart(step, e) {
+    _selectNextPart(step) {
         if(!this.option("text")) {
             return;
         }
@@ -247,7 +274,7 @@ let DateBoxMask = DateBoxBase.inherit({
         if(this._dateParts[index].isStub) {
             let isBoundaryIndex = index === 0 && step < 0 || index === this._dateParts.length - 1 && step > 0;
             if(!isBoundaryIndex) {
-                this._selectNextPart(step >= 0 ? step + 1 : step - 1, e);
+                this._selectNextPart(step >= 0 ? step + 1 : step - 1);
                 return;
             } else {
                 index = this._activePartIndex;
@@ -260,7 +287,6 @@ let DateBoxMask = DateBoxBase.inherit({
 
         this._activePartIndex = index;
         this._caret(this._getActivePartProp("caret"));
-        e && e.preventDefault();
     },
 
     _getActivePartLimits() {
@@ -327,7 +353,7 @@ let DateBoxMask = DateBoxBase.inherit({
         }
     },
 
-    _partIncrease(step, e) {
+    _partIncrease(step) {
         this._setNewDateIfEmpty();
 
         let limits = this._getActivePartLimits(),
@@ -337,8 +363,6 @@ let DateBoxMask = DateBoxBase.inherit({
         newValue = newValue < limits.min ? limits.max : newValue;
 
         this._setActivePartValue(newValue);
-
-        e && e.preventDefault();
     },
 
     _maskClickHandler() {
@@ -356,10 +380,10 @@ let DateBoxMask = DateBoxBase.inherit({
             this._renderDateParts();
             this._maskValue = date;
             this._renderDisplayText(this._getDisplayedText(this._maskValue));
-            this._selectNextPart(0, e);
-        } else {
-            e.preventDefault();
+            this._selectNextPart(0);
         }
+
+        e.preventDefault();
     },
 
     _isValueDirty() {
@@ -378,6 +402,7 @@ let DateBoxMask = DateBoxBase.inherit({
     _enterHandler(e) {
         this._fireChangeEvent();
         this._selectNextPart(FORWARD, e);
+        e.preventDefault();
     },
 
     _focusOutHandler(e) {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
@@ -331,9 +331,11 @@ if(devices.real().deviceType === "desktop") {
 
                 this.keyboard.press("up");
                 assert.equal(this.$input.val(), group.up, "group '" + group.pattern + "' increased");
+                assert.ok(this.keyboard.event.isDefaultPrevented(), "event should be prevented to save text selection after the press");
 
                 this.keyboard.press("down");
                 assert.equal(this.$input.val(), group.down, "group '" + group.pattern + "' decreased");
+                assert.ok(this.keyboard.event.isDefaultPrevented(), "event should be prevented to save text selection after the press");
             }.bind(this));
         });
 


### PR DESCRIPTION
A browser clears the datebox's selection when the user press up/down key. It is the default behavior. This shoud not happens in the dxDateBox with masks. In this editor the actual date part should be always selected. This pull request prevents the default browser behavior in described case. 