### PR TITLE
fix for DataGrid columns.headerFilter.dataSource as function

### DIFF
--- a/js/ui/grid_core/ui.grid_core.header_filter.js
+++ b/js/ui/grid_core/ui.grid_core.header_filter.js
@@ -212,7 +212,7 @@ var HeaderFilterController = modules.ViewController.inherit((function() {
             }
 
             if(isFunction(headerFilterDataSource)) {
-                headerFilterDataSource.call(column, options);
+                options.dataSource = headerFilterDataSource.call(column, options);
             }
 
             origPostProcess = options.dataSource.postProcess;


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
In the DataGrid columns config there is need ability to set function in the columns.headerFilter.dataSource. I see in the source code that result of call of columns.headerFilter.dataSource() not assigned anywhere and I fix it.