### PR TITLE
dxDataGrid: Fix the "Cannot read property '0' of undefined" error occurs on an attempt to manipulate columns at runtime (T715902)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -1137,7 +1137,8 @@ module.exports = {
                     optionSetter,
                     columns,
                     changeType,
-                    fullOptionName;
+                    fullOptionName,
+                    initialColumn;
 
                 if(arguments.length === 3) {
                     return optionGetter(column, { functionsAsIs: true });
@@ -1171,12 +1172,12 @@ module.exports = {
                         // T346972
                         if(inArray(optionName, USER_STATE_FIELD_NAMES) < 0 && optionName !== "visibleWidth") {
                             columns = that.option("columns");
-                            column = that.getColumnByPath(fullOptionName, columns);
-                            if(typeUtils.isString(column)) {
-                                column = columns[columnIndex] = { dataField: column };
+                            initialColumn = that.getColumnByPath(fullOptionName, columns);
+                            if(typeUtils.isString(initialColumn)) {
+                                initialColumn = columns[columnIndex] = { dataField: initialColumn };
                             }
-                            if(column) {
-                                optionSetter(column, value, { functionsAsIs: true });
+                            if(initialColumn && checkUserStateColumn(initialColumn, column)) {
+                                optionSetter(initialColumn, value, { functionsAsIs: true });
                             }
                         }
                         updateColumnChanges(that, changeType, optionName, columnIndex);
@@ -1399,9 +1400,9 @@ module.exports = {
 
                     if(columnIndexes.length) {
                         if(columns) {
-                            column = columnIndexes.reduce(function(prevColumn, index) {
-                                return prevColumn ? prevColumn.columns[index] : columns[index];
-                            }, 0);
+                            column = columnIndexes.reduce(function(column, index) {
+                                return column && column.columns && column.columns[index];
+                            }, { columns: columns });
                         } else {
                             column = getColumnByIndexes(that, columnIndexes);
                         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -5087,6 +5087,28 @@ QUnit.test("Sorting should be reset to the initialized state after a column is u
     assert.strictEqual(this.columnsController.getColumns()[0].sortOrder, "desc", "sortOrder");
 });
 
+QUnit.test("Initial columns should not be changed on an attempt to manipulate columns at runtime", function(assert) {
+    // arrange
+    this.applyOptions({ columns: [
+        { dataField: "field1", caption: "field 1" },
+        { dataField: "field2", caption: "field 2" },
+        { dataField: "field3", caption: "field 3" }
+    ] });
+
+    // act
+    this.deleteColumn(2);
+    this.addColumn({ dataField: "field4" });
+    this.columnsController.columnOption(2, "caption", "Test");
+
+    // assert
+    assert.deepEqual(this.option("columns"), [
+        { dataField: "field1", caption: "field 1" },
+        { dataField: "field2", caption: "field 2" },
+        { dataField: "field3", caption: "field 3" }
+    ], "initial columns");
+});
+
+
 QUnit.module("Sorting/Grouping", { beforeEach: setupModule, afterEach: teardownModule });
 
 QUnit.test("disabled sorting", function(assert) {
@@ -8252,6 +8274,43 @@ QUnit.test("Delete band column via API", function(assert) {
     assert.strictEqual(visibleColumns.length, 1, "column count");
     assert.strictEqual(visibleColumns[0].dataField, "TestField1", "dataField of the column");
     assert.strictEqual(this.columnsController.getRowCount(), 1, "header row count");
+});
+
+// T715902
+QUnit.test("No exceptions on an attempt to manipulate columns at runtime", function(assert) {
+    // arrange
+    var visibleColumns;
+
+    this.applyOptions({
+        columns: [
+            { dataField: "TestField1", caption: "Column 1" },
+            { dataField: "TestField2", caption: "Column 2" },
+            { dataField: "TestField3", caption: "Column 3" }
+        ]
+    });
+
+    try {
+        // act
+        this.deleteColumn(2);
+        this.addColumn({ caption: "band", isBand: true });
+        this.addColumn({ dataField: "TestField4", ownerBand: 2 });
+        this.columnOption(3, "caption", "Column 4");
+
+        // assert
+        visibleColumns = this.columnsController.getVisibleColumns(0);
+        assert.strictEqual(visibleColumns.length, 3, "column count of the first row");
+        assert.strictEqual(visibleColumns[0].dataField, "TestField1", "dataField of the first column of the first row");
+        assert.strictEqual(visibleColumns[1].dataField, "TestField2", "dataField of the second column of the first row");
+        assert.strictEqual(visibleColumns[2].caption, "band", "caption of the third column of the first row");
+
+        visibleColumns = this.columnsController.getVisibleColumns(1);
+        assert.strictEqual(visibleColumns.length, 1, "column count of the second row");
+        assert.strictEqual(visibleColumns[0].dataField, "TestField4", "dataField of the first column of the second row");
+        assert.strictEqual(visibleColumns[0].caption, "Column 4", "caption of the first column of the second row");
+    } catch(e) {
+        // assert
+        assert.ok(false, "exception");
+    }
 });
 
 


### PR DESCRIPTION
See https://devexpress.com/issue=T715902