### PR TITLE
Prevent DateBox validation error according to min/max rules on widget init (T741986)

### DIFF
--- a/js/ui/date_box/ui.date_box.js
+++ b/js/ui/date_box/ui.date_box.js
@@ -415,10 +415,6 @@ var DateBox = DropDownEditor.inherit({
 
         this.callBase();
 
-        if(this.option("isValid")) {
-            this._validateValue(this.dateOption("value"));
-        }
-
         this._refreshFormatClass();
         this._refreshPickerTypeClass();
 
@@ -606,6 +602,7 @@ var DateBox = DropDownEditor.inherit({
             currentValue = this.dateOption("value");
 
         if(text === this._getDisplayedText(currentValue)) {
+            this._validateValue(currentValue);
             return;
         }
 

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -265,15 +265,15 @@ QUnit.test("clear button press should save value change event", function(assert)
     assert.ok(onValueChanged.getCall(1).args[0].event, "event was saved");
 });
 
-QUnit.test("out of range value should be marked as invalid on init", function(assert) {
-    var $dateBox = $("#widthRootStyle").dxDateBox({
+QUnit.test("out of range value should not be marked as invalid on init", assert => {
+    const $dateBox = $("#widthRootStyle").dxDateBox({
             value: new Date(2015, 3, 20),
             min: new Date(2014, 3, 20),
             max: new Date(2014, 4, 20)
         }),
         dateBox = $dateBox.dxDateBox("instance");
 
-    assert.notOk(dateBox.option("isValid"), "widget is invalid");
+    assert.ok(dateBox.option("isValid"), "widget is valid on init");
 });
 
 QUnit.test("it shouild be impossible to set out of range time to dxDateBox using ui (T394206)", function(assert) {
@@ -3855,6 +3855,27 @@ QUnit.test("dxDateBox should validate value after change 'min' option", function
     assert.ok(dateBox.option("isValid"), "datebox is valid");
 });
 
+QUnit.testInActiveWindow("DateBox should validate value after remove an invalid characters", function(assert) {
+    const $element = $("#dateBox");
+    const dateBox = $element.dxDateBox({
+        value: new Date(2015, 6, 18)
+    }).dxDateBox("instance");
+    const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+    const keyboard = keyboardMock($input);
+
+    keyboard
+        .caret(dateBox.option("text").length - 1)
+        .type("d")
+        .press("enter");
+
+    assert.notOk(dateBox.option("isValid"));
+
+    keyboard
+        .press("backspace")
+        .press("enter");
+
+    assert.ok(dateBox.option("isValid"));
+});
 
 QUnit.module("DateBox number and string value support", {
     beforeEach: function() {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
