### PR TITLE
Make exportFromMarkup use theme's background color by default (T827373)

### DIFF
--- a/js/viz/core/export.js
+++ b/js/viz/core/export.js
@@ -231,7 +231,7 @@ export const exportFromMarkup = function(markup, options) {
     options.exportedAction = options.onExported;
     options.fileSavingAction = options.onFileSaving;
     options.margin = isDefined(options.margin) ? options.margin : MARGIN;
-    options.backgroundColor = isDefined(options.backgroundColor) ? options.backgroundColor : getBackgroundColorFromMarkup(markup);
+    options.backgroundColor = isDefined(options.backgroundColor) ? options.backgroundColor : (getBackgroundColorFromMarkup(markup) || themeModule.getTheme().backgroundColor);
     clientExporter.export(markup, options, getCreatorFunc(options.format));
 };
 

--- a/testing/tests/DevExpress.viz.core/export.tests.js
+++ b/testing/tests/DevExpress.viz.core/export.tests.js
@@ -557,7 +557,7 @@ QUnit.test("exportFromMarkup method. Defaults", function(assert) {
         fileSavingAction: undefined,
         exportingAction: undefined,
         exportedAction: undefined,
-        backgroundColor: undefined
+        backgroundColor: "#ffffff"
     }, "Export options");
 });
 
@@ -669,6 +669,28 @@ QUnit.test("exportFromMarkup. backgroundColor from markup", function(assert) {
     }, "Export options");
 });
 
+QUnit.test("exportFromMarkup. backgroundColor from current theme", function(assert) {
+    // arrange
+    var options = {
+            width: 600,
+            height: 400
+        },
+        markup = 'testMarkup',
+        currentTheme = themeModule.currentTheme();
+
+    themeModule.currentTheme("someTheme.light");
+
+    try {
+        // act
+        exportModule.exportFromMarkup(markup, options);
+
+        // assert
+        assert.equal(clientExporter.export.getCall(0).args[1].backgroundColor, "some_theme_color");
+    } finally {
+        themeModule.currentTheme(currentTheme);
+    }
+});
+
 QUnit.test("exportWidgets method. Defaults", function(assert) {
     // arrange
     exportModule.combineMarkups.returns({ markup: "testMarkup", width: 600, height: 400 });
@@ -696,7 +718,7 @@ QUnit.test("exportWidgets method. Defaults", function(assert) {
         fileSavingAction: undefined,
         exportingAction: undefined,
         exportedAction: undefined,
-        backgroundColor: undefined
+        backgroundColor: "#ffffff"
     }, "Export options");
 });
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
