### PR TITLE
Test/CI upates

### DIFF
--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -76,6 +76,7 @@ function run_test {
             if [ "$HEADLESS" == "true" ]; then
                 google-chrome-stable \
                     --no-sandbox \
+                    --disable-dev-shm-usage \
                     --disable-gpu \
                     --user-data-dir=/tmp/chrome \
                     --headless \
@@ -85,6 +86,7 @@ function run_test {
             else
                 dbus-launch --exit-with-session google-chrome-stable \
                     --no-sandbox \
+                    --disable-dev-shm-usage \
                     --disable-gpu \
                     --user-data-dir=/tmp/chrome \
                     --no-first-run \

--- a/testing/runner/.gitignore
+++ b/testing/runner/.gitignore
@@ -1,0 +1,3 @@
+.vs
+launchSettings.json
+*.user

--- a/testing/runner/Program.cs
+++ b/testing/runner/Program.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.PlatformAbstractions;
 using Newtonsoft.Json.Serialization;
 using Runner.Tools;
 
@@ -21,7 +20,7 @@ namespace Runner
         {
             try
             {
-                var rootPath = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "../../..");
+                var rootPath = Path.Combine(AppContext.BaseDirectory, "../../..");
                 Ports.Load(Path.Combine(rootPath, "ports.json"));
 
                 var url = "http://0.0.0.0:" + Ports.Get("qunit");

--- a/testing/runner/runner.csproj
+++ b/testing/runner/runner.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web" ToolsVersion="15.0">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <StartupObject>Runner.Program</StartupObject>
     <OutputType>Exe</OutputType>
     <OutputPath>bin/</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>portable</DebugType>
+    <RazorCompileToolset>PrecompilationTool</RazorCompileToolset>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Add `--disable-dev-shm-usage` flag. Prerequisite for Chrome > 74. See https://github.com/karma-runner/karma-chrome-launcher/issues/198#issuecomment-515150920.
- Upgrade `testing/runner` to .NET Core 2.1