### PR TITLE
Update DropDownEditor buttons container styles for the generic theme

### DIFF
--- a/styles/widgets/generic/dropDownEditor.generic.less
+++ b/styles/widgets/generic/dropDownEditor.generic.less
@@ -159,7 +159,7 @@
 
     &:not(.dx-state-readonly) {
         .dx-texteditor-buttons-container {
-            display: block;
+            display: flex;
         }
     }
 }

--- a/styles/widgets/generic/dropDownEditor.generic.less
+++ b/styles/widgets/generic/dropDownEditor.generic.less
@@ -124,7 +124,7 @@
         &.dx-rtl.dx-editor-underlined {
             .dx-texteditor-input {
                 padding-right: 0;
-            } 
+            }
         }
 
         &.dx-show-clear-button {
@@ -154,12 +154,6 @@
             .dx-editor-filled& {
                 background-color: @dropdowneditor-filled-button-hover-bg;
             }
-        }
-    }
-
-    &:not(.dx-state-readonly) {
-        .dx-texteditor-buttons-container {
-            display: flex;
         }
     }
 }


### PR DESCRIPTION
It looks we don't need to set this style here because we have only [one place](https://github.com/DevExpress/DevExtreme/blob/19_1/styles/widgets/generic/textEditor.generic.less#L88) where 'display' style is not a 'flex' as in [common](https://github.com/DevExpress/DevExtreme/blob/19_1/styles/widgets/common/textEditor.less#L44) styles.
