### PR TITLE
Don't reset left icon margin in the dxDropDownButton

### DIFF
--- a/styles/widgets/common/dropDownButton.less
+++ b/styles/widgets/common/dropDownButton.less
@@ -30,12 +30,10 @@
     }
 
     &.dx-button-has-text .dx-icon.dx-icon-right {
-        margin-left: 0;
         margin-right: -6px;
 
         .dx-rtl & {
             margin-left: -6px;
-            margin-right: 0;
         }
     }
 }


### PR DESCRIPTION
1. dxDropDownButton should get dxButton's icon margin between text and right icon
2. dxDropDownButton should get -6px margin between the right icon and the border
3. rtlEnabled should mirror this values

![image](https://user-images.githubusercontent.com/16186141/58412265-ca503700-807e-11e9-9035-4c710259a441.png)