### PR TITLE
Remove prevent safari scrolling data on overlay dispose

### DIFF
--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -1435,6 +1435,7 @@ var Overlay = Widget.inherit({
         this._toggleSubscriptions(false);
         this._updateZIndexStackPosition(false);
         this._toggleTabTerminator(false);
+        this._toggleSafariScrolling(true);
 
         this._actions = null;
 


### PR DESCRIPTION
Fix QUnit tests for lookup with iOS UA
