### PR TITLE
DataGrid: Fix item count updating in pager after calling refresh(true)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.pager.js
+++ b/js/ui/grid_core/ui.grid_core.pager.js
@@ -20,6 +20,7 @@ var PagerView = modules.View.inherit({
                 if(pager) {
                     pager.option({
                         pageCount: dataController.pageCount(),
+                        totalCount: dataController.totalCount(),
                         hasKnownLastPage: dataController.hasKnownLastPage()
                     });
                 } else {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
@@ -269,6 +269,7 @@ QUnit.test("pageCount is updated on partial update with repaintChangesOnly", fun
     assert.equal(pagerView._getPager().option.callCount, 1, "pager option call count after partial update");
     assert.deepEqual(pagerView._getPager().option.getCall(0).args, [{
         hasKnownLastPage: true, // T697587
+        totalCount: 143, // #7259
         pageCount: 20
     }], "pager option args");
 });


### PR DESCRIPTION
Fix #7259