### PR TITLE
 Add an invalid state appearance for HTMLEditor

### DIFF
--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -147,6 +147,18 @@ const HtmlEditor = Editor.inherit({
         return this.$element().find(`.${HTML_EDITOR_CONTENT_CLASS}`);
     },
 
+    _focusInHandler: function() {
+        this._toggleFocusClass(true, this.$element());
+
+        this.callBase.apply(this, arguments);
+    },
+
+    _focusOutHandler: function() {
+        this._toggleFocusClass(false, this.$element());
+
+        this.callBase.apply(this, arguments);
+    },
+
     _initMarkup: function() {
         this._$htmlContainer = $("<div>").addClass(QUILL_CONTAINER_CLASS);
 

--- a/styles/widgets/common/htmlEditor.less
+++ b/styles/widgets/common/htmlEditor.less
@@ -4,6 +4,8 @@
 @LIST_STYLE_OUTER_WIDTH: @LIST_STYLE_MARGIN + @LIST_STYLE_WIDTH;
 @MAX_INDENT: 9;
 
+@TRANSPARENT_BORDER: 1px solid transparent;
+
 .add-counter-reset(@counter, @start: 1) when (@counter >= @start) {
     .add-counter-reset(@counter - 1, @start);
     counter-reset+_: ~"list-@{counter}";
@@ -54,6 +56,7 @@
 .dx-htmleditor {
     display: flex;
     flex-direction: column;
+    border: @TRANSPARENT_BORDER;
 }
 
 .dx-quill-container {
@@ -276,12 +279,12 @@
 
 .dx-htmleditor-toolbar-separator {
     height: 100%;
-    border-left: 1px solid transparent;
+    border-left: @TRANSPARENT_BORDER;
 }
 
 .dx-htmleditor-toolbar-menu-separator {
     width: 100%;
-    border-top: 1px solid transparent;
+    border-top: @TRANSPARENT_BORDER;
 
     &::before {
         content: none;

--- a/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
+++ b/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
@@ -632,7 +632,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
+++ b/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
@@ -631,6 +631,10 @@
 @gallery-navbutton-border-radius: @base-border-radius - 4px;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: darken(@base-element-bg, 10%);
 @htmleditor-default-format-active-bg: darken(@base-accent, 10%);

--- a/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
+++ b/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
@@ -413,6 +413,10 @@
 @gallery-navbutton-border-radius: @base-border-radius - 4px;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: @base-bg;
 @htmleditor-default-format-active-bg: @base-default;

--- a/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
+++ b/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
@@ -414,7 +414,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/generic/color-schemes/dark/generic.dark.less
+++ b/styles/widgets/generic/color-schemes/dark/generic.dark.less
@@ -629,7 +629,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/generic/color-schemes/dark/generic.dark.less
+++ b/styles/widgets/generic/color-schemes/dark/generic.dark.less
@@ -628,6 +628,10 @@
 @gallery-navbutton-border-radius: @base-border-radius - 4px;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: lighten(@base-element-bg, 10%);
 @htmleditor-default-format-active-bg: darken(@base-accent, 10%);

--- a/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
+++ b/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
@@ -632,6 +632,10 @@
 @gallery-navbutton-border-radius: @base-border-radius - 4px;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: lighten(@base-element-bg, 10%);
 @htmleditor-default-format-active-bg: lighten(@base-accent, 10%);

--- a/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
+++ b/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
@@ -633,7 +633,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
+++ b/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
@@ -637,6 +637,10 @@
 @gallery-navbutton-border-radius: @base-border-radius - 4px;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: lighten(@base-element-bg, 10%);
 @htmleditor-default-format-active-bg: lighten(@base-accent, 10%);

--- a/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
+++ b/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
@@ -638,7 +638,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
+++ b/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
@@ -629,7 +629,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
+++ b/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
@@ -628,6 +628,10 @@
 @gallery-navbutton-border-radius: @base-border-radius - 4px;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: lighten(@base-element-bg, 10%);
 @htmleditor-default-format-active-bg: lighten(@base-accent, 10%);

--- a/styles/widgets/generic/color-schemes/light/generic.light.less
+++ b/styles/widgets/generic/color-schemes/light/generic.light.less
@@ -631,7 +631,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/generic/color-schemes/light/generic.light.less
+++ b/styles/widgets/generic/color-schemes/light/generic.light.less
@@ -630,6 +630,10 @@
 @gallery-navbutton-border-radius: @base-border-radius - 4px;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: darken(@base-element-bg, 10%);
 @htmleditor-default-format-active-bg: darken(@base-accent, 10%);

--- a/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
+++ b/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
@@ -633,6 +633,10 @@
 @gallery-navbutton-border-radius: @base-border-radius - 4px;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: darken(@base-element-bg, 10%);
 @htmleditor-default-format-active-bg: darken(@base-accent, 10%);

--- a/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
+++ b/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
@@ -634,7 +634,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/generic/htmlEditor.generic.less
+++ b/styles/widgets/generic/htmlEditor.generic.less
@@ -4,7 +4,6 @@
     }
 
     border-color: @htmleditor-border-color;
-    border-radius: @htmleditor-border-radius;
 
     &.dx-invalid {
         border-color: @htmleditor-invalid-faded-border-color;

--- a/styles/widgets/generic/htmlEditor.generic.less
+++ b/styles/widgets/generic/htmlEditor.generic.less
@@ -2,6 +2,18 @@
     .dx-htmleditor-toolbar-wrapper:first-child {
         border-bottom: 1px solid @htmleditor-toolbar-border-color;
     }
+
+    border-color: @htmleditor-border-color;
+    border-radius: @htmleditor-border-radius;
+
+    &.dx-invalid {
+        border-color: @htmleditor-invalid-faded-border-color;
+        
+        &.dx-state-focused {
+            border-color: @htmleditor-invalid-border-color;
+        }
+    }
+
 }
 
 .dx-htmleditor-content {

--- a/styles/widgets/material/color-schemes/material.dark.less
+++ b/styles/widgets/material/color-schemes/material.dark.less
@@ -614,6 +614,10 @@
 @gallery-navbutton-active-color: @base-accent;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: darken(@button-normal-bg, 10%);
 @htmleditor-default-format-active-bg: darken(@button-default-bg, 10%);

--- a/styles/widgets/material/color-schemes/material.dark.less
+++ b/styles/widgets/material/color-schemes/material.dark.less
@@ -615,7 +615,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/material/color-schemes/material.light.less
+++ b/styles/widgets/material/color-schemes/material.light.less
@@ -614,6 +614,10 @@
 @gallery-navbutton-active-color: @base-accent;
 
 // HtmlEditor
+@htmleditor-border-color: @base-border-color;
+@htmleditor-border-radius: @base-border-radius;
+@htmleditor-invalid-border-color: @base-invalid-color;
+@htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;
 @htmleditor-normal-format-active-bg: darken(@button-normal-bg, 10%);
 @htmleditor-default-format-active-bg: darken(@button-default-bg, 10%);

--- a/styles/widgets/material/color-schemes/material.light.less
+++ b/styles/widgets/material/color-schemes/material.light.less
@@ -615,7 +615,6 @@
 
 // HtmlEditor
 @htmleditor-border-color: @base-border-color;
-@htmleditor-border-radius: @base-border-radius;
 @htmleditor-invalid-border-color: @base-invalid-color;
 @htmleditor-invalid-faded-border-color: @base-invalid-faded-border-color;
 @htmleditor-toolbar-border-color: @base-border-color;

--- a/styles/widgets/material/htmlEditor.material.less
+++ b/styles/widgets/material/htmlEditor.material.less
@@ -4,7 +4,6 @@
     }
 
     border-color: @htmleditor-border-color;
-    border-radius: @htmleditor-border-radius;
 
     &.dx-invalid {
         border-color: @htmleditor-invalid-faded-border-color;

--- a/styles/widgets/material/htmlEditor.material.less
+++ b/styles/widgets/material/htmlEditor.material.less
@@ -2,6 +2,17 @@
     .dx-htmleditor-toolbar-wrapper:first-child {
         border-bottom: 1px solid @htmleditor-toolbar-border-color;
     }
+
+    border-color: @htmleditor-border-color;
+    border-radius: @htmleditor-border-radius;
+
+    &.dx-invalid {
+        border-color: @htmleditor-invalid-faded-border-color;
+        
+        &.dx-state-focused {
+            border-color: @htmleditor-invalid-border-color;
+        }
+    }
 }
 
 .dx-htmleditor-content {

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 
 import "ui/html_editor";
-
+const FOCUS_STATE_CLASS = "dx-state-focused";
 const { test, module } = QUnit;
 
 const moduleConfig = {
@@ -31,5 +31,25 @@ module("Events", moduleConfig, () => {
 
         assert.strictEqual(focusInStub.callCount, 1, "Editor is focused");
         assert.strictEqual(focusOutStub.callCount, 1, "Editor is blurred");
+    });
+
+    test("focus events should toggle 'dx-state-focused' class", (assert) => {
+        const clock = sinon.useFakeTimers();
+
+        this.instance.focus();
+        clock.tick();
+
+        const $element = this.instance.$element();
+        const $focusTarget = this.instance._focusTarget();
+
+        assert.ok($element.hasClass(FOCUS_STATE_CLASS), "element has focused class");
+        assert.ok($focusTarget.hasClass(FOCUS_STATE_CLASS), "focusTarget has focused class");
+
+        $(this.instance._focusTarget()).blur();
+        clock.tick();
+
+        assert.notOk($element.hasClass(FOCUS_STATE_CLASS), "element doesn't have focused class");
+        assert.notOk($focusTarget.hasClass(FOCUS_STATE_CLASS), "focusTarget doesn't have focused class");
+        clock.restore();
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarIntegration.tests.js
@@ -201,21 +201,23 @@ QUnit.module("Toolbar integration", {
 
     test("Editor should consider toolbar height", (assert => {
         const height = 100;
+        const $container = $("#htmlEditor");
         let markup = "";
 
         for(let i = 1; i < 50; i++) {
             markup += `<p>test ${i}</p>`;
         }
 
-        $("#htmlEditor").html(markup).dxHtmlEditor({
+        $container.html(markup).dxHtmlEditor({
             height: height,
             toolbar: { items: ["bold"] }
         });
 
-        const quillContainerHeight = $(`#htmlEditor .${QUILL_CONTAINER_CLASS}`).outerHeight();
-        const toolbarHeight = $(`#htmlEditor .${TOOLBAR_WRAPPER_CLASS}`).outerHeight();
+        const quillContainerHeight = $container.find(`.${QUILL_CONTAINER_CLASS}`).outerHeight();
+        const toolbarHeight = $container.find(`.${TOOLBAR_WRAPPER_CLASS}`).outerHeight();
+        const bordersWidth = parseInt($container.css("border-top-width")) + parseInt($container.css("border-bottom-width"));
 
-        assert.roughEqual(quillContainerHeight + toolbarHeight, height, 1, "Toolbar + editor equals to the predefined height");
+        assert.roughEqual(quillContainerHeight + toolbarHeight + bordersWidth, height, 1, "Toolbar + editor equals to the predefined height");
     }));
 
     test("Toolbar correctly disposed after repaint", (assert) => {


### PR DESCRIPTION
Results:
![focused_editor](https://user-images.githubusercontent.com/9039982/52717871-2ea92800-2fb3-11e9-9031-49a6299624e7.png)
![unfocused_editor](https://user-images.githubusercontent.com/9039982/52717873-2ea92800-2fb3-11e9-986a-9266d08cc489.png)

