### PR TITLE
dxDiagram - use drawer for options panel, fix toolbar issues

### DIFF
--- a/js/ui/diagram/ui.diagram.commands.js
+++ b/js/ui/diagram/ui.diagram.commands.js
@@ -70,19 +70,34 @@ const DiagramCommands = {
                 name: DiagramCommand.ConnectorLineOption,
                 widget: "dxSelectBox",
                 text: "Line Option",
-                items: ["Straight", "Orthogonal"]
+                items: [
+                    { name: "Straight", value: 0 },
+                    { name: "Orthogonal", value: 1 }
+                ],
+                displayExpr: "name",
+                valueExpr: "value"
             },
             {
                 name: DiagramCommand.ConnectorStartLineEnding,
                 widget: "dxSelectBox",
                 text: "Start Line Ending",
-                items: ["None", "Arrow"]
+                items: [
+                    { name: "None", value: 0 },
+                    { name: "Arrow", value: 1 }
+                ],
+                displayExpr: "name",
+                valueExpr: "value"
             },
             {
                 name: DiagramCommand.ConnectorEndLineEnding,
                 widget: "dxSelectBox",
                 text: "End Line Ending",
-                items: ["None", "Arrow"]
+                items: [
+                    { name: "None", value: 0 },
+                    { name: "Arrow", value: 1 }
+                ],
+                displayExpr: "name",
+                valueExpr: "value"
             },
             {
                 name: DiagramCommand.AutoLayoutTree,

--- a/js/ui/diagram/ui.diagram.js
+++ b/js/ui/diagram/ui.diagram.js
@@ -1,5 +1,6 @@
 import $ from "../../core/renderer";
 import Widget from "../widget/ui.widget";
+import Drawer from "../drawer";
 import registerComponent from "../../core/component_registrator";
 import DiagramToolbar from "./ui.diagram.toolbar";
 import DiagramToolbox from "./ui.diagram.toolbox";
@@ -10,6 +11,7 @@ import { hasWindow } from "../../core/utils/window";
 const DIAGRAM_CLASS = "dx-diagram";
 const DIAGRAM_TOOLBAR_WRAPPER_CLASS = DIAGRAM_CLASS + "-toolbar-wrapper";
 const DIAGRAM_CONTENT_WRAPPER_CLASS = DIAGRAM_CLASS + "-content-wrapper";
+const DIAGRAM_DRAWER_WRAPPER_CLASS = DIAGRAM_CLASS + "-drawer-wrapper";
 const DIAGRAM_CONTENT_CLASS = DIAGRAM_CLASS + "-content";
 
 class Diagram extends Widget {
@@ -22,9 +24,7 @@ class Diagram extends Widget {
         const isServerSide = !hasWindow();
         this.$element().addClass(DIAGRAM_CLASS);
 
-        const $toolbarWrapper = $("<div>")
-            .addClass(DIAGRAM_TOOLBAR_WRAPPER_CLASS)
-            .appendTo(this.$element());
+        this._renderToolbar();
 
         const $contentWrapper = $("<div>")
             .addClass(DIAGRAM_CONTENT_WRAPPER_CLASS)
@@ -33,25 +33,56 @@ class Diagram extends Widget {
         const $toolbox = $("<div>")
             .appendTo($contentWrapper);
 
-        const $content = $("<div>")
-            .addClass(DIAGRAM_CONTENT_CLASS)
-            .appendTo($contentWrapper);
+        const $mainElement = this._renderMainElement($contentWrapper);
 
-        const $options = $("<div>")
-            .appendTo($contentWrapper);
-
-        this._createComponent($toolbarWrapper, DiagramToolbar, {
-            onContentReady: (e) => this._diagramInstance.barManager.registerBar(e.component.bar)
-        });
         this._createComponent($toolbox, DiagramToolbox, {
             onShapeCategoryRendered: (e) => !isServerSide && this._diagramInstance.createToolbox(e.$element[0], 40, 8, {}, e.category)
         });
-        this._createComponent($options, DiagramOptions, {
+
+        !isServerSide && this._diagramInstance.createDocument($mainElement[0]);
+    }
+
+    _renderToolbar() {
+        const $toolbarWrapper = $("<div>")
+            .addClass(DIAGRAM_TOOLBAR_WRAPPER_CLASS)
+            .appendTo(this.$element());
+        this._toolbarInstance = this._createComponent($toolbarWrapper, DiagramToolbar, {
             onContentReady: (e) => this._diagramInstance.barManager.registerBar(e.component.bar)
         });
-
-        !isServerSide && this._diagramInstance.createDocument($content[0]);
     }
+
+    _renderMainElement($parent) {
+        const $drawerWrapper = $("<div>")
+            .addClass(DIAGRAM_DRAWER_WRAPPER_CLASS)
+            .appendTo($parent);
+
+        const $drawer = $("<div>")
+            .appendTo($drawerWrapper);
+
+        const $content = $("<div>")
+            .addClass(DIAGRAM_CONTENT_CLASS)
+            .appendTo($drawer);
+
+        const drawer = this._createComponent($drawer, Drawer, {
+            closeOnOutsideClick: true,
+            openedStateMode: "overlap",
+            position: "right",
+            template: ($options) => {
+                this._createComponent($options, DiagramOptions, {
+                    onContentReady: (e) => this._diagramInstance.barManager.registerBar(e.component.bar)
+                });
+            }
+        });
+
+        this._toolbarInstance.option("onUIItemToggle", (e) => {
+            if(e.name === "options") {
+                drawer.toggle();
+            }
+        });
+
+        return $content;
+    }
+
     _initDiagram() {
         const { DiagramControl } = getDiagram();
         this._diagramInstance = new DiagramControl();

--- a/js/ui/diagram/ui.diagram.js
+++ b/js/ui/diagram/ui.diagram.js
@@ -74,7 +74,7 @@ class Diagram extends Widget {
             }
         });
 
-        this._toolbarInstance.option("onUIItemToggle", (e) => {
+        this._toolbarInstance.option("onWidgetCommand", (e) => {
             if(e.name === "options") {
                 drawer.toggle();
             }

--- a/js/ui/diagram/ui.diagram.options.js
+++ b/js/ui/diagram/ui.diagram.options.js
@@ -72,7 +72,7 @@ class DiagramOptions extends Widget {
         }
     }
     _onDiagramOptionChanged(key, value) {
-        if(!this._uiLocked && value !== undefined) {
+        if(!this._updateLocked && value !== undefined) {
             const valueConverter = this._valueConverters[key];
             if(valueConverter) {
                 value = valueConverter.getValue(value);
@@ -85,9 +85,9 @@ class DiagramOptions extends Widget {
         if(valueConverter) {
             value = valueConverter.setValue(value);
         }
-        this._uiLocked = true;
+        this._updateLocked = true;
         this._formInstance.updateData(key.toString(), value);
-        this._uiLocked = false;
+        this._updateLocked = false;
     }
     _setEnabled(enabled) {
         this._formInstance.option("disabled", !enabled);

--- a/js/ui/diagram/ui.diagram.toolbar.js
+++ b/js/ui/diagram/ui.diagram.toolbar.js
@@ -12,10 +12,19 @@ import "../check_box";
 const ACTIVE_FORMAT_CLASS = "dx-format-active";
 const TOOLBAR_CLASS = "dx-diagram-toolbar";
 
+const UI_ITEMS = [
+    {
+        name: "options",
+        icon: "preferences",
+        hint: "Show Page Properties"
+    }
+];
+
 class DiagramToolbar extends Widget {
     _init() {
         this.bar = new DiagramBar(this);
         this._toolbarWidgets = {};
+        this._createOnUIItemToggle();
         super._init();
     }
     _initMarkup() {
@@ -27,26 +36,41 @@ class DiagramToolbar extends Widget {
     }
     _renderToolbar($toolbar) {
         this._toolbarInstance = this._createComponent($toolbar, Toolbar, {
-            dataSource: this._prepareToolbarItems()
+            dataSource: this._prepareCommandItems().concat(this._prepareUIItems())
         });
     }
-    _prepareToolbarItems() {
-        return this._getButtons().map(item => {
-            return extend(true, {
-                widget: item.widget || "dxButton",
-                location: "before",
-                locateInMenu: "auto",
+    _prepareUIItems() {
+        return UI_ITEMS.map(item => extend(true,
+            this._createItem(item, "after"),
+            {
                 options: {
-                    text: item.text,
-                    hint: item.hint,
-                    icon: item.icon,
-                    onInitialized: (e) => this._onToolbarItemInitialized(e.component, item.name)
+                    onClick: (e) => this._onUIItemToggleAction({ name: item.name })
                 }
-            }, this._createWidgetActionOptions(item), this._createWidgetOptions(item));
-        });
+            })
+        );
+    }
+    _prepareCommandItems() {
+        return this._getButtons().map(item => extend(true,
+            this._createItem(item, "before"),
+            this._createWidgetActionOptions(item),
+            this._createWidgetOptions(item))
+        );
     }
     _onToolbarItemInitialized(widget, name) {
         this._toolbarWidgets[name] = widget;
+    }
+    _createItem(item, location) {
+        return {
+            widget: item.widget || "dxButton",
+            location: location,
+            locateInMenu: "auto",
+            options: {
+                text: item.text,
+                hint: item.hint,
+                icon: item.icon,
+                onInitialized: (e) => this._onToolbarItemInitialized(e.component, item.name)
+            }
+        };
     }
     _createWidgetOptions({ widget, items }) {
         if(widget === "dxSelectBox") {
@@ -78,6 +102,9 @@ class DiagramToolbar extends Widget {
     _onButtonClick(itemName) {
         this.bar._raiseBarCommandExecuted(itemName);
     }
+    _createOnUIItemToggle() {
+        this._onUIItemToggleAction = this._createActionByOption("onUIItemToggle");
+    }
 
     _setItemEnabled(name, enabled) {
         if(name in this._toolbarWidgets) {
@@ -95,6 +122,15 @@ class DiagramToolbar extends Widget {
             widget.option("value", value);
         } else if(value !== undefined) {
             widget.$element().toggleClass(ACTIVE_FORMAT_CLASS, value);
+        }
+    }
+    _optionChanged(args) {
+        switch(args.name) {
+            case "onUIItemToggle":
+                this._createOnUIItemToggle();
+                break;
+            default:
+                this.callBase(args);
         }
     }
 }

--- a/styles/widgets/common/diagram.less
+++ b/styles/widgets/common/diagram.less
@@ -17,14 +17,17 @@
         flex-basis: 0;
     }
 
-    .dx-diagram-toolbox,
-    .dx-diagram-options {
-        flex: 300px 0;
+    .dx-diagram-toolbox {
+        flex: 240px 0;
+        overflow-y: auto;
     }
-    .dx-diagram-content {
+    .dx-diagram-drawer-wrapper {
         flex: 1;
     }
-    .dx-diagram-toolbox {
-        overflow-y: auto;
+    .dx-diagram-content {
+        height: 100%;
+    }
+    .dx-diagram-options .dx-accordion {
+        width: 280px;
     }
 }

--- a/styles/widgets/generic/diagram.generic.less
+++ b/styles/widgets/generic/diagram.generic.less
@@ -28,6 +28,7 @@
 
 .dx-diagram-toolbox,
 .dx-diagram-options {
+    background: @overlay-content-bg;
     .dx-accordion .dx-accordion-item {
         border: none;
     }

--- a/styles/widgets/material/diagram.material.less
+++ b/styles/widgets/material/diagram.material.less
@@ -28,6 +28,7 @@
 
 .dx-diagram-toolbox,
 .dx-diagram-options {
+    background: @overlay-content-bg;
     .dx-accordion .dx-accordion-item {
         border: none;
     }

--- a/testing/tests/DevExpress.ui.widgets/diagram.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/diagram.tests.js
@@ -22,7 +22,7 @@ const moduleConfig = {
 QUnit.module("Diagram Toolbar", moduleConfig, () => {
     test("should fill toolbar with default items", (assert) => {
         let toolbar = this.$element.find(TOOLBAR_SELECTOR).dxToolbar("instance");
-        assert.equal(toolbar.option("dataSource").length, 17);
+        assert.ok(toolbar.option("dataSource").length > 10);
     });
     test("should enable items on diagram request", (assert) => {
         let undoButton = findToolbarItem(this.$element, "undo").dxButton("instance");


### PR DESCRIPTION
Use the Drawer widget for the options panel to reduce minimal width required by the widget (allows to use the widget in the demos).