### PR TITLE
Select preloaded items in dxTagBox with pre-grouped data (part of T756894)

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -403,7 +403,7 @@ var DropDownList = DropDownEditor.inherit({
         return this._loadItem(value).always(callback);
     },
 
-    _loadItem: function(value, cache) {
+    _getItemFromPlain: function(value, cache) {
         var plainItems,
             selectedItem;
 
@@ -425,6 +425,12 @@ var DropDownList = DropDownEditor.inherit({
             }).bind(this))[0];
         }
 
+        return selectedItem;
+    },
+
+    _loadItem: function(value, cache) {
+        var selectedItem = this._getItemFromPlain(value, cache);
+
         return selectedItem !== undefined
             ? new Deferred().resolve(selectedItem).promise()
             : this._loadValue(value);
@@ -433,7 +439,7 @@ var DropDownList = DropDownEditor.inherit({
     _getPlainItems: function(items) {
         var plainItems = [];
 
-        items = items || this.option("items") || [];
+        items = items || this.option("items") || this._dataSource.items() || [];
 
         for(var i = 0; i < items.length; i++) {
             if(items[i] && items[i].items) {

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -893,6 +893,21 @@ const TagBox = SelectBox.inherit({
         }
     },
 
+    _isGroupedData: function() {
+        return this.option("grouped") && !this._dataSource.group();
+    },
+
+    _getFilteredGroupedItems: function(values) {
+        var selectedItems = [];
+        values.forEach(function(value) {
+            var item = this._getItemFromPlain(value);
+            if(isDefined(item)) {
+                selectedItems.push(item);
+            }
+        }.bind(this));
+        return selectedItems;
+    },
+
     _loadTagsData: function() {
         const values = this._getValue();
         const tagData = new Deferred();
@@ -901,6 +916,9 @@ const TagBox = SelectBox.inherit({
 
         this._getFilteredItems(values)
             .done((filteredItems) => {
+                if(!filteredItems.length && this._isGroupedData()) {
+                    filteredItems = this._getFilteredGroupedItems(values);
+                }
                 const items = this._createTagsData(values, filteredItems);
                 items.always(function(data) {
                     tagData.resolve(data);

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -5421,6 +5421,43 @@ QUnit.module("regression", {
         assert.equal($.trim($tagContainer.text()), "Item1Item3", "selected values are rendered");
     });
 
+    QUnit.test("selection should work with pregrouped data without paging and with preloaded datasource", (assert) => {
+        const ds = new DataSource({
+            store: [
+                { key: "Category 1", items: [{ id: 11, name: "Item 11" }, { id: 12, name: "Item 12" }] },
+                { key: "Category 2", items: [{ id: 21, name: "Item 21" }, { id: 22, name: "Item 22" }] }
+            ]
+        });
+        ds.load();
+
+        const $tagBox = $("#tagBox").dxTagBox({
+            dataSource: ds,
+            valueExpr: "id",
+            displayExpr: "name",
+            value: [21],
+            grouped: true
+        });
+
+        assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text(), "Item 21", "Tag was selected");
+    });
+
+    QUnit.test("selection should work with pregrouped data without paging", (assert) => {
+        const $tagBox = $("#tagBox").dxTagBox({
+            dataSource: new DataSource({
+                store: [
+                    { key: "Category 1", items: [{ id: 11, name: "Item 11" }, { id: 12, name: "Item 12" }] },
+                    { key: "Category 2", items: [{ id: 21, name: "Item 21" }, { id: 22, name: "Item 22" }] }
+                ]
+            }),
+            valueExpr: "id",
+            displayExpr: "name",
+            value: [21],
+            grouped: true
+        });
+
+        assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text(), "Item 21", "Tag was selected");
+    });
+
     QUnit.testInActiveWindow("focusout event should remove focus class from the widget", assert => {
         const $tagBox = $("#tagBox").dxTagBox({});
         const $input = $tagBox.find(`.${TEXTBOX_CLASS}`);

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -5441,23 +5441,6 @@ QUnit.module("regression", {
         assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text(), "Item 21", "Tag was selected");
     });
 
-    QUnit.test("selection should work with pregrouped data without paging", (assert) => {
-        const $tagBox = $("#tagBox").dxTagBox({
-            dataSource: new DataSource({
-                store: [
-                    { key: "Category 1", items: [{ id: 11, name: "Item 11" }, { id: 12, name: "Item 12" }] },
-                    { key: "Category 2", items: [{ id: 21, name: "Item 21" }, { id: 22, name: "Item 22" }] }
-                ]
-            }),
-            valueExpr: "id",
-            displayExpr: "name",
-            value: [21],
-            grouped: true
-        });
-
-        assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text(), "Item 21", "Tag was selected");
-    });
-
     QUnit.testInActiveWindow("focusout event should remove focus class from the widget", assert => {
         const $tagBox = $("#tagBox").dxTagBox({});
         const $input = $tagBox.find(`.${TEXTBOX_CLASS}`);

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -5441,6 +5441,27 @@ QUnit.module("regression", {
         assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text(), "Item 21", "Tag was selected");
     });
 
+    QUnit.test("selection should work with pregrouped data without paging", (assert) => {
+        const loadMock = sinon.stub().returns([
+            { key: "Category 1", items: [{ id: 11, name: "Item 11" }, { id: 12, name: "Item 12" }] },
+            { key: "Category 2", items: [{ id: 21, name: "Item 21" }, { id: 22, name: "Item 22" }] }
+        ]);
+        const ds = new DataSource({
+            load: loadMock
+        });
+
+        const $tagBox = $("#tagBox").dxTagBox({
+            dataSource: ds,
+            valueExpr: "id",
+            displayExpr: "name",
+            value: [21],
+            grouped: true
+        });
+
+        assert.strictEqual(loadMock.callCount, 1, "there was only one load");
+        assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text(), "Item 21", "Tag was selected");
+    });
+
     QUnit.testInActiveWindow("focusout event should remove focus class from the widget", assert => {
         const $tagBox = $("#tagBox").dxTagBox({});
         const $input = $tagBox.find(`.${TEXTBOX_CLASS}`);


### PR DESCRIPTION
This is a fix for this problem: T756894.

**The problem**: When a user gives pregrouped data in dxTagBox's dataSource and sets a grouped option to true, tags don't render.

**The solution** Convert all loaded items to a plain structure and search items by id.

This problem is partially fixed because it is impossible to filter items in the remote dataSource when the data is pre-grouped. This PR fixes the problem only when the data is already loaded.

We cannot add pre-grouped data support to the DevExtreme DataSource now because it leads to breaking changes in DataGrid.