### PR TITLE
Fix changing an item's option without re-render Form when using the itemOption method (T801789) (#9643)

### DIFF
--- a/js/ui/form/ui.form.item_option_action.js
+++ b/js/ui/form/ui.form.item_option_action.js
@@ -1,0 +1,20 @@
+export default class ItemOptionAction {
+    constructor(options) {
+        const { item, itemsRunTimeInfo, value } = options;
+        this.item = item;
+        this.itemsRunTimeInfo = itemsRunTimeInfo;
+        this.value = value;
+    }
+
+    getInstance() {
+        return this.itemsRunTimeInfo.findWidgetInstanceByItem(this.item);
+    }
+
+    getItemContainer() {
+        return this.itemsRunTimeInfo.findItemContainerByItem(this.item);
+    }
+
+    tryExecute() {
+        return true;
+    }
+}

--- a/js/ui/form/ui.form.item_options_actions.js
+++ b/js/ui/form/ui.form.item_options_actions.js
@@ -1,0 +1,56 @@
+import ItemOptionAction from "./ui.form.item_option_action";
+import { data } from "../../core/element_data";
+
+class WidgetOptionItemOptionAction extends ItemOptionAction {
+    tryExecute() {
+        const instance = this.getInstance();
+        instance.option(this.value);
+        return super.tryExecute();
+    }
+}
+
+class ValidationRulesItemOptionAction extends ItemOptionAction {
+    tryExecute() {
+        const instance = this.getInstance();
+        const validator = data(instance.$element()[0], "dxValidator");
+        if(validator) {
+            const filterRequired = item => item.type === "required";
+            const oldContainsRequired = (validator.option("validationRules") || []).some(filterRequired);
+            const newContainsRequired = (this.item.validationRules || []).some(filterRequired);
+            if(!oldContainsRequired && !newContainsRequired || oldContainsRequired && newContainsRequired) {
+                validator.option("validationRules", this.item.validationRules);
+                return super.tryExecute();
+            }
+        }
+        return false;
+    }
+}
+
+class CssClassItemOptionAction extends ItemOptionAction {
+    constructor(options) {
+        super(options);
+        this.previousValue = options.previousValue;
+    }
+
+    tryExecute() {
+        const $itemContainer = this.getItemContainer();
+        $itemContainer.removeClass(this.previousValue).addClass(this.value);
+        return super.tryExecute();
+    }
+}
+
+const tryCreateItemOptionAction = (optionName, itemActionOptions) => {
+    switch(optionName) {
+        case "editorOptions":
+        case "buttonOptions":
+            return new WidgetOptionItemOptionAction(itemActionOptions);
+        case "validationRules":
+            return new ValidationRulesItemOptionAction(itemActionOptions);
+        case "cssClass":
+            return new CssClassItemOptionAction(itemActionOptions);
+        default:
+            return null;
+    }
+};
+
+export default tryCreateItemOptionAction;

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -2249,6 +2249,7 @@ const Scheduler = Widget.inherit({
             var startDateExpr = this._dataAccessors.expr.startDateExpr,
                 endDateExpr = this._dataAccessors.expr.endDateExpr;
 
+            formData.recurrenceRule = formData.recurrenceRule || null;
             AppointmentForm.updateFormData(this._appointmentForm, formData);
             this._appointmentForm.option("readOnly", this._editAppointmentData ? !this._editing.allowUpdating : false);
 

--- a/js/ui/scheduler/ui.scheduler.recurrence_editor.js
+++ b/js/ui/scheduler/ui.scheduler.recurrence_editor.js
@@ -732,9 +732,10 @@ const RecurrenceEditor = Editor.inherit({
     _valueChangedHandler(args) {
         const value = args.component.option("value");
         const field = args.component.option("field");
+        const freqEditorValue = this._freqEditor && this._freqEditor.option("value");
         let visible = true;
 
-        if(field === "freq" && value === "never") {
+        if(field === "freq" && value === "never" || field !== "freq" && freqEditorValue === "never") {
             visible = false;
             this.option("value", "");
         } else {

--- a/testing/tests/DevExpress.ui.widgets.form/form.API.option_items_cssClass.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.API.option_items_cssClass.tests.js
@@ -6,281 +6,290 @@ import "ui/form/ui.form";
 import "common.css!";
 import "generic_light.css!";
 
-var INVALID_CLASS = "dx-invalid";
+const INVALID_CLASS = "dx-invalid";
 
 QUnit.testStart(function() {
-    var markup = '<div id="form"></div>';
+    const markup = '<div id="form"></div>';
     $("#qunit-fixture").html(markup);
 });
 
-QUnit.module("Public API: option(items.cssClass)");
-
-QUnit.testInActiveWindow("SimpleItem(undefined -> null)", function(assert) {
-    var form = $("#form").dxForm({
-        items: [
-            {
+[false, true].forEach(useItemOption => {
+    QUnit.module(`Public API: ${useItemOption ? "itemOption(option, cssClass)" : "option(items.cssClass)"}`, () => {
+        const createForm = items => {
+            items = items || [{
                 itemType: "simple",
                 editorType: "dxTextBox",
                 name: "item1"
-            },
-        ]
-    }).dxForm("instance");
+            }];
+            return $("#form").dxForm({ items: items }).dxForm("instance");
+        };
 
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+        QUnit.testInActiveWindow("SimpleItem(undefined -> null)", assert => {
+            const form = createForm();
 
-    form.option("items[0].cssClass", null);
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
 
-    assert.strictEqual(form.itemOption("item1").cssClass, null, "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), null, "form.option(items[0].cssClass)");
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
-});
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", null);
+            } else {
+                form.option("items[0].cssClass", null);
+            }
 
-QUnit.testInActiveWindow("SimpleItem(undefined -> class1)", function(assert) {
-    var form = $("#form").dxForm({
-        items: [
-            {
-                itemType: "simple",
-                editorType: "dxTextBox",
-                name: "item1"
-            },
-        ]
-    }).dxForm("instance");
+            assert.strictEqual(form.itemOption("item1").cssClass, null, "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), null, "form.option(items[0].cssClass)");
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
+        });
 
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+        QUnit.testInActiveWindow("SimpleItem(undefined -> class1)", assert => {
+            const form = createForm();
 
-    form.option("items[0].cssClass", "class1");
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
 
-    assert.strictEqual(form.itemOption("item1").cssClass, "class1", "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), "class1", "form.option(items[0].cssClass)");
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
-    assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
-});
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", "class1");
+            } else {
+                form.option("items[0].cssClass", "class1");
+            }
 
-QUnit.testInActiveWindow("SimpleItem(null -> undefined)", function(assert) {
-    var form = $("#form").dxForm({
-        items: [
-            {
+            assert.strictEqual(form.itemOption("item1").cssClass, "class1", "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), "class1", "form.option(items[0].cssClass)");
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
+            assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+        });
+
+        QUnit.testInActiveWindow("SimpleItem(null -> undefined)", assert => {
+            const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
                 name: "item1",
                 cssClass: null
-            },
-        ]
-    }).dxForm("instance");
+            }]);
 
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
 
-    form.option("items[0].cssClass", undefined);
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", undefined);
+            } else {
+                form.option("items[0].cssClass", undefined);
+            }
 
-    assert.strictEqual(form.itemOption("item1").cssClass, undefined, "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), undefined, "form.option(items[0].cssClass)");
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
-});
+            assert.strictEqual(form.itemOption("item1").cssClass, undefined, "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), undefined, "form.option(items[0].cssClass)");
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
+        });
 
-QUnit.testInActiveWindow("SimpleItem(null -> class1)", function(assert) {
-    var form = $("#form").dxForm({
-        items: [
-            {
+        QUnit.testInActiveWindow("SimpleItem(null -> class1)", assert => {
+            const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
                 name: "item1",
                 cssClass: null
-            },
-        ]
-    }).dxForm("instance");
+            }]);
 
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
 
-    form.option("items[0].cssClass", "class1");
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", "class1");
+            } else {
+                form.option("items[0].cssClass", "class1");
+            }
 
-    assert.strictEqual(form.itemOption("item1").cssClass, "class1", "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), "class1", "form.option(items[0].cssClass)");
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
-    assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
-});
+            assert.strictEqual(form.itemOption("item1").cssClass, "class1", "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), "class1", "form.option(items[0].cssClass)");
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
+            assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+        });
 
-QUnit.testInActiveWindow("SimpleItem(class1 -> undefined)", function(assert) {
-    var form = $("#form").dxForm({
-        items: [
-            {
+        QUnit.testInActiveWindow("SimpleItem(class1 -> undefined)", assert => {
+            const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
                 name: "item1",
                 cssClass: "class1"
-            },
-        ]
-    }).dxForm("instance");
+            }]);
 
-    assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
 
-    form.option("items[0].cssClass", undefined);
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", undefined);
+            } else {
+                form.option("items[0].cssClass", undefined);
+            }
 
-    assert.strictEqual(form.itemOption("item1").cssClass, undefined, "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), undefined, "form.option(items[0].cssClass)");
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
-    assert.strictEqual($("#form").find(".class1").length, 0, "$(#form).find(class1).length");
-});
+            assert.strictEqual(form.itemOption("item1").cssClass, undefined, "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), undefined, "form.option(items[0].cssClass)");
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
+            assert.strictEqual($("#form").find(".class1").length, 0, "$(#form).find(class1).length");
+        });
 
-QUnit.testInActiveWindow("SimpleItem(class1 -> null)", function(assert) {
-    var form = $("#form").dxForm({
-        items: [
-            {
+        QUnit.testInActiveWindow("SimpleItem(class1 -> null)", assert => {
+            const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
                 name: "item1",
                 cssClass: "class1"
-            },
-        ]
-    }).dxForm("instance");
+            }]);
 
-    assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
 
-    form.option("items[0].cssClass", null);
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", null);
+            } else {
+                form.option("items[0].cssClass", null);
+            }
 
-    assert.strictEqual(form.itemOption("item1").cssClass, null, "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), null, "form.option(items[0].cssClass)");
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
-    assert.strictEqual($("#form").find(".class1").length, 0, "$(#form).find(class1).length");
-});
+            assert.strictEqual(form.itemOption("item1").cssClass, null, "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), null, "form.option(items[0].cssClass)");
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
+            assert.strictEqual($("#form").find(".class1").length, 0, "$(#form).find(class1).length");
+        });
 
-QUnit.testInActiveWindow("SimpleItem(class1 -> class2)", function(assert) {
-    var form = $("#form").dxForm({
-        items: [
-            {
+        QUnit.testInActiveWindow("SimpleItem(class1 -> class2)", assert => {
+            const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
                 name: "item1",
                 cssClass: "class1",
                 validationRules: [{
                     type: "custom",
-                    validationCallback: function() { return false; }
+                    validationCallback: () => false
                 }]
-            },
-        ]
-    }).dxForm("instance");
+            }]);
 
-    form.validate();
-    assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `initial [${INVALID_CLASS}].length`);
+            form.validate();
+            assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `initial [${INVALID_CLASS}].length`);
 
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
-    assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
 
-    form.option("items[0].cssClass", "class2");
-
-    assert.strictEqual(form.itemOption("item1").cssClass, "class2", "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), "class2", "form.option(items[0].cssClass)");
-    assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `final [${INVALID_CLASS}].length`);
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
-    assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
-});
-
-QUnit.testInActiveWindow("SimpleItem(class1 -> class2) in form with 2 items", function(assert) {
-    var form = $("#form").dxForm({
-        items: [
-            {
-                itemType: "simple",
-                editorType: "dxTextBox",
-                name: "item1",
-                cssClass: "class1"
-            },
-            {
-                itemType: "simple",
-                editorType: "dxTextBox",
-                validationRules: [{
-                    type: "custom",
-                    validationCallback: function() { return false; }
-                }]
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", "class2");
+            } else {
+                form.option("items[0].cssClass", "class2");
             }
-        ]
-    }).dxForm("instance");
 
-    form.validate();
-    assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `initial [${INVALID_CLASS}].length`);
+            assert.strictEqual(form.itemOption("item1").cssClass, "class2", "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), "class2", "form.option(items[0].cssClass)");
+            assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `final [${INVALID_CLASS}].length`);
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
+            assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
+        });
 
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
-    assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+        QUnit.testInActiveWindow("SimpleItem(class1 -> class2) in form with 2 items", assert => {
+            const form = createForm([
+                {
+                    itemType: "simple",
+                    editorType: "dxTextBox",
+                    name: "item1",
+                    cssClass: "class1"
+                },
+                {
+                    itemType: "simple",
+                    editorType: "dxTextBox",
+                    validationRules: [{
+                        type: "custom",
+                        validationCallback: function() { return false; }
+                    }]
+                }
+            ]);
 
-    form.option("items[0].cssClass", "class2");
+            form.validate();
+            assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `initial [${INVALID_CLASS}].length`);
 
-    assert.strictEqual(form.itemOption("item1").cssClass, "class2", "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), "class2", "form.option(items[0].cssClass)");
-    assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `final [${INVALID_CLASS}].length`);
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
-    assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
-});
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
 
