### PR TITLE
Improve accessibility for number box and dropDownEditors (T801129)

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -330,6 +330,10 @@ var DropDownEditor = TextBox.inherit({
         this.$element().wrapInner($("<div>").addClass(DROP_DOWN_EDITOR_INPUT_WRAPPER));
         this._$container = this.$element().children().eq(0);
 
+        this._setDefaultAria();
+    },
+
+    _setDefaultAria: function() {
         this.setAria({
             "haspopup": "true",
             "autocomplete": "list"
@@ -495,9 +499,10 @@ var DropDownEditor = TextBox.inherit({
         this._setPopupOption("visible", opened);
 
         this.setAria({
-            "expanded": opened,
-            "owns": (opened || undefined) && this._popupContentId
+            "expanded": opened
         });
+
+        this.setAria("owns", ((opened || undefined) && this._popupContentId), this.$element());
     },
 
     _createPopup: function() {
@@ -526,10 +531,14 @@ var DropDownEditor = TextBox.inherit({
         this._popup.option("onContentReady", this._contentReadyHandler.bind(this));
         this._contentReadyHandler();
 
-        this._popupContentId = "dx-" + new Guid();
-        this.setAria("id", this._popupContentId, this._popup.$content());
+        this._setPopupContentId(this._popup.$content());
 
         this._bindInnerWidgetOptions(this._popup, "dropDownOptions");
+    },
+
+    _setPopupContentId($popupContent) {
+        this._popupContentId = "dx-" + new Guid();
+        this.setAria("id", this._popupContentId, $popupContent);
     },
 
     _contentReadyHandler: commonUtils.noop,

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -579,7 +579,6 @@ var DropDownList = DropDownEditor.inherit({
 
         this._setAriaTargetForList();
         this._list.option("_listAttributes", { "role": "combobox" });
-        this.setArea("controls", this._listId);
 
         this._renderPreventBlur(this._$list);
     },
@@ -600,7 +599,15 @@ var DropDownList = DropDownEditor.inherit({
 
         this.setAria({
             "activedescendant": opened && this._list.getFocusedItemId(),
-            "owns": opened && this._listId
+            "controls": opened && this._listId
+        });
+
+    },
+
+    _setDefaultAria: function() {
+        this.setAria({
+            "haspopup": "listbox",
+            "autocomplete": "list"
         });
     },
 

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -579,6 +579,7 @@ var DropDownList = DropDownEditor.inherit({
 
         this._setAriaTargetForList();
         this._list.option("_listAttributes", { "role": "combobox" });
+        this.setArea("controls", this._listId);
 
         this._renderPreventBlur(this._$list);
     },

--- a/js/ui/lookup.js
+++ b/js/ui/lookup.js
@@ -834,6 +834,8 @@ var Lookup = DropDownList.inherit({
             "hidden": this._popupHiddenHandler.bind(this)
         });
 
+        this._setPopupContentId(this._popup.$content());
+
         this._popup.option("onContentReady", this._contentReadyHandler.bind(this));
         this._contentReadyHandler();
     },

--- a/js/ui/number_box/number_box.base.js
+++ b/js/ui/number_box/number_box.base.js
@@ -246,7 +246,7 @@ var NumberBoxBase = TextEditor.inherit({
 
         var value = this.option("value");
 
-        this.setAria("valuenow", value);
+        this.setAria("valuenow", value || 0);
         this.option("text", this._input().val());
         this._updateButtons();
 

--- a/js/ui/number_box/number_box.base.js
+++ b/js/ui/number_box/number_box.base.js
@@ -244,9 +244,7 @@ var NumberBoxBase = TextEditor.inherit({
             this._toggleEmptinessEventHandler();
         }
 
-        var value = this.option("value");
-
-        this.setAria("valuenow", value || 0);
+        this.setAria("valuenow", commonUtils.ensureDefined(this.option("value"), ""));
         this.option("text", this._input().val());
         this._updateButtons();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -1409,14 +1409,12 @@ QUnit.test("aria-autocomplete property on input", function(assert) {
 
 QUnit.test("aria-owns should be removed when popup is not visible", function(assert) {
     var $dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor({ opened: true }),
-        $input = $dropDownEditor.find(`.${TEXT_EDITOR_INPUT_CLASS}`),
         instance = $dropDownEditor.dxDropDownEditor("instance");
 
-    assert.notEqual($input.attr("aria-owns"), undefined, "owns exists");
-    assert.equal($input.attr("aria-owns"), $(".dx-popup-content").attr("id"), "aria-owns points to popup's content id");
+    assert.notEqual($dropDownEditor.attr("aria-owns"), undefined, "owns exists");
+    assert.equal($dropDownEditor.attr("aria-owns"), $(".dx-popup-content").attr("id"), "aria-owns points to popup's content id");
 
     instance.close();
 
-    assert.strictEqual($input.attr("aria-owns"), undefined, "owns does not exist");
+    assert.strictEqual($dropDownEditor.attr("aria-owns"), undefined, "owns does not exist");
 });
-

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -1301,7 +1301,7 @@ QUnit.module("aria accessibility", moduleConfig, () => {
         const $dropDownList = $("#dropDownList").dxDropDownList({ opened: true });
         const $input = $dropDownList.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const instance = $dropDownList.dxDropDownList("instance");
-        const $list = instance.content().find(`.${LIST_CLASS}`);
+        const $list = $(instance.content()).find(`.${LIST_CLASS}`);
 
         assert.notEqual($input.attr("aria-controls"), undefined, "controls exists");
         assert.equal($input.attr("aria-controls"), $list.attr("id"), "aria-controls points to list's id");

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -28,6 +28,8 @@ QUnit.testStart(() => {
 const LIST_ITEM_SELECTOR = ".dx-list-item";
 const STATE_FOCUSED_CLASS = "dx-state-focused";
 const TEXTEDITOR_INPUT_CLASS = "dx-texteditor-input";
+const POPUP_CONTENT_CLASS = "dx-popup-content";
+const LIST_CLASS = "dx-list";
 
 const moduleConfig = {
     beforeEach: () => {
@@ -96,7 +98,7 @@ QUnit.module("focus policy", {
     QUnit.test("hover and focus states for list should be initially disabled on mobile devices only", (assert) => {
         this.instance.option("opened", true);
 
-        const list = $(".dx-list").dxList("instance");
+        const list = $(`.${LIST_CLASS}`).dxList("instance");
 
         if(devices.real().deviceType === "desktop") {
             assert.ok(list.option("hoverStateEnabled"), "hover state should be enabled on desktop");
@@ -110,7 +112,7 @@ QUnit.module("focus policy", {
     QUnit.test("changing hover and focus states for list should be enabled on desktop only", (assert) => {
         this.instance.option("opened", true);
 
-        const list = $(".dx-list").dxList("instance");
+        const list = $(`.${LIST_CLASS}`).dxList("instance");
 
         this.instance.option({ hoverStateEnabled: false, focusStateEnabled: false });
 
@@ -177,7 +179,7 @@ QUnit.module("keyboard navigation", {
 
         this.instance.open();
 
-        const $list = $(this.instance.content()).find(".dx-list");
+        const $list = $(this.instance.content()).find(`.${LIST_CLASS}`);
 
         $list.on("mousedown", e => {
             // note: you should not prevent pointerdown because it will prevent click on ios real devices
@@ -196,7 +198,7 @@ QUnit.module("keyboard navigation", {
         });
 
         const $content = $(this.instance.content());
-        const $list = $content.find(".dx-list");
+        const $list = $content.find(`.${LIST_CLASS}`);
 
         assert.notOk($list.attr("tabIndex"), "list have no tabindex");
     });
@@ -219,7 +221,7 @@ QUnit.module("keyboard navigation", {
         });
 
         const $content = $(this.instance.content());
-        const list = $content.find(".dx-list").dxList("instance");
+        const list = $content.find(`.${LIST_CLASS}`).dxList("instance");
         const $listItem = $content.find(LIST_ITEM_SELECTOR).eq(0);
 
         list.option("focusedElement", $listItem);
@@ -723,7 +725,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
             opened: true
         });
 
-        const list = $(".dx-list").dxList("instance");
+        const list = $(`.${LIST_CLASS}`).dxList("instance");
 
         assert.equal(list.option("keyExpr"), null, "keyExpr is correct");
     });
@@ -736,7 +738,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
             opened: true
         }).dxDropDownList("instance");
 
-        const list = $(".dx-list").dxList("instance");
+        const list = $(`.${LIST_CLASS}`).dxList("instance");
 
         assert.equal(list.option("keyExpr"), "id", "keyExpr should be passed on init");
 
@@ -962,7 +964,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
 
         this.clock.tick();
 
-        $(".dx-list").dxList("_loadNextPage");
+        $(`.${LIST_CLASS}`).dxList("_loadNextPage");
 
         this.clock.tick();
 
@@ -1116,7 +1118,7 @@ QUnit.module("popup", moduleConfig, () => {
             width: 200
         });
 
-        const listInstance = $(".dx-list").dxList("instance");
+        const listInstance = $(`.${LIST_CLASS}`).dxList("instance");
 
         listInstance.option("pageLoadMode", "scrollBottom");
         listInstance.option("useNativeScrolling", "true");
@@ -1158,7 +1160,7 @@ QUnit.module("popup", moduleConfig, () => {
 
         $dropDownList.dxDropDownList("instance").open();
 
-        const listInstance = $(".dx-list").dxList("instance");
+        const listInstance = $(`.${LIST_CLASS}`).dxList("instance");
 
         listInstance.option("pageLoadMode", "scrollBottom");
         listInstance.option("useNativeScrolling", "true");
@@ -1288,11 +1290,25 @@ QUnit.module("render input addons", moduleConfig, () => {
 
 QUnit.module("aria accessibility", moduleConfig, () => {
     QUnit.test("aria-owns should point to list", assert => {
-        const $input = $("#dropDownList").dxDropDownList({ opened: true }).find("." + TEXTEDITOR_INPUT_CLASS);
-        const $list = $(".dx-list");
+        const $dropDownList = $("#dropDownList").dxDropDownList({ opened: true });
+        const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
 
-        assert.notEqual($input.attr("aria-owns"), undefined, "aria-owns exists");
-        assert.equal($input.attr("aria-owns"), $list.attr("id"), "aria-owns equals list's id");
+        assert.notEqual($dropDownList.attr("aria-owns"), undefined, "aria-owns exists");
+        assert.equal($dropDownList.attr("aria-owns"), $popupContent.attr("id"), "aria-owns equals popup content's id");
+    });
+
+    QUnit.test("aria-controls should be removed when popup is not visible", function(assert) {
+        const $dropDownList = $("#dropDownList").dxDropDownList({ opened: true });
+        const $input = $dropDownList.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const instance = $dropDownList.dxDropDownList("instance");
+        const $list = instance.content().find(`.${LIST_CLASS}`);
+
+        assert.notEqual($input.attr("aria-controls"), undefined, "controls exists");
+        assert.equal($input.attr("aria-controls"), $list.attr("id"), "aria-controls points to list's id");
+
+        instance.close();
+
+        assert.strictEqual($input.attr("aria-controls"), undefined, "controls does not exist");
     });
 
     QUnit.test("input's aria-activedescendant attribute should point to the focused item", assert => {
@@ -1302,7 +1318,7 @@ QUnit.module("aria accessibility", moduleConfig, () => {
             focusStateEnabled: true
         });
 
-        const $list = $(".dx-list");
+        const $list = $(`.${LIST_CLASS}`);
         const list = $list.dxList("instance");
         const $input = $dropDownList.find("." + TEXTEDITOR_INPUT_CLASS);
         const $item = $list.find(".dx-list-item:eq(1)");
@@ -1317,7 +1333,7 @@ QUnit.module("aria accessibility", moduleConfig, () => {
         assert.expect(2);
 
         const dropDownList = $("#dropDownList").dxDropDownList({ opened: true }).dxDropDownList("instance");
-        const list = $(".dx-list").dxList("instance");
+        const list = $(`.${LIST_CLASS}`).dxList("instance");
         const $input = $("#dropDownList").find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.deepEqual(list._getAriaTarget(), dropDownList._getAriaTarget());
@@ -1341,7 +1357,7 @@ QUnit.module("dropdownlist with groups", {
             grouped: true
         }).dxDropDownList("instance");
 
-        const list = $(".dx-list").dxList("instance");
+        const list = $(`.${LIST_CLASS}`).dxList("instance");
         assert.strictEqual(list.option("grouped"), true, "grouped option is passed to the list");
         assert.deepEqual(list.option("items"), dropDownList.option("items"), "items is equal");
 
@@ -1360,7 +1376,7 @@ QUnit.module("dropdownlist with groups", {
             groupTemplate: groupTemplate1
         }).dxDropDownList("instance");
 
-        const list = $(".dx-list").dxList("instance");
+        const list = $(`.${LIST_CLASS}`).dxList("instance");
         assert.strictEqual(list.option("groupTemplate"), groupTemplate1, "groupTemplate has been passed on init");
 
         const groupTemplate2 = new Template("<div>Test</div>");

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -3003,11 +3003,13 @@ QUnit.module("aria accessibility", () => {
 
                 let list = $(`.${LIST_CLASS}`).dxList("instance");
                 checkAsserts({ $target: list.$element(), role: "listbox", isActiveDescendant: true, isOwns: false, tabIndex: '0' });
-                checkAsserts({ $target: $field, role: "combobox", isActiveDescendant: true, isOwns: true, tabIndex: '0' });
+                checkAsserts({ $target: $field, role: "combobox", isActiveDescendant: true, isOwns: false, tabIndex: '0' });
+                checkAsserts({ $target: $element, role: undefined, isActiveDescendant: false, isOwns: true });
 
                 $element.dxLookup("instance").option("searchEnabled", !searchEnabled);
                 checkAsserts({ $target: list.$element(), role: "listbox", isActiveDescendant: true, isOwns: false, tabIndex: '0' });
-                checkAsserts({ $target: $field, role: "combobox", isActiveDescendant: true, isOwns: true, tabIndex: '0' });
+                checkAsserts({ $target: $field, role: "combobox", isActiveDescendant: true, isOwns: false, tabIndex: '0' });
+                checkAsserts({ $target: $element, role: undefined, isActiveDescendant: false, isOwns: true });
             });
         });
     }

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
@@ -2040,6 +2040,15 @@ QUnit.module("aria accessibility", {}, () => {
         assert.ok(inputElement.hasAttribute("aria-valuemax"), "required 'aria-valuemax' attribute is defined");
     });
 
+    QUnit.test("aria valuenow is 0 for numberBox with null value (T801129)", (assert) => {
+        const $element = $("#numberbox").dxNumberBox({
+            value: null
+        });
+
+        const $input = $element.find(".dx-texteditor-input");
+        assert.equal($input.attr("aria-valuenow"), 0, "attribute is defined");
+    });
+
     QUnit.test("aria properties", (assert) => {
         const $element = $("#numberbox").dxNumberBox({
             min: 12,

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
@@ -2040,13 +2040,13 @@ QUnit.module("aria accessibility", {}, () => {
         assert.ok(inputElement.hasAttribute("aria-valuemax"), "required 'aria-valuemax' attribute is defined");
     });
 
-    QUnit.test("aria valuenow is 0 for numberBox with null value (T801129)", (assert) => {
+    QUnit.test("aria valuenow is defined for numberBox with null value (T801129)", (assert) => {
         const $element = $("#numberbox").dxNumberBox({
             value: null
         });
 
         const $input = $element.find(".dx-texteditor-input");
-        assert.equal($input.attr("aria-valuenow"), 0, "attribute is defined");
+        assert.strictEqual($input.attr("aria-valuenow"), "", "attribute is defined");
     });
 
     QUnit.test("aria properties", (assert) => {

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -4811,12 +4811,14 @@ QUnit.module("aria accessibility", () => {
 
                 let list = $(`.${LIST_CLASS}`).dxList("instance");
                 checkAsserts({ $target: list.$element(), role: "listbox", isActiveDescendant: true, isOwns: false, tabIndex: undefined });
-                checkAsserts({ $target: $input, role: "combobox", isActiveDescendant: true, isOwns: true, tabIndex: '0' });
+                checkAsserts({ $target: $input, role: "combobox", isActiveDescendant: true, isOwns: false, tabIndex: '0' });
+                checkAsserts({ $target: $element, role: undefined, isActiveDescendant: false, isOwns: true });
 
                 $element.dxSelectBox("instance").option("searchEnabled", !searchEnabled);
                 $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
                 checkAsserts({ $target: list.$element(), role: "listbox", isActiveDescendant: true, isOwns: false, tabIndex: undefined });
-                checkAsserts({ $target: $input, role: "combobox", isActiveDescendant: true, isOwns: true, tabIndex: '0' });
+                checkAsserts({ $target: $input, role: "combobox", isActiveDescendant: true, isOwns: false, tabIndex: '0' });
+                checkAsserts({ $target: $element, role: undefined, isActiveDescendant: false, isOwns: true });
             });
         });
     }


### PR DESCRIPTION
Spinbuttons [required](https://www.w3.org/TR/wai-aria/#spinbutton) valuenow = 0 even if it is null.
And combobox [required](https://www.w3.org/TR/wai-aria/#combobox) aria-controls, dropDownLists haspopup [required](https://www.w3.org/TR/wai-aria/#aria-haspopup) "listbox" value and aria-owns  [must be set](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html#ex3_label) for a container.