### PR TITLE
Revert "Default template shouldn't be created from comments (T711311)…

### DIFF
--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -36,7 +36,6 @@ var UI_FEEDBACK = "UIFeedback",
     FOCUS_NAMESPACE = "Focus",
     ANONYMOUS_TEMPLATE_NAME = "template",
     TEXT_NODE = 3,
-    COMMENT_NODE = 8,
     TEMPLATE_SELECTOR = "[data-options*='dxTemplate']",
     TEMPLATE_WRAPPER_CLASS = "dx-template-wrapper";
 
@@ -315,16 +314,15 @@ var Widget = DOMComponent.inherit({
     },
 
     _extractAnonymousTemplate: function() {
-        const templates = this.option("integrationOptions.templates"),
+        var templates = this.option("integrationOptions.templates"),
             anonymousTemplateName = this._getAnonymousTemplateName(),
             $anonymousTemplate = this.$element().contents().detach();
 
-        const $notJunkTemplateContent = $anonymousTemplate.filter(function(_, element) {
-                const isCommentNode = element.nodeType === COMMENT_NODE,
-                    isTextNode = element.nodeType === TEXT_NODE,
+        var $notJunkTemplateContent = $anonymousTemplate.filter(function(_, element) {
+                var isTextNode = element.nodeType === TEXT_NODE,
                     isEmptyText = $(element).text().trim().length < 1;
 
-                return !(isTextNode && isEmptyText) && !isCommentNode;
+                return !(isTextNode && isEmptyText);
             }),
             onlyJunkTemplateContent = $notJunkTemplateContent.length < 1;
 

--- a/testing/tests/DevExpress.ui/collectionWidget.tests.js
+++ b/testing/tests/DevExpress.ui/collectionWidget.tests.js
@@ -257,16 +257,6 @@ QUnit.module("render", {
         assert.equal($element.find(".test").length, 2);
     });
 
-    QUnit.test("anonymous item template with comment", function(assert) {
-        const $element = $("<div>").append($("<!--></-->"));
-
-        new TestComponent($element, {
-            items: [1, 2]
-        });
-
-        assert.equal($element.text(), "12");
-    });
-
     QUnit.test("'itemTemplate' as DOM node", assert => {
         const $element = $("#cmp");
 


### PR DESCRIPTION
Dashboard team use following code:
```
<div  data-bind=" dxPopover: { }">
       <!-- ko lazy: { template: 'dx-dashboard-context-menu-panel-content' } -->
       <!-- /ko -->
 </div>
```
So we need to find another way to fix Vue templates