### PR TITLE
Add new Store.registerClass to register alias for CustomStore

### DIFF
--- a/js/data/abstract_store.js
+++ b/js/data/abstract_store.js
@@ -333,14 +333,19 @@ Store.create = function(alias, options) {
     return new storeImpl[alias](options);
 };
 
+Store.registerClass = function(type, alias) {
+    if (alias) {
+        storeImpl[alias] = type
+    }
+    return type
+}
+
 Store.inherit = function(inheritor) {
     return function(members, alias) {
         var type = inheritor.apply(this, [members]);
-        if(alias) {
-            storeImpl[alias] = type;
-        }
+        Store.registerClass(type, alias);
         return type;
-    };
+    }
 }(Store.inherit);
 
 module.exports = Store;

--- a/js/data/abstract_store.js
+++ b/js/data/abstract_store.js
@@ -338,7 +338,7 @@ Store.registerClass = function(type, alias) {
         storeImpl[alias] = type
     }
     return type
-}
+};
 
 Store.inherit = function(inheritor) {
     return function(members, alias) {

--- a/js/data/abstract_store.js
+++ b/js/data/abstract_store.js
@@ -334,10 +334,10 @@ Store.create = function(alias, options) {
 };
 
 Store.registerClass = function(type, alias) {
-    if (alias) {
-        storeImpl[alias] = type
+    if(alias) {
+        storeImpl[alias] = type;
     }
-    return type
+    return type;
 };
 
 Store.inherit = function(inheritor) {
@@ -345,7 +345,7 @@ Store.inherit = function(inheritor) {
         var type = inheritor.apply(this, [members]);
         Store.registerClass(type, alias);
         return type;
-    }
+    };
 }(Store.inherit);
 
 module.exports = Store;

--- a/testing/tests/DevExpress.data/abstractStore.test.js
+++ b/testing/tests/DevExpress.data/abstractStore.test.js
@@ -1,0 +1,11 @@
+import Store from "data/abstract_store";
+
+QUnit.module("Abstract Store", function() {
+    class MyStore { }
+    QUnit.test("registerClass", assert => {
+        Store.registerClass(MyStore, "my-store");
+        const
+            customStore = Store.create("my-store");
+        assert.ok(customStore instanceof MyStore);
+    });
+});


### PR DESCRIPTION
Add new `Store.registerClass` to register `CustomStore` class inheritor.
Currently `Store.inherit` allows register direct inheritor from `Store` and it doesn't support javascript classes. In other words, you should write:

```js
export const XafLookupStore = Store.inherit({
    ctor: function(options) {
        ...
    },
    load: function(loadOptions: DxLookupLoadOptions) {
        ...
    }
}, "store")
```
instead of
```js
export class XafLookupStore extends CustomStore {  ... }
Store.registerClass(XafLookupStore, "store");
```
I've tested it locally all works like a charm