### PR TITLE
AspNet: Add sendValidationRequest method for MVC remote validation

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -10,7 +10,8 @@
                 require("./ui/validation_engine"),
                 require("./core/utils/iterator"),
                 require("./core/utils/dom").extractTemplateMarkup,
-                require("./core/utils/string").encodeHtml
+                require("./core/utils/string").encodeHtml,
+                require("./core/utils/ajax")
             );
         });
     } else {
@@ -22,10 +23,11 @@
             DevExpress.validationEngine,
             DevExpress.utils.iterator,
             DevExpress.utils.dom.extractTemplateMarkup,
-            DevExpress.utils.string.encodeHtml
+            DevExpress.utils.string.encodeHtml,
+            DevExpress.utils.ajax
         );
     }
-})(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils, extractTemplateMarkup, encodeHtml) {
+})(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils, extractTemplateMarkup, encodeHtml, ajax) {
     var templateCompiler = createTemplateCompiler();
     var pendingCreateComponentRoutines = [ ];
 
@@ -178,6 +180,35 @@
                     items.length && summary.option("items", items);
                 }
             }
+        },
+
+        sendValidationRequest: function(propertyName, propertyValue, url, method) {
+            var d = $.Deferred();
+            var data = { };
+            data[propertyName] = propertyValue;
+
+            ajax.sendRequest({
+                url: url,
+                dataType: "json",
+                method: method || "GET",
+                data: data
+            }).then(function(response) {
+                if(typeof response === "string") {
+                    d.resolve({
+                        isValid: false,
+                        message: response
+                    });
+                } else {
+                    d.resolve(response);
+                }
+            }, function(xhr) {
+                d.reject({
+                    isValid: false,
+                    message: xhr.responseText
+                });
+            });
+
+            return d.promise();
         }
     };
 });

--- a/testing/tests/DevExpress.aspnet/aspnet_bundled.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet_bundled.tests.js
@@ -2,6 +2,7 @@ SystemJS.config({
     meta: {
         "/testing/*": { format: "global" },
         "/testing/helpers/jQueryEventsPatch.js": { format: "system" },
+        "/testing/helpers/ajaxMock.js": { format: "cjs" },
         "/testing/helpers/dataPatch.js": { format: "system" },
         "/artifacts/transpiled/aspnet.js": { format: "global" }
     }
@@ -9,6 +10,7 @@ SystemJS.config({
 
 define(function(require) {
     window.DevExpress_ui_widget_errors = require("/artifacts/transpiled/ui/widget/ui.errors");
+    window.ajaxMock = require("/testing/helpers/ajaxMock.js");
     require("/artifacts/transpiled/bundles/dx.web.js");
     require("/artifacts/transpiled/aspnet.js");
     require("/testing/tests/DevExpress.aspnet/aspnet.tests.js");


### PR DESCRIPTION
The `sendValidationRequest` method will be used in `async` rule `validationCallback` mapped from the `[Remote]` attribute:

- **Model:**
![image](https://user-images.githubusercontent.com/1420883/65704717-b4d03580-e08f-11e9-9f98-cb59f1948ca3.png)

- **View:**
![image](https://user-images.githubusercontent.com/1420883/65704780-d3363100-e08f-11e9-8a6f-b831259d63cc.png)

- **Page source:**
![image](https://user-images.githubusercontent.com/1420883/65705128-7f781780-e090-11e9-8150-4b85093f9107.png)





