### PR TITLE
Validation - Adds extra parameters to validationCallback

### DIFF
--- a/js/ui/form/ui.form.layout_manager.js
+++ b/js/ui/form/ui.form.layout_manager.js
@@ -833,7 +833,12 @@ const LayoutManager = Widget.inherit({
         if(Array.isArray(validationRules) && validationRules.length) {
             this._createComponent($editor, Validator, {
                 validationRules: validationRules,
-                validationGroup: this.option("validationGroup")
+                validationGroup: this.option("validationGroup"),
+                dataGetter: function() {
+                    return {
+                        formItem: item
+                    };
+                }
             });
         }
     },

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -253,7 +253,10 @@ const ValidatingController = modules.Controller.inherit((function() {
                         applyValidationResults: defaultValidationResult
                     },
                     dataGetter: function() {
-                        return createObjectWithChanges(editData.oldData, editData.data);
+                        return {
+                            data: createObjectWithChanges(editData.oldData, editData.data),
+                            column
+                        };
                     }
                 });
 

--- a/js/ui/validation_engine.js
+++ b/js/ui/validation_engine.js
@@ -235,6 +235,8 @@ class CustomRuleValidator extends BaseRuleValidator {
      * @type_function_param1_field2 rule:object
      * @type_function_param1_field3 validator:object
      * @type_function_param1_field4 data:object
+     * @type_function_param1_field5 column:object
+     * @type_function_param1_field6 formItem:object
      */
     /**
      * @name CustomRule.message
@@ -257,14 +259,14 @@ class CustomRuleValidator extends BaseRuleValidator {
         }
         const validator = rule.validator,
             dataGetter = validator && typeUtils.isFunction(validator.option) && validator.option("dataGetter"),
-            data = typeUtils.isFunction(dataGetter) && dataGetter(),
+            extraParams = typeUtils.isFunction(dataGetter) && dataGetter(),
             params = {
                 value: value,
                 validator: validator,
                 rule: rule
             };
-        if(data) {
-            params.data = data;
+        if(extraParams) {
+            extend(params, extraParams);
         }
         return rule.validationCallback(params);
     }
@@ -289,6 +291,8 @@ class AsyncRuleValidator extends CustomRuleValidator {
      * @type_function_param1_field2 rule:object
      * @type_function_param1_field3 validator:object
      * @type_function_param1_field4 data:object
+     * @type_function_param1_field5 column:object
+     * @type_function_param1_field6 formItem:object
      */
     /**
      * @name AsyncRule.message
@@ -314,14 +318,14 @@ class AsyncRuleValidator extends CustomRuleValidator {
         }
         const validator = rule.validator,
             dataGetter = validator && typeUtils.isFunction(validator.option) && validator.option("dataGetter"),
-            data = typeUtils.isFunction(dataGetter) && dataGetter(),
+            extraParams = typeUtils.isFunction(dataGetter) && dataGetter(),
             params = {
                 value: value,
                 validator: validator,
                 rule: rule
             };
-        if(data) {
-            params.data = data;
+        if(extraParams) {
+            extend(params, extraParams);
         }
         const callbackResult = rule.validationCallback(params);
         if(!typeUtils.isPromise(callbackResult)) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -11185,6 +11185,86 @@ QUnit.test("Only valid data is saved (async)", function(assert) {
     assert.equal($formRow.find(".dx-validation-pending").length, 1, "There is one pending editor in first row");
 });
 
+QUnit.test("AsyncRule.validationCallback accepts extra parameters", function(assert) {
+    // arrange
+    let rowsView = this.rowsView,
+        testElement = $("#container"),
+        inputElement;
+    const validationCallback = sinon.spy(function() { return new Deferred().resolve().promise(); });
+
+    rowsView.render(testElement);
+
+    this.applyOptions({
+        loadingTimeout: undefined,
+        editing: {
+            mode: "form",
+            allowUpdating: true,
+        },
+        columns: [{
+            dataField: "age",
+            validationRules: [{
+                type: "async",
+                validationCallback: validationCallback
+            }]
+        }]
+    });
+
+    // act
+    this.editRow(0);
+
+    inputElement = getInputElements(testElement).first();
+    inputElement.val("");
+    inputElement.trigger("change");
+
+    assert.equal(validationCallback.callCount, 1, "valdiationCallback should be called once");
+
+    const params = validationCallback.getCall(0).args[0];
+
+    assert.ok(params.data, "data should be passed");
+    assert.strictEqual(params.column.dataField, "age", "column.dataField === 'age'");
+    assert.ok(params.column.validationRules, "column.validationRules !== null");
+});
+
+QUnit.test("CustomRule.validationCallback accepts extra parameters", function(assert) {
+    // arrange
+    let rowsView = this.rowsView,
+        testElement = $("#container"),
+        inputElement;
+    const validationCallback = sinon.spy(function() { return true; });
+
+    rowsView.render(testElement);
+
+    this.applyOptions({
+        loadingTimeout: undefined,
+        editing: {
+            mode: "form",
+            allowUpdating: true,
+        },
+        columns: [{
+            dataField: "age",
+            validationRules: [{
+                type: "custom",
+                validationCallback: validationCallback
+            }]
+        }]
+    });
+
+    // act
+    this.editRow(0);
+
+    inputElement = getInputElements(testElement).first();
+    inputElement.val("");
+    inputElement.trigger("change");
+
+    assert.equal(validationCallback.callCount, 1, "valdiationCallback should be called once");
+
+    const params = validationCallback.getCall(0).args[0];
+
+    assert.ok(params.data, "data should be passed");
+    assert.strictEqual(params.column.dataField, "age", "column.dataField === 'age'");
+    assert.ok(params.column.validationRules, "column.validationRules !== null");
+});
+
 // T506863
 QUnit.testInActiveWindow("Show the revert button when a row updating is canceled", function(assert) {
     // arrange

--- a/testing/tests/DevExpress.ui.widgets.editors/validationEngine.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationEngine.tests.js
@@ -805,10 +805,9 @@ QUnit.test("Custom validation rule when value is array", function(assert) {
     assert.deepEqual(customCallback.getCall(0).args[0].value, value, "value is correct");
 });
 
-QUnit.test("Validation callback must have the 'data' in arguments when validator has 'dataGetter' option", function(assert) {
-    var params,
-        customCallback = sinon.spy(function() { return true; }),
-        data = { test: "test" },
+QUnit.test("Validation callback must have extra parameters in arguments when validator has 'dataGetter' option", function(assert) {
+    const customCallback = sinon.spy(function() { return true; }),
+        data = { field1: "test1", field2: "test2" },
         validator = {
             option: function(optionName) {
                 if(optionName === "dataGetter") {
@@ -830,11 +829,12 @@ QUnit.test("Validation callback must have the 'data' in arguments when validator
     assert.ok(result, "Result is defined");
     assert.ok(customCallback.calledOnce, "Validation callback was called");
 
-    params = customCallback.getCall(0).args[0];
+    const params = customCallback.getCall(0).args[0];
     assert.equal(params.value, value, "Correct value should be passed");
     assert.strictEqual(params.validator, validator, "Validator should be passed");
     assert.strictEqual(params.rule, rule, "Rule should be passed");
-    assert.strictEqual(params.data, data, "Data should be passed");
+    assert.strictEqual(params.field1, "test1", "Extra field1 should be passed");
+    assert.strictEqual(params.field2, "test2", "Extra field2 should be passed");
 });
 
 
@@ -1383,8 +1383,7 @@ QUnit.test("One rule is reevaluated", function(assert) {
     });
 });
 
-QUnit.test("Validation callback must have the 'data' in arguments when validator has 'dataGetter' option", function(assert) {
-    let params;
+QUnit.test("Validation callback must have extra parameters in arguments when validator has 'dataGetter' option", function(assert) {
     const customCallback = sinon.spy(function() {
             const d = new Deferred();
             d.resolve({
@@ -1392,7 +1391,7 @@ QUnit.test("Validation callback must have the 'data' in arguments when validator
             });
             return d.promise();
         }),
-        data = { test: "test" },
+        data = { field1: "test1", field2: "test2" },
         validator = {
             option: function(optionName) {
                 if(optionName === "dataGetter") {
@@ -1413,11 +1412,12 @@ QUnit.test("Validation callback must have the 'data' in arguments when validator
     assert.ok(result, "Result is defined");
     assert.ok(customCallback.calledOnce, "Validation callback was called");
 
-    params = customCallback.getCall(0).args[0];
+    const params = customCallback.getCall(0).args[0];
     assert.equal(params.value, value, "Correct value should be passed");
     assert.strictEqual(params.validator, validator, "Validator should be passed");
     assert.strictEqual(params.rule, rule, "Rule should be passed");
-    assert.strictEqual(params.data, data, "Data should be passed");
+    assert.strictEqual(params.field1, "test1", "Extra field1 should be passed");
+    assert.strictEqual(params.field2, "test2", "Extra field2 should be passed");
 });
 
 

--- a/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import { extend } from "core/utils/extend";
 import { logger } from "core/utils/console";
 import ValidationEngine from "ui/validation_engine";
+import { Deferred } from "core/utils/deferred";
 
 import "ui/form/ui.form";
 import "ui/text_area";
@@ -155,6 +156,70 @@ QUnit.test("Validate with template wrapper", assert => {
 
     // assert
     assert.equal(validationSpy.callCount, 1, "invalid editors count");
+});
+
+QUnit.test("CustomRule.validationCallback accepts formItem", assert => {
+    // arrange
+    const validationSpy = sinon.spy(),
+        form = $("#form").dxForm({
+            formData: {
+                name: ""
+            },
+            items: [{
+                dataField: "name",
+                itemType: "simple",
+                validationRules: [{
+                    type: "custom",
+                    message: "Name is required",
+                    validationCallback: validationSpy
+                }]
+            }]
+        }).dxForm("instance");
+
+    // act
+    form.validate();
+
+    // assert
+    assert.equal(validationSpy.callCount, 1, "valdiationCallback should be called once");
+
+    const params = validationSpy.getCall(0).args[0];
+
+    assert.ok(params.formItem, "formItem should be passed");
+    assert.strictEqual(params.formItem.dataField, "name", "formItem.dataField === 'name'");
+    assert.strictEqual(params.formItem.itemType, "simple", "formItem.itemType === 'simple'");
+    assert.ok(params.formItem.validationRules, "formItem.validationRule !== null");
+});
+
+QUnit.test("AsyncRule.validationCallback accepts formItem", assert => {
+    // arrange
+    const validationSpy = sinon.spy(function() { return new Deferred().resolve().promise(); }),
+        form = $("#form").dxForm({
+            formData: {
+                name: ""
+            },
+            items: [{
+                dataField: "name",
+                itemType: "simple",
+                validationRules: [{
+                    type: "async",
+                    message: "Name is required",
+                    validationCallback: validationSpy
+                }]
+            }]
+        }).dxForm("instance");
+
+    // act
+    form.validate();
+
+    // assert
+    assert.equal(validationSpy.callCount, 1, "valdiationCallback should be called once");
+
+    const params = validationSpy.getCall(0).args[0];
+
+    assert.ok(params.formItem, "formItem should be passed");
+    assert.strictEqual(params.formItem.dataField, "name", "formItem.dataField === 'name'");
+    assert.strictEqual(params.formItem.itemType, "simple", "formItem.itemType === 'simple'");
+    assert.ok(params.formItem.validationRules, "formItem.validationRule !== null");
 });
 
 QUnit.test("Validate with a custom validation group", assert => {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1726,7 +1726,7 @@ declare module DevExpress.ui {
         /** @name AsyncRule.type */
         type?: 'required' | 'numeric' | 'range' | 'stringLength' | 'custom' | 'compare' | 'pattern' | 'email' | 'async';
         /** @name AsyncRule.validationCallback */
-        validationCallback?: ((options: { value?: string | number, rule?: any, validator?: any, data?: any }) => Promise<any> | JQueryPromise<any>);
+        validationCallback?: ((options: { value?: string | number, rule?: any, validator?: any, data?: any, column?: any, formItem?: any }) => Promise<any> | JQueryPromise<any>);
     }
     /** @name ColCountResponsible */
     export interface ColCountResponsible {
@@ -1818,7 +1818,7 @@ declare module DevExpress.ui {
         /** @name CustomRule.type */
         type?: 'required' | 'numeric' | 'range' | 'stringLength' | 'custom' | 'compare' | 'pattern' | 'email' | 'async';
         /** @name CustomRule.validationCallback */
-        validationCallback?: ((options: { value?: string | number, rule?: any, validator?: any, data?: any }) => boolean);
+        validationCallback?: ((options: { value?: string | number, rule?: any, validator?: any, data?: any, column?: any, formItem?: any }) => boolean);
     }
     /** @name DataExpressionMixin.Options */
     export interface DataExpressionMixinOptions<T = DataExpressionMixin> {


### PR DESCRIPTION
validationCallback accepts the following extra params:

1. **column** - the current column to which the validator belongs. Exists only when you validate a DataGrid or TreeList cell's value.

2. **formItem** - the current Form item to which the validator belongs. Exists only when you validate a Form editor.
