### PR TITLE
Fix blinking test in MS Edge (https://trello.com/c/HyC0Shoz)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -1508,7 +1508,7 @@ QUnit.test("fullText updated, if pasted text is accepted", function(assert) {
         mask: "xy",
         maskRules: {
             "x": "x",
-            "y": (char, index, fullText) => {
+            "y": function(char, index, fullText) {
                 if(firstTimeCall) {
                     assert.equal(fullText, "x_", "x is accepted");
                 }

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -1499,12 +1499,12 @@ QUnit.test("custom function get fullText and current index", function(assert) {
     });
 });
 
-QUnit.test("fullText updated, if pasted text is accepted", (assert) => {
+QUnit.test("fullText updated, if pasted text is accepted", function(assert) {
     // Fix blinking on blur in MS Edge (https://trello.com/c/HyC0Shoz)
     assert.expect(1);
-    let firstTimeCall = true;
+    var firstTimeCall = true;
 
-    const $textEditor = $("#texteditor").dxTextEditor({
+    var $textEditor = $("#texteditor").dxTextEditor({
         mask: "xy",
         maskRules: {
             "x": "x",
@@ -1519,8 +1519,8 @@ QUnit.test("fullText updated, if pasted text is accepted", (assert) => {
         }
     });
 
-    const $input = $textEditor.find(".dx-texteditor-input");
-    const keyboard = keyboardMock($input, true);
+    var $input = $textEditor.find(".dx-texteditor-input");
+    var keyboard = keyboardMock($input, true);
 
     keyboard.caret(0).paste("xy");
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -1499,20 +1499,28 @@ QUnit.test("custom function get fullText and current index", function(assert) {
     });
 });
 
-QUnit.test("fullText updated, if pasted text is accepted", function(assert) {
-    var $textEditor = $("#texteditor").dxTextEditor({
+QUnit.test("fullText updated, if pasted text is accepted", (assert) => {
+    // Fix blinking on blur in MS Edge (https://trello.com/c/HyC0Shoz)
+    assert.expect(1);
+    let firstTimeCall = true;
+
+    const $textEditor = $("#texteditor").dxTextEditor({
         mask: "xy",
         maskRules: {
             "x": "x",
-            "y": function(char, index, fullText) {
-                assert.equal(fullText, "x_", "x is accepted");
+            "y": (char, index, fullText) => {
+                if(firstTimeCall) {
+                    assert.equal(fullText, "x_", "x is accepted");
+                }
+
+                firstTimeCall = false;
                 return char === "y";
             }
         }
     });
 
-    var $input = $textEditor.find(".dx-texteditor-input");
-    var keyboard = keyboardMock($input, true);
+    const $input = $textEditor.find(".dx-texteditor-input");
+    const keyboard = keyboardMock($input, true);
 
     keyboard.caret(0).paste("xy");
 });


### PR DESCRIPTION
This test checks that fullText parameter has been updated after first pasted char is processed. We expect this check once but in fact this check calls more than one time: on paste and on focusout. We have focusout event during test execution sometimes only in MS Edge