### PR TITLE
Fix NumberBox and DropDownEditor issues after the accessibility audit (T749661)

### DIFF
--- a/js/core/utils/dom.js
+++ b/js/core/utils/dom.js
@@ -152,11 +152,6 @@ var normalizeTemplateElement = function(element) {
     return $element;
 };
 
-var toggleAttr = function($target, attr, value) {
-    value ? $target.attr(attr, value) : $target.removeAttr(attr);
-};
-
-
 var clipboardText = function(event, text) {
     var clipboard = (event.originalEvent && event.originalEvent.clipboardData) || window.clipboardData;
 
@@ -202,6 +197,5 @@ exports.clearSelection = clearSelection;
 exports.uniqueId = uniqueId;
 exports.closestCommonParent = closestCommonParent;
 exports.clipboardText = clipboardText;
-exports.toggleAttr = toggleAttr;
 exports.contains = contains;
 exports.getPublicElement = getPublicElement;

--- a/js/localization/messages/cs.json
+++ b/js/localization/messages/cs.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "Žádná data k zobrazení",
 
+        "dxDropDownEditor-selectLabel": "Výběr",
+
         "validation-required": "povinné",
         "validation-required-formatted": "{0} je povinných",
         "validation-numeric": "Hodnota musí být číslo",

--- a/js/localization/messages/de.json
+++ b/js/localization/messages/de.json
@@ -11,6 +11,7 @@
         "Back": "Zurück",
         "OK": "OK",
         "dxCollectionWidget-noDataText": "Keine Daten verfügbar",
+        "dxDropDownEditor-selectLabel": "Auswählen",
         "validation-required": "Pflichtfeld",
         "validation-required-formatted": "{0} ist ein Pflichtfeld",
         "validation-numeric": "Der Wert muss eine Zahl sein",

--- a/js/localization/messages/el.json
+++ b/js/localization/messages/el.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "Δεν υπάρχουν δεδομένα προς εμφάνιση",
 
+        "dxDropDownEditor-selectLabel": "Επιλέξτε",
+
         "validation-required": "Απαιτείται συμπλήρωση",
         "validation-required-formatted": "{0} είναι απαιτούμενο προς συμπλήρωση",
         "validation-numeric": "Η τιμή του πεδίου πρέπει να είναι αριθμητική",

--- a/js/localization/messages/en.json
+++ b/js/localization/messages/en.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "No data to display",
 
+        "dxDropDownEditor-selectLabel": "Select",
+
         "validation-required": "Required",
         "validation-required-formatted": "{0} is required",
         "validation-numeric": "Value must be a number",

--- a/js/localization/messages/es.json
+++ b/js/localization/messages/es.json
@@ -11,6 +11,7 @@
         "Back": "Volver",
         "OK": "Aceptar",
         "dxCollectionWidget-noDataText": "Sin datos para mostrar",
+        "dxDropDownEditor-selectLabel": "Seleccionar",
         "validation-required": "Obligatorio",
         "validation-required-formatted": "{0} es obligatorio",
         "validation-numeric": "Valor debe ser un número",

--- a/js/localization/messages/fi.json
+++ b/js/localization/messages/fi.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "Ei näytettäviä tietoja",
 
+        "dxDropDownEditor-selectLabel": "Valitse",
+
         "validation-required": "Pakollinen",
         "validation-required-formatted": "{0} on pakollinen",
         "validation-numeric": "Arvon on oltava luku",

--- a/js/localization/messages/fr.json
+++ b/js/localization/messages/fr.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "Pas de données",
 
+        "dxDropDownEditor-selectLabel": "Sélection",
+
         "validation-required": "Obligatoire",
         "validation-required-formatted": "{0} est obligatoire",
         "validation-numeric": "La valeur doit être un nombre",

--- a/js/localization/messages/it.json
+++ b/js/localization/messages/it.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "Nessun dato da mostrare",
 
+        "dxDropDownEditor-selectLabel": "Seleziona",
+
         "validation-required": "Richiesto",
         "validation-required-formatted": "{0} è richiesto",
         "validation-numeric": "Il valore deve essere numerico",

--- a/js/localization/messages/ja.json
+++ b/js/localization/messages/ja.json
@@ -11,6 +11,7 @@
         "Back": "戻る",
         "OK": "OK",
         "dxCollectionWidget-noDataText": "表示するデータがありません。",
+        "dxDropDownEditor-selectLabel": "選択",
         "validation-required": "必須",
         "validation-required-formatted": "{0} は必須です。",
         "validation-numeric": "数値を指定してください。",

--- a/js/localization/messages/nl.json
+++ b/js/localization/messages/nl.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "Geen gegevens om te tonen",
 
+        "dxDropDownEditor-selectLabel": "Kiezen",
+
         "validation-required": "Verplicht",
         "validation-required-formatted": "{0} is verplicht",
         "validation-numeric": "Waarde moet numeriek zijn",

--- a/js/localization/messages/pt.json
+++ b/js/localization/messages/pt.json
@@ -11,6 +11,7 @@
         "Back": "Voltar",
         "OK": "OK",
         "dxCollectionWidget-noDataText": "Sem dados",
+        "dxDropDownEditor-selectLabel": "Selecione",
         "validation-required": "Preenchimento obrigatório",
         "validation-required-formatted": "{0} é de preenchimento obrigatório",
         "validation-numeric": "Valor deve ser um número",

--- a/js/localization/messages/ru.json
+++ b/js/localization/messages/ru.json
@@ -11,6 +11,7 @@
         "Back": "Назад",
         "OK": "OK",
         "dxCollectionWidget-noDataText": "Нет данных для отображения",
+        "dxDropDownEditor-selectLabel": "Выбрать",
         "validation-required": "Поле необходимо заполнить",
         "validation-required-formatted": "Необходимо заполнить: {0}",
         "validation-numeric": "Значение должно быть числом",

--- a/js/localization/messages/sl.json
+++ b/js/localization/messages/sl.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "Ni podatkov za prikaz",
 
+        "dxDropDownEditor-selectLabel": "Izberi",
+
         "validation-required": "Obvezen podatek",
         "validation-required-formatted": "Podatek {0} je obvezen",
         "validation-numeric": "Vrednost mora biti število",

--- a/js/localization/messages/sv.json
+++ b/js/localization/messages/sv.json
@@ -13,6 +13,8 @@
 
         "dxCollectionWidget-noDataText": "Inget data att visa",
 
+        "dxDropDownEditor-selectLabel": "Välj",
+
         "validation-required": "Krävs",
         "validation-required-formatted": "{0} krävs",
         "validation-numeric": "Värdet måste vara ett nummer",

--- a/js/localization/messages/zh.json
+++ b/js/localization/messages/zh.json
@@ -13,6 +13,8 @@
 
     "dxCollectionWidget-noDataText": "没有要显示的数据",
 
+    "dxDropDownEditor-selectLabel": "选择",
+
     "validation-required": "必需",
     "validation-required-formatted": "{0} 是必需的",
     "validation-numeric": "值必须是一个数字",

--- a/js/ui/button.js
+++ b/js/ui/button.js
@@ -382,7 +382,7 @@ var Button = Widget.inherit({
         var ariaLabel = text || icon || "";
         ariaLabel = ariaLabel.toString().trim();
 
-        this.setAria("label", ariaLabel);
+        this.setAria("label", ariaLabel.length ? ariaLabel : null);
     },
 
     _renderType: function() {

--- a/js/ui/drop_down_editor/ui.drop_down_button.js
+++ b/js/ui/drop_down_editor/ui.drop_down_button.js
@@ -1,10 +1,13 @@
 import $ from "../../core/renderer";
 import eventsEngine from "../../events/core/events_engine";
+import messageLocalization from "../../localization/message";
 import TextEditorButton from "../text_box/texteditor_button_collection/button";
 import Button from "../button";
 
 const DROP_DOWN_EDITOR_BUTTON_CLASS = "dx-dropdowneditor-button";
 const DROP_DOWN_EDITOR_BUTTON_VISIBLE = "dx-dropdowneditor-button-visible";
+
+const BUTTON_MESSAGE = "dxDropDownEditor-selectLabel";
 
 export default class ClearButton extends TextEditorButton {
     _attachEvents(instance) {
@@ -25,6 +28,7 @@ export default class ClearButton extends TextEditorButton {
         this._addToContainer($element);
 
         const instance = editor._createComponent($element, Button, options);
+        instance.setAria("label", messageLocalization.format(BUTTON_MESSAGE));
 
         this._legacyRender(editor.$element(), $element, options.visible);
 

--- a/js/ui/number_box/number_box.base.js
+++ b/js/ui/number_box/number_box.base.js
@@ -275,8 +275,8 @@ var NumberBoxBase = TextEditor.inherit({
         });
 
         this.setAria({
-            "valuemin": commonUtils.ensureDefined(this.option("min"), null),
-            "valuemax": commonUtils.ensureDefined(this.option("max"), null)
+            "valuemin": commonUtils.ensureDefined(this.option("min"), ""),
+            "valuemax": commonUtils.ensureDefined(this.option("max"), "")
         });
     },
 

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -523,7 +523,7 @@ var Widget = DOMComponent.inherit({
     },
 
     _renderHint: function() {
-        domUtils.toggleAttr(this.$element(), "title", this.option("hint"));
+        this.$element().attr("title", this.option("hint"));
     },
 
     _renderContent: function() {
@@ -976,7 +976,7 @@ var Widget = DOMComponent.inherit({
                 attrValue = attrValue.toString();
             }
 
-            domUtils.toggleAttr(option.target, attrName, attrValue);
+            option.target.attr(attrName, attrValue);
         };
 
         if(!typeUtils.isPlainObject(arguments[0])) {

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -523,7 +523,8 @@ var Widget = DOMComponent.inherit({
     },
 
     _renderHint: function() {
-        this.$element().attr("title", this.option("hint"));
+        var hint = this.option("hint");
+        this.$element().attr("title", hint ? hint : null);
     },
 
     _renderContent: function() {

--- a/testing/helpers/gridBaseMocks.js
+++ b/testing/helpers/gridBaseMocks.js
@@ -888,7 +888,7 @@ module.exports = function($, gridCore, columnResizingReordering, domUtils, commo
                     attrValue = attrValue.toString();
                 }
 
-                domUtils.toggleAttr(option.target, attrName, attrValue);
+                option.target.attr(attrName, attrValue);
             };
 
             if(!$.isPlainObject(arguments[0])) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsResizingReorderingModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsResizingReorderingModule.tests.js
@@ -56,7 +56,6 @@ var ColumnsController = columnsModule.controllers.columns;
 import { RowsView } from "ui/data_grid/ui.data_grid.rows";
 import { GroupingHeaderPanelExtender } from "ui/data_grid/ui.data_grid.grouping";
 import { HeaderPanel } from "ui/data_grid/ui.data_grid.header_panel";
-import domUtils from "core/utils/dom";
 import Action from "core/action";
 import devices from "core/devices";
 import publicComponentUtils from "core/utils/public_component";
@@ -768,7 +767,7 @@ function getEvent(options) {
                             attrValue = attrValue.toString();
                         }
 
-                        domUtils.toggleAttr(option.target, attrName, attrValue);
+                        option.target.attr(attrName, attrValue);
                     };
 
                     if(!$.isPlainObject(arguments[0])) {
@@ -3024,7 +3023,7 @@ function getEvent(options) {
                             attrValue = attrValue.toString();
                         }
 
-                        domUtils.toggleAttr(option.target, attrName, attrValue);
+                        option.target.attr(attrName, attrValue);
                     };
 
                     if(!$.isPlainObject(arguments[0])) {

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.markup.tests.js
@@ -44,6 +44,11 @@ module("DropDownEditor markup", {
         assert.ok($dropDownButton.hasClass(DROP_DOWN_EDITOR_BUTTON_CLASS));
     });
 
+    test("dxDropDownEditor button should have correct aria-label attribute", (assert) => {
+        const $dropDownButton = this.rootElement.find(`.${DROP_DOWN_EDITOR_BUTTON_CLASS}`);
+        assert.strictEqual($dropDownButton.attr("aria-label"), "Select", "'aria-label' is correct");
+    });
+
     test("input wrapper must be upper than button", (assert) => {
         const $inputWrapper = this.rootElement.children();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
@@ -2032,11 +2032,12 @@ QUnit.module("aria accessibility", {}, () => {
     QUnit.test("default render", (assert) => {
         const $element = $("#numberbox").dxNumberBox({});
         const $input = $element.find(".dx-texteditor-input");
+        const inputElement = $input.get(0);
 
         assert.equal($input.attr("role"), "spinbutton", "aria role is correct");
         assert.equal($input.attr("aria-valuenow"), "0", "required 'aria-valuenow' attribute is defined");
-        assert.ok($input.hasAttribute("aria-valuemin"), "required 'aria-valuemin' attribute is defined");
-        assert.ok($input.hasAttribute("aria-valuemax"), "required 'aria-valuemax' attribute is defined");
+        assert.ok(inputElement.hasAttribute("aria-valuemin"), "required 'aria-valuemin' attribute is defined");
+        assert.ok(inputElement.hasAttribute("aria-valuemax"), "required 'aria-valuemax' attribute is defined");
     });
 
     QUnit.test("aria properties", (assert) => {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
@@ -2034,6 +2034,10 @@ QUnit.module("aria accessibility", {}, () => {
         const $input = $element.find(".dx-texteditor-input");
 
         assert.equal($input.attr("role"), "spinbutton", "aria role is correct");
+        assert.equal($input.attr("aria-valuenow"), "0", "required 'aria-valuenow' attribute is defined");
+        assert.equal($input.attr("aria-valuemin"), "", "required 'aria-valuemin' attribute is defined");
+        assert.equal($input.attr("aria-valuemax"), "", "required 'aria-valuemax' attribute is defined");
+
     });
 
     QUnit.test("aria properties", (assert) => {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
@@ -2029,15 +2029,14 @@ QUnit.module("number validation", {}, () => {
 });
 
 QUnit.module("aria accessibility", {}, () => {
-    QUnit.test("aria role", (assert) => {
+    QUnit.test("default render", (assert) => {
         const $element = $("#numberbox").dxNumberBox({});
         const $input = $element.find(".dx-texteditor-input");
 
         assert.equal($input.attr("role"), "spinbutton", "aria role is correct");
         assert.equal($input.attr("aria-valuenow"), "0", "required 'aria-valuenow' attribute is defined");
-        assert.equal($input.attr("aria-valuemin"), "", "required 'aria-valuemin' attribute is defined");
-        assert.equal($input.attr("aria-valuemax"), "", "required 'aria-valuemax' attribute is defined");
-
+        assert.ok($input.hasAttribute("aria-valuemin"), "required 'aria-valuemin' attribute is defined");
+        assert.ok($input.hasAttribute("aria-valuemax"), "required 'aria-valuemax' attribute is defined");
     });
 
     QUnit.test("aria properties", (assert) => {
@@ -2066,7 +2065,7 @@ QUnit.module("aria accessibility", {}, () => {
         assert.strictEqual($input.attr("aria-valuemax"), "0", "aria max is correct");
     });
 
-    QUnit.test("the dxNumberBox should not have valuemin when max only is specified", (assert) => {
+    QUnit.test("the dxNumberBox should have value[min/max] when max or min only is specified", (assert) => {
         const $element = $("#numberbox").dxNumberBox({
             max: 30,
             value: 25
@@ -2074,20 +2073,20 @@ QUnit.module("aria accessibility", {}, () => {
         const numberBox = $element.dxNumberBox("instance");
         const $input = $element.find(".dx-texteditor-input").get(0);
 
-        assert.notOk($input.hasAttribute("aria-valuemin"), "there is no valuemin");
+        assert.ok($input.hasAttribute("aria-valuemin"), "there is valuemin");
 
         numberBox.option({
             min: 4,
             max: undefined
         });
-        assert.notOk($input.hasAttribute("aria-valuemax"), "there is no valuemax");
+        assert.ok($input.hasAttribute("aria-valuemax"), "there is valuemax");
         assert.strictEqual($($input).attr("aria-valuemin"), "4", "valuemin is correct");
 
         numberBox.option({
             min: undefined,
             max: undefined
         });
-        assert.notOk($input.hasAttribute("aria-valuemax"), "there is no valuemin");
-        assert.notOk($input.hasAttribute("aria-valuemax"), "there is no valuemax");
+        assert.ok($input.hasAttribute("aria-valuemax"), "there is valuemin");
+        assert.ok($input.hasAttribute("aria-valuemax"), "there is valuemax");
     });
 });


### PR DESCRIPTION
- Incorrect `aria-valuemin` attribute value when the NumberBox `min` option is equal to `0` - fixed in #8507
- Unclean description of the DropDownEditor button. Screenreaders recognize it as a "button" and it is not clear what action it should perform. We have added the attribute "aria-label" with the value "Select" to the DropDownEditor button.
- NumberBox has a `spinbutton` role. This means that the element must have 3 mandatory attributes: `aria-valuemin`, `aria-valuemax`, `aria-valuenow`. According the [specification](https://www.w3.org/TR/wai-aria-1.1/#spinbutton):
>If missing or not a number, the implicit values of these attributes are as follows:
>
>The implicit value of aria-valuemin is that there is no minimum value.
>The implicit value of aria-valuemax is that there is no maximum value.