### PR TITLE
DateBox: Fix unit test on iOS devices (T824701)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -543,7 +543,7 @@ QUnit.module("hidden input", {}, () => {
 
         $element
             .find(`.${TEXTEDITOR_INPUT_CLASS}`)
-            .on("dxclick", clickSpy);
+            .on("click", clickSpy);
 
         $element
             .find(`.${DROP_DOWN_BUTTON_CLASS}`)


### PR DESCRIPTION
Since we [call a native click method](https://github.com/DevExpress/DevExtreme/pull/10353/files#diff-269491805abaa44e3aa5e0e00207760cR49) on an input element, we will subscribe to the native click handler to assert.