### PR TITLE
Use 'generic' theme for 'android' and 'win' devices

### DIFF
--- a/js/ui/themes.js
+++ b/js/ui/themes.js
@@ -241,9 +241,12 @@ function current(options) {
 function themeNameFromDevice(device) {
     var themeName = device.platform;
 
-
-    if(themeName === "ios") {
-        themeName += "7";
+    switch(themeName) {
+        case "ios":
+            return "ios7";
+        case "android":
+        case "win":
+            return "generic";
     }
 
     return themeName;

--- a/testing/tests/DevExpress.ui/themes.tests.js
+++ b/testing/tests/DevExpress.ui/themes.tests.js
@@ -562,4 +562,9 @@ require("style-compiler-test-server/known-css-files");
         assert.equal("ios7", themeNameFromDevice({ platform: "ios", version: [99] }));
         assert.equal("ios7", themeNameFromDevice({ platform: "ios" }));
     });
+
+    QUnit.test("themeNameFromDevice for removed mobile themes (breaking change BC4928)", function(assert) {
+        assert.equal(themes.themeNameFromDevice({ platform: "android" }), "generic");
+        assert.equal(themes.themeNameFromDevice({ platform: "win" }), "generic");
+    });
 })();


### PR DESCRIPTION
Reason: [BC4928](https://www.devexpress.com/Support/Center/VersionHistory?TechnologyName=DevExtreme&StartBuildName=19.1.3#BC4928), 'Mobile device-specific themes' paragraph