### PR TITLE
Fix the same height for text editors with custom buttons or without them (T730398)

### DIFF
--- a/styles/widgets/generic/button.generic.less
+++ b/styles/widgets/generic/button.generic.less
@@ -218,8 +218,8 @@
     > .dx-button {
         margin: 1px @GENERIC_EDITOR_CUSTOM_BUTTON_MARGIN;
         > .dx-button-content {
-            padding-top: @GENERIC_BASE_INLINE_WIDGET_TOP_PADDING - @GENERIC_BUTTON_BORDER_WEIGHT - 1px;
-            padding-bottom: @GENERIC_BASE_INLINE_WIDGET_BOTTOM_PADDING - @GENERIC_BUTTON_BORDER_WEIGHT - 1px;
+            padding-top: @GENERIC_BASE_INLINE_WIDGET_TOP_PADDING - @GENERIC_BUTTON_BORDER_WEIGHT - 2px;
+            padding-bottom: @GENERIC_BASE_INLINE_WIDGET_BOTTOM_PADDING - @GENERIC_BUTTON_BORDER_WEIGHT - 2px;
         }
     }
 }

--- a/styles/widgets/material/button.material.less
+++ b/styles/widgets/material/button.material.less
@@ -380,6 +380,7 @@
 .dx-editor-underlined {
     .dx-texteditor-buttons-container {
         > .dx-button {
+            height: 29px;
             margin: 0 @MATERIAL_EDITOR_CUSTOM_BUTTON_MARGIN 3px;
 
             .dx-button-content {

--- a/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
@@ -257,6 +257,25 @@ module("rendering", () => {
             assert.strictEqual($after.length, 1);
             assert.strictEqual($before.length, 0);
         });
+
+        test("custom button should not change the widget height", (assert) => {
+            const $textBox = $("<div>").appendTo("#qunit-fixture").dxTextBox({
+                value: "text",
+                stylingMode: "underlined"
+            });
+            const startHeight = $textBox.height();
+            const textBox = $textBox.dxTextBox("instance");
+
+            textBox.option("buttons", [{
+                name: "custom",
+                location: "after",
+                options: {
+                    text: "custom"
+                }
+            }]);
+
+            assert.strictEqual($textBox.height(), startHeight);
+        });
     });
 
     module("numberBox", () => {


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
