### PR TITLE
DataGrid.Export - Support allowExporting in some scenarios with bands (T810780) (#9834)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.export.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.export.tests.js
@@ -1339,6 +1339,63 @@ QUnit.test("Columns - hide column headers", function(assert) {
     );
 });
 
+QUnit.test("Columns - show column headers & single column", function(assert) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="1" topLeftCell="A2" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_100 + '" min="1" max="1" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c></row>' +
+        '<row r="2" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="3" t="s"><v>1</v></c></row>' +
+        '</sheetData></worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                { dataField: 'f1', width: 100 },
+            ],
+            dataSource: [{ f1: "1_f1" }],
+            showColumnHeaders: true
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+});
+
+function _runHideSingleColumnTest(assert, hideByVisible, helper) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols></cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:0" outlineLevel="0" x14ac:dyDescent="0.25"></row>' +
+        '</sheetData></worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                { dataField: 'f1', width: 100, visible: hideByVisible ? false : true, allowExporting: (!hideByVisible) ? false : true },
+            ],
+            dataSource: [{ f1: "1_f1" }],
+            showColumnHeaders: true
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+}
+
+QUnit.test("Columns - show column headers & hide single column, hide by visible", function(assert) {
+    _runHideSingleColumnTest(assert, true, helper);
+});
+
+QUnit.test("Columns - show column headers & hide single column, hide by allowExporting", function(assert) {
+    _runHideSingleColumnTest(assert, false, helper);
+});
+
 QUnit.test("Columns - hide column headers & mixed visibleIndex", function(assert) {
     const worksheet = helper.WORKSHEET_HEADER_XML +
         '<sheetPr/><dimension ref="A1:C1"/>' +
@@ -1508,7 +1565,151 @@ QUnit.test("Bands - show column headers", function(assert) {
     );
 });
 
-QUnit.test("Bands - show column headers & 'column.visible: false'", function(assert) {
+QUnit.test("Bands - show column headers, single child column", function(assert) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="2" topLeftCell="A3" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_100 + '" min="1" max="1" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c></row>' +
+        '<row r="2" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="0" t="s"><v>1</v></c></row>' +
+        '<row r="3" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A3" s="3" t="s"><v>2</v></c></row>' +
+        '</sheetData>' +
+        '</worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                {
+                    caption: 'Band1',
+                    columns: [
+                        { dataField: "f1", width: 100 },
+                    ]
+                }
+            ],
+            showColumnHeaders: true,
+            dataSource: [{ f1: "1_f1" }]
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+});
+
+QUnit.test("Bands - show column headers & band without children", function(assert) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="1" topLeftCell="A2" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_100 + '" min="1" max="1" />' +
+        '<col width="127.86" min="2" max="2" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c><c r="B1" s="0" t="s"><v>1</v></c></row>' +
+        '<row r="2" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="3" t="s"><v>2</v></c><c r="B2" s="3" t="s" /></row>' +
+        '</sheetData>' +
+        '</worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                { dataField: "f1", width: 100 },
+                {
+                    caption: 'Band1',
+                }
+            ],
+            showColumnHeaders: true,
+            dataSource: [{ f1: "1_f1" }]
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+});
+
+QUnit.test("Bands - show column headers & hide band, hide by visible", function(assert) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="1" topLeftCell="A2" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_100 + '" min="1" max="1" />' +
+        '<col width="' + excelColumnWidthFrom_200 + '" min="2" max="2" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c><c r="B1" s="0" t="s"><v>1</v></c></row>' +
+        '<row r="2" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="3" t="s"><v>2</v></c><c r="B2" s="3" t="s"><v>3</v></c></row>' +
+        '</sheetData>' +
+        '</worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                { dataField: "f1", width: 100 },
+                {
+                    caption: 'Band1',
+                    visible: false,
+                    allowExporting: true,
+                    columns: [
+                        { dataField: "f2", width: 50 },
+                        { dataField: "f3", width: 200 },
+                    ]
+                },
+                { dataField: "f4", width: 200 },
+            ],
+            showColumnHeaders: true,
+            dataSource: [{ f1: "1_f1", f2: "1_f2", f3: "1_f3", f4: "1_f4" }]
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+});
+
+QUnit.skip("Bands - show column headers & hide band, hide by allowExporting is NOT SUPPORTED", function(assert) {
+});
+
+QUnit.test("Bands - show column headers & hide all columns in band, hide by visible", function(assert) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="1" topLeftCell="A2" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_100 + '" min="1" max="1" />' +
+        '<col width="127.86" min="2" max="2" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c><c r="B1" s="0" t="s"><v>1</v></c></row>' +
+        '<row r="2" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="3" t="s"><v>2</v></c><c r="B2" s="3" t="s" /></row>' +
+        '</sheetData>' +
+        '</worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                { dataField: "f1", width: 100 },
+                {
+                    caption: 'Band1',
+                    columns: [
+                        { dataField: "f2", width: 50, visible: false, allowExporting: true },
+                        { dataField: "f3", width: 200, visible: false, allowExporting: true },
+                    ]
+                },
+                { dataField: "f4", width: 200, visible: false },
+            ],
+            showColumnHeaders: true,
+            dataSource: [{ f1: "1_f1", f2: "1_f2", f3: "1_f3", f4: "1_f4" }]
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+});
+
+QUnit.skip("Bands - show column headers & hide all columns in band, hide by allowExporting is NOT SUPPORTED", function(assert) {
+});
+
+function _runBandsShowColumnHeadersHideColumnTest(assert, hideByVisible, helper) {
     const worksheet = helper.WORKSHEET_HEADER_XML +
         '<sheetPr/><dimension ref="A1:C1"/>' +
         '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="2" topLeftCell="A3" /></sheetView></sheetViews>' +
@@ -1521,6 +1722,7 @@ QUnit.test("Bands - show column headers & 'column.visible: false'", function(ass
         '<sheetData>' +
         '<row r="1" spans="1:3" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c><c r="B1" s="0" t="s"><v>1</v></c><c r="C1" s="0" t="s" /></row>' +
         '<row r="2" spans="1:3" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="0" t="s" /><c r="B2" s="0" t="s"><v>2</v></c><c r="C2" s="0" t="s"><v>3</v></c></row>' +
+        '<row r="3" spans="1:3" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A3" s="3" t="s"><v>4</v></c><c r="B3" s="3" t="s"><v>5</v></c><c r="C3" s="3" t="s"><v>6</v></c></row>' +
         '</sheetData>' +
         '<mergeCells count="2"><mergeCell ref="A1:A2" /><mergeCell ref="B1:C1" /></mergeCells>' +
         '</worksheet>';
@@ -1533,17 +1735,226 @@ QUnit.test("Bands - show column headers & 'column.visible: false'", function(ass
                 {
                     caption: 'Band1',
                     columns: [
-                        { dataField: "f2", width: 50, visible: false },
+                        { dataField: "f2", width: 50, visible: hideByVisible ? false : true, allowExporting: (!hideByVisible) ? false : true },
                         { dataField: "f3", width: 200 },
                         { dataField: "f4", width: 200 },
                     ]
                 }
             ],
             showColumnHeaders: true,
-            dataSource: []
+            dataSource: [{ f1: "1_f1", f2: "1_f2", f3: "1_f3", f4: "1_f4" }]
         },
         { worksheet, fixedColumnWidth_100: false }
     );
+}
+
+QUnit.test("Bands - show column headers & hide column, hide by visible", function(assert) {
+    _runBandsShowColumnHeadersHideColumnTest(assert, true, helper);
+});
+
+QUnit.test("Bands - show column headers & hide column, hide by allowExporting", function(assert) {
+    _runBandsShowColumnHeadersHideColumnTest(assert, false, helper);
+});
+
+function _runBandsShowColumnHeadersHideColumnLevel3Config1Test(assert, hideByVisible, helper) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="3" topLeftCell="A4" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_50 + '" min="1" max="1" />' +
+        '<col width="' + excelColumnWidthFrom_200 + '" min="2" max="2" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c><c r="B1" s="0" t="s" /></row>' +
+        '<row r="2" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="0" t="s"><v>1</v></c><c r="B2" s="0" t="s" /></row>' +
+        '<row r="3" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A3" s="0" t="s"><v>2</v></c><c r="B3" s="0" t="s"><v>3</v></c></row>' +
+        '<row r="4" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A4" s="3" t="s"><v>4</v></c><c r="B4" s="3" t="s"><v>5</v></c></row>' +
+        '</sheetData>' +
+        '<mergeCells count="2"><mergeCell ref="A1:B1" /><mergeCell ref="A2:B2" /></mergeCells>' +
+        '</worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                {
+                    caption: 'Band1',
+                    columns: [
+                        {
+                            caption: 'Band1_Band1',
+                            columns: [
+                                { dataField: "f1", width: 100, visible: hideByVisible ? false : true, allowExporting: (!hideByVisible) ? false : true },
+                                { dataField: "f2", width: 50 },
+                                { dataField: "f3", width: 200 },
+                            ]
+                        }
+                    ]
+                }
+            ],
+            showColumnHeaders: true,
+            dataSource: [{ f1: "1_f1", f2: "1_f2", f3: "1_f3" }]
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+}
+
+QUnit.test("Bands - show column headers & hide column, Level3, config1, hide by visible", function(assert) {
+    _runBandsShowColumnHeadersHideColumnLevel3Config1Test(assert, true, helper);
+});
+
+QUnit.test("Bands - show column headers & hide column, Level3, config1, hide by allowExporting", function(assert) {
+    _runBandsShowColumnHeadersHideColumnLevel3Config1Test(assert, false, helper);
+});
+
+function _runBandsShowColumnHeadersHideColumnLevel3Config2Test(assert, hideByVisible, helper) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="3" topLeftCell="A4" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_100 + '" min="1" max="1" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c></row>' +
+        '<row r="2" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="0" t="s"><v>1</v></c></row>' +
+        '<row r="3" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A3" s="0" t="s"><v>2</v></c></row>' +
+        '<row r="4" spans="1:1" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A4" s="3" t="s"><v>3</v></c></row>' +
+        '</sheetData>' +
+        '</worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                {
+                    caption: 'Band1',
+                    columns: [
+                        {
+                            caption: 'Band1_Band1',
+                            columns: [
+                                { dataField: "f1", width: 100 },
+                                { dataField: "f2", width: 50, visible: hideByVisible ? false : true, allowExporting: (!hideByVisible) ? false : true },
+                            ]
+                        }
+                    ]
+                }
+            ],
+            showColumnHeaders: true,
+            dataSource: [{ f1: "1_f1", f2: "1_f2" }]
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+}
+
+QUnit.test("Bands - show column headers & hide column, Level3, config2, hide by visible", function(assert) {
+    _runBandsShowColumnHeadersHideColumnLevel3Config2Test(assert, true, helper);
+});
+
+QUnit.test("Bands - show column headers & hide column, Level3, config2, hide by allowExporting", function(assert) {
+    _runBandsShowColumnHeadersHideColumnLevel3Config2Test(assert, false, helper);
+});
+
+function _runBandsShowColumnHeadersHideColumnLevel3ComplexConfig1Test(assert, hideByVisible, helper) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="3" topLeftCell="A4" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_50 + '" min="1" max="1" />' +
+        '<col width="' + excelColumnWidthFrom_200 + '" min="2" max="2" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c><c r="B1" s="0" t="s" /></row>' +
+        '<row r="2" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="0" t="s"><v>1</v></c><c r="B2" s="0" t="s" /></row>' +
+        '<row r="3" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A3" s="0" t="s"><v>2</v></c><c r="B3" s="0" t="s"><v>3</v></c></row>' +
+        '<row r="4" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A4" s="3" t="s"><v>4</v></c><c r="B4" s="3" t="s"><v>5</v></c></row>' +
+        '</sheetData>' +
+        '<mergeCells count="2"><mergeCell ref="A1:B1" /><mergeCell ref="A2:B2" /></mergeCells>' +
+        '</worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                {
+                    caption: 'Band1',
+                    columns: [
+                        { dataField: "f1", width: 100, visible: hideByVisible ? false : true, allowExporting: (!hideByVisible) ? false : true },
+                        {
+                            caption: 'Band1_Band1',
+                            columns: [
+                                { dataField: "f2", width: 50 },
+                                { dataField: "f3", width: 200 },
+                            ]
+                        }
+                    ]
+                }
+            ],
+            showColumnHeaders: true,
+            dataSource: [{ f1: "1_f1", f2: "1_f2", f3: "1_f3" }]
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+}
+
+QUnit.test("Bands - show column headers & hide column, Level3 complex, config1, hide by visible", function(assert) {
+    _runBandsShowColumnHeadersHideColumnLevel3ComplexConfig1Test(assert, true, helper);
+});
+
+QUnit.skip("Bands - show column headers & hide column, Level3 complex, config1, hide by allowExporting is NOT SUPPORTED", function(assert) {
+    _runBandsShowColumnHeadersHideColumnLevel3ComplexConfig1Test(assert, false, helper);
+});
+
+function _runBandsShowColumnHeadersHideColumnLevel3ComplexConfig2Test(assert, hideByVisible, helper) {
+    const worksheet = helper.WORKSHEET_HEADER_XML +
+        '<sheetPr/><dimension ref="A1:C1"/>' +
+        '<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane activePane="bottomLeft" state="frozen" ySplit="3" topLeftCell="A4" /></sheetView></sheetViews>' +
+        '<sheetFormatPr defaultRowHeight="15" outlineLevelRow="0" x14ac:dyDescent="0.25"/>' +
+        '<cols>' +
+        '<col width="' + excelColumnWidthFrom_50 + '" min="1" max="1" />' +
+        '<col width="' + excelColumnWidthFrom_200 + '" min="2" max="2" />' +
+        '</cols>' +
+        '<sheetData>' +
+        '<row r="1" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A1" s="0" t="s"><v>0</v></c><c r="B1" s="0" t="s" /></row>' +
+        '<row r="2" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A2" s="0" t="s"><v>1</v></c><c r="B2" s="0" t="s" /></row>' +
+        '<row r="3" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A3" s="0" t="s"><v>2</v></c><c r="B3" s="0" t="s"><v>3</v></c></row>' +
+        '<row r="4" spans="1:2" outlineLevel="0" x14ac:dyDescent="0.25"><c r="A4" s="3" t="s"><v>4</v></c><c r="B4" s="3" t="s"><v>5</v></c></row>' +
+        '</sheetData>' +
+        '<mergeCells count="2"><mergeCell ref="A1:B1" /><mergeCell ref="A2:B2" /></mergeCells>' +
+        '</worksheet>';
+
+    helper.runGeneralTest(
+        assert,
+        {
+            columns: [
+                {
+                    caption: 'Band1',
+                    columns: [
+                        {
+                            caption: 'Band1_Band1',
+                            columns: [
+                                { dataField: "f2", width: 50 },
+                                { dataField: "f3", width: 200 },
+                            ]
+                        },
+                        { dataField: "f1", width: 100, visible: hideByVisible ? false : true, allowExporting: (!hideByVisible) ? false : true }
+                    ]
+                }
+            ],
+            showColumnHeaders: true,
+            dataSource: [{ f1: "1_f1", f2: "1_f2", f3: "1_f3" }]
+        },
+        { worksheet, fixedColumnWidth_100: false }
+    );
+}
+
+QUnit.test("Bands - show column headers & hide column, Level3 complex, config2, hide by visible", function(assert) {
+    _runBandsShowColumnHeadersHideColumnLevel3ComplexConfig2Test(assert, true, helper);
+});
+
+QUnit.skip("Bands - show column headers & hide column, Level3 complex, config2, hide by allowExporting is NOT SUPPORTED", function(assert) {
+    _runBandsShowColumnHeadersHideColumnLevel3ComplexConfig2Test(assert, false, helper);
 });
 
 QUnit.test("Bands - show column headers & 'column.visible: false' in onExporting/Exported", function(assert) {


### PR DESCRIPTION
* Add tests to check results for several visible/allowExporting configurations and allow to hide some child column from a band by allowExporting.

* Avoid 'exportColspan: undefined' properties and correct some expected values for server testing environment.

* Reorganize 'QUnit.test' calls to one level.

* Additional tests for allowExporting/visible with bands

* Use reduce instead of forEach and add more tests for peculiar cases

(cherry picked from commit 9b27318bf19aea2b335b77643fb25abc2d5616a8)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
