### PR TITLE
dxScheduler - appointments should be rendered on the same line after navigating to the next month if crossScrollingEnabled set to true(T804721)

### DIFF
--- a/js/ui/scheduler/rendering_strategies/ui.scheduler.appointments.strategy.base.js
+++ b/js/ui/scheduler/rendering_strategies/ui.scheduler.appointments.strategy.base.js
@@ -250,50 +250,40 @@ class BaseRenderingStrategy {
         return width;
     }
 
-    _getSortedPositions(arr) {
-        var result = [],
-            // unstable sorting fix
-            __tmpIndex = 0;
+    _getSortedPositions(positionList) {
+        const result = [];
 
-        for(var i = 0, arrLength = arr.length; i < arrLength; i++) {
-            for(var j = 0, itemLength = arr[i].length; j < itemLength; j++) {
-                var item = arr[i][j];
+        const round = value => Math.round(value * 100) / 100;
+        const createSortedItem = (rowIndex, cellIndex, top, left, position, isStart, allDay, tmpIndex) => {
+            return {
+                i: rowIndex,
+                j: cellIndex,
+                top: round(top),
+                left: round(left),
+                cellPosition: position,
+                isStart: isStart,
+                allDay: allDay,
+                __tmpIndex: tmpIndex
+            };
+        };
 
-                var start = {
-                    i: i,
-                    j: j,
-                    top: item.top,
-                    left: item.left,
-                    cellPosition: item.cellPosition,
-                    isStart: true,
-                    allDay: item.allDay,
-                    __tmpIndex: __tmpIndex
-                };
+        let tmpIndex = 0; // unstable sorting fix
 
-                __tmpIndex++;
+        for(let rowIndex = 0, rowCount = positionList.length; rowIndex < rowCount; rowIndex++) {
+            for(let cellIndex = 0, cellCount = positionList[rowIndex].length; cellIndex < cellCount; cellIndex++) {
+                const { top, left, height, width, cellPosition, allDay } = positionList[rowIndex][cellIndex];
 
-                var end = {
-                    i: i,
-                    j: j,
-                    top: item.top + item.height,
-                    left: item.left + item.width,
-                    cellPosition: item.cellPosition,
-                    isStart: false,
-                    allDay: item.allDay,
-                    __tmpIndex: __tmpIndex
-                };
+                const start = createSortedItem(rowIndex, cellIndex, top, left, cellPosition, true, allDay, tmpIndex);
+                tmpIndex++;
+
+                const end = createSortedItem(rowIndex, cellIndex, top + height, left + width, cellPosition, false, allDay, tmpIndex);
+                tmpIndex++;
 
                 result.push(start, end);
-
-                __tmpIndex++;
             }
         }
 
-        result.sort((function(a, b) {
-            return this._sortCondition(a, b);
-        }).bind(this));
-
-        return result;
+        return result.sort((a, b) => this._sortCondition(a, b));
     }
 
     _fixUnstableSorting(comparisonResult, a, b) {

--- a/js/ui/scheduler/rendering_strategies/ui.scheduler.appointments.strategy.base.js
+++ b/js/ui/scheduler/rendering_strategies/ui.scheduler.appointments.strategy.base.js
@@ -253,7 +253,8 @@ class BaseRenderingStrategy {
     _getSortedPositions(positionList) {
         const result = [];
 
-        const round = value => Math.round(value * 100) / 100;
+        // const round = value => Math.round(value * 100) / 100;
+        const round = value => Math.round(value);
         const createSortedItem = (rowIndex, cellIndex, top, left, position, isStart, allDay, tmpIndex) => {
             return {
                 i: rowIndex,

--- a/js/ui/scheduler/rendering_strategies/ui.scheduler.appointments.strategy.base.js
+++ b/js/ui/scheduler/rendering_strategies/ui.scheduler.appointments.strategy.base.js
@@ -253,8 +253,7 @@ class BaseRenderingStrategy {
     _getSortedPositions(positionList) {
         const result = [];
 
-        // const round = value => Math.round(value * 100) / 100;
-        const round = value => Math.round(value);
+        const round = value => Math.round(value * 100) / 100;
         const createSortedItem = (rowIndex, cellIndex, top, left, position, isStart, allDay, tmpIndex) => {
             return {
                 i: rowIndex,

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
@@ -1919,15 +1919,8 @@ var SchedulerWorkSpace = Widget.inherit({
     },
 
     _getCellPosition: function($cell) {
-        var isRtl = this.option("rtlEnabled"),
-            position = $cell.position();
-
-        if(position) {
-            position.left = Math.round(position.left * 100) / 100;
-            position.top = Math.round(position.top * 100) / 100;
-        }
-
-        if(isRtl) {
+        const position = $cell.position();
+        if(this.option("rtlEnabled")) {
             position.left += $cell.get(0).getBoundingClientRect().width;
         }
         return position;

--- a/testing/tests/DevExpress.ui.widgets.scheduler/helpers.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/helpers.js
@@ -150,6 +150,17 @@ export class SchedulerTestWrapper {
             }
         };
 
+        this.navigator = {
+            getNavigator: () => $(".dx-scheduler-navigator"),
+            getCaption: () => $(".dx-scheduler-navigator").find(".dx-scheduler-navigator-caption").text(),
+            clickOnPrevButton: () => {
+                this.navigator.getNavigator().find(".dx-scheduler-navigator-previous").trigger("dxclick");
+            },
+            clickOnNextButton: () => {
+                this.navigator.getNavigator().find(".dx-scheduler-navigator-next").trigger("dxclick");
+            }
+        },
+
         this.grouping = {
             getGroupHeaders: () => $(".dx-scheduler-group-header"),
             getGroupHeader: (index = 0) => this.grouping.getGroupHeaders().eq(index),


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
