### PR TITLE
Do bubbling for `focusin` and `focusout` events (Fix T814132)

### DIFF
--- a/js/events/core/events_engine.js
+++ b/js/events/core/events_engine.js
@@ -25,7 +25,7 @@ var NATIVE_EVENTS_TO_TRIGGER = {
     "focusin": "focus",
     "focusout": "blur"
 };
-var NO_BUBBLE_EVENTS = ["blur", "focusout", "focus", "focusin", "load"];
+var NO_BUBBLE_EVENTS = ["blur", "focus", "load"];
 
 var forcePassiveFalseEventNames = ["touchmove", "wheel", "mousewheel"]; // "touchstart"?
 

--- a/testing/tests/DevExpress.ui.events/eventsEngine.tests.js
+++ b/testing/tests/DevExpress.ui.events/eventsEngine.tests.js
@@ -198,6 +198,20 @@ QUnit.test("'focusin' and 'focus' events call element.focus, 'focusout' and 'blu
     focus.restore();
 });
 
+QUnit.test("focusin event bubbling", function(assert) {
+    var textBox = document.createElement("input");
+    var container = document.createElement(container);
+    var handlerSpy = sinon.spy();
+
+    container.appendChild(textBox);
+
+    eventsEngine.on(container, "focusin", handlerSpy);
+
+    eventsEngine.trigger(textBox, "focusin");
+
+    assert.equal(handlerSpy.callCount, 1);
+});
+
 QUnit.test("prevent triggered 'load' event bubbling to body", function(assert) {
     var done = assert.async();
     var image = document.createElement("img");


### PR DESCRIPTION
It looks like we've added too much no-bubbling events here: https://github.com/nightskylark/DevExtreme/commit/58e53a66f14262c77b40cfa956c8a874696bf836