### PR TITLE
Improve sizes and icon position for underlined texteditor in the material theme (T809959)

### DIFF
--- a/styles/widgets/material/button.material.less
+++ b/styles/widgets/material/button.material.less
@@ -385,7 +385,7 @@
     .dx-texteditor-buttons-container {
         > .dx-button.dx-button-mode-text {
             height: @MATERIAL_UNDERLINED_EDITOR_BUTTON_HEIGHT;
-            margin: 0 @MATERIAL_EDITOR_CUSTOM_BUTTON_MARGIN 3px;
+            margin: 1px @MATERIAL_EDITOR_CUSTOM_BUTTON_MARGIN 3px;
 
             .dx-button-content {
                 display: flex;

--- a/styles/widgets/material/button.material.less
+++ b/styles/widgets/material/button.material.less
@@ -15,7 +15,7 @@
     @MATERIAL_BUTTON_ACTIVE_BOX_SHADOW_SIZE: 0 4px 6px;
 }
 
-
+@MATERIAL_UNDERLINED_EDITOR_BUTTON_HEIGHT: 28px;
 @MATERIAL_BUTTON_PADDING: @MATERIAL_BUTTON_VERTICAL_PADDING @MATERIAL_BUTTON_HORIZONTAL_PADDING;
 @MATERIAL_BUTTON_ICONONLY_PADDING: @MATERIAL_BUTTON_VERTICAL_PADDING;
 @MATERIAL_BUTTON_ICON_SIZE: @MATERIAL_BASE_ICON_SIZE;
@@ -383,9 +383,33 @@
 
 .dx-editor-underlined {
     .dx-texteditor-buttons-container {
-        > .dx-button {
-            height: 29px;
+        > .dx-button.dx-button-mode-text {
+            height: @MATERIAL_UNDERLINED_EDITOR_BUTTON_HEIGHT;
             margin: 0 @MATERIAL_EDITOR_CUSTOM_BUTTON_MARGIN 3px;
+
+            .dx-button-content {
+                display: flex;
+                padding-top: @MATERIAL_BUTTON_VERTICAL_PADDING - 1px;
+
+                .dx-icon {
+                    align-self: center;
+                    margin-top: 1px;
+                }
+            }
+
+            &.dx-button-has-text {
+                .dx-button-content .dx-icon {
+                    margin-top: 3px;
+                }
+            }
+
+            &:not(.dx-button-has-text) {
+                min-width: @MATERIAL_UNDERLINED_EDITOR_BUTTON_HEIGHT;
+
+                .dx-button-content {
+                    padding: 2px;
+                }
+            }
         }
 
         &:first-child {


### PR DESCRIPTION
New:
![icon buttons](https://user-images.githubusercontent.com/23214056/64858055-f80dbb80-d62e-11e9-80dd-6eea0241fa65.png)

