### PR TITLE
dxDateBox - control shouldn't changes PM to AM when increment hours (T721723)

### DIFF
--- a/js/ui/date_box/ui.time_view.js
+++ b/js/ui/date_box/ui.time_view.js
@@ -177,17 +177,27 @@ var TimeView = Editor.inherit({
             min: -1,
             max: 24,
             value: this._getValue().getHours(),
-            onValueChanged: (function(args) {
-                var hours = this._convertMaxHourToMin(args.value),
-                    time = new Date(this._getValue());
-
-                time.setHours(hours);
-                uiDateUtils.normalizeTime(time);
-                this.option("value", time);
-            }).bind(this)
+            onValueChanged: this._onHourBoxValueChanged.bind(this),
         }, this._getNumberBoxConfig()));
 
         this._hourBox.setAria("label", "hours");
+    },
+
+    _onHourBoxValueChanged: function(args) {
+        var currentValue = this._getValue(),
+            newHours = this._convertMaxHourToMin(this._getCalculatedHours(currentValue.getHours(), args.previousValue, args.value)),
+            newValue = new Date(currentValue);
+
+        newValue.setHours(newHours);
+        uiDateUtils.normalizeTime(newValue);
+        this.option("value", newValue);
+    },
+
+    _getCalculatedHours: function(currentHours, prevHours, newHours) {
+        if(Math.abs(prevHours - newHours) === 1) {
+            return currentHours + (newHours - prevHours);
+        }
+        return newHours;
     },
 
     _convertMaxHourToMin: function(hours) {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -4386,10 +4386,14 @@ QUnit.module("DateBox number and string value support", {
             pickerType: "calendar"
         });
 
-        const instance = $dateBox.dxDateBox("instance");
-        instance.open();
+        const dateBox = $dateBox.dxDateBox("instance");
 
+        dateBox.open();
         const formatSelectBox = $(".dx-timeview-format12").dxSelectBox("instance");
+        const $hourDown = $(dateBox.content()).parent().find(".dx-numberbox-spin-down").eq(0);
+        const $hourUp = $(dateBox.content()).parent().find(".dx-numberbox-spin-up").eq(0);
+        const $hoursInput = $(".dx-numberbox").eq(0).find("." + TEXTEDITOR_INPUT_CLASS);
+
         assert.equal(formatSelectBox.option("value"), TIMEVIEW_FORMAT12_PM, "correct value on init");
 
         formatSelectBox.option("value", TIMEVIEW_FORMAT12_AM);
@@ -4397,6 +4401,21 @@ QUnit.module("DateBox number and string value support", {
             .find(".dx-button.dx-popup-done")
             .trigger("dxclick");
 
-        assert.equal(instance.option("value").valueOf(), (new Date(2018, 6, 6, 4)).valueOf(), "DateBox value is formatted");
+        assert.equal(dateBox.option("value").valueOf(), (new Date(2018, 6, 6, 4)).valueOf(), "DateBox value is formatted");
+
+        dateBox.option("value", new Date(2018, 6, 6, 16));
+        dateBox.open();
+
+        $hourDown.trigger("dxpointerdown");
+        assert.ok(formatSelectBox.option("value") === TIMEVIEW_FORMAT12_PM, "date format should be PM after decrement hours");
+
+        $hourUp.trigger("dxpointerdown");
+        assert.ok(formatSelectBox.option("value") === TIMEVIEW_FORMAT12_PM, "date format should be PM after increment hours");
+
+        $hoursInput.val(9).trigger("change");
+        assert.ok(formatSelectBox.option("value") === TIMEVIEW_FORMAT12_AM, "date format should be AM after change value to 9");
+
+        $hoursInput.val(16).trigger("change");
+        assert.ok(formatSelectBox.option("value") === TIMEVIEW_FORMAT12_PM, "date format should be PM after change value to 16");
     });
 });


### PR DESCRIPTION
…T721723) (#8291)

* fix PM to AM when hour is changed

* Refactoring ui.time_view.js.
Add test for this bug.

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
