### PR TITLE
Change default for contentTemplate of the dxDropDownBox

### DIFF
--- a/js/ui/drop_down_box.js
+++ b/js/ui/drop_down_box.js
@@ -71,14 +71,14 @@ var DropDownBox = DropDownEditor.inherit({
             /**
              * @name dxDropDownBoxOptions.contentTemplate
              * @type template|function
-             * @default null
+             * @default 'content'
              * @type_function_param1 templateData:object
              * @type_function_param1_field1 component:dxDropDownBox
              * @type_function_param1_field2 value:any
              * @type_function_param2 contentElement:dxElement
              * @type_function_return string|Node|jQuery
              */
-            contentTemplate: null,
+            contentTemplate: "content",
 
             /**
              * @name dxDropDownBoxOptions.dropDownOptions
@@ -263,6 +263,14 @@ var DropDownBox = DropDownEditor.inherit({
                 context: this
             }));
         }
+    },
+
+    _renderPopupContent: function() {
+        if(this.option("contentTemplate") === ANONYMOUS_TEMPLATE_NAME) {
+            return;
+        }
+
+        return this.callBase();
     },
 
     _popupConfig: function() {

--- a/testing/tests/DevExpress.ui.widgets/popup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/popup.tests.js
@@ -1123,6 +1123,7 @@ QUnit.module("rendering", {
 });
 
 QUnit.test("anonymous content template rendering", function(assert) {
+    var $inner = $("#popupWithAnonymousTmpl .testContent");
     var $popup = $("#popupWithAnonymousTmpl").dxPopup({
         visible: true
     });
@@ -1130,6 +1131,7 @@ QUnit.test("anonymous content template rendering", function(assert) {
     var $content = $popup.dxPopup("$content");
 
     assert.equal($.trim($content.text()), "TestContent", "content rendered");
+    assert.equal($content.find(".testContent").get(0), $inner[0], "content should not lost the link");
 });
 
 QUnit.test("custom content template is applied even if there is 'content' template in popup", function(assert) {

--- a/testing/tests/DevExpress.ui/defaultOptions.tests.js
+++ b/testing/tests/DevExpress.ui/defaultOptions.tests.js
@@ -307,6 +307,7 @@ testComponentDefaults(DropDownBox,
     {
         openOnFieldClick: true,
         acceptCustomValue: false,
+        contentTemplate: "content",
         valueChangeEvent: "change"
     }
 );


### PR DESCRIPTION
This change is required for Angular approach. When contentTemplate is null, the data is not available inside of template