### PR TITLE
Fix unexpected scrollbar appearance when zooming  (T691054)

### DIFF
--- a/js/ui/scroll_view/ui.scrollable.simulated.js
+++ b/js/ui/scroll_view/ui.scrollable.simulated.js
@@ -442,10 +442,10 @@ var Scroller = Class.inherit({
     _updateScrollbar: deferUpdater(function() {
         const containerSize = this._containerSize();
         const contentSize = this._contentSize();
-        
-        // NOTE: Real container and content sizes can be very fractional number when scaling.
-        //       Let's remember sizes when scale = 100% to decide is scrollbar needed by more concrete numbers.
-        //       We can do it cause container size to content size ratio should remain approximately the same at any zoom.
+
+        //      NOTE: Real container and content sizes can be very fractional number when scaling.
+        //          Let's remember sizes when scale = 100% to decide is scrollbar needed by more concrete numbers.
+        //          We can do it cause container size to content size ratio should remain approximately the same at any zoom.
         const baseContainerSize = this._getBaseDimension(this._$container.get(0), this._dimension);
         const baseContentSize = this._getBaseDimension(this._$content.get(0), this._dimension);
 

--- a/js/ui/scroll_view/ui.scrollable.simulated.js
+++ b/js/ui/scroll_view/ui.scrollable.simulated.js
@@ -455,6 +455,7 @@ var Scroller = Class.inherit({
                 contentSize,
                 baseContainerSize,
                 baseContentSize,
+                isScrollUsedInsideOfScrollable: true,
                 scaleRatio: this._getScaleRatio()
             });
         });

--- a/js/ui/scroll_view/ui.scrollable.simulated.js
+++ b/js/ui/scroll_view/ui.scrollable.simulated.js
@@ -189,7 +189,8 @@ var Scroller = Class.inherit({
             const realDimension = this._getRealDimension(element, this._dimension);
             const baseDimension = this._getBaseDimension(element, this._dimension);
 
-            // round ratio to make size calculations more accurate
+            // NOTE: Ratio can be a very fractional number, which leads to inaccuracy in the calculation of sizes.
+            //      To reduce the inaccuracy and prevent the unexpected appearance of a scrollbar, round to hundredths.
             this._scaleRatio = Math.round((realDimension / baseDimension * 100)) / 100;
         }
 
@@ -439,10 +440,12 @@ var Scroller = Class.inherit({
     },
 
     _updateScrollbar: deferUpdater(function() {
-        // real sizes (considering to zoom)
         const containerSize = this._containerSize();
         const contentSize = this._contentSize();
-        // base sizes (zoom = 100%)
+        
+        // NOTE: Real container and content sizes can be very fractional number when scaling.
+        //       Let's remember sizes when scale = 100% to decide is scrollbar needed by more concrete numbers.
+        //       We can do it cause container size to content size ratio should remain approximately the same at any zoom.
         const baseContainerSize = this._getBaseDimension(this._$container.get(0), this._dimension);
         const baseContentSize = this._getBaseDimension(this._$content.get(0), this._dimension);
 

--- a/js/ui/scroll_view/ui.scrollable.simulated.js
+++ b/js/ui/scroll_view/ui.scrollable.simulated.js
@@ -456,7 +456,6 @@ var Scroller = Class.inherit({
                 contentSize,
                 baseContainerSize,
                 baseContentSize,
-                isScrollUsedInsideOfScrollable: true,
                 scaleRatio: this._getScaleRatio()
             });
         });

--- a/js/ui/scroll_view/ui.scrollable.simulated.js
+++ b/js/ui/scroll_view/ui.scrollable.simulated.js
@@ -189,7 +189,8 @@ var Scroller = Class.inherit({
             const realDimension = this._getRealDimension(element, this._dimension);
             const baseDimension = this._getBaseDimension(element, this._dimension);
 
-            this._scaleRatio = realDimension / baseDimension;
+            // round ratio to make size calculations more accurate
+            this._scaleRatio = Math.round((realDimension / baseDimension * 100)) / 100;
         }
 
         return this._scaleRatio || 1;
@@ -438,13 +439,19 @@ var Scroller = Class.inherit({
     },
 
     _updateScrollbar: deferUpdater(function() {
+        // real sizes (considering to zoom)
         const containerSize = this._containerSize();
         const contentSize = this._contentSize();
+        // base sizes (zoom = 100%)
+        const baseContainerSize = this._getBaseDimension(this._$container.get(0), this._dimension);
+        const baseContentSize = this._getBaseDimension(this._$content.get(0), this._dimension);
 
         deferRender(() => {
             this._scrollbar.option({
-                containerSize: containerSize,
-                contentSize: contentSize,
+                containerSize,
+                contentSize,
+                baseContainerSize,
+                baseContentSize,
                 scaleRatio: this._getScaleRatio()
             });
         });

--- a/js/ui/scroll_view/ui.scrollable.simulated.js
+++ b/js/ui/scroll_view/ui.scrollable.simulated.js
@@ -189,8 +189,8 @@ var Scroller = Class.inherit({
             const realDimension = this._getRealDimension(element, this._dimension);
             const baseDimension = this._getBaseDimension(element, this._dimension);
 
-            // NOTE: Ratio can be a very fractional number, which leads to inaccuracy in the calculation of sizes.
-            //      To reduce the inaccuracy and prevent the unexpected appearance of a scrollbar, round to hundredths.
+            // NOTE: Ratio can be a fractional number, which leads to inaccuracy in the calculation of sizes.
+            //       We should round it to hundredths in order to reduce the inaccuracy and prevent the unexpected appearance of a scrollbar.
             this._scaleRatio = Math.round((realDimension / baseDimension * 100)) / 100;
         }
 
@@ -443,9 +443,10 @@ var Scroller = Class.inherit({
         const containerSize = this._containerSize();
         const contentSize = this._contentSize();
 
-        //      NOTE: Real container and content sizes can be very fractional number when scaling.
-        //          Let's remember sizes when scale = 100% to decide is scrollbar needed by more concrete numbers.
-        //          We can do it cause container size to content size ratio should remain approximately the same at any zoom.
+        // NOTE: Real container and content sizes can be a fractional number when scaling.
+        //       Let's save sizes when scale = 100% to decide whether it is necessary to show
+        //       the scrollbar based on by more precise numbers. We can do it because the container
+        //       size to content size ratio should remain approximately the same at any zoom.
         const baseContainerSize = this._getBaseDimension(this._$container.get(0), this._dimension);
         const baseContentSize = this._getBaseDimension(this._$content.get(0), this._dimension);
 

--- a/js/ui/scroll_view/ui.scrollbar.js
+++ b/js/ui/scroll_view/ui.scrollbar.js
@@ -175,7 +175,7 @@ var Scrollbar = Widget.inherit({
             baseContainerSize = Math.round(this.option("baseContainerSize")),
             baseContentSize = Math.round(this.option("baseContentSize"));
 
-        // NOTE: if current scrollbar's using outside of scrollbalbe
+        // NOTE: if current scrollbar's using outside of scrollable
         if(isNaN(baseContainerSize)) {
             baseContainerSize = containerSize;
             baseContentSize = contentSize;

--- a/js/ui/scroll_view/ui.scrollbar.js
+++ b/js/ui/scroll_view/ui.scrollbar.js
@@ -35,6 +35,7 @@ var Scrollbar = Widget.inherit({
             visibilityMode: SCROLLBAR_VISIBLE.onScroll,
             containerSize: 0,
             contentSize: 0,
+            isScrollUsedInsideOfScrollable: false,
             expandable: true,
             scaleRatio: 1
         });
@@ -173,9 +174,10 @@ var Scrollbar = Widget.inherit({
         var containerSize = Math.round(this.option("containerSize")),
             contentSize = Math.round(this.option("contentSize")),
             baseContainerSize = Math.round(this.option("baseContainerSize")),
-            baseContentSize = Math.round(this.option("baseContentSize"));
+            baseContentSize = Math.round(this.option("baseContentSize")),
+            isScrollUsedInsideOfScrollable = Math.round(this.option("isScrollUsedInsideOfScrollable"));
 
-        if(isNaN(baseContentSize)) {
+        if(!isScrollUsedInsideOfScrollable) {
             baseContainerSize = containerSize;
             baseContentSize = contentSize;
         }
@@ -235,6 +237,8 @@ var Scrollbar = Widget.inherit({
                 break;
             case "scaleRatio":
                 this._update();
+                break;
+            case "isScrollUsedInsideOfScrollable":
                 break;
             default:
                 this.callBase.apply(this, arguments);

--- a/js/ui/scroll_view/ui.scrollbar.js
+++ b/js/ui/scroll_view/ui.scrollbar.js
@@ -175,7 +175,7 @@ var Scrollbar = Widget.inherit({
             contentSize = Math.round(this.option("contentSize")),
             baseContainerSize = Math.round(this.option("baseContainerSize")),
             baseContentSize = Math.round(this.option("baseContentSize")),
-            isScrollUsedInsideOfScrollable = Math.round(this.option("isScrollUsedInsideOfScrollable"));
+            isScrollUsedInsideOfScrollable = this.option("isScrollUsedInsideOfScrollable");
 
         if(!isScrollUsedInsideOfScrollable) {
             baseContainerSize = containerSize;

--- a/js/ui/scroll_view/ui.scrollbar.js
+++ b/js/ui/scroll_view/ui.scrollbar.js
@@ -35,7 +35,6 @@ var Scrollbar = Widget.inherit({
             visibilityMode: SCROLLBAR_VISIBLE.onScroll,
             containerSize: 0,
             contentSize: 0,
-            isScrollUsedInsideOfScrollable: false,
             expandable: true,
             scaleRatio: 1
         });
@@ -174,10 +173,10 @@ var Scrollbar = Widget.inherit({
         var containerSize = Math.round(this.option("containerSize")),
             contentSize = Math.round(this.option("contentSize")),
             baseContainerSize = Math.round(this.option("baseContainerSize")),
-            baseContentSize = Math.round(this.option("baseContentSize")),
-            isScrollUsedInsideOfScrollable = this.option("isScrollUsedInsideOfScrollable");
+            baseContentSize = Math.round(this.option("baseContentSize"));
 
-        if(!isScrollUsedInsideOfScrollable) {
+        // NOTE: if current scrollbar's using outside of scrollbalbe
+        if(isNaN(baseContainerSize)) {
             baseContainerSize = containerSize;
             baseContentSize = contentSize;
         }
@@ -237,8 +236,6 @@ var Scrollbar = Widget.inherit({
                 break;
             case "scaleRatio":
                 this._update();
-                break;
-            case "isScrollUsedInsideOfScrollable":
                 break;
             default:
                 this.callBase.apply(this, arguments);

--- a/js/ui/scroll_view/ui.scrollbar.js
+++ b/js/ui/scroll_view/ui.scrollbar.js
@@ -129,7 +129,7 @@ var Scrollbar = Widget.inherit({
     },
 
     _adjustVisibility: function(visible) {
-        if(this.containerToContentRatio() && !this._needScrollbar()) {
+        if(this._baseContainerToContentRatio && !this._needScrollbar()) {
             return false;
         }
 
@@ -168,12 +168,19 @@ var Scrollbar = Widget.inherit({
         return -location * this._thumbRatio;
     },
 
+
     _update: function() {
         var containerSize = Math.round(this.option("containerSize")),
-            contentSize = Math.round(this.option("contentSize"));
+            contentSize = Math.round(this.option("contentSize")),
+            baseContainerSize = Math.round(this.option("baseContainerSize")),
+            baseContentSize = Math.round(this.option("baseContentSize"));
 
-        this._containerToContentRatio = (contentSize ? containerSize / contentSize : containerSize);
-        var thumbSize = Math.round(Math.max(Math.round(containerSize * this._containerToContentRatio), THUMB_MIN_SIZE));
+        // base sizes ratio for more accurate understanding is scrollbar needed
+        this._baseContainerToContentRatio = (baseContentSize ? baseContainerSize / baseContentSize : baseContainerSize);
+
+        // real sizes ratio
+        this._realContainerToContentRatio = (contentSize ? containerSize / contentSize : containerSize);
+        var thumbSize = Math.round(Math.max(Math.round(containerSize * this._realContainerToContentRatio), THUMB_MIN_SIZE));
         this._thumbRatio = (containerSize - thumbSize) / (this.option("scaleRatio") * (contentSize - containerSize));
 
         this.option(this._dimension, thumbSize / this.option("scaleRatio"));
@@ -185,11 +192,11 @@ var Scrollbar = Widget.inherit({
     },
 
     _needScrollbar: function() {
-        return !this._isHidden() && (this._containerToContentRatio < 1);
+        return !this._isHidden() && (this._baseContainerToContentRatio < 1);
     },
 
     containerToContentRatio: function() {
-        return this._containerToContentRatio;
+        return this._realContainerToContentRatio;
     },
 
     _normalizeSize: function(size) {
@@ -214,6 +221,10 @@ var Scrollbar = Widget.inherit({
             case "containerSize":
             case "contentSize":
                 this.option()[args.name] = this._normalizeSize(args.value);
+                this._update();
+                break;
+            case "baseContentSize":
+            case "baseContainerSize":
                 this._update();
                 break;
             case "visibilityMode":

--- a/js/ui/scroll_view/ui.scrollbar.js
+++ b/js/ui/scroll_view/ui.scrollbar.js
@@ -180,10 +180,7 @@ var Scrollbar = Widget.inherit({
             baseContentSize = contentSize;
         }
 
-        // base sizes ratio for more accurate understanding is scrollbar needed
         this._baseContainerToContentRatio = (baseContentSize ? baseContainerSize / baseContentSize : baseContainerSize);
-
-        // real sizes ratio
         this._realContainerToContentRatio = (contentSize ? containerSize / contentSize : containerSize);
         var thumbSize = Math.round(Math.max(Math.round(containerSize * this._realContainerToContentRatio), THUMB_MIN_SIZE));
         this._thumbRatio = (containerSize - thumbSize) / (this.option("scaleRatio") * (contentSize - containerSize));

--- a/js/ui/scroll_view/ui.scrollbar.js
+++ b/js/ui/scroll_view/ui.scrollbar.js
@@ -175,6 +175,11 @@ var Scrollbar = Widget.inherit({
             baseContainerSize = Math.round(this.option("baseContainerSize")),
             baseContentSize = Math.round(this.option("baseContentSize"));
 
+        if(isNaN(baseContentSize)) {
+            baseContainerSize = containerSize;
+            baseContentSize = contentSize;
+        }
+
         // base sizes ratio for more accurate understanding is scrollbar needed
         this._baseContainerToContentRatio = (baseContentSize ? baseContainerSize / baseContentSize : baseContainerSize);
 

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.scrollbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.scrollbar.tests.js
@@ -4,6 +4,7 @@ import animationFrame from "animation/frame";
 import devices from "core/devices";
 import Scrollbar from "ui/scroll_view/ui.scrollbar";
 import pointerMock from "../../../helpers/pointerMock.js";
+import Scrollable from "ui/scroll_view/ui.scrollable";
 
 import "common.css!";
 
@@ -599,4 +600,18 @@ QUnit.test("content size should be rounded to prevent unexpected scrollbar appea
     });
 
     assert.ok(scrollbar.$element().is(":hidden"), "scrollbar is not visible");
+});
+
+QUnit.test("scrollbar shood be hidden when container size is almost similar to content size when zooming", function(assert) {
+    let scrollable = new Scrollable($('#scrollable'), {
+        'useNative': false
+    });
+
+    let verticalScroller = scrollable._strategy._scrollers['vertical'];
+    let verticalRealSizeStub = sinon.stub(verticalScroller, '_getRealDimension');
+    verticalRealSizeStub.withArgs(verticalScroller._$container.get(0), verticalScroller._dimension).returns(404)
+        .withArgs(verticalScroller._$content.get(0), verticalScroller._dimension).returns(405);
+    sinon.stub(verticalScroller, '_getBaseDimension').returns(405);
+    scrollable.update();
+    assert.notOk(verticalScroller._scrollbar._needScrollbar(), "scrollbar is hidden");
 });

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.scrollbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.scrollbar.tests.js
@@ -602,7 +602,7 @@ QUnit.test("content size should be rounded to prevent unexpected scrollbar appea
     assert.ok(scrollbar.$element().is(":hidden"), "scrollbar is not visible");
 });
 
-QUnit.test("scrollbar shood be hidden when container size is almost similar to content size when zooming", function(assert) {
+QUnit.test("scrollbar should be hidden when container size is almost similar to content size when zooming", function(assert) {
     let scrollable = new Scrollable($('#scrollable'), {
         'useNative': false
     });
@@ -612,6 +612,8 @@ QUnit.test("scrollbar shood be hidden when container size is almost similar to c
     verticalRealSizeStub.withArgs(verticalScroller._$container.get(0), verticalScroller._dimension).returns(404)
         .withArgs(verticalScroller._$content.get(0), verticalScroller._dimension).returns(405);
     sinon.stub(verticalScroller, '_getBaseDimension').returns(405);
+
     scrollable.update();
+
     assert.notOk(verticalScroller._scrollbar._needScrollbar(), "scrollbar is hidden");
 });

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.scrollbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.scrollbar.tests.js
@@ -607,17 +607,20 @@ QUnit.test("scrollbar should be hidden when container size is almost similar to 
         'useNative': false
     });
 
+    const dimension = "height";
     const fakeContainerSizeWhenZoomIs125 = 404;
     const fakeContentSizeWhenZoomIs125 = 405;
     const fakeContentAndContainerSizeWhenZoomIs100 = 405;
 
-    const verticalScroller = scrollable._strategy._scrollers['vertical'];
-    const verticalRealSizeStub = sinon.stub(verticalScroller, '_getRealDimension');
-    verticalRealSizeStub.withArgs(verticalScroller._$container.get(0), verticalScroller._dimension).returns(fakeContainerSizeWhenZoomIs125)
-        .withArgs(verticalScroller._$content.get(0), verticalScroller._dimension).returns(fakeContentSizeWhenZoomIs125);
-    sinon.stub(verticalScroller, '_getBaseDimension').returns(fakeContentAndContainerSizeWhenZoomIs100);
+    const scroller = scrollable._strategy._scrollers['vertical'];
+    const scrollerContainer = scroller._$container.get(0);
+    const scrollerContent = scroller._$content.get(0);
+
+    sinon.stub(scrollerContainer, 'getBoundingClientRect').returns({ [dimension]: fakeContainerSizeWhenZoomIs125 });
+    sinon.stub(scrollerContent, 'getBoundingClientRect').returns({ [dimension]: fakeContentSizeWhenZoomIs125 });
+    sinon.stub(scroller, '_getBaseDimension').returns(fakeContentAndContainerSizeWhenZoomIs100);
 
     scrollable.update();
 
-    assert.notOk(verticalScroller._scrollbar._needScrollbar(), "scrollbar is hidden");
+    assert.notOk(scroller._scrollbar._needScrollbar(), "scrollbar is hidden");
 });

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.scrollbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.scrollbar.tests.js
@@ -603,15 +603,19 @@ QUnit.test("content size should be rounded to prevent unexpected scrollbar appea
 });
 
 QUnit.test("scrollbar should be hidden when container size is almost similar to content size when zooming", function(assert) {
-    let scrollable = new Scrollable($('#scrollable'), {
+    const scrollable = new Scrollable($('#scrollable'), {
         'useNative': false
     });
 
-    let verticalScroller = scrollable._strategy._scrollers['vertical'];
-    let verticalRealSizeStub = sinon.stub(verticalScroller, '_getRealDimension');
-    verticalRealSizeStub.withArgs(verticalScroller._$container.get(0), verticalScroller._dimension).returns(404)
-        .withArgs(verticalScroller._$content.get(0), verticalScroller._dimension).returns(405);
-    sinon.stub(verticalScroller, '_getBaseDimension').returns(405);
+    const fakeContainerSizeWhenZoomIs125 = 404;
+    const fakeContentSizeWhenZoomIs125 = 405;
+    const fakeContentAndContainerSizeWhenZoomIs100 = 405;
+
+    const verticalScroller = scrollable._strategy._scrollers['vertical'];
+    const verticalRealSizeStub = sinon.stub(verticalScroller, '_getRealDimension');
+    verticalRealSizeStub.withArgs(verticalScroller._$container.get(0), verticalScroller._dimension).returns(fakeContainerSizeWhenZoomIs125)
+        .withArgs(verticalScroller._$content.get(0), verticalScroller._dimension).returns(fakeContentSizeWhenZoomIs125);
+    sinon.stub(verticalScroller, '_getBaseDimension').returns(fakeContentAndContainerSizeWhenZoomIs100);
 
     scrollable.update();
 


### PR DESCRIPTION
* Problem: unnecessary scrollbar appearance as result of browser zooming
* Reason: size recalculation's uncertainty because of work with float numbers
* Solution: rounding the resulting sizes to hundredths and scrollbar showing/hiding depending of the ratio of the container and content when zoom is 100%