### PR TITLE
Add default item template to the dxDropDownButton (T759404)

### DIFF
--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -190,7 +190,7 @@ let DropDownButton = Widget.inherit({
 
             /**
              * @name dxDropDownButtonOptions.items
-             * @type Array<CollectionWidgetItem, object>
+             * @type Array<dxDropDownButtonItem, object>
              * @default null
              */
             items: null,

--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -36,6 +36,20 @@ let DropDownButton = Widget.inherit({
         return extend(this.callBase(), {
 
             /**
+             * @name dxDropDownButtonItem
+             * @inherits dxListItem
+             * @type object
+             */
+            /**
+             * @name dxDropDownButtonItem.key
+             * @hidden
+             */
+            /**
+             * @name dxDropDownButtonItem.showChevron
+             * @hidden
+             */
+
+            /**
              * @name dxDropDownButtonOptions.itemTemplate
              * @type template|function
              * @default "item"

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2099,7 +2099,7 @@ declare module DevExpress.ui {
         /** @name dxDropDownButton.Options.itemTemplate */
         itemTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DevExpress.core.dxElement) => string | Element | JQuery);
         /** @name dxDropDownButton.Options.items */
-        items?: Array<CollectionWidgetItem | any>;
+        items?: Array<dxDropDownButtonItem | any>;
         /** @name dxDropDownButton.Options.keyExpr */
         keyExpr?: string;
         /** @name dxDropDownButton.Options.noDataText */
@@ -2141,6 +2141,10 @@ declare module DevExpress.ui {
         toggle(): Promise<void> & JQueryPromise<void>;
         /** @name dxDropDownButton.toggle(visibility) */
         toggle(visibility: boolean): Promise<void> & JQueryPromise<void>;
+    }
+
+    /** @name dxDropDownButtonItem */
+    export interface dxDropDownButtonItem extends dxListItem {
     }
     /** @name dxDropDownEditor.Options */
     export interface dxDropDownEditorOptions<T = dxDropDownEditor> extends dxTextBoxOptions<T> {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2142,7 +2142,6 @@ declare module DevExpress.ui {
         /** @name dxDropDownButton.toggle(visibility) */
         toggle(visibility: boolean): Promise<void> & JQueryPromise<void>;
     }
-
     /** @name dxDropDownButtonItem */
     export interface dxDropDownButtonItem extends dxListItem {
     }


### PR DESCRIPTION
Default Item Template is not defined in the API reference and it's impossible to set several options (e.g. icon and badge) in the Razor syntax. This pull request fixes this problem