### PR TITLE
DateBox: Fix native pickers showing if the drop-down button is clicked on a mobile device (T824701)

### DIFF
--- a/styles/widgets/common/dateBox.less
+++ b/styles/widgets/common/dateBox.less
@@ -9,6 +9,15 @@
 .dx-datebox-native {
     .dx-texteditor-buttons-container {
         pointer-events: none;
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: 100%;
+    }
+
+    &.dx-rtl .dx-texteditor-buttons-container {
+        right: auto;
+        left: 0;
     }
 
     &.dx-state-focused.dx-texteditor-empty {


### PR DESCRIPTION
**In 18.2:**
![18.2.10](https://user-images.githubusercontent.com/1420883/67487927-78d0c600-f677-11e9-87cf-a9101fd36d4e.png)

**In 19.1:**
![19.1.7](https://user-images.githubusercontent.com/1420883/67487725-1d063d00-f677-11e9-8205-f602f060ca24.png)

**After this fix in 19.1:**
![fix](https://user-images.githubusercontent.com/1420883/67488146-f8f72b80-f677-11e9-9ae8-4e58ee2c0187.png)

