### PR TITLE
Use ES5 in object tests

### DIFF
--- a/testing/tests/DevExpress.core/utils.object.tests.js
+++ b/testing/tests/DevExpress.core/utils.object.tests.js
@@ -180,6 +180,6 @@ QUnit.test("deepExtendArraySafe utility does not throw an error with 'null' deep
 });
 
 QUnit.test("deepExtendArraySafe utility does not pollute object prototype", function(assert) {
-    objectUtils.deepExtendArraySafe({ }, JSON.parse(`{ "__proto__": { "pollution": true }}`), true);
+    objectUtils.deepExtendArraySafe({ }, JSON.parse("{ \"__proto__\": { \"pollution\": true }}"), true);
     assert.ok(!("pollution" in { }), "object prototype is not polluted");
 });


### PR DESCRIPTION
Fixes object test in IE after #8322:
![image](https://user-images.githubusercontent.com/1420883/59179488-d225d600-8b6a-11e9-9853-5acef798859c.png)
