### PR TITLE
Fix HtmlEditor image formatting

### DIFF
--- a/js/ui/html_editor/formats/image.js
+++ b/js/ui/html_editor/formats/image.js
@@ -23,15 +23,19 @@ class ExtImage extends Image {
     }
 
     static formats(domNode) {
-        let formats = super.formats(domNode);
-        const src = domNode.getAttribute("src");
+        var formats = super.formats(domNode);
 
-        if(src) {
-            formats["src"] = src;
-        }
+        formats["imageSrc"] = domNode.getAttribute("src");
 
-        if(domNode.style["float"]) {
-            formats["float"] = domNode.style["float"];
+        return formats;
+    }
+
+    formats() {
+        const formats = super.formats();
+        const floatValue = this.domNode.style["float"];
+
+        if(floatValue) {
+            formats["float"] = floatValue;
         }
 
         return formats;

--- a/js/ui/html_editor/formats/image.js
+++ b/js/ui/html_editor/formats/image.js
@@ -23,7 +23,7 @@ class ExtImage extends Image {
     }
 
     static formats(domNode) {
-        var formats = super.formats(domNode);
+        let formats = super.formats(domNode);
 
         formats["imageSrc"] = domNode.getAttribute("src");
 

--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -271,7 +271,7 @@ class ToolbarModule extends BaseModule {
             { dataField: "src", label: { text: format(DIALOG_IMAGE_FIELD_URL) } },
             { dataField: "width", label: { text: format(DIALOG_IMAGE_FIELD_WIDTH) } },
             { dataField: "height", label: { text: format(DIALOG_IMAGE_FIELD_HEIGHT) } },
-            { dataField: "alt", label: { text: format(DIALOG_IMAGE_FIELD_ALT) } },
+            { dataField: "alt", label: { text: format(DIALOG_IMAGE_FIELD_ALT) } }
         ];
     }
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarIntegration.tests.js
@@ -3,6 +3,8 @@ import $ from "jquery";
 import "ui/html_editor";
 import fx from "animation/fx";
 
+import keyboardMock from "../../../helpers/keyboardMock.js";
+
 const TOOLBAR_CLASS = "dx-htmleditor-toolbar";
 const TOOLBAR_WRAPPER_CLASS = "dx-htmleditor-toolbar-wrapper";
 const TOOLBAR_FORMAT_WIDGET_CLASS = "dx-htmleditor-toolbar-format";
@@ -17,6 +19,12 @@ const DIALOG_CLASS = "dx-formdialog";
 const DIALOG_FORM_CLASS = "dx-formdialog-form";
 const BUTTON_CLASS = "dx-button";
 const LIST_ITEM_CLASS = "dx-list-item";
+const FIELD_ITEM_CLASS = "dx-field-item";
+const TEXTEDITOR_INPUT_CLASS = "dx-texteditor-input";
+
+const WHITE_PIXEL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQYGWP4////fwAJ+wP93BEhJAAAAABJRU5ErkJggg==";
+const BLACK_PIXEL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQYGWNgYmL6DwABFgEGpP/tHAAAAABJRU5ErkJggg==";
+const ORANGE_PIXEL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQYGWP4z8j4HwAFBQIB6OfkUgAAAABJRU5ErkJggg==";
 
 const { test } = QUnit;
 
@@ -278,7 +286,7 @@ QUnit.module("Toolbar integration", {
     test("SelectBox should keep selected value after format applying", (assert) => {
         $("#htmlEditor").dxHtmlEditor({
             toolbar: { items: [{ formatName: "size", formatValues: ["10px", "11px"] }] }
-        }).dxHtmlEditor("instance");
+        });
 
         const $formatWidget = $("#htmlEditor").find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`);
 
@@ -293,5 +301,72 @@ QUnit.module("Toolbar integration", {
         const value = $formatWidget.find(`.${INPUT_CLASS}`).val();
 
         assert.strictEqual(value, "11px", "SelectBox contain selected value");
+    });
+
+    function prepareImageUpdateTest(caretPosition, selectionLength) {
+        return (assert) => {
+            const done = assert.async();
+            const $container = $("#htmlEditor");
+            const instance = $container.dxHtmlEditor({
+                toolbar: { items: ["image"] },
+                value: `<img src=${WHITE_PIXEL}>`,
+                onValueChanged: ({ value }) => {
+                    assert.ok(value.indexOf(WHITE_PIXEL) === -1, "There is no white pixel");
+                    assert.ok(value.indexOf(BLACK_PIXEL) !== -1, "There is a black pixel");
+                    done();
+                }
+            }).dxHtmlEditor("instance");
+
+            instance.setSelection(caretPosition, selectionLength);
+            $container
+                .find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`)
+                .trigger("dxclick");
+
+            const $srcInput = $(`.${FIELD_ITEM_CLASS} .${TEXTEDITOR_INPUT_CLASS}`).first().val("");
+
+            keyboardMock($srcInput.eq(0))
+                .type(BLACK_PIXEL)
+                .change()
+                .press("enter");
+        };
+    }
+
+    test("image should be correctly updated after change a source and caret placed after", prepareImageUpdateTest(1, 0));
+
+    test("image should be correctly updated after change a source and caret placed before an image", prepareImageUpdateTest(0, 0));
+
+    test("selected image should be correctly updated after change a source and caret placed after", prepareImageUpdateTest(1, 1));
+
+    test("selected image should be correctly updated after change a source and caret placed before an image", prepareImageUpdateTest(0, 1));
+
+    test("image should be correctly updated after change a source and caret placed between two images", (assert) => {
+        const done = assert.async();
+        const $container = $("#htmlEditor");
+        const instance = $container.dxHtmlEditor({
+            toolbar: { items: ["image"] },
+            value: `<img src=${WHITE_PIXEL}><img src=${BLACK_PIXEL}>`,
+            onValueChanged: ({ value }) => {
+                const blackIndex = value.indexOf(BLACK_PIXEL);
+                const orangeIndex = value.indexOf(ORANGE_PIXEL);
+
+                assert.ok(value.indexOf(WHITE_PIXEL) === -1, "There is no white pixel");
+                assert.ok(blackIndex !== -1, "There is a black pixel");
+                assert.ok(orangeIndex !== -1, "There is an orange pixel");
+                assert.ok(orangeIndex < blackIndex, "orange pixel placed before black pixel");
+                done();
+            }
+        }).dxHtmlEditor("instance");
+
+        instance.setSelection(1, 0);
+        $container
+            .find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`)
+            .trigger("dxclick");
+
+        const $srcInput = $(`.${FIELD_ITEM_CLASS} .${TEXTEDITOR_INPUT_CLASS}`).first().val("");
+
+        keyboardMock($srcInput.eq(0))
+            .type(ORANGE_PIXEL)
+            .change()
+            .press("enter");
     });
 });


### PR DESCRIPTION
This PR fix 2 issues related to the work with images via Toolbar:
* "image" button won't highlighting
* the source of an existing image isn't updating correctly