### PR TITLE
Deprecate `decimalSeparator` and `thousandsSeparator` config props

### DIFF
--- a/js/core/config.js
+++ b/js/core/config.js
@@ -40,12 +40,14 @@ const config = {
     * @name globalConfig.decimalSeparator
     * @type string
     * @default "."
+    * @deprecated
     */
     decimalSeparator: ".",
     /**
     * @name globalConfig.thousandsSeparator
     * @type string
     * @default ","
+    * @deprecated
     */
     thousandsSeparator: ",",
     /**
@@ -155,12 +157,23 @@ const config = {
     }
 };
 
+const deprecatedFields = [ "decimalSeparator", "thousandsSeparator" ];
+
 const configMethod = (...args) => {
     if(!args.length) {
         return config;
     }
 
-    extendUtils.extend(config, args[0]);
+    const newConfig = args[0];
+
+    deprecatedFields.forEach((deprecatedField) => {
+        if(newConfig[deprecatedField]) {
+            const message = "Intl localization included in the DevExtreme. We recommend setting the locale so that the separators are selected based on it.";
+            errors.log("W0003", "config", deprecatedField, "19.2", message);
+        }
+    });
+
+    extendUtils.extend(config, newConfig);
 };
 
 if(typeof DevExpress !== "undefined" && DevExpress.config) {

--- a/js/core/config.js
+++ b/js/core/config.js
@@ -168,7 +168,7 @@ const configMethod = (...args) => {
 
     deprecatedFields.forEach((deprecatedField) => {
         if(newConfig[deprecatedField]) {
-            const message = "Intl localization included in the DevExtreme. We recommend setting the locale so that the separators are selected based on it.";
+            const message = `Now, the ${deprecatedField} is selected based on the specified locale.`;
             errors.log("W0003", "config", deprecatedField, "19.2", message);
         }
     });

--- a/testing/tests/DevExpress.core/config.tests.js
+++ b/testing/tests/DevExpress.core/config.tests.js
@@ -1,6 +1,6 @@
-var config = require("core/config");
-
-require("bundles/modules/core");
+import config from "core/config";
+import errors from "core/errors";
+import "bundles/modules/core";
 
 QUnit.module("DevExtreme global config");
 
@@ -56,4 +56,31 @@ QUnit.test("default DevExpress.config contains 'useJQuery' with true value", fun
 QUnit.test("default DevExpress.config contains 'editorStylingMode' with undefined value", function(assert) {
     assert.ok("editorStylingMode" in config());
     assert.strictEqual(config().editorStylingMode, undefined);
+});
+
+QUnit.test("deprecated fields", function(assert) {
+    const originalLog = errors.log;
+    const log = [];
+
+    errors.log = (...args) => {
+        log.push(args);
+    };
+
+    try {
+        config({ decimalSeparator: "*" });
+        config({ thousandsSeparator: "*" });
+
+        assert.equal(log.length, 2);
+        assert.strictEqual(log[0][0], "W0003");
+        assert.strictEqual(log[0][1], "config");
+        assert.strictEqual(log[0][2], "decimalSeparator");
+        assert.strictEqual(log[0][3], "19.2");
+
+        assert.strictEqual(log[1][0], "W0003");
+        assert.strictEqual(log[1][1], "config");
+        assert.strictEqual(log[1][2], "thousandsSeparator");
+        assert.strictEqual(log[1][3], "19.2");
+    } finally {
+        errors.log = originalLog;
+    }
 });

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -784,6 +784,7 @@ declare module DevExpress {
     export function eventsHandler(event: dxEvent, extraParameters: any): boolean;
     /** @name globalConfig */
     export interface globalConfig {
+        /** @deprecated */
         /** @name globalConfig.decimalSeparator */
         decimalSeparator?: string;
         /** @name globalConfig.defaultCurrency */
@@ -800,6 +801,7 @@ declare module DevExpress {
         rtlEnabled?: boolean;
         /** @name globalConfig.serverDecimalSeparator */
         serverDecimalSeparator?: string;
+        /** @deprecated */
         /** @name globalConfig.thousandsSeparator */
         thousandsSeparator?: string;
         /** @name globalConfig.useLegacyStoreResult */


### PR DESCRIPTION
Breaking Change T817510 - Intl localization utilities are now included in the DevExtreme bundle  