### PR TITLE
Fix blinking test in MS Edge (https://trello.com/c/HyC0Shoz)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -1539,12 +1539,20 @@ QUnit.module("custom mask maskRules", moduleConfig, () => {
     });
 
     QUnit.test("fullText updated, if pasted text is accepted", (assert) => {
+        // Fix blinking on blur in MS Edge (https://trello.com/c/HyC0Shoz)
+        assert.expect(1);
+        let firstTimeCall = true;
+
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "xy",
             maskRules: {
                 "x": "x",
                 "y": (char, index, fullText) => {
-                    assert.equal(fullText, "x_", "x is accepted");
+                    if(firstTimeCall) {
+                        assert.equal(fullText, "x_", "x is accepted");
+                    }
+
+                    firstTimeCall = false;
                     return char === "y";
                 }
             }


### PR DESCRIPTION
This test checks that fullText parameter has been updated after first pasted char is processed. We expect this check once but in fact this check calls more than one time: on paste and on focusout. We have focusout event during test execution sometimes only in MS Edge