### PR TITLE
Fixes the reset method for editors

### DIFF
--- a/js/ui/date_box/ui.date_box.base.js
+++ b/js/ui/date_box/ui.date_box.base.js
@@ -328,7 +328,7 @@ var DateBox = DropDownEditor.inherit({
         this._initStrategy();
         this.option(extend({}, this._strategy.getDefaultOptions(), this._userOptions));
         delete this._userOptions;
-
+        this._skipCustomValidation = false;
         this.callBase();
     },
 
@@ -632,7 +632,10 @@ var DateBox = DropDownEditor.inherit({
     },
 
     _validateValue: function(value) {
-        return this._applyInternalValidation(value) && this._applyCustomValidation(value);
+        const internalResult = this._applyInternalValidation(value),
+            customResult = !this._skipCustomValidation ? this._applyCustomValidation(value) : true;
+        this._skipCustomValidation = false;
+        return internalResult && customResult;
     },
 
     _applyInternalValidation(value) {
@@ -874,6 +877,8 @@ var DateBox = DropDownEditor.inherit({
     },
 
     reset: function() {
+        const defaultOptions = this._getDefaultOptions();
+        this._skipCustomValidation = defaultOptions.value === this.dateOption("value");
         this.callBase();
         this._updateValue(this.dateOption("value"));
     }

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -271,6 +271,7 @@ const TagBox = SelectBox.inherit({
             /**
             * @name dxTagBoxOptions.value
             * @type Array<string,number,Object>
+            * @default []
             */
             value: [],
 
@@ -1394,6 +1395,11 @@ const TagBox = SelectBox.inherit({
 
     reset: function() {
         this._restoreInputText();
+        const defaultValue = this._getDefaultOptions().value,
+            currentValue = this.option("value");
+        if(defaultValue && defaultValue.length === 0 && currentValue && defaultValue.length === currentValue.length) {
+            return;
+        }
         this.callBase();
     },
 

--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -104,9 +104,9 @@ var Validator = DOMComponent.inherit({
         this.callBase();
         this._initGroupRegistration();
 
+        this._skipValidation = false;
         this.focused = Callbacks();
         this._initAdapter();
-
     },
 
     _initGroupRegistration: function() {
@@ -147,6 +147,9 @@ var Validator = DOMComponent.inherit({
                 adapter = new DefaultAdapter(dxStandardEditor, this);
 
                 adapter.validationRequestsCallbacks.add(function(args) {
+                    if(that._skipValidation) {
+                        return;
+                    }
                     that.validate(args);
                 });
 
@@ -256,7 +259,9 @@ var Validator = DOMComponent.inherit({
                 brokenRule: null
             };
 
+        this._skipValidation = true;
         adapter.reset();
+        this._skipValidation = false;
         this._resetValidationRules();
         this._applyValidationResult(result, adapter);
     },

--- a/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
@@ -6,18 +6,31 @@ var $ = require("jquery"),
 
 require("common.css!");
 require("generic_light.css!");
+
 require("ui/text_box");
 require("ui/date_box");
 require("ui/number_box");
+require("ui/autocomplete");
+require("ui/calendar");
+require("ui/check_box");
+require("ui/drop_down_box");
+require("ui/html_editor");
+require("ui/lookup");
+require("ui/radio_group");
+require("ui/select_box");
+require("ui/tag_box");
+require("ui/text_area");
+
 
 var Fixture = Class.inherit({
-    createInstance: function(editor, editorOptions, validatorOptions) {
+    createInstance: function(editor, editorOptions, validatorOptions, keyboard = true) {
         var $element = $("<div/>")[editor](editorOptions).dxValidator(validatorOptions);
         this.$element = $element;
 
         this.$input = $element.find(".dx-texteditor-input");
-
-        this.keyboard = keyboardMock(this.$input);
+        if(keyboard) {
+            this.keyboard = keyboardMock(this.$input);
+        }
         this.editor = $element[editor]("instance");
         this.validator = Validator.getInstance($element);
 
@@ -31,7 +44,7 @@ var Fixture = Class.inherit({
     },
 
     teardown: function() {
-        this.$element.remove();
+        this.$element && this.$element.remove();
         ValidationEngine.initGroups();
     }
 });
@@ -91,6 +104,33 @@ var Fixture = Class.inherit({
         assert.ok(editorValidationError, "Editor should have specific validation error");
         assert.strictEqual(editorValidationError.editorSpecific, undefined, "editorSpecific flag should not be set");
         assert.strictEqual(editorValidationError.message, "Required", "Message should came from dxValidator");
+    });
+
+    QUnit.test("Editor/Validator.reset should not validate null value", function(assert) {
+        const editors = [
+            "dxAutocomplete", "dxCalendar", "dxCheckBox", "dxDateBox",
+            "dxDropDownBox", "dxHtmlEditor", "dxLookup", "dxNumberBox",
+            "dxRadioGroup", "dxSelectBox", "dxTagBox", "dxTextArea", "dxTextBox"];
+
+        const validationCallback = sinon.spy();
+        editors.forEach(editor => {
+            this.fixture.createInstance(editor, { }, {
+                validationRules: [{
+                    type: "custom",
+                    validationCallback: validationCallback
+                }]
+            }, false);
+
+            this.fixture.editor.reset();
+
+            assert.notOk(validationCallback.called, `validationCallback should not be called for ${editor} after ${editor}.reset`);
+
+            this.fixture.validator.reset();
+
+            assert.notOk(validationCallback.called, `validationCallback should not be called for ${editor} after dxValidator.reset`);
+
+            this.fixture.teardown();
+        });
     });
 
     QUnit.test("T525700: numberBox and Validator - validation on focusout with validation rule range", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
@@ -20,6 +20,9 @@ require("ui/radio_group");
 require("ui/select_box");
 require("ui/tag_box");
 require("ui/text_area");
+require("ui/slider");
+require("ui/range_slider");
+require("ui/switch");
 
 
 var Fixture = Class.inherit({
@@ -109,15 +112,17 @@ var Fixture = Class.inherit({
     QUnit.test("Editor/Validator.reset should not validate null value", function(assert) {
         const editors = [
             "dxAutocomplete", "dxCalendar", "dxCheckBox", "dxDateBox",
-            "dxDropDownBox", "dxHtmlEditor", "dxLookup", "dxNumberBox",
-            "dxRadioGroup", "dxSelectBox", "dxTagBox", "dxTextArea", "dxTextBox"];
+            "dxDropDownBox", "dxHtmlEditor", "dxLookup", "dxRadioGroup",
+            "dxRangeSlider", "dxSelectBox", "dxSlider", "dxSwitch",
+            "dxTagBox", "dxTextArea", "dxTextBox"];
 
-        const validationCallback = sinon.spy();
+
         editors.forEach(editor => {
+            const validationCallback = sinon.spy();
             this.fixture.createInstance(editor, { }, {
                 validationRules: [{
                     type: "custom",
-                    validationCallback: validationCallback
+                    validationCallback
                 }]
             }, false);
 
@@ -131,6 +136,26 @@ var Fixture = Class.inherit({
 
             this.fixture.teardown();
         });
+    });
+
+    QUnit.test("NumberBox.reset should validate value", function(assert) {
+        const validationCallback = sinon.spy();
+        this.fixture.createInstance("dxNumberBox", { }, {
+            validationRules: [{
+                type: "custom",
+                validationCallback
+            }]
+        }, false);
+
+        this.fixture.editor.reset();
+        // This happens because the default dxNumberBox.value is 0, but the dxNumberBox.reset method resets it to null.
+        // Validation is executed due to the valueChanged event.
+        // When we decide to break this behavior, we can add "dxNumberBox" to the editors array in the test case above and delete this test.
+        assert.ok(validationCallback.calledOnce, `validationCallback should be called after dxNumberBox.reset`);
+
+        this.fixture.validator.reset();
+        // Since the value is reset to null by the editor.reset method, the validator.reset method should not execute validationCallback.
+        assert.ok(validationCallback.calledOnce, `validationCallback should not be called after dxValidator.reset`);
     });
 
     QUnit.test("T525700: numberBox and Validator - validation on focusout with validation rule range", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
@@ -47,7 +47,7 @@ var Fixture = Class.inherit({
     },
 
     teardown: function() {
-        this.$element && this.$element.remove();
+        this.$element.remove();
         ValidationEngine.initGroups();
     }
 });
@@ -109,15 +109,13 @@ var Fixture = Class.inherit({
         assert.strictEqual(editorValidationError.message, "Required", "Message should came from dxValidator");
     });
 
-    QUnit.test("Editor/Validator.reset should not validate null value", function(assert) {
-        const editors = [
-            "dxAutocomplete", "dxCalendar", "dxCheckBox", "dxDateBox",
-            "dxDropDownBox", "dxHtmlEditor", "dxLookup", "dxRadioGroup",
-            "dxRangeSlider", "dxSelectBox", "dxSlider", "dxSwitch",
-            "dxTagBox", "dxTextArea", "dxTextBox"];
-
-
-        editors.forEach(editor => {
+    [
+        "dxAutocomplete", "dxCalendar", "dxCheckBox", "dxDateBox",
+        "dxDropDownBox", "dxHtmlEditor", "dxLookup", "dxRadioGroup",
+        "dxRangeSlider", "dxSelectBox", "dxSlider", "dxSwitch",
+        "dxTagBox", "dxTextArea", "dxTextBox"
+    ].forEach(editor => {
+        QUnit.test(`${editor}.reset should not validate the default value`, function(assert) {
             const validationCallback = sinon.spy();
             this.fixture.createInstance(editor, { }, {
                 validationRules: [{
@@ -128,17 +126,26 @@ var Fixture = Class.inherit({
 
             this.fixture.editor.reset();
 
-            assert.notOk(validationCallback.called, `validationCallback should not be called for ${editor} after ${editor}.reset`);
+            assert.notOk(validationCallback.called, "validationCallback should not be called");
+        });
+
+        QUnit.test(`Validator.reset should not validate the default value for ${editor}`, function(assert) {
+            const validationCallback = sinon.spy();
+            this.fixture.createInstance(editor, { }, {
+                validationRules: [{
+                    type: "custom",
+                    validationCallback
+                }]
+            }, false);
 
             this.fixture.validator.reset();
 
-            assert.notOk(validationCallback.called, `validationCallback should not be called for ${editor} after dxValidator.reset`);
-
-            this.fixture.teardown();
+            assert.notOk(validationCallback.called, "validationCallback should not be called");
         });
     });
 
-    QUnit.test("NumberBox.reset should validate value", function(assert) {
+
+    QUnit.test("NumberBox.reset should validate the default value", function(assert) {
         const validationCallback = sinon.spy();
         this.fixture.createInstance("dxNumberBox", { }, {
             validationRules: [{
@@ -151,11 +158,20 @@ var Fixture = Class.inherit({
         // This happens because the default dxNumberBox.value is 0, but the dxNumberBox.reset method resets it to null.
         // Validation is executed due to the valueChanged event.
         // When we decide to break this behavior, we can add "dxNumberBox" to the editors array in the test case above and delete this test.
-        assert.ok(validationCallback.calledOnce, `validationCallback should be called after dxNumberBox.reset`);
+        assert.ok(validationCallback.called, `validationCallback should be called after dxNumberBox.reset`);
+    });
+    QUnit.test("Validator.reset should not validate the default NumberBox value", function(assert) {
+        const validationCallback = sinon.spy();
+        this.fixture.createInstance("dxNumberBox", { }, {
+            validationRules: [{
+                type: "custom",
+                validationCallback
+            }]
+        }, false);
 
         this.fixture.validator.reset();
-        // Since the value is reset to null by the editor.reset method, the validator.reset method should not execute validationCallback.
-        assert.ok(validationCallback.calledOnce, `validationCallback should not be called after dxValidator.reset`);
+
+        assert.notOk(validationCallback.called, "validationCallback should not be called");
     });
 
     QUnit.test("T525700: numberBox and Validator - validation on focusout with validation rule range", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
@@ -382,7 +382,7 @@ QUnit.test("validate -> resetValues when there are invalid validation rules", fu
     formItems.forEach(item => assert.strictEqual(form.getEditor(item.dataField).option("isValid"), true, "form.getEditor." + item.dataField));
     assert.equal(findInvalidElements$(form).length, 0, "There are no invalid elements");
     assert.equal(findInvalidSummaryElements$(form).length, 0, "There are no validation summary items");
-    assert.equal(validationCallbackLog.length, /* TODO: avoid all the calls */ 3, "validationCallbackLog on resetValues: " + JSON.stringify(validationCallbackLog));
+    assert.equal(validationCallbackLog.length, /* TODO: avoid all the calls */ 1, "validationCallbackLog on resetValues: " + JSON.stringify(validationCallbackLog));
 
     form.dispose();
 });


### PR DESCRIPTION
1. Fixes the reset method for the dxDateBox and dxTagBox widgets. Validation is not requested when the method is called if the current value equals the default value.

2. dxValidator.reset does not execute the validation.
