### PR TITLE
Fix lookup focused state in material theme (T803588)

### DIFF
--- a/styles/widgets/material/lookup.material.less
+++ b/styles/widgets/material/lookup.material.less
@@ -65,12 +65,6 @@
         }
     }
 
-    &.dx-state-focused {
-        &:before {
-            content: none;
-        }
-    }
-
     &.dx-invalid {
         border-bottom-color: @base-invalid-faded-border-color;
 
@@ -92,6 +86,25 @@
 
 .dx-lookup-field {
     font-size: @MATERIAL_LOOKUP_FONT_SIZE;
+
+    .dx-texteditor {
+        border: none;
+
+        &:before,
+        &:after {
+            content: none;
+        }
+
+        &.dx-state-hover,
+        &.dx-state-focused,
+        &.dx-state-active,
+        &.dx-state-disabled,
+        &.dx-state-readonly,
+        &.dx-state-readonly.dx-state-hover,
+        & {
+            background-color: transparent;
+        }
+    }
 }
 
 .dx-lookup-arrow {


### PR DESCRIPTION
Fix the error in https://github.com/DevExpress/DevExtreme/commit/d642f9bf3ebfe5d66341d1cd5e4a1a50b8257912

Turn off all states for the editor in the field template, but leave the state of lookup itself.
