### PR TITLE
Update quill to 1.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "devexpress-diagram": "0.0.30",
     "jszip": "^2.0.0 || ^3.0.0",
-    "quill": "^1.3.6",
+    "quill": "^1.3.7",
     "showdown": "^1.8.6",
     "turndown": "^5.0.1"
   },


### PR DESCRIPTION
Fix the "[Reverve tabnapping](https://www.npmjs.com/advisories/1039)" vulnerability
