### PR TITLE
Custom textEditor buttons  icons have incorrect vertical alignment inthe Material theme (T809959)

### DIFF
--- a/styles/widgets/material/button.material.less
+++ b/styles/widgets/material/button.material.less
@@ -386,10 +386,6 @@
         > .dx-button {
             height: 29px;
             margin: 0 @MATERIAL_EDITOR_CUSTOM_BUTTON_MARGIN 3px;
-
-            .dx-button-content {
-                padding-bottom: 3px;
-            }
         }
 
         &:first-child {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
