### PR TITLE
dxScheduler - appointment should has correct width in chrome based browser (T712431)

### DIFF
--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
@@ -2198,7 +2198,6 @@ var SchedulerWorkSpace = Widget.inherit({
 
     getCellWidth: function() {
         var cell = this._getCells().first().get(0);
-
         return cell && cell.getBoundingClientRect().width;
     },
 

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space_month.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space_month.js
@@ -74,6 +74,19 @@ var SchedulerWorkSpaceMonth = SchedulerWorkSpace.inherit({
         return date;
     },
 
+    // TODO: temporary fix, in the future, if we replace table layout on div layout, getCellWidth method need remove. Details in T712431
+    // TODO: there is a test for this bug, when changing the layout, the test will also be useless
+    getCellWidth: function() {
+        const cells = this._getCells();
+        const firstCell = cells.eq(0).get(0);
+        const secondCell = cells.eq(1).get(0);
+
+        const firstCellWidth = firstCell && firstCell.getBoundingClientRect().width || 0;
+        const secondCellWidth = secondCell && secondCell.getBoundingClientRect().width || 0;
+
+        return (firstCellWidth + secondCellWidth) / 2;
+    },
+
     _calculateHiddenInterval: function() {
         return 0;
     },

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.adaptivity.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.adaptivity.tests.js
@@ -1,6 +1,6 @@
 import $ from "jquery";
 import fx from "animation/fx";
-import { SchedulerTestWrapper, TOOLBAR_TOP_LOCATION, TOOLBAR_BOTTOM_LOCATION } from "./helpers.js";
+import { SchedulerTestWrapper, initTestMarkup, TOOLBAR_TOP_LOCATION, TOOLBAR_BOTTOM_LOCATION } from "./helpers.js";
 import { getSimpleDataArray } from './data.js';
 import resizeCallbacks from "core/utils/resize_callbacks";
 import devices from "core/devices";
@@ -12,13 +12,7 @@ import "ui/scheduler/ui.scheduler";
 
 const { testStart, test, module } = QUnit;
 
-testStart(() => {
-    $("#qunit-fixture").html(
-        `<div id="scheduler">
-            <div data-options="dxTemplate: { name: 'template' }">Task Template</div>
-        </div>`
-    );
-});
+testStart(() => initTestMarkup());
 
 const createInstance = function(options) {
     const defaultOption = {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
@@ -16,19 +16,14 @@ import { DataSource } from "data/data_source/data_source";
 import CustomStore from "data/custom_store";
 import dataUtils from "core/element_data";
 import dateSerialization from "core/utils/date_serialization";
-import { SchedulerTestWrapper } from "./helpers.js";
+import { SchedulerTestWrapper, initTestMarkup, createWrapper } from "./helpers.js";
 
 import "ui/scheduler/ui.scheduler";
 import "ui/switch";
 import "common.css!";
 import "generic_light.css!";
 
-QUnit.testStart(function() {
-    $("#qunit-fixture").html(
-        '<div id="scheduler">\
-            <div data-options="dxTemplate: { name: \'template\' }">Task Template</div>\
-            </div>');
-});
+QUnit.testStart(() => initTestMarkup());
 
 var DATE_TABLE_CELL_CLASS = "dx-scheduler-date-table-cell",
     APPOINTMENT_CLASS = "dx-scheduler-appointment";
@@ -56,6 +51,35 @@ function skipTestOnMobile(assert) {
     }
     return isMobile;
 }
+
+
+QUnit.module("T712431", () => {
+    // TODO: there is a test for T712431 bug, when replace table layout on div layout, the test will also be useless
+    const MIN_APPOINTMENT_WIDTH = 936;
+
+    QUnit.test(`Appointment width should be not less ${MIN_APPOINTMENT_WIDTH}px with width control 1100px`, function(assert) {
+        const data = [
+            {
+                text: "Website Re-Design Plan 2",
+                startDate: new Date(2017, 4, 7, 9, 30),
+                endDate: new Date(2017, 4, 12, 17, 20)
+            }
+        ];
+
+        const scheduler = createWrapper({
+            dataSource: data,
+            views: ["month"],
+            currentView: "month",
+            currentDate: new Date(2017, 4, 25),
+            startDayHour: 9,
+            width: 1100,
+            height: 600
+        });
+
+        const appointment = scheduler.appointments.getAppointment();
+        assert.ok(appointment.outerWidth() > MIN_APPOINTMENT_WIDTH);
+    });
+});
 
 QUnit.module("Integration: Appointments", {
     beforeEach: function() {


### PR DESCRIPTION
…owser (T712431) (#8652)

* Hypothesis testing

* Test hypotheses

* Add test.
Refactoring getCellWidth method

* Add comment to test

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
