### PR TITLE
Replace inner options cache to the widget's level

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -279,8 +279,7 @@ var DropDownEditor = TextBox.inherit({
         this.callBase();
         this._initVisibilityActions();
         this._initPopupInitializedAction();
-        this._clearDropDownOptionsCache();
-        this._cacheDropDownOptions(this.option("dropDownOptions"));
+        this._initInnerOptionCache("dropDownOptions");
     },
 
     _initVisibilityActions: function() {
@@ -542,12 +541,8 @@ var DropDownEditor = TextBox.inherit({
         this._renderPopupContent();
     },
 
-    _cacheDropDownOptions: function(dropDownOptions) {
-        this._dropDownOptionsCache = extend(this._dropDownOptionsCache, dropDownOptions);
-    },
-
     _renderPopup: function() {
-        this._popup = this._createComponent(this._$popup, Popup, extend(this._popupConfig(), this._dropDownOptionsCache));
+        this._popup = this._createComponent(this._$popup, Popup, extend(this._popupConfig(), this._getInnerOptionsCache("dropDownOptions")));
 
         this._popup.on({
             "showing": this._popupShowingHandler.bind(this),
@@ -669,10 +664,6 @@ var DropDownEditor = TextBox.inherit({
         var isOutsideClick = !isInputClicked && !isDropDownButtonClicked;
 
         return isOutsideClick;
-    },
-
-    _clearDropDownOptionsCache: function() {
-        this._dropDownOptionsCache = {};
     },
 
     _clean: function() {
@@ -830,7 +821,7 @@ var DropDownEditor = TextBox.inherit({
                 break;
             case "dropDownOptions":
                 this._popupOptionChanged(args);
-                this._cacheDropDownOptions(args.value);
+                this._cacheInnerOptions("dropDownOptions", args.value);
                 break;
             case "popupPosition":
             case "deferRendering":

--- a/js/ui/editor/editor.js
+++ b/js/ui/editor/editor.js
@@ -30,13 +30,13 @@ var READONLY_STATE_CLASS = "dx-state-readonly",
 var Editor = Widget.inherit({
     ctor: function() {
         this.showValidationMessageTimeout = null;
-        this._tooltipOptionsCache = {};
         this.callBase.apply(this, arguments);
     },
 
     _init: function() {
         this.callBase();
         this.validationRequest = Callbacks();
+        this._initInnerOptionCache("validationTooltipOptions");
 
         var $element = this.$element();
 
@@ -154,7 +154,6 @@ var Editor = Widget.inherit({
         this._setSubmitElementName(this.option("name"));
 
         this.callBase();
-        this._cacheTooltipOptions(this.option("validationTooltipOptions"));
         this._renderValidationState();
     },
 
@@ -175,13 +174,6 @@ var Editor = Widget.inherit({
 
     _saveValueChangeEvent: function(e) {
         this._valueChangeEventInstance = e;
-    },
-
-    _bindInnerWidgetOptions: function(innerWidget, optionsContainer) {
-        this._options[optionsContainer] = extend({}, innerWidget.option());
-        innerWidget.on("optionChanged", function(e) {
-            this._options[optionsContainer] = extend({}, e.component.option());
-        }.bind(this));
     },
 
     _focusInHandler: function(e) {
@@ -206,10 +198,6 @@ var Editor = Widget.inherit({
 
     _canValueBeChangedByClick: function() {
         return false;
-    },
-
-    _cacheTooltipOptions: function(validationTooltipOptions) {
-        this._tooltipOptionsCache = extend(this._tooltipOptionsCache, validationTooltipOptions);
     },
 
     _renderValidationState: function() {
@@ -250,7 +238,7 @@ var Editor = Widget.inherit({
                 visible: true,
                 propagateOutsideClick: true,
                 _checkParentVisibility: false
-            }, this._tooltipOptionsCache));
+            }, this._getInnerOptionsCache("validationTooltipOptions")));
 
             this._$validationMessage
                 .toggleClass(INVALID_MESSAGE_AUTO, validationMessageMode === "auto")
@@ -359,7 +347,7 @@ var Editor = Widget.inherit({
                 break;
             case "validationTooltipOptions":
                 this._setValidationTooltipOptions(this._getOptionsFromContainer(args));
-                this._cacheTooltipOptions(args.value);
+                this._cacheInnerOptions("validationTooltipOptions", args.value);
                 break;
             case "readOnly":
                 this._toggleReadOnlyState();

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -241,6 +241,31 @@ var Widget = DOMComponent.inherit({
         this._extractAnonymousTemplate();
     },
 
+    _clearInnerOptionCache: function(optionContainer) {
+        this[optionContainer + "Cache"] = {};
+    },
+
+    _cacheInnerOptions: function(optionContainer, optionValue) {
+        var cacheName = optionContainer + "Cache";
+        this[cacheName] = extend(this[cacheName], optionValue);
+    },
+
+    _getInnerOptionsCache: function(optionContainer) {
+        return this[optionContainer + "Cache"];
+    },
+
+    _initInnerOptionCache: function(optionContainer) {
+        this._clearInnerOptionCache(optionContainer);
+        this._cacheInnerOptions(optionContainer, this.option(optionContainer));
+    },
+
+    _bindInnerWidgetOptions: function(innerWidget, optionsContainer) {
+        this._options[optionsContainer] = extend({}, innerWidget.option());
+        innerWidget.on("optionChanged", function(e) {
+            this._options[optionsContainer] = extend({}, e.component.option());
+        }.bind(this));
+    },
+
     _extractTemplates: function() {
         var templates = this.option("integrationOptions.templates"),
             templateElements = this.$element().contents().filter(TEMPLATE_SELECTOR);


### PR DESCRIPTION
This functionality is required for widgets on different levels of the hierarchy: dxSelectBox (popup), dxMenu (overlay), dxTextBox (validation overlay), dxDropDownButton (inner buttonGroup and popup). The widget.js is their closest common parent.