### PR TITLE
Add tests for the default button/menu template styles (T747772, T738205, T742980, T636219) (#8878)

### DIFF
--- a/testing/helpers/checkStyleHelper.js
+++ b/testing/helpers/checkStyleHelper.js
@@ -1,0 +1,41 @@
+import devices from "core/devices";
+import browser from "core/utils/browser";
+import typeUtils from "core/utils/type";
+
+export function testInChromeOnDesktopActiveWindow(name, testCallback) {
+    if(devices.real().deviceType === "desktop" && browser.webkit) {
+        QUnit.testInActiveWindow.call(null, name, testCallback);
+    } else {
+        QUnit.skip.call(null, name + " [testInChromeOnDesktopActiveWindow]", testCallback);
+    }
+}
+
+export function getTextOverflow(element) {
+    return window.getComputedStyle(element).textOverflow;
+}
+
+export function getWhiteSpace(element) {
+    return window.getComputedStyle(element).whiteSpace;
+}
+
+export function getOverflowX(element) {
+    return window.getComputedStyle(element).overflowX;
+}
+
+export function getBackgroundColor(element) {
+    let elementBackgroundColor = window.getComputedStyle(element).backgroundColor;
+    let currentElement = element.parentNode;
+    while(currentElement.parentNode !== document.documentElement && typeUtils.isDefined(currentElement.parentNode)) {
+        let currentStyle = window.getComputedStyle(currentElement);
+        if(elementBackgroundColor !== currentStyle.backgroundColor) {
+            elementBackgroundColor = currentStyle.backgroundColor;
+            break;
+        }
+        currentElement = currentElement.parentNode;
+    }
+    return elementBackgroundColor;
+}
+
+export function getColor(element) {
+    return window.getComputedStyle(element).color;
+}

--- a/testing/tests/DevExpress.ui.widgets/button.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/button.tests.js
@@ -2,9 +2,11 @@ import $ from "jquery";
 import ValidationEngine from "ui/validation_engine";
 import Validator from "ui/validator";
 import keyboardMock from "../../helpers/keyboardMock.js";
+import * as checkStyleHelper from "../../helpers/checkStyleHelper.js";
 
 import "ui/button";
 import "common.css!";
+import "generic_light.css!";
 
 QUnit.testStart(() => {
     const markup =
@@ -348,5 +350,51 @@ QUnit.module("submit behavior", {
         this.$element.dxButton({ onClick: clickHandlerSpy });
         this.clickButton();
         assert.ok(clickHandlerSpy.calledOnce);
+    });
+});
+
+QUnit.module("templates", () => {
+    checkStyleHelper.testInChromeOnDesktopActiveWindow("parent styles when button is not focused", function(assert) {
+        const $template = $("<div>").text("test1");
+        $("#button").dxButton({
+            template: function() { return $template; }
+        });
+        $("#input1").focus();
+
+        assert.equal(checkStyleHelper.getColor($template[0]), "rgb(51, 51, 51)", "color");
+        assert.equal(checkStyleHelper.getBackgroundColor($template[0]), "rgb(255, 255, 255)", "backgroundColor");
+        assert.equal(checkStyleHelper.getOverflowX($template[0].parentNode), "visible", "overflowX");
+        assert.equal(checkStyleHelper.getTextOverflow($template[0].parentNode), "clip", "textOverflow");
+        assert.equal(checkStyleHelper.getWhiteSpace($template[0].parentNode), "normal", "whiteSpace");
+    });
+
+    checkStyleHelper.testInChromeOnDesktopActiveWindow("parent styles when button is focused, text is not empty", function(assert) {
+        const $template = $("<div>").text("test1");
+        const $button = $("#button").dxButton({
+            text: "not empty",
+            template: function() { return $template; }
+        });
+        $button.dxButton("instance").focus();
+
+        assert.strictEqual(checkStyleHelper.getColor($template[0]), "rgb(51, 51, 51)", "color");
+        assert.strictEqual(checkStyleHelper.getBackgroundColor($template[0]), "rgb(217, 217, 217)", "backgroundColor");
+        assert.strictEqual(checkStyleHelper.getOverflowX($template[0].parentNode), "hidden", "overflowX");
+        assert.strictEqual(checkStyleHelper.getTextOverflow($template[0].parentNode), "ellipsis", "textOverflow");
+        assert.strictEqual(checkStyleHelper.getWhiteSpace($template[0].parentNode), "nowrap", "whiteSpace");
+    });
+
+    checkStyleHelper.testInChromeOnDesktopActiveWindow("parent styles when button is focused, text is empty", function(assert) {
+        const $template = $("<div>").text("test1");
+        const $button = $("#button").dxButton({
+            text: null,
+            template: function() { return $template; }
+        });
+        $button.dxButton("instance").focus();
+
+        assert.strictEqual(checkStyleHelper.getColor($template[0]), "rgb(51, 51, 51)", "color");
+        assert.strictEqual(checkStyleHelper.getBackgroundColor($template[0]), "rgb(217, 217, 217)", "backgroundColor");
+        assert.strictEqual(checkStyleHelper.getOverflowX($template[0].parentNode), "visible", "overflowX");
+        assert.strictEqual(checkStyleHelper.getTextOverflow($template[0].parentNode), "clip", "textOverflow");
+        assert.strictEqual(checkStyleHelper.getWhiteSpace($template[0].parentNode), "normal", "whiteSpace");
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/menu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menu.tests.js
@@ -2,7 +2,6 @@ var $ = require("jquery"),
     devices = require("core/devices"),
     fx = require("animation/fx"),
     renderer = require("core/renderer"),
-    viewPort = require("core/utils/view_port").value,
     isRenderer = require("core/utils/type").isRenderer,
     config = require("core/config"),
     Submenu = require("ui/menu/ui.submenu"),
@@ -13,9 +12,11 @@ var $ = require("jquery"),
     CustomStore = require("data/custom_store"),
     ArrayStore = require("data/array_store"),
     eventsEngine = require("events/core/events_engine"),
-    DataSource = require("data/data_source/data_source").DataSource;
+    DataSource = require("data/data_source/data_source").DataSource,
+    checkStyleHelper = require("../../helpers/checkStyleHelper.js");
 
 require("common.css!");
+require("generic_light.css!");
 
 QUnit.testStart(function() {
     var markup =
@@ -33,8 +34,6 @@ QUnit.testStart(function() {
 
     $("#qunit-fixture").html(markup);
 });
-
-viewPort($("#qunit-fixture").addClass("dx-viewport"));
 
 var DX_MENU_CLASS = "dx-menu",
     DX_SUBMENU_CLASS = "dx-submenu",
@@ -382,6 +381,44 @@ QUnit.test("Render vertical menu with leftOrTop submenuDirection", function(asse
     fixtures.simple.drop();
 });
 
+QUnit.module("Menu - templates", {
+    beforeEach: function() {
+        fx.off = true;
+    },
+    afterEach: function() {
+        fx.off = false;
+    }
+});
+
+checkStyleHelper.testInChromeOnDesktopActiveWindow("Item template styles when item is not focused", function(assert) {
+    const $template = $("<div>").text("test1");
+    createMenu({
+        items: [{ text: "item1" }],
+        itemTemplate: function() { return $template; }
+    });
+    $("#input1").focus();
+
+    assert.strictEqual(checkStyleHelper.getColor($template[0]), "rgb(51, 51, 51)", "color");
+    assert.strictEqual(checkStyleHelper.getBackgroundColor($template[0]), "rgba(0, 0, 0, 0)", "backgroundColor");
+    assert.strictEqual(checkStyleHelper.getOverflowX($template[0].parentNode), "visible", "overflowX");
+    assert.strictEqual(checkStyleHelper.getTextOverflow($template[0].parentNode), "clip", "textOverflow");
+    assert.strictEqual(checkStyleHelper.getWhiteSpace($template[0].parentNode), "nowrap", "whiteSpace");
+});
+
+checkStyleHelper.testInChromeOnDesktopActiveWindow("Item template styles when item is focused", function(assert) {
+    const $template = $("<div>").text("test1");
+    const menu = createMenu({
+        items: [{ text: "item1" }],
+        itemTemplate: function() { return $template; }
+    });
+    menu.instance.focus();
+
+    assert.strictEqual(checkStyleHelper.getColor($template[0]), "rgb(255, 255, 255)", "color");
+    assert.strictEqual(checkStyleHelper.getBackgroundColor($template[0]), "rgb(51, 122, 183)", "backgroundColor");
+    assert.strictEqual(checkStyleHelper.getOverflowX($template[0].parentNode), "visible", "overflowX");
+    assert.strictEqual(checkStyleHelper.getTextOverflow($template[0].parentNode), "clip", "textOverflow");
+    assert.strictEqual(checkStyleHelper.getWhiteSpace($template[0].parentNode), "nowrap", "whiteSpace");
+});
 
 QUnit.module("Menu - selection", {
     beforeEach: function() {


### PR DESCRIPTION
* Add tests for button/menu styles (T747772, T738205, T742980, T636219)

* Rename and use 'QUnit.skip' in incorrect environment

* Remove typo.

* Simplify run test logic

* Use ' !== document' instead of magic 'for(i < 5)'

* Migrate from the 'checkXXX(assert, ..)' template to the 'assert.strictEqual(CheckStyleHelper.getXXX(), expectedXXX, "XXX")' template

* Typo: document -> document.documentElement

* Export each function separately

* Move tests from xxx.markup.test.js files to xxx.test.js files

* Move tests from menu.markup.test.js files to menu.test.js files

* Rollback all changes in xxx.markup.test.js files

* Add inactive test comment to see a reason in results

* Fit the existing 'export function' naming convention

(cherry picked from commit 18cb3aac752395b5d9f90269f613667c49780ce9)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
