### PR TITLE
Fix the name argument of the simple item template when the dataField is defined in the Form (T757499)

### DIFF
--- a/js/ui/form/ui.form.layout_manager.js
+++ b/js/ui/form/ui.form.layout_manager.js
@@ -628,7 +628,7 @@ const LayoutManager = Widget.inherit({
         var instance = that._renderEditor({
             $container: $editor,
             dataField: item.dataField,
-            name: name,
+            name: item.name,
             editorType: item.editorType,
             editorOptions: item.editorOptions,
             template: that._getTemplateByFieldItem(item),

--- a/testing/tests/DevExpress.knockout/form.tests.js
+++ b/testing/tests/DevExpress.knockout/form.tests.js
@@ -590,7 +590,7 @@ QUnit.test("The formData is empty object when formData has 'undefined' value", f
     assert.deepEqual(viewModel.formData(), { });
 });
 
-QUnit.test("The name argument should contains in the template of the simple item", assert => {
+QUnit.test("Check name argument of the simple item template when name is defined", assert => {
     // arrange
     const viewModel = {
         items: [{ name: "TestName", template: "simpleTemplate2" }]
@@ -601,4 +601,43 @@ QUnit.test("The name argument should contains in the template of the simple item
 
     // assert
     assert.strictEqual($("#name").text(), "TestName", "the name argument of template");
+});
+
+QUnit.test("Check name argument of the simple item template when name and dataField are defined", assert => {
+    // arrange
+    const viewModel = {
+        items: [{ name: "TestName", dataField: "TestDataField", template: "simpleTemplate2" }]
+    };
+    const $form = $("#simpleTemplateForm2");
+
+    ko.applyBindings(viewModel, $form.get(0));
+
+    // assert
+    assert.strictEqual($("#name").text(), "TestName", "the name argument of template");
+});
+
+QUnit.test("Check name argument of the simple item template when name is undefined", assert => {
+    // arrange
+    const viewModel = {
+        items: [{ template: "simpleTemplate2" }]
+    };
+    const $form = $("#simpleTemplateForm2");
+
+    ko.applyBindings(viewModel, $form.get(0));
+
+    // assert
+    assert.strictEqual($("#name").text(), "", "the name argument of template");
+});
+
+QUnit.test("Check name argument of the simple item template when name is undefined and dataField is defined", assert => {
+    // arrange
+    const viewModel = {
+        items: [{ dataField: "TestDataField", template: "simpleTemplate2" }]
+    };
+    const $form = $("#simpleTemplateForm2");
+
+    ko.applyBindings(viewModel, $form.get(0));
+
+    // assert
+    assert.strictEqual($("#name").text(), "", "the name argument of template");
 });

--- a/testing/tests/DevExpress.ui.widgets.form/form.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.markup.tests.js
@@ -796,7 +796,7 @@ QUnit.module("Form", () => {
         assert.equal(buttonValidationGroup, "test", "Button validationGroup is OK");
     });
 
-    test("The name argument should be defined in the template of a simple item", (assert) => {
+    test("Check name argument of the simple item template when name is defined", (assert) => {
         const templateStub = sinon.stub();
         $("#form").dxForm({
             items: [{
@@ -806,6 +806,42 @@ QUnit.module("Form", () => {
         });
 
         assert.equal(templateStub.getCall(0).args[0].name, "TestName", "name argument");
+    });
+
+    test("Check name argument of the simple item template when name and dataField are defined", (assert) => {
+        const templateStub = sinon.stub();
+        $("#form").dxForm({
+            items: [{
+                dataField: "TestDataField",
+                name: "TestName",
+                template: templateStub
+            }]
+        });
+
+        assert.equal(templateStub.getCall(0).args[0].name, "TestName", "name argument");
+    });
+
+    test("Check name argument of the simple item template when name is undefined", (assert) => {
+        const templateStub = sinon.stub();
+        $("#form").dxForm({
+            items: [{
+                template: templateStub
+            }]
+        });
+
+        assert.equal(templateStub.getCall(0).args[0].name, undefined, "name argument");
+    });
+
+    test("Check name argument of the simple item template when name is undefined and dataField is defined", (assert) => {
+        const templateStub = sinon.stub();
+        $("#form").dxForm({
+            items: [{
+                dataField: "TestDataField",
+                template: templateStub
+            }]
+        });
+
+        assert.equal(templateStub.getCall(0).args[0].name, undefined, "name argument");
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
@@ -2806,6 +2806,32 @@ QUnit.module("Templates", () => {
         assert.equal(textArea.option("value"), layoutManager.option("layoutData.test"), "Widget's value equal to bound datafield");
     });
 
+    test("Check arguments of the template", (assert) => {
+        const templateStub = sinon.stub();
+        const layoutManager = $("#container").dxLayoutManager({
+            items: [{
+                name: "TestName",
+                dataField: "TestDataField",
+                editorType: "dxColorBox",
+                editorOptions: {
+                    text: "TestText"
+                },
+                template: templateStub
+            }]
+        }).dxLayoutManager("instance");
+
+        const args = templateStub.getCall(0).args;
+        assert.equal(args[0].name, "TestName", "name argument");
+        assert.equal(args[0].dataField, "TestDataField", "dataField argument");
+        assert.equal(args[0].editorType, "dxColorBox", "editorType argument");
+        assert.propEqual(args[0].editorOptions, {
+            inputAttr: {},
+            name: "TestDataField",
+            text: "TestText"
+        }, "editorOptions argument");
+        assert.equal(args[0].component, layoutManager, "component argument");
+    });
+
     test("Check template bound to data", (assert) => {
         // arrange
         let $testContainer = $("#container");

--- a/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
@@ -2820,16 +2820,14 @@ QUnit.module("Templates", () => {
             }]
         }).dxLayoutManager("instance");
 
-        const args = templateStub.getCall(0).args;
-        assert.equal(args[0].name, "TestName", "name argument");
-        assert.equal(args[0].dataField, "TestDataField", "dataField argument");
-        assert.equal(args[0].editorType, "dxColorBox", "editorType argument");
-        assert.propEqual(args[0].editorOptions, {
-            inputAttr: {},
-            name: "TestDataField",
-            text: "TestText"
-        }, "editorOptions argument");
-        assert.equal(args[0].component, layoutManager, "component argument");
+        const args = templateStub.firstCall.args[0];
+        assert.strictEqual(args.name, "TestName", "name argument");
+        assert.strictEqual(args.dataField, "TestDataField", "dataField argument");
+        assert.strictEqual(args.editorType, "dxColorBox", "editorType argument");
+        assert.deepEqual(args.editorOptions.inputAttr, {}, "editorOptions.inputAttr argument");
+        assert.strictEqual(args.editorOptions.name, "TestDataField", "editorOptions.name argument");
+        assert.strictEqual(args.editorOptions.text, "TestText", "editorOptions.text argument");
+        assert.equal(args.component, layoutManager, "component argument");
     });
 
     test("Check template bound to data", (assert) => {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
