### PR TITLE
Add possibility to prevent an outside click without preventing the event (T710079)

### DIFF
--- a/js/ui/context_menu/ui.context_menu.js
+++ b/js/ui/context_menu/ui.context_menu.js
@@ -568,6 +568,7 @@ var ContextMenu = MenuBase.inherit((function() {
                 overlayOptions = {
                     focusStateEnabled: this.option("focusStateEnabled"),
                     animation: overlayAnimation,
+                    innerOverlay: true,
                     closeOnOutsideClick: this._closeOnOutsideClickHandler.bind(this),
                     propagateOutsideClick: true,
                     closeOnTargetScroll: true,

--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -39,6 +39,7 @@ var OVERLAY_CLASS = "dx-overlay",
     OVERLAY_CONTENT_CLASS = "dx-overlay-content",
     OVERLAY_SHADER_CLASS = "dx-overlay-shader",
     OVERLAY_MODAL_CLASS = "dx-overlay-modal",
+    INNER_OVERLAY_CLASS = "dx-inner-overlay",
     INVISIBLE_STATE_CLASS = "dx-state-invisible",
 
     ANONYMOUS_TEMPLATE_NAME = "content",
@@ -349,6 +350,7 @@ var Overlay = Widget.inherit({
             onResizeStart: null,
             onResize: null,
             onResizeEnd: null,
+            innerOverlay: false,
 
             // NOTE: private options
 
@@ -442,6 +444,7 @@ var Overlay = Widget.inherit({
 
         this._$wrapper = $("<div>").addClass(OVERLAY_WRAPPER_CLASS);
         this._$content = $("<div>").addClass(OVERLAY_CONTENT_CLASS);
+        this._initInnerOverlayClass();
 
         var $element = this.$element();
         this._$wrapper.addClass($element.attr("class"));
@@ -463,6 +466,10 @@ var Overlay = Widget.inherit({
         this._initHideTopOverlayHandler(options.hideTopOverlayHandler);
 
         this.callBase(options);
+    },
+
+    _initInnerOverlayClass: function() {
+        this._$content.toggleClass(INNER_OVERLAY_CLASS, this.option("innerOverlay"));
     },
 
     _initTarget: function(target) {
@@ -545,7 +552,8 @@ var Overlay = Widget.inherit({
 
         var $container = this._$content,
             isAttachedTarget = $(window.document).is(e.target) || domUtils.contains(window.document, e.target),
-            outsideClick = isAttachedTarget && !($container.is(e.target) || domUtils.contains($container.get(0), e.target));
+            isContextMenu = $(e.target).closest("." + INNER_OVERLAY_CLASS).length,
+            outsideClick = isAttachedTarget && !isContextMenu && !($container.is(e.target) || domUtils.contains($container.get(0), e.target));
 
         if(outsideClick && closeOnOutsideClick) {
             if(this.option("shading")) {
@@ -1468,6 +1476,9 @@ var Overlay = Widget.inherit({
             case "container":
                 this._initContainer(value);
                 this._invalidate();
+                break;
+            case "innerOverlay":
+                this._initInnerOverlayClass();
                 break;
             case "deferRendering":
             case "contentTemplate":

--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -552,8 +552,8 @@ var Overlay = Widget.inherit({
 
         var $container = this._$content,
             isAttachedTarget = $(window.document).is(e.target) || domUtils.contains(window.document, e.target),
-            isContextMenu = $(e.target).closest("." + INNER_OVERLAY_CLASS).length,
-            outsideClick = isAttachedTarget && !isContextMenu && !($container.is(e.target) || domUtils.contains($container.get(0), e.target));
+            isInnerOverlay = $(e.target).closest("." + INNER_OVERLAY_CLASS).length,
+            outsideClick = isAttachedTarget && !isInnerOverlay && !($container.is(e.target) || domUtils.contains($container.get(0), e.target));
 
         if(outsideClick && closeOnOutsideClick) {
             if(this.option("shading")) {

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
@@ -1,18 +1,18 @@
-var $ = require("jquery"),
-    devices = require("core/devices"),
-    fx = require("animation/fx"),
-    ContextMenu = require("ui/context_menu"),
-    eventUtils = require("events/utils"),
-    contextMenuEvent = require("events/contextmenu"),
-    isRenderer = require("core/utils/type").isRenderer,
-    config = require("core/config"),
-    keyboardMock = require("../../helpers/keyboardMock.js");
+import $ from "jquery";
+import devices from "core/devices";
+import fx from "animation/fx";
+import ContextMenu from "ui/context_menu";
+import eventUtils from "events/utils";
+import contextMenuEvent from "events/contextmenu";
+import { isRenderer } from "core/utils/type";
+import config from "core/config";
+import keyboardMock from "../../helpers/keyboardMock.js";
 
-require("ui/button");
-require("common.css!");
+import "ui/button";
+import "common.css!";
 
-QUnit.testStart(function() {
-    var markup =
+QUnit.testStart(() => {
+    const markup =
         '<div id="simpleMenu"></div>\
         <div id="menuTarget"></div>\
         <div id="menuTarget2"></div>\
@@ -21,19 +21,19 @@ QUnit.testStart(function() {
     $("#qunit-fixture").html(markup);
 });
 
-var DX_CONTEXT_MENU_CLASS = "dx-context-menu",
-    DX_MENU_ITEM_CLASS = "dx-menu-item",
-    DX_MENU_ITEM_CONTENT_CLASS = "dx-menu-item-content",
-    DX_MENU_PHONE_CLASS = "dx-menu-phone-overlay",
-    DX_MENU_ITEM_SELECTED_CLASS = "dx-menu-item-selected",
-    DX_STATE_HOVER_CLASS = "dx-state-hover",
-    DX_STATE_FOCUSED_CLASS = "dx-state-focused",
-    DX_MENU_ITEM_EXPANDED_CLASS = "dx-menu-item-expanded",
-    DX_MENU_ITEM_POPOUT_CLASS = "dx-menu-item-popout",
-    DX_SUBMENU_CLASS = "dx-submenu",
-    DX_HAS_SUBMENU_CLASS = "dx-menu-item-has-submenu";
+const DX_CONTEXT_MENU_CLASS = "dx-context-menu";
+const DX_MENU_ITEM_CLASS = "dx-menu-item";
+const DX_MENU_ITEM_CONTENT_CLASS = "dx-menu-item-content";
+const DX_MENU_PHONE_CLASS = "dx-menu-phone-overlay";
+const DX_MENU_ITEM_SELECTED_CLASS = "dx-menu-item-selected";
+const DX_STATE_HOVER_CLASS = "dx-state-hover";
+const DX_STATE_FOCUSED_CLASS = "dx-state-focused";
+const DX_MENU_ITEM_EXPANDED_CLASS = "dx-menu-item-expanded";
+const DX_MENU_ITEM_POPOUT_CLASS = "dx-menu-item-popout";
+const DX_SUBMENU_CLASS = "dx-submenu";
+const DX_HAS_SUBMENU_CLASS = "dx-menu-item-has-submenu";
 
-var isDeviceDesktop = function(assert) {
+const isDeviceDesktop = assert => {
     if(devices.real().deviceType !== "desktop") {
         assert.ok(true, "skip this test on mobile devices");
         return false;
@@ -41,8 +41,8 @@ var isDeviceDesktop = function(assert) {
     return true;
 };
 
-var moduleConfig = {
-    beforeEach: function() {
+const moduleConfig = {
+    beforeEach: () => {
         fx.off = true;
 
         this.items = [
@@ -57,299 +57,312 @@ var moduleConfig = {
         this.clock = sinon.useFakeTimers();
     },
 
-    afterEach: function() {
+    afterEach: () => {
         fx.off = false;
     }
 };
 
-QUnit.module("Rendering", moduleConfig);
+QUnit.module("Rendering", moduleConfig, () => {
+    QUnit.test("all items in root level should be wrapped in submenu", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: "item1" }], visible: true });
+        const $itemsContainer = instance.itemsContainer();
 
-QUnit.test("all items in root level should be wrapped in submenu", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: "item1" }], visible: true }),
+        assert.ok($itemsContainer.children().hasClass(DX_SUBMENU_CLASS), "items are wrapped in submenu");
+    });
+
+    QUnit.test("lazy rendering: not render overlay on init", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: "item1" }] });
+        let $itemsContainer = instance.itemsContainer();
+
+        assert.ok(!$itemsContainer, "no itemsContainer");
+
+        instance.show();
         $itemsContainer = instance.itemsContainer();
+        assert.ok($itemsContainer.length, "overlay is defined");
+    });
 
-    assert.ok($itemsContainer.children().hasClass(DX_SUBMENU_CLASS), "items are wrapped in submenu");
-});
-
-QUnit.test("lazy rendering: not render overlay on init", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: "item1" }] }),
-        $itemsContainer = instance.itemsContainer();
-
-    assert.ok(!$itemsContainer, "no itemsContainer");
-
-    instance.show();
-    $itemsContainer = instance.itemsContainer();
-    assert.ok($itemsContainer.length, "overlay is defined");
-});
-
-QUnit.test("item click should not prevent document click handler", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("item click should not prevent document click handler", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "a" }]
-        }),
-        documentClickHandler = sinon.stub();
+        });
 
-    $(document).on("click", documentClickHandler);
-    instance.show();
-    var $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
-    $($items.eq(0)).trigger("click");
+        const documentClickHandler = sinon.stub();
 
-    assert.equal(documentClickHandler.callCount, 1, "click was not prevented");
-    $(document).off("click");
-});
+        $(document).on("click", documentClickHandler);
+        instance.show();
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        $($items.eq(0)).trigger("click");
 
-QUnit.test("context menu items with submenu should have 'has-submenu' class", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        assert.equal(documentClickHandler.callCount, 1, "click was not prevented");
+        $(document).off("click");
+    });
+
+    QUnit.test("context menu items with submenu should have 'has-submenu' class", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item1", items: [{ text: "item11" }] }],
             visible: true
-        }),
+        });
+
+        let $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+
+        $($items.eq(0)).trigger("dxclick");
+
         $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-    $($items.eq(0)).trigger("dxclick");
+        assert.ok($items.eq(0).hasClass(DX_HAS_SUBMENU_CLASS), "item with children has special class");
+        assert.notOk($items.eq(1).hasClass(DX_HAS_SUBMENU_CLASS), "item without children has not special class");
+    });
 
-    $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
-
-    assert.ok($items.eq(0).hasClass(DX_HAS_SUBMENU_CLASS), "item with children has special class");
-    assert.notOk($items.eq(1).hasClass(DX_HAS_SUBMENU_CLASS), "item without children has not special class");
-});
-
-QUnit.test("context menu items with submenu should have item popout", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("context menu items with submenu should have item popout", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item1", items: [{ text: "item11" }] }],
             visible: true
-        }),
-        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        });
 
-    assert.equal($items.find("." + DX_MENU_ITEM_POPOUT_CLASS).length, 1, "only one item popout exist");
-    assert.equal($items.eq(0).find("." + DX_MENU_ITEM_POPOUT_CLASS).length, 1, "popout is on the first item");
-});
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("item container should have special class for phone devices", function(assert) {
-    var device = devices.current();
+        assert.equal($items.find("." + DX_MENU_ITEM_POPOUT_CLASS).length, 1, "only one item popout exist");
+        assert.equal($items.eq(0).find("." + DX_MENU_ITEM_POPOUT_CLASS).length, 1, "popout is on the first item");
+    });
 
-    devices.current({ deviceType: "phone" });
+    QUnit.test("item container should have special class for phone devices", (assert) => {
+        const device = devices.current();
 
-    try {
-        var instance = new ContextMenu(this.$element, { visible: true });
-        assert.ok(instance.itemsContainer().hasClass(DX_MENU_PHONE_CLASS));
-    } finally {
-        devices.current(device);
-    }
-});
+        devices.current({ deviceType: "phone" });
 
-QUnit.test("context menu should create only root level at first", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        try {
+            const instance = new ContextMenu(this.$element, { visible: true });
+            assert.ok(instance.itemsContainer().hasClass(DX_MENU_PHONE_CLASS));
+        } finally {
+            devices.current(device);
+        }
+    });
+
+    QUnit.test("context menu should create only root level at first", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11" }] }],
             visible: true
-        }),
-        submenus = instance.itemsContainer().find("." + DX_SUBMENU_CLASS);
+        });
 
-    assert.equal(submenus.length, 1, "only root level rendered");
-});
+        const submenus = instance.itemsContainer().find("." + DX_SUBMENU_CLASS);
 
-QUnit.test("root level should not be rendered without items", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [], visible: true }),
-        submenus = instance.itemsContainer().find("." + DX_SUBMENU_CLASS);
+        assert.equal(submenus.length, 1, "only root level rendered");
+    });
 
-    assert.equal(submenus.length, 0, "there is no submenus in menu");
-});
+    QUnit.test("root level should not be rendered without items", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [], visible: true });
+        const submenus = instance.itemsContainer().find("." + DX_SUBMENU_CLASS);
 
-QUnit.test("submenus should not be rendered without items", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        assert.equal(submenus.length, 0, "there is no submenus in menu");
+    });
+
+    QUnit.test("submenus should not be rendered without items", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             visible: true,
             items: [{ text: "item1", items: [] }]
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        });
 
-    $($rootItem).trigger("dxclick");
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
 
-    var submenus = instance.itemsContainer().find("." + DX_SUBMENU_CLASS);
+        $($rootItem).trigger("dxclick");
 
-    assert.equal(submenus.length, 1, "empty submenu should not rendered");
-    assert.equal($itemsContainer.find("." + DX_MENU_ITEM_POPOUT_CLASS).length, 0, "there are no popouts in items");
-    assert.notOk($rootItem.hasClass(DX_HAS_SUBMENU_CLASS), "root item has no 'has-submenu' class");
-});
+        const submenus = instance.itemsContainer().find("." + DX_SUBMENU_CLASS);
 
-QUnit.test("onSubmenuCreated should be fired after submenu was rendered", function(assert) {
-    var onSubmenuCreated = sinon.spy(),
-        instance = new ContextMenu(this.$element, {
+        assert.equal(submenus.length, 1, "empty submenu should not rendered");
+        assert.equal($itemsContainer.find("." + DX_MENU_ITEM_POPOUT_CLASS).length, 0, "there are no popouts in items");
+        assert.notOk($rootItem.hasClass(DX_HAS_SUBMENU_CLASS), "root item has no 'has-submenu' class");
+    });
+
+    QUnit.test("onSubmenuCreated should be fired after submenu was rendered", (assert) => {
+        const onSubmenuCreated = sinon.spy();
+
+        const instance = new ContextMenu(this.$element, {
             visible: true,
-            onSubmenuCreated: onSubmenuCreated,
+            onSubmenuCreated,
             items: [{ text: "item1", items: [{ text: "item11" }] }]
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        });
 
-    $($rootItem).trigger("dxclick");
-    assert.equal(onSubmenuCreated.callCount, 1, "handler was called once");
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
 
-    $($rootItem).trigger("dxclick");
-    assert.equal(onSubmenuCreated.callCount, 1, "handler should not be called after the second click");
+        $($rootItem).trigger("dxclick");
+        assert.equal(onSubmenuCreated.callCount, 1, "handler was called once");
 
-    instance.hide();
-    instance.show();
-    $($rootItem).trigger("dxclick");
-    assert.equal(onSubmenuCreated.callCount, 1, "handler should not be called after the second showing");
-});
+        $($rootItem).trigger("dxclick");
+        assert.equal(onSubmenuCreated.callCount, 1, "handler should not be called after the second click");
 
-QUnit.test("contextMenu should not create a new overlay after refresh", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: 1 }, { text: 2 }] });
+        instance.hide();
+        instance.show();
+        $($rootItem).trigger("dxclick");
+        assert.equal(onSubmenuCreated.callCount, 1, "handler should not be called after the second showing");
+    });
 
-    instance.option("items", [{ text: 3 }, { text: 4 }]);
-    instance.show();
-    assert.equal($(".dx-overlay").length, 1, "only one overlay should exists");
-});
+    QUnit.test("contextMenu should not create a new overlay after refresh", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: 1 }, { text: 2 }] });
 
-QUnit.test("submenus in the same level should have same horizontal offset", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        instance.option("items", [{ text: 3 }, { text: 4 }]);
+        instance.show();
+        assert.equal($(".dx-overlay").length, 1, "only one overlay should exists");
+    });
+
+    QUnit.test("submenus in the same level should have same horizontal offset", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             target: "#menuTarget",
             items: [
                 { text: "item1", items: [{ text: "subItem1" }] },
                 { text: "item2WithVeryVeryLongCaption", items: [{ text: "subItem2" }] }
             ],
             visible: true
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS),
-        offsets = [];
+        });
 
-    $($items.eq(0)).trigger("dxclick");
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
-    offsets[0] = $items.eq(1).offset().left;
+        const $itemsContainer = instance.itemsContainer();
+        let $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        const offsets = [];
 
-    $($items.eq(2)).trigger("dxclick");
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
-    offsets[1] = $items.eq(3).offset().left;
+        $($items.eq(0)).trigger("dxclick");
+        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        offsets[0] = $items.eq(1).offset().left;
 
-    assert.equal(offsets[0], offsets[1], "offsets are equal");
-});
+        $($items.eq(2)).trigger("dxclick");
+        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        offsets[1] = $items.eq(3).offset().left;
 
-QUnit.test("event handlers should be bound for detached target", function(assert) {
-    var $target = $("#menuTarget"),
-        $parent = $target.parent();
+        assert.equal(offsets[0], offsets[1], "offsets are equal");
+    });
 
-    $target.detach();
+    QUnit.test("event handlers should be bound for detached target", (assert) => {
+        const $target = $("#menuTarget");
+        const $parent = $target.parent();
 
-    var contextMenu = new ContextMenu(this.$element, { target: "#menuTarget", items: [{ text: "a" }] });
-    $parent.append($target);
-    $($target).trigger("dxcontextmenu");
+        $target.detach();
 
-    assert.ok(contextMenu.option("visible"), "context menu is shown after detached target been attached");
-});
+        const contextMenu = new ContextMenu(this.$element, { target: "#menuTarget", items: [{ text: "a" }] });
+        $parent.append($target);
+        $($target).trigger("dxcontextmenu");
 
-QUnit.test("not create keyboardProcessor on rendering", function(assert) {
-    var instance = new ContextMenu(this.$element, {});
+        assert.ok(contextMenu.option("visible"), "context menu is shown after detached target been attached");
+    });
 
-    assert.notOk(instance._keyboardProcessor, "keyboard processor is undefined");
-});
+    QUnit.test("not create keyboardProcessor on rendering", (assert) => {
+        const instance = new ContextMenu(this.$element, {});
 
-QUnit.module("Showing and hiding context menu", moduleConfig);
-
-QUnit.test("visible option should toggle menu's visibility", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: 1, items: [{ text: 11 }] }], visible: true }),
-        $itemsContainer = instance.itemsContainer();
-
-    assert.ok($itemsContainer.is(":visible"), "menu is visible");
-
-    instance.option("visible", false);
-    assert.notOk($itemsContainer.is(":visible"), "menu is invisible");
-
-    instance.option("visible", true);
-    assert.ok($itemsContainer.is(":visible"), "menu is visible");
-});
-
-QUnit.test("context menu should not leak overlays", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
-
-    instance.option("items", [{ text: 1 }]);
-    assert.equal($(".dx-overlay").length, 1, "overlays cleaned correctly");
-});
-
-QUnit.test("show method should toggle menu's visibility", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: false });
-
-    instance.show();
-    assert.ok(instance.option("visible"), "option visible was changed to true");
-});
-
-QUnit.test("hide method should toggle menu's visibility", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
-
-    instance.hide();
-    assert.notOk(instance.option("visible"), "option visible was changed to false");
-});
-
-QUnit.test("expanded class should be removed from submenus after hiding menu with hide method", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-            items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
-            visible: true
-        }),
-        $itemsContainer = instance.itemsContainer();
-
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
-
-    instance.hide();
-
-    var $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
-
-    $items.each(function(_, item) {
-        var $item = $(item),
-            itemText = $item.find(".dx-menu-item-text").first().text();
-
-        assert.notOk($item.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), itemText + " has no expanded class");
+        assert.notOk(instance._keyboardProcessor, "keyboard processor is undefined");
     });
 });
 
-QUnit.test("expanded class should be removed from submenus after hiding menu with visible option", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+QUnit.module("Showing and hiding context menu", moduleConfig, () => {
+    QUnit.test("visible option should toggle menu's visibility", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: 1, items: [{ text: 11 }] }], visible: true });
+        const $itemsContainer = instance.itemsContainer();
+
+        assert.ok($itemsContainer.is(":visible"), "menu is visible");
+
+        instance.option("visible", false);
+        assert.notOk($itemsContainer.is(":visible"), "menu is invisible");
+
+        instance.option("visible", true);
+        assert.ok($itemsContainer.is(":visible"), "menu is visible");
+    });
+
+    QUnit.test("context menu should not leak overlays", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
+
+        instance.option("items", [{ text: 1 }]);
+        assert.equal($(".dx-overlay").length, 1, "overlays cleaned correctly");
+    });
+
+    QUnit.test("show method should toggle menu's visibility", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: false });
+
+        instance.show();
+        assert.ok(instance.option("visible"), "option visible was changed to true");
+    });
+
+    QUnit.test("hide method should toggle menu's visibility", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
+
+        instance.hide();
+        assert.notOk(instance.option("visible"), "option visible was changed to false");
+    });
+
+    QUnit.test("expanded class should be removed from submenus after hiding menu with hide method", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true
-        }),
-        $itemsContainer = instance.itemsContainer();
+        });
 
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
+        const $itemsContainer = instance.itemsContainer();
 
-    instance.option("visible", false);
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
 
-    var $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        instance.hide();
 
-    $items.each(function(_, item) {
-        var $item = $(item),
-            itemText = $item.find(".dx-menu-item-text").first().text();
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-        assert.notOk($item.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), itemText + " has no expanded class");
+        $items.each((_, item) => {
+            const $item = $(item);
+            const itemText = $item.find(".dx-menu-item-text").first().text();
+
+            assert.notOk($item.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), itemText + " has no expanded class");
+        });
     });
-});
 
-QUnit.test("expanded class should be removed from submenus after hiding menu with outside click", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("expanded class should be removed from submenus after hiding menu with visible option", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true
-        }),
-        $itemsContainer = instance.itemsContainer();
+        });
 
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
+        const $itemsContainer = instance.itemsContainer();
 
-    $(document).trigger("dxpointerdown");
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
 
-    var $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        instance.option("visible", false);
 
-    $items.each(function(_, item) {
-        var $item = $(item),
-            itemText = $item.find(".dx-menu-item-text").first().text();
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-        assert.notOk($item.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), itemText + " has no expanded class");
+        $items.each((_, item) => {
+            const $item = $(item);
+            const itemText = $item.find(".dx-menu-item-text").first().text();
+
+            assert.notOk($item.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), itemText + " has no expanded class");
+        });
     });
-});
 
-QUnit.test("context menu should not be shown if target is disabled", function(assert) {
-    try {
-        var eventCounter = 0,
-            incrementCounter = function() { eventCounter++; },
-            instance = new ContextMenu(this.$element, {
+    QUnit.test("expanded class should be removed from submenus after hiding menu with outside click", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
+            visible: true
+        });
+
+        const $itemsContainer = instance.itemsContainer();
+
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
+
+        $(document).trigger("dxpointerdown");
+
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+
+        $items.each((_, item) => {
+            const $item = $(item);
+            const itemText = $item.find(".dx-menu-item-text").first().text();
+
+            assert.notOk($item.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), itemText + " has no expanded class");
+        });
+    });
+
+    QUnit.test("context menu should not be shown if target is disabled", (assert) => {
+        try {
+            let eventCounter = 0;
+            const incrementCounter = () => {
+                eventCounter++;
+            };
+
+            const instance = new ContextMenu(this.$element, {
                 items: [{ text: "item 1" }],
                 target: "#menuTarget",
                 visible: false,
@@ -359,20 +372,23 @@ QUnit.test("context menu should not be shown if target is disabled", function(as
                 onPositioned: incrementCounter
             });
 
-        $("#menuTarget").addClass("dx-state-disabled").trigger("dxcontextmenu");
+            $("#menuTarget").addClass("dx-state-disabled").trigger("dxcontextmenu");
 
-        assert.notOk(instance.option("visible"), "context menu is not visible");
-        assert.equal(eventCounter, 0, "visibility callbacks does not fired");
-    } finally {
-        $("#menuTarget").removeClass("dx-state-disabled");
-    }
-});
+            assert.notOk(instance.option("visible"), "context menu is not visible");
+            assert.equal(eventCounter, 0, "visibility callbacks does not fired");
+        } finally {
+            $("#menuTarget").removeClass("dx-state-disabled");
+        }
+    });
 
-QUnit.test("context menu should not be shown if it is disabled", function(assert) {
-    try {
-        var eventCounter = 0,
-            incrementCounter = function() { eventCounter++; },
-            instance = new ContextMenu(this.$element, {
+    QUnit.test("context menu should not be shown if it is disabled", (assert) => {
+        try {
+            let eventCounter = 0;
+            const incrementCounter = () => {
+                eventCounter++;
+            };
+
+            const instance = new ContextMenu(this.$element, {
                 items: [{ text: "item 1" }],
                 disabled: true,
                 target: "#menuTarget",
@@ -383,63 +399,84 @@ QUnit.test("context menu should not be shown if it is disabled", function(assert
                 onPositioned: incrementCounter
             });
 
+            $("#menuTarget").trigger("dxcontextmenu");
+
+            assert.notOk(instance.option("visible"), "context menu is not visible");
+            assert.equal(eventCounter, 0, "visibility callbacks does not fired");
+        } finally {
+            $("#menuTarget").removeClass("dx-state-disabled");
+        }
+    });
+
+    QUnit.test("context menu should be shown after submenuDirection option change", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
+        let $itemsContainer;
+
+        instance.option("visible", false);
+        instance.option("submenuDirection", "left");
+        $itemsContainer = instance.itemsContainer();
+        assert.ok(!$itemsContainer, "menu is removed");
+
+        instance.show();
+        $itemsContainer = instance.itemsContainer();
+        assert.ok($itemsContainer.is(":visible"), "menu is rendered again");
+    });
+
+    QUnit.test("context menu's overlay should have flipfit position as native context menu", (assert) => {
+        new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
+
+        const overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
+        assert.equal(overlay.option("position").collision, "flipfit", "position is correct");
+    });
+
+    QUnit.test("overlay should have innerOverlay option", (assert) => {
+        new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
+
+        const overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
+        assert.ok(overlay.option("innerOverlay"));
+    });
+
+    QUnit.test("Document should be default target", (assert) => {
+        const showingHandler = sinon.stub();
+
+        new ContextMenu(this.$element, {
+            items: [{ text: "item 1" }],
+            onShowing: showingHandler
+        });
+
+        $(window).trigger("dxcontextmenu");
+        assert.equal(showingHandler.callCount, 0, "context menu is not subscribed on the window");
+
+        $(document).trigger("dxcontextmenu");
+        assert.equal(showingHandler.callCount, 1, "context menu is subscribed on the document");
+    });
+
+    // T459373
+    QUnit.test("Show context menu when position and target is defined", (assert) => {
+        let overlay;
+
+        const instance = new ContextMenu(this.$element, {
+            target: $("#menuTarget"),
+            items: [{ text: "item 1" }],
+            visible: false,
+            position: {
+                at: "bottom center",
+                my: "top center",
+                of: $("#menuShower")
+            }
+        });
+
         $("#menuTarget").trigger("dxcontextmenu");
 
-        assert.notOk(instance.option("visible"), "context menu is not visible");
-        assert.equal(eventCounter, 0, "visibility callbacks does not fired");
-    } finally {
-        $("#menuTarget").removeClass("dx-state-disabled");
-    }
-});
-
-QUnit.test("context menu should be shown after submenuDirection option change", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true }),
-        $itemsContainer;
-
-    instance.option("visible", false);
-    instance.option("submenuDirection", "left");
-    $itemsContainer = instance.itemsContainer();
-    assert.ok(!$itemsContainer, "menu is removed");
-
-    instance.show();
-    $itemsContainer = instance.itemsContainer();
-    assert.ok($itemsContainer.is(":visible"), "menu is rendered again");
-});
-
-QUnit.test("context menu's overlay should have flipfit position as native context menu", function(assert) {
-    new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
-
-    var overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
-    assert.equal(overlay.option("position").collision, "flipfit", "position is correct");
-});
-
-QUnit.test("overlay should have innerOverlay option", function(assert) {
-    new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
-
-    var overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
-    assert.ok(overlay.option("innerOverlay"));
-});
-
-QUnit.test("Document should be default target", function(assert) {
-    var showingHandler = sinon.stub();
-
-    new ContextMenu(this.$element, {
-        items: [{ text: "item 1" }],
-        onShowing: showingHandler
+        overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
+        assert.ok(instance.option("visible"), "context menu is visible");
+        assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
     });
 
-    $(window).trigger("dxcontextmenu");
-    assert.equal(showingHandler.callCount, 0, "context menu is not subscribed on the window");
+    QUnit.test("Show context menu when position.of is defined", (assert) => {
+        let overlay;
 
-    $(document).trigger("dxcontextmenu");
-    assert.equal(showingHandler.callCount, 1, "context menu is subscribed on the document");
-});
-
-// T459373
-QUnit.test("Show context menu when position and target is defined", function(assert) {
-    var overlay,
-        instance = new ContextMenu(this.$element, {
-            target: $("#menuTarget"),
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }],
             visible: false,
             position: {
@@ -449,50 +486,33 @@ QUnit.test("Show context menu when position and target is defined", function(ass
             }
         });
 
-    $("#menuTarget").trigger("dxcontextmenu");
+        $("#menuShower").trigger("dxcontextmenu");
 
-    overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
-    assert.ok(instance.option("visible"), "context menu is visible");
-    assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
-});
+        overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
+        assert.ok(instance.option("visible"), "context menu is visible");
+        assert.deepEqual(overlay.option("position.of").get(0), $("#menuShower").get(0), "position is correct");
+    });
 
-QUnit.test("Show context menu when position.of is defined", function(assert) {
-    var overlay,
-        instance = new ContextMenu(this.$element, {
-            items: [{ text: "item 1" }],
-            visible: false,
-            position: {
-                at: "bottom center",
-                my: "top center",
-                of: $("#menuShower")
-            }
-        });
+    QUnit.test("Show context menu when position is undefined", (assert) => {
+        let overlay;
 
-    $("#menuShower").trigger("dxcontextmenu");
-
-    overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
-    assert.ok(instance.option("visible"), "context menu is visible");
-    assert.deepEqual(overlay.option("position.of").get(0), $("#menuShower").get(0), "position is correct");
-});
-
-QUnit.test("Show context menu when position is undefined", function(assert) {
-    var overlay,
-        instance = new ContextMenu(this.$element, {
+        const instance = new ContextMenu(this.$element, {
             target: $("#menuTarget"),
             items: [{ text: "item 1" }],
             visible: false
         });
 
-    $("#menuTarget").trigger("dxcontextmenu");
+        $("#menuTarget").trigger("dxcontextmenu");
 
-    overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
-    assert.ok(instance.option("visible"), "context menu is visible");
-    assert.ok(overlay.option("position.of") instanceof $.Event, "position is correct");
-});
+        overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
+        assert.ok(instance.option("visible"), "context menu is visible");
+        assert.ok(overlay.option("position.of") instanceof $.Event, "position is correct");
+    });
 
-QUnit.test("Show context menu via api when position is defined", function(assert) {
-    var overlay,
-        instance = new ContextMenu(this.$element, {
+    QUnit.test("Show context menu via api when position is defined", (assert) => {
+        let overlay;
+
+        const instance = new ContextMenu(this.$element, {
             target: $("#menuTarget"),
             items: [{ text: "item 1" }],
             visible: false,
@@ -503,148 +523,156 @@ QUnit.test("Show context menu via api when position is defined", function(assert
             }
         });
 
-    instance.show();
+        instance.show();
 
-    overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
-    assert.ok(instance.option("visible"), "context menu is visible");
-    assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
-});
+        overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
+        assert.ok(instance.option("visible"), "context menu is visible");
+        assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
+    });
 
-QUnit.test("Show context menu via api when position is undefined", function(assert) {
-    var overlay,
-        instance = new ContextMenu(this.$element, {
+    QUnit.test("Show context menu via api when position is undefined", (assert) => {
+        let overlay;
+
+        const instance = new ContextMenu(this.$element, {
             target: $("#menuTarget"),
             items: [{ text: "item 1" }],
             visible: false
         });
 
-    instance.show();
+        instance.show();
 
-    overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
-    assert.ok(instance.option("visible"), "context menu is visible");
-    assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
-});
-
-QUnit.test("show/hide methods should return Deferred", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        target: $("#menuTarget"),
-        items: [{ text: "item 1" }],
-        visible: false
+        overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
+        assert.ok(instance.option("visible"), "context menu is visible");
+        assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
     });
 
-    var d = instance.show();
+    QUnit.test("show/hide methods should return Deferred", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            target: $("#menuTarget"),
+            items: [{ text: "item 1" }],
+            visible: false
+        });
 
-    assert.ok($.isFunction(d.promise), "type object is the Deferred");
+        let d = instance.show();
 
-    d = instance.hide();
+        assert.ok($.isFunction(d.promise), "type object is the Deferred");
 
-    assert.ok($.isFunction(d.promise), "type object is the Deferred");
+        d = instance.hide();
+
+        assert.ok($.isFunction(d.promise), "type object is the Deferred");
+    });
 });
 
-QUnit.module("Showing and hiding submenus", moduleConfig);
-
-QUnit.test("submenu should be shown after click on root item", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+QUnit.module("Showing and hiding submenus", moduleConfig, () => {
+    QUnit.test("submenu should be shown after click on root item", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item1", items: [{ text: "item11" }] }],
             visible: true
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        });
 
-    $($rootItem).trigger("dxclick");
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
 
-    var submenus = $itemsContainer.find("." + DX_SUBMENU_CLASS);
+        $($rootItem).trigger("dxclick");
 
-    assert.equal(submenus.length, 2, "submenu was rendered");
-    assert.ok(submenus.eq(1).is(":visible"), "submenu is visible");
-    assert.ok($rootItem.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was added");
-});
+        const submenus = $itemsContainer.find("." + DX_SUBMENU_CLASS);
 
-QUnit.test("all submenus should hide after click on item from different branch", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        assert.equal(submenus.length, 2, "submenu was rendered");
+        assert.ok(submenus.eq(1).is(":visible"), "submenu is visible");
+        assert.ok($rootItem.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was added");
+    });
+
+    QUnit.test("all submenus should hide after click on item from different branch", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11" }] }, { text: "item 2" }],
             visible: true
-        }),
-        $itemsContainer = instance.itemsContainer(),
+        });
+
+        const $itemsContainer = instance.itemsContainer();
+        let $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+
+        $($items.eq(0)).trigger("dxclick");
         $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        $($items.eq(2)).trigger("dxclick");
 
-    $($items.eq(0)).trigger("dxclick");
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
-    $($items.eq(2)).trigger("dxclick");
+        assert.notOk($items.eq(0).is(":visible"), "first submenu item was hidden");
+        assert.notOk($items.eq(1).is(":visible"), "second submenu item was hidden");
+        assert.notOk($items.eq(0).hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was removed from first item");
+    });
 
-    assert.notOk($items.eq(0).is(":visible"), "first submenu item was hidden");
-    assert.notOk($items.eq(1).is(":visible"), "second submenu item was hidden");
-    assert.notOk($items.eq(0).hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was removed from first item");
-});
-
-QUnit.test("submenu should not hide after click on parent submenu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("submenu should not hide after click on parent submenu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $items;
+        });
 
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        const $itemsContainer = instance.itemsContainer();
+        let $items;
 
-    assert.ok($items.eq(2).is(":visible"), "last submenu item was shown");
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
+        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
 
-    $($items.eq(1)).trigger("dxclick");
-    assert.ok($items.eq(1).is(":visible"), "first submenu item is visible");
-    assert.ok($items.eq(1).hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was not removed");
-});
+        assert.ok($items.eq(2).is(":visible"), "last submenu item was shown");
 
-QUnit.test("submenu should not hide after second click on root item", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        $($items.eq(1)).trigger("dxclick");
+        assert.ok($items.eq(1).is(":visible"), "first submenu item is visible");
+        assert.ok($items.eq(1).hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was not removed");
+    });
+
+    QUnit.test("submenu should not hide after second click on root item", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item1", items: [{ text: "item11" }] }],
             visible: true
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        });
 
-    $($rootItem).trigger("dxclick");
-    $($rootItem).trigger("dxclick");
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
 
-    var submenus = $itemsContainer.find("." + DX_SUBMENU_CLASS);
+        $($rootItem).trigger("dxclick");
+        $($rootItem).trigger("dxclick");
 
-    assert.equal(submenus.length, 2, "submenu was rendered");
-    assert.ok(submenus.eq(1).is(":visible"), "submenu was expanded");
-    assert.ok($rootItem.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was not removed");
-});
+        const submenus = $itemsContainer.find("." + DX_SUBMENU_CLASS);
 
-QUnit.test("context menu should not blink after second hover on root item", function(assert) {
-    if(!isDeviceDesktop(assert)) return;
+        assert.equal(submenus.length, 2, "submenu was rendered");
+        assert.ok(submenus.eq(1).is(":visible"), "submenu was expanded");
+        assert.ok($rootItem.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was not removed");
+    });
 
-    var hideSubmenu;
+    QUnit.test("context menu should not blink after second hover on root item", (assert) => {
+        if(!isDeviceDesktop(assert)) {
+            return;
+        }
 
-    try {
-        var instance = new ContextMenu(this.$element, {
+        let hideSubmenu;
+
+        try {
+            const instance = new ContextMenu(this.$element, {
                 items: [{ text: 1, items: [{ text: 11 }] }],
                 visible: true,
                 showSubmenuMode: { name: "onHover", delay: 0 }
-            }),
-            $itemsContainer = instance.itemsContainer(),
-            $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+            });
 
-        // todo: remove private spy if better solution will found
-        hideSubmenu = sinon.spy(instance, "_hideSubmenu");
+            const $itemsContainer = instance.itemsContainer();
+            const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
 
-        $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
-        this.clock.tick(0);
+            // todo: remove private spy if better solution will found
+            hideSubmenu = sinon.spy(instance, "_hideSubmenu");
 
-        $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
-        this.clock.tick(0);
+            $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
+            this.clock.tick(0);
 
-        assert.equal(hideSubmenu.callCount, 0, "submenu should not hides anytime");
-    } finally {
-        hideSubmenu.restore();
-    }
-});
+            $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
+            this.clock.tick(0);
 
-QUnit.test("custom slide animation should work for submenus", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+            assert.equal(hideSubmenu.callCount, 0, "submenu should not hides anytime");
+        } finally {
+            hideSubmenu.restore();
+        }
+    });
+
+    QUnit.test("custom slide animation should work for submenus", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             visible: true,
             animation: {
                 show: {
@@ -655,468 +683,488 @@ QUnit.test("custom slide animation should work for submenus", function(assert) {
             },
             items: [{ text: "itemA", items: [{ text: "Item A-A" }] }],
             target: "#menuTarget"
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        });
 
-    try {
-        fx.off = false;
-        $($rootItem).trigger("dxclick");
-        this.clock.tick(500);
-    } finally {
-        fx.off = true;
-    }
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
 
-    var $submenus = $itemsContainer.find("." + DX_SUBMENU_CLASS),
-        parentLeft = $submenus.eq(0).offset().left,
-        childrenLeft = $submenus.eq(1).offset().left;
+        try {
+            fx.off = false;
+            $($rootItem).trigger("dxclick");
+            this.clock.tick(500);
+        } finally {
+            fx.off = true;
+        }
 
-    assert.ok(parentLeft < childrenLeft, "child item should not overlap parent item");
+        const $submenus = $itemsContainer.find("." + DX_SUBMENU_CLASS);
+        const parentLeft = $submenus.eq(0).offset().left;
+        const childrenLeft = $submenus.eq(1).offset().left;
+
+        assert.ok(parentLeft < childrenLeft, "child item should not overlap parent item");
+    });
 });
 
+QUnit.module("Visibility callbacks", moduleConfig, () => {
+    QUnit.test("onHiding and onHidden options with outside click", (assert) => {
+        const events = [];
 
-QUnit.module("Visibility callbacks", moduleConfig);
+        new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            visible: true,
+            onHiding() {
+                events.push("onHiding");
+            },
+            onHidden() {
+                events.push("onHidden");
+            }
+        });
 
-QUnit.test("onHiding and onHidden options with outside click", function(assert) {
-    var events = [];
-
-    new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        visible: true,
-        onHiding: function() {
-            events.push("onHiding");
-        },
-        onHidden: function() {
-            events.push("onHidden");
-        }
+        $(document).trigger("dxpointerdown");
+        assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
     });
 
-    $(document).trigger("dxpointerdown");
-    assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
-});
+    QUnit.test("onHiding and onHidden options with hide method", (assert) => {
+        const events = [];
 
-QUnit.test("onHiding and onHidden options with hide method", function(assert) {
-    var events = [],
-        instance = new ContextMenu(this.$element, {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             visible: true,
-            onHiding: function() {
+            onHiding() {
                 events.push("onHiding");
             },
-            onHidden: function() {
+            onHidden() {
                 events.push("onHidden");
             }
         });
 
-    instance.hide();
-    assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
-});
+        instance.hide();
+        assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
+    });
 
-QUnit.test("onHiding and onHidden options with visible option", function(assert) {
-    var events = [],
-        instance = new ContextMenu(this.$element, {
+    QUnit.test("onHiding and onHidden options with visible option", (assert) => {
+        const events = [];
+
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             visible: true,
-            onHiding: function() {
+            onHiding() {
                 events.push("onHiding");
             },
-            onHidden: function() {
+            onHidden() {
                 events.push("onHidden");
             }
         });
 
-    instance.option("visible", false);
-    assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
-});
+        instance.option("visible", false);
+        assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
+    });
 
-QUnit.test("visibility callbacks should not fire for submenus", function(assert) {
-    var events = [],
-        instance = new ContextMenu(this.$element, {
+    QUnit.test("visibility callbacks should not fire for submenus", (assert) => {
+        let events = [];
+
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }, { text: 2, items: [{ text: 21 }] }],
             visible: true,
-            onHiding: function() {
+            onHiding() {
                 events.push("onHiding");
             },
-            onHidden: function() {
+            onHidden() {
                 events.push("onHidden");
             },
-            onShowing: function() {
+            onShowing() {
                 events.push("onShowing");
             },
-            onShown: function() {
-                events.push("onShown");
-            }
-        }),
-        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
-
-    events = [];
-
-    $($items.eq(0)).trigger("dxclick");
-    $($items.eq(1)).trigger("dxclick");
-
-    assert.deepEqual(events, [], "events was not triggered");
-});
-
-QUnit.test("onShowing and onShown options with show method", function(assert) {
-    var events = [],
-        instance = new ContextMenu(this.$element, {
-            items: [{ text: 1 }],
-            visible: false,
-            onShowing: function() {
-                events.push("onShowing");
-            },
-            onShown: function() {
+            onShown() {
                 events.push("onShown");
             }
         });
 
-    instance.show();
-    assert.deepEqual(events, ["onShowing", "onShown"], "events triggered and trigger order is correct");
-});
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("onShowing and onShown options should fire when visible is initially true", function(assert) {
-    var events = [];
+        events = [];
 
-    new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        visible: true,
-        onShowing: function() {
-            events.push("onShowing");
-        },
-        onShown: function() {
-            events.push("onShown");
-        }
+        $($items.eq(0)).trigger("dxclick");
+        $($items.eq(1)).trigger("dxclick");
+
+        assert.deepEqual(events, [], "events was not triggered");
     });
 
-    assert.deepEqual(events, ["onShowing", "onShown"], "events triggered and trigger order is correct");
-});
+    QUnit.test("onShowing and onShown options with show method", (assert) => {
+        const events = [];
 
-QUnit.test("onShowing and onShown options with visible option", function(assert) {
-    var events = [],
-        instance = new ContextMenu(this.$element, {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             visible: false,
-            onShowing: function() {
+            onShowing() {
                 events.push("onShowing");
             },
-            onShown: function() {
+            onShown() {
                 events.push("onShown");
             }
         });
 
-    instance.option("visible", true);
-    assert.deepEqual(events, ["onShowing", "onShown"], "events triggered and trigger order is correct");
+        instance.show();
+        assert.deepEqual(events, ["onShowing", "onShown"], "events triggered and trigger order is correct");
+    });
+
+    QUnit.test("onShowing and onShown options should fire when visible is initially true", (assert) => {
+        const events = [];
+
+        new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            visible: true,
+            onShowing() {
+                events.push("onShowing");
+            },
+            onShown() {
+                events.push("onShown");
+            }
+        });
+
+        assert.deepEqual(events, ["onShowing", "onShown"], "events triggered and trigger order is correct");
+    });
+
+    QUnit.test("onShowing and onShown options with visible option", (assert) => {
+        const events = [];
+
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            visible: false,
+            onShowing() {
+                events.push("onShowing");
+            },
+            onShown() {
+                events.push("onShown");
+            }
+        });
+
+        instance.option("visible", true);
+        assert.deepEqual(events, ["onShowing", "onShown"], "events triggered and trigger order is correct");
+    });
 });
 
+QUnit.module("Options", moduleConfig, () => {
+    QUnit.test("onItemClick option", (assert) => {
+        assert.expect(1);
 
-QUnit.module("Options", moduleConfig);
-
-QUnit.test("onItemClick option", function(assert) {
-    assert.expect(1);
-
-    var instance = new ContextMenu(this.$element, {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "a" }],
-            onItemClick: function(e) {
+            onItemClick(e) {
                 assert.ok(true, "onItemClick fired");
             },
             visible: true
-        }),
-        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        });
 
-    $($items.eq(0)).trigger("dxclick");
-});
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("itemsExpr option", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        $($items.eq(0)).trigger("dxclick");
+    });
+
+    QUnit.test("itemsExpr option", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             visible: true,
             items: [{ text: "itemA", subItems: [{ text: "itemB" }] }],
             itemsExpr: "subItems"
-        }),
-        $item = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS).eq(0);
+        });
 
-    $($item).trigger("dxclick");
+        const $item = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS).eq(0);
 
-    var $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        $($item).trigger("dxclick");
 
-    assert.equal($items.length, 2, "second level is rendered");
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-});
-
-QUnit.test("target option as string", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        visible: false,
-        items: [{ text: "itemA" }],
-        target: "#menuTarget"
+        assert.equal($items.length, 2, "second level is rendered");
     });
 
-    $("#menuTarget").trigger("dxcontextmenu");
+    QUnit.test("target option as string", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            visible: false,
+            items: [{ text: "itemA" }],
+            target: "#menuTarget"
+        });
 
-    assert.ok(instance.option("visible"), "menu was shown");
-});
+        $("#menuTarget").trigger("dxcontextmenu");
 
-QUnit.test("target option as jQuery", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        visible: false,
-        items: [{ text: "itemA" }],
-        target: $("#menuTarget")
+        assert.ok(instance.option("visible"), "menu was shown");
     });
 
-    $("#menuTarget").trigger("dxcontextmenu");
+    QUnit.test("target option as jQuery", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            visible: false,
+            items: [{ text: "itemA" }],
+            target: $("#menuTarget")
+        });
 
-    assert.ok(instance.option("visible"), "menu was shown");
-});
+        $("#menuTarget").trigger("dxcontextmenu");
 
-QUnit.test("target option as DOM element", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        visible: false,
-        items: [{ text: "itemA" }],
-        target: document.getElementById('menuTarget')
+        assert.ok(instance.option("visible"), "menu was shown");
     });
 
-    $("#menuTarget").trigger("dxcontextmenu");
+    QUnit.test("target option as DOM element", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            visible: false,
+            items: [{ text: "itemA" }],
+            target: document.getElementById('menuTarget')
+        });
 
-    assert.ok(instance.option("visible"), "menu was shown");
-});
+        $("#menuTarget").trigger("dxcontextmenu");
 
-QUnit.test("target option changing should change the target", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        visible: false,
-        items: [{ text: "itemA" }],
-        target: "#menuTarget"
+        assert.ok(instance.option("visible"), "menu was shown");
     });
 
-    instance.option("target", "#menuTarget2");
+    QUnit.test("target option changing should change the target", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            visible: false,
+            items: [{ text: "itemA" }],
+            target: "#menuTarget"
+        });
 
-    $("#menuTarget").trigger("dxcontextmenu");
-    assert.notOk(instance.option("visible"), "menu was not shown");
+        instance.option("target", "#menuTarget2");
 
-    $("#menuTarget2").trigger("dxcontextmenu");
-    assert.ok(instance.option("visible"), "menu was shown");
-});
+        $("#menuTarget").trigger("dxcontextmenu");
+        assert.notOk(instance.option("visible"), "menu was not shown");
 
-QUnit.test("showSubmenuMode hover without delay", function(assert) {
-    if(!isDeviceDesktop(assert)) return;
+        $("#menuTarget2").trigger("dxcontextmenu");
+        assert.ok(instance.option("visible"), "menu was shown");
+    });
 
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("showSubmenuMode hover without delay", (assert) => {
+        if(!isDeviceDesktop(assert)) {
+            return;
+        }
+
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             visible: true,
             showSubmenuMode: { name: "onHover", delay: 0 }
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0),
-        $items;
+        });
 
-    $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
-    this.clock.tick(0);
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        let $items;
 
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
+        this.clock.tick(0);
 
-    assert.equal($items.length, 2, "second item was rendered");
-});
+        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("showSubmenuMode hover with custom delay", function(assert) {
-    if(!isDeviceDesktop(assert)) return;
+        assert.equal($items.length, 2, "second item was rendered");
+    });
 
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("showSubmenuMode hover with custom delay", (assert) => {
+        if(!isDeviceDesktop(assert)) {
+            return;
+        }
+
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             visible: true,
             showSubmenuMode: { name: "onHover", delay: 1 }
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0),
-        $items;
+        });
 
-    $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
-    this.clock.tick(1);
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        let $items;
 
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
+        this.clock.tick(1);
 
-    assert.equal($items.length, 2, "second item was rendered");
-});
+        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("submenu should not be shown if hover was ended before show delay time exceeded", function(assert) {
-    if(!isDeviceDesktop(assert)) return;
+        assert.equal($items.length, 2, "second item was rendered");
+    });
 
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("submenu should not be shown if hover was ended before show delay time exceeded", (assert) => {
+        if(!isDeviceDesktop(assert)) {
+            return;
+        }
+
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             visible: true,
             showSubmenuMode: { name: "onHover", delay: 500 }
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0),
-        $items;
+        });
 
-    $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
-    this.clock.tick(400);
-    $($itemsContainer).trigger($.Event("dxhoverend", { target: $rootItem.get(0) }));
-    this.clock.tick(100);
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        let $items;
 
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
+        this.clock.tick(400);
+        $($itemsContainer).trigger($.Event("dxhoverend", { target: $rootItem.get(0) }));
+        this.clock.tick(100);
 
-    assert.equal($items.length, 1, "second item was not rendered");
-});
+        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("showSubmenuMode click with custom delay", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        assert.equal($items.length, 1, "second item was not rendered");
+    });
+
+    QUnit.test("showSubmenuMode click with custom delay", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             visible: true,
             showSubmenuMode: { name: "onClick", delay: 500 }
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0),
-        $items;
+        });
 
-    $($rootItem).trigger("dxclick");
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        let $items;
 
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        $($rootItem).trigger("dxclick");
 
-    assert.equal($items.length, 2, "delay should be ignored");
-});
+        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("showSubmenuMode click during hover delay", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        assert.equal($items.length, 2, "delay should be ignored");
+    });
+
+    QUnit.test("showSubmenuMode click during hover delay", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             visible: true,
             showSubmenuMode: { name: "onHover", delay: 500 }
-        }),
-        $itemsContainer = instance.itemsContainer(),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0),
-        $items;
+        });
 
-    $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
-    this.clock.tick(1);
-    $($rootItem).trigger("dxclick");
+        const $itemsContainer = instance.itemsContainer();
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        let $items;
 
-    $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        $($itemsContainer).trigger($.Event("dxhoverstart", { target: $rootItem.get(0) }));
+        this.clock.tick(1);
+        $($rootItem).trigger("dxclick");
 
-    assert.equal($items.length, 2, "delay should be ignored");
-});
+        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("context menu should not crash when items changing during onShowing event", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: 1 }, { text: 2 }],
-        onShowing: function() {
-            this.option("items", [{ text: 3 }, { text: 4 }]);
-        }
+        assert.equal($items.length, 2, "delay should be ignored");
     });
 
-    instance.show();
-    assert.ok(1, "context menu did not crash");
-});
+    QUnit.test("context menu should not crash when items changing during onShowing event", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }, { text: 2 }],
+            onShowing() {
+                this.option("items", [{ text: 3 }, { text: 4 }]);
+            }
+        });
 
-QUnit.test("context menu should not show if showing is prevented during onPositioning action", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        onPositioning: function(e) {
-            e.cancel = true;
-        }
+        instance.show();
+        assert.ok(1, "context menu did not crash");
     });
 
-    $("#menuTarget").trigger("dxcontextmenu");
-    assert.notOk(instance.option("visible"));
-});
+    QUnit.test("context menu should not show if showing is prevented during onPositioning action", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            onPositioning(e) {
+                e.cancel = true;
+            }
+        });
 
-QUnit.test("context menu should not show if showing is prevented during onShowing action", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        onShowing: function(e) {
-            e.cancel = true;
-        }
+        $("#menuTarget").trigger("dxcontextmenu");
+        assert.notOk(instance.option("visible"));
     });
 
-    $("#menuTarget").trigger("dxcontextmenu");
-    assert.notOk(instance.option("visible"));
-});
+    QUnit.test("context menu should not show if showing is prevented during onShowing action", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            onShowing(e) {
+                e.cancel = true;
+            }
+        });
 
-QUnit.test("default browser menu should not be prevented if context menu showing is prevented", function(assert) {
-    new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        onShowing: function(e) {
-            e.cancel = true;
-        }
+        $("#menuTarget").trigger("dxcontextmenu");
+        assert.notOk(instance.option("visible"));
     });
 
-    var e = $.Event("dxcontextmenu");
+    QUnit.test("default browser menu should not be prevented if context menu showing is prevented", (assert) => {
+        new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            onShowing(e) {
+                e.cancel = true;
+            }
+        });
 
-    $("#menuTarget").trigger(e);
-    assert.notOk(e.isDefaultPrevented(), "default behavior should not be prevented");
-});
+        const e = $.Event("dxcontextmenu");
 
-QUnit.test("default browser menu should not be prevented if context menu positioning is prevented", function(assert) {
-    new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        onPositioning: function(e) {
-            e.cancel = true;
-        }
+        $("#menuTarget").trigger(e);
+        assert.notOk(e.isDefaultPrevented(), "default behavior should not be prevented");
     });
 
-    var e = $.Event("dxcontextmenu");
+    QUnit.test("default browser menu should not be prevented if context menu positioning is prevented", (assert) => {
+        new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            onPositioning(e) {
+                e.cancel = true;
+            }
+        });
 
-    $("#menuTarget").trigger(e);
-    assert.notOk(e.isDefaultPrevented(), "default behavior should not be prevented");
-});
+        const e = $.Event("dxcontextmenu");
 
-QUnit.test("show event should not be handled by other menus targeted on the parent div", function(assert) {
-    new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget"
+        $("#menuTarget").trigger(e);
+        assert.notOk(e.isDefaultPrevented(), "default behavior should not be prevented");
     });
 
-    var e = $.Event("dxcontextmenu");
+    QUnit.test("show event should not be handled by other menus targeted on the parent div", (assert) => {
+        new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget"
+        });
 
-    $("#menuTarget").trigger(e);
-    assert.ok(e.isPropagationStopped(), "propagation was stopped");
-});
+        const e = $.Event("dxcontextmenu");
 
-QUnit.test("disabling for nested item should work correctly", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        $("#menuTarget").trigger(e);
+        assert.ok(e.isPropagationStopped(), "propagation was stopped");
+    });
+
+    QUnit.test("disabling for nested item should work correctly", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             target: "#menuTarget",
             visible: true
-        }),
+        });
+
+        let $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+
+        $($items.eq(0)).trigger("dxclick");
         $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-    $($items.eq(0)).trigger("dxclick");
-    $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        instance.option("items[0].items[0].disabled", true);
 
-    instance.option("items[0].items[0].disabled", true);
+        assert.ok($items.eq(1).hasClass("dx-state-disabled"), "item was disabled");
+    });
 
-    assert.ok($items.eq(1).hasClass("dx-state-disabled"), "item was disabled");
-});
+    QUnit.test("onItemContextMenu option when context menu initially hidden", (assert) => {
+        let fired = 0;
+        let args = {};
 
-QUnit.test("onItemContextMenu option when context menu initially hidden", function(assert) {
-    var fired = 0,
-        args = {},
-        instance = new ContextMenu(this.$element, {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }, { text: 2 }],
-            onItemContextMenu: function(e) {
+            onItemContextMenu(e) {
                 fired++;
                 args = e;
             },
             visible: false
-        }),
-        eventName = eventUtils.addNamespace(contextMenuEvent.name, instance.NAME);
+        });
 
-    instance.show();
+        const eventName = eventUtils.addNamespace(contextMenuEvent.name, instance.NAME);
 
-    $(document).on(eventName, function() {
-        fired++;
+        instance.show();
+
+        $(document).on(eventName, () => {
+            fired++;
+        });
+
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        $($items.eq(0)).trigger("dxcontextmenu");
+
+        assert.equal(fired, 1, "event fired only in action");
+        assert.strictEqual($(args.itemElement)[0], $items[0], "item element is correct");
+        assert.equal(args.itemData.text, "1", "item data is correct");
     });
 
-    var $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
-    $($items.eq(0)).trigger("dxcontextmenu");
-
-    assert.equal(fired, 1, "event fired only in action");
-    assert.strictEqual($(args.itemElement)[0], $items[0], "item element is correct");
-    assert.equal(args.itemData.text, "1", "item data is correct");
-});
-
-QUnit.test("Separator should not be shown if last rendered item was in other level", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("Separator should not be shown if last rendered item was in other level", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [
                 {
                     text: 'Item 1', items: [
@@ -1131,275 +1179,290 @@ QUnit.test("Separator should not be shown if last rendered item was in other lev
                 }
             ],
             visible: true
-        }),
-        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        });
 
-    $($items.eq(0)).trigger("dxclick");
-    $($items.eq(1)).trigger("dxclick");
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-    assert.equal(instance.itemsContainer().find(".dx-menu-separator").length, 0, "separator should not be rendered");
-});
+        $($items.eq(0)).trigger("dxclick");
+        $($items.eq(1)).trigger("dxclick");
 
-QUnit.test("showEvent can prevent showing", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        showEvent: null
+        assert.equal(instance.itemsContainer().find(".dx-menu-separator").length, 0, "separator should not be rendered");
     });
 
-    $("#menuTarget").trigger("dxcontextmenu");
+    QUnit.test("showEvent can prevent showing", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            showEvent: null
+        });
 
-    assert.ok(!instance.option("visible"), "default behaviour was prevented");
-});
+        $("#menuTarget").trigger("dxcontextmenu");
 
-QUnit.test("showEvent set as string", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        showEvent: "dxclick"
+        assert.ok(!instance.option("visible"), "default behaviour was prevented");
     });
 
-    $("#menuTarget").trigger("dxclick");
-    assert.ok(instance.option("visible"), "context menu was shown");
-});
+    QUnit.test("showEvent set as string", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            showEvent: "dxclick"
+        });
 
-QUnit.test("showEvent set as string with several events", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        showEvent: "dxclick dxhover"
+        $("#menuTarget").trigger("dxclick");
+        assert.ok(instance.option("visible"), "context menu was shown");
     });
 
-    $("#menuTarget").trigger("dxclick");
-    assert.ok(instance.option("visible"), "context menu was shown");
+    QUnit.test("showEvent set as string with several events", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            showEvent: "dxclick dxhover"
+        });
 
-    instance.hide();
-    assert.ok(!instance.option("visible"));
+        $("#menuTarget").trigger("dxclick");
+        assert.ok(instance.option("visible"), "context menu was shown");
 
-    $("#menuTarget").trigger("dxhover");
-    assert.ok(instance.option("visible"), "context menu was shown");
-});
+        instance.hide();
+        assert.ok(!instance.option("visible"));
 
-QUnit.test("showEvent set as object", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        showEvent: {
-            name: "click",
-            delay: 500
+        $("#menuTarget").trigger("dxhover");
+        assert.ok(instance.option("visible"), "context menu was shown");
+    });
+
+    QUnit.test("showEvent set as object", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            showEvent: {
+                name: "click",
+                delay: 500
+            }
+        });
+
+        $("#menuTarget").trigger("click");
+        assert.ok(!instance.option("visible"));
+        this.clock.tick(500);
+        assert.ok(instance.option("visible"), "context menu was shown");
+    });
+
+    QUnit.test("showEvent set only as delay", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+            target: "#menuTarget",
+            showEvent: {
+                delay: 500
+            }
+        });
+
+        $("#menuTarget").trigger("dxcontextmenu");
+        assert.ok(!instance.option("visible"));
+        this.clock.tick(500);
+        assert.ok(instance.option("visible"), "context menu was shown");
+    });
+
+    QUnit.test("items change should clear focused item", (assert) => {
+        const items1 = [{ text: "item 1" }, { text: "item 2" }];
+        const items2 = [{ text: "item 3" }, { text: "item 4" }];
+        const instance = new ContextMenu(this.$element, { items: items1, focusStateEnabled: true, visible: true });
+
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("enter");
+
+        assert.equal($(instance.option("focusedElement")).length, 1, "focused element is set");
+
+        instance.option("items", items2);
+        assert.notOk(instance.option("focusedElement"), "focused element is cleaned");
+    });
+
+    QUnit.test("items changed should not break keyboard navigation", (assert) => {
+        if(!isDeviceDesktop(assert)) {
+            return;
         }
+
+        const instance = new ContextMenu(this.$element, {});
+        instance.option({ visible: true, items: [{ text: "1" }, { text: "2" }] });
+
+        const overlay = instance.itemsContainer();
+        keyboardMock(overlay)
+            .keyDown("down");
+
+        assert.equal($(instance.option("focusedElement")).text(), "1", "focused element is correct");
     });
-
-    $("#menuTarget").trigger("click");
-    assert.ok(!instance.option("visible"));
-    this.clock.tick(500);
-    assert.ok(instance.option("visible"), "context menu was shown");
 });
 
-QUnit.test("showEvent set only as delay", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: 1 }],
-        target: "#menuTarget",
-        showEvent: {
-            delay: 500
-        }
+QUnit.module("Public api", moduleConfig, () => {
+    QUnit.test("itemsContainer method should return overlay content", (assert) => {
+        const instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
+
+        assert.ok(instance.itemsContainer().hasClass("dx-overlay-content"));
+        assert.ok(instance.itemsContainer().hasClass(DX_CONTEXT_MENU_CLASS));
     });
-
-    $("#menuTarget").trigger("dxcontextmenu");
-    assert.ok(!instance.option("visible"));
-    this.clock.tick(500);
-    assert.ok(instance.option("visible"), "context menu was shown");
 });
 
-QUnit.test("items change should clear focused item", function(assert) {
-    var items1 = [{ text: "item 1" }, { text: "item 2" }],
-        items2 = [{ text: "item 3" }, { text: "item 4" }],
-        instance = new ContextMenu(this.$element, { items: items1, focusStateEnabled: true, visible: true });
-
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("enter");
-
-    assert.equal($(instance.option("focusedElement")).length, 1, "focused element is set");
-
-    instance.option("items", items2);
-    assert.notOk(instance.option("focusedElement"), "focused element is cleaned");
-});
-
-QUnit.test("items changed should not break keyboard navigation", function(assert) {
-    if(!isDeviceDesktop(assert)) return;
-
-    var instance = new ContextMenu(this.$element, {});
-    instance.option({ visible: true, items: [{ text: "1" }, { text: "2" }] });
-
-    var overlay = instance.itemsContainer();
-    keyboardMock(overlay)
-        .keyDown("down");
-
-    assert.equal($(instance.option("focusedElement")).text(), "1", "focused element is correct");
-});
-
-
-QUnit.module("Public api", moduleConfig);
-
-QUnit.test("itemsContainer method should return overlay content", function(assert) {
-    var instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
-
-    assert.ok(instance.itemsContainer().hasClass("dx-overlay-content"));
-    assert.ok(instance.itemsContainer().hasClass(DX_CONTEXT_MENU_CLASS));
-});
-
-
-QUnit.module("Behavior", moduleConfig);
-
-QUnit.test("it should be possible to update items on item click", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+QUnit.module("Behavior", moduleConfig, () => {
+    QUnit.test("it should be possible to update items on item click", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "a" }],
-            onItemClick: function(e) {
+            onItemClick(e) {
                 e.component.option("items", [{ text: "b" }]);
             }
-        }),
-        $items;
+        });
 
-    instance.show();
-    $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
-    assert.equal($items.eq(0).text(), "a", "items was rendered");
+        let $items;
 
-    $($items.eq(0)).trigger("dxclick");
-    instance.show();
-    $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        instance.show();
+        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        assert.equal($items.eq(0).text(), "a", "items was rendered");
 
-    assert.equal(instance.option("items")[0].text, "b", "items were changed");
-    assert.equal($items.eq(0).text(), "b", "items was changed");
-});
+        $($items.eq(0)).trigger("dxclick");
+        instance.show();
+        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("context menu should hide after click on item without children", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+        assert.equal(instance.option("items")[0].text, "b", "items were changed");
+        assert.equal($items.eq(0).text(), "b", "items was changed");
+    });
+
+    QUnit.test("context menu should hide after click on item without children", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "a" }],
             visible: true
-        }),
-        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        });
 
-    $($items.eq(0)).trigger("dxclick");
-    assert.notOk(instance.option("visible"), "menu was hidden");
-});
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("submenu shouldn't be hidden after click on item with children (T640708)", function(assert) {
-    var contextMenuItems = [
-        {
-            text: 'item',
-            items: [
-                { text: 'item1',
-                    items: [
-                        { text: 'item1.1' },
-                        { text: 'item1.2' }] },
-                { text: 'item1.3' }]
-        }
-    ];
+        $($items.eq(0)).trigger("dxclick");
+        assert.notOk(instance.option("visible"), "menu was hidden");
+    });
 
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("submenu shouldn't be hidden after click on item with children (T640708)", (assert) => {
+        const contextMenuItems = [
+            {
+                text: 'item',
+                items: [
+                    {
+                        text: 'item1',
+                        items: [
+                            { text: 'item1.1' },
+                            { text: 'item1.2' }]
+                    },
+                    { text: 'item1.3' }]
+            }
+        ];
+
+        const instance = new ContextMenu(this.$element, {
             dataSource: contextMenuItems,
             visible: true
-        }),
+        });
+
+        let $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+
+        $($items.eq(0)).trigger("dxclick");
+        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        $($items.eq(1)).trigger("dxclick");
         $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-    $($items.eq(0)).trigger("dxclick");
-    $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
-    $($items.eq(1)).trigger("dxclick");
-    $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        assert.equal(getVisibleSubmenuCount(instance), 3, "All submenus is visible");
+    });
 
-    assert.equal(getVisibleSubmenuCount(instance), 3, "All submenus is visible");
-});
-
-QUnit.test("context menu should not hide after click when item.closeMenuOnClick is false", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("context menu should not hide after click when item.closeMenuOnClick is false", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "a", closeMenuOnClick: false }],
             visible: true
-        }),
-        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        });
 
-    $($items.eq(0)).trigger("dxclick");
-    assert.ok(instance.option("visible"), "menu is visible");
-});
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
 
-QUnit.test("context menu should hide after outside click", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
-        visible: true
+        $($items.eq(0)).trigger("dxclick");
+        assert.ok(instance.option("visible"), "menu is visible");
     });
 
-    $(document).trigger("dxpointerdown");
+    QUnit.test("context menu should hide after outside click", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
+            visible: true
+        });
 
-    assert.notOk(instance.option("visible"), "menu was hidden");
-});
+        $(document).trigger("dxpointerdown");
 
-QUnit.test("context menu should not hide after outsideclick when event is canceled", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
-        visible: true,
-        onHiding: function(e) {
-            e.cancel = true;
-        }
+        assert.notOk(instance.option("visible"), "menu was hidden");
     });
 
-    $(document).trigger("dxpointerdown");
+    QUnit.test("context menu should not hide after outsideclick when event is canceled", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
+            visible: true,
+            onHiding(e) {
+                e.cancel = true;
+            }
+        });
 
-    assert.ok(instance.option("visible"), "menu is visible");
-});
+        $(document).trigger("dxpointerdown");
 
-QUnit.test("context menu should not block outside click for other overlays on outside click", function(assert) {
-    var otherOverlay = $("<div>").appendTo("#qunit-fixture").dxOverlay({
+        assert.ok(instance.option("visible"), "menu is visible");
+    });
+
+    QUnit.test("context menu should not block outside click for other overlays on outside click", (assert) => {
+        const otherOverlay = $("<div>").appendTo("#qunit-fixture").dxOverlay({
             closeOnOutsideClick: true,
             visible: true
-        }).dxOverlay("instance"),
-        contextMenu = new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
+        }).dxOverlay("instance");
 
-    $(document).trigger("dxpointerdown");
+        const contextMenu = new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
 
-    assert.notOk(otherOverlay.option("visible"), "other overlay was hidden");
-    assert.notOk(contextMenu.option("visible"), "context menu was hidden");
-});
+        $(document).trigger("dxpointerdown");
 
-QUnit.test("context menu should prevent default behavior if it shows", function(assert) {
-    new ContextMenu(this.$element, {
-        items: [{ text: "item 1" }],
-        target: "#menuTarget",
-        visible: false
+        assert.notOk(otherOverlay.option("visible"), "other overlay was hidden");
+        assert.notOk(contextMenu.option("visible"), "context menu was hidden");
     });
 
-    var contextMenuEvent = $.Event("contextmenu", { pointerType: "mouse" });
+    QUnit.test("context menu should prevent default behavior if it shows", (assert) => {
+        new ContextMenu(this.$element, {
+            items: [{ text: "item 1" }],
+            target: "#menuTarget",
+            visible: false
+        });
 
-    $("#menuTarget").trigger(contextMenuEvent);
-    assert.ok(contextMenuEvent.isDefaultPrevented(), "default prevented");
-});
+        const contextMenuEvent = $.Event("contextmenu", { pointerType: "mouse" });
 
-QUnit.test("onItemClick should fire for submenus", function(assert) {
-    var itemClickArgs = [],
-        items = [{ text: "item 1", customField: "custom 1", items: [{ text: "item 11", customField: "custom 11" }] }],
-        instance = new ContextMenu(this.$element, {
-            onItemClick: function(arg) {
+        $("#menuTarget").trigger(contextMenuEvent);
+        assert.ok(contextMenuEvent.isDefaultPrevented(), "default prevented");
+    });
+
+    QUnit.test("onItemClick should fire for submenus", (assert) => {
+        const itemClickArgs = [];
+        const items = [{
+            text: "item 1",
+            customField: "custom 1",
+            items: [{ text: "item 11", customField: "custom 11" }]
+        }];
+
+        const instance = new ContextMenu(this.$element, {
+            onItemClick(arg) {
                 itemClickArgs.push(arg.itemData);
             },
-            items: items
-        }),
-        $itemsContainer;
+            items
+        });
 
-    instance.show();
-    $itemsContainer = instance.itemsContainer();
+        let $itemsContainer;
 
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
-    $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
+        instance.show();
+        $itemsContainer = instance.itemsContainer();
 
-    assert.deepEqual(itemClickArgs, [items[0], items[0].items[0]], "onItemClick fired with correct arguments");
-});
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
+        $($itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(1)).trigger("dxclick");
 
-QUnit.test("First item should not get focus after menu shown", function(assert) {
-    var focusedElementChangeCount = 0,
-        instance = new ContextMenu(this.$element, {
+        assert.deepEqual(itemClickArgs, [items[0], items[0].items[0]], "onItemClick fired with correct arguments");
+    });
+
+    QUnit.test("First item should not get focus after menu shown", (assert) => {
+        let focusedElementChangeCount = 0;
+
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }],
             focusStateEnabled: true,
             target: "#menuTarget",
-            onOptionChanged: function(e) {
+            onOptionChanged(e) {
                 if(e.name === "focusedElement") {
                     focusedElementChangeCount++;
                 }
@@ -1407,630 +1470,644 @@ QUnit.test("First item should not get focus after menu shown", function(assert) 
             visible: false
         });
 
-    instance.show();
+        instance.show();
 
-    assert.equal(focusedElementChangeCount, 0, "focusedElement should not be changed");
-    assert.equal(instance.option("focusedElement"), null, "focusedElement should be cleared");
-    assert.equal(instance.itemsContainer().find("." + DX_STATE_FOCUSED_CLASS).length, 0, "there are no focused elements in ui");
-});
+        assert.equal(focusedElementChangeCount, 0, "focusedElement should not be changed");
+        assert.equal(instance.option("focusedElement"), null, "focusedElement should be cleared");
+        assert.equal(instance.itemsContainer().find("." + DX_STATE_FOCUSED_CLASS).length, 0, "there are no focused elements in ui");
+    });
 
-QUnit.test("incomplete show animation should be stopped when new submenu item starts to show", function(assert) {
-    var origFxStop = fx.stop,
-        stopCalls = 0,
-        instance = new ContextMenu(this.$element, {
+    QUnit.test("incomplete show animation should be stopped when new submenu item starts to show", (assert) => {
+        const origFxStop = fx.stop;
+        let stopCalls = 0;
+
+        const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "Item 1", items: [{ text: "Item 11" }] },
                 { text: "Item 2", items: [{ text: "Item 21" }] }
             ],
             visible: true
-        }),
-        $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+        });
 
-    fx.stop = function($element) {
-        if($element.hasClass(DX_SUBMENU_CLASS)) {
-            stopCalls++;
+        const $items = instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS);
+
+        fx.stop = $element => {
+            if($element.hasClass(DX_SUBMENU_CLASS)) {
+                stopCalls++;
+            }
+        };
+
+        try {
+            fx.off = false;
+
+            $($items.eq(0)).trigger("dxclick");
+            $($items.eq(1)).trigger("dxclick");
+
+            assert.equal(stopCalls, 3, "animation should stops before each submenu showing");
+        } finally {
+            fx.off = true;
+            fx.stop = origFxStop;
         }
-    };
-
-    try {
-        fx.off = false;
-
-        $($items.eq(0)).trigger("dxclick");
-        $($items.eq(1)).trigger("dxclick");
-
-        assert.equal(stopCalls, 3, "animation should stops before each submenu showing");
-    } finally {
-        fx.off = true;
-        fx.stop = origFxStop;
-    }
+    });
 });
 
-
-QUnit.module("Selection", moduleConfig);
-
-QUnit.test("select item via item.selected property", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+QUnit.module("Selection", moduleConfig, () => {
+    QUnit.test("select item via item.selected property", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", selected: true, items: [{ text: "item 111" }] }] }],
             visible: true
-        }),
-        $itemContainer = instance.itemsContainer();
+        });
 
-    assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 0, "no selected items");
+        const $itemContainer = instance.itemsContainer();
 
-    $($itemContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
-    assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 1, "one selected items");
-});
+        assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 0, "no selected items");
 
-QUnit.test("select item via selectedItem option", function(assert) {
-    var items = [{ text: "item 1", selected: true, items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
-        instance = new ContextMenu(this.$element, {
-            items: items,
+        $($itemContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
+        assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 1, "one selected items");
+    });
+
+    QUnit.test("select item via selectedItem option", (assert) => {
+        const items = [{ text: "item 1", selected: true, items: [{ text: "item 11", items: [{ text: "item 111" }] }] }];
+
+        const instance = new ContextMenu(this.$element, {
+            items,
             selectedItem: items[0].items[0],
             visible: true
-        }),
-        $itemContainer = instance.itemsContainer();
+        });
 
-    assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 0, "no selected items");
-    assert.notOk(items[0].selected, "selection was removed from 1st item");
+        const $itemContainer = instance.itemsContainer();
 
-    $($itemContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
-    assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 1, "one selected items");
-    assert.ok(items[0].items[0].selected, "nested item selected");
-});
+        assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 0, "no selected items");
+        assert.notOk(items[0].selected, "selection was removed from 1st item");
 
-QUnit.test("changing selection via selectedItem option", function(assert) {
-    var items = [{ text: "item 1", selected: true, items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
-        instance = new ContextMenu(this.$element, {
-            items: items,
+        $($itemContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
+        assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 1, "one selected items");
+        assert.ok(items[0].items[0].selected, "nested item selected");
+    });
+
+    QUnit.test("changing selection via selectedItem option", (assert) => {
+        const items = [{ text: "item 1", selected: true, items: [{ text: "item 11", items: [{ text: "item 111" }] }] }];
+
+        const instance = new ContextMenu(this.$element, {
+            items,
             visible: true
-        }),
-        $itemContainer = instance.itemsContainer();
-
-    assert.ok(items[0].selected, "1st item is selected");
-
-    $($itemContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
-    instance.option("selectedItem", items[0].items[0]);
-
-    assert.ok(items[0].items[0].selected, "nested item is selected");
-    assert.notOk(items[0].selected, "first item is not selected");
-});
-
-
-QUnit.module("Aria accessibility", moduleConfig);
-
-QUnit.test("aria-owns should pointed to overlay", function(assert) {
-    var instance = new ContextMenu(this.$element, {}),
-        $itemsContainer;
-
-    assert.equal(this.$element.attr("aria-owns"), undefined, "aria-owns is not defined if popup is not visible");
-
-    instance.show();
-    $itemsContainer = instance.itemsContainer();
-    assert.notEqual(this.$element.attr("aria-owns"), undefined, "aria-owns is defined after show");
-    assert.equal($itemsContainer.attr("id"), this.$element.attr("aria-owns"), "aria-owns and overlay's id are equals");
-});
-
-QUnit.test("aria role on overlay content", function(assert) {
-    var instance = new ContextMenu(this.$element, {}),
-        $itemsContainer;
-
-    instance.show();
-    $itemsContainer = instance.itemsContainer();
-    assert.equal($itemsContainer.attr("role"), "menu", "role of overlay exists after open");
-});
-
-QUnit.test("aria-activedescendant should have correct target", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-            items: [1, 2, 3],
-            focusStateEnabled: true,
-        }),
-        $itemsContainer;
-
-    instance.show();
-    $itemsContainer = instance.itemsContainer();
-
-    assert.notEqual($itemsContainer.attr("aria-activedescendant"), undefined, "aria-activedescendant is on the overlay");
-    assert.equal(this.$element.attr("aria-activedescendant"), undefined, "no aria-activedescendant on the element");
-});
-
-
-QUnit.module("Keyboard navigation", moduleConfig);
-
-QUnit.test("onItemClick should fire when enter pressed", function(assert) {
-    var itemClicked = 0,
-        instance = new ContextMenu(this.$element, {
-            items: [1, 2, 3],
-            focusStateEnabled: true,
-            onItemClick: function() { itemClicked++; }
         });
 
-    instance.show();
+        const $itemContainer = instance.itemsContainer();
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("enter");
+        assert.ok(items[0].selected, "1st item is selected");
 
-    assert.equal(itemClicked, 1, "press enter on item call item click action");
+        $($itemContainer.find("." + DX_MENU_ITEM_CLASS).eq(0)).trigger("dxclick");
+        instance.option("selectedItem", items[0].items[0]);
+
+        assert.ok(items[0].items[0].selected, "nested item is selected");
+        assert.notOk(items[0].selected, "first item is not selected");
+    });
 });
 
-QUnit.test("hide menu when space pressed", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: "item 1" }, { text: "item 2" }],
-        focusStateEnabled: true
+QUnit.module("Aria accessibility", moduleConfig, () => {
+    QUnit.test("aria-owns should pointed to overlay", (assert) => {
+        const instance = new ContextMenu(this.$element, {});
+        let $itemsContainer;
+
+        assert.equal(this.$element.attr("aria-owns"), undefined, "aria-owns is not defined if popup is not visible");
+
+        instance.show();
+        $itemsContainer = instance.itemsContainer();
+        assert.notEqual(this.$element.attr("aria-owns"), undefined, "aria-owns is defined after show");
+        assert.equal($itemsContainer.attr("id"), this.$element.attr("aria-owns"), "aria-owns and overlay's id are equals");
     });
 
-    instance.show();
+    QUnit.test("aria role on overlay content", (assert) => {
+        const instance = new ContextMenu(this.$element, {});
+        let $itemsContainer;
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("space");
+        instance.show();
+        $itemsContainer = instance.itemsContainer();
+        assert.equal($itemsContainer.attr("role"), "menu", "role of overlay exists after open");
+    });
 
-    assert.notOk(instance.option("visible"));
+    QUnit.test("aria-activedescendant should have correct target", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [1, 2, 3],
+            focusStateEnabled: true,
+        });
+
+        let $itemsContainer;
+
+        instance.show();
+        $itemsContainer = instance.itemsContainer();
+
+        assert.notEqual($itemsContainer.attr("aria-activedescendant"), undefined, "aria-activedescendant is on the overlay");
+        assert.equal(this.$element.attr("aria-activedescendant"), undefined, "no aria-activedescendant on the element");
+    });
 });
 
-QUnit.test("select item when space pressed", function(assert) {
-    var items = [{ text: "item 1" }, { text: "item 2" }],
-        instance = new ContextMenu(this.$element, {
-            items: items,
+QUnit.module("Keyboard navigation", moduleConfig, () => {
+    QUnit.test("onItemClick should fire when enter pressed", (assert) => {
+        let itemClicked = 0;
+
+        const instance = new ContextMenu(this.$element, {
+            items: [1, 2, 3],
+            focusStateEnabled: true,
+            onItemClick() {
+                itemClicked++;
+            }
+        });
+
+        instance.show();
+
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("enter");
+
+        assert.equal(itemClicked, 1, "press enter on item call item click action");
+    });
+
+    QUnit.test("hide menu when space pressed", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1" }, { text: "item 2" }],
+            focusStateEnabled: true
+        });
+
+        instance.show();
+
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("space");
+
+        assert.notOk(instance.option("visible"));
+    });
+
+    QUnit.test("select item when space pressed", (assert) => {
+        const items = [{ text: "item 1" }, { text: "item 2" }];
+
+        const instance = new ContextMenu(this.$element, {
+            items,
             selectByClick: true,
             focusStateEnabled: true,
             selectionMode: "single"
         });
 
-    instance.show();
+        instance.show();
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("space");
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("space");
 
-    assert.equal(instance.option("selectedItem").text, "item 2", "correct item is selected");
-    assert.ok(items[1].selected, "item has selected property");
-});
-
-QUnit.test("when selectionMode is none, not select item when space pressed", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: "item 1" }, { text: "item 2" }],
-        selectByClick: true,
-        focusStateEnabled: true,
-        selectionMode: "single"
+        assert.equal(instance.option("selectedItem").text, "item 2", "correct item is selected");
+        assert.ok(items[1].selected, "item has selected property");
     });
 
-    instance.option("selectionMode", "none");
-
-    instance.show();
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("space");
-
-    assert.equal(instance.option("selectedItem"), null, "no item is selected");
-});
-
-QUnit.test("select item when space pressed on inner level", function(assert) {
-    var items = [{ text: "item 1" }, { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }] }],
-        instance = new ContextMenu(this.$element, {
-            items: items,
+    QUnit.test("when selectionMode is none, not select item when space pressed", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1" }, { text: "item 2" }],
             selectByClick: true,
             focusStateEnabled: true,
             selectionMode: "single"
         });
 
-    instance.show();
+        instance.option("selectionMode", "none");
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("right")
-        .keyDown("down")
-        .keyDown("space");
+        instance.show();
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("space");
 
-    assert.equal(instance.option("selectedItem").text, "item 22", "correct item is selected");
-});
+        assert.equal(instance.option("selectedItem"), null, "no item is selected");
+    });
 
-QUnit.test("onSelectionChanged handle fire when space pressed", function(assert) {
-    var itemSelected = 0,
-        instance = new ContextMenu(this.$element, {
+    QUnit.test("select item when space pressed on inner level", (assert) => {
+        const items = [{ text: "item 1" }, { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }] }];
+
+        const instance = new ContextMenu(this.$element, {
+            items,
+            selectByClick: true,
+            focusStateEnabled: true,
+            selectionMode: "single"
+        });
+
+        instance.show();
+
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("right")
+            .keyDown("down")
+            .keyDown("space");
+
+        assert.equal(instance.option("selectedItem").text, "item 22", "correct item is selected");
+    });
+
+    QUnit.test("onSelectionChanged handle fire when space pressed", (assert) => {
+        let itemSelected = 0;
+
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }],
             selectByClick: true,
             selectionMode: "single",
             focusStateEnabled: true,
-            onSelectionChanged: function() {
+            onSelectionChanged() {
                 itemSelected++;
             }
         });
 
-    instance.show();
+        instance.show();
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("space");
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("space");
 
-    assert.equal(itemSelected, 1, "press space on item call item select");
-});
+        assert.equal(itemSelected, 1, "press space on item call item select");
+    });
 
-QUnit.test("when selectionMode is none, onSelectionChanged handle not fire when space pressed", function(assert) {
-    var itemSelected = 0,
-        instance = new ContextMenu(this.$element, {
+    QUnit.test("when selectionMode is none, onSelectionChanged handle not fire when space pressed", (assert) => {
+        let itemSelected = 0;
+
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }],
             selectByClick: true,
             selectionMode: "none",
             focusStateEnabled: true,
-            onSelectionChanged: function() {
+            onSelectionChanged() {
                 itemSelected++;
             }
         });
 
-    instance.show();
+        instance.show();
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("space");
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("space");
 
-    assert.equal(itemSelected, 0, "press space on item call item select");
-});
+        assert.equal(itemSelected, 0, "press space on item call item select");
+    });
 
-QUnit.test("hide context menu when esc pressed", function(assert) {
-    var instance = new ContextMenu(this.$element, { focusStateEnabled: true });
+    QUnit.test("hide context menu when esc pressed", (assert) => {
+        const instance = new ContextMenu(this.$element, { focusStateEnabled: true });
 
-    instance.show();
+        instance.show();
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("esc");
+        keyboardMock(instance.itemsContainer())
+            .keyDown("esc");
 
-    assert.ok(!instance.option("visible"), "context menu is hidden");
-});
+        assert.ok(!instance.option("visible"), "context menu is hidden");
+    });
 
-QUnit.test("when press right arrow key we only show submenu if exist", function(assert) {
-    var instance = new ContextMenu(this.$element, {
+    QUnit.test("when press right arrow key we only show submenu if exist", (assert) => {
+        const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }, { text: "item 2", items: [{ text: "item 21" }] }],
             focusStateEnabled: true
-        }),
-        keyboard;
+        });
 
-    instance.show();
+        let keyboard;
 
-    keyboard = keyboardMock(instance.itemsContainer());
+        instance.show();
 
-    keyboard
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("right");
+        keyboard = keyboardMock(instance.itemsContainer());
 
-    assert.equal(isRenderer(instance.option("focusedElement")), !!config().useJQuery, "focusedElement is correct");
-    assert.equal(getFocusedItemText(instance), "item 21", "focus on first item of second submenu");
-    assert.equal(getVisibleSubmenuCount(instance), 2, "we see two submenus");
+        keyboard
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("right");
 
-    keyboard
-        .keyDown("right");
+        assert.equal(isRenderer(instance.option("focusedElement")), !!config().useJQuery, "focusedElement is correct");
+        assert.equal(getFocusedItemText(instance), "item 21", "focus on first item of second submenu");
+        assert.equal(getVisibleSubmenuCount(instance), 2, "we see two submenus");
 
-    assert.equal(getFocusedItemText(instance), "item 21", "after second right arrow key press we do nothing because item2-1 has not submenu");
-    assert.equal(getVisibleSubmenuCount(instance), 2, "we still see two submenus");
-});
+        keyboard
+            .keyDown("right");
 
-QUnit.test("don't open submenu on right key press when item is disabled", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: "item 1" }, { text: "item 2", disabled: true, items: [{ text: "item 21" }] }],
-        focusStateEnabled: true
+        assert.equal(getFocusedItemText(instance), "item 21", "after second right arrow key press we do nothing because item2-1 has not submenu");
+        assert.equal(getVisibleSubmenuCount(instance), 2, "we still see two submenus");
     });
 
-    instance.show();
+    QUnit.test("don't open submenu on right key press when item is disabled", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1" }, { text: "item 2", disabled: true, items: [{ text: "item 21" }] }],
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("right");
+        instance.show();
 
-    assert.equal(instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS).length, 2, "submenu was not rendered");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("right");
 
-QUnit.test("end key work only in current submenu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "item 1" },
-            { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }, { text: "item 23" }] },
-            { text: "item 3" }
-        ],
-        focusStateEnabled: true
+        assert.equal(instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS).length, 2, "submenu was not rendered");
     });
 
-    instance.show();
+    QUnit.test("end key work only in current submenu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "item 1" },
+                { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }, { text: "item 23" }] },
+                { text: "item 3" }
+            ],
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("right")
-        .keyDown("down")
-        .keyDown("end");
+        instance.show();
 
-    assert.equal($(instance.option("focusedElement")).text(), "item 23", "focus on last item of current submenu");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("right")
+            .keyDown("down")
+            .keyDown("end");
 
-QUnit.test("home key work only in current submenu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "item 1" },
-            { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }, { text: "item 23" }] },
-            { text: "item 3" }
-        ],
-        focusStateEnabled: true
+        assert.equal($(instance.option("focusedElement")).text(), "item 23", "focus on last item of current submenu");
     });
 
-    instance.show();
+    QUnit.test("home key work only in current submenu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "item 1" },
+                { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }, { text: "item 23" }] },
+                { text: "item 3" }
+            ],
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("right")
-        .keyDown("down")
-        .keyDown("home");
+        instance.show();
 
-    assert.equal($(instance.option("focusedElement")).text(), "item 21", "focus on first item of current submenu");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("right")
+            .keyDown("down")
+            .keyDown("home");
 
-QUnit.test("down key work only in current submenu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "item 1" },
-            { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }, { text: "item 23" }] },
-            { text: "item 3" }
-        ],
-        focusStateEnabled: true
+        assert.equal($(instance.option("focusedElement")).text(), "item 21", "focus on first item of current submenu");
     });
 
-    instance.show();
+    QUnit.test("down key work only in current submenu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "item 1" },
+                { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }, { text: "item 23" }] },
+                { text: "item 3" }
+            ],
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("right")
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("down");
+        instance.show();
 
-    assert.equal($(instance.option("focusedElement")).text(), "item 22", "focus on first item of current submenu");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("right")
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("down");
 
-QUnit.test("up key work only in current submenu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "item 1" },
-            { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }, { text: "item 23" }] },
-            { text: "item 3" }
-        ],
-        focusStateEnabled: true
+        assert.equal($(instance.option("focusedElement")).text(), "item 22", "focus on first item of current submenu");
     });
 
-    instance.show();
+    QUnit.test("up key work only in current submenu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "item 1" },
+                { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }, { text: "item 23" }] },
+                { text: "item 3" }
+            ],
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("right")
-        .keyDown("up")
-        .keyDown("up")
-        .keyDown("up")
-        .keyDown("up");
+        instance.show();
 
-    assert.equal($(instance.option("focusedElement")).text(), "item 23", "focus on first item of current submenu");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("right")
+            .keyDown("up")
+            .keyDown("up")
+            .keyDown("up")
+            .keyDown("up");
 
-QUnit.test("left arrow key should not close context menu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: "item 1" }],
-        focusStateEnabled: true
+        assert.equal($(instance.option("focusedElement")).text(), "item 23", "focus on first item of current submenu");
     });
 
-    instance.show();
+    QUnit.test("left arrow key should not close context menu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1" }],
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("left");
+        instance.show();
 
-    assert.ok(instance.option("visible"), "context menu is visible");
-    assert.equal(getVisibleSubmenuCount(instance), 1, "submenu should not open");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("left");
 
-QUnit.test("left arrow key should hide only previous submenu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "item 1" },
-            { text: "item 2", items: [{ text: "item 21" }, { text: "item 22", items: [] }, { text: "item 23" }] },
-            { text: "item 3" }
-        ],
-        focusStateEnabled: true
+        assert.ok(instance.option("visible"), "context menu is visible");
+        assert.equal(getVisibleSubmenuCount(instance), 1, "submenu should not open");
     });
 
-    instance.show();
+    QUnit.test("left arrow key should hide only previous submenu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "item 1" },
+                { text: "item 2", items: [{ text: "item 21" }, { text: "item 22", items: [] }, { text: "item 23" }] },
+                { text: "item 3" }
+            ],
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("right")
-        .keyDown("down")
-        .keyDown("right")
-        .keyDown("left");
+        instance.show();
 
-    assert.equal(getVisibleSubmenuCount(instance), 1, "only root submenu is visible");
-    assert.equal(getFocusedItemText(instance), "item 2", "focus on second item of root submenu");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("right")
+            .keyDown("down")
+            .keyDown("right")
+            .keyDown("left");
 
-QUnit.test("rtl: when press left arrow key we only show submenu if exist", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: "item 1" }, { text: "item 2", items: [{ text: "item 21" }] }],
-        rtlEnabled: true,
-        focusStateEnabled: true
+        assert.equal(getVisibleSubmenuCount(instance), 1, "only root submenu is visible");
+        assert.equal(getFocusedItemText(instance), "item 2", "focus on second item of root submenu");
     });
 
-    instance.show();
+    QUnit.test("rtl: when press left arrow key we only show submenu if exist", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1" }, { text: "item 2", items: [{ text: "item 21" }] }],
+            rtlEnabled: true,
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("left");
+        instance.show();
 
-    assert.equal(getFocusedItemText(instance), "item 21", "focus on first item of second submenu");
-    assert.equal(getVisibleSubmenuCount(instance), 2, "we see two submenus");
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("left");
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("left");
+        assert.equal(getFocusedItemText(instance), "item 21", "focus on first item of second submenu");
+        assert.equal(getVisibleSubmenuCount(instance), 2, "we see two submenus");
 
-    assert.equal(getFocusedItemText(instance), "item 21", "after second right arrow key press we do nothing because item2-1 has not submenu");
-    assert.equal(getVisibleSubmenuCount(instance), 2, "we still see two submenus");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("left");
 
-QUnit.test("rtl: right arrow key should not close context menu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [{ text: "item 1", items: [{ text: "item 11" }] }],
-        rtlEnabled: true,
-        focusStateEnabled: true
+        assert.equal(getFocusedItemText(instance), "item 21", "after second right arrow key press we do nothing because item2-1 has not submenu");
+        assert.equal(getVisibleSubmenuCount(instance), 2, "we still see two submenus");
     });
 
-    instance.show();
+    QUnit.test("rtl: right arrow key should not close context menu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: "item 1", items: [{ text: "item 11" }] }],
+            rtlEnabled: true,
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("right");
+        instance.show();
 
-    assert.ok(instance.option("visible"), "context menu is visible");
-    assert.equal(getVisibleSubmenuCount(instance), 1, "submenu should not open");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("right");
 
-QUnit.test("rtl: right arrow key should hide only previous submenu", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "item 1" },
-            { text: "item 2", items: [{ text: "item 21" }, { text: "item 22", items: [] }, { text: "item 23" }] },
-            { text: "item 3" }
-        ],
-        rtlEnabled: true,
-        focusStateEnabled: true
+        assert.ok(instance.option("visible"), "context menu is visible");
+        assert.equal(getVisibleSubmenuCount(instance), 1, "submenu should not open");
     });
 
-    instance.show();
+    QUnit.test("rtl: right arrow key should hide only previous submenu", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "item 1" },
+                { text: "item 2", items: [{ text: "item 21" }, { text: "item 22", items: [] }, { text: "item 23" }] },
+                { text: "item 3" }
+            ],
+            rtlEnabled: true,
+            focusStateEnabled: true
+        });
 
-    keyboardMock(instance.itemsContainer())
-        .keyDown("down")
-        .keyDown("down")
-        .keyDown("left")
-        .keyDown("down")
-        .keyDown("left")
-        .keyDown("right");
+        instance.show();
 
-    assert.equal(getVisibleSubmenuCount(instance), 1, "only root submenu is visible");
-    assert.equal(getFocusedItemText(instance), "item 2", "focus on second item of root submenu");
-});
+        keyboardMock(instance.itemsContainer())
+            .keyDown("down")
+            .keyDown("down")
+            .keyDown("left")
+            .keyDown("down")
+            .keyDown("left")
+            .keyDown("right");
 
-QUnit.test("Moving focus should starts from the hovered item", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "Item 1" },
-            { text: "Item 2" },
-            { text: "Item 3" }
-        ],
-        focusStateEnabled: true
+        assert.equal(getVisibleSubmenuCount(instance), 1, "only root submenu is visible");
+        assert.equal(getFocusedItemText(instance), "item 2", "focus on second item of root submenu");
     });
 
-    instance.show();
+    QUnit.test("Moving focus should starts from the hovered item", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "Item 1" },
+                { text: "Item 2" },
+                { text: "Item 3" }
+            ],
+            focusStateEnabled: true
+        });
 
-    var $itemsContainer = instance.itemsContainer(),
-        $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        instance.show();
 
-    $($itemsContainer).trigger({ target: $items.eq(1).get(0), type: "dxpointerenter", pointerType: "mouse" });
+        const $itemsContainer = instance.itemsContainer();
+        const $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
 
-    assert.equal($items.filter("." + DX_STATE_FOCUSED_CLASS).length, 0, "There are no focused items on show");
-    assert.ok($items.eq(1).hasClass(DX_STATE_HOVER_CLASS), "Item 2 was hovered");
-    assert.notOk($items.eq(1).hasClass(DX_STATE_FOCUSED_CLASS), "Item 2 was not focused on hover");
+        $($itemsContainer).trigger({ target: $items.eq(1).get(0), type: "dxpointerenter", pointerType: "mouse" });
 
-    keyboardMock($itemsContainer)
-        .keyDown("down");
+        assert.equal($items.filter("." + DX_STATE_FOCUSED_CLASS).length, 0, "There are no focused items on show");
+        assert.ok($items.eq(1).hasClass(DX_STATE_HOVER_CLASS), "Item 2 was hovered");
+        assert.notOk($items.eq(1).hasClass(DX_STATE_FOCUSED_CLASS), "Item 2 was not focused on hover");
 
-    assert.equal($itemsContainer.find("." + DX_STATE_FOCUSED_CLASS).text(), "Item 3", "last item was focused");
-});
+        keyboardMock($itemsContainer)
+            .keyDown("down");
 
-QUnit.test("Moving focus should starts from the hovered item in nested level", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            {
-                text: "Item 1", items: [
-                    { text: "Item 11" },
-                    { text: "Item 12" },
-                    { text: "Item 13" }
-                ]
-            },
-            { text: "Item 2" }
-        ],
-        focusStateEnabled: true
+        assert.equal($itemsContainer.find("." + DX_STATE_FOCUSED_CLASS).text(), "Item 3", "last item was focused");
     });
 
-    instance.show();
+    QUnit.test("Moving focus should starts from the hovered item in nested level", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                {
+                    text: "Item 1", items: [
+                        { text: "Item 11" },
+                        { text: "Item 12" },
+                        { text: "Item 13" }
+                    ]
+                },
+                { text: "Item 2" }
+            ],
+            focusStateEnabled: true
+        });
 
-    var $itemsContainer = instance.itemsContainer(),
-        kb = keyboardMock($itemsContainer),
-        $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
+        instance.show();
 
-    kb.keyDown("down");
-    $($rootItem).trigger("dxclick");
-    assert.ok($rootItem.hasClass(DX_STATE_FOCUSED_CLASS), "root item is stay focused after the click");
+        const $itemsContainer = instance.itemsContainer();
+        const kb = keyboardMock($itemsContainer);
+        const $rootItem = $itemsContainer.find("." + DX_MENU_ITEM_CLASS).eq(0);
 
-    var $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
+        kb.keyDown("down");
+        $($rootItem).trigger("dxclick");
+        assert.ok($rootItem.hasClass(DX_STATE_FOCUSED_CLASS), "root item is stay focused after the click");
 
-    $($itemsContainer).trigger({ target: $items.eq(2).get(0), type: "dxpointerenter", pointerType: "mouse" });
+        const $items = $itemsContainer.find("." + DX_MENU_ITEM_CLASS);
 
-    assert.ok($items.eq(2).hasClass(DX_STATE_HOVER_CLASS), "Item 12 was hovered");
-    assert.notOk($items.eq(2).hasClass(DX_STATE_FOCUSED_CLASS), "Item 12 was not focused on hover");
+        $($itemsContainer).trigger({ target: $items.eq(2).get(0), type: "dxpointerenter", pointerType: "mouse" });
 
-    kb.keyDown("down");
+        assert.ok($items.eq(2).hasClass(DX_STATE_HOVER_CLASS), "Item 12 was hovered");
+        assert.notOk($items.eq(2).hasClass(DX_STATE_FOCUSED_CLASS), "Item 12 was not focused on hover");
 
-    assert.ok($items.eq(3).hasClass(DX_STATE_FOCUSED_CLASS), "Item 13 is focused");
-});
+        kb.keyDown("down");
 
-QUnit.test("Disabled item should be skipped when keyboard navigation", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "Item 1", disabled: true },
-            { text: "Item 2" }
-        ],
-        focusStateEnabled: true
+        assert.ok($items.eq(3).hasClass(DX_STATE_FOCUSED_CLASS), "Item 13 is focused");
     });
 
-    instance.show();
+    QUnit.test("Disabled item should be skipped when keyboard navigation", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "Item 1", disabled: true },
+                { text: "Item 2" }
+            ],
+            focusStateEnabled: true
+        });
 
-    var $itemsContainer = instance.itemsContainer(),
-        $items = instance.itemElements(),
-        kb = keyboardMock($itemsContainer);
+        instance.show();
 
-    kb.keyDown("down");
+        const $itemsContainer = instance.itemsContainer();
+        const $items = instance.itemElements();
+        const kb = keyboardMock($itemsContainer);
 
-    assert.ok($items.eq(1).hasClass(DX_STATE_FOCUSED_CLASS), "disabled item was skipped");
-});
+        kb.keyDown("down");
 
-QUnit.test("Focus should follow the nested hovered item if item in the parent level is focused", function(assert) {
-    var instance = new ContextMenu(this.$element, {
-        items: [
-            { text: "Item 1" },
-            { text: "Item 2", items: [{ text: "Item 21" }, { text: "Item 22" }] }
-        ],
-        focusStateEnabled: true
+        assert.ok($items.eq(1).hasClass(DX_STATE_FOCUSED_CLASS), "disabled item was skipped");
     });
 
-    instance.show();
+    QUnit.test("Focus should follow the nested hovered item if item in the parent level is focused", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [
+                { text: "Item 1" },
+                { text: "Item 2", items: [{ text: "Item 21" }, { text: "Item 22" }] }
+            ],
+            focusStateEnabled: true
+        });
 
-    var $itemsContainer = instance.itemsContainer(),
-        $items = instance.itemElements(),
-        kb = keyboardMock($itemsContainer);
+        instance.show();
 
-    $($items.eq(1)).trigger("dxclick");
-    kb.keyDown("up");
+        const $itemsContainer = instance.itemsContainer();
+        const $items = instance.itemElements();
+        const kb = keyboardMock($itemsContainer);
 
-    var $nestedItem = instance.itemElements().eq(2);
-    $($itemsContainer).trigger({ target: $nestedItem.get(0), type: "dxpointerenter", pointerType: "mouse" });
+        $($items.eq(1)).trigger("dxclick");
+        kb.keyDown("up");
 
-    assert.ok($items.eq(0).hasClass(DX_STATE_FOCUSED_CLASS), "Item 1 is focused");
-    assert.ok($nestedItem.hasClass(DX_STATE_HOVER_CLASS), "Item 21 is hovered");
+        const $nestedItem = instance.itemElements().eq(2);
+        $($itemsContainer).trigger({ target: $nestedItem.get(0), type: "dxpointerenter", pointerType: "mouse" });
 
-    kb.keyDown("down");
+        assert.ok($items.eq(0).hasClass(DX_STATE_FOCUSED_CLASS), "Item 1 is focused");
+        assert.ok($nestedItem.hasClass(DX_STATE_HOVER_CLASS), "Item 21 is hovered");
 
-    assert.ok(instance.itemElements().eq(3).hasClass(DX_STATE_FOCUSED_CLASS), "Item 22 is focused");
+        kb.keyDown("down");
+
+        assert.ok(instance.itemElements().eq(3).hasClass(DX_STATE_FOCUSED_CLASS), "Item 22 is focused");
+    });
 });
 
 

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
@@ -413,6 +413,13 @@ QUnit.test("context menu's overlay should have flipfit position as native contex
     assert.equal(overlay.option("position").collision, "flipfit", "position is correct");
 });
 
+QUnit.test("overlay should have innerOverlay option", function(assert) {
+    new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
+
+    var overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
+    assert.ok(overlay.option("innerOverlay"));
+});
+
 QUnit.test("Document should be default target", function(assert) {
     var showingHandler = sinon.stub();
 

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -112,6 +112,7 @@ var OVERLAY_CLASS = "dx-overlay",
     OVERLAY_CONTENT_CLASS = "dx-overlay-content",
     OVERLAY_SHADER_CLASS = "dx-overlay-shader",
     OVERLAY_MODAL_CLASS = "dx-overlay-modal",
+    INNER_OVERLAY_CLASS = "dx-inner-overlay",
 
     HOVER_STATE_CLASS = "dx-state-hover",
     DISABLED_STATE_CLASS = "dx-state-disabled",
@@ -137,6 +138,18 @@ QUnit.module("render", moduleConfig);
 QUnit.test("overlay class should be added to overlay", function(assert) {
     var $element = $("#overlay").dxOverlay();
     assert.ok($element.hasClass(OVERLAY_CLASS));
+});
+
+QUnit.test("inner overlay class should depend on innerOverlay option", function(assert) {
+    var overlay = $("#overlay").dxOverlay({
+            innerOverlay: true
+        }).dxOverlay("instance"),
+        $content = $(overlay.content());
+
+    assert.ok($content.hasClass(INNER_OVERLAY_CLASS));
+
+    overlay.option("innerOverlay", false);
+    assert.notOk($content.hasClass(INNER_OVERLAY_CLASS));
 });
 
 QUnit.test("content should be present when widget instance exists", function(assert) {
@@ -1486,6 +1499,23 @@ QUnit.test("overlay should not be hidden after click inside was present", functi
         .click();
 
     assert.equal(overlay.option("visible"), true, "overlay is not hidden");
+});
+
+QUnit.test("click in the inner overlay should not be an outside click", function(assert) {
+    var overlay1 = $("#overlay").dxOverlay({
+            closeOnOutsideClick: true,
+            visible: true
+        }).dxOverlay("instance"),
+        overlay2 = $("#overlay2").dxOverlay({
+            closeOnOutsideClick: true,
+            innerOverlay: true,
+            visible: true,
+            propagateOutsideClick: true
+        }).dxOverlay("instance");
+
+    $(overlay2.content()).trigger("dxpointerdown");
+
+    assert.equal(overlay1.option("visible"), true, "Bottom overlay should not get outside click when inner overlay clicked");
 });
 
 // T494814


### PR DESCRIPTION
There are two different cases:

1. T710079: When the dxContextMenu is inside the dxDropDownBox. In this case when the user selects an item, dxDropDownBox should not be closed
2. T655391 (#4991): When the dxContextMenu is single it should not prevent the click event on document click and let other overlays to handle it.

This pull request allows to set overlay as the inner overlay. Click inside of the inner overlay is not an outside click for other overlays on the page.