### PR TITLE
 Fix appointmentData and itemData arguments in the templates of the Scheduler (T712866)

### DIFF
--- a/js/ui/scheduler/ui.scheduler.appointment_tooltip.js
+++ b/js/ui/scheduler/ui.scheduler.appointment_tooltip.js
@@ -33,10 +33,7 @@ var appointmentTooltip = {
 
         this._$tooltip = $("<div>").appendTo(instance.$element()).addClass(APPOINTMENT_TOOLTIP_WRAPPER_CLASS);
 
-        appointmentData = this.instance.fire("appendSingleAppointmentData", {
-            appointmentData: appointmentData,
-            singleAppointmentData: singleAppointmentData
-        });
+        var targetedAppointmentData = instance.fire("getTargetedAppointmentData", appointmentData, $appointment);
 
         this._tooltip = instance._createComponent(this._$tooltip, Tooltip, {
             visible: true,
@@ -45,6 +42,7 @@ var appointmentTooltip = {
             contentTemplate: new FunctionTemplate(function(options) {
                 return template.render({
                     model: appointmentData,
+                    targetedAppointmentData: targetedAppointmentData,
                     container: options.container
                 });
             }),

--- a/js/ui/scheduler/ui.scheduler.appointments.drop_down.js
+++ b/js/ui/scheduler/ui.scheduler.appointments.drop_down.js
@@ -119,10 +119,10 @@ var dropDownAppointments = Class.inherit({
                 config.event.stopPropagation();
 
                 this.instance.fire("showEditAppointmentPopup", { data: config.appointmentData });
-            }
-            ).bind(this)
+            }).bind(this)
         });
     },
+
     _createDropDownMenu: function(config, isCompact) {
         var $menu = config.$element,
             items = config.items,
@@ -163,17 +163,8 @@ var dropDownAppointments = Class.inherit({
                 activeStateEnabled: false,
                 focusStateEnabled: this.instance.option("focusStateEnabled"),
                 itemTemplate: new FunctionTemplate(function(options) {
-                    var itemData = options.model,
-                        startDate = itemData.settings ? itemData.settings[0].startDate : itemData.startDate;
-
-                    itemData = that.instance.fire("appendSingleAppointmentData", {
-                        appointmentData: itemData,
-                        index: options.index,
-                        startDate: startDate
-                    });
-
                     return template.render({
-                        model: itemData,
+                        model: options.model,
                         index: options.index,
                         container: options.container
                     });
@@ -186,7 +177,6 @@ var dropDownAppointments = Class.inherit({
                     var $item = args.itemElement,
                         itemData = args.itemData,
                         settings = itemData.settings;
-
 
                     eventsEngine.on($item, DRAG_START_EVENT_NAME, that._dragStartHandler.bind(that, $item, itemData, settings, $menu));
 
@@ -218,7 +208,6 @@ var dropDownAppointments = Class.inherit({
 
         settings[0].isCompact = false;
         settings[0].virtual = false;
-
 
         var appointmentData = {
             itemData: itemData,

--- a/js/ui/scheduler/ui.scheduler.appointments.js
+++ b/js/ui/scheduler/ui.scheduler.appointments.js
@@ -485,13 +485,8 @@ var SchedulerAppointments = CollectionWidget.inherit({
     },
 
     _createItemByTemplate: function(itemTemplate, renderArgs) {
-        var itemData = this.invoke("appendSingleAppointmentData", {
-            appointmentData: renderArgs.itemData,
-            index: renderArgs.index,
-            startDate: this._currentAppointmentSettings.startDate
-        });
         return itemTemplate.render({
-            model: itemData,
+            model: renderArgs.itemData,
             container: renderArgs.container,
             index: renderArgs.index
         });

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -152,6 +152,7 @@ var Scheduler = Widget.inherit({
                 * @default "appointmentTooltip"
                 * @type_function_param1 appointmentData:object
                 * @type_function_param2 contentElement:dxElement
+                * @type_function_param3 targetedAppointmentData:object
                 * @type_function_return string|Node|jQuery
                 */
 
@@ -889,7 +890,6 @@ var Scheduler = Widget.inherit({
             noDataText: messageLocalization.format("dxCollectionWidget-noDataText"),
 
             allowMultipleCellSelection: true,
-            displayedAppointmentDataField: null,
 
             _appointmentTooltipOffset: { x: 0, y: 0 },
             _appointmentTooltipButtonsPosition: "bottom",
@@ -1349,8 +1349,6 @@ var Scheduler = Widget.inherit({
             case "dateSerializationFormat":
                 break;
             case "maxAppointmentsPerCell":
-                break;
-            case "displayedAppointmentDataField":
                 break;
             case "startDateExpr":
             case "endDateExpr":
@@ -2624,6 +2622,14 @@ var Scheduler = Widget.inherit({
 
     _needUpdateAppointmentData: function($appointment) {
         return $appointment.hasClass("dx-scheduler-appointment-compact") || $appointment.hasClass("dx-scheduler-appointment-recurrence");
+    },
+
+    _getNormalizedTemplateArgs: function(options) {
+        var args = this.callBase(options);
+        if("targetedAppointmentData" in options) {
+            args.push(options.targetedAppointmentData);
+        }
+        return args;
     },
 
     subscribe: function(subject, action) {

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -307,6 +307,7 @@ var subscribes = {
 
         return cellWidth;
     },
+
     getEndDate: function(appointmentData) {
         return this._getEndDate(appointmentData);
     },
@@ -558,22 +559,6 @@ var subscribes = {
         }, this._subscribes["convertDateByTimezone"].bind(this));
     },
 
-    appendSingleAppointmentData: function(config) {
-        var appointmentData = config.appointmentData,
-            singleAppointmentData = config.singleAppointmentData;
-
-        var field = this.option("displayedAppointmentDataField"),
-            result = extend({}, appointmentData);
-
-        if(this._isAppointmentRecurrence(appointmentData) && typeUtils.isDefined(field)) {
-            singleAppointmentData = singleAppointmentData || this._subscribes["getTargetedAppointmentData"].call(this, appointmentData, undefined, config.index, config.startDate);
-
-            result[field] = singleAppointmentData;
-        }
-
-        return result;
-    },
-
     dayHasAppointment: function(day, appointment, trimTime) {
         return this.dayHasAppointment(day, appointment, trimTime);
     },
@@ -766,9 +751,10 @@ var subscribes = {
     },
 
     getTargetedAppointmentData: function(appointmentData, appointmentElement, appointmentIndex, startDate) {
-        var recurringData = this._getSingleAppointmentData(appointmentData, {
+        var $appointmentElement = $(appointmentElement),
+            recurringData = this._getSingleAppointmentData(appointmentData, {
                 skipDateCalculation: true,
-                $appointment: $(appointmentElement),
+                $appointment: $appointmentElement,
                 skipHoursProcessing: true,
                 startDate: startDate
             }),
@@ -777,6 +763,10 @@ var subscribes = {
         extend(true, result, appointmentData, recurringData);
 
         this._convertDatesByTimezoneBack(false, result);
+
+        if(typeUtils.isDefined(appointmentIndex)) {
+            appointmentIndex = $appointmentElement.data(this._appointments._itemIndexKey());
+        }
 
         // TODO: _getSingleAppointmentData already uses a related cell data for appointment that contains info about resources
         appointmentElement && this.setTargetedAppointmentResources(result, appointmentElement, appointmentIndex);
@@ -838,6 +828,5 @@ var subscribes = {
     getStartDayHour: function() {
         return this.option("startDayHour");
     }
-
 };
 module.exports = subscribes;

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -764,7 +764,7 @@ var subscribes = {
 
         this._convertDatesByTimezoneBack(false, result);
 
-        if(typeUtils.isDefined(appointmentIndex)) {
+        if(!typeUtils.isDefined(appointmentIndex)) {
             appointmentIndex = $appointmentElement.data(this._appointments._itemIndexKey());
         }
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
@@ -59,36 +59,6 @@ QUnit.testStart(function() {
         afterEach: function() {
             this.clock.restore();
             fx.off = false;
-        },
-        checkAppointmentDataInTooltipTemplate: function(assert, dataSource, currentDate) {
-            this.instance.option({
-                dataSource: dataSource,
-                height: 600,
-                currentDate: currentDate,
-                currentView: "month",
-                views: ["month"],
-                appointmentTooltipTemplate: function(appointmentData) {
-                    assert.equal(dataSource.indexOf(appointmentData), 0, "appointment data contains in the data source");
-                }
-            });
-
-            $(this.instance.$element().find(".dx-scheduler-appointment").eq(0)).trigger("dxclick");
-            this.clock.tick(300);
-        },
-        checkItemDataInDropDownTemplate: function(assert, dataSource, currentDate) {
-            this.instance.option({
-                dataSource: dataSource,
-                height: 600,
-                maxAppointmentsPerCell: 1,
-                currentDate: currentDate,
-                currentView: "month",
-                views: ["month"],
-                dropDownAppointmentTemplate: function(itemData) {
-                    assert.ok(dataSource.indexOf(itemData) > -1, "appointment data contains in the data source");
-                }
-            });
-
-            $(".dx-scheduler-dropdown-appointments").eq(0).dxDropDownMenu("instance").open();
         }
     });
 
@@ -108,7 +78,6 @@ QUnit.testStart(function() {
 
         assert.ok(true, "Widget works correctly");
     });
-
 
     QUnit.test("Scheduler shouldn't have paginate in default DataSource", function(assert) {
         this.instance.option({ dataSource: this.tasks });
@@ -310,93 +279,6 @@ QUnit.testStart(function() {
         assert.strictEqual(dataAccessors.setter.recurrenceRule, undefined, "setter for recurrenceRule is OK");
     });
 
-    QUnit.test("the targetedAppointmentData parameter appends to arguments of the appointment tooltip template for a recurrence rule", function(assert) {
-        this.instance.option({
-            dataSource: [{
-                startDate: new Date(2015, 4, 24, 9),
-                endDate: new Date(2015, 4, 24, 11),
-                allDay: true,
-                recurrenceRule: "FREQ=DAILY;COUNT=3",
-                text: "Task 2"
-            }],
-            height: 600,
-            currentDate: new Date(2015, 4, 24),
-            currentView: "month",
-            views: ["month"],
-            appointmentTooltipTemplate: function(data, index, targetedAppointmentData) {
-                assert.deepEqual(targetedAppointmentData, {
-                    allDay: true,
-                    endDate: new Date(2015, 4, 25, 11),
-                    recurrenceRule: "FREQ=DAILY;COUNT=3",
-                    startDate: new Date(2015, 4, 25, 9),
-                    text: "Task 2"
-                });
-            }
-        });
-
-        $(this.instance.$element().find(".dx-scheduler-appointment").eq(1)).trigger("dxclick");
-        this.clock.tick(300);
-    });
-
-    QUnit.test("the targetedAppointmentData parameter appends to arguments of the appointment tooltip template for a non-recurrence rule", function(assert) {
-        this.instance.option({
-            dataSource: [{
-                startDate: new Date(2015, 4, 24, 9),
-                endDate: new Date(2015, 4, 24, 11),
-                text: "Task 1"
-            }],
-            height: 600,
-            currentDate: new Date(2015, 4, 24),
-            currentView: "month",
-            views: ["month"],
-            appointmentTooltipTemplate: function(data, index, targetedAppointmentData) {
-                assert.deepEqual(targetedAppointmentData, {
-                    startDate: new Date(2015, 4, 24, 9),
-                    endDate: new Date(2015, 4, 24, 11),
-                    text: "Task 1"
-                });
-            }
-        });
-
-        $(this.instance.$element().find(".dx-scheduler-appointment").eq(0)).trigger("dxclick");
-        this.clock.tick(300);
-    });
-
-    QUnit.skip("the targetedAppointmentData parameter appends to arguments of the drop down appointment template for a recurrence rule", function(assert) {
-        var data = [{
-            startDate: new Date(2015, 4, 24, 9),
-            endDate: new Date(2015, 4, 24, 11),
-            recurrenceRule: "FREQ=DAILY;COUNT=3",
-            allDay: true,
-            text: "Task 1"
-        }, {
-            startDate: new Date(2015, 4, 24, 9),
-            endDate: new Date(2015, 4, 24, 11),
-            allDay: true,
-            recurrenceRule: "FREQ=DAILY;COUNT=2",
-            text: "Task 2"
-        }];
-
-        this.instance.option({
-            dataSource: data,
-            maxAppointmentsPerCell: 1,
-            currentDate: new Date(2015, 4, 24),
-            views: ["month"],
-            dropDownAppointmentTemplate: function(itemData, itemIndex, itemElement, targetedAppointmentData) {
-                assert.deepEqual(targetedAppointmentData, {
-                    endDate: new Date(2015, 4, 26, 9),
-                    recurrenceRule: "FREQ=DAILY;COUNT=3",
-                    startDate: new Date(2015, 4, 25, 9),
-                    allDay: true,
-                    text: "Task 1"
-                }, "appointmentData is should be an instance");
-            },
-            currentView: "month"
-        });
-
-        $(".dx-scheduler-dropdown-appointments").eq(0).dxDropDownMenu("instance").open();
-    });
-
     QUnit.test("appointmentCollectorTemplate rendering args should be correct", function(assert) {
         this.instance.option({
             dataSource: [{
@@ -422,84 +304,6 @@ QUnit.testStart(function() {
             currentView: "month"
         });
     });
-
-    QUnit.test("The appointmentData argument of the appointment tooltip template is should be instance of the data source", function(assert) {
-        var dataSource = [{
-            startDate: new Date(2015, 4, 24, 9),
-            endDate: new Date(2015, 4, 24, 11),
-            allDay: true,
-            text: "Task 1"
-        }, {
-            startDate: new Date(2015, 4, 25),
-            endDate: new Date(2015, 4, 25),
-            allDay: true,
-            text: "Task 2"
-        }];
-
-        this.checkAppointmentDataInTooltipTemplate(assert, dataSource, new Date(2015, 4, 24));
-    });
-
-    QUnit.test("The appointmentData argument of the appointment tooltip template is should be instance of the data source for recurrence rule", function(assert) {
-        var dataSource = [{
-            startDate: new Date(2015, 4, 24, 9),
-            endDate: new Date(2015, 4, 24, 11),
-            recurrenceRule: "FREQ=DAILY;COUNT=3",
-            allDay: true,
-            text: "Task 1"
-        }, {
-            startDate: new Date(2015, 4, 24, 19),
-            endDate: new Date(2015, 4, 24, 31),
-            allDay: true,
-            recurrenceRule: "FREQ=DAILY;COUNT=2",
-            text: "Task 2"
-        }];
-
-        this.checkAppointmentDataInTooltipTemplate(assert, dataSource, new Date(2015, 4, 24));
-    });
-
-    QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source", function(assert) {
-        var dataSource = [{
-            startDate: new Date(2015, 4, 24, 9),
-            endDate: new Date(2015, 4, 24, 11),
-            allDay: true,
-            text: "Task 1"
-        }, {
-            startDate: new Date(2015, 4, 24, 15),
-            endDate: new Date(2015, 4, 24, 20),
-            allDay: true,
-            text: "Task 2"
-        }, {
-            startDate: new Date(2015, 4, 24, 45),
-            endDate: new Date(2015, 4, 24, 55),
-            allDay: true,
-            text: "Task 3"
-        }];
-        this.checkItemDataInDropDownTemplate(assert, dataSource, new Date(2015, 4, 24));
-    });
-
-    QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source for recurrence rule", function(assert) {
-        var dataSource = [{
-            startDate: new Date(2015, 4, 24, 9),
-            endDate: new Date(2015, 4, 24, 11),
-            recurrenceRule: "FREQ=DAILY;COUNT=3",
-            allDay: true,
-            text: "Task 1"
-        }, {
-            startDate: new Date(2015, 4, 24, 19),
-            endDate: new Date(2015, 4, 24, 31),
-            allDay: true,
-            recurrenceRule: "FREQ=DAILY;COUNT=2",
-            text: "Task 2"
-        }, {
-            startDate: new Date(2015, 4, 24, 24),
-            endDate: new Date(2015, 4, 24, 34),
-            allDay: true,
-            recurrenceRule: "FREQ=DAILY;COUNT=4",
-            text: "Task 3"
-        }];
-        this.checkItemDataInDropDownTemplate(assert, dataSource, new Date(2015, 4, 24));
-    });
-
 })("Initialization");
 
 (function() {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
@@ -280,98 +280,27 @@ QUnit.testStart(function() {
         assert.strictEqual(dataAccessors.setter.recurrenceRule, undefined, "setter for recurrenceRule is OK");
     });
 
-    QUnit.test("appointmentTemplate rendering args should be correct if displayedAppointmentDataField is specified", function(assert) {
-        var counter = 0;
-
+    QUnit.test("the targetedAppointmentData parameter appends to arguments of the appointment tooltip template for a recurrence rule", function(assert) {
         this.instance.option({
             dataSource: [{
-                startDate: new Date(2015, 4, 24, 9, 10),
-                endDate: new Date(2015, 4, 24, 11, 1),
+                startDate: new Date(2015, 4, 24, 9),
+                endDate: new Date(2015, 4, 24, 11),
                 allDay: true,
-                recurrenceRule: "FREQ=DAILY;COUNT=2",
+                recurrenceRule: "FREQ=DAILY;COUNT=3",
                 text: "Task 2"
             }],
             height: 600,
             currentDate: new Date(2015, 4, 24),
-            displayedAppointmentDataField: "Field",
             currentView: "month",
             views: ["month"],
-            appointmentTemplate: function(data) {
-                if(counter === 1) {
-                    assert.deepEqual(data.Field, {
-                        startDate: new Date(2015, 4, 25, 9, 10),
-                        endDate: new Date(2015, 4, 25, 11, 1),
-                        allDay: true,
-                        recurrenceRule: "FREQ=DAILY;COUNT=2",
-                        text: "Task 2"
-                    }, "occurence args is correct");
-                }
-                counter++;
-            }
-        });
-    });
-
-    QUnit.test("additional field should be applied in appointmentTemplate only for recurrence appointment", function(assert) {
-        this.instance.option({
-            dataSource: [{
-                startDate: new Date(2015, 4, 10, 9, 10),
-                endDate: new Date(2015, 4, 24, 11, 1),
-                allDay: true,
-                text: "Task 2"
-            }],
-            height: 600,
-            currentDate: new Date(2015, 4, 24),
-            displayedAppointmentDataField: "Field",
-            currentView: "month",
-            views: ["month"],
-            appointmentTemplate: function(data) {
-                assert.strictEqual(data.Field, undefined);
-            }
-        });
-    });
-
-    QUnit.test("additional field should be applied in appointmentTemplate only when displayedAppointmentDataField is set", function(assert) {
-        this.instance.option({
-            dataSource: [{
-                startDate: new Date(2015, 4, 24, 9, 10),
-                endDate: new Date(2015, 4, 24, 11, 1),
-                recurrenceRule: "FREQ=DAILY;COUNT=2",
-                allDay: true,
-                text: "Task 2"
-            }],
-            height: 600,
-            currentDate: new Date(2015, 4, 24),
-            displayedAppointmentDataField: null,
-            currentView: "month",
-            views: ["month"],
-            appointmentTemplate: function(data) {
-                assert.strictEqual(data.Field, undefined);
-            }
-        });
-    });
-
-    QUnit.test("appointmentTooltipTemplate rendering args should be correct if displayedAppointmentDataField is specified", function(assert) {
-        this.instance.option({
-            dataSource: [{
-                startDate: new Date(2015, 4, 24, 9, 10),
-                endDate: new Date(2015, 4, 24, 11, 1),
-                allDay: true,
-                recurrenceRule: "FREQ=DAILY;COUNT=2",
-                text: "Task 2"
-            }],
-            height: 600,
-            currentDate: new Date(2015, 4, 24),
-            displayedAppointmentDataField: "Field",
-            currentView: "month",
-            views: ["month"],
-            appointmentTooltipTemplate: function(data) {
-                assert.deepEqual(data.Field, {
-                    startDate: new Date(2015, 4, 25, 9, 10),
-                    endDate: new Date(2015, 4, 25, 11, 1),
+            appointmentTooltipTemplate: function(data, index, targetedAppointmentData) {
+                assert.deepEqual(targetedAppointmentData, {
                     allDay: true,
-                    recurrenceRule: "FREQ=DAILY;COUNT=2",
+                    endDate: new Date(2015, 4, 25, 11),
+                    recurrenceRule: "FREQ=DAILY;COUNT=3",
+                    startDate: new Date(2015, 4, 25, 9),
                     text: "Task 2"
-                }, "occurence args is correct");
+                });
             }
         });
 
@@ -379,33 +308,57 @@ QUnit.testStart(function() {
         this.clock.tick(300);
     });
 
-    QUnit.test("dropDownAppointmentTemplate rendering args should be correct if displayedAppointmentDataField is specified", function(assert) {
+    QUnit.test("the targetedAppointmentData parameter appends to arguments of the appointment tooltip template for a non-recurrence rule", function(assert) {
         this.instance.option({
             dataSource: [{
-                startDate: new Date(2015, 4, 24, 9, 10),
-                endDate: new Date(2015, 4, 24, 11, 1),
-                recurrenceRule: "FREQ=DAILY;COUNT=2",
-                allDay: true,
+                startDate: new Date(2015, 4, 24, 9),
+                endDate: new Date(2015, 4, 24, 11),
                 text: "Task 1"
-            }, {
-                startDate: new Date(2015, 4, 24, 9, 10),
-                endDate: new Date(2015, 4, 24, 11, 1),
-                allDay: true,
-                recurrenceRule: "FREQ=DAILY;COUNT=2",
-                text: "Task 2"
             }],
+            height: 600,
+            currentDate: new Date(2015, 4, 24),
+            currentView: "month",
+            views: ["month"],
+            appointmentTooltipTemplate: function(data, index, targetedAppointmentData) {
+                assert.deepEqual(targetedAppointmentData, {
+                    startDate: new Date(2015, 4, 24, 9),
+                    endDate: new Date(2015, 4, 24, 11),
+                    text: "Task 1"
+                });
+            }
+        });
+
+        $(this.instance.$element().find(".dx-scheduler-appointment").eq(0)).trigger("dxclick");
+        this.clock.tick(300);
+    });
+
+    QUnit.skip("the targetedAppointmentData parameter appends to arguments of the drop down appointment template for a recurrence rule", function(assert) {
+        var data = [{
+            startDate: new Date(2015, 4, 24, 9),
+            endDate: new Date(2015, 4, 24, 11),
+            recurrenceRule: "FREQ=DAILY;COUNT=3",
+            allDay: true,
+            text: "Task 1"
+        }, {
+            startDate: new Date(2015, 4, 24, 9),
+            endDate: new Date(2015, 4, 24, 11),
+            allDay: true,
+            recurrenceRule: "FREQ=DAILY;COUNT=2",
+            text: "Task 2"
+        }];
+
+        this.instance.option({
+            dataSource: data,
             maxAppointmentsPerCell: 1,
             currentDate: new Date(2015, 4, 24),
-            displayedAppointmentDataField: "Field",
             views: ["month"],
-            dropDownAppointmentTemplate: function(data) {
-                assert.deepEqual(data.Field.startDate, new Date(2015, 4, 25, 9, 10), "Start date of part is ok");
-                assert.deepEqual(data.Field.endDate, new Date(2015, 4, 25, 11, 1), "End date of part is ok");
+            dropDownAppointmentTemplate: function(appointmentData) {
+                assert.equal(data.indexOf(appointmentData), 0, "appointmentData is should be an instance");
             },
             currentView: "month"
         });
 
-        $(".dx-scheduler-dropdown-appointments").eq(1).dxDropDownMenu("instance").open();
+        $(".dx-scheduler-dropdown-appointments").eq(0).dxDropDownMenu("instance").open();
     });
 
     QUnit.test("appointmentCollectorTemplate rendering args should be correct", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
@@ -59,6 +59,36 @@ QUnit.testStart(function() {
         afterEach: function() {
             this.clock.restore();
             fx.off = false;
+        },
+        checkAppointmentDataInTooltipTemplate: function(assert, dataSource, currentDate) {
+            this.instance.option({
+                dataSource: dataSource,
+                height: 600,
+                currentDate: currentDate,
+                currentView: "month",
+                views: ["month"],
+                appointmentTooltipTemplate: function(appointmentData) {
+                    assert.equal(dataSource.indexOf(appointmentData), 0, "appointment data contains in the data source");
+                }
+            });
+
+            $(this.instance.$element().find(".dx-scheduler-appointment").eq(0)).trigger("dxclick");
+            this.clock.tick(300);
+        },
+        checkItemDataInDropDownTemplate: function(assert, dataSource, currentDate) {
+            this.instance.option({
+                dataSource: dataSource,
+                height: 600,
+                maxAppointmentsPerCell: 1,
+                currentDate: currentDate,
+                currentView: "month",
+                views: ["month"],
+                dropDownAppointmentTemplate: function(itemData) {
+                    assert.ok(dataSource.indexOf(itemData) > -1, "appointment data contains in the data source");
+                }
+            });
+
+            $(".dx-scheduler-dropdown-appointments").eq(0).dxDropDownMenu("instance").open();
         }
     });
 
@@ -352,8 +382,14 @@ QUnit.testStart(function() {
             maxAppointmentsPerCell: 1,
             currentDate: new Date(2015, 4, 24),
             views: ["month"],
-            dropDownAppointmentTemplate: function(appointmentData) {
-                assert.equal(data.indexOf(appointmentData), 0, "appointmentData is should be an instance");
+            dropDownAppointmentTemplate: function(itemData, itemIndex, itemElement, targetedAppointmentData) {
+                assert.deepEqual(targetedAppointmentData, {
+                    endDate: new Date(2015, 4, 26, 9),
+                    recurrenceRule: "FREQ=DAILY;COUNT=3",
+                    startDate: new Date(2015, 4, 25, 9),
+                    allDay: true,
+                    text: "Task 1"
+                }, "appointmentData is should be an instance");
             },
             currentView: "month"
         });
@@ -385,6 +421,83 @@ QUnit.testStart(function() {
             },
             currentView: "month"
         });
+    });
+
+    QUnit.test("The appointmentData argument of the appointment tooltip template is should be instance of the data source", function(assert) {
+        var dataSource = [{
+            startDate: new Date(2015, 4, 24, 9),
+            endDate: new Date(2015, 4, 24, 11),
+            allDay: true,
+            text: "Task 1"
+        }, {
+            startDate: new Date(2015, 4, 25),
+            endDate: new Date(2015, 4, 25),
+            allDay: true,
+            text: "Task 2"
+        }];
+
+        this.checkAppointmentDataInTooltipTemplate(assert, dataSource, new Date(2015, 4, 24));
+    });
+
+    QUnit.test("The appointmentData argument of the appointment tooltip template is should be instance of the data source for recurrence rule", function(assert) {
+        var dataSource = [{
+            startDate: new Date(2015, 4, 24, 9),
+            endDate: new Date(2015, 4, 24, 11),
+            recurrenceRule: "FREQ=DAILY;COUNT=3",
+            allDay: true,
+            text: "Task 1"
+        }, {
+            startDate: new Date(2015, 4, 24, 19),
+            endDate: new Date(2015, 4, 24, 31),
+            allDay: true,
+            recurrenceRule: "FREQ=DAILY;COUNT=2",
+            text: "Task 2"
+        }];
+
+        this.checkAppointmentDataInTooltipTemplate(assert, dataSource, new Date(2015, 4, 24));
+    });
+
+    QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source", function(assert) {
+        var dataSource = [{
+            startDate: new Date(2015, 4, 24, 9),
+            endDate: new Date(2015, 4, 24, 11),
+            allDay: true,
+            text: "Task 1"
+        }, {
+            startDate: new Date(2015, 4, 24, 15),
+            endDate: new Date(2015, 4, 24, 20),
+            allDay: true,
+            text: "Task 2"
+        }, {
+            startDate: new Date(2015, 4, 24, 45),
+            endDate: new Date(2015, 4, 24, 55),
+            allDay: true,
+            text: "Task 3"
+        }];
+        this.checkItemDataInDropDownTemplate(assert, dataSource, new Date(2015, 4, 24));
+    });
+
+    QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source for recurrence rule", function(assert) {
+        var dataSource = [{
+            startDate: new Date(2015, 4, 24, 9),
+            endDate: new Date(2015, 4, 24, 11),
+            recurrenceRule: "FREQ=DAILY;COUNT=3",
+            allDay: true,
+            text: "Task 1"
+        }, {
+            startDate: new Date(2015, 4, 24, 19),
+            endDate: new Date(2015, 4, 24, 31),
+            allDay: true,
+            recurrenceRule: "FREQ=DAILY;COUNT=2",
+            text: "Task 2"
+        }, {
+            startDate: new Date(2015, 4, 24, 24),
+            endDate: new Date(2015, 4, 24, 34),
+            allDay: true,
+            recurrenceRule: "FREQ=DAILY;COUNT=4",
+            text: "Task 3"
+        }];
+        this.checkItemDataInDropDownTemplate(assert, dataSource, new Date(2015, 4, 24));
     });
 
 })("Initialization");

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
@@ -74,6 +74,21 @@ QUnit.module("Integration: Appointments", {
     afterEach: function() {
         fx.off = false;
         this.clock.restore();
+    },
+    checkItemDataInDropDownTemplate: function(assert, dataSource, currentDate) {
+        this.createInstance({
+            dataSource: dataSource,
+            height: 600,
+            maxAppointmentsPerCell: 1,
+            currentDate: currentDate,
+            currentView: "month",
+            views: ["month"],
+            dropDownAppointmentTemplate: function(itemData) {
+                assert.ok(dataSource.indexOf(itemData) > -1, "appointment data contains in the data source");
+            }
+        });
+
+        $(".dx-scheduler-dropdown-appointments").eq(0).dxDropDownMenu("instance").open();
     }
 });
 
@@ -2822,7 +2837,6 @@ QUnit.test("DropDown appointments should not be duplicated when items option cha
     assert.equal(ddAppointments.length, 3, "There are 3 drop down appts");
 });
 
-
 QUnit.test("Recurrence appointment should be rendered correctly when currentDate was changed: month view", function(assert) {
     var appointment = {
         startDate: new Date(2015, 1, 14, 0),
@@ -3933,7 +3947,6 @@ QUnit.test("Appointment should be dragged correctly between the groups in vertic
     assert.deepEqual(appointmentData.id, 2, "Group is OK");
 });
 
-
 QUnit.test("Long appt parts should have correct coordinates if duration > week in vertical grouped workspace Month", function(assert) {
     this.createInstance({
         dataSource: [{
@@ -4085,3 +4098,45 @@ QUnit.test("Tail of long appointment should have a right position, groupByDate =
     assert.roughEqual($appointmentTail.position().left, $cell.position().left, 1.001, "Tail has a right position");
 });
 
+QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source", function(assert) {
+    var dataSource = [{
+        startDate: new Date(2015, 4, 24, 9),
+        endDate: new Date(2015, 4, 24, 11),
+        allDay: true,
+        text: "Task 1"
+    }, {
+        startDate: new Date(2015, 4, 24, 15),
+        endDate: new Date(2015, 4, 24, 20),
+        allDay: true,
+        text: "Task 2"
+    }, {
+        startDate: new Date(2015, 4, 24, 45),
+        endDate: new Date(2015, 4, 24, 55),
+        allDay: true,
+        text: "Task 3"
+    }];
+    this.checkItemDataInDropDownTemplate(assert, dataSource, new Date(2015, 4, 24));
+});
+
+QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source for recurrence rule", function(assert) {
+    var dataSource = [{
+        startDate: new Date(2015, 4, 24, 9),
+        endDate: new Date(2015, 4, 24, 11),
+        recurrenceRule: "FREQ=DAILY;COUNT=3",
+        allDay: true,
+        text: "Task 1"
+    }, {
+        startDate: new Date(2015, 4, 24, 19),
+        endDate: new Date(2015, 4, 24, 31),
+        allDay: true,
+        recurrenceRule: "FREQ=DAILY;COUNT=2",
+        text: "Task 2"
+    }, {
+        startDate: new Date(2015, 4, 24, 24),
+        endDate: new Date(2015, 4, 24, 34),
+        allDay: true,
+        recurrenceRule: "FREQ=DAILY;COUNT=4",
+        text: "Task 3"
+    }];
+    this.checkItemDataInDropDownTemplate(assert, dataSource, new Date(2015, 4, 24));
+});


### PR DESCRIPTION
The appointmentData and itemData arguments are not set to the templates as instance, because before call template rendering used extending for an object. This behavior has happened after fix T678456.
This PR contains re-fix T678456. So was to add the targetedAppointmentData as a parameter for 
the appointmentTooltip template and dropDownAppointment template.
