### PR TITLE
Fix dxLookup popup opening  second time after scrolling in the material theme (T739167)

### DIFF
--- a/js/ui/lookup.js
+++ b/js/ui/lookup.js
@@ -803,8 +803,13 @@ var Lookup = DropDownList.inherit({
         var flipped = this._popup._$wrapper.hasClass(LOOKUP_POPOVER_FLIP_VERTICAL_CLASS);
         if(selectedIndex === -1 || flipped) return;
 
-        var selectedListItem = $(this._list.element()).find("." + LIST_ITEM_SELECTED_CLASS),
-            differenceOfHeights = (selectedListItem.height() - $(this.element()).height()) / 2,
+        var selectedListItem = $(this._list.element()).find("." + LIST_ITEM_SELECTED_CLASS);
+
+        if(selectedListItem.offset().top < 0) {
+            this._scrollToSelectedItem();
+        }
+
+        var differenceOfHeights = (selectedListItem.height() - $(this.element()).height()) / 2,
             popupContentParent = $(this._popup.content()).parent(),
             differenceOfOffsets = selectedListItem.offset().top - popupContentParent.offset().top,
             lookupTop = $(this.element()).offset().top,

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -3029,6 +3029,14 @@ QUnit.test("Check popup position offset for Material theme", function(assert) {
 
         assert.roughEqual($popup.find(".dx-overlay-content").position().top, -3.5, 1, "offset of the lookup if first item is selected");
 
+        lookup._list.scrollTo(100);
+
+        lookup.close();
+
+        $(lookup.field()).trigger("dxclick");
+
+        assert.roughEqual($popup.find(".dx-overlay-content").position().top, -3.5, 1, "offset of the lookup after scrolling and without item selecting");
+
         lookup.close();
 
         lookup.option("value", "purple");


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