-QUnit.testInActiveWindow("ButtonItem(class1 -> class2)", function(assert) {
-    if(devices.real().deviceType !== "desktop") {
-        assert.ok(true, "desktop specific test");
-        return;
-    }
-    var form = $("#form").dxForm({
-        items: [{
-            itemType: "button",
-            name: "item1",
-            cssClass: "class1",
-            buttonOptions: { icon: "icon1" }
-        }]
-    }).dxForm("instance");
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", "class2");
+            } else {
+                form.option("items[0].cssClass", "class2");
+            }
 
-    $("#form").find(".dx-button").focus();
-    assert.ok($("#form").find(".dx-button").is(":focus"), "initial focus");
-    assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+            assert.strictEqual(form.itemOption("item1").cssClass, "class2", "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), "class2", "form.option(items[0].cssClass)");
+            assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `final [${INVALID_CLASS}].length`);
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
+        });
 
-    form.option("items[0].cssClass", "class2");
-
-    assert.strictEqual(form.itemOption("item1").cssClass, "class2", "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), "class2", "form.option(items[0].cssClass)");
-    assert.ok($("#form").find(".dx-button").is(":focus"), "final focus");
-    assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
-});
-
-QUnit.testInActiveWindow("ButtonItem(class1 -> class2) in form with 2 items", function(assert) {
-    if(devices.real().deviceType !== "desktop") {
-        assert.ok(true, "desktop specific test");
-        return;
-    }
-    var form = $("#form").dxForm({
-        items: [
-            {
+        QUnit.testInActiveWindow("ButtonItem(class1 -> class2)", assert => {
+            if(devices.real().deviceType !== "desktop") {
+                assert.ok(true, "desktop specific test");
+                return;
+            }
+            const form = createForm([{
                 itemType: "button",
                 name: "item1",
                 cssClass: "class1",
                 buttonOptions: { icon: "icon1" }
-            },
-            {
-                itemType: "simple",
-                editorType: "dxTextBox",
-                validationRules: [{
-                    type: "custom",
-                    validationCallback: function() { return false; }
-                }]
+            }]);
+
+            $("#form").find(".dx-button").focus();
+            assert.ok($("#form").find(".dx-button").is(":focus"), "initial focus");
+            assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", "class2");
+            } else {
+                form.option("items[0].cssClass", "class2");
             }
-        ]
-    }).dxForm("instance");
 
-    form.validate();
-    assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `initial [${INVALID_CLASS}].length`);
+            assert.strictEqual(form.itemOption("item1").cssClass, "class2", "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), "class2", "form.option(items[0].cssClass)");
+            assert.ok($("#form").find(".dx-button").is(":focus"), "final focus");
+            assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
+        });
 
-    $("#form").find(".dx-texteditor-input").focus();
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
-    assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+        QUnit.testInActiveWindow("ButtonItem(class1 -> class2) in form with 2 items", assert => {
+            if(devices.real().deviceType !== "desktop") {
+                assert.ok(true, "desktop specific test");
+                return;
+            }
+            const form = createForm([
+                {
+                    itemType: "button",
+                    name: "item1",
+                    cssClass: "class1",
+                    buttonOptions: { icon: "icon1" }
+                },
+                {
+                    itemType: "simple",
+                    editorType: "dxTextBox",
+                    validationRules: [{
+                        type: "custom",
+                        validationCallback: () => false
+                    }]
+                }
+            ]);
 
-    form.option("items[0].cssClass", "class2");
+            form.validate();
+            assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `initial [${INVALID_CLASS}].length`);
 
-    assert.strictEqual(form.itemOption("item1").cssClass, "class2", "form.itemOption(item1).cssClass");
-    assert.strictEqual(form.option("items[0].cssClass"), "class2", "form.option(items[0].cssClass)");
-    assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `final [${INVALID_CLASS}].length`);
-    assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
-    assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
+            $("#form").find(".dx-texteditor-input").focus();
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
+
+            if(useItemOption) {
+                form.itemOption("item1", "cssClass", "class2");
+            } else {
+                form.option("items[0].cssClass", "class2");
+            }
+
+            assert.strictEqual(form.itemOption("item1").cssClass, "class2", "form.itemOption(item1).cssClass");
+            assert.strictEqual(form.option("items[0].cssClass"), "class2", "form.option(items[0].cssClass)");
+            assert.strictEqual($("#form").find(`.${INVALID_CLASS}`).length, 1, `final [${INVALID_CLASS}].length`);
+            assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "initial focus");
+            assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
+        });
+    });
 });

--- a/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
@@ -425,7 +425,7 @@ QUnit.testInActiveWindow("Remove RangeRule from item.validationRules", assert =>
         runRemoveRangedRuleTest({ newValidationRules, useItemOption: false, isKeepFocusSupported: true });
     });
     [undefined, null, []].forEach(newValidationRules => {
-        runRemoveRangedRuleTest({ newValidationRules, useItemOption: true, isKeepFocusSupported: false });
+        runRemoveRangedRuleTest({ newValidationRules, useItemOption: true, isKeepFocusSupported: true });
     });
 });
 


### PR DESCRIPTION


* fix changing an item's option witout re-render Form when using the itemOption method

* fix scheduler test and refactoring

* fix scheduler test on the small screen

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
