### PR TITLE
Allow Toolbar to provide it's own templates for the items

### DIFF
--- a/js/ui/toolbar/ui.toolbar.base.js
+++ b/js/ui/toolbar/ui.toolbar.base.js
@@ -81,7 +81,8 @@ var ToolbarBase = AsyncCollectionWidget.inherit({
 
             this._getTemplate("dx-polymorph-widget").render({
                 container: $container,
-                model: rawModel
+                model: rawModel,
+                parent: this
             });
         }.bind(this), ["text", "html", "widget", "options"], this.option("integrationOptions.watchMethod"));
 

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -51,7 +51,11 @@ var DX_POLYMORPH_WIDGET_TEMPLATE = new FunctionTemplate(function(options) {
             errors.log("W0001", "dxToolbar - 'widget' item field", deprecatedName, "16.1", "Use: '" + widgetName + "' instead");
         }
 
-        widgetElement[widgetName](widgetOptions);
+        if(options.parent) {
+            options.parent._createComponent(widgetElement, widgetName, widgetOptions);
+        } else {
+            widgetElement[widgetName](widgetOptions);
+        }
 
         return widgetElement;
     }

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -199,6 +199,35 @@ QUnit.test("Buttons has default style in generic theme", function(assert) {
     assert.notOk(button.hasClass("dx-button-mode-text"));
 });
 
+QUnit.test("Toolbar provides it's own templates for the item widgets", function(assert) {
+    var templateUsed;
+
+    this.element.dxToolbar({
+        items: [{
+            location: 'before',
+            widget: 'dxButton',
+            options: { template: 'custom' }
+        }],
+        integrationOptions: {
+            templates: {
+                custom: {
+                    render: (options) => {
+                        templateUsed = true;
+                        $("<div>")
+                            .attr("data-options", "dxTemplate: { name: 'custom' }")
+                            .addClass("custom-template")
+                            .text("Custom text")
+                            .appendTo(options.container);
+                    }
+                }
+            }
+        }
+    });
+
+    assert.ok(templateUsed);
+    assert.equal(this.element.find(".custom-template").length, 1);
+});
+
 
 QUnit.module("toolbar with menu", {
     beforeEach: function() {


### PR DESCRIPTION
Fixes [T722059](https://www.devexpress.com/Support/Center/Question/Details/T722059/the-widget-that-resides-in-the-datagrid-toolbar-does-not-use-a-template-declared-at-the)