### PR TITLE
Fix uncaught exception when calling svgText.setMaxSize with detached element (T820606)

### DIFF
--- a/js/viz/core/renderers/renderer.js
+++ b/js/viz/core/renderers/renderer.js
@@ -850,7 +850,7 @@ function setMaxSize(maxWidth, maxHeight, options = {}) {
 
     const { width, height } = that._getElementBBox();
 
-    if(width > maxWidth || maxHeight && height > maxHeight) {
+    if((width || height) && (width > maxWidth || maxHeight && height > maxHeight)) {
         if(maxWidth - ellipsisWidth < 0) {
             ellipsisMaxWidth = 0;
         } else {

--- a/testing/tests/DevExpress.viz.renderers/SvgElement.tests.js
+++ b/testing/tests/DevExpress.viz.renderers/SvgElement.tests.js
@@ -6241,5 +6241,17 @@ function checkDashStyle(assert, elem, result, style, value) {
             assert.ok(result.textChanged);
             assert.equal(domAdapter.querySelectorAll(text.element, "title").length, 1);
         });
+
+        QUnit.test("T820606. call setMaxHeight for detached text element", function(assert) {
+            var text = this.createText().attr({ x: 35, y: 100, fill: "black", stroke: "black", text: "200K" });
+
+            this.prepareRenderBeforeEllipsis();
+            text.setMaxSize(-103, undefined, {
+                wordWrap: "normal",
+                textOverflow: "hide"
+            });
+
+            assert.equal(text.element.textContent, "200K");
+        });
     }
 })();


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
