### PR TITLE
File manager  - Move file providers to widget folder and use actions instead of functions for event handlers

### DIFF
--- a/js/bundles/modules/file_providers.js
+++ b/js/bundles/modules/file_providers.js
@@ -1,6 +1,8 @@
 import DevExpress from "./core";
+import WebAPIFileProvider from "../../ui/file_manager/file_provider/file_provider.webapi";
+import OneDriveFileProvider from "../../ui/file_manager/file_provider/file_provider.onedrive";
 
 module.exports = DevExpress.FileProviders = DevExpress.FileProviders || {};
 
-DevExpress.FileProviders.WebAPI = require("../../file_provider/file_provider.webapi");
-DevExpress.FileProviders.OneDrive = require("../../file_provider/file_provider.onedrive");
+DevExpress.FileProviders.WebAPI = WebAPIFileProvider;
+DevExpress.FileProviders.OneDrive = OneDriveFileProvider;

--- a/js/bundles/modules/parts/file_providers.js
+++ b/js/bundles/modules/parts/file_providers.js
@@ -1,9 +1,10 @@
-var DevExpress = require("./core");
+import DevExpress from "./core";
 
 /// BUNDLER_PARTS
 /* FileProviders (dx.module-core.js) */
 
-var fileProviders = DevExpress.FileProviders = require("../../../bundles/modules/file_providers");
+import fileProviders from "../../../bundles/modules/file_providers";
+DevExpress.FileProviders = fileProviders;
 
 /// BUNDLER_PARTS_END
 

--- a/js/ui/file_manager/file_provider/file_provider.ajax.js
+++ b/js/ui/file_manager/file_provider/file_provider.ajax.js
@@ -1,5 +1,5 @@
-import ajax from "../core/utils/ajax";
-import { Deferred } from "../core/utils/deferred";
+import ajax from "../../../core/utils/ajax";
+import { Deferred } from "../../../core/utils/deferred";
 import { FileProvider } from "./file_provider";
 import ArrayFileProvider from "./file_provider.array";
 

--- a/js/ui/file_manager/file_provider/file_provider.array.js
+++ b/js/ui/file_manager/file_provider/file_provider.array.js
@@ -1,4 +1,4 @@
-import { each } from "../core/utils/iterator";
+import { each } from "../../../core/utils/iterator";
 
 import { FileProvider, FileManagerItem } from "./file_provider";
 

--- a/js/ui/file_manager/file_provider/file_provider.array.js
+++ b/js/ui/file_manager/file_provider/file_provider.array.js
@@ -1,3 +1,4 @@
+import { ensureDefined } from "../../../core/utils/common";
 import { each } from "../../../core/utils/iterator";
 
 import { FileProvider, FileManagerItem } from "./file_provider";
@@ -19,7 +20,7 @@ class ArrayFileProvider extends FileProvider {
 
     createFolder(parentFolder, name) {
         const newItem = {
-            name: name,
+            name,
             isFolder: true
         };
         const array = this._getChildrenArray(parentFolder.dataItem);
@@ -46,14 +47,14 @@ class ArrayFileProvider extends FileProvider {
         });
     }
 
-    _createCopy(dataItem) {
+    _createCopy({ name, children, isFolder }) {
         const result = {
-            name: dataItem.name,
-            isFolder: dataItem.isFolder
+            name,
+            isFolder
         };
-        if(dataItem.children) {
+        if(children) {
             result.children = [];
-            each(dataItem.children, (_, childItem) => {
+            each(children, (_, childItem) => {
                 const childCopy = this._createCopy(childItem);
                 result.children.push(childCopy);
             });
@@ -61,13 +62,13 @@ class ArrayFileProvider extends FileProvider {
         return result;
     }
 
-    _deleteItem(item) {
+    _deleteItem({ parentPath, dataItem }) {
         let array = this._data;
-        if(item.parentPath !== "") {
-            const entry = this._findItem(item.parentPath);
-            array = entry.children;
+        if(parentPath !== "") {
+            const { children } = this._findItem(parentPath);
+            array = children;
         }
-        const index = array.indexOf(item.dataItem);
+        const index = array.indexOf(dataItem);
         array.splice(index, 1);
     }
 
@@ -76,10 +77,7 @@ class ArrayFileProvider extends FileProvider {
         if(!dataItem) {
             array = this._data;
         } else {
-            if(!dataItem.children) {
-                dataItem.children = [];
-            }
-            array = dataItem.children;
+            array = dataItem.children = ensureDefined(dataItem.children, []);
         }
         return array;
     }

--- a/js/ui/file_manager/file_provider/file_provider.js
+++ b/js/ui/file_manager/file_provider/file_provider.js
@@ -1,4 +1,4 @@
-import { pathCombine, getFileExtension } from "../ui/file_manager/ui.file_manager.utils";
+import { pathCombine, getFileExtension } from "../ui.file_manager.utils";
 
 const DEFAULT_FILE_UPLOAD_CHUNK_SIZE = 200000;
 

--- a/js/ui/file_manager/file_provider/file_provider.onedrive.js
+++ b/js/ui/file_manager/file_provider/file_provider.onedrive.js
@@ -1,7 +1,7 @@
-import ajax from "../core/utils/ajax";
-import { Deferred } from "../core/utils/deferred";
-import { noop } from "../core/utils/common";
-import { each } from "../core/utils/iterator";
+import ajax from "../../../core/utils/ajax";
+import { Deferred } from "../../../core/utils/deferred";
+import { noop } from "../../../core/utils/common";
+import { each } from "../../../core/utils/iterator";
 
 import { FileProvider, FileManagerItem } from "./file_provider";
 

--- a/js/ui/file_manager/file_provider/file_provider.webapi.js
+++ b/js/ui/file_manager/file_provider/file_provider.webapi.js
@@ -1,8 +1,8 @@
-import ajax from "../core/utils/ajax";
-import { noop } from "../core/utils/common";
-import Guid from "../core/guid";
-import windowUtils from "../core/utils/window";
-import { each } from "../core/utils/iterator";
+import ajax from "../../../core/utils/ajax";
+import { noop } from "../../../core/utils/common";
+import Guid from "../../../core/guid";
+import windowUtils from "../../../core/utils/window";
+import { each } from "../../../core/utils/iterator";
 
 import { FileProvider, FileManagerItem } from "./file_provider";
 

--- a/js/ui/file_manager/file_provider/file_provider.webapi.js
+++ b/js/ui/file_manager/file_provider/file_provider.webapi.js
@@ -1,12 +1,12 @@
 import ajax from "../../../core/utils/ajax";
 import { noop } from "../../../core/utils/common";
 import Guid from "../../../core/guid";
-import windowUtils from "../../../core/utils/window";
+import { getWindow } from "../../../core/utils/window";
 import { each } from "../../../core/utils/iterator";
 
 import { FileProvider, FileManagerItem } from "./file_provider";
 
-const window = windowUtils.getWindow();
+const window = getWindow();
 const FILE_CHUNK_BLOB_NAME = "chunk";
 const FILE_CHUNK_META_DATA_NAME = "chunkMetadata";
 
@@ -74,7 +74,7 @@ class WebAPIFileProvider extends FileProvider {
         }));
 
         return ajax.sendRequest({
-            url: url,
+            url,
             method: "POST",
             dataType: "text",
             data: formData,

--- a/js/ui/file_manager/ui.file_manager.breadcrumbs.js
+++ b/js/ui/file_manager/ui.file_manager.breadcrumbs.js
@@ -10,6 +10,8 @@ const FILE_MANAGER_BREADCRUMBS_CLASS = "dx-filemanager-breadcrumbs";
 class FileManagerBreadcrumbs extends Widget {
 
     _initMarkup() {
+        this._createOnPathChangedAction();
+
         this._menu = this._createComponent(this.$element(), Menu, {
             dataSource: this._getMenuItems(),
             onItemClick: this._onItemClick.bind(this)
@@ -56,25 +58,20 @@ class FileManagerBreadcrumbs extends Widget {
     }
 
     _onItemClick(e) {
+        const path = this.option("path");
+
         let newPath = "";
         if(e.itemData.isParentItem) {
-            newPath = this._getParentPath();
+            newPath = getParentPath(path);
         } else if(e.itemData.isPartItem) {
             newPath = this._getPathByMenuItemIndex(e.itemIndex);
         } else {
             return;
         }
 
-        const path = this.option("path");
         if(newPath !== path) {
-            const handler = this.option("onPathChanged");
-            handler(newPath);
+            this._onPathChangedAction({ newPath });
         }
-    }
-
-    _getParentPath() {
-        const path = this.option("path");
-        return getParentPath(path);
     }
 
     _getPathByMenuItemIndex(index) {
@@ -94,6 +91,10 @@ class FileManagerBreadcrumbs extends Widget {
         return result;
     }
 
+    _createOnPathChangedAction() {
+        this._onPathChangedAction = this._createActionByOption("onPathChanged");
+    }
+
     _getDefaultOptions() {
         return extend(super._getDefaultOptions(), {
             path: "",
@@ -107,6 +108,9 @@ class FileManagerBreadcrumbs extends Widget {
         switch(name) {
             case "path":
                 this.repaint();
+                break;
+            case "onPathChanged":
+                this._createOnPathChangedAction();
                 break;
             default:
                 super._optionChanged(args);

--- a/js/ui/file_manager/ui.file_manager.dialog.folder_chooser.js
+++ b/js/ui/file_manager/ui.file_manager.dialog.folder_chooser.js
@@ -16,7 +16,7 @@ class FileManagerFolderChooserDialog extends FileManagerDialogBase {
     }
 
     _getDialogOptions() {
-        return extend(super._getDefaultOptions(), {
+        return extend(super._getDialogOptions(), {
             width: 400,
             height: "80%",
             title: "Select Destination Folder",

--- a/js/ui/file_manager/ui.file_manager.dialog.js
+++ b/js/ui/file_manager/ui.file_manager.dialog.js
@@ -9,6 +9,8 @@ const FILE_MANAGER_DIALOG_CONTENT = "dx-filemanager-dialog";
 class FileManagerDialogBase extends Widget {
 
     _initMarkup() {
+        this._createOnClosedAction();
+
         const options = this._getDialogOptions();
 
         this._popup = this._createComponent(this.$element(), Popup, {
@@ -76,16 +78,29 @@ class FileManagerDialogBase extends Widget {
     }
 
     _onPopupHidden() {
-        const closedHandler = this.option("onClosed");
-        if(closedHandler) {
-            closedHandler(this._dialogResult);
-        }
+        this._onClosedAction({ dialogResult: this._dialogResult });
+    }
+
+    _createOnClosedAction() {
+        this._onClosedAction = this._createActionByOption("onClosed");
     }
 
     _getDefaultOptions() {
         return extend(super._getDefaultOptions(), {
             onClosed: null
         });
+    }
+
+    _optionChanged(args) {
+        const name = args.name;
+
+        switch(name) {
+            case "onClosed":
+                this._createOnPathChangedAction();
+                break;
+            default:
+                super._optionChanged(args);
+        }
     }
 
 }

--- a/js/ui/file_manager/ui.file_manager.dialog.name_editor.js
+++ b/js/ui/file_manager/ui.file_manager.dialog.name_editor.js
@@ -21,7 +21,7 @@ class FileManagerNameEditorDialog extends FileManagerDialogBase {
     }
 
     _getDialogOptions() {
-        return extend(super._getDefaultOptions(), {
+        return extend(super._getDialogOptions(), {
             width: 340,
             height: 180,
             title: this.option("title"),

--- a/js/ui/file_manager/ui.file_manager.file_uploader.js
+++ b/js/ui/file_manager/ui.file_manager.file_uploader.js
@@ -21,6 +21,8 @@ const FILE_MANAGER_PROGRESS_BOX_CANCEL_BUTTON = FILE_MANAGER_PROGRESS_BOX + "-ca
 class FileManagerFileUploader extends Widget {
 
     _initMarkup() {
+        this._initActions();
+
         this._progressPanel = this._createComponent($("<div>"), FileManagerUploadProgressPanel, {});
 
         this.$element()
@@ -77,7 +79,7 @@ class FileManagerFileUploader extends Widget {
         const progressBoxTitle = `Uploading ${files.length} files`;
         const progressBox = this._progressPanel.addProgressBox(progressBoxTitle, null);
 
-        const controllerGetter = this.option("onGetController");
+        const controllerGetter = this.option("getController");
         const session = new FileManagerUploadSession({
             controller: controllerGetter(),
             onProgress: value => progressBox.updateProgress(value * 100),
@@ -103,31 +105,42 @@ class FileManagerFileUploader extends Widget {
     }
 
     _onFilesUploaded() {
-        this._raiseOnFilesUploaded();
+        this._actions.onFilesUploaded();
     }
 
     _raiseOnErrorOccurred(args) {
-        this._raiseEvent("ErrorOccurred", args);
+        this._actions.onErrorOccurred({ info: args });
     }
 
-    _raiseOnFilesUploaded() {
-        this._raiseEvent("FilesUploaded");
-    }
-
-    _raiseEvent(eventName, argument) {
-        const optionName = "on" + eventName;
-        const handler = this.option(optionName);
-        if(handler) {
-            handler.call(this, argument);
-        }
+    _initActions() {
+        this._actions = {
+            onFilesUploaded: this._createActionByOption("onFilesUploaded"),
+            onErrorOccurred: this._createActionByOption("onErrorOccurred")
+        };
     }
 
     _getDefaultOptions() {
         return extend(super._getDefaultOptions(), {
-            onGetController: null,
+            getController: null,
             onFilesUploaded: null,
             onErrorOccurred: null
         });
+    }
+
+    _optionChanged(args) {
+        const name = args.name;
+
+        switch(name) {
+            case "getController":
+                this.repaint();
+                break;
+            case "onFilesUploaded":
+            case "onErrorOccurred":
+                this._actions[name] = this._createActionByOption(name);
+                break;
+            default:
+                super._optionChanged(args);
+        }
     }
 
 }
@@ -321,6 +334,8 @@ class FileManagerUploadProgressPanel extends Widget {
 class FileManagerUploadProgressBox extends Widget {
 
     _initMarkup() {
+        this._createOnCancelAction();
+
         const titleText = this.option("title");
         const $title = $("<span>").text(titleText).addClass(FILE_MANAGER_PROGRESS_BOX_TITLE);
 
@@ -358,14 +373,11 @@ class FileManagerUploadProgressBox extends Widget {
             text: "Canceling..."
         });
 
-        this._raiseCancel();
+        this._onCancelAction();
     }
 
-    _raiseCancel() {
-        const handler = this.option("onCancel");
-        if(handler) {
-            handler();
-        }
+    _createOnCancelAction() {
+        this._onCancelAction = this._createActionByOption("onCancel");
     }
 
     _getDefaultOptions() {
@@ -373,6 +385,21 @@ class FileManagerUploadProgressBox extends Widget {
             title: "",
             onCancel: null
         });
+    }
+
+    _optionChanged(args) {
+        const name = args.name;
+
+        switch(name) {
+            case "title":
+                this.repaint();
+                break;
+            case "onCancel":
+                this._createOnCancelAction();
+                break;
+            default:
+                super._optionChanged(args);
+        }
     }
 
 }

--- a/js/ui/file_manager/ui.file_manager.file_uploader.js
+++ b/js/ui/file_manager/ui.file_manager.file_uploader.js
@@ -299,8 +299,8 @@ class FileManagerUploadProgressPanel extends Widget {
 
     addProgressBox(title, onCancel) {
         const progressBox = this._createComponent($("<div>"), FileManagerUploadProgressBox, {
-            title: title,
-            onCancel: onCancel
+            title,
+            onCancel
         });
         this._$container.append(progressBox.$element());
 

--- a/js/ui/file_manager/ui.file_manager.files_tree_view.js
+++ b/js/ui/file_manager/ui.file_manager.files_tree_view.js
@@ -6,7 +6,7 @@ import Widget from "../widget/ui.widget";
 import { extend } from "../../core/utils/extend";
 import TreeViewSearch from "../tree_view/ui.tree_view.search";
 
-import { FileManagerItem } from "../../file_provider/file_provider";
+import { FileManagerItem } from "./file_provider/file_provider";
 import { getPathParts, pathCombine } from "./ui.file_manager.utils";
 
 class FileManagerFilesTreeView extends Widget {

--- a/js/ui/file_manager/ui.file_manager.files_tree_view.js
+++ b/js/ui/file_manager/ui.file_manager.files_tree_view.js
@@ -12,6 +12,7 @@ import { getPathParts, pathCombine } from "./ui.file_manager.utils";
 class FileManagerFilesTreeView extends Widget {
 
     _initMarkup() {
+        this._initActions();
         this._initCurrentPathState();
 
         this._filesTreeView = this._createComponent(this.$element(), TreeViewSearch, {
@@ -57,18 +58,11 @@ class FileManagerFilesTreeView extends Widget {
     }
 
     _raiseCurrentFolderChanged() {
-        this._raiseEvent("CurrentFolderChanged");
+        this._actions.onCurrentFolderChanged();
     }
 
     _raiseClick() {
-        this._raiseEvent("Click");
-    }
-
-    _raiseEvent(eventName) {
-        const handler = this.option("on" + eventName);
-        if(handler) {
-            handler();
-        }
+        this._actions.onClick();
     }
 
     _initCurrentPathState() {
@@ -128,12 +122,35 @@ class FileManagerFilesTreeView extends Widget {
         }
     }
 
+    _initActions() {
+        this._actions = {
+            onCurrentFolderChanged: this._createActionByOption("onCurrentFolderChanged"),
+            onClick: this._createActionByOption("onClick")
+        };
+    }
+
     _getDefaultOptions() {
         return extend(super._getDefaultOptions(), {
             getItems: null,
             onCurrentFolderChanged: null,
             onClick: null
         });
+    }
+
+    _optionChanged(args) {
+        const name = args.name;
+
+        switch(name) {
+            case "getItems":
+                this.repaint();
+                break;
+            case "onCurrentFolderChanged":
+            case "onClick":
+                this._actions[name] = this._createActionByOption(name);
+                break;
+            default:
+                super._optionChanged(args);
+        }
     }
 
     refreshData() {

--- a/js/ui/file_manager/ui.file_manager.item_list.thumbnails.js
+++ b/js/ui/file_manager/ui.file_manager.item_list.thumbnails.js
@@ -347,7 +347,7 @@ class FileManagerThumbnailsItemList extends FileManagerItemListBase {
 
     _getDefaultOptions() {
         return extend(super._getDefaultOptions(), {
-            focusStateEnabled: true,
+            focusStateEnabled: true
         });
     }
 

--- a/js/ui/file_manager/ui.file_manager.js
+++ b/js/ui/file_manager/ui.file_manager.js
@@ -17,11 +17,11 @@ import FileManagerBreadcrumbs from "./ui.file_manager.breadcrumbs";
 import { FileManagerFileCommands } from "./ui.file_manager.commands";
 import { getName, getParentPath } from "./ui.file_manager.utils";
 
-import { FileProvider, FileManagerItem } from "../../file_provider/file_provider";
-import ArrayFileProvider from "../../file_provider/file_provider.array";
-import AjaxFileProvider from "../../file_provider/file_provider.ajax";
-import OneDriveFileProvider from "../../file_provider/file_provider.onedrive";
-import WebAPIFileProvider from "../../file_provider/file_provider.webapi";
+import { FileProvider, FileManagerItem } from "./file_provider/file_provider";
+import ArrayFileProvider from "./file_provider/file_provider.array";
+import AjaxFileProvider from "./file_provider/file_provider.ajax";
+import OneDriveFileProvider from "./file_provider/file_provider.onedrive";
+import WebAPIFileProvider from "./file_provider/file_provider.webapi";
 
 const FILE_MANAGER_CLASS = "dx-filemanager";
 const FILE_MANAGER_CONTAINER_CLASS = FILE_MANAGER_CLASS + "-container";

--- a/js/ui/file_manager/ui.file_manager.js
+++ b/js/ui/file_manager/ui.file_manager.js
@@ -44,7 +44,7 @@ class FileManager extends Widget {
         this._currentFolder = new FileManagerItem("", "", true);
 
         const toolbar = this._createComponent($("<div>"), FileManagerToolbar, {
-            "onItemClick": this._onToolbarItemClick.bind(this)
+            "onItemClick": ({ itemName }) => this._onToolbarItemClick(itemName)
         });
         toolbar.$element().addClass(FILE_MANAGER_TOOLBAR_CLASS);
 
@@ -69,11 +69,11 @@ class FileManager extends Widget {
                 getSingleSelectedItem: this._getSingleSelectedItem.bind(this),
                 getMultipleSelectedItems: this._getMultipleSelectedItems.bind(this)
             },
-            onSuccess: (message, updateOnlyFiles) => {
+            onSuccess: ({ message, updatedOnlyFiles }) => {
                 this._showSuccess(message);
-                this._refreshData(updateOnlyFiles);
+                this._refreshData(updatedOnlyFiles);
             },
-            onError: (title, details) => this._showError(title + ": " + this._getErrorText(details)),
+            onError: ({ title, details }) => this._showError(title + ": " + this._getErrorText(details)),
             onCreating: () => this._setItemsViewAreaActive(false)
         });
         this._editing.$element().addClass(FILE_MANAGER_EDITING_CONTAINER_CLASS);
@@ -119,10 +119,10 @@ class FileManager extends Widget {
 
         const options = {
             selectionMode: selectionOptions.mode,
-            onGetItems: this._getItemListItems.bind(this),
-            onError: this._showError.bind(this),
-            onSelectedItemOpened: item => this._tryOpen(item),
-            onContextMenuItemClick: this._onContextMenuItemClick.bind(this),
+            getItems: this._getItemListItems.bind(this),
+            onError: ({ error }) => this._showError(error),
+            onSelectedItemOpened: ({ item }) => this._tryOpen(item),
+            onContextMenuItemClick: ({ name, fileItem }) => this._onContextMenuItemClick(name, fileItem),
             getItemThumbnail: this._getItemThumbnail.bind(this)
         };
 
@@ -136,7 +136,7 @@ class FileManager extends Widget {
     _createBreadcrumbs() {
         this._breadcrumbs = this._createComponent($("<div>"), FileManagerBreadcrumbs, {
             path: "",
-            onPathChanged: path => this.setCurrentFolderPath(path)
+            onPathChanged: e => this.setCurrentFolderPath(e.newPath)
         });
     }
 
@@ -151,7 +151,7 @@ class FileManager extends Widget {
     }
 
     _onContextMenuItemClick(name, fileItem) {
-        let command = FileManagerFileCommands.find(c => c.name === name);
+        const command = FileManagerFileCommands.find(c => c.name === name);
         command && command.handler(this, fileItem);
     }
 
@@ -404,9 +404,8 @@ class FileManager extends Widget {
             case "fileSystemStore":
             case "selection":
             case "itemList":
-                this.repaint();
-                break;
             case "customThumbnail":
+                this.repaint();
                 break;
             default:
                 super._optionChanged(args);

--- a/js/ui/file_manager/ui.file_manager.toolbar.js
+++ b/js/ui/file_manager/ui.file_manager.toolbar.js
@@ -4,21 +4,38 @@ import { FileManagerFileCommands } from "./ui.file_manager.commands";
 import Widget from "../widget/ui.widget";
 import Button from "../button";
 import { extend } from "../../core/utils/extend";
-import typeUtils from "../../core/utils/type";
 
 class FileManagerToolbar extends Widget {
 
     _initMarkup() {
+        this._createOnItemClickAction();
+
         for(let i = 0; i < FileManagerFileCommands.length; i++) {
             const itemButton = this._createButton(FileManagerFileCommands[i].text, FileManagerFileCommands[i].name);
             this.$element().append(itemButton.$element());
         }
     }
 
+    _createOnItemClickAction() {
+        this._onItemClickAction = this._createActionByOption("onItemClick");
+    }
+
     _getDefaultOptions() {
         return extend(super._getDefaultOptions(), {
             onItemClick: null
         });
+    }
+
+    _optionChanged(args) {
+        const name = args.name;
+
+        switch(name) {
+            case "onItemClick":
+                this._createOnItemClickAction();
+                break;
+            default:
+                super._optionChanged(args);
+        }
     }
 
     _createButton(text, name) {
@@ -28,10 +45,9 @@ class FileManagerToolbar extends Widget {
         });
     }
 
-    _onButtonClick(buttonName) {
-        const handler = this.option("onItemClick");
-        if(buttonName && typeUtils.isFunction(handler)) {
-            handler(buttonName);
+    _onButtonClick(itemName) {
+        if(itemName) {
+            this._onItemClickAction({ itemName });
         }
     }
 

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/webAPIProvider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/webAPIProvider.tests.js
@@ -1,7 +1,7 @@
 import "ui/file_manager";
-import { FileManagerItem } from "file_provider/file_provider";
+import { FileManagerItem } from "ui/file_manager/file_provider/file_provider";
 
-import WebAPIFileProvider from "file_provider/file_provider.webapi";
+import WebAPIFileProvider from "ui/file_manager/file_provider/file_provider.webapi";
 import ajaxMock from "../../../helpers/ajaxMock.js";
 import { when } from "core/utils/deferred";
 


### PR DESCRIPTION
Key points:
- file providers have been moved from `js` root folder to file manager widget folder
- internal widgets now use actions instead of the pure functions for event handlers. Actions are created using a `_createActionByOption()` method. See details in [discussion](https://github.com/DevExpress/DevExtreme/pull/7355#pullrequestreview-217614237)
- almost all the suggestions from [this review](https://github.com/DevExpress/DevExtreme/pull/7355#pullrequestreview-217728734) have been applied
