### PR TITLE
Remove usage of a deprecated API from the pointer mock

### DIFF
--- a/testing/helpers/nativePointerMock.js
+++ b/testing/helpers/nativePointerMock.js
@@ -469,7 +469,8 @@
                         $.each(result, function(i) {
                             result[i] = createTouchByOptions(this);
                         });
-                        return document.createTouchList.apply(document, result);
+
+                        return result;
                     };
 
                     touches = createTouchListByArray(touches);


### PR DESCRIPTION
This PR fix event tests for Chrome with the forced device mode.
https://www.chromestatus.com/feature/5185332291043328