### PR TITLE
Prevent DateBox validation error according to min/max rules on widget init (T741986)

### DIFF
--- a/js/ui/date_box/ui.date_box.base.js
+++ b/js/ui/date_box/ui.date_box.base.js
@@ -415,10 +415,6 @@ var DateBox = DropDownEditor.inherit({
 
         this.callBase();
 
-        if(this.option("isValid")) {
-            this._validateValue(this.dateOption("value"));
-        }
-
         this._refreshFormatClass();
         this._refreshPickerTypeClass();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -265,7 +265,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.ok(onValueChanged.getCall(1).args[0].event, "event was saved");
     });
 
-    QUnit.test("out of range value should be marked as invalid on init", assert => {
+    QUnit.test("out of range value should not be marked as invalid on init", assert => {
         const $dateBox = $("#widthRootStyle").dxDateBox({
             value: new Date(2015, 3, 20),
             min: new Date(2014, 3, 20),
@@ -274,7 +274,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
 
         const dateBox = $dateBox.dxDateBox("instance");
 
-        assert.notOk(dateBox.option("isValid"), "widget is invalid");
+        assert.ok(dateBox.option("isValid"), "widget is valid on init");
     });
 
     QUnit.test("it shouild be impossible to set out of range time to dxDateBox using ui (T394206)", assert => {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
