### PR TITLE
Publish opened option for the dxDropDownButton

### DIFF
--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -161,6 +161,13 @@ let DropDownButton = Widget.inherit({
             onItemClick: null,
 
             /**
+             * @name dxDropDownButtonOptions.opened
+             * @type boolean
+             * @default false
+             */
+            opened: false,
+
+            /**
              * @name dxDropDownButtonOptions.items
              * @type Array<CollectionWidgetItem, object>
              * @default null
@@ -268,7 +275,7 @@ let DropDownButton = Widget.inherit({
         this.$element().addClass(DROP_DOWN_BUTTON_CLASS);
         this._renderButtonGroup();
         this._loadSelectedItem().done(this._updateActionButton.bind(this));
-        if(!this.option("deferRendering")) {
+        if(!this.option("deferRendering") || this.option("opened")) {
             this._renderPopup();
         }
     },
@@ -406,6 +413,7 @@ let DropDownButton = Widget.inherit({
             width: "auto",
             height: "auto",
             shading: false,
+            visible: this.option("opened"),
             position: {
                 of: this.$element(),
                 collision: "flipfit",
@@ -590,6 +598,9 @@ let DropDownButton = Widget.inherit({
                 break;
             case "dropDownOptions":
                 this._innerOptionChanged(this._popup, args);
+                break;
+            case "opened":
+                this.toggle(value);
                 break;
             case "focusStateEnabled":
             case "hoverStateEnabled":

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
@@ -494,6 +494,17 @@ QUnit.module("public methods", {
         assert.strictEqual(popup.option("visible"), false, "popup is closed");
         assert.ok(typeUtils.isPromise(closePromise), "close should return promise");
     });
+
+    QUnit.test("opened option", (assert) => {
+        const dropDownButton = new DropDownButton("#dropDownButton2", {
+            opened: true
+        });
+
+        assert.ok(getPopup(dropDownButton).option("visible"), "popup is opened");
+
+        dropDownButton.option("opened", false);
+        assert.notOk(getPopup(dropDownButton).option("visible"), "popup is closed");
+    });
 });
 
 QUnit.module("data expressions", {

--- a/testing/tests/DevExpress.ui/defaultOptions.tests.js
+++ b/testing/tests/DevExpress.ui/defaultOptions.tests.js
@@ -318,6 +318,7 @@ testComponentDefaults(DropDownButton, {}, {
     keyExpr: "this",
     displayExpr: "this",
     useSelectMode: false,
+    opened: false,
     splitButton: false,
     selectedItemKey: null,
     focusStateEnabled: true,


### PR DESCRIPTION
Opened option should be published because it is inconvenient and sometimes impossible to use dropDownOptions.visible in React and Angular approaches, especially when dxDropDownButton is the part of the dxToolbar