### PR TITLE
Center the text position in text editor button for the Material theme

### DIFF
--- a/styles/widgets/material/button.material.less
+++ b/styles/widgets/material/button.material.less
@@ -390,6 +390,7 @@
 
             .dx-button-content {
                 display: flex;
+                justify-content: center;
                 padding-top: @MATERIAL_BUTTON_VERTICAL_PADDING - 1px;
 
                 .dx-icon {


### PR DESCRIPTION
fix after #9731 
![center text position](https://user-images.githubusercontent.com/23214056/65318497-5e05c000-dba6-11e9-9dfb-25d532c2b3c7.png)
