### PR TITLE
Editors: Fix test assertion args

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
@@ -852,7 +852,7 @@ if(devices.real().deviceType === "desktop") {
         test("Typing a letter in the year section should not lead to an infinite loop", (assert) => {
             this.instance.option("displayFormat", "yyyy");
 
-            sinon.stub(this.instance, "_partIncrease").throws();
+            sinon.stub(this.instance, "_partIncrease").throws(new Error);
 
             try {
                 this.keyboard.type("s");

--- a/testing/tests/DevExpress.ui.widgets.editors/fileUploader.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/fileUploader.tests.js
@@ -1443,7 +1443,7 @@ QUnit.test("upload of specific file should start after click on corresponding 'u
     const request = this.xhrMock.getInstanceAt();
 
     assert.ok(request.uploaded, "upload is done");
-    assert.ok(request.loadedSize, files[1].size, "correct file was uploaded");
+    assert.strictEqual(request.loadedSize, files[1].size, "correct file was uploaded");
 });
 
 QUnit.test("file upload buttons should be removed after upload started", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.markup.tests.js
@@ -55,7 +55,7 @@ QUnit.test("tagbox should have base class", function(assert) {
     assert.notOk($tagBox.hasClass(SKIP_GESTURE_EVENT_CLASS), "tagbox has no skip gesture event class");
 
     var $tagContainer = $tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS);
-    assert.equal($tagContainer.length, 1, "tag container exists", "tagbox should have tag container");
+    assert.equal($tagContainer.length, 1, "tagbox should have tag container");
 
     var $tags = $tagBox.find("." + TAGBOX_TAG_CLASS),
         $tagContent = $tags.find("." + TAGBOX_TAG_CONTENT_CLASS);

--- a/testing/tests/DevExpress.ui.widgets.editors/timeView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/timeView.tests.js
@@ -416,7 +416,7 @@ QUnit.test("boundary hours should change correctly after day time changing", fun
     assert.equal(instance.option("value").toString(), new Date(2011, 0, 1, 12, 0, 0, 0), "time is correct");
 
     formatField.option("value", TIMEVIEW_FORMAT12_AM);
-    assert.equal(instance.option("value").toString(), new Date(2011, 0, 1, 0, 0, 0, 0), 0, "time is correct");
+    assert.equal(instance.option("value").toString(), new Date(2011, 0, 1, 0, 0, 0, 0), "time is correct");
 });
 
 QUnit.test("midday part should not be changed when clock moves back through the boundary (T808116)", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/validationEngine.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationEngine.tests.js
@@ -1687,7 +1687,7 @@ QUnit.test("Simple group - can register validator in group", function(assert) {
     var groupConfig = ValidationEngine.getGroupConfig(group);
     assert.ok(groupConfig, "Group was registered in Validation Engine");
     assert.equal(groupConfig.validators.length, 1, "Single validator was registered in group Validation Engine");
-    assert.ok(groupConfig.validators[0], validator, "Validator was registered in correct group");
+    assert.strictEqual(groupConfig.validators[0], validator, "Validator was registered in correct group");
 });
 
 QUnit.test("Simple group - validator should not be duplicated in group", function(assert) {
@@ -1702,7 +1702,7 @@ QUnit.test("Simple group - validator should not be duplicated in group", functio
     var groupConfig = ValidationEngine.getGroupConfig(group);
     assert.ok(groupConfig, "Group was registered in Validation Engine");
     assert.equal(groupConfig.validators.length, 1, "Single validator was registered in group Validation Engine");
-    assert.ok(groupConfig.validators[0], validator, "Validator was registered in correct group");
+    assert.strictEqual(groupConfig.validators[0], validator, "Validator was registered in correct group");
 });
 
 QUnit.test("Simple group - can register validator in undefined group", function(assert) {
@@ -1715,7 +1715,7 @@ QUnit.test("Simple group - can register validator in undefined group", function(
     var groupConfig = ValidationEngine.getGroupConfig();
     assert.ok(groupConfig, "Group was registered in Validation Engine");
     assert.equal(groupConfig.validators.length, 1, "Single validator was registered in group Validation Engine");
-    assert.ok(groupConfig.validators[0], validator, "Validator was registered in correct group");
+    assert.strictEqual(groupConfig.validators[0], validator, "Validator was registered in correct group");
 });
 
 QUnit.test("Simple group - remove validator registration", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/validationSummary.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationSummary.tests.js
@@ -155,7 +155,7 @@ QUnit.testStart(function() {
         var itemElements = this.fixture.$summaryContainer.find(".dx-validationsummary-item");
         assert.equal(itemElements.length, 1, "Single item element should be rendered");
         itemElements.trigger("click");
-        assert.ok(validator.focus.calledOnce, true, "Validator should be focused");
+        assert.ok(validator.focus.calledOnce, "Validator should be focused");
     });
 })("General");
 


### PR DESCRIPTION
Helps to enable the [assert-args](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md) rule of ESLint QUnit plugin (#10691).