### PR TITLE
DataGrid: Fix cannot read property 'style' of undefined (T744668)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.grid_view.js
+++ b/js/ui/grid_core/ui.grid_core.grid_view.js
@@ -533,7 +533,7 @@ var ResizingController = modules.ViewController.inherit({
         let groupElement = this.component.$element().children().get(0),
             scrollable = this._rowsView.getScrollable();
 
-        if(groupElement.style.height && (!scrollable || !scrollable.scrollTop())) {
+        if(groupElement && groupElement.style.height && (!scrollable || !scrollable.scrollTop())) {
             groupElement.style.height = "";
         }
     },


### PR DESCRIPTION
Pull request regarding ticket T744668:

https://www.devexpress.com/Support/Center/Question/Details/T744668/datagrid-cell-loading-is-broken-after-updating-to-version-19-1-3
