### PR TITLE
diagram - fix select buttons in edge

### DIFF
--- a/styles/widgets/common/diagram.less
+++ b/styles/widgets/common/diagram.less
@@ -68,6 +68,10 @@
                 
                 .dx-textbox {
                     width: 0px;
+                    .dx-texteditor-input {
+                        width: 0;
+                        padding-left: 0;
+                    }
                 }
             }
         }


### PR DESCRIPTION
It fixes selectbuttons width in Edge (input inside a selectbutton should be collapsed)