### PR TITLE
Scheduler: Fix test assertion args

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
@@ -332,7 +332,7 @@ module("Integration: Appointment tooltip", moduleConfig, () => {
 
         scheduler.appointments.click(1);
 
-        assert.ok(scheduler.tooltip.getContentElement().length, 1, "one tooltip was shown");
+        assert.equal(scheduler.tooltip.getContentElement().length, 1, "one tooltip was shown");
         assert.equal(scheduler.tooltip.getTitleText(), "Task 2", "tooltip title is correct");
         assert.equal(scheduler.tooltip.getDateElement().length, 1, "dates container was rendered");
         assert.equal(scheduler.tooltip.hasDeleteButton(), 1, "buttons container was rendered");

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
@@ -623,7 +623,7 @@ QUnit.test("Recurrence repeat-type editor should have default 'never' value afte
 
     freqEditor.option("value", "daily");
 
-    assert.ok(repeatTypeEditor.option("value"), 'never', "Repeat-type editor value is ok");
+    assert.strictEqual(repeatTypeEditor.option("value"), 'never', "Repeat-type editor value is ok");
 });
 
 QUnit.test("Disabled appointment could not be focused", function(assert) {


### PR DESCRIPTION
Helps to enable the [assert-args](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md) rule of ESLint QUnit plugin (#10691).