### PR TITLE
DataGrid.ExcelJS - Rename exportColumnWidth to keepColumnWidths

### DIFF
--- a/js/exporter/exceljs/exportDataGrid.js
+++ b/js/exporter/exceljs/exportDataGrid.js
@@ -10,7 +10,7 @@ const MAX_EXCEL_COLUMN_WIDTH = 255;
 function exportDataGrid(options) {
     if(!isDefined(options)) return;
 
-    let { customizeCell, component, worksheet, topLeftCell = { row: 1, column: 1 }, excelFilterEnabled, exportColumnWidth = true } = options;
+    let { customizeCell, component, worksheet, topLeftCell = { row: 1, column: 1 }, excelFilterEnabled, keepColumnWidths = true } = options;
 
     worksheet.properties.outlineProperties = {
         summaryBelow: false,
@@ -30,7 +30,7 @@ function exportDataGrid(options) {
             let headerRowCount = dataProvider.getHeaderRowCount();
             let dataRowsCount = dataProvider.getRowsCount();
 
-            if(exportColumnWidth) {
+            if(keepColumnWidths) {
                 _setColumnsWidth(worksheet, columns, result.from.column);
             }
 

--- a/testing/tests/DevExpress.exporter/exceljsParts/exceljs.tests.js
+++ b/testing/tests/DevExpress.exporter/exceljsParts/exceljs.tests.js
@@ -63,7 +63,7 @@ QUnit.module("API", moduleConfig, () => {
 
         [true, false].forEach((excelFilterEnabled) => {
             let options = topLeftCellOption + `, excelFilterEnabled: ${excelFilterEnabled}`;
-            const getDataGridConfig = (dataGrid, expectedCustomizeCellArgs, exportColumnWidth = true) => {
+            const getDataGridConfig = (dataGrid, expectedCustomizeCellArgs, keepColumnWidths = true) => {
                 const result = {
                     component: dataGrid,
                     worksheet: this.worksheet,
@@ -75,7 +75,7 @@ QUnit.module("API", moduleConfig, () => {
                     },
                     excelFilterEnabled: excelFilterEnabled,
                 };
-                result.exportColumnWidth = exportColumnWidth;
+                result.keepColumnWidths = keepColumnWidths;
                 return result;
             };
 
@@ -245,7 +245,7 @@ QUnit.module("API", moduleConfig, () => {
                 });
             });
 
-            QUnit.test("Header - 2 column, exportColumnWidth: false" + options, (assert) => {
+            QUnit.test("Header - 2 column, keepColumnWidths: false" + options, (assert) => {
                 const done = assert.async();
 
                 let dataGrid = $("#dataGrid").dxDataGrid({


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
