### PR TITLE
Include dx.aspnet.mvc.js to npm dist dir

### DIFF
--- a/build/gulp/npm.js
+++ b/build/gulp/npm.js
@@ -32,7 +32,6 @@ var DIST_GLOBS = [
     'artifacts/**/*.*',
     '!' + context.TRANSPILED_PATH + "/**/*.*",
     '!artifacts/npm/**/*.*',
-    '!artifacts/js/dx.aspnet.mvc.js',
     '!artifacts/js/angular**/*.*',
     '!artifacts/js/angular*',
     '!artifacts/js/knockout*',


### PR DESCRIPTION
Motivation: allow ASP.NET Core users to add this script via [LibMan + unpkg](https://docs.microsoft.com/en-us/ASPNET/core/client-side/libman/).