### PR TITLE
Viz: Fix test assertion args

### DIFF
--- a/testing/tests/DevExpress.exporter/imageCreator.tests.js
+++ b/testing/tests/DevExpress.exporter/imageCreator.tests.js
@@ -1793,7 +1793,7 @@ QUnit.test("Text decoration", function(assert) {
             assert.equal(overlineDecoration.args.x, 250, "Overline decoration line x");
             assert.roughEqual(overlineDecoration.args.y, 7.2, 0.5, "Overline decoration line y");
             assert.roughEqual(overlineDecoration.args.height, 1.2, 0.1, "Overline decoration line height");
-            assert.strictEqual(overlineDecoration.args.width, 100, 8, "Overline decoration line width");
+            assert.strictEqual(overlineDecoration.args.width, 100, "Overline decoration line width");
             assert.equal(that.drawnElements[7].style.fillStyle, "#aaff23", "Overline decoration line fill color");
 
             // Line-through decoration assert

--- a/testing/tests/DevExpress.viz.charts/chart.part3.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chart.part3.tests.js
@@ -1015,7 +1015,7 @@ QUnit.test("Create Horizontal Legend with single named series, position = outsid
     assert.strictEqual(legendCtorArgs.backgroundClass, "dxc-border", "background class");
     assert.strictEqual(legendCtorArgs.itemGroupClass, "dxc-item", "item group class");
     assert.strictEqual(legendCtorArgs.textField, "seriesName", "text field");
-    assert.ok($.isFunction(legendCtorArgs.getFormatObject), true, "getFormatObject is function");
+    assert.ok($.isFunction(legendCtorArgs.getFormatObject), "getFormatObject is function");
     assert.deepEqual(legendCtorArgs.getFormatObject({
         id: "id",
         text: "text",

--- a/testing/tests/DevExpress.viz.charts/polarChart.tests.js
+++ b/testing/tests/DevExpress.viz.charts/polarChart.tests.js
@@ -386,11 +386,11 @@ QUnit.test("Pass angles to axes. Process unnormalized angle", function(assert) {
     var argumentAxisOptions = this.createAxis.getCall(0).returnValue.updateOptions.lastCall.args[0],
         valueAxisOptions = this.createAxis.getCall(1).returnValue.updateOptions.lastCall.args[0];
 
-    assert.equal(argumentAxisOptions.startAngle, 194, "startAngle", "argumentAxis startAngle");
-    assert.equal(argumentAxisOptions.endAngle, 554, "endAngle", "argumentAxis endAngle");
+    assert.equal(argumentAxisOptions.startAngle, 194, "argumentAxis startAngle");
+    assert.equal(argumentAxisOptions.endAngle, 554, "argumentAxis endAngle");
 
-    assert.equal(valueAxisOptions.startAngle, 194, "startAngle", "valueAxis startAngle");
-    assert.equal(valueAxisOptions.endAngle, 554, "endAngle", "valueAxis end");
+    assert.equal(valueAxisOptions.startAngle, 194, "valueAxis startAngle");
+    assert.equal(valueAxisOptions.endAngle, 554, "valueAxis end");
 });
 
 QUnit.test("Pass angles to axes. Process incorrect angle", function(assert) {
@@ -403,11 +403,11 @@ QUnit.test("Pass angles to axes. Process incorrect angle", function(assert) {
     var argumentAxisOptions = this.createAxis.getCall(0).returnValue.updateOptions.lastCall.args[0],
         valueAxisOptions = this.createAxis.getCall(1).returnValue.updateOptions.lastCall.args[0];
 
-    assert.equal(argumentAxisOptions.startAngle, 0, "startAngle", "argumentAxis startAngle");
-    assert.equal(argumentAxisOptions.endAngle, 360, "endAngle", "argumentAxis endAngle");
+    assert.equal(argumentAxisOptions.startAngle, 0, "argumentAxis startAngle");
+    assert.equal(argumentAxisOptions.endAngle, 360, "argumentAxis endAngle");
 
-    assert.equal(valueAxisOptions.startAngle, 0, "startAngle", "valueAxis startAngle");
-    assert.equal(valueAxisOptions.endAngle, 360, "endAngle", "valueAxis end");
+    assert.equal(valueAxisOptions.startAngle, 0, "valueAxis startAngle");
+    assert.equal(valueAxisOptions.endAngle, 360, "valueAxis end");
 });
 
 QUnit.test("create axes", function(assert) {

--- a/testing/tests/DevExpress.viz.core.series/baseSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/baseSeries.tests.js
@@ -3750,7 +3750,7 @@ QUnit.test("Set Hover point with point.selected. ", function(assert) {
     this.series.hoverPoint(this.point);
 
     assert.equal(this.point.fullState, 2 | 1, "fullState");
-    assert.ok(this.point.applyView.callCount, 2, "Point style");
+    assert.strictEqual(this.point.applyView.callCount, 2, "Point style");
 });
 
 QUnit.test("Set Hover point view without change state with point.selected. ", function(assert) {
@@ -3761,7 +3761,7 @@ QUnit.test("Set Hover point view without change state with point.selected. ", fu
 
     this.series.notify({ action: "pointHover", target: this.series.getAllPoints()[1] });
 
-    assert.ok(this.point.setView.lastCall.args[0], "hover", "Point style");
+    assert.strictEqual(this.point.setView.lastCall.args[0], "hover", "Point style");
 });
 
 // Release hover
@@ -3791,7 +3791,7 @@ QUnit.test("Release hover point with point.selected. ", function(assert) {
     });
 
     assert.equal(this.point.fullState, 2, "fullState");
-    assert.ok(this.point.resetView.lastCall.args[0], "selection", "Point style");
+    assert.strictEqual(this.point.resetView.lastCall.args[0], "selection", "Point style");
 });
 
 QUnit.test("Release hover view point with series.hover. ", function(assert) {
@@ -3837,7 +3837,7 @@ QUnit.test("Release hover view point with series.selected. ", function(assert) {
     // act
     this.series.notify({ action: "clearPointHover", target: this.series.getAllPoints()[1] });
 
-    assert.ok(this.point.resetView.lastCall.args[0], "selection", "Point style");
+    assert.strictEqual(this.point.resetView.lastCall.args[0], "selection", "Point style");
 });
 
 QUnit.test("Release hover view point with point.selected. ", function(assert) {
@@ -3846,7 +3846,7 @@ QUnit.test("Release hover view point with point.selected. ", function(assert) {
     // act
     this.series.notify({ action: "clearPointHover", target: this.series.getAllPoints()[1] });
 
-    assert.ok(this.point.resetView.lastCall.args[0], "selection", "Point style");
+    assert.strictEqual(this.point.resetView.lastCall.args[0], "selection", "Point style");
 });
 
 QUnit.test("apply point view after drawing selected series", function(assert) {

--- a/testing/tests/DevExpress.viz.core.series/baseSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/baseSeries.tests.js
@@ -3791,7 +3791,7 @@ QUnit.test("Release hover point with point.selected. ", function(assert) {
     });
 
     assert.equal(this.point.fullState, 2, "fullState");
-    assert.strictEqual(this.point.resetView.lastCall.args[0], "selection", "Point style");
+    assert.strictEqual(this.point.resetView.lastCall.args[0], "hover", "Reset hover view");
 });
 
 QUnit.test("Release hover view point with series.hover. ", function(assert) {
@@ -3837,7 +3837,7 @@ QUnit.test("Release hover view point with series.selected. ", function(assert) {
     // act
     this.series.notify({ action: "clearPointHover", target: this.series.getAllPoints()[1] });
 
-    assert.strictEqual(this.point.resetView.lastCall.args[0], "selection", "Point style");
+    assert.strictEqual(this.point.resetView.lastCall.args[0], "hover", "Reset hover view");
 });
 
 QUnit.test("Release hover view point with point.selected. ", function(assert) {
@@ -3846,7 +3846,7 @@ QUnit.test("Release hover view point with point.selected. ", function(assert) {
     // act
     this.series.notify({ action: "clearPointHover", target: this.series.getAllPoints()[1] });
 
-    assert.strictEqual(this.point.resetView.lastCall.args[0], "selection", "Point style");
+    assert.strictEqual(this.point.resetView.lastCall.args[0], "hover", "Reset hover view");
 });
 
 QUnit.test("apply point view after drawing selected series", function(assert) {

--- a/testing/tests/DevExpress.viz.core/export.integration.tests.js
+++ b/testing/tests/DevExpress.viz.core/export.integration.tests.js
@@ -67,7 +67,7 @@ QUnit.test('Export method. Defined options', function(assert) {
     firstExportCall.args[1].fileSavingAction();
 
     // assert
-    assert.ok(exportFunc.callCount, 1, "export was called one time");
+    assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
     assert.equal(firstExportCall.args[0], this.renderer.root.element, "export data");
 
     assert.equal(firstExportCall.args[1].width, 200, "width");
@@ -104,7 +104,7 @@ QUnit.test('Export method. PNG format', function(assert) {
 
     // assert
     var firstExportCall = exportFunc.getCall(0);
-    assert.ok(exportFunc.callCount, 1, "export was called one time");
+    assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
     assert.equal(firstExportCall.args[1].format, "PNG", "format");
 });
 
@@ -128,7 +128,7 @@ QUnit.test('Export method. JPEG format', function(assert) {
 
     // assert
     var firstExportCall = exportFunc.getCall(0);
-    assert.ok(exportFunc.callCount, 1, "export was called one time");
+    assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
     assert.equal(firstExportCall.args[1].format, "JPEG", "format");
 });
 
@@ -152,7 +152,7 @@ QUnit.test('Export method. GIF format', function(assert) {
 
     // assert
     var firstExportCall = exportFunc.getCall(0);
-    assert.ok(exportFunc.callCount, 1, "export was called one time");
+    assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
     assert.equal(firstExportCall.args[1].format, "GIF", "format");
 });
 
@@ -176,7 +176,7 @@ QUnit.test('Export method. SVG format', function(assert) {
 
     // assert
     var firstExportCall = exportFunc.getCall(0);
-    assert.ok(exportFunc.callCount, 1, "export was called one time");
+    assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
     assert.equal(firstExportCall.args[1].format, "SVG", "format");
 });
 
@@ -200,7 +200,7 @@ QUnit.test('Export method. PDF format', function(assert) {
 
     // assert
     var firstExportCall = exportFunc.getCall(0);
-    assert.ok(exportFunc.callCount, 1, "export was called one time");
+    assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
     assert.equal(firstExportCall.args[1].format, "PDF", "format");
 });
 
@@ -226,7 +226,7 @@ QUnit.test('Export method. invalid format', function(assert) {
 
     // assert
     var firstExportCall = exportFunc.getCall(0);
-    assert.ok(exportFunc.callCount, 1, "export was called one time");
+    assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
     assert.equal(firstExportCall.args[1].format, "PNG", "format");
     assert.equal(incidentOccurred.callCount, 0);
 });
@@ -255,7 +255,7 @@ QUnit.test('Export method. unsopported image format', function(assert) {
 
     // assert
     var firstExportCall = exportFunc.getCall(0);
-    assert.ok(exportFunc.callCount, 1, "export was called one time");
+    assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
     assert.equal(firstExportCall.args[1].format, "PNG", "format");
     assert.equal(incidentOccurred.callCount, 1);
     assert.deepEqual(incidentOccurred.getCall(0).args[0].target.id, "W2108");
@@ -501,7 +501,7 @@ QUnit.test('Print method - use export to prepare image, create hidden iFrame wit
     deferred.done(function(imageSrc) {
         assert.ok(fileSavingEventArgs.cancel, "file should not be saved");
 
-        assert.ok(exportFunc.callCount, 1, "export was called one time");
+        assert.strictEqual(exportFunc.callCount, 1, "export was called one time");
         assert.equal(firstExportCall.args[0], that.renderer.root.element, "export data");
 
         assert.equal(firstExportCall.args[1].width, 200, "width");

--- a/testing/tests/DevExpress.viz.core/legend.tests.js
+++ b/testing/tests/DevExpress.viz.core/legend.tests.js
@@ -1919,7 +1919,7 @@ QUnit.test('Erase legend on update options', function(assert) {
     this.legend.update([]);
 
     assert.deepEqual(this.renderer.g.getCall(1).returnValue.remove.lastCall.args, [], 'group is removed');
-    assert.ok(this.renderer.g.getCall(1).returnValue.remove.lastCall.calledAfter(titleGroup.linkRemove.lastCall), [], 'group is removed');
+    assert.ok(this.renderer.g.getCall(1).returnValue.remove.lastCall.calledAfter(titleGroup.linkRemove.lastCall), 'group is removed');
 });
 
 QUnit.test('Check groups order', function(assert) {

--- a/testing/tests/DevExpress.viz.renderers/SvgElement.tests.js
+++ b/testing/tests/DevExpress.viz.renderers/SvgElement.tests.js
@@ -2066,7 +2066,7 @@ function checkDashStyle(assert, elem, result, style, value) {
         // act
         rect.animate({ translateY: 100, translateX: 200 });
 
-        assert.ok(rect.renderer.animateElement.callCount, 1, "renderer.animateElement is called");
+        assert.strictEqual(rect.renderer.animateElement.callCount, 1, "renderer.animateElement is called");
         assert.deepEqual(rect.renderer.animateElement.args[0][1].transform.from, { translateY: 100, translateX: 200 }, "renderer.animateElement's attrs param");
     });
 

--- a/testing/tests/DevExpress.viz.vectorMap/mapLayer.element.tests.js
+++ b/testing/tests/DevExpress.viz.vectorMap/mapLayer.element.tests.js
@@ -473,7 +473,7 @@ QUnit.test("Proxy.coordinates", function(assert) {
 
 QUnit.test("Proxy.attribute", function(assert) {
     assert.strictEqual(this.element.proxy.attribute("prop1"), undefined, "getter");
-    assert.strictEqual(this.element.proxy.attribute("prop1", "test-1"), this.element.proxy, "return value", "setter");
+    assert.strictEqual(this.element.proxy.attribute("prop1", "test-1"), this.element.proxy, "return value - setter");
     assert.deepEqual(this.element.proxy.attribute(), { prop1: "test-1", tag: "attributes" }, "getter - all");
     assert.strictEqual(this.element.proxy.attribute("prop1"), "test-1", "getter");
 });

--- a/testing/tests/DevExpress.viz.vectorMap/mapLayer.tests.js
+++ b/testing/tests/DevExpress.viz.vectorMap/mapLayer.tests.js
@@ -527,7 +527,7 @@ QUnit.test("Create with customization", function(assert) {
     var proxies = $.map(StubMapLayerElement.items, function(item) { return item.proxy; });
 
     assert.deepEqual(customize.lastCall.args, [proxies], "callback args");
-    assert.ok(customize.lastCall.thisValue, this.widget, "callback context");
+    assert.strictEqual(customize.lastCall.thisValue, this.widget, "callback context");
     $.each(StubMapLayerElement.items, function(i, item) {
         assert.ok(customize.calledBefore(item.project.lastCall), "callback is called before item - " + i);
     });


### PR DESCRIPTION
Helps to enable the [assert-args](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md) rule of ESLint QUnit plugin (#10691).