### PR TITLE
Rename option and move it on the top level

### DIFF
--- a/js/docEnums.js
+++ b/js/docEnums.js
@@ -96,7 +96,7 @@
  */
 
 /**
- * @typedef {string} Enums.BarGaugeLabelOverlappingBehavior
+ * @typedef {string} Enums.BarGaugeResolveLabelOverlapping
  * @enum {'hide'|'none'}
  */
 

--- a/js/viz/core/themes/generic.light.js
+++ b/js/viz/core/themes/generic.light.js
@@ -1017,13 +1017,13 @@ registerTheme({
         backgroundColor: "#e0e0e0",
         relativeInnerRadius: 0.3,
         barSpacing: 4,
+        resolveLabelOverlapping: "hide",
         label: {
             indent: 20,
             connectorWidth: 2,
             font: {
                 size: 16
-            },
-            overlappingBehavior: "hide"
+            }
         },
         legend: {
             visible: false

--- a/js/viz/docs/docgauges.js
+++ b/js/viz/docs/docgauges.js
@@ -728,14 +728,14 @@ var dxBarGauge = {
             family: undefined,
             weight: 400,
             opacity: 1
-        },
-        /**
-        * @name dxBarGaugeOptions.label.overlappingBehavior
-        * @type Enums.BarGaugeLabelOverlappingBehavior
-        * @default 'hide'
-        */
-        overlappingBehavior: "hide"
+        }
     },
+    /**
+    * @name dxBarGaugeOptions.resolveLabelOverlapping
+    * @type Enums.BarGaugeResolveLabelOverlapping
+    * @default 'hide'
+    */
+    resolveLabelOverlapping: "hide",
     /**
     * @name dxBarGaugeOptions.startValue
     * @type number

--- a/js/viz/gauges/bar_gauge.js
+++ b/js/viz/gauges/bar_gauge.js
@@ -249,7 +249,7 @@ var dxBarGauge = dxBaseGauge.inherit({
     _checkOverlap: function() {
         const that = this,
             bars = that._bars,
-            overlapStrategy = _normalizeEnum(that._getOption("label").overlappingBehavior);
+            overlapStrategy = _normalizeEnum(that._getOption("resolveLabelOverlapping", true));
 
         if(overlapStrategy === "none") {
             return;

--- a/testing/tests/DevExpress.viz.gauges/barGauge.tests.js
+++ b/testing/tests/DevExpress.viz.gauges/barGauge.tests.js
@@ -263,10 +263,7 @@ QUnit.module('Positioning', $.extend({}, environment, {
 }));
 
 function checkPositioning(name, options, callback) {
-    if(options.label !== null) {
-        options.label = options.label || {};
-        $.extend(options.label, { overlappingBehavior: "none" });
-    }
+    options.resolveLabelOverlapping = "none";
     QUnit.test(name, function(assert) {
         this.$container.dxBarGauge($.extend({}, options, { animation: false }));
         callback.apply(this, arguments);
@@ -507,9 +504,7 @@ QUnit.test('Values are changed', function(assert) {
     var done = assert.async(),
         gauge = this.$container.dxBarGauge({
             values: [10, 20, 30],
-            label: {
-                overlappingBehavior: "none"
-            }
+            resolveLabelOverlapping: "none"
         }).dxBarGauge('instance');
     var group = this.getBarsGroup();
     group.animationComplete = $.proxy(function() {
@@ -542,9 +537,7 @@ QUnit.test('Some values are not changed', function(assert) {
     var done = assert.async(),
         gauge = this.$container.dxBarGauge({
             values: [10, 20, 30],
-            label: {
-                overlappingBehavior: "none"
-            }
+            resolveLabelOverlapping: "none"
         }).dxBarGauge('instance');
     var group = this.getBarsGroup();
     group.animationComplete = $.proxy(function() {
@@ -1071,9 +1064,7 @@ QUnit.module("Label overlapping behavior", function(hooks) {
     QUnit.test("None", function(assert) {
         this.$container.dxBarGauge({
             values: [19, 20],
-            label: {
-                overlappingBehavior: "none"
-            },
+            resolveLabelOverlapping: "none",
             animation: {
                 enabled: false
             }
@@ -1132,9 +1123,7 @@ QUnit.module("Label overlapping behavior", function(hooks) {
 
         this.$container.dxBarGauge({
             values: [19, 20, 39, 40],
-            label: {
-                overlappingBehavior: "hide"
-            },
+            resolveLabelOverlapping: "hide",
             animation: {
                 enabled: false
             }
@@ -1177,9 +1166,7 @@ QUnit.module("Label overlapping behavior", function(hooks) {
         var that = this;
         this.$container.dxBarGauge({
             values: [19, 20],
-            label: {
-                overlappingBehavior: "none"
-            },
+            resolveLabelOverlapping: "none",
             animation: true
         });
 
@@ -1242,9 +1229,7 @@ QUnit.module("Label overlapping behavior", function(hooks) {
 
         this.$container.dxBarGauge({
             values: [19, 20, 39, 40],
-            label: {
-                overlappingBehavior: "hide"
-            },
+            resolveLabelOverlapping: "hide",
             animation: true
         });
 


### PR DESCRIPTION
Old usage:
```javascript
const barGaugeOptions = {
  ...
  label: { overlappingBehavior: "hide" | "none" },
  ...
};
```
After changes:
```javascript
const barGaugeOptions = {
  ...
  resolveLabelOverlapping: "hide" | "none",
  ...
};
```