### PR TITLE
Fix validator._validationInfo.result.complete updating

### DIFF
--- a/js/integration/knockout/validation.js
+++ b/js/integration/knockout/validation.js
@@ -33,7 +33,8 @@ const koDxValidator = Class.inherit({
 
     _updateValidationResult(result) {
         if(!this._validationInfo.result || this._validationInfo.result.id !== result.id) {
-            this._validationInfo.result = extend({}, result);
+            const complete = this._validationInfo.deferred && this._validationInfo.result.complete;
+            this._validationInfo.result = extend({}, result, { complete });
         } else {
             for(let prop in result) {
                 if(prop !== "id" && prop !== "complete") {

--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -293,7 +293,8 @@ const Validator = DOMComponent.inherit({
 
     _updateValidationResult(result) {
         if(!this._validationInfo.result || this._validationInfo.result.id !== result.id) {
-            this._validationInfo.result = extend({}, result);
+            const complete = this._validationInfo.deferred && this._validationInfo.result.complete;
+            this._validationInfo.result = extend({}, result, { complete });
         } else {
             for(let prop in result) {
                 if(prop !== "id" && prop !== "complete") {

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
@@ -4,7 +4,7 @@ import Class from "core/class";
 import DefaultAdapter from "ui/validation/default_adapter";
 import ValidationEngine from "ui/validation_engine";
 import { Deferred } from "core/utils/deferred";
-import { isDeferred } from "core/utils/type";
+import { isPromise } from "core/utils/type";
 import Promise from "core/polyfills/promise";
 
 import "ui/validator";
@@ -643,7 +643,7 @@ QUnit.test("Validator should not be re-validated on pending with the same value"
 
     assert.strictEqual(result1.status, "pending", "result1.status === 'pending'");
     assert.strictEqual(result1.id, result2.id, "The result id's should be the same");
-    assert.ok(isDeferred(result1.complete), "result1.complete is a Deferred object");
+    assert.ok(isPromise(result1.complete), "result1.complete is a Promise object");
     assert.strictEqual(result1.complete, result2.complete, "result1.complete === result2.complete");
     result1.complete.then(function(res) {
         assert.strictEqual(result1.id, res.id, "result1.id === res.id");
@@ -681,8 +681,7 @@ QUnit.test("Validator should resolve result.complete with the last value", funct
 
     assert.strictEqual(result1.status, "pending", "result1.status === 'pending'");
     assert.notOk(result1 === result2, "Results should be different");
-    assert.ok(isDeferred(result1.complete), "result1.complete is a Deferred object");
-    assert.ok(isDeferred(result2.complete), "result2.complete is a Deferred object");
+    assert.ok(result1.complete === result2.complete, "result1.complete === result2.complete");
     Promise.all([result1.complete, result2.complete]).then(function(values) {
         assert.ok(values.length === 2, "Results should be resolved twice");
         assert.notOk(values[0].id === result1.id, "The first result should not equal resolved result");

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
@@ -5,7 +5,6 @@ import DefaultAdapter from "ui/validation/default_adapter";
 import ValidationEngine from "ui/validation_engine";
 import { Deferred } from "core/utils/deferred";
 import { isPromise } from "core/utils/type";
-import Promise from "core/polyfills/promise";
 
 import "ui/validator";
 
@@ -682,13 +681,11 @@ QUnit.test("Validator should resolve result.complete with the last value", funct
     assert.strictEqual(result1.status, "pending", "result1.status === 'pending'");
     assert.notOk(result1 === result2, "Results should be different");
     assert.ok(result1.complete === result2.complete, "result1.complete === result2.complete");
-    Promise.all([result1.complete, result2.complete]).then(function(values) {
-        assert.ok(values.length === 2, "Results should be resolved twice");
-        assert.notOk(values[0].id === result1.id, "The first result should not equal resolved result");
-        assert.strictEqual(result2.id, values[1].id, "The second result should equal resolved result");
-        assert.ok(validatedHandler.calledOnce, "Validated handler should be called");
-        assert.strictEqual(values[0].id, values[1].id, "Resolved results should be the same");
-        assert.strictEqual(values[0].value, values[1].value, "Values of resolved results should be the same");
+    result2.complete.then(function(resolvedResult) {
+        assert.notOk(resolvedResult.id === result1.id, "result1 should not equal resolved result");
+        assert.strictEqual(result2.id, resolvedResult.id, "result2 should equal resolved result");
+        assert.ok(validatedHandler.calledOnce, "Validated handler should be called once");
+        assert.strictEqual(result2.value, resolvedResult.value, "result2.value === resolvedResult.value");
         done();
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
@@ -4,7 +4,7 @@ import Class from "core/class";
 import DefaultAdapter from "ui/validation/default_adapter";
 import ValidationEngine from "ui/validation_engine";
 import { Deferred } from "core/utils/deferred";
-import { isPromise } from "core/utils/type";
+import { isDeferred } from "core/utils/type";
 import Promise from "core/polyfills/promise";
 
 import "ui/validator";
@@ -643,7 +643,7 @@ QUnit.test("Validator should not be re-validated on pending with the same value"
 
     assert.strictEqual(result1.status, "pending", "result1.status === 'pending'");
     assert.strictEqual(result1.id, result2.id, "The result id's should be the same");
-    assert.ok(isPromise(result1.complete), "result1.complete is a Promise object");
+    assert.ok(isDeferred(result1.complete), "result1.complete is a Deferred object");
     assert.strictEqual(result1.complete, result2.complete, "result1.complete === result2.complete");
     result1.complete.then(function(res) {
         assert.strictEqual(result1.id, res.id, "result1.id === res.id");
@@ -681,8 +681,8 @@ QUnit.test("Validator should resolve result.complete with the last value", funct
 
     assert.strictEqual(result1.status, "pending", "result1.status === 'pending'");
     assert.notOk(result1 === result2, "Results should be different");
-    assert.ok(isPromise(result1.complete), "result1.complete is a Promise object");
-    assert.ok(isPromise(result2.complete), "result2.complete is a Promise object");
+    assert.ok(isDeferred(result1.complete), "result1.complete is a Deferred object");
+    assert.ok(isDeferred(result2.complete), "result2.complete is a Deferred object");
     Promise.all([result1.complete, result2.complete]).then(function(values) {
         assert.ok(values.length === 2, "Results should be resolved twice");
         assert.notOk(values[0].id === result1.id, "The first result should not equal resolved result");

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
@@ -680,7 +680,7 @@ QUnit.test("Validator should resolve result.complete with the last value", funct
 
     assert.strictEqual(result1.status, "pending", "result1.status === 'pending'");
     assert.notOk(result1 === result2, "Results should be different");
-    assert.ok(result1.complete === result2.complete, "result1.complete === result2.complete");
+    assert.strictEqual(result1.complete, result2.complete, "result1.complete === result2.complete");
     result2.complete.then(function(resolvedResult) {
         assert.notOk(resolvedResult.id === result1.id, "result1 should not equal resolved result");
         assert.strictEqual(result2.id, resolvedResult.id, "result2 should equal resolved result");


### PR DESCRIPTION
The Validator._validationInfo.result.complete option should not be overridden when the Validator.validate method is called for a new value when a previous validating request is not completed.