### PR TITLE
TreeView - fix rendering with _ _ charachters in id (T832172)

### DIFF
--- a/js/core/utils/common.js
+++ b/js/core/utils/common.js
@@ -215,8 +215,14 @@ const pairToObject = function(raw, preventRound) {
     return { h, v };
 };
 
-const escapeCssQuery = function(query) {
-    return isString(query) ? query.split('\\').join('\\\\') : query;
+const escapeCssSearchQuery = function(query) {
+    if(isString(query)) {
+        const replacements = ['\\', '\'', "\""];
+        each(replacements, (_, replacement) => {
+            query = query.split(replacement).join('\\' + replacement);
+        });
+    }
+    return query;
 };
 
 const getKeyHash = function(key) {
@@ -345,4 +351,4 @@ exports.noop = noop;
 exports.asyncNoop = asyncNoop;
 exports.grep = grep;
 exports.equalByValue = equalByValue;
-exports.escapeCssQuery = escapeCssQuery;
+exports.escapeCssSearchQuery = escapeCssSearchQuery;

--- a/js/core/utils/common.js
+++ b/js/core/utils/common.js
@@ -215,16 +215,6 @@ const pairToObject = function(raw, preventRound) {
     return { h, v };
 };
 
-const escapeCssSearchQuery = function(query) {
-    if(isString(query)) {
-        const replacements = ['\\', '\'', "\""];
-        each(replacements, (_, replacement) => {
-            query = query.split(replacement).join('\\' + replacement);
-        });
-    }
-    return query;
-};
-
 const getKeyHash = function(key) {
     if(key instanceof Guid) {
         return key.toString();
@@ -351,4 +341,3 @@ exports.noop = noop;
 exports.asyncNoop = asyncNoop;
 exports.grep = grep;
 exports.equalByValue = equalByValue;
-exports.escapeCssSearchQuery = escapeCssSearchQuery;

--- a/js/core/utils/common.js
+++ b/js/core/utils/common.js
@@ -200,7 +200,6 @@ const denormalizeKey = function(key) {
     return key;
 };
 
-
 const pairToObject = function(raw, preventRound) {
     const pair = splitPair(raw);
     let h = preventRound ? parseFloat(pair && pair[0]) : parseInt(pair && pair[0], 10);

--- a/js/core/utils/common.js
+++ b/js/core/utils/common.js
@@ -180,12 +180,26 @@ const splitPair = function(raw) {
 
 const normalizeKey = function(id) {
     let key = isString(id) ? id : id.toString();
-    return encodeURIComponent(key);
+    const arr = key.match(/[^a-zA-Z0-9_]/g);
+
+    arr && each(arr, (_, sign) => {
+        key = key.replace(sign, "__" + sign.charCodeAt() + "__");
+    });
+    return key;
 };
 
 const denormalizeKey = function(key) {
-    return decodeURIComponent(key);
+    const arr = key.match(/__\d+__/g);
+
+    arr && arr.forEach((char) => {
+        const charCode = parseInt(char.replace("__", ""));
+
+        key = key.replace(char, String.fromCharCode(charCode));
+    });
+
+    return key;
 };
+
 
 const pairToObject = function(raw, preventRound) {
     const pair = splitPair(raw);
@@ -200,6 +214,10 @@ const pairToObject = function(raw, preventRound) {
     }
 
     return { h, v };
+};
+
+const escapeCssQuery = function(query) {
+    return query.split('\\').join('\\\\');
 };
 
 const getKeyHash = function(key) {
@@ -328,3 +346,4 @@ exports.noop = noop;
 exports.asyncNoop = asyncNoop;
 exports.grep = grep;
 exports.equalByValue = equalByValue;
+exports.escapeCssQuery = escapeCssQuery;

--- a/js/core/utils/common.js
+++ b/js/core/utils/common.js
@@ -180,24 +180,11 @@ const splitPair = function(raw) {
 
 const normalizeKey = function(id) {
     let key = isString(id) ? id : id.toString();
-    const arr = key.match(/[^a-zA-Z0-9_]/g);
-
-    arr && each(arr, (_, sign) => {
-        key = key.replace(sign, "__" + sign.charCodeAt() + "__");
-    });
-    return key;
+    return encodeURIComponent(key);
 };
 
 const denormalizeKey = function(key) {
-    const arr = key.match(/__\d+__/g);
-
-    arr && arr.forEach((char) => {
-        const charCode = parseInt(char.replace("__", ""));
-
-        key = key.replace(char, String.fromCharCode(charCode));
-    });
-
-    return key;
+    return decodeURIComponent(key);
 };
 
 const pairToObject = function(raw, preventRound) {

--- a/js/core/utils/common.js
+++ b/js/core/utils/common.js
@@ -216,7 +216,7 @@ const pairToObject = function(raw, preventRound) {
 };
 
 const escapeCssQuery = function(query) {
-    return query.split('\\').join('\\\\');
+    return isString(query) ? query.split('\\').join('\\\\') : query;
 };
 
 const getKeyHash = function(key) {

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1702,7 +1702,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
 
     _escapeCssSearchQuery: function(query) {
         if(isString(query)) {
-            return ['\\', '\'', "\""].reduce((result, replacement) => result.split(replacement).join(`\\${replacement}`), query);
+            return query.replace(/('|"|\\)/g, '\\' + '$1');
         }
         return query;
     },

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1703,7 +1703,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
 
     _escapeSpecialCharacters: function(query) {
         return isString(query)
-            ? query.replace(/('|"|\\)/g, '\\' + '$1')
+            ? query.replace(/('|"|\\)/g, '\\$1')
             : query;
     },
 

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -132,7 +132,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
             }
             return cache.$nodeByKey[key] || $();
         }
-        const element = this.$element().get(0).querySelector(`[${DATA_ITEM_ID}='${this._escapeCssSearchQuery(key)}']`);
+        const element = this.$element().get(0).querySelector(`[${DATA_ITEM_ID}='${this._escapeSpecialCharacters(key)}']`);
         return $(element);
     },
 
@@ -1701,7 +1701,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
         }
     },
 
-    _escapeCssSearchQuery: function(query) {
+    _escapeSpecialCharacters: function(query) {
         if(isString(query)) {
             return query.replace(/('|"|\\)/g, '\\' + '$1');
         }

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -132,7 +132,8 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
             }
             return cache.$nodeByKey[key] || $();
         }
-        return this.$element().find(`[${DATA_ITEM_ID}='${this._escapeCssSearchQuery(key)}']`);
+        const element = this.$element().get(0).querySelector(`[${DATA_ITEM_ID}='${this._escapeCssSearchQuery(key)}']`);
+        return $(element);
     },
 
     _activeStateUnit: "." + ITEM_CLASS,

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -5,7 +5,7 @@ import messageLocalization from "../../localization/message";
 import clickEvent from "../../events/click";
 import commonUtils from "../../core/utils/common";
 import windowUtils from "../../core/utils/window";
-import { isDefined, isPrimitive, isFunction } from "../../core/utils/type";
+import { isDefined, isPrimitive, isFunction, isString } from "../../core/utils/type";
 import { extend } from "../../core/utils/extend";
 import { each } from "../../core/utils/iterator";
 import { getPublicElement } from "../../core/utils/dom";
@@ -132,7 +132,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
             }
             return cache.$nodeByKey[key] || $();
         }
-        return this.$element().find(`[${DATA_ITEM_ID}='${commonUtils.escapeCssSearchQuery(key)}']`);
+        return this.$element().find(`[${DATA_ITEM_ID}='${this._escapeCssSearchQuery(key)}']`);
     },
 
     _activeStateUnit: "." + ITEM_CLASS,
@@ -1698,6 +1698,16 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
             const collapsedNode = this._getClosestNonDisabledNode($focusedNode);
             collapsedNode.length && this.option("focusedElement", getPublicElement(collapsedNode));
         }
+    },
+
+    _escapeCssSearchQuery: function(query) {
+        if(isString(query)) {
+            const replacements = ['\\', '\'', "\""];
+            each(replacements, (_, replacement) => {
+                query = query.split(replacement).join('\\' + replacement);
+            });
+        }
+        return query;
     },
 
     /**

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1702,10 +1702,9 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
     },
 
     _escapeSpecialCharacters: function(query) {
-        if(isString(query)) {
-            return query.replace(/('|"|\\)/g, '\\' + '$1');
-        }
-        return query;
+        return isString(query)
+            ? query.replace(/('|"|\\)/g, '\\' + '$1')
+            : query;
     },
 
     /**

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1702,9 +1702,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
 
     _escapeCssSearchQuery: function(query) {
         if(isString(query)) {
-            if(isString(query)) {
-                return ['\\', '\'', "\""].reduce((result, replacement) => result.split(replacement).join(`\\${replacement}`), query);
-            }
+            return ['\\', '\'', "\""].reduce((result, replacement) => result.split(replacement).join(`\\${replacement}`), query);
         }
         return query;
     },

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -1702,10 +1702,9 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
 
     _escapeCssSearchQuery: function(query) {
         if(isString(query)) {
-            const replacements = ['\\', '\'', "\""];
-            each(replacements, (_, replacement) => {
-                query = query.split(replacement).join('\\' + replacement);
-            });
+            if(isString(query)) {
+                return ['\\', '\'', "\""].reduce((result, replacement) => result.split(replacement).join(`\\${replacement}`), query);
+            }
         }
         return query;
     },

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -132,7 +132,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
             }
             return cache.$nodeByKey[key] || $();
         }
-        return this.$element().find(`[${DATA_ITEM_ID}='${commonUtils.escapeCssQuery(key)}']`);
+        return this.$element().find(`[${DATA_ITEM_ID}='${commonUtils.escapeCssSearchQuery(key)}']`);
     },
 
     _activeStateUnit: "." + ITEM_CLASS,

--- a/js/ui/tree_view/ui.tree_view.base.js
+++ b/js/ui/tree_view/ui.tree_view.base.js
@@ -119,7 +119,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
     },
 
     _getNodeElement: function(node, cache) {
-        const normalizedKey = commonUtils.normalizeKey(node.internalFields.key);
+        const key = node.internalFields.key;
         if(cache) {
             if(!cache.$nodeByKey) {
                 cache.$nodeByKey = {};
@@ -130,9 +130,9 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
                     cache.$nodeByKey[key] = $node;
                 });
             }
-            return cache.$nodeByKey[normalizedKey] || $();
+            return cache.$nodeByKey[key] || $();
         }
-        return this.$element().find(`[${DATA_ITEM_ID}='${normalizedKey}']`);
+        return this.$element().find(`[${DATA_ITEM_ID}='${commonUtils.escapeCssQuery(key)}']`);
     },
 
     _activeStateUnit: "." + ITEM_CLASS,
@@ -839,7 +839,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
     _createDOMElement: function($nodeContainer, node) {
         const $node = $("<li>")
             .addClass(NODE_CLASS)
-            .attr(DATA_ITEM_ID, commonUtils.normalizeKey(node.internalFields.key))
+            .attr(DATA_ITEM_ID, node.internalFields.key)
             .prependTo($nodeContainer);
 
         this.setAria({
@@ -1018,7 +1018,7 @@ const TreeViewBase = HierarchicalCollectionWidget.inherit({
 
     _getNodeByElement: function(itemElement) {
         const $node = $(itemElement).closest("." + NODE_CLASS);
-        const key = commonUtils.denormalizeKey($node.attr(DATA_ITEM_ID));
+        const key = $node.attr(DATA_ITEM_ID);
 
         return this._dataAdapter.getNodeByKey(key);
     },

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -1,6 +1,6 @@
 /* global internals, initTree */
 
-import { each } from "../../../../js/core/utils/iterator";
+import { each } from "../../../../js/core/utils/iterator.js";
 
 QUnit.module("Lazy rendering");
 
@@ -39,8 +39,9 @@ QUnit.test("Expanding nodes should work with special charactes in id", function(
         });
         assert.equal(false, $treeView.find('[aria-level="2"]').is(':visible'));
 
-        $treeView.find('[aria-level="1"]').find('.dx-treeview-toggle-item-visibility').click();
+        $treeView.find('[aria-level="1"]').find('.dx-treeview-toggle-item-visibility').trigger('dxclick.dxTreeView');
         assert.equal(true, $treeView.find('[aria-level="2"]').is(':visible'));
+        $treeView.dxTreeView('instance').dispose();
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -30,7 +30,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 
 ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'].forEach((testId) => {
     QUnit.test(`Nodes expanding should work with special charactes in id - ${testId}`, function(assert) {
-        const treeView = createInstance({
+        let treeView = createInstance({
                 dataSource: [
                     { id: testId, text: "item1", selected: false, expanded: false },
                     { id: testId + 'item1_1', parentId: testId, text: "item1_1", selected: false, expanded: false }
@@ -44,6 +44,8 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
         assert.equal(childItem.length, 0);
 
         treeView.instance.expandItem(parentItem);
+        childItem = treeView.getElement().find('[aria-level="2"]');
+        assert.equal(childItem.length, 1);
         assert.equal(treeView.hasInvisibleClass(childItem), false);
     });
 
@@ -67,7 +69,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
     });
 
     QUnit.test(`Search should work with special charactes in the nodes ids - ${testId}`, function(assert) {
-        const treeView = createInstance({
+        let treeView = createInstance({
                 dataSource: [
                     { id: testId, text: "item1", selected: false, expanded: false },
                     { id: testId + 'item1_1', parentId: testId, text: "item1_1", selected: false, expanded: false },
@@ -77,19 +79,27 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
                 searchEnabled: true,
                 height: 500
             }),
-            parentItem = treeView.getElement().find('[aria-label="1"]'),
+            parentItem = treeView.getElement().find('[aria-label="item1"]'),
             childItem = treeView.getElement().find('[aria-label="item1_1"]'),
             anotherItem = treeView.getElement().find('[aria-label="item2"]');
 
+        assert.equal(parentItem.length, 1);
         assert.equal(childItem.length, 0);
         assert.equal(anotherItem.length, 1);
 
         const $input = treeView.getElement().find('.dx-texteditor-input');
         keyboardMock($input).type("1_1");
 
+        parentItem = treeView.getElement().find('[aria-label="item1"]');
+        assert.equal(parentItem.length, 1);
         assert.equal(treeView.hasInvisibleClass(parentItem), false);
+
+        childItem = treeView.getElement().find('[aria-label="item1_1"]');
+        assert.equal(childItem.length, 1);
         assert.equal(treeView.hasInvisibleClass(childItem), false);
-        assert.equal(anotherItem.length, 1);
+
+        anotherItem = treeView.getElement().find('[aria-label="item2"]');
+        assert.equal(anotherItem.length, 0);
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -24,6 +24,24 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
     assert.equal(items.length, 2);
 });
 
+QUnit.test("Expanding nodes should work with special charactes in id", function(assert) {
+    var testParentId = '!/#$%&\'()"+,./:;<=>?@[]^`{|}~';
+
+    var $treeView = initTree({
+        dataSource: [
+            { id: testParentId, text: "item1", selected: false, expanded: false },
+            { id: 'aaaa', parentId: testParentId, text: "item2", selected: false, expanded: false }
+        ],
+        dataStructure: "plain",
+        height: 500
+    });
+
+    assert.equal(false, $treeView.find('[aria-level="2"]').is(':visible'));
+
+    $treeView.find('[aria-level="1"]').find('.dx-treeview-toggle-item-visibility').click();
+    assert.equal(true, $treeView.find('[aria-level="2"]').is(':visible'));
+});
+
 QUnit.test("Nested item should be rendered after click on toggle visibility icon", function(assert) {
     var $treeView = initTree({
         items: [{ id: 1, text: "Item 1", items: [{ id: 3, text: "Item 3" }] }, { id: 2, text: "Item 2" }]

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -25,7 +25,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 });
 
 QUnit.test("Expanding nodes should work with special charactes in id", function(assert) {
-    var testId = '!/#$%&\'()"+,./:;<=>?@[]^`{|}~';
+    var testId = '!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,';
 
     var $treeView = initTree({
         dataSource: [

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -1,6 +1,4 @@
 /* global internals, initTree */
-import keyboardMock from "../../../helpers/keyboardMock.js";
-
 import TreeViewTestWrapper from "../../../helpers/TreeViewTestHelper.js";
 const createInstance = (options) => new TreeViewTestWrapper(options);
 
@@ -28,7 +26,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
     assert.equal(items.length, 2);
 });
 
-['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'].forEach((testId) => {
+['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+', 1, 2.18, Number(3), true, 0].forEach((testId) => {
     QUnit.test(`Nodes expanding should work with special charactes in id - ${testId}`, function(assert) {
         let treeView = createInstance({
                 dataSource: [
@@ -36,6 +34,8 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
                     { id: testId + 'item1_1', parentId: testId, text: "item1_1", selected: false, expanded: false }
                 ],
                 dataStructure: "plain",
+                rootValue: -1,
+                keyExpr: 'id',
                 height: 500
             }),
             parentItem = treeView.getElement().find('[aria-level="1"]'),
@@ -56,6 +56,8 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
                 { id: testId + 'item1_1', parentId: testId, text: "item1_1", selected: false, expanded: true }
             ],
             dataStructure: "plain",
+            rootValue: -1,
+            keyExpr: 'id',
             showCheckBoxesMode: "normal",
             height: 500
         });
@@ -76,6 +78,8 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
                     { id: 'item2', text: "item2", selected: false, expanded: false }
                 ],
                 dataStructure: "plain",
+                rootValue: -1,
+                keyExpr: 'id',
                 searchEnabled: true,
                 height: 500
             }),
@@ -87,8 +91,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
         assert.equal(childItem.length, 0);
         assert.equal(anotherItem.length, 1);
 
-        const $input = treeView.getElement().find('.dx-texteditor-input');
-        keyboardMock($input).type("1_1");
+        treeView.instance.option('searchValue', "1_1");
 
         parentItem = treeView.getElement().find('[aria-label="item1"]');
         assert.equal(parentItem.length, 1);

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -1,5 +1,5 @@
 /* global internals, initTree */
-
+import keyboardMock from "../../../helpers/keyboardMock.js";
 
 QUnit.module("Lazy rendering");
 
@@ -25,7 +25,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
     assert.equal(items.length, 2);
 });
 
-QUnit.test("Expanding nodes should work with special charactes in id", function(assert) {
+QUnit.test("Nodes expanding should work with special charactes in id", function(assert) {
     const testIds = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
     testIds.forEach(testId => {
         var $treeView = initTree({
@@ -38,7 +38,7 @@ QUnit.test("Expanding nodes should work with special charactes in id", function(
         });
         assert.equal($treeView.find('[aria-level="2"]').is(':visible'), false);
 
-        $treeView.find('[aria-level="1"]').find('.dx-treeview-toggle-item-visibility').trigger('dxclick.dxTreeView');
+        $treeView.find('[aria-level="1"]').find(internals.TOGGLE_ITEM_VISIBILITY_CLASS).trigger('dxclick.dxTreeView');
         assert.equal($treeView.find('[aria-level="2"]').is(':visible'), true);
         $treeView.dxTreeView('instance').dispose();
     });
@@ -63,6 +63,33 @@ QUnit.test("Nodes selection should work with special charactes in id", function(
         $treeView.find('[aria-level="1"]').find('.dx-checkbox').first().trigger('dxclick.dxCheckBox');
         assert.equal($treeView.find('[aria-level="1"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
         assert.equal($treeView.find('[aria-level="2"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
+        $treeView.dxTreeView('instance').dispose();
+    });
+});
+
+QUnit.test("Search should work with special charactes in the nodes ids", function(assert) {
+    const testIds = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
+    testIds.forEach(testId => {
+        var $treeView = initTree({
+            dataSource: [
+                { id: testId, text: "item1", selected: false, expanded: false },
+                { id: testId + '_child', parentId: testId, text: "item2", selected: false, expanded: false },
+                { id: 'bbb', text: "item3", selected: false, expanded: false }
+            ],
+            dataStructure: "plain",
+            searchEnabled: true,
+            height: 500
+        });
+        assert.equal($treeView.find('[aria-label="item2"]').is(':visible'), false);
+
+        const $input = $treeView.find('.dx-texteditor-input');
+        const keyboard = keyboardMock($input);
+        keyboard.type("2");
+
+        assert.equal($treeView.find('[aria-label="item1"]').is(':visible'), true);
+        assert.equal($treeView.find('[aria-label="item2"]').is(':visible'), true);
+        assert.equal($treeView.find('[aria-label="item3"]').is(':visible'), false);
+        $treeView.dxTreeView('instance').dispose();
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -27,7 +27,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 });
 
 QUnit.test("Expanding nodes should work with special charactes in id", function(assert) {
-    let testCases = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
+    const testIDs = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
     each(testCases, (index, testId) => {
         var $treeView = initTree({
             dataSource: [

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -3,14 +3,16 @@
 QUnit.module("Lazy rendering");
 
 QUnit.test("Render treeView with special symbols in id", function(assert) {
+    const sampleId = "!/#$%&'()*+,./:;<=>?@[\\]^`{|}~__";
     var $treeView = initTree({
-            items: [{ id: "!/#$%&'()*+,./:;<=>?@[\\]^`{|}~", text: "Item 1" }]
+            items: [{ id: sampleId, text: "Item 1" }]
         }),
         $item = $treeView.find("." + internals.NODE_CLASS),
         item = $treeView.dxTreeView("option", "items")[0];
 
-    assert.ok($item.attr("data-item-id").length > item.id.length * 4);
-
+    assert.ok($item.attr("data-item-id").length);
+    assert.equal(sampleId, $treeView.dxTreeView('instance')._getNodeByElement($item).id);
+    assert.equal(sampleId, item.id);
 });
 
 QUnit.test("Only root nodes should be rendered by default", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -25,12 +25,12 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 });
 
 QUnit.test("Expanding nodes should work with special charactes in id", function(assert) {
-    var testParentId = '!/#$%&\'()"+,./:;<=>?@[]^`{|}~';
+    var testId = '!/#$%&\'()"+,./:;<=>?@[]^`{|}~';
 
     var $treeView = initTree({
         dataSource: [
-            { id: testParentId, text: "item1", selected: false, expanded: false },
-            { id: 'aaaa', parentId: testParentId, text: "item2", selected: false, expanded: false }
+            { id: testId, text: "item1", selected: false, expanded: false },
+            { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: false }
         ],
         dataStructure: "plain",
         height: 500

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -1,6 +1,9 @@
 /* global internals, initTree */
 import keyboardMock from "../../../helpers/keyboardMock.js";
 
+import TreeViewTestWrapper from "../../../helpers/TreeViewTestHelper.js";
+const createInstance = (options) => new TreeViewTestWrapper(options);
+
 QUnit.module("Lazy rendering");
 
 QUnit.test("Render treeView with special symbols in id", function(assert) {
@@ -27,7 +30,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 
 ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'].forEach((testId) => {
     QUnit.test(`Nodes expanding should work with special charactes in id - ${testId}`, function(assert) {
-        let $treeView = initTree({
+        const $treeView = initTree({
                 dataSource: [
                     { id: testId, text: "item1", selected: false, expanded: false },
                     { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: false }
@@ -46,7 +49,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
     });
 
     QUnit.test(`Nodes selection should work with special charactes in id - ${testId}`, function(assert) {
-        let $treeView = initTree({
+        const treeViewTestHelper = createInstance({
                 dataSource: [
                     { id: testId, text: "item1", selected: false, expanded: true },
                     { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: true }
@@ -55,20 +58,18 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
                 showCheckBoxesMode: "normal",
                 height: 500
             }),
-            treeView = $treeView.dxTreeView('instance');
+            treeView = treeViewTestHelper.getInstance();
 
-        assert.equal($treeView.find('[aria-level="1"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), false);
-        assert.equal($treeView.find('[aria-level="2"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), false);
+        treeViewTestHelper.checkSelectedNodes([]);
 
-        let elem = $treeView.find('[aria-level="1"]');
+        let elem = treeViewTestHelper.getElement().find('[aria-level="1"]');
         treeView.selectItem(elem);
 
-        assert.equal($treeView.find('[aria-level="1"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
-        assert.equal($treeView.find('[aria-level="2"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
+        treeViewTestHelper.checkSelectedNodes([0, 1]);
     });
 
     QUnit.test(`Search should work with special charactes in the nodes ids - ${testId}`, function(assert) {
-        let $treeView = initTree({
+        const $treeView = initTree({
             dataSource: [
                 { id: testId, text: "item1", selected: false, expanded: false },
                 { id: testId + '_child', parentId: testId, text: "item2", selected: false, expanded: false },

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -1,5 +1,7 @@
 /* global internals, initTree */
 
+import { each } from "../../../../js/core/utils/iterator";
+
 QUnit.module("Lazy rendering");
 
 QUnit.test("Render treeView with special symbols in id", function(assert) {
@@ -25,21 +27,21 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 });
 
 QUnit.test("Expanding nodes should work with special charactes in id", function(assert) {
-    var testId = '!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,';
+    let testCases = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
+    each(testCases, (index, testId) => {
+        var $treeView = initTree({
+            dataSource: [
+                { id: testId, text: "item1", selected: false, expanded: false },
+                { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: false }
+            ],
+            dataStructure: "plain",
+            height: 500
+        });
+        assert.equal(false, $treeView.find('[aria-level="2"]').is(':visible'));
 
-    var $treeView = initTree({
-        dataSource: [
-            { id: testId, text: "item1", selected: false, expanded: false },
-            { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: false }
-        ],
-        dataStructure: "plain",
-        height: 500
+        $treeView.find('[aria-level="1"]').find('.dx-treeview-toggle-item-visibility').click();
+        assert.equal(true, $treeView.find('[aria-level="2"]').is(':visible'));
     });
-
-    assert.equal(false, $treeView.find('[aria-level="2"]').is(':visible'));
-
-    $treeView.find('[aria-level="1"]').find('.dx-treeview-toggle-item-visibility').click();
-    assert.equal(true, $treeView.find('[aria-level="2"]').is(':visible'));
 });
 
 QUnit.test("Nested item should be rendered after click on toggle visibility icon", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -30,64 +30,66 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 
 ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'].forEach((testId) => {
     QUnit.test(`Nodes expanding should work with special charactes in id - ${testId}`, function(assert) {
-        const $treeView = initTree({
+        const treeView = createInstance({
                 dataSource: [
                     { id: testId, text: "item1", selected: false, expanded: false },
-                    { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: false }
+                    { id: testId + 'item1_1', parentId: testId, text: "item1_1", selected: false, expanded: false }
                 ],
                 dataStructure: "plain",
                 height: 500
             }),
-            treeView = $treeView.dxTreeView('instance');
+            parentItem = treeView.getElement().find('[aria-level="1"]'),
+            childItem = treeView.getElement().find('[aria-level="2"]');
 
-        assert.equal($treeView.find('[aria-level="2"]').is(':visible'), false);
+        assert.equal(childItem.length, 0);
 
-        const elem = $treeView.find('[aria-level="1"]');
-        treeView.expandItem(elem);
-
-        assert.equal($treeView.find('[aria-level="2"]').is(':visible'), true);
+        treeView.instance.expandItem(parentItem);
+        assert.equal(treeView.hasInvisibleClass(childItem), false);
     });
 
     QUnit.test(`Nodes selection should work with special charactes in id - ${testId}`, function(assert) {
-        const treeViewTestHelper = createInstance({
-                dataSource: [
-                    { id: testId, text: "item1", selected: false, expanded: true },
-                    { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: true }
-                ],
-                dataStructure: "plain",
-                showCheckBoxesMode: "normal",
-                height: 500
-            }),
-            treeView = treeViewTestHelper.getInstance();
+        const treeView = createInstance({
+            dataSource: [
+                { id: testId, text: "item1", selected: false, expanded: true },
+                { id: testId + 'item1_1', parentId: testId, text: "item1_1", selected: false, expanded: true }
+            ],
+            dataStructure: "plain",
+            showCheckBoxesMode: "normal",
+            height: 500
+        });
 
-        treeViewTestHelper.checkSelectedNodes([]);
+        treeView.checkSelectedNodes([]);
 
-        let elem = treeViewTestHelper.getElement().find('[aria-level="1"]');
-        treeView.selectItem(elem);
+        const elem = treeView.getElement().find('[aria-level="1"]');
+        treeView.instance.selectItem(elem);
 
-        treeViewTestHelper.checkSelectedNodes([0, 1]);
+        treeView.checkSelectedNodes([0, 1]);
     });
 
     QUnit.test(`Search should work with special charactes in the nodes ids - ${testId}`, function(assert) {
-        const $treeView = initTree({
-            dataSource: [
-                { id: testId, text: "item1", selected: false, expanded: false },
-                { id: testId + '_child', parentId: testId, text: "item2", selected: false, expanded: false },
-                { id: 'bbb', text: "item3", selected: false, expanded: false }
-            ],
-            dataStructure: "plain",
-            searchEnabled: true,
-            height: 500
-        });
-        assert.equal($treeView.find('[aria-label="item2"]').is(':visible'), false);
+        const treeView = createInstance({
+                dataSource: [
+                    { id: testId, text: "item1", selected: false, expanded: false },
+                    { id: testId + 'item1_1', parentId: testId, text: "item1_1", selected: false, expanded: false },
+                    { id: 'item2', text: "item2", selected: false, expanded: false }
+                ],
+                dataStructure: "plain",
+                searchEnabled: true,
+                height: 500
+            }),
+            parentItem = treeView.getElement().find('[aria-label="1"]'),
+            childItem = treeView.getElement().find('[aria-label="item1_1"]'),
+            anotherItem = treeView.getElement().find('[aria-label="item2"]');
 
-        const $input = $treeView.find('.dx-texteditor-input');
-        const keyboard = keyboardMock($input);
-        keyboard.type("2");
+        assert.equal(childItem.length, 0);
+        assert.equal(anotherItem.length, 1);
 
-        assert.equal($treeView.find('[aria-label="item1"]').is(':visible'), true);
-        assert.equal($treeView.find('[aria-label="item2"]').is(':visible'), true);
-        assert.equal($treeView.find('[aria-label="item3"]').is(':visible'), false);
+        const $input = treeView.getElement().find('.dx-texteditor-input');
+        keyboardMock($input).type("1_1");
+
+        assert.equal(treeView.hasInvisibleClass(parentItem), false);
+        assert.equal(treeView.hasInvisibleClass(childItem), false);
+        assert.equal(anotherItem.length, 1);
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -28,7 +28,7 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 
 QUnit.test("Expanding nodes should work with special charactes in id", function(assert) {
     const testIDs = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
-    each(testCases, (index, testId) => {
+    testIDs.forEach(testId => {
         var $treeView = initTree({
             dataSource: [
                 { id: testId, text: "item1", selected: false, expanded: false },

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -27,41 +27,48 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 
 ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'].forEach((testId) => {
     QUnit.test(`Nodes expanding should work with special charactes in id - ${testId}`, function(assert) {
-        var $treeView = initTree({
-            dataSource: [
-                { id: testId, text: "item1", selected: false, expanded: false },
-                { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: false }
-            ],
-            dataStructure: "plain",
-            height: 500
-        });
+        let $treeView = initTree({
+                dataSource: [
+                    { id: testId, text: "item1", selected: false, expanded: false },
+                    { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: false }
+                ],
+                dataStructure: "plain",
+                height: 500
+            }),
+            treeView = $treeView.dxTreeView('instance');
+
         assert.equal($treeView.find('[aria-level="2"]').is(':visible'), false);
 
-        $treeView.find('[aria-level="1"]').find("." + internals.TOGGLE_ITEM_VISIBILITY_CLASS).trigger('dxclick.dxTreeView');
+        const elem = $treeView.find('[aria-level="1"]');
+        treeView.expandItem(elem);
+
         assert.equal($treeView.find('[aria-level="2"]').is(':visible'), true);
     });
 
     QUnit.test(`Nodes selection should work with special charactes in id - ${testId}`, function(assert) {
-        var $treeView = initTree({
-            dataSource: [
-                { id: testId, text: "item1", selected: false, expanded: true },
-                { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: true }
-            ],
-            dataStructure: "plain",
-            showCheckBoxesMode: "normal",
-            height: 500
-        });
+        let $treeView = initTree({
+                dataSource: [
+                    { id: testId, text: "item1", selected: false, expanded: true },
+                    { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: true }
+                ],
+                dataStructure: "plain",
+                showCheckBoxesMode: "normal",
+                height: 500
+            }),
+            treeView = $treeView.dxTreeView('instance');
 
         assert.equal($treeView.find('[aria-level="1"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), false);
         assert.equal($treeView.find('[aria-level="2"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), false);
 
-        $treeView.find('[aria-level="1"]').find('.dx-checkbox').first().trigger('dxclick.dxCheckBox');
+        let elem = $treeView.find('[aria-level="1"]');
+        treeView.selectItem(elem);
+
         assert.equal($treeView.find('[aria-level="1"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
         assert.equal($treeView.find('[aria-level="2"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
     });
 
     QUnit.test(`Search should work with special charactes in the nodes ids - ${testId}`, function(assert) {
-        var $treeView = initTree({
+        let $treeView = initTree({
             dataSource: [
                 { id: testId, text: "item1", selected: false, expanded: false },
                 { id: testId + '_child', parentId: testId, text: "item2", selected: false, expanded: false },

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -25,9 +25,8 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
     assert.equal(items.length, 2);
 });
 
-QUnit.test("Nodes expanding should work with special charactes in id", function(assert) {
-    const testIds = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
-    testIds.forEach(testId => {
+['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'].forEach((testId) => {
+    QUnit.test(`Nodes expanding should work with special charactes in id - ${testId}`, function(assert) {
         var $treeView = initTree({
             dataSource: [
                 { id: testId, text: "item1", selected: false, expanded: false },
@@ -40,13 +39,9 @@ QUnit.test("Nodes expanding should work with special charactes in id", function(
 
         $treeView.find('[aria-level="1"]').find("." + internals.TOGGLE_ITEM_VISIBILITY_CLASS).trigger('dxclick.dxTreeView');
         assert.equal($treeView.find('[aria-level="2"]').is(':visible'), true);
-        $treeView.dxTreeView('instance').dispose();
     });
-});
 
-QUnit.test("Nodes selection should work with special charactes in id", function(assert) {
-    const testIds = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
-    testIds.forEach(testId => {
+    QUnit.test(`Nodes selection should work with special charactes in id - ${testId}`, function(assert) {
         var $treeView = initTree({
             dataSource: [
                 { id: testId, text: "item1", selected: false, expanded: true },
@@ -63,13 +58,9 @@ QUnit.test("Nodes selection should work with special charactes in id", function(
         $treeView.find('[aria-level="1"]').find('.dx-checkbox').first().trigger('dxclick.dxCheckBox');
         assert.equal($treeView.find('[aria-level="1"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
         assert.equal($treeView.find('[aria-level="2"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
-        $treeView.dxTreeView('instance').dispose();
     });
-});
 
-QUnit.test("Search should work with special charactes in the nodes ids", function(assert) {
-    const testIds = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
-    testIds.forEach(testId => {
+    QUnit.test(`Search should work with special charactes in the nodes ids - ${testId}`, function(assert) {
         var $treeView = initTree({
             dataSource: [
                 { id: testId, text: "item1", selected: false, expanded: false },
@@ -89,7 +80,6 @@ QUnit.test("Search should work with special charactes in the nodes ids", functio
         assert.equal($treeView.find('[aria-label="item1"]').is(':visible'), true);
         assert.equal($treeView.find('[aria-label="item2"]').is(':visible'), true);
         assert.equal($treeView.find('[aria-label="item3"]').is(':visible'), false);
-        $treeView.dxTreeView('instance').dispose();
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -26,8 +26,8 @@ QUnit.test("Only root nodes should be rendered by default", function(assert) {
 });
 
 QUnit.test("Expanding nodes should work with special charactes in id", function(assert) {
-    const testIDs = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
-    testIDs.forEach(testId => {
+    const testIds = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
+    testIds.forEach(testId => {
         var $treeView = initTree({
             dataSource: [
                 { id: testId, text: "item1", selected: false, expanded: false },

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -38,7 +38,7 @@ QUnit.test("Nodes expanding should work with special charactes in id", function(
         });
         assert.equal($treeView.find('[aria-level="2"]').is(':visible'), false);
 
-        $treeView.find('[aria-level="1"]').find(internals.TOGGLE_ITEM_VISIBILITY_CLASS).trigger('dxclick.dxTreeView');
+        $treeView.find('[aria-level="1"]').find("." + internals.TOGGLE_ITEM_VISIBILITY_CLASS).trigger('dxclick.dxTreeView');
         assert.equal($treeView.find('[aria-level="2"]').is(':visible'), true);
         $treeView.dxTreeView('instance').dispose();
     });

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -36,11 +36,33 @@ QUnit.test("Expanding nodes should work with special charactes in id", function(
             dataStructure: "plain",
             height: 500
         });
-        assert.equal(false, $treeView.find('[aria-level="2"]').is(':visible'));
+        assert.equal($treeView.find('[aria-level="2"]').is(':visible'), false);
 
         $treeView.find('[aria-level="1"]').find('.dx-treeview-toggle-item-visibility').trigger('dxclick.dxTreeView');
-        assert.equal(true, $treeView.find('[aria-level="2"]').is(':visible'));
+        assert.equal($treeView.find('[aria-level="2"]').is(':visible'), true);
         $treeView.dxTreeView('instance').dispose();
+    });
+});
+
+QUnit.test("Nodes selection should work with special charactes in id", function(assert) {
+    const testIds = ['!/#$%&\'()"+./:;<=>?@[]^`{|}~\\,', '____2______.jpg', 'E:\\test\\[gsdfgfd]  |  \'[some__file]', '!@#$%^&*()_+'];
+    testIds.forEach(testId => {
+        var $treeView = initTree({
+            dataSource: [
+                { id: testId, text: "item1", selected: false, expanded: true },
+                { id: 'aaaa', parentId: testId, text: "item2", selected: false, expanded: true }
+            ],
+            dataStructure: "plain",
+            showCheckBoxesMode: "normal",
+            height: 500
+        });
+
+        assert.equal($treeView.find('[aria-level="1"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), false);
+        assert.equal($treeView.find('[aria-level="2"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), false);
+
+        $treeView.find('[aria-level="1"]').find('.dx-checkbox').first().trigger('dxclick.dxCheckBox');
+        assert.equal($treeView.find('[aria-level="1"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
+        assert.equal($treeView.find('[aria-level="2"]').find('.dx-checkbox').hasClass('dx-checkbox-checked'), true);
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/lazyRendering.js
@@ -1,6 +1,5 @@
 /* global internals, initTree */
 
-import { each } from "../../../../js/core/utils/iterator.js";
 
 QUnit.module("Lazy rendering");
 


### PR DESCRIPTION
Bugfix T832172

Tree View load with errors if file names contains double underscores in dataSource id