### PR TITLE
Alternate ASP.NET template syntax

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -30,12 +30,16 @@
 })(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils, extractTemplateMarkup, encodeHtml, ajax) {
     var templateCompiler = createTemplateCompiler();
     var pendingCreateComponentRoutines = [ ];
+    var enableAlternateTemplateTags = true;
 
     function createTemplateCompiler() {
         var OPEN_TAG = "<%",
             CLOSE_TAG = "%>",
             ENCODE_QUALIFIER = "-",
             INTERPOLATE_QUALIFIER = "=";
+
+        var EXTENDED_OPEN_TAG = /[<[]%/g,
+            EXTENDED_CLOSE_TAG = /%[>\]]/g;
 
         function acceptText(bag, text) {
             if(text) {
@@ -59,12 +63,12 @@
 
         return function(text) {
             var bag = ["var _ = [];", "with(obj||{}) {"],
-                chunks = text.split(OPEN_TAG);
+                chunks = text.split(enableAlternateTemplateTags ? EXTENDED_OPEN_TAG : OPEN_TAG);
 
             acceptText(bag, chunks.shift());
 
             for(var i = 0; i < chunks.length; i++) {
-                var tmp = chunks[i].split(CLOSE_TAG);
+                var tmp = chunks[i].split(enableAlternateTemplateTags ? EXTENDED_CLOSE_TAG : CLOSE_TAG);
                 if(tmp.length !== 2) {
                     throw "Template syntax error";
                 }
@@ -166,6 +170,10 @@
             if(setTemplateEngine) {
                 setTemplateEngine(createTemplateEngine());
             }
+        },
+
+        enableAlternateTemplateTags: function(value) {
+            enableAlternateTemplateTags = value;
         },
 
         createValidationSummaryItems: function(validationGroup, editorNames) {

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -261,15 +261,21 @@
             setTemplateEngine("default");
         }
     }, function() {
-        var testTemplate = function(name, templateSource, expected) {
+        var testTemplate = function(name, templateSource, expected, enableAlternateTemplateTags) {
             QUnit.test(name, function(assert) {
                 var $template = $("#simpleTemplate");
 
                 $template.text(templateSource);
-                $("#button").dxButton({
-                    text: "Test button",
-                    template: $template
-                });
+
+                aspnet.enableAlternateTemplateTags(enableAlternateTemplateTags !== false);
+                try {
+                    $("#button").dxButton({
+                        text: "Test button",
+                        template: $template
+                    });
+                } finally {
+                    aspnet.enableAlternateTemplateTags(true);
+                }
 
                 assert.equal($(".dx-button-content").text(), expected);
             });
@@ -321,6 +327,11 @@
         );
 
         testTemplate("obj", "<%- obj.text %>", "Test button");
+
+        QUnit.module("Alternate syntax (T831170)", function() {
+            testTemplate("enabled", "a [%= 'b' %] c", "a b c");
+            testTemplate("disabled", "[%= 123 %]", "[%= 123 %]", false);
+        });
     });
 
     QUnit.test("Transcluded content (T691770, T693379)", function(assert) {


### PR DESCRIPTION
Workaround against https://github.com/aspnet/AspNetCore/issues/17028
Resolves https://devexpress.com/issue=T831170

This allows square brackets in [ERB-style constructs](https://docs.devexpress.com/AspNetCore/401029/devextreme-based-controls/concepts/templates#erb-style-constructs):

```
[%= value %]
```

Enabled by default.

To disable: 
```js
DevExpress.aspnet.enableAlternateTemplateTags(false);
```