### PR TITLE
Blur body when bluring of an element is impossible (for IE)

### DIFF
--- a/js/core/utils/dom.js
+++ b/js/core/utils/dom.js
@@ -12,9 +12,16 @@ var $ = require("../../core/renderer"),
     elementStrategy;
 
 var resetActiveElement = function() {
-    var activeElement = domAdapter.getActiveElement();
-    if(activeElement && activeElement !== domAdapter.getBody() && activeElement.blur) {
-        activeElement.blur();
+    var activeElement = domAdapter.getActiveElement(),
+        body = domAdapter.getBody();
+
+    // todo: remove this hack after msie 11 support stopped
+    if(activeElement && activeElement !== body && activeElement.blur) {
+        try {
+            activeElement.blur();
+        } catch(e) {
+            body.blur();
+        }
     }
 };
 

--- a/testing/tests/DevExpress.core/utils.dom.tests.js
+++ b/testing/tests/DevExpress.core/utils.dom.tests.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import domUtils from "core/utils/dom";
+import domAdapter from "core/dom_adapter";
 import support from "core/utils/support";
 import styleUtils from "core/utils/style";
 import devices from "core/devices";
@@ -87,6 +88,23 @@ QUnit.test("clearSelection should not run if selectionType is 'Caret'", function
 
     } finally {
         window.getSelection = originalGetSelection;
+    }
+});
+
+QUnit.test("resetActiveElement should not throw an error in IE", function(assert) {
+    var getActiveElement = sinon.stub(domAdapter, "getActiveElement").returns({
+        blur: function() {
+            throw "IE throws an 'Incorrect Function' exception in blur method";
+        }
+    });
+    var bodyBlur = sinon.spy(document.body, "blur");
+
+    try {
+        domUtils.resetActiveElement();
+        assert.strictEqual(bodyBlur.callCount, 1, "body should be blured if blur function on element does not work");
+    } finally {
+        bodyBlur.restore();
+        getActiveElement.restore();
     }
 });
 


### PR DESCRIPTION
IE browser throws an exception after click on the "test" word:

```
<body>
    <div id="test">
        <div id="ftest" tabindex="0">
            test
        </div>
    </div>
</body>

<script type="text/javascript">
    var el = document.getElementById("test");
    var el2 = document.getElementById("ftest");
    el.onclick = function () {
        el.msRequestFullscreen();
        setTimeout(function () {
            el2.focus();
            setTimeout(function () {
                // try {
                    el2.blur();
                 // } catch (e) {
                 //    document.body.blur();
                 // }
            }, 500)
        }, 100)
    }
</script>
```

DevExtreme widgets call blur manually in some cases, for example, on overlay's hidding. This pull request is a temporary solution before microsoft fixed this problem in IE or MS IE 11 support stopped