### PR TITLE
dxScheduler - appointment should has correct width in chrome based browser, refix bug (T712431)

### DIFF
--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space_month.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space_month.js
@@ -77,14 +77,12 @@ var SchedulerWorkSpaceMonth = SchedulerWorkSpace.inherit({
     // TODO: temporary fix, in the future, if we replace table layout on div layout, getCellWidth method need remove. Details in T712431
     // TODO: there is a test for this bug, when changing the layout, the test will also be useless
     getCellWidth: function() {
-        const cells = this._getCells();
-        const firstCell = cells.eq(0).get(0);
-        const secondCell = cells.eq(1).get(0);
+        const DAYS_IN_WEEK = 7;
 
-        const firstCellWidth = firstCell && firstCell.getBoundingClientRect().width || 0;
-        const secondCellWidth = secondCell && secondCell.getBoundingClientRect().width || 0;
+        let averageWidth = 0;
+        this._getCells().slice(0, DAYS_IN_WEEK).each((index, element) => averageWidth += element.getBoundingClientRect().width);
 
-        return (firstCellWidth + secondCellWidth) / 2;
+        return averageWidth / DAYS_IN_WEEK;
     },
 
     _calculateHiddenInterval: function() {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.agenda.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.agenda.tests.js
@@ -1360,7 +1360,7 @@ QUnit.test("Long appointment should be rendered correctly after changing view", 
     $appointments = this.instance.$element().find(".dx-scheduler-appointment");
 
     assert.equal($appointments.length, 1, "appointment is OK");
-    assert.roughEqual($appointments.eq(0).outerWidth(), cellWidth * 4, 2.001, "appointment size is OK");
+    assert.roughEqual($appointments.eq(0).outerWidth(), cellWidth * 4, 2.5, "appointment size is OK");
 });
 
 QUnit.test("Timepanel rows count should be OK for long appointment", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
@@ -55,7 +55,7 @@ function skipTestOnMobile(assert) {
 
 QUnit.module("T712431", () => {
     // TODO: there is a test for T712431 bug, when replace table layout on div layout, the test will also be useless
-    const MIN_APPOINTMENT_WIDTH = 936;
+    const MIN_APPOINTMENT_WIDTH = 941;
 
     QUnit.test(`Appointment width should be not less ${MIN_APPOINTMENT_WIDTH}px with width control 1100px`, function(assert) {
         const data = [

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
@@ -55,9 +55,9 @@ function skipTestOnMobile(assert) {
 
 QUnit.module("T712431", () => {
     // TODO: there is a test for T712431 bug, when replace table layout on div layout, the test will also be useless
-    const MIN_APPOINTMENT_WIDTH = 941;
+    const APPOINTMENT_WIDTH = 941;
 
-    QUnit.test(`Appointment width should be not less ${MIN_APPOINTMENT_WIDTH}px with width control 1100px`, function(assert) {
+    QUnit.test(`Appointment width should be not less ${APPOINTMENT_WIDTH}px with width control 1100px`, function(assert) {
         const data = [
             {
                 text: "Website Re-Design Plan 2",
@@ -77,7 +77,7 @@ QUnit.module("T712431", () => {
         });
 
         const appointment = scheduler.appointments.getAppointment();
-        assert.ok(appointment.outerWidth() > MIN_APPOINTMENT_WIDTH);
+        assert.roughEqual(appointment.outerWidth(), APPOINTMENT_WIDTH, 1);
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/layoutManager.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/layoutManager.tests.js
@@ -667,11 +667,11 @@ QUnit.test("Two rival appointments should have correct positions", function(asse
 
     assert.equal(firstAppointmentPosition.left, 0, "appointment is rendered in right place");
     assert.roughEqual(firstAppointmentPosition.top, 26, 1.5, "appointment is rendered in right place");
-    assert.equal($appointment.eq(0).outerWidth(), $tableCell.outerWidth(), "appointment has a right size");
+    assert.roughEqual($appointment.eq(0).outerWidth(), $tableCell.outerWidth(), 0.6, "appointment has a right size");
 
     assert.equal(secondAppointmentPosition.left, 0, "appointment is rendered in right place");
     assert.roughEqual(secondAppointmentPosition.top, 46, 1.5, "appointment is rendered in right place");
-    assert.equal($appointment.eq(1).outerWidth(), $tableCell.outerWidth(), "appointment has a right size");
+    assert.roughEqual($appointment.eq(1).outerWidth(), $tableCell.outerWidth(), 0.6, "appointment has a right size");
 });
 
 QUnit.test("Collapsing appointments should have specific class", function(assert) {
@@ -720,11 +720,11 @@ QUnit.test("Four rival appointments should have correct positions", function(ass
 
     assert.equal(firstAppointmentPosition.left, 0, "appointment is rendered in right place");
     assert.roughEqual(firstAppointmentPosition.top, 26, 1.5, "appointment is rendered in right place");
-    assert.equal($appointment.eq(0).outerWidth(), $tableCell.outerWidth(), "appointment has a right size");
+    assert.roughEqual($appointment.eq(0).outerWidth(), $tableCell.outerWidth(), 0.6, "appointment has a right size");
 
     assert.equal(secondAppointmentPosition.left, 0, "appointment is rendered in right place");
     assert.roughEqual(secondAppointmentPosition.top, 46, 1.5, "appointment is rendered in right place");
-    assert.equal($appointment.eq(1).outerWidth(), $tableCell.outerWidth(), "appointment has a right size");
+    assert.roughEqual($appointment.eq(1).outerWidth(), $tableCell.outerWidth(), 0.6, "appointment has a right size");
 
     assert.roughEqual(thirdAppointmentPosition.left, 21, 1.5, "appointment is rendered in right place");
     assert.roughEqual(thirdAppointmentPosition.top, 3, 1.5, "appointment is rendered in right place");
@@ -758,7 +758,7 @@ QUnit.test("Rival duplicated appointments should have correct positions", functi
 
     assert.equal(firstAppointmentPosition.left, 0, "appointment is rendered in right place");
     assert.roughEqual(firstAppointmentPosition.top, 26, 1.5, "appointment is rendered in right place");
-    assert.equal($appointment.eq(0).outerWidth(), $tableCell.outerWidth(), "appointment has a right size");
+    assert.roughEqual($appointment.eq(0).outerWidth(), $tableCell.outerWidth(), 0.6, "appointment has a right size");
 
     assert.equal(secondAppointmentPosition.left, 0, "appointment is rendered in right place");
     assert.roughEqual(secondAppointmentPosition.top, 46, 1.5, "appointment is rendered in right place");


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
