### PR TITLE
Validate - small refactoring

### DIFF
--- a/js/integration/knockout/validation.js
+++ b/js/integration/knockout/validation.js
@@ -47,7 +47,7 @@ const koDxValidator = Class.inherit({
         const currentResult = this._validationInfo && this._validationInfo.result,
             value = this.target();
         if(currentResult && currentResult.status === VALIDATION_STATUS_PENDING && currentResult.value === value) {
-            return currentResult;
+            return extend({}, currentResult);
         }
         let result = ValidationEngine.validate(value, this.validationRules, this.name);
         result.id = new Guid().toString();
@@ -57,7 +57,7 @@ const koDxValidator = Class.inherit({
                 this._applyValidationResult(res);
             }
         });
-        return this._validationInfo.result;
+        return extend({}, this._validationInfo.result);
     },
 
     reset() {

--- a/js/ui/validation_engine.js
+++ b/js/ui/validation_engine.js
@@ -607,7 +607,7 @@ const GroupConfig = Class.inherit({
             this._raiseValidatedEvent(result);
         }
         this._updateValidationInfo(result);
-        return result;
+        return extend({}, this._validationInfo.result);
     },
 
     _subscribeToChangeEvents(validator) {

--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -237,7 +237,7 @@ const Validator = DOMComponent.inherit({
             rules = this._getValidationRules();
         const currentResult = this._validationInfo && this._validationInfo.result;
         if(currentResult && currentResult.status === VALIDATION_STATUS_PENDING && currentResult.value === value) {
-            return currentResult;
+            return extend({}, currentResult);
         }
         let result;
         if(bypass) {
@@ -255,7 +255,7 @@ const Validator = DOMComponent.inherit({
                 this._applyValidationResult(res, adapter);
             }
         });
-        return this._validationInfo.result;
+        return extend({}, this._validationInfo.result);
     },
 
     /**

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
@@ -642,7 +642,7 @@ QUnit.test("Validator should not be re-validated on pending with the same value"
         result2 = validator.validate();
 
     assert.strictEqual(result1.status, "pending", "result1.status === 'pending'");
-    assert.strictEqual(result1, result2, "The result should be the same");
+    assert.strictEqual(result1.id, result2.id, "The result id's should be the same");
     assert.ok(isPromise(result1.complete), "result1.complete is a Promise object");
     assert.strictEqual(result1.complete, result2.complete, "result1.complete === result2.complete");
     result1.complete.then(function(res) {


### PR DESCRIPTION
dxValidator.validate and dxValidationGroup.validate methods returns copies of their internal validation result object. This is done for preventing users from mutating results on their side.
