### PR TITLE
Revert styles for editors with percentage width inside a table for IE11 (T756307)

### DIFF
--- a/styles/widgets/common/tagBox.less
+++ b/styles/widgets/common/tagBox.less
@@ -1,8 +1,6 @@
 .dx-tagbox {
     .dx-texteditor-input {
         width: auto;
-        flex-basis: auto;
-        flex-grow: 0;
     }
 
     &.dx-tagbox-default-template {

--- a/styles/widgets/common/textEditor.less
+++ b/styles/widgets/common/textEditor.less
@@ -68,7 +68,6 @@
     height: 100%;
     outline: 0;
     border: 0;
-    flex-basis: 100%;
     .user-select(text);
 
     &:-webkit-autofill + .dx-placeholder {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -1141,33 +1141,4 @@ QUnit.module("regressions", moduleConfig, () => {
         $input.triggerHandler("blur");
         assert.equal(handler.callCount, 2, "'change' event is not fired after focus out without value change");
     });
-
-
-    QUnit.test("TextEditor cannot change table column percent width (T756307)", (assert) => {
-        const markup =
-            '<table id="test-table" style="width: 280px" >\
-                <thead>\
-                    <th style="width: 50%;">head 1</th>\
-                    <th style="width: 50%;">head 2</th>\
-                </thead>\
-                <tr>\
-                    <td>\
-                        <div id="content" style="width: 100%">long content, long content, long content</div>\
-                    </td>\
-                    <td>\
-                        <div id="content-with-editor" style="width: 100%">long content, long content, long content</div>\
-                        <div id="table-texteditor"></div>\
-                    </td>\
-                </tr>\
-            <table>';
-        $("#qunit-fixture").html(markup);
-
-        $("#table-texteditor").dxTextEditor({
-            value: "val",
-            width: "30%"
-        });
-
-        assert.equal($("#content").width(), $("#content-with-editor").width(), "table columns have equal width");
-        $("#test-table").remove();
-    });
 });


### PR DESCRIPTION
This reverts commit 092fa37f669cf056be279dd95a15baa9b5a3a5c0.

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
