### PR TITLE
Slider focus handler should keep widget's context and consider the state of 'focusStateEnabled' option

### DIFF
--- a/js/ui/slider/ui.slider.js
+++ b/js/ui/slider/ui.slider.js
@@ -224,14 +224,6 @@ var Slider = TrackBar.inherit({
 
             useInkRipple: false,
 
-            onFocusIn: function() {
-                this._toggleValidationMessage(true);
-            },
-
-            onFocusOut: function() {
-                this._toggleValidationMessage(false);
-            },
-
             validationMessageOffset: themes.isMaterial() ? { h: 18, v: 0 } : { h: 7, v: 4 },
 
             focusStateEnabled: true
@@ -247,8 +239,8 @@ var Slider = TrackBar.inherit({
 
     _toggleValidationMessage: function(visible) {
         if(!this.option("isValid")) {
-            var $element = this.$element();
-            $element.toggleClass(INVALID_MESSAGE_VISIBLE_CLASS, visible);
+            this.$element()
+                .toggleClass(INVALID_MESSAGE_VISIBLE_CLASS, visible);
         }
     },
 
@@ -289,6 +281,27 @@ var Slider = TrackBar.inherit({
         this._renderLabels();
         this._renderStartHandler();
         this._renderAriaMinAndMax();
+    },
+
+    _attachFocusEvents: function() {
+        this.callBase();
+
+        var focusInEvent = eventUtils.addNamespace("focusin", this.NAME);
+        var focusOutEvent = eventUtils.addNamespace("focusout", this.NAME);
+
+        var $focusTarget = this._focusTarget();
+        eventsEngine.on($focusTarget, focusInEvent, this._toggleValidationMessage.bind(this, true));
+        eventsEngine.on($focusTarget, focusOutEvent, this._toggleValidationMessage.bind(this, false));
+    },
+
+    _detachFocusEvents: function() {
+        this.callBase();
+
+        var focusEvents = eventUtils.addNamespace("focusin", this.NAME) + " " + eventUtils.addNamespace("focusout", this.NAME);
+        var $focusTarget = this._focusTarget();
+
+        this._toggleValidationMessage(false);
+        eventsEngine.off($focusTarget, focusEvents);
     },
 
     _render: function() {

--- a/js/ui/slider/ui.slider.js
+++ b/js/ui/slider/ui.slider.js
@@ -17,16 +17,17 @@ var $ = require("../../core/renderer"),
     themes = require("../themes"),
     Deferred = require("../../core/utils/deferred").Deferred;
 
-var SLIDER_CLASS = "dx-slider",
-    SLIDER_WRAPPER_CLASS = "dx-slider-wrapper",
-    SLIDER_HANDLE_SELECTOR = ".dx-slider-handle",
-    SLIDER_BAR_CLASS = "dx-slider-bar",
-    SLIDER_RANGE_CLASS = "dx-slider-range",
-    SLIDER_RANGE_VISIBLE_CLASS = "dx-slider-range-visible",
-    SLIDER_LABEL_CLASS = "dx-slider-label",
-    SLIDER_LABEL_POSITION_CLASS_PREFIX = "dx-slider-label-position-",
-    SLIDER_TOOLTIP_POSITION_CLASS_PREFIX = "dx-slider-tooltip-position-",
-    INVALID_MESSAGE_VISIBLE_CLASS = "dx-invalid-message-visible";
+var SLIDER_CLASS = "dx-slider";
+var SLIDER_WRAPPER_CLASS = "dx-slider-wrapper";
+var SLIDER_HANDLE_SELECTOR = ".dx-slider-handle";
+var SLIDER_BAR_CLASS = "dx-slider-bar";
+var SLIDER_RANGE_CLASS = "dx-slider-range";
+var SLIDER_RANGE_VISIBLE_CLASS = "dx-slider-range-visible";
+var SLIDER_LABEL_CLASS = "dx-slider-label";
+var SLIDER_LABEL_POSITION_CLASS_PREFIX = "dx-slider-label-position-";
+var SLIDER_TOOLTIP_POSITION_CLASS_PREFIX = "dx-slider-tooltip-position-";
+var INVALID_MESSAGE_VISIBLE_CLASS = "dx-invalid-message-visible";
+var SLIDER_VALIDATION_NAMESPACE = "Validation";
 
 /**
 * @name dxSliderBase
@@ -286,8 +287,9 @@ var Slider = TrackBar.inherit({
     _attachFocusEvents: function() {
         this.callBase();
 
-        var focusInEvent = eventUtils.addNamespace("focusin", this.NAME);
-        var focusOutEvent = eventUtils.addNamespace("focusout", this.NAME);
+        var namespace = this.NAME + SLIDER_VALIDATION_NAMESPACE;
+        var focusInEvent = eventUtils.addNamespace("focusin", namespace);
+        var focusOutEvent = eventUtils.addNamespace("focusout", namespace);
 
         var $focusTarget = this._focusTarget();
         eventsEngine.on($focusTarget, focusInEvent, this._toggleValidationMessage.bind(this, true));
@@ -297,11 +299,10 @@ var Slider = TrackBar.inherit({
     _detachFocusEvents: function() {
         this.callBase();
 
-        var focusEvents = eventUtils.addNamespace("focusin", this.NAME) + " " + eventUtils.addNamespace("focusout", this.NAME);
         var $focusTarget = this._focusTarget();
 
         this._toggleValidationMessage(false);
-        eventsEngine.off($focusTarget, focusEvents);
+        eventsEngine.off($focusTarget, this.NAME + SLIDER_VALIDATION_NAMESPACE);
     },
 
     _render: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/slider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/slider.tests.js
@@ -1530,9 +1530,9 @@ module("validation", () => {
         const handle = $slider.find(`.${ SLIDER_HANDLE_CLASS }`).first();
 
         handle.trigger("focusin");
-        instance.option("focusStateEnabled", "false");
+        instance.option("focusStateEnabled", false);
 
         assert.notOk($slider.hasClass(INVALID_MESSAGE_VISIBLE_CLASS));
-        assert.equal($(".dx-overlay-wrapper.dx-invalid-message").css("visibility"), "hidden", "validation message is hidden");
+        assert.strictEqual($(".dx-overlay-wrapper.dx-invalid-message").css("visibility"), "hidden", "validation message is hidden");
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/slider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/slider.tests.js
@@ -1517,4 +1517,22 @@ module("validation", () => {
         assert.notOk($slider.hasClass(INVALID_MESSAGE_VISIBLE_CLASS));
         assert.equal($(".dx-overlay-wrapper.dx-invalid-message").css("visibility"), "hidden", "validation message is hidden");
     });
+
+    testInActiveWindow("validation message should be hidden once focusStateEnabled option switch off", assert => {
+        const $slider = $("#slider");
+        const instance = $slider.dxSlider({
+            max: 100,
+            min: 0,
+            value: 50,
+            isValid: false,
+            validationError: { message: "Test message" }
+        }).dxSlider("instance");
+        const handle = $slider.find(`.${ SLIDER_HANDLE_CLASS }`).first();
+
+        handle.trigger("focusin");
+        instance.option("focusStateEnabled", "false");
+
+        assert.notOk($slider.hasClass(INVALID_MESSAGE_VISIBLE_CLASS));
+        assert.equal($(".dx-overlay-wrapper.dx-invalid-message").css("visibility"), "hidden", "validation message is hidden");
+    });
 });


### PR DESCRIPTION
It fix tests for our demos after #6736