### PR TITLE
DataGrid: Doc comments for CustomizeExcelCell group/total summary exporting members (#6849)

### DIFF
--- a/js/exporter/excel/excel.doc_comments.js
+++ b/js/exporter/excel/excel.doc_comments.js
@@ -47,3 +47,19 @@
 * @name ExcelDataGridCell.value
 * @type any
 */
+/**
+* @name ExcelDataGridCell.totalSummaryItemName
+* @type string
+*/
+/**
+* @name ExcelDataGridCell.groupSummaryItems
+* @type Array<Object>
+*/
+/**
+* @name ExcelDataGridCell.groupSummaryItems.name
+* @type string
+*/
+/**
+* @name ExcelDataGridCell.groupSummaryItems.value
+* @type any
+*/


### PR DESCRIPTION
* DataGrid: Allow to customize Excel group/total summary cells (#6758)

* Allow to customize Excel cell value for DataGrid group/summary/total cells

* Renames

* Enhance test scenario

* Test "Change group cell with group summary items value" configuration

* Remove 'skip values' code

* Change 'for' to 'map'

* DataGrid: Allow to customize Excel group/total summary cells (DocComments)

* Change name to value

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
