### PR TITLE
dxScheduler - shouldn't hide after scroll in browser height is small (T755449)

### DIFF
--- a/js/ui/scheduler/tooltip_strategies/desktopTooltipStrategy.js
+++ b/js/ui/scheduler/tooltip_strategies/desktopTooltipStrategy.js
@@ -172,6 +172,12 @@ class TooltipManyAppointmentsBehavior extends TooltipBehaviorBase {
 }
 
 export class DesktopTooltipStrategy extends TooltipStrategyBase {
+
+    constructor(scheduler) {
+        super(scheduler);
+        this.skipHidingOnScroll = false;
+    }
+
     _showCore(target, dataList, isSingleBehavior) {
         this.behavior = this._createBehavior(isSingleBehavior, target);
         super._showCore(target, dataList, isSingleBehavior);
@@ -232,10 +238,26 @@ export class DesktopTooltipStrategy extends TooltipStrategyBase {
 
         return this.scheduler._createComponent(this.$tooltip, Tooltip, {
             target: target,
+            onShowing: this._onTooltipShowing.bind(this),
+            closeOnTargetScroll: () => this.skipHidingOnScroll,
             maxHeight: MAX_TOOLTIP_HEIGHT,
             rtlEnabled: this.scheduler.option("rtlEnabled"),
             contentTemplate: () => list.$element()
         });
+    }
+
+    dispose() {
+        clearTimeout(this.skipHidingOnScrollTimeId);
+    }
+
+    _onTooltipShowing() {
+        clearTimeout(this.skipHidingOnScrollTimeId);
+
+        this.skipHidingOnScroll = true;
+        this.skipHidingOnScrollTimeId = setTimeout(() => {
+            this.skipHidingOnScroll = false;
+            clearTimeout(this.skipHidingOnScrollTimeId);
+        }, 0);
     }
 
     _createTooltipElement() {

--- a/js/ui/scheduler/tooltip_strategies/tooltipStrategyBase.js
+++ b/js/ui/scheduler/tooltip_strategies/tooltipStrategyBase.js
@@ -37,6 +37,7 @@ export class TooltipStrategyBase {
             this._showCore(target, dataList, isSingleItemBehavior);
         }
     }
+
     _showCore(target, dataList, isSingleItemBehavior) {
         if(!this.tooltip) {
             this.list = this._createList(target, dataList);
@@ -50,6 +51,9 @@ export class TooltipStrategyBase {
 
         this.tooltip.option("visible", true);
         this.list.option("focusStateEnabled", this.scheduler.option("focusStateEnabled"));
+    }
+
+    dispose() {
     }
 
     hide() {

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -1783,6 +1783,7 @@ const Scheduler = Widget.inherit({
     },
 
     _dispose: function() {
+        this._appointmentTooltip && this._appointmentTooltip.dispose();
         this.hideAppointmentPopup();
         this.hideAppointmentTooltip();
 

--- a/testing/functional/helpers/scheduler.test.helper.ts
+++ b/testing/functional/helpers/scheduler.test.helper.ts
@@ -1,0 +1,17 @@
+import { Selector, ClientFunction } from "testcafe";
+
+export default class SchedulerTestHelper {
+    scheduler: Selector;
+
+    constructor(selector: string) {
+        this.scheduler = Selector(selector);
+    }
+
+    getAppointment(index = 0) {
+        return this.scheduler.find(`.dx-scheduler-appointment`).nth(index);
+    }
+
+    isTooltipVisible() {
+        return Selector(".dx-scheduler-appointment-tooltip-wrapper.dx-overlay-wrapper .dx-list").exists;
+    }
+}

--- a/testing/functional/tests/scheduler/tooltipBehavior.ts
+++ b/testing/functional/tests/scheduler/tooltipBehavior.ts
@@ -1,0 +1,48 @@
+import { createWidget, getContainerFileUrl } from '../../helpers/testHelper';
+import SchedulerTestHelper from '../../helpers/scheduler.test.helper';
+import { ClientFunction } from 'testcafe';
+
+fixture `Tooltip behavior when scrolling`
+    .page(getContainerFileUrl());
+
+const scheduler = new SchedulerTestHelper("#container");
+const scrollBrowser = ClientFunction(() => window.scrollBy(0,500));
+const disableAnimation = ClientFunction(() => (window as any).DevExpress.fx.off = true);
+
+const createScheduler = async () => {
+    await disableAnimation();
+
+    createWidget("dxScheduler", {
+        dataSource: [{
+            text: "Website Re-Design Plan",
+            startDate: new Date(2017, 4, 22, 9, 30),
+            endDate: new Date(2017, 4, 22, 11, 30)
+        }],
+        views: ["week"],
+		currentView: "week",
+		currentDate: new Date(2017, 4, 25),
+		startDayHour: 9,
+		height: 600
+    });
+}
+
+test("Tooltip shouldn't hide after scroll in browser height is small (T755449)", async t => {
+    await t.resizeWindow(600, 400)
+        .click(scheduler.getAppointment())
+        .expect(scheduler.isTooltipVisible()).ok();
+
+    await scrollBrowser();
+
+    await t.expect(scheduler.isTooltipVisible()).notOk();
+
+}).before(async () => await createScheduler());
+
+test("Tooltip should hide after scroll", async t => {
+    await t.resizeWindow(600, 600)
+        .click(scheduler.getAppointment())
+        .expect(scheduler.isTooltipVisible()).ok();
+
+    await scrollBrowser();
+
+    await t.expect(scheduler.isTooltipVisible()).notOk();
+}).before(async () => await createScheduler());


### PR DESCRIPTION
* fix: add timeout.
add tests.

* Refactoring

* remove space

* fix timeId

* Move clearTimout to base class

* Add clear timer

* Refactoring tests

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
