### PR TITLE
Fix dxNumberBox, parse: isCustomParser wrong check

### DIFF
--- a/js/ui/number_box/number_box.mask.js
+++ b/js/ui/number_box/number_box.mask.js
@@ -268,7 +268,7 @@ var NumberBoxMask = NumberBoxBase.inherit({
 
     _parse: function(text, format) {
         var formatOption = this.option("format"),
-            isCustomParser = typeUtils.isFunction(formatOption.formatter),
+            isCustomParser = typeUtils.isFunction(formatOption.parser),
             parser = isCustomParser ? formatOption.parser : number.parse;
 
         return parser(text, format);


### PR DESCRIPTION
The change is pretty obvious, no reason to explain it further.

Thanks