### PR TITLE
L10n: Use the latest version for cldr-core and cldr-numbers-full

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "babel-preset-env": "^1.6.1",
     "bootstrap": "^4.3.1",
     "cldr-core": "latest",
-    "cldr-numbers-full": "^35.1.0",
+    "cldr-numbers-full": "latest",
     "cldrjs": "^0.5.0",
     "del": "^2.2.2",
     "devextreme-internal-tools": "^1.1.0",


### PR DESCRIPTION
Fixes the `Cannot find module '..\..\node_modules\cldr-numbers-full\main\ga-GB\numbers.json` error here:
https://github.com/DevExpress/DevExtreme/blob/36b115999de3052df785c4fc7759ecaaae6bc89e/build/gulp/localization.js#L56