### PR TITLE
Fix design issues in the dxDropDownButton (T731522)

### DIFF
--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -72,7 +72,7 @@ let DropDownButton = Widget.inherit({
             selectedItemKey: null,
 
             /**
-             * @name dxDropDownButtonOptions.selectedItemKey
+             * @name dxDropDownButtonOptions.stylingMode
              * @type Enums.ButtonStylingMode
              * @default 'outlined'
              */

--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -346,15 +346,14 @@ let DropDownButton = Widget.inherit({
                     y: -1
                 }
             },
-            contentTemplate: () => {
-                this._list = this._createComponent($("<div>"), List, this._listOptions());
+            contentTemplate: ($container) => {
+                const $listContainer = $("<div>").appendTo($container);
+                this._list = this._createComponent($listContainer, List, this._listOptions());
 
                 this._list.registerKeyHandler("escape", this._escHandler.bind(this));
                 this._list.registerKeyHandler("tab", this._escHandler.bind(this));
                 this._list.registerKeyHandler("leftArrow", this._escHandler.bind(this));
                 this._list.registerKeyHandler("rightArrow", this._escHandler.bind(this));
-
-                return this._list.$element();
             }
         }, this._getInnerOptionsCache("dropDownOptions"));
     },

--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -72,6 +72,13 @@ let DropDownButton = Widget.inherit({
             selectedItemKey: null,
 
             /**
+             * @name dxDropDownButtonOptions.selectedItemKey
+             * @type Enums.ButtonStylingMode
+             * @default 'outlined'
+             */
+            stylingMode: "outlined",
+
+            /**
              * @name dxDropDownButtonOptions.deferRendering
              * @type boolean
              * @default true
@@ -299,7 +306,9 @@ let DropDownButton = Widget.inherit({
         return extend({
             items: this._getButtonGroupItems(),
             onItemClick: this._buttonGroupItemClick.bind(this),
-            stylingMode: "outlined",
+            width: this.option("width"),
+            height: this.option("height"),
+            stylingMode: this.option("stylingMode"),
             selectionMode: "none"
         }, this._getInnerOptionsCache("buttonGroupOptions"));
     },
@@ -310,8 +319,14 @@ let DropDownButton = Widget.inherit({
             focusStateEnabled: false,
             deferRendering: this.option("deferRendering"),
             minWidth: 130,
-            closeOnOutsideClick: function(e) {
-                return !($(e.target).closest(`.${DROP_DOWN_BUTTON_TOGGLE_CLASS}`).length);
+            closeOnOutsideClick: (e) => {
+                const $toggleButton = $(e.target).closest(`.${DROP_DOWN_BUTTON_TOGGLE_CLASS}`);
+                if(!$toggleButton.length) {
+                    return true;
+                }
+
+                const $element = $toggleButton.closest(`.${DROP_DOWN_BUTTON_CLASS}`);
+                return $element.get(0) !== this.$element().get(0);
             },
             showTitle: false,
             animation: {
@@ -330,9 +345,7 @@ let DropDownButton = Widget.inherit({
                     y: -1
                 }
             },
-            contentTemplate: (content) => {
-                const $content = $(content);
-                $content.addClass(DROP_DOWN_BUTTON_CONTENT);
+            contentTemplate: () => {
                 this._list = this._createComponent($("<div>"), List, this._listOptions());
 
                 this._list.registerKeyHandler("escape", this._escHandler.bind(this));
@@ -340,7 +353,7 @@ let DropDownButton = Widget.inherit({
                 this._list.registerKeyHandler("leftArrow", this._escHandler.bind(this));
                 this._list.registerKeyHandler("rightArrow", this._escHandler.bind(this));
 
-                $content.append(this._list.$element());
+                return this._list.$element();
             }
         }, this._getInnerOptionsCache("dropDownOptions"));
     },
@@ -385,6 +398,7 @@ let DropDownButton = Widget.inherit({
         const $popup = $("<div>");
         this.$element().append($popup);
         this._popup = this._createComponent($popup, Popup, this._popupOptions());
+        $(this._popup.content()).addClass(DROP_DOWN_BUTTON_CONTENT);
         this._bindInnerWidgetOptions(this._popup, "dropDownOptions");
     },
 
@@ -445,10 +459,10 @@ let DropDownButton = Widget.inherit({
 
     _updateActionButton(selectedItem) {
         if(this.option("useSelectMode")) {
-            this._buttonGroup.option("items[0]", extend({}, this._actionButtonConfig(), {
+            this.option({
                 text: this._getDisplayValue(selectedItem),
                 icon: isPlainObject(selectedItem) ? selectedItem.icon : undefined
-            }));
+            });
         }
 
         this._setOptionSilent("selectedItem", selectedItem);
@@ -516,6 +530,11 @@ let DropDownButton = Widget.inherit({
                 this._buttonGroup.option("items[0]", extend({}, this._actionButtonConfig(), {
                     text: value
                 }));
+                break;
+            case "stylingMode":
+            case "width":
+            case "height":
+                this._buttonGroup.option(name, value);
                 break;
             case "itemTemplate":
             case "grouped":

--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -305,6 +305,7 @@ let DropDownButton = Widget.inherit({
     _buttonGroupOptions() {
         return extend({
             items: this._getButtonGroupItems(),
+            focusStateEnabled: this.option("focusStateEnabled"),
             onItemClick: this._buttonGroupItemClick.bind(this),
             width: this.option("width"),
             height: this.option("height"),
@@ -362,6 +363,7 @@ let DropDownButton = Widget.inherit({
         const selectedItemKey = this.option("selectedItemKey");
         return {
             selectionMode: "single",
+            focusStateEnabled: this.option("focusStateEnabled"),
             selectedItemKeys: selectedItemKey ? [selectedItemKey] : [],
             grouped: this.option("grouped"),
             keyExpr: this.option("keyExpr"),
@@ -507,6 +509,10 @@ let DropDownButton = Widget.inherit({
                 break;
             case "dropDownOptions":
                 this._innerOptionChanged(this._popup, args);
+                break;
+            case "focusStateEnabled":
+                this._setListOption(name, value);
+                this._buttonGroup.option(name, value);
                 break;
             case "items":
                 this._dataSource = null;

--- a/styles/widgets/common/dropDownButton.less
+++ b/styles/widgets/common/dropDownButton.less
@@ -7,7 +7,7 @@
         padding: 0;
     }
 
-    & .dx-list .dx-empty-message {
+    & .dx-list .dx-empty-message, & .dx-list .dx-list-item {
         border: none;
     }
 }

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
@@ -77,6 +77,32 @@ QUnit.module("markup", {
         assert.strictEqual($actionButtonText, "", "action button text is empty");
         assert.strictEqual($listItemText, "", "item text is empty");
     });
+
+    QUnit.test("width option should be transfered to buttonGroup", (assert) => {
+        const dropDownButton = new DropDownButton("#dropDownButton2", {
+            text: "Item 1",
+            icon: "box",
+            width: 235
+        });
+
+        assert.strictEqual(getButtonGroup(dropDownButton).option("width"), 235, "width was successfully transfered");
+
+        dropDownButton.option("width", 135);
+        assert.strictEqual(getButtonGroup(dropDownButton).option("width"), 135, "width was successfully changed");
+    });
+
+    QUnit.test("stylingMode option should be transfered to buttonGroup", (assert) => {
+        const dropDownButton = new DropDownButton("#dropDownButton2", {
+            text: "Item 1",
+            icon: "box",
+            stylingMode: "text"
+        });
+
+        assert.strictEqual(getButtonGroup(dropDownButton).option("stylingMode"), "text", "stylingMode was successfully transfered");
+
+        dropDownButton.option("stylingMode", "outlined");
+        assert.strictEqual(getButtonGroup(dropDownButton).option("stylingMode"), "outlined", "stylingMode was successfully changed");
+    });
 });
 
 QUnit.module("button group integration", {}, () => {
@@ -135,6 +161,25 @@ QUnit.module("button group integration", {}, () => {
 
         assert.strictEqual(instance.option("buttonGroupOptions.stylingMode"), "outlined", "option is correct");
     });
+
+    QUnit.test("text and icon options should depend on selection", (assert) => {
+        const instance = new DropDownButton("#dropDownButton", {
+            text: "Item 1",
+            icon: "box",
+            keyExpr: "id",
+            displayExpr: "text",
+            items: [{ id: 1, text: "User", icon: "user" }, { id: 2, text: "Group", icon: "group" }],
+            selectedItemKey: 1,
+            useSelectMode: true
+        });
+
+        assert.strictEqual(instance.option("text"), "User", "text option is correct");
+        assert.strictEqual(instance.option("icon"), "user", "icon option is correct");
+
+        instance.option("selectedItemKey", 2);
+        assert.strictEqual(instance.option("text"), "Group", "text option is correct");
+        assert.strictEqual(instance.option("icon"), "group", "icon option is correct");
+    });
 });
 
 QUnit.module("popup integration", {
@@ -148,6 +193,20 @@ QUnit.module("popup integration", {
 }, () => {
     QUnit.test("popup content should have special class", (assert) => {
         assert.ok($(this.popup.content()).hasClass(DROP_DOWN_BUTTON_CONTENT), "popup has special class");
+    });
+
+    QUnit.test("popup content should have special class when custom template is used", (assert) => {
+        const instance = new DropDownButton("#dropDownButton2", {
+            deferRendering: false,
+            dropDownOptions: {
+                contentTemplate: () => {
+                    return "Custom Content";
+                }
+            }
+        });
+
+        const $popupContent = $(getPopup(instance).content());
+        assert.ok($popupContent.hasClass(DROP_DOWN_BUTTON_CONTENT), "popup has special class");
     });
 
     QUnit.test("popup should have correct options after rendering", (assert) => {
@@ -210,7 +269,23 @@ QUnit.module("popup integration", {
         eventsEngine.trigger($toggleButton, "dxpointerdown");
         eventsEngine.trigger($toggleButton, "dxclick");
         assert.notOk(this.instance.option("dropDownOptions.visible"), "popup is hidden");
+    });
 
+    QUnit.test("click on other toggle button should be outside", (assert) => {
+        const otherButton = new DropDownButton("#dropDownButton2", {
+            text: "Text",
+            icon: "box",
+            splitButton: true
+        });
+
+        let $toggleButton = getToggleButton(this.instance);
+        eventsEngine.trigger($toggleButton, "dxclick");
+        assert.ok(this.instance.option("dropDownOptions.visible"), "popup is visible");
+
+        $toggleButton = getToggleButton(otherButton);
+        eventsEngine.trigger($toggleButton, "dxpointerdown");
+        eventsEngine.trigger($toggleButton, "dxclick");
+        assert.notOk(this.instance.option("dropDownOptions.visible"), "popup is hidden");
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
@@ -805,6 +805,8 @@ QUnit.module("keyboard navigation", {
     beforeEach: () => {
         this.$element = $("#dropDownButton");
         this.dropDownButton = new DropDownButton(this.$element, {
+            focusStateEnabled: true,
+            deferRendering: false,
             items: [
                 { name: "Item 1", id: 1 },
                 { name: "Item 2", id: 2 },
@@ -819,6 +821,15 @@ QUnit.module("keyboard navigation", {
         this.keyboard.press("right"); // TODO: Remove after T730639 fix
     }
 }, () => {
+    QUnit.test("focusStateEnabled option should be transfered to list and buttonGroup", (assert) => {
+        assert.ok(getList(this.dropDownButton).option("focusStateEnabled"), "list got option on init");
+        assert.ok(getButtonGroup(this.dropDownButton).option("focusStateEnabled"), "buttonGroup got option on init");
+
+        this.dropDownButton.option("focusStateEnabled", false);
+        assert.notOk(getList(this.dropDownButton).option("focusStateEnabled"), "list got option on change");
+        assert.notOk(getButtonGroup(this.dropDownButton).option("focusStateEnabled"), "buttonGroup got option on change");
+    });
+
     QUnit.testInActiveWindow("arrow right and left should select a button", (assert) => {
         this.keyboard.press("right");
         assert.ok(this.$toggleButton.hasClass("dx-state-focused"), "toggle button is focused");

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -109,6 +109,18 @@ interface JQuery {
     dxDeferRendering(options: string, ...params: any[]): any;
     dxDeferRendering(options: DevExpress.ui.dxDeferRenderingOptions): JQuery;
 }
+
+interface JQuery {
+    dxDiagram(): JQuery;
+
+    dxDiagram(options: "instance"): DevExpress.ui.dxDiagram;
+
+    dxDiagram(options: string): any;
+
+    dxDiagram(options: string, ...params: any[]): any;
+
+    dxDiagram(options: DevExpress.ui.dxDiagramOptions): JQuery;
+}
 interface JQuery {
     dxDrawer(): JQuery;
     dxDrawer(options: "instance"): DevExpress.ui.dxDrawer;
@@ -6032,6 +6044,16 @@ declare module DevExpress.ui {
     export class dxDeferRendering extends Widget {
         constructor(element: Element, options?: dxDeferRenderingOptions)
         constructor(element: JQuery, options?: dxDeferRenderingOptions)
+    }
+
+    /** @name dxDiagram.Options */
+    export interface dxDiagramOptions extends WidgetOptions<dxDiagram> {
+    }
+
+    /** @name dxDiagram */
+    export class dxDiagram extends Widget {
+        constructor(element: Element, options?: dxDiagramOptions)
+        constructor(element: JQuery, options?: dxDiagramOptions)
     }
     /** @name dxDrawer.Options */
     export interface dxDrawerOptions extends WidgetOptions<dxDrawer> {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -110,13 +110,6 @@ interface JQuery {
     dxDeferRendering(options: DevExpress.ui.dxDeferRenderingOptions): JQuery;
 }
 interface JQuery {
-    dxDiagram(): JQuery;
-    dxDiagram(options: "instance"): DevExpress.ui.dxDiagram;
-    dxDiagram(options: string): any;
-    dxDiagram(options: string, ...params: any[]): any;
-    dxDiagram(options: DevExpress.ui.dxDiagramOptions): JQuery;
-}
-interface JQuery {
     dxDrawer(): JQuery;
     dxDrawer(options: "instance"): DevExpress.ui.dxDrawer;
     dxDrawer(options: string): any;
@@ -6040,14 +6033,6 @@ declare module DevExpress.ui {
         constructor(element: Element, options?: dxDeferRenderingOptions)
         constructor(element: JQuery, options?: dxDeferRenderingOptions)
     }
-    /** @name dxDiagram.Options */
-    export interface dxDiagramOptions extends WidgetOptions<dxDiagram> {
-    }
-    /** @name dxDiagram */
-    export class dxDiagram extends Widget {
-        constructor(element: Element, options?: dxDiagramOptions)
-        constructor(element: JQuery, options?: dxDiagramOptions)
-    }
     /** @name dxDrawer.Options */
     export interface dxDrawerOptions extends WidgetOptions<dxDrawer> {
         /** @name dxDrawer.Options.animationDuration */
@@ -6140,6 +6125,8 @@ declare module DevExpress.ui {
         selectedItemKey?: string | number;
         /** @name dxDropDownButton.Options.splitButton */
         splitButton?: boolean;
+        /** @name dxDropDownButton.Options.stylingMode */
+        stylingMode?: 'text' | 'outlined' | 'contained';
         /** @name dxDropDownButton.Options.text */
         text?: string;
         /** @name dxDropDownButton.Options.useSelectMode */


### PR DESCRIPTION
1. Don't show item delimiters in all themes
2. Use dx-dropdownbutton-content class when custom template is used
3. Update text and icon options when selection changed
4. Provide a way to set width/height/stylingMode of the dxDropDownButton
5. Close the popup when toggle button of other dropDownButton was clicked