### PR TITLE
Handle error when trying to get input selection on specific Android versions (T680247)

### DIFF
--- a/js/ui/text_box/utils.caret.js
+++ b/js/ui/text_box/utils.caret.js
@@ -6,56 +6,32 @@ var $ = require("../../core/renderer"),
 var isFocusingOnCaretChange = browser.msie || browser.safari;
 
 var getCaret = function(input) {
-    if(isObsoleteBrowser(input)) {
-        return getCaretForObsoleteBrowser(input);
+    var range;
+
+    try {
+        range = {
+            start: input.selectionStart,
+            end: input.selectionEnd
+        };
+    } catch(e) {
+        range = {
+            start: 0,
+            end: 0
+        };
     }
 
-    return {
-        start: input.selectionStart,
-        end: input.selectionEnd
-    };
+    return range;
 };
 
 var setCaret = function(input, position) {
-    if(isObsoleteBrowser(input)) {
-        setCaretForObsoleteBrowser(input, position);
-        return;
-    }
     if(!domAdapter.getBody().contains(input)) {
         return;
     }
 
-    input.selectionStart = position.start;
-    input.selectionEnd = position.end;
-};
-
-var isObsoleteBrowser = function(input) {
-    return !input.setSelectionRange;
-};
-
-var getCaretForObsoleteBrowser = function(input) {
-    var range = domAdapter.getSelection().createRange();
-    var rangeCopy = range.duplicate();
-
-    range.move('character', -input.value.length);
-    range.setEndPoint('EndToStart', rangeCopy);
-
-    return {
-        start: range.text.length,
-        end: range.text.length + rangeCopy.text.length
-    };
-};
-
-var setCaretForObsoleteBrowser = function(input, position) {
-    if(!domAdapter.getBody().contains(input)) {
-        return;
-    }
-
-    var range = input.createTextRange();
-    range.collapse(true);
-    range.moveStart("character", position.start);
-    range.moveEnd("character", position.end - position.start);
-    range.select();
+    try {
+        input.selectionStart = position.start;
+        input.selectionEnd = position.end;
+    } catch(e) { }
 };
 
 var caret = function(input, position) {

--- a/js/ui/text_box/utils.caret.js
+++ b/js/ui/text_box/utils.caret.js
@@ -1,12 +1,12 @@
-var $ = require("../../core/renderer"),
-    isDefined = require("../../core/utils/type").isDefined,
-    browser = require("../../core/utils/browser"),
-    domAdapter = require("../../core/dom_adapter");
+import $ from "../../core/renderer";
+import { isDefined } from "../../core/utils/type";
+import browser from "../../core/utils/browser";
+import domAdapter from "../../core/dom_adapter";
 
-var isFocusingOnCaretChange = browser.msie || browser.safari;
+const isFocusingOnCaretChange = browser.msie || browser.safari;
 
-var getCaret = function(input) {
-    var range;
+const getCaret = function(input) {
+    let range;
 
     try {
         range = {
@@ -23,7 +23,7 @@ var getCaret = function(input) {
     return range;
 };
 
-var setCaret = function(input, position) {
+const setCaret = function(input, position) {
     if(!domAdapter.getBody().contains(input)) {
         return;
     }
@@ -34,7 +34,7 @@ var setCaret = function(input, position) {
     } catch(e) { }
 };
 
-var caret = function(input, position) {
+const caret = function(input, position) {
     input = $(input).get(0);
 
     if(!isDefined(position)) {

--- a/testing/tests/DevExpress.utils/utils.caret.tests.js
+++ b/testing/tests/DevExpress.utils/utils.caret.tests.js
@@ -2,82 +2,84 @@ import $ from "jquery";
 import caret from "ui/text_box/utils.caret";
 import keyboardMock from "../../helpers/keyboardMock.js";
 
-QUnit.module("caret");
+const { module: testModule, test } = QUnit;
 
-QUnit.test("get caret position", function(assert) {
-    var caretPosition = { start: 1, end: 2 };
-    var $input = $("<input>").appendTo("#qunit-fixture");
+testModule("caret", () => {
+    test("get caret position", (assert) => {
+        const caretPosition = { start: 1, end: 2 };
+        const $input = $("<input>").appendTo("#qunit-fixture");
 
-    var keyboard = keyboardMock($input, true);
+        const keyboard = keyboardMock($input, true);
 
-    keyboard.type("12345").caret({ start: 1, end: 2 });
+        keyboard.type("12345").caret({ start: 1, end: 2 });
 
-    assert.deepEqual(caret($input), caretPosition, "caret position is correct");
-});
+        assert.deepEqual(caret($input), caretPosition, "caret position is correct");
+    });
 
-QUnit.test("set caret position", function(assert) {
-    var caretPosition = { start: 1, end: 2 };
-    var $input = $("<input>").val("12345").appendTo("#qunit-fixture");
+    test("set caret position", (assert) => {
+        const caretPosition = { start: 1, end: 2 };
+        const $input = $("<input>").val("12345").appendTo("#qunit-fixture");
 
-    $input.focus();
-    caret($input, caretPosition);
+        $input.focus();
+        caret($input, caretPosition);
 
-    assert.deepEqual(caret($input), caretPosition, "caret position set correctly");
-});
+        assert.deepEqual(caret($input), caretPosition, "caret position set correctly");
+    });
 
-QUnit.test("T341277 - an exception if element is not in document", function(assert) {
-    var caretPosition = { start: 1, end: 2 },
-        input = document.createElement("input");
+    test("T341277 - an exception if element is not in document", (assert) => {
+        const caretPosition = { start: 1, end: 2 };
+        const input = document.createElement("input");
 
-    try {
-        caret(input, caretPosition);
-        assert.ok(true, "exception is not thrown");
-    } catch(e) {
-        assert.ok(false, "exception is thrown");
-    }
-});
-
-QUnit.test("'getCaret' does not raise an error when it is impossible to get a range", (assert) => {
-    const pseudoInput = {
-        get selectionStart() {
-            throw "You can not get a selection";
-        },
-
-        get selectionEnd() {
-            throw "You can not get a selection";
+        try {
+            caret(input, caretPosition);
+            assert.ok(true, "exception is not thrown");
+        } catch(e) {
+            assert.ok(false, "exception is thrown");
         }
-    };
+    });
 
-    try {
-        assert.deepEqual(caret(pseudoInput), { start: 0, end: 0 });
-        assert.ok(true, "exception is not thrown");
-    } catch(e) {
-        assert.ok(false, "exception is thrown");
-    }
-});
+    test("'getCaret' does not raise an error when it is impossible to get a range", (assert) => {
+        const pseudoInput = {
+            get selectionStart() {
+                throw "You can not get a selection";
+            },
 
-QUnit.test("'setCaret' does not raise an error when it is impossible to set a range", (assert) => {
-    const caretPosition = { start: 1, end: 2 };
-    const initialDescriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'selectionStart');
-    const getterSetterConfig = {
-        get: function() {
-            throw "You can not get a selection";
-        },
-        set: function(value) {
-            throw "You can not set a selection";
+            get selectionEnd() {
+                throw "You can not get a selection";
+            }
+        };
+
+        try {
+            assert.deepEqual(caret(pseudoInput), { start: 0, end: 0 });
+            assert.ok(true, "exception is not thrown");
+        } catch(e) {
+            assert.ok(false, "exception is thrown");
         }
-    };
+    });
 
-    Object.defineProperty(HTMLInputElement.prototype, 'selectionStart', $.extend({}, initialDescriptor, getterSetterConfig));
+    test("'setCaret' does not raise an error when it is impossible to set a range", (assert) => {
+        const caretPosition = { start: 1, end: 2 };
+        const initialDescriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'selectionStart');
+        const getterSetterConfig = {
+            get: function() {
+                throw "You can not get a selection";
+            },
+            set: function(value) {
+                throw "You can not set a selection";
+            }
+        };
 
-    const input = $("<input>").appendTo("#qunit-fixture").get(0);
+        Object.defineProperty(HTMLInputElement.prototype, 'selectionStart', $.extend({}, initialDescriptor, getterSetterConfig));
 
-    try {
-        caret(input, caretPosition);
-        assert.ok(true, "exception is not thrown");
-    } catch(e) {
-        assert.ok(false, "exception is thrown");
-    }
+        const input = $("<input>").appendTo("#qunit-fixture").get(0);
 
-    Object.defineProperty(HTMLInputElement.prototype, 'selectionStart', initialDescriptor);
+        try {
+            caret(input, caretPosition);
+            assert.ok(true, "exception is not thrown");
+        } catch(e) {
+            assert.ok(false, "exception is thrown");
+        }
+
+        Object.defineProperty(HTMLInputElement.prototype, 'selectionStart', initialDescriptor);
+    });
 });

--- a/testing/tests/DevExpress.utils/utils.caret.tests.js
+++ b/testing/tests/DevExpress.utils/utils.caret.tests.js
@@ -1,6 +1,6 @@
-var $ = require("jquery"),
-    caret = require("ui/text_box/utils.caret"),
-    keyboardMock = require("../../helpers/keyboardMock.js");
+import $ from "jquery";
+import caret from "ui/text_box/utils.caret";
+import keyboardMock from "../../helpers/keyboardMock.js";
 
 QUnit.module("caret");
 
@@ -35,4 +35,49 @@ QUnit.test("T341277 - an exception if element is not in document", function(asse
     } catch(e) {
         assert.ok(false, "exception is thrown");
     }
+});
+
+QUnit.test("'getCaret' does not raise an error when it is impossible to get a range", (assert) => {
+    const pseudoInput = {
+        get selectionStart() {
+            throw "You can not get a selection";
+        },
+
+        get selectionEnd() {
+            throw "You can not get a selection";
+        }
+    };
+
+    try {
+        assert.deepEqual(caret(pseudoInput), { start: 0, end: 0 });
+        assert.ok(true, "exception is not thrown");
+    } catch(e) {
+        assert.ok(false, "exception is thrown");
+    }
+});
+
+QUnit.test("'setCaret' does not raise an error when it is impossible to set a range", (assert) => {
+    const caretPosition = { start: 1, end: 2 };
+    const initialDescriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'selectionStart');
+    const getterSetterConfig = {
+        get: function() {
+            throw "You can not get a selection";
+        },
+        set: function(value) {
+            throw "You can not set a selection";
+        }
+    };
+
+    Object.defineProperty(HTMLInputElement.prototype, 'selectionStart', $.extend({}, initialDescriptor, getterSetterConfig));
+
+    const input = $("<input>").appendTo("#qunit-fixture").get(0);
+
+    try {
+        caret(input, caretPosition);
+        assert.ok(true, "exception is not thrown");
+    } catch(e) {
+        assert.ok(false, "exception is thrown");
+    }
+
+    Object.defineProperty(HTMLInputElement.prototype, 'selectionStart', initialDescriptor);
 });


### PR DESCRIPTION
Some versions of Android (5.0, 5.1) trigger an exception when trying to get selectionStart value for input elements that do not support selection (e.g. with type `number`). Modern devices do not trigger an exception

In addition, the code to support IE8 has been removed (`*ObsoleteBrowser` entries)