### PR TITLE
Remove Knockout from the list of supported frameworks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ var button = new DevExpress.ui.dxButton(element, { text: 'Hello World!' });
 
 DevExtreme supports deep integration with the following client-side technologies:
 
-- [jQuery plugins](https://js.devexpress.com/Documentation/Guide/Getting_Started/Widget_Basics_-_jQuery/Create_and_Configure_a_Widget/)
-- [Knockout bindings](https://js.devexpress.com/Documentation/Guide/Getting_Started/Widget_Basics_-_Knockout/Create_and_Configure_a_Widget/)
+- [jQuery](https://js.devexpress.com/Documentation/Guide/Getting_Started/Widget_Basics_-_jQuery/Create_and_Configure_a_Widget/)
 - [Angular](https://github.com/DevExpress/devextreme-angular#readme)
 - [React](https://github.com/DevExpress/devextreme-react#readme)
 - [Vue](https://github.com/DevExpress/devextreme-vue#readme)


### PR DESCRIPTION
NB: Knockout is still fully supported, we just stop promoting it because it is outdated