### PR TITLE
diagram toolbar: separators, items border, sizing

### DIFF
--- a/js/ui/diagram/ui.diagram.commands.js
+++ b/js/ui/diagram/ui.diagram.commands.js
@@ -3,6 +3,9 @@ import { fileSaver } from "../../exporter/file_saver";
 import { isFunction } from "../../core/utils/type";
 import { getWindow } from "../../core/utils/window";
 
+const SEPARATOR = { widget: "separator" };
+const SIZING = { sm: "sm" };
+
 const DiagramCommands = {
     getToolbar: function() {
         const { DiagramCommand } = getDiagram();
@@ -19,6 +22,7 @@ const DiagramCommands = {
                 icon: "redo",
                 text: "Redo",
             },
+            SEPARATOR,
             {
                 command: DiagramCommand.FontName,
                 beginGroup: true,
@@ -28,8 +32,10 @@ const DiagramCommands = {
             {
                 command: DiagramCommand.FontSize,
                 widget: "dxSelectBox",
-                items: ["8pt", "9pt", "10pt", "11pt", "12pt", "14pt", "16pt", "18pt", "20pt", "22pt", "24pt", "26pt", "28pt", "36pt", "48pt", "72pt"]
+                items: ["8pt", "9pt", "10pt", "11pt", "12pt", "14pt", "16pt", "18pt", "20pt", "22pt", "24pt", "26pt", "28pt", "36pt", "48pt", "72pt"],
+                sizing: SIZING.sm
             },
+            SEPARATOR,
             {
                 command: DiagramCommand.Bold,
                 hint: "Bold",
@@ -48,6 +54,7 @@ const DiagramCommands = {
                 text: "Underline",
                 icon: "underline"
             },
+            SEPARATOR,
             {
                 command: DiagramCommand.FontColor,
                 text: "Text Color",
@@ -63,6 +70,7 @@ const DiagramCommands = {
                 text: "Fill Color",
                 widget: "dxColorBox"
             },
+            SEPARATOR,
             {
                 command: DiagramCommand.TextLeftAlign,
                 hint: "Align Left",
@@ -82,6 +90,7 @@ const DiagramCommands = {
                 text: "Align Right",
                 icon: "alignright"
             },
+            SEPARATOR,
             {
                 command: DiagramCommand.ConnectorLineOption,
                 widget: "dxSelectBox",
@@ -97,6 +106,7 @@ const DiagramCommands = {
                 command: DiagramCommand.ConnectorStartLineEnding,
                 widget: "dxSelectBox",
                 text: "Start Line Ending",
+                sizing: SIZING.sm,
                 items: [
                     { name: "None", value: 0 },
                     { name: "Arrow", value: 1 }
@@ -113,8 +123,10 @@ const DiagramCommands = {
                     { name: "Arrow", value: 1 }
                 ],
                 displayExpr: "name",
+                sizing: SIZING.sm,
                 valueExpr: "value"
             },
+            SEPARATOR,
             {
                 widget: "dxButton",
                 icon: "export",
@@ -300,15 +312,18 @@ const DiagramCommands = {
             },
             {
                 command: DiagramCommand.SelectAll,
-                text: "Select All"
+                text: "Select All",
+                beginGroup: true
             },
             {
                 command: DiagramCommand.Delete,
-                text: "Delete"
+                text: "Delete",
+                beginGroup: true
             },
             {
                 command: DiagramCommand.BringToFront,
-                text: "Bring to Front"
+                text: "Bring to Front",
+                beginGroup: true
             },
             {
                 command: DiagramCommand.SendToBack,

--- a/js/ui/diagram/ui.diagram.toolbar.js
+++ b/js/ui/diagram/ui.diagram.toolbar.js
@@ -11,6 +11,7 @@ import "../color_box";
 import "../check_box";
 
 const ACTIVE_FORMAT_CLASS = "dx-format-active";
+const SIZING_FORMAT_CLASS_PREFIX = "dx-format-";
 const TOOLBAR_CLASS = "dx-diagram-toolbar";
 const WIDGET_COMMANDS = [
     {
@@ -20,6 +21,8 @@ const WIDGET_COMMANDS = [
         text: "Properties",
     }
 ];
+const TOOLBAR_SEPARATOR_CLASS = "dx-diagram-toolbar-separator";
+const TOOLBAR_MENU_SEPARATOR_CLASS = "dx-diagram-toolbar-menu-separator";
 
 class DiagramToolbar extends Widget {
     _init() {
@@ -48,6 +51,7 @@ class DiagramToolbar extends Widget {
 
     _prepareToolbarItems(items, location, actionHandler) {
         return items.map(item => extend(true,
+            { location: location, locateInMenu: "auto" },
             this._createItem(item, location, actionHandler),
             this._createItemOptions(item),
             this._createItemActionOptions(item, actionHandler)
@@ -55,11 +59,21 @@ class DiagramToolbar extends Widget {
     }
 
     _createItem(item, location, actionHandler) {
+        if(item.widget === "separator") {
+            return {
+                template: (data, index, element) => {
+                    $(element).addClass(TOOLBAR_SEPARATOR_CLASS);
+                },
+                menuItemTemplate: (data, index, element) => {
+                    $(element).addClass(TOOLBAR_MENU_SEPARATOR_CLASS);
+                }
+            };
+        }
         return {
             widget: item.widget || "dxButton",
-            location: location,
-            locateInMenu: "auto",
+            cssClass: item.sizing && (SIZING_FORMAT_CLASS_PREFIX + item.sizing),
             options: {
+                stylingMode: "text",
                 text: item.text,
                 hint: item.hint,
                 icon: item.icon,
@@ -72,9 +86,16 @@ class DiagramToolbar extends Widget {
         if(widget === "dxSelectBox") {
             return {
                 options: {
+                    stylingMode: "filled",
                     items,
                     valueExpr,
                     displayExpr
+                }
+            };
+        } else if(widget === "dxColorBox") {
+            return {
+                options: {
+                    stylingMode: "filled"
                 }
             };
         } else if(!widget || widget === "dxButton") {

--- a/styles/widgets/common/diagram.less
+++ b/styles/widgets/common/diagram.less
@@ -52,10 +52,4 @@
             content: none;
         }
     }
-
-    .dx-format-sm {
-        .dx-texteditor {
-            width: 90px;
-        }
-    }
 }

--- a/styles/widgets/common/diagram.less
+++ b/styles/widgets/common/diagram.less
@@ -38,4 +38,24 @@
     .dx-diagram-right-panel .dx-accordion {
         width: 280px;
     }
+
+    .dx-diagram-toolbar-separator {
+        height: 100%;
+        border-left: @TRANSPARENT_BORDER;
+    }
+    
+    .dx-diagram-toolbar-menu-separator {
+        width: 100%;
+        border-top: @TRANSPARENT_BORDER;
+    
+        &::before {
+            content: none;
+        }
+    }
+
+    .dx-format-sm {
+        .dx-texteditor {
+            width: 90px;
+        }
+    }
 }

--- a/styles/widgets/generic/diagram.generic.less
+++ b/styles/widgets/generic/diagram.generic.less
@@ -44,4 +44,16 @@
             background-color: @diagram-danger-format-active-bg;
         }
     }
+
+    .dx-dropdowneditor.dx-editor-filled {
+        background-color: transparent;
+    }
+
+    .dx-diagram-toolbar-separator {
+        border-left-color: @diagram-toolbar-border-color;
+    }
+    
+    .dx-diagram-toolbar-menu-separator {
+        border-top-color: @diagram-toolbar-border-color;
+    }
 }

--- a/styles/widgets/generic/diagram.generic.less
+++ b/styles/widgets/generic/diagram.generic.less
@@ -16,6 +16,14 @@
             .dx-accordion-item:first-of-type {
                 border-top: none;
             }
+            .dx-state-focused {
+                &.dx-accordion-item {
+                    border-color: @accordion-item-border-color;
+                }
+                &.dx-accordion-item-closed:not(:last-of-type) {
+                    border-bottom-color: transparent;
+                }
+            }
         }
     }
     .dx-diagram-left-panel {
@@ -55,5 +63,11 @@
     
     .dx-diagram-toolbar-menu-separator {
         border-top-color: @diagram-toolbar-border-color;
+    }
+
+    .dx-format-sm {
+        .dx-texteditor {
+            width: 90px;
+        }
     }
 }

--- a/styles/widgets/material/diagram.material.less
+++ b/styles/widgets/material/diagram.material.less
@@ -45,4 +45,17 @@
             background-color: @diagram-danger-format-active-bg;
         }
     }
+
+    .dx-dropdowneditor.dx-editor-filled {
+        background-color: transparent;
+    }
+
+    .dx-diagram-toolbar-separator {
+        height: 50%;
+        border-left-color: @diagram-toolbar-border-color;
+    }
+    
+    .dx-diagram-toolbar-menu-separator {
+        border-top-color: @diagram-toolbar-border-color;
+    }
 }

--- a/styles/widgets/material/diagram.material.less
+++ b/styles/widgets/material/diagram.material.less
@@ -16,6 +16,14 @@
             .dx-accordion-item:first-of-type {
                 border-top: none;
             }
+            .dx-state-focused {
+                &.dx-accordion-item {
+                    border-color: @accordion-item-border-color;
+                }
+                &.dx-accordion-item-closed:not(:last-of-type) {
+                    border-bottom-color: transparent;
+                }
+            }
         }
     }
 
@@ -57,5 +65,11 @@
     
     .dx-diagram-toolbar-menu-separator {
         border-top-color: @diagram-toolbar-border-color;
+    }
+
+    .dx-format-sm {
+        .dx-texteditor {
+            width: 110px;
+        }
     }
 }


### PR DESCRIPTION
1. Adds separators to the toolbar
2. Fixes toolbar items style - removed excess borders from buttons and background from selectboxes
3. Added contextmenu beginGroup
4. Support different width of toolbar items