### PR TITLE
Change way to find knockout context for parent elements

### DIFF
--- a/js/integration/knockout/template.js
+++ b/js/integration/knockout/template.js
@@ -36,7 +36,7 @@ var KoTemplate = TemplateBase.inherit({
             var containerElement = container.get(0);
             var node = getClosestNodeWithContext(containerElement);
             var containerContext = ko.contextFor(node);
-            data = data === undefined ? ko.dataFor(node) : data || {};
+            data = data !== undefined ? data : ko.dataFor(node) || {};
 
             if(containerContext) {
                 return (data === containerContext.$data)

--- a/js/integration/knockout/template.js
+++ b/js/integration/knockout/template.js
@@ -36,7 +36,7 @@ var KoTemplate = TemplateBase.inherit({
             var containerElement = container.get(0);
             var node = getClosestNodeWithContext(containerElement);
             var containerContext = ko.contextFor(node);
-            data = data !== undefined ? data : ko.dataFor(node) || {};
+            data = data === undefined ? ko.dataFor(node) : data || {};
 
             if(containerContext) {
                 return (data === containerContext.$data)

--- a/js/integration/knockout/template.js
+++ b/js/integration/knockout/template.js
@@ -4,7 +4,7 @@ var $ = require("../../core/renderer"),
     typeUtils = require("../../core/utils/type"),
     TemplateBase = require("../../ui/widget/ui.template_base"),
     domUtils = require("../../core/utils/dom"),
-    getNodeWithContext = require("./utils").getNodeWithContext;
+    getClosestNodeWithContext = require("./utils").getClosestNodeWithContext;
 
 var getParentContext = function(data) {
     var parentNode = domAdapter.createElement("div");

--- a/js/integration/knockout/template.js
+++ b/js/integration/knockout/template.js
@@ -3,7 +3,8 @@ var $ = require("../../core/renderer"),
     ko = require("knockout"),
     typeUtils = require("../../core/utils/type"),
     TemplateBase = require("../../ui/widget/ui.template_base"),
-    domUtils = require("../../core/utils/dom");
+    domUtils = require("../../core/utils/dom"),
+    getNodeWithContext = require("./utils").getNodeWithContext;
 
 var getParentContext = function(data) {
     var parentNode = domAdapter.createElement("div");
@@ -33,9 +34,9 @@ var KoTemplate = TemplateBase.inherit({
     _prepareDataForContainer: function(data, container) {
         if(container && container.length) {
             var containerElement = container.get(0);
-            var containerContext = ko.contextFor(containerElement);
-
-            data = data !== undefined ? data : ko.dataFor(containerElement) || {};
+            var node = getNodeWithContext(containerElement);
+            var containerContext = ko.contextFor(node);
+            data = data !== undefined ? data : ko.dataFor(node) || {};
 
             if(containerContext) {
                 return (data === containerContext.$data)

--- a/js/integration/knockout/template.js
+++ b/js/integration/knockout/template.js
@@ -34,7 +34,7 @@ var KoTemplate = TemplateBase.inherit({
     _prepareDataForContainer: function(data, container) {
         if(container && container.length) {
             var containerElement = container.get(0);
-            var node = getNodeWithContext(containerElement);
+            var node = getClosestNodeWithContext(containerElement);
             var containerContext = ko.contextFor(node);
             data = data !== undefined ? data : ko.dataFor(node) || {};
 

--- a/js/integration/knockout/utils.js
+++ b/js/integration/knockout/utils.js
@@ -10,4 +10,4 @@ const getClosestNodeWithContext = (node) => {
     return node;
 };
 
-module.exports.getClosestNodeWithContext  = getClosestNodeWithContext;
+module.exports.getClosestNodeWithContext = getClosestNodeWithContext;

--- a/js/integration/knockout/utils.js
+++ b/js/integration/knockout/utils.js
@@ -4,7 +4,7 @@ const ko = require("knockout");
 const getClosestNodeWithContext = (node) => {
     var context = ko.contextFor(node);
     if(!context && node.parentNode) {
-        return getNodeWithContext(node.parentNode);
+        return getClosestNodeWithContext(node.parentNode);
     }
 
     return node;

--- a/js/integration/knockout/utils.js
+++ b/js/integration/knockout/utils.js
@@ -10,4 +10,4 @@ const getClosestNodeWithContext = (node) => {
     return node;
 };
 
-module.exports.getNodeWithContext = getNodeWithContext;
+module.exports.getClosestNodeWithContext  = getClosestNodeWithContext ;

--- a/js/integration/knockout/utils.js
+++ b/js/integration/knockout/utils.js
@@ -1,7 +1,7 @@
 
 const ko = require("knockout");
 
-const getNodeWithContext = (node) => {
+const getClosestNodeWithContext = (node) => {
     var context = ko.contextFor(node);
     if(!context && node.parentNode) {
         return getNodeWithContext(node.parentNode);

--- a/js/integration/knockout/utils.js
+++ b/js/integration/knockout/utils.js
@@ -1,0 +1,13 @@
+
+const ko = require("knockout");
+
+const getNodeWithContext = (node) => {
+    var context = ko.contextFor(node);
+    if(!context && node.parentNode) {
+        return getNodeWithContext(node.parentNode);
+    }
+
+    return node;
+};
+
+module.exports.getNodeWithContext = getNodeWithContext;

--- a/js/integration/knockout/utils.js
+++ b/js/integration/knockout/utils.js
@@ -10,4 +10,4 @@ const getClosestNodeWithContext = (node) => {
     return node;
 };
 
-module.exports.getClosestNodeWithContext  = getClosestNodeWithContext ;
+module.exports.getClosestNodeWithContext  = getClosestNodeWithContext;


### PR DESCRIPTION
Knockout API [was changed](https://github.com/knockout/knockout/issues/2445) in 3.5.0
Now it is necessary to get context from parent elements