### PR TITLE
Validator should get checking value from the validation request at first (T801086)

### DIFF
--- a/js/ui/validation/default_adapter.js
+++ b/js/ui/validation/default_adapter.js
@@ -9,8 +9,8 @@ var DefaultAdapter = Class.inherit({
 
         that.validationRequestsCallbacks = Callbacks();
 
-        var handler = function() {
-            that.validationRequestsCallbacks.fire();
+        var handler = function(args) {
+            that.validationRequestsCallbacks.fire(args);
         };
 
         editor.validationRequest.add(handler);

--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -146,8 +146,8 @@ var Validator = DOMComponent.inherit({
             if(dxStandardEditor) {
                 adapter = new DefaultAdapter(dxStandardEditor, this);
 
-                adapter.validationRequestsCallbacks.add(function() {
-                    that.validate();
+                adapter.validationRequestsCallbacks.add(function(args) {
+                    that.validate(args);
                 });
 
                 this.option("adapter", adapter);
@@ -160,13 +160,13 @@ var Validator = DOMComponent.inherit({
 
         if(callbacks) {
             if(Array.isArray(callbacks)) {
-                callbacks.push(function() {
-                    that.validate();
+                callbacks.push(function(args) {
+                    that.validate(args);
                 });
             } else {
                 errors.log("W0014", "validationRequestsCallbacks", "jQuery.Callbacks", "17.2", "Use the array instead");
-                callbacks.add(function() {
-                    that.validate();
+                callbacks.add(function(args) {
+                    that.validate(args);
                 });
             }
         }
@@ -219,12 +219,12 @@ var Validator = DOMComponent.inherit({
     * @publicName validate()
     * @return dxValidatorResult
     */
-    validate: function() {
+    validate: function(args) {
         var that = this,
             adapter = that.option("adapter"),
             name = that.option("name"),
             bypass = adapter.bypass && adapter.bypass(),
-            value = adapter.getValue(),
+            value = (args && args.value !== undefined) ? args.value : adapter.getValue(),
             currentError = adapter.getCurrentValidationError && adapter.getCurrentValidationError(),
             rules = this._getValidationRules(),
             result;

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -3834,6 +3834,25 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "widget is valid");
     });
 
+    QUnit.test("required validator should not block valuechange in datetime strategy", (assert) => {
+        const $dateBox = $("#dateBox").dxDateBox({
+            type: "datetime",
+            opened: true,
+            value: null
+        }).dxValidator({
+            validationRules: [{
+                type: "required"
+            }]
+        });
+        const dateBox = $dateBox.dxDateBox("instance");
+        const $done = $(dateBox.content()).parent().find(".dx-popup-done.dx-button");
+
+        $done.trigger("dxclick");
+
+        assert.ok(dateBox.option("isValid"), "widget is valid");
+        assert.ok(dateBox.option("value"), "value is not empty");
+    });
+
     QUnit.test("widget is still valid after drop down is opened", assert => {
         const startDate = new Date(2015, 1, 1, 8, 12);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -3837,6 +3837,7 @@ QUnit.module("datebox validation", {}, () => {
     QUnit.test("required validator should not block valuechange in datetime strategy", (assert) => {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "datetime",
+            pickerType: "calendar",
             opened: true,
             value: null
         }).dxValidator({

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
@@ -540,7 +540,7 @@ QUnit.test("validator should validate value passed in the validation request", f
 
     adapter.getValue.returns("123");
     adapter.validationRequestsCallbacks.fire({
-        value: "1"
+        value: ""
     });
 
     assert.strictEqual(validatedHandler.firstCall.args[0].isValid, false, "empty value should be validated");

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
@@ -522,6 +522,30 @@ QUnit.test("Validation happens on firing callback, results are shown by our widg
     assert.ok(validatedHandler.calledOnce, "Validated handler should be called");
 });
 
+QUnit.test("validator should validate value passed in the validation request", function(assert) {
+    var that = this,
+        adapter = {
+            getValue: sinon.stub(),
+            validationRequestsCallbacks: $.Callbacks()
+        },
+        validatedHandler = sinon.stub();
+
+    that.fixture.createValidator({
+        adapter: adapter,
+        validationRules: [{
+            type: "required"
+        }],
+        onValidated: validatedHandler
+    });
+
+    adapter.getValue.returns("123");
+    adapter.validationRequestsCallbacks.fire({
+        value: "1"
+    });
+
+    assert.strictEqual(validatedHandler.firstCall.args[0].isValid, false, "empty value should be validated");
+});
+
 QUnit.test("Validation happens on firing callback, result are applied through custom validator", function(assert) {
     var that = this,
         adapter = {


### PR DESCRIPTION
A value of an editor should be validated BEFORE being applied. 
Before this pull request, the dx validator took value to check from the editor. It is the incorrect behavior because we should not check an old value but should check the new one and apply it if valid.
This pull request fixes the problem. The validator check requested value at first and than check an actual editor value if the first one is not exist