### PR TITLE
dxDiagram - replace colorbox with colorbuttons (T739191)

### DIFF
--- a/images/widgets/common/diagram/button-fill.svg
+++ b/images/widgets/common/diagram/button-fill.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 18 18" style="enable-background:new 0 0 18 18;" xml:space="preserve">
+<path d="M5,0L4,1l2,2L0,9l7,7l7-7L5,0z M2,9l5-5l5,5H2z" fill="currentColor"/>
+<path d="M15,10c0,0-3,3-3,5.5c0,0,0,0.1,0,0.1c0,1.3,1.3,2.4,3,2.4c1.7,0,3-1.1,3-2.4c0,0,0-0.1,0-0.1
+	C18,13,15,10,15,10z M13,15.5c0-2,2-4,2-4s0.7,0.7,1.3,1.7L13,15.5z" fill="currentColor"/>
+</svg>

--- a/js/ui/diagram/ui.diagram.commands.js
+++ b/js/ui/diagram/ui.diagram.commands.js
@@ -6,7 +6,8 @@ import { getWindow } from "../../core/utils/window";
 const SEPARATOR = { widget: "separator" };
 const CSS_CLASSES = {
     SMALL_SELECT: "dx-diagram-select-sm",
-    BUTTON_SELECT: "dx-diagram-select-b"
+    BUTTON_SELECT: "dx-diagram-select-b",
+    BUTTON_COLOR: "dx-diagram-color-b",
 };
 
 const DiagramCommands = {
@@ -61,17 +62,23 @@ const DiagramCommands = {
             {
                 command: DiagramCommand.FontColor,
                 text: "Text Color",
-                widget: "dxColorBox"
+                widget: "dxColorBox",
+                icon: "dx-icon dx-icon-color",
+                cssClass: CSS_CLASSES.BUTTON_COLOR
             },
             {
                 command: DiagramCommand.StrokeColor,
                 text: "Line Color",
-                widget: "dxColorBox"
+                widget: "dxColorBox",
+                icon: "dx-icon dx-icon-background",
+                cssClass: CSS_CLASSES.BUTTON_COLOR
             },
             {
                 command: DiagramCommand.FillColor,
                 text: "Fill Color",
-                widget: "dxColorBox"
+                widget: "dxColorBox",
+                icon: "dx-diagram-i dx-diagram-i-button-fill",
+                cssClass: CSS_CLASSES.BUTTON_COLOR
             },
             SEPARATOR,
             {

--- a/js/ui/diagram/ui.diagram.toolbar.js
+++ b/js/ui/diagram/ui.diagram.toolbar.js
@@ -81,48 +81,75 @@ class DiagramToolbar extends Widget {
             }
         };
     }
-    _createItemOptions({ widget, items, valueExpr, displayExpr, showText, hint }) {
+    _createItemOptions({ widget, items, valueExpr, displayExpr, showText, hint, icon }) {
         if(widget === "dxSelectBox") {
-            const isSelectButton = items.every(i => i.icon !== undefined);
-            let options = {
-                options: {
-                    stylingMode: "filled",
-                    items,
-                    hint: hint,
-                    valueExpr,
-                    displayExpr
-                }
-            };
-            if(isSelectButton) {
-                options = extend(true, options, {
-                    options: {
-                        fieldTemplate: (data, container) => {
-                            $("<i>")
-                                .addClass(data && data.icon)
-                                .appendTo(container);
-                            $("<div>").dxTextBox({
-                                readOnly: true,
-                                stylingMode: "outlined"
-                            }).appendTo(container);
-                        },
-                        itemTemplate: (data) => {
-                            return `<i class="${data.icon}"${data.hint && ` title="${data.hint}`}"}></i>`;
-                        }
-                    }
-                });
-            }
-            return options;
+            return this._createSelectBoxItemOptions(hint, items, valueExpr, displayExpr);
         } else if(widget === "dxColorBox") {
-            return {
-                options: {
-                    stylingMode: "filled"
-                }
-            };
+            return this._createColorBoxItemOptions(hint, icon);
         } else if(!widget || widget === "dxButton") {
             return {
                 showText: showText || "inMenu"
             };
         }
+    }
+    _createSelectBoxItemOptions(hint, items, valueExpr, displayExpr) {
+        let options = this._createSelectBoxBaseItemOptions(hint);
+        options = extend(true, options, {
+            options: {
+                items,
+                valueExpr,
+                displayExpr
+            }
+        });
+        const isSelectButton = items.every(i => i.icon !== undefined);
+        if(isSelectButton) {
+            options = extend(true, options, {
+                options: {
+                    fieldTemplate: (data, container) => {
+                        $("<i>")
+                            .addClass(data && data.icon)
+                            .appendTo(container);
+                        $("<div>").dxTextBox({
+                            readOnly: true,
+                            stylingMode: "outlined"
+                        }).appendTo(container);
+                    },
+                    itemTemplate: (data) => {
+                        return `<i class="${data.icon}"${data.hint && ` title="${data.hint}`}"}></i>`;
+                    }
+                }
+            });
+        }
+        return options;
+    }
+    _createColorBoxItemOptions(hint, icon) {
+        let options = this._createSelectBoxBaseItemOptions(hint);
+        if(icon) {
+            options = extend(true, options, {
+                options: {
+                    openOnFieldClick: true,
+                    fieldTemplate: (data, container) => {
+                        $("<i>")
+                            .addClass(icon)
+                            .css("borderBottomColor", data)
+                            .appendTo(container);
+                        $("<div>").dxTextBox({
+                            readOnly: true,
+                            stylingMode: "outlined"
+                        }).appendTo(container);
+                    }
+                }
+            });
+        }
+        return options;
+    }
+    _createSelectBoxBaseItemOptions(hint) {
+        return {
+            options: {
+                stylingMode: "filled",
+                hint: hint,
+            }
+        };
     }
     _createItemActionOptions(item, handler) {
         switch(item.widget) {

--- a/styles/widgets/base/diagram.less
+++ b/styles/widgets/base/diagram.less
@@ -22,6 +22,10 @@
     .dx-diagram-i-connector-straight {
         .diagram-icon-colored(data-uri('image/svg+xml;charset=UTF-8', 'images/widgets/common/diagram/connector-straight.svg'), @new-color, 32px, 22px);
     }
+
+    .dx-diagram-i-button-fill {
+        .diagram-icon-colored(data-uri('image/svg+xml;charset=UTF-8', 'images/widgets/common/diagram/button-fill.svg'), @new-color, 18px, 18px);
+    }
 }
 
 .diagram-icon-colored(@data-uri, @current-color, @width, @height) {

--- a/styles/widgets/common/diagram.less
+++ b/styles/widgets/common/diagram.less
@@ -54,7 +54,7 @@
     }
 
     .dx-diagram-toolbar {
-        .dx-diagram-select-b {
+        .dx-diagram-select-b, .dx-diagram-color-b {
             .dx-texteditor {
                 width: auto;
             }

--- a/styles/widgets/generic/diagram.generic.less
+++ b/styles/widgets/generic/diagram.generic.less
@@ -68,12 +68,21 @@
         width: 90px;
     }
 
-    .dx-diagram-select-b {
+    .dx-diagram-select-b, .dx-diagram-color-b {
         .dx-dropdowneditor-field-template-wrapper {
-            .dx-diagram-i {
+            .dx-diagram-i, .dx-icon {
                 margin-left: 8px;
                 margin-right: 7px;
             }
+            .dx-icon {
+                font-size: 18px;
+            }
+        }
+    }
+    .dx-diagram-color-b .dx-dropdowneditor-field-template-wrapper {
+        .dx-diagram-i, .dx-icon {
+            border-bottom-width: 3px;
+            border-bottom-style: solid;
         }
     }
 }

--- a/styles/widgets/material/diagram.material.less
+++ b/styles/widgets/material/diagram.material.less
@@ -89,12 +89,21 @@
         width: 110px;
     }
 
-    .dx-diagram-select-b {
+    .dx-diagram-select-b, .dx-diagram-color-b {
         .dx-dropdowneditor-field-template-wrapper {
-            .dx-diagram-i {
+            .dx-diagram-i, .dx-icon {
                 margin-left: 12px;
                 margin-right: 12px;
             }
+            .dx-icon {
+                font-size: 18px;
+            }
+        }
+    }
+    .dx-diagram-color-b .dx-dropdowneditor-field-template-wrapper {
+        .dx-diagram-i, .dx-icon {
+            border-bottom-width: 3px;
+            border-bottom-style: solid;
         }
     }
 }

--- a/testing/tests/DevExpress.ui.widgets/diagram.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/diagram.tests.js
@@ -23,6 +23,10 @@ const moduleConfig = {
     }
 };
 
+function getToolbarIcon(button) {
+    return button.find(".dx-dropdowneditor-field-template-wrapper").find(".dx-diagram-i, .dx-icon");
+}
+
 QUnit.module("Diagram Toolbar", moduleConfig, () => {
     test("should fill toolbar with default items", (assert) => {
         let toolbar = this.$element.find(TOOLBAR_SELECTOR).dxToolbar("instance");
@@ -68,16 +72,21 @@ QUnit.module("Diagram Toolbar", moduleConfig, () => {
     });
     test("colorbuttons should show an active color", (assert) => {
         const colorButton = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-color-b").first();
-        const getIcon = () => colorButton.find(".dx-dropdowneditor-field-template-wrapper").find(".dx-diagram-i, .dx-icon");
-        assert.equal(getIcon().css("borderBottomColor"), "rgb(0, 0, 0)");
+        assert.equal(getToolbarIcon(colorButton).css("borderBottomColor"), "rgb(0, 0, 0)");
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.FontColor).execute("rgb(255, 0, 0)");
-        assert.equal(getIcon().css("borderBottomColor"), "rgb(255, 0, 0)", "button changed via command");
+        assert.equal(getToolbarIcon(colorButton).css("borderBottomColor"), "rgb(255, 0, 0)", "button changed via command");
         colorButton.find(".dx-dropdowneditor-button").trigger("dxclick");
         const $overlayContent = $(".dx-colorbox-overlay");
         $overlayContent.find(".dx-colorview-label-hex").find(".dx-textbox").dxTextBox("instance").option("value", "00ff00");
         $overlayContent.find(".dx-colorview-buttons-container .dx-colorview-apply-button").trigger("dxclick");
         assert.equal(this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.FontColor).getState().value, "#00ff00", "color changed by color button");
-        assert.equal(getIcon().css("borderBottomColor"), "rgb(0, 255, 0)", "button changed via coloredit");
+        assert.equal(getToolbarIcon(colorButton).css("borderBottomColor"), "rgb(0, 255, 0)", "button changed via coloredit");
+    });
+    test("colorbutton should show dropdown on icon click", (assert) => {
+        const colorButton = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-color-b").first();
+        const colorBox = colorButton.find(".dx-colorbox").dxColorBox("instance");
+        getToolbarIcon(colorButton).trigger("dxclick");
+        assert.ok(colorBox.option("opened"), true);
     });
 });
 QUnit.module("Context Menu", moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets/diagram.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/diagram.tests.js
@@ -54,10 +54,30 @@ QUnit.module("Diagram Toolbar", moduleConfig, () => {
     });
     test("selectboxes with icon items should be replaced with select buttons", (assert) => {
         const $selectButtonTemplates = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-select-b").find(".dx-dropdowneditor-field-template-wrapper");
-        assert.ok($selectButtonTemplates.length > 0);
+        assert.ok($selectButtonTemplates.length > 0, "select buttons are rendered");
         const selectButtonsCount = $selectButtonTemplates.length;
         assert.equal($selectButtonTemplates.find(".dx-diagram-i").length, selectButtonsCount, "icons are rendered");
         assert.equal($selectButtonTemplates.find(".dx-textbox")[0].offsetWidth, 0, "textbox is hidden");
+    });
+    test("colorboxes should be replaced with color buttons", (assert) => {
+        const $selectButtonTemplates = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-color-b").find(".dx-dropdowneditor-field-template-wrapper");
+        assert.ok($selectButtonTemplates.length > 0, "color buttons are rendered");
+        const selectButtonsCount = $selectButtonTemplates.length;
+        assert.equal($selectButtonTemplates.find(".dx-diagram-i, .dx-icon").length, selectButtonsCount, "icons are rendered");
+        assert.equal($selectButtonTemplates.find(".dx-textbox")[0].offsetWidth, 0, "textbox is hidden");
+    });
+    test("colorbuttons should show an active color", (assert) => {
+        const colorButton = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-color-b").first();
+        const getIcon = () => colorButton.find(".dx-dropdowneditor-field-template-wrapper").find(".dx-diagram-i, .dx-icon");
+        assert.equal(getIcon().css("borderBottomColor"), "rgb(0, 0, 0)");
+        this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.FontColor).execute("rgb(255, 0, 0)");
+        assert.equal(getIcon().css("borderBottomColor"), "rgb(255, 0, 0)", "button changed via command");
+        colorButton.find(".dx-dropdowneditor-button").trigger("dxclick");
+        const $overlayContent = $(".dx-colorbox-overlay");
+        $overlayContent.find(".dx-colorview-label-hex").find(".dx-textbox").dxTextBox("instance").option("value", "00ff00");
+        $overlayContent.find(".dx-colorview-buttons-container .dx-colorview-apply-button").trigger("dxclick");
+        assert.equal(this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.FontColor).getState().value, "#00ff00", "color changed by color button");
+        assert.equal(getIcon().css("borderBottomColor"), "rgb(0, 255, 0)", "button changed via coloredit");
     });
 });
 QUnit.module("Context Menu", moduleConfig, () => {


### PR DESCRIPTION
It replaces colorboxes with dropdown buttons with a color indicator in the diagram widget's toolbar