### PR TITLE
Fix the position of the ContextMenu when the target option changing dynamically (T705189)

### DIFF
--- a/js/ui/context_menu/ui.context_menu.js
+++ b/js/ui/context_menu/ui.context_menu.js
@@ -907,7 +907,6 @@ var ContextMenu = MenuBase.inherit((function() {
                     break;
                 case "target":
                     args.previousValue && this._detachShowContextMenuEvents(args.previousValue);
-                    this.option("position").of = null;
                     this._invalidate();
                     break;
                 case "closeOnOutsideClick":

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
@@ -1298,6 +1298,28 @@ QUnit.module("Public api", moduleConfig, () => {
         assert.ok(instance.itemsContainer().hasClass("dx-overlay-content"));
         assert.ok(instance.itemsContainer().hasClass(DX_CONTEXT_MENU_CLASS));
     });
+
+    QUnit.test("Overlay's position should be correct when the target option is changed", (assert) => {
+        const instance = new ContextMenu(this.$element, {
+            items: [{ text: 1 }],
+        });
+
+        instance.option("target", "#menuTarget");
+
+        const $target = $("#menuTarget");
+        $target
+            .trigger($.Event("dxcontextmenu", {
+                pageX: 120,
+                pageY: 50
+            }));
+
+        const position = instance._overlay.option("position");
+        assert.equal(position.at, "top left", "at of overlay position");
+        assert.equal(position.my, "top left", "my of overlay position");
+        assert.equal(position.of.pageX, 120, "pageX of overlay position");
+        assert.equal(position.of.pageY, 50, "pageX of overlay position");
+        assert.equal(position.of.target, $target.get(0), "target of overlay position");
+    });
 });
 
 QUnit.module("Behavior", moduleConfig, () => {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
