### PR TITLE
Fix calls count of the content ready event  when the expandAll method is used (T720800)

### DIFF
--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1024,7 +1024,6 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
         }
 
         this._dataAdapter.toggleExpansion(node.internalFields.key, state);
-        node.internalFields.expanded = state;
 
         if(this._hasChildren(node)) {
             const $node = this._getNodeElement(node);
@@ -1865,8 +1864,9 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
     */
     expandAll: function() {
         each(this._dataAdapter.getData(), (function(_, node) {
-            this._toggleExpandedState(node.internalFields.key, true);
+            this._dataAdapter.toggleExpansion(node.internalFields.key, true);
         }).bind(this));
+        this.repaint();
     },
 
     /**

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
@@ -1,4 +1,4 @@
-/* global DATA, internals, initTree */
+/* global DATA, internals, initTree, makeSlowDataSource */
 
 import $ from "jquery";
 import { noop } from "core/utils/common";

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
@@ -472,4 +472,108 @@ module("Expanded items", {
         assert.notOk(nodes[0].items[0].expanded, "item 11");
         assert.notOk(nodes[0].items[0].items[0].expanded, "item 111");
     });
+
+    test("Content ready event is thrown once when the expandAll is called", function(assert) {
+        const contentReadyStub = sinon.stub();
+        const $treeView = initTree({
+            items: [{
+                text: "1",
+                id: 1,
+                items: [{
+                    text: "11",
+                    id: 11,
+                    items: [{
+                        text: "111",
+                        id: 111
+                    }]
+                }]
+            }],
+            onContentReady: contentReadyStub
+        });
+        const treeView = $treeView.dxTreeView("instance");
+
+        treeView.expandAll();
+
+        assert.equal(contentReadyStub.callCount, 2, "event is thrown twice");
+    });
+
+    test("Content ready event is thrown once when the expandAll is called with the slow data source", function(assert) {
+        const contentReadyStub = sinon.stub();
+        const $treeView = initTree({
+            dataSource: makeSlowDataSource($.extend(true, [],
+                [
+                    { id: 1, parentId: 0, text: "Animals" },
+                    { id: 2, parentId: 1, text: "Cat" },
+                    { id: 3, parentId: 2, text: "Dog" },
+                    { id: 4, parentId: 3, text: "Cow" }
+                ]
+            )),
+            dataStructure: "plain",
+            onContentReady: contentReadyStub
+        });
+        const treeView = $treeView.dxTreeView("instance");
+
+        this.clock.tick(400);
+
+        treeView.expandAll();
+
+        this.clock.tick(400);
+
+        assert.equal(contentReadyStub.callCount, 2, "event is thrown twice");
+    });
+
+    test("Content ready event is thrown once when the expandAll is called with the slow data source and the virtual mode", function(assert) {
+        const contentReadyStub = sinon.stub();
+        const $treeView = initTree({
+            dataSource: makeSlowDataSource($.extend(true, [],
+                [
+                    { id: 1, parentId: 0, text: "Animals" },
+                    { id: 2, parentId: 1, text: "Cat" },
+                    { id: 3, parentId: 2, text: "Dog" },
+                    { id: 4, parentId: 3, text: "Cow" }
+                ]
+            )),
+            dataStructure: "plain",
+            virtualModeEnabled: true,
+            onContentReady: contentReadyStub
+        });
+        const treeView = $treeView.dxTreeView("instance");
+
+        this.clock.tick(400);
+
+        treeView.expandAll();
+
+        this.clock.tick(400);
+
+        assert.equal(contentReadyStub.callCount, 2, "event is thrown once");
+    });
+
+    test("Content ready event is thrown once when the expandAll is called with load data on demand", function(assert) {
+        const contentReadyStub = sinon.stub();
+        const data = [
+            { id: 1, parentID: 0, text: "Animals" },
+            { id: 2, parentID: 1, text: "Cat" },
+            { id: 21, parentID: 1, text: "Pussy Cat", hasItems: false },
+            { id: 3, parentID: 2, text: "Dog" },
+            { id: 4, parentID: 3, text: "Cow", hasItems: false }
+        ];
+        const $treeView = initTree({
+            createChildren: parent => {
+                const parentID = parent ? parent.itemData.id : 0;
+                return data.filter(item => item.parentID === parentID);
+            },
+            rootValue: 1,
+            dataStructure: "plain",
+            onContentReady: contentReadyStub
+        });
+        const treeView = $treeView.dxTreeView("instance");
+
+        this.clock.tick(400);
+
+        treeView.expandAll();
+
+        this.clock.tick(400);
+
+        assert.equal(contentReadyStub.callCount, 2, "event is thrown twice");
+    });
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
