### PR TITLE
Scheduler: Changing drop target calculation when dragging appointment

### DIFF
--- a/js/events/drag.js
+++ b/js/events/drag.js
@@ -269,25 +269,20 @@ var DragEmitter = GestureEmitter.inherit({
         if(isDraggingElement) {
             return false;
         }
-
-        var draggingElementPosition = getItemPosition(config, this._$element);
         var targetPosition = getItemPosition(config, $target);
-
-        if(draggingElementPosition.left < targetPosition.left) {
+        if(e.pageX < targetPosition.left) {
             return false;
         }
-        if(draggingElementPosition.top < targetPosition.top) {
+        if(e.pageY < targetPosition.top) {
             return false;
         }
-
         var targetSize = getItemSize(config, $target);
-        if(draggingElementPosition.left > targetPosition.left + targetSize.width) {
+        if(e.pageX > targetPosition.left + targetSize.width) {
             return false;
         }
-        if(draggingElementPosition.top > targetPosition.top + targetSize.height) {
+        if(e.pageY > targetPosition.top + targetSize.height) {
             return false;
         }
-
         return $target;
     },
 

--- a/js/events/drag.js
+++ b/js/events/drag.js
@@ -270,19 +270,21 @@ var DragEmitter = GestureEmitter.inherit({
             return false;
         }
 
+        var draggingElementPosition = getItemPosition(config, this._$element);
         var targetPosition = getItemPosition(config, $target);
-        if(e.pageX < targetPosition.left) {
+        
+        if(draggingElementPosition.left < targetPosition.left) {
             return false;
         }
-        if(e.pageY < targetPosition.top) {
+        if(draggingElementPosition.top < targetPosition.top) {
             return false;
         }
 
         var targetSize = getItemSize(config, $target);
-        if(e.pageX > targetPosition.left + targetSize.width) {
+        if(draggingElementPosition.left > targetPosition.left + targetSize.width) {
             return false;
         }
-        if(e.pageY > targetPosition.top + targetSize.height) {
+        if(draggingElementPosition.top > targetPosition.top + targetSize.height) {
             return false;
         }
 

--- a/js/events/drag.js
+++ b/js/events/drag.js
@@ -269,7 +269,7 @@ var DragEmitter = GestureEmitter.inherit({
         if(isDraggingElement) {
             return false;
         }
-        
+
         var targetPosition = getItemPosition(config, $target);
         if(e.pageX < targetPosition.left) {
             return false;
@@ -277,7 +277,7 @@ var DragEmitter = GestureEmitter.inherit({
         if(e.pageY < targetPosition.top) {
             return false;
         }
-        
+
         var targetSize = getItemSize(config, $target);
         if(e.pageX > targetPosition.left + targetSize.width) {
             return false;
@@ -285,7 +285,7 @@ var DragEmitter = GestureEmitter.inherit({
         if(e.pageY > targetPosition.top + targetSize.height) {
             return false;
         }
-        
+
         return $target;
     },
 

--- a/js/events/drag.js
+++ b/js/events/drag.js
@@ -272,7 +272,7 @@ var DragEmitter = GestureEmitter.inherit({
 
         var draggingElementPosition = getItemPosition(config, this._$element);
         var targetPosition = getItemPosition(config, $target);
-        
+
         if(draggingElementPosition.left < targetPosition.left) {
             return false;
         }

--- a/js/events/drag.js
+++ b/js/events/drag.js
@@ -269,6 +269,7 @@ var DragEmitter = GestureEmitter.inherit({
         if(isDraggingElement) {
             return false;
         }
+        
         var targetPosition = getItemPosition(config, $target);
         if(e.pageX < targetPosition.left) {
             return false;
@@ -276,6 +277,7 @@ var DragEmitter = GestureEmitter.inherit({
         if(e.pageY < targetPosition.top) {
             return false;
         }
+        
         var targetSize = getItemSize(config, $target);
         if(e.pageX > targetPosition.left + targetSize.width) {
             return false;
@@ -283,6 +285,7 @@ var DragEmitter = GestureEmitter.inherit({
         if(e.pageY > targetPosition.top + targetSize.height) {
             return false;
         }
+        
         return $target;
     },
 

--- a/js/ui/scheduler/ui.scheduler.appointments.js
+++ b/js/ui/scheduler/ui.scheduler.appointments.js
@@ -790,6 +790,11 @@ var SchedulerAppointments = CollectionWidget.inherit({
                 });
 
                 translator.move($appointment, coordinates);
+            },
+            adjustDropPosition = function(event, $element) {
+                var offset = $element.offset();
+                event.pageX = offset.left;
+                event.pageY = offset.top;
             };
         this.notifyObserver("getDraggableAppointmentArea", {
             callback: function(result) {
@@ -818,6 +823,7 @@ var SchedulerAppointments = CollectionWidget.inherit({
             },
             onDrag: function(args) {
                 correctCoordinates(args.element);
+                adjustDropPosition(args.event, args.element);
             },
             onDragEnd: function(args) {
                 correctCoordinates(args.element, true);

--- a/js/ui/scheduler/ui.scheduler.appointments.js
+++ b/js/ui/scheduler/ui.scheduler.appointments.js
@@ -791,8 +791,8 @@ var SchedulerAppointments = CollectionWidget.inherit({
 
                 translator.move($appointment, coordinates);
             },
-            adjustDropPosition = function(event, $element) {
-                var offset = $element.offset();
+            adjustDropPosition = function(event, element) {
+                var offset = $(element).offset();
                 event.pageX = offset.left;
                 event.pageY = offset.top;
             };

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointments.tests.js
@@ -543,7 +543,7 @@ QUnit.test("Allday appointment should stay in allDayContainer after small draggi
     var $appointment = $("#allDayContainer .dx-scheduler-appointment"),
         pointer = pointerMock($appointment).start();
 
-    pointer.dragStart().drag(0, -30);
+    pointer.dragStart().drag(0, 30);
     pointer.dragEnd();
 
     assert.equal($("#allDayContainer .dx-scheduler-appointment").length, 1, "appointment is in allDayContainer");


### PR DESCRIPTION
The issue derived from support ticket https://www.devexpress.com/Support/Center/Question/Details/T728235/when-dragging-events-in-timelinemonth-boxes-shifts

Problem
In current implementation, when dragging events in scheduler, dropping point is always under mouse cursor. With small draggable items it is sufficient to drop under cursor, but when event box is wide, drop area under mouse cursor becomes unintuitive.

To reproduce
See demo https://codepen.io/anon/pen/RdXqJv
When grabbing a multi-day event (3 days or more) in scheduler month view grab the bottom-right corner. 
Slightly move the mouse (mouse may stay in the same cell area) and release it. Notice that events start day is shifted by events initial duration. What user would expect is that accidental minor drag would not change the event and drop it to the same date cell. 

Fix
The fix changes calculation of dropping point for scheduler event boxes. Instead of dropping box under the mouse cursor, the item is dropped under its top-left edge position. This is way more intuitive for the users.

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
