### PR TITLE
 Fix keyboard handling for macOS IME keyboard (T740181)

### DIFF
--- a/js/ui/widget/ui.keyboard_processor.js
+++ b/js/ui/widget/ui.keyboard_processor.js
@@ -5,8 +5,15 @@ import { inArray } from "../../core/utils/array";
 import { each } from "../../core/utils/iterator";
 import { addNamespace, normalizeKeyName } from "../../events/utils";
 
+const COMPOSITION_START_EVENT = "compositionstart";
+const COMPOSITION_END_EVENT = "compositionend";
+const KEYDOWN_EVENT = "keydown";
+const NAMESPACE = "KeyboardProcessor";
+
 const KeyboardProcessor = Class.inherit({
-    _keydown: addNamespace("keydown", "KeyboardProcessor"),
+    _keydown: addNamespace(KEYDOWN_EVENT, NAMESPACE),
+    _compositionStart: addNamespace(COMPOSITION_START_EVENT, NAMESPACE),
+    _compositionEnd: addNamespace(COMPOSITION_END_EVENT, NAMESPACE),
 
     ctor: function(options) {
         options = options || {};
@@ -23,13 +30,18 @@ const KeyboardProcessor = Class.inherit({
             this._processFunction = (e) => {
                 this.process(e);
             };
+            this._toggleProcessingWithContext = this.toggleProcessing.bind(this);
+
             eventsEngine.on(this._element, this._keydown, this._processFunction);
+            eventsEngine.on(this._element, this._compositionStart, this._toggleProcessingWithContext);
+            eventsEngine.on(this._element, this._compositionEnd, this._toggleProcessingWithContext);
         }
     },
 
     dispose: function() {
         if(this._element) {
             eventsEngine.off(this._element, this._keydown, this._processFunction);
+            eventsEngine.off(this._element, this._keydown, this._toggleProcessingWithContext);
         }
         this._element = undefined;
         this._handler = undefined;
@@ -51,7 +63,7 @@ const KeyboardProcessor = Class.inherit({
     },
 
     attachChildProcessor: function() {
-        var childProcessor = new KeyboardProcessor();
+        const childProcessor = new KeyboardProcessor();
         this._childProcessors.push(childProcessor);
         return childProcessor;
     },
@@ -63,11 +75,15 @@ const KeyboardProcessor = Class.inherit({
     },
 
     process: function(e) {
-        if(this._focusTarget && this._focusTarget !== e.target && inArray(e.target, this._focusTarget) < 0) {
+        const isNotFocusTarget = this._focusTarget && this._focusTarget !== e.target && inArray(e.target, this._focusTarget) < 0;
+        const shouldSkipProcessing = this._isComposingJustFinished && e.which === 229 || this._isComposing || isNotFocusTarget;
+
+        this._isComposingJustFinished = false;
+        if(shouldSkipProcessing) {
             return false;
         }
 
-        var args = {
+        const args = {
             keyName: normalizeKeyName(e),
             key: e.key,
             code: e.code,
@@ -80,15 +96,19 @@ const KeyboardProcessor = Class.inherit({
             originalEvent: e
         };
 
-        var handlerResult = this._handler && this._handler.call(this._context, args);
+        const handlerResult = this._handler && this._handler.call(this._context, args);
 
         if(handlerResult && this._childProcessors) {
-            each(this._childProcessors, function(index, childProcessor) {
+            each(this._childProcessors, (index, childProcessor) => {
                 childProcessor.process(e);
             });
         }
-    }
+    },
 
+    toggleProcessing: function({ type }) {
+        this._isComposing = type === COMPOSITION_START_EVENT;
+        this._isComposingJustFinished = !this._isComposing;
+    }
 });
 
 module.exports = KeyboardProcessor;

--- a/js/ui/widget/ui.keyboard_processor.js
+++ b/js/ui/widget/ui.keyboard_processor.js
@@ -41,7 +41,8 @@ const KeyboardProcessor = Class.inherit({
     dispose: function() {
         if(this._element) {
             eventsEngine.off(this._element, this._keydown, this._processFunction);
-            eventsEngine.off(this._element, this._keydown, this._toggleProcessingWithContext);
+            eventsEngine.off(this._element, this._compositionStart, this._toggleProcessingWithContext);
+            eventsEngine.off(this._element, this._compositionEnd, this._toggleProcessingWithContext);
         }
         this._element = undefined;
         this._handler = undefined;

--- a/testing/tests/DevExpress.ui/keyboardProcessor.tests.js
+++ b/testing/tests/DevExpress.ui/keyboardProcessor.tests.js
@@ -85,4 +85,47 @@ QUnit.module("keyboardProcessor", {
 
         assert.ok(stubHandler.notCalled, "event was not processed");
     });
+
+    test("keyboardProcessor should not process events during IME composition", (assert) => {
+        const stubHandler = sinon.stub();
+
+        this.processor = new KeyboardProcessor({
+            element: this.element,
+            handler: stubHandler
+        });
+
+        this.element.trigger($.Event("compositionstart"));
+        this.element.trigger(this.keyDownEvent);
+        assert.ok(stubHandler.notCalled, "event was not processed");
+
+        this.element.trigger($.Event("compositionend"));
+        this.element.trigger(this.keyDownEvent);
+        assert.ok(stubHandler.calledOnce, "event has been processed");
+    });
+
+    test("keyboardProcessor should not process event after compositionend with a '229' keycode [MacOS Safari specific behavior]", (assert) => {
+        const stubHandler = sinon.stub();
+
+        this.processor = new KeyboardProcessor({
+            element: this.element,
+            handler: stubHandler
+        });
+
+        this.element.trigger($.Event("compositionstart"));
+        this.element.trigger(this.keyDownEvent);
+        assert.ok(stubHandler.notCalled, "event was not processed");
+
+        this.element.trigger($.Event("compositionend"));
+
+        const enterComposition = $.Event("keydown");
+        enterComposition.key = "Enter";
+        enterComposition.which = 229;
+
+        this.element.trigger(enterComposition);
+        assert.ok(stubHandler.notCalled, "event was not processed");
+
+        enterComposition.which = 13;
+        this.element.trigger(enterComposition);
+        assert.ok(stubHandler.calledOnce, "event has been processed");
+    });
 });


### PR DESCRIPTION
Safari on OS X may send a keydown of 229 after compositionend (after pressing "Enter"  to confirm), we should skip it processing