### PR TITLE
DataGrid: Fix the "Cannot read property 'off' of undefined" error when disposing of the shared dataSource (T752955)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -114,7 +114,8 @@ module.exports = gridCore.Controller.inherit((function() {
         },
         dispose: function(isSharedDataSource) {
             var that = this,
-                dataSource = that._dataSource;
+                dataSource = that._dataSource,
+                store = dataSource.store();
 
             dataSource.off("changed", that._dataChangedHandler);
             dataSource.off("customizeStoreLoadOptions", that._dataLoadingHandler);
@@ -122,7 +123,8 @@ module.exports = gridCore.Controller.inherit((function() {
             dataSource.off("loadingChanged", that._loadingChangedHandler);
             dataSource.off("loadError", that._loadErrorHandler);
             dataSource.off("changing", that._changingHandler);
-            dataSource.store().off("push", that._pushHandler);
+            store && store.off("push", that._pushHandler);
+
             if(!isSharedDataSource) {
                 dataSource.dispose();
             }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -12898,6 +12898,28 @@ QUnit.test("assign loaded dataSource", function(assert) {
     assert.equal(this.dataController.pageCount(), 2, "page count");
 });
 
+// T752955
+QUnit.test("There are no exceptions when disposing of the shared dataSource", function(assert) {
+    // arrange
+    this.setupDataGridModules({
+        dataSource: this.dataSource
+    });
+
+    this.clock.tick();
+
+    try {
+        // act
+        this.dataSource.dispose();
+        this.dataController.dataSource().dispose(true);
+
+        // assert
+        assert.ok(true, "No exception");
+    } catch(e) {
+        // assert
+        assert.ok(false, "exception");
+    }
+});
+
 QUnit.module("Exporting", {
     beforeEach: function() {
         this.array = [


### PR DESCRIPTION
See https://devexpress.com/issue=T752955