### PR TITLE
Fix lost aspnet.createComponent calls (T810336)

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -123,11 +123,19 @@
     }
 
     function createComponent(name, options, id, validatorOptions) {
-        var render = function() {
+        var selector = "#" + id.replace(/[^\w-]/g, "\\$&");
+
+        var render = function(_, container) {
+            var $element = $(selector, container);
+            if(!$element.length) {
+                // This means that the callback originates from a nested template
+                // of another widget within this template.
+                return;
+            }
+
             templateRendered.remove(render);
 
-            var selector = "#" + id.replace(/[^\w-]/g, "\\$&"),
-                $component = $(selector)[name](options);
+            var $component = $element[name](options);
             if($.isPlainObject(validatorOptions)) {
                 $component.dxValidator(validatorOptions);
             }

--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -123,11 +123,11 @@
     }
 
     function createComponent(name, options, id, validatorOptions) {
-        var render = function(_, container) {
+        var render = function() {
             templateRendered.remove(render);
 
             var selector = "#" + id.replace(/[^\w-]/g, "\\$&"),
-                $component = $(selector, container)[name](options);
+                $component = $(selector)[name](options);
             if($.isPlainObject(validatorOptions)) {
                 $component.dxValidator(validatorOptions);
             }

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -452,4 +452,34 @@
         }
     });
 
+    QUnit.test("T810336", function(assert) {
+        aspnet.setTemplateEngine();
+
+        window.__createButton = function(buttonID) {
+            DevExpress.aspnet.createComponent("dxButton", { text: buttonID }, buttonID);
+        };
+
+        try {
+            $("#qunit-fixture").html(
+                '<div id="popup1"></div>' +
+                '<script id="popup1_contentTemplate" type="text/html">' +
+                '  <div id="b1"></div><% __createButton("b1") %>' +
+                '  <div id="b2"></div><% __createButton("b2") %>' +
+                '</script>'
+            );
+
+            $("#popup1").dxPopup({
+                contentTemplate: $("#popup1_contentTemplate"),
+                visible: true
+            });
+
+            assert.ok($("#b1").dxButton("instance"));
+            assert.ok($("#b2").dxButton("instance"));
+
+        } finally {
+            setTemplateEngine("default");
+            delete window.__createButton;
+        }
+    });
+
 }));

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -415,7 +415,7 @@
 
 
             $("#qunit-fixture").html(
-                '<div id="popop1">' +
+                '<div id="popup1">' +
                 '</div>' +
 
                 '<script id="popup1_contentTemplate" type="text/html">' +
@@ -429,7 +429,7 @@
                 '</script>'
             );
 
-            $("#popop1").dxPopup({
+            $("#popup1").dxPopup({
                 contentTemplate: $("#popup1_contentTemplate"),
                 visible: true
             });


### PR DESCRIPTION
Issue: https://devexpress.com/issue=T810336

After the PR https://github.com/DevExpress/DevExtreme/pull/8948, the order of `createComponent` routines has changed to depth-first.

The test case reproduces the issue. The callback registered to initialize the second button (`#b2`) is fired during the render of the default template of the first button (`#b1`). The scoped jQuery wrapper `$("#" + id, container)` prevents `#b2` from being found within the contents of `#b1`. 

I considered 3 options to fix the issue:
- Remove the context argument: https://github.com/DevExpress/DevExtreme/commit/338e0d4ac3d5ac05b117d1e0b2d8a3e7892a6fac (it has been there since May 2016).
- Keep the handler in queue until the element is found: https://github.com/DevExpress/DevExtreme/commit/6169fbe36b3b543cb155f723fdcb62ee31e857ff
- Use a single `templateRendered` callback and collect handlers in an internal array (`pendingCreateComponentRoutines`). I guess this is the best option.

I'm interested in your opinions.