### PR TITLE
Stylelint: Ignore all files except *.css and *.less

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,6 +1,6 @@
 {
     "extends": "stylelint-config-standard",
-    "ignoreFiles": "**/*.json",
+    "ignoreFiles": "!**/*.{css,less}",
     "rules": {
         "indentation": [4, { ignore: ["inside-parens"] }],
         "max-empty-lines": 2,


### PR DESCRIPTION
To avoid linting unnecessary files in the stylelint plugin for VS Code:
![image](https://user-images.githubusercontent.com/1420883/60022215-0b4a6400-969c-11e9-97c8-b19e4dc7d0d8.png)
