### PR TITLE
Fix form's data when it has the empty object and it's changed via API (T740853)

### DIFF
--- a/js/ui/form/ui.form.layout_manager.js
+++ b/js/ui/form/ui.form.layout_manager.js
@@ -758,7 +758,7 @@ var LayoutManager = Widget.inherit({
 
     _renderEditor: function(options) {
         var dataValue = this._getDataByField(options.dataField),
-            defaultEditorOptions = { value: dataValue },
+            defaultEditorOptions = dataValue !== undefined ? { value: dataValue } : {},
             isDeepExtend = true,
             editorOptions;
 

--- a/js/ui/scheduler/ui.scheduler.appointment_form.js
+++ b/js/ui/scheduler/ui.scheduler.appointment_form.js
@@ -120,7 +120,7 @@ var SchedulerAppointmentForm = {
                             endDateEditor = that._appointmentForm.getEditor(dataExprs.endDateExpr),
                             endValue = dateSerialization.deserializeDate(endDateEditor.option("value"));
 
-                        if(endValue < value) {
+                        if(typeUtils.isDefined(endValue) && typeUtils.isDefined(value) && endValue < value) {
                             var duration = endValue.getTime() - previousValue.getTime();
                             endDateEditor.option("value", new Date(value.getTime() + duration));
                         }

--- a/testing/tests/DevExpress.ui.widgets.form/form.API.option_formData.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.API.option_formData.tests.js
@@ -37,22 +37,21 @@ QUnit.test("Set { formData: null, items: [dataField1] }, call option(formData, {
 QUnit.test("Set { formData: null, items: [dataField1] }, call option(formData, null)", function(assert) {
     var form = $("#form").dxForm({ formData: null, items: ["dataField1"] }).dxForm("instance");
     form.option("formData", null);
-    assert.propEqual(form.option("formData"), { dataField1: "" });
+    assert.propEqual(form.option("formData"), {});
     assert.equal(form.getEditor("dataField1").option("value"), "");
 });
 
 QUnit.test("Set { formData: {}, items: [dataField1] }, call option(formData, null)", function(assert) {
     var form = $("#form").dxForm({ formData: {}, items: ["dataField1"] }).dxForm("instance");
     form.option("formData", null);
-    assert.propEqual(form.option("formData"), { dataField1: "" });
+    assert.propEqual(form.option("formData"), {});
     assert.equal(form.getEditor("dataField1").option("value"), "");
 });
 
 QUnit.test("Set { formData: {}, items: [dataField1] }, call option(formData, {})", function(assert) {
     var form = $("#form").dxForm({ formData: {}, items: ["dataField1"] }).dxForm("instance");
-    var formData = {};
-    form.option("formData", formData);
-    assert.equal(form.option("formData"), formData);
+    form.option("formData", {});
+    assert.propEqual(form.option("formData"), {});
     assert.equal(form.getEditor("dataField1").option("value"), "");
 });
 

--- a/testing/tests/DevExpress.ui.widgets.form/form.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.tests.js
@@ -254,7 +254,7 @@ QUnit.test("Reset editor's value when the formData option is empty object", func
     assert.equal(form.getEditor("room").option("value"), null, "editor for the room dataField");
 
     assert.deepEqual(values[0], { dataField: "name", value: "" }, "value of name dataField");
-    assert.deepEqual(values[3], { dataField: "room", value: null }, "value of room dataField");
+    assert.deepEqual(values[1], { dataField: "room", value: null }, "value of room dataField");
 });
 
 QUnit.test("Reset editor's value when the formData option is null", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.form/form.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.tests.js
@@ -255,6 +255,13 @@ QUnit.test("Reset editor's value when the formData option is empty object", func
 
     assert.deepEqual(values[0], { dataField: "name", value: "" }, "value of name dataField");
     assert.deepEqual(values[1], { dataField: "room", value: null }, "value of room dataField");
+
+    values = [];
+    form.option("formData", {});
+
+    assert.equal(form.getEditor("name").option("value"), "", "editor for the name dataField");
+    assert.equal(form.getEditor("room").option("value"), null, "editor for the room dataField");
+    assert.equal(values.length, 0, "onFieldDataChanged event is not called if the empty object is set to formData a second time");
 });
 
 QUnit.test("Reset editor's value when the formData option is null", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
@@ -1768,7 +1768,7 @@ QUnit.module("Layout manager", () => {
         selectBox = $testContainer.find(".dx-selectbox").first().dxSelectBox("instance");
 
         // assert
-        assert.deepEqual(selectBox.option("value"), undefined);
+        assert.deepEqual(selectBox.option("value"), null);
     });
 
     test("Update value in dxSelectBox editor when data option is changed", (assert) => {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointmentPopup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointmentPopup.tests.js
@@ -582,15 +582,15 @@ QUnit.test("allDay changing should switch only type in editors, if startDate is 
 
     assert.equal(startDate.option("type"), "datetime", "type is right");
     assert.equal(endDate.option("type"), "datetime", "type is right");
-    assert.deepEqual(startDate.option("value"), undefined, "value is right");
-    assert.deepEqual(endDate.option("value"), undefined, "value is right");
+    assert.deepEqual(startDate.option("value"), null, "value is right");
+    assert.deepEqual(endDate.option("value"), null, "value is right");
 
     allDayEditor.option("value", true);
 
     assert.equal(startDate.option("type"), "date", "type is right after turning off allDay");
     assert.equal(endDate.option("type"), "date", "type is right after turning off allDay");
-    assert.deepEqual(startDate.option("value"), undefined, "startdate is OK");
-    assert.deepEqual(endDate.option("value"), undefined, "enddate is OK");
+    assert.deepEqual(startDate.option("value"), null, "startdate is OK");
+    assert.deepEqual(endDate.option("value"), null, "enddate is OK");
 });
 
 QUnit.test("There are no exceptions when select date on the appointment popup, startDate > endDate", function(assert) {


### PR DESCRIPTION
There is the following Form's configuration:
```
const form = $("#popup").dxForm({
                formData: {},
                items: [{
                    dataField: "ID",  
                }]
            }).dxForm('instance');
```
If for the Form set the empty object `form.option('formData',  {});` then the Form widget  changes the privious `formData ` to `{ ID: "" }`. But the "ID" data field is not changed via UI.
This behavior adduces to thrown the value changed event for the Angular framework.