### PR TITLE
Don't hide custom editor buttons in readonly state (T743776)

### DIFF
--- a/js/ui/button.js
+++ b/js/ui/button.js
@@ -347,7 +347,7 @@ var Button = Widget.inherit({
     _renderClick: function() {
         var that = this,
             eventName = eventUtils.addNamespace(clickEvent.name, this.NAME),
-            actionConfig = { };
+            actionConfig = { excludeValidators: ["readOnly"] };
 
         if(this.option("useSubmitBehavior")) {
             actionConfig.afterExecute = function(e) {

--- a/js/ui/drop_down_editor/ui.drop_down_button.js
+++ b/js/ui/drop_down_editor/ui.drop_down_button.js
@@ -54,7 +54,7 @@ export default class ClearButton extends TextEditorButton {
     _isVisible() {
         const { editor } = this;
 
-        return editor.option("showDropDownButton");
+        return super._isVisible() && editor.option("showDropDownButton");
     }
 
     // TODO: get rid of it

--- a/js/ui/number_box/number_box.spins.js
+++ b/js/ui/number_box/number_box.spins.js
@@ -67,7 +67,7 @@ export default class SpinButtons extends TextEditorButton {
     _isVisible() {
         const { editor } = this;
 
-        return editor.option("showSpinButtons");
+        return super._isVisible() && editor.option("showSpinButtons");
     }
 
     _isTouchFriendly() {

--- a/js/ui/text_box/texteditor_button_collection/button.js
+++ b/js/ui/text_box/texteditor_button_collection/button.js
@@ -34,7 +34,9 @@ export default class TextEditorButton {
     }
 
     _isVisible() {
-        throw "Not implemented";
+        const { editor, options } = this;
+
+        return options.visible || !editor.option("readOnly");
     }
 
     _isDisabled() {

--- a/js/ui/text_box/texteditor_button_collection/button.js
+++ b/js/ui/text_box/texteditor_button_collection/button.js
@@ -8,7 +8,7 @@ export default class TextEditorButton {
         this.$placeMarker = null;
         this.editor = editor;
         this.name = name;
-        this.options = options;
+        this.options = options || {};
     }
 
     _addPlaceMarker($container) {
@@ -34,6 +34,10 @@ export default class TextEditorButton {
     }
 
     _isVisible() {
+        throw "Not implemented";
+    }
+
+    _isDisabled() {
         throw "Not implemented";
     }
 

--- a/js/ui/text_box/texteditor_button_collection/custom.js
+++ b/js/ui/text_box/texteditor_button_collection/custom.js
@@ -1,6 +1,7 @@
 import $ from "../../../core/renderer";
 import TextEditorButton from "./button";
 import Button from "../../button";
+import { extend } from "../../../core/utils/extend";
 import eventsEngine from "../../../events/core/events_engine";
 import hoverEvents from "../../../events/hover";
 import clickEvent from "../../../events/click";
@@ -28,7 +29,9 @@ export default class CustomButton extends TextEditorButton {
 
         this._addToContainer($element);
 
-        const instance = editor._createComponent($element, Button, this.options);
+        const instance = editor._createComponent($element, Button, extend({}, this.options, {
+            disabled: this._isDisabled()
+        }));
 
         return {
             $element,
@@ -36,9 +39,28 @@ export default class CustomButton extends TextEditorButton {
         };
     }
 
+    update() {
+        const isUpdated = super.update();
+
+        if(this.instance) {
+            this.instance.option("disabled", this._isDisabled());
+        }
+
+        return isUpdated;
+    }
+
     _isVisible() {
         const { editor } = this;
 
         return editor.option("visible");
+    }
+
+    _isDisabled() {
+        const isDefinedByUser = this.options.disabled !== undefined;
+        if(isDefinedByUser) {
+            return this.instance ? this.instance.option("disabled") : this.options.disabled;
+        } else {
+            return this.editor.option("readOnly");
+        }
     }
 }

--- a/styles/widgets/generic/textEditor.generic.less
+++ b/styles/widgets/generic/textEditor.generic.less
@@ -84,9 +84,6 @@
             border-style: none;
             border-bottom-style: dashed;
         }
-        .dx-texteditor-buttons-container {
-            display: none;
-        }
     }
 
     &.dx-state-hover {

--- a/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
@@ -276,6 +276,52 @@ module("rendering", () => {
 
             assert.strictEqual($textBox.height(), startHeight);
         });
+
+        test("custom button should be disabled in readOnly state by default", (assert) => {
+            const textBox = $("<div>").appendTo("#qunit-fixture").dxTextBox({
+                value: "text",
+                buttons: [
+                    {
+                        name: "custom",
+                        location: "after",
+                        options: {
+                            text: "custom"
+                        }
+                    }
+                ],
+                readOnly: true
+            }).dxTextBox("instance");
+            const button = textBox.getButton("custom");
+
+            assert.ok(button.option("disabled"), "button is disabled");
+
+            textBox.option("readOnly", false);
+            assert.notOk(button.option("disabled"), "button is enabled");
+        });
+
+        test("custom button should not be disabled in readOnly state if it was specified by a user", (assert) => {
+            const textBox = $("<div>").appendTo("#qunit-fixture").dxTextBox({
+                value: "text",
+                buttons: [
+                    {
+                        name: "custom",
+                        location: "after",
+                        options: {
+                            disabled: false,
+                            text: "custom"
+                        }
+                    }
+                ],
+                readOnly: true
+            }).dxTextBox("instance");
+            const button = textBox.getButton("custom");
+
+            assert.notOk(button.option("disabled"), "button is enabled");
+
+            button.option("disabled", true);
+            textBox.option("readOnly", false);
+            assert.ok(button.option("disabled"), "button is disabled");
+        });
     });
 
     module("numberBox", () => {

--- a/testing/tests/DevExpress.ui.widgets/button.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/button.tests.js
@@ -93,6 +93,18 @@ QUnit.module("options changed callbacks", {
         assert.ok(this.element.hasClass("dx-state-disabled"));
     });
 
+    QUnit.test("readOnly validator should be excluded for the click action", (assert) => {
+        const clickHandler = sinon.spy();
+
+        this.instance.option({
+            onClick: clickHandler
+        });
+
+        this.element.addClass("dx-state-readonly");
+        this.element.trigger("dxclick");
+        assert.strictEqual(clickHandler.callCount, 1, "click handler was executed");
+    });
+
     QUnit.test("T325811 - 'text' option change should not lead to widget clearing", (assert) => {
         const $testElement = $("<div>").appendTo(this.element);
         assert.ok($testElement.parent().hasClass("dx-button"), "test element is in button");


### PR DESCRIPTION
This PR adds following behavior:

1. If disabled state of the button is not specified by a user, the CUSTOM button will be disabled when the `readOnly` option is `true` and enabled otherwise.

2. If disabled state is specified by the user, the CUSTOM button ignores the `readOnly` option and gets the disabled state from the user defined one.

The user can change disabled state of the button in run time with the `optionChanged` event and the `getButton` method.

3. Predefined buttons are always invisible in readOnly state