### PR TITLE
Prevent stale PR merges at Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,18 @@ clone:
 
 pipeline:
 
+  pr-fix:
+    image: alpine/git
+    commands:
+      - git config user.email "devextreme-ci@devexpress.com"
+      - git fetch origin "$DRONE_BRANCH"
+      - git fetch origin "+refs/pull/$DRONE_PULL_REQUEST/head:"
+      - git checkout -qf "$DRONE_BRANCH"
+      - git rebase "$DRONE_COMMIT_SHA"
+    when:
+      event:
+        - pull_request
+
   build:
     image: devexpress/devextreme-build:19_1
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,7 @@ clone:
   git-pr:
     image: alpine/git
     commands:
+      - "echo \"PR $DRONE_PULL_REQUEST: $DRONE_REPO#$DRONE_BRANCH \u2190 $DRONE_COMMIT_SHA\""
       - git init
       - git config user.email "devextreme-ci@devexpress.com"      
       - git remote add origin "https://github.com/$DRONE_REPO.git"

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,20 +4,22 @@ clone:
   git:
     image: plugins/git
     depth: 50
+    when:
+      event: [ push, tag ]
 
-pipeline:
-
-  pr-fix:
+  git-pr:
     image: alpine/git
     commands:
-      - git config user.email "devextreme-ci@devexpress.com"
+      - git init
+      - git remote add origin "https://github.com/$DRONE_REPO.git"
       - git fetch origin "$DRONE_BRANCH"
       - git fetch origin "+refs/pull/$DRONE_PULL_REQUEST/head:"
       - git checkout -qf "$DRONE_BRANCH"
-      - git rebase "$DRONE_COMMIT_SHA"
+      - git merge --squash "$DRONE_COMMIT_SHA"
     when:
-      event:
-        - pull_request
+      event: [ pull_request ]    
+
+pipeline:
 
   build:
     image: devexpress/devextreme-build:19_1

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,7 @@ clone:
     image: alpine/git
     commands:
       - git init
+      - git config user.email "devextreme-ci@devexpress.com"      
       - git remote add origin "https://github.com/$DRONE_REPO.git"
       - git fetch origin "$DRONE_BRANCH"
       - git fetch origin "+refs/pull/$DRONE_PULL_REQUEST/head:"


### PR DESCRIPTION
Change PR checkout logic at Drone.

`refs/pull/*/merge` are not reliable.

> **Warning!** Please do not depend on using Git directly or `GET /repos/:owner/:repo/git/refs/:ref` for updates to `merge` Git refs, because this content becomes outdated without warning.
> https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests

> The /merge refs that are being used here are an undocumented feature and you shouldn’t be relying on them. That feature was build to power Pull Requests in the Web UI, it was not built to be used by 3rd party services. Because it’s undocumented – you should not have any expectations about behavior, the behavior might change at any time and those refs might completely go away without warning.
> https://discourse.drone.io/t/1100

Related:
- https://github.com/drone-plugins/drone-git/issues/41
- https://github.com/drone-plugins/drone-git/pull/38
- https://github.com/drone/drone/issues/2417
- https://discourse.drone.io/t/1165
