### PR TITLE
Grids: Fix test assertion args

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
@@ -2482,7 +2482,7 @@ QUnit.test("Check 'onAdaptiveDetailRowPreparing' action", function(assert) {
     $($itemContent).trigger("dxclick");
 
     // assert
-    assert.ok(form.option("colCount"), 5, "colCount of form");
+    assert.strictEqual(form.option("colCount"), 5, "colCount of form");
     assert.equal(form.option("items[0].label.text"), "LaLa", "text of item's label");
     assert.ok(isContentReadyCalled, "customer's content ready is called");
     assert.ok(isCustomizeItemCalled, "customer's customize item func is called");

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -3148,7 +3148,7 @@ QUnit.test("update string lookup for calculated column", function(assert) {
     assert.strictEqual(this.columnsController.getColumns()[0].dataType, 'number');
     assert.strictEqual(this.columnsController.getColumns()[0].lookup.dataType, 'string');
     assert.ok(this.columnsController.getColumns()[0].lookup.calculateCellValue, 'calculateCellValue for lookup exists');
-    assert.ok(this.columnsController.getColumns()[0].lookup.calculateCellValue(2), '123-45-67', 'calculateCellValue for lookup works correctly');
+    assert.strictEqual(this.columnsController.getColumns()[0].lookup.calculateCellValue(2), '123-45-67', 'calculateCellValue for lookup works correctly');
 });
 
 // T200352

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsResizingReorderingModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsResizingReorderingModule.tests.js
@@ -3361,7 +3361,7 @@ function getEvent(options) {
 
         // assert
         assert.ok($draggingHeader.length === 1, 'draggingHeader element');
-        assert.ok($draggingHeader.css('display'), 'none', 'display is none');
+        assert.strictEqual($draggingHeader.css('display'), 'none', 'display is none');
         assert.ok($draggingHeader.hasClass("dx-widget"), "Widget class");
     });
 
@@ -3385,7 +3385,7 @@ function getEvent(options) {
 
         // assert
         assert.ok($draggingHeader.length === 1, 'draggingHeader element');
-        assert.ok($draggingHeader.css('display'), 'none', 'display is none');
+        assert.strictEqual($draggingHeader.css('display'), 'none', 'display is none');
     });
 
     QUnit.test('Init dragging header when allowReordering true and allowGrouping false', function(assert) {
@@ -3408,7 +3408,7 @@ function getEvent(options) {
 
         // assert
         assert.ok($draggingHeader.length === 1, 'draggingHeader element');
-        assert.ok($draggingHeader.css('display'), 'none', 'display is none');
+        assert.strictEqual($draggingHeader.css('display'), 'none', 'display is none');
     });
 
     // T112084

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -4630,7 +4630,7 @@ QUnit.test("selectAll should works correctly if item count less than pageSize", 
 
     // assert
     assert.equal(this.getVisibleRows().length, 50, "visible row count");
-    assert.ok(this.totalCount(), 50, "total count");
+    assert.strictEqual(this.totalCount(), 50, "total count");
     assert.ok(this.selectionController.isSelectAll(), "select all state");
 });
 
@@ -5550,7 +5550,7 @@ QUnit.test("clearFilter without argument", function(assert) {
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 
     // arrange
     that.dataController.changed.add(function() {
@@ -5603,7 +5603,7 @@ QUnit.test("clearFilter for dataSource", function(assert) {
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob", "Bobbi"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 
     // act
     that.dataController.clearFilter("dataSource");
@@ -5618,7 +5618,7 @@ QUnit.test("clearFilter for dataSource", function(assert) {
     assert.deepEqual(that.dataController.filter(), null, "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob", "Bobbi"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 });
 
 // T238430
@@ -5652,7 +5652,7 @@ QUnit.test("clearFilter for search", function(assert) {
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 
     // act
     that.dataController.clearFilter("search");
@@ -5667,7 +5667,7 @@ QUnit.test("clearFilter for search", function(assert) {
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 });
 
 // T238430
@@ -5701,7 +5701,7 @@ QUnit.test("clearFilter for filter row", function(assert) {
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 
     // act
     that.dataController.clearFilter("row");
@@ -5749,7 +5749,7 @@ QUnit.test("clearFilter for header filter", function(assert) {
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 
     // act
     that.dataController.clearFilter("header");
@@ -5763,7 +5763,7 @@ QUnit.test("clearFilter for header filter", function(assert) {
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, undefined, "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 });
 
 // T238430
@@ -5797,7 +5797,7 @@ QUnit.test("clearFilter didn't apply by incorrect filter name", function(assert)
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 
     // act
     that.dataController.clearFilter("test");
@@ -5811,7 +5811,7 @@ QUnit.test("clearFilter didn't apply by incorrect filter name", function(assert)
     assert.ok(Array.isArray(that.dataController.filter()), "filter dataSource");
     assert.equal(columns.length, 2, "count columns");
     assert.deepEqual(columns[0].filterValues, ["Alex", "Dan", "Bob"], "filter values of the first column");
-    assert.deepEqual(columns[1].filterValue, 19, "filter values", "filter value of the second column");
+    assert.deepEqual(columns[1].filterValue, 19, "filter value of the second column");
 });
 
 // B233043
@@ -11085,9 +11085,9 @@ QUnit.test("collapseRow", function(assert) {
 
     // assert
     assert.ok(collapseRowResult0 && collapseRowResult0.done, "collapseRow result 0 is deferred");
-    assert.ok(collapseRowResult0.state(), "resolved", "collapseRow result 0 state is resolved");
+    assert.strictEqual(collapseRowResult0.state(), "resolved", "collapseRow result 0 state is resolved");
     assert.ok(collapseRowResult1 && collapseRowResult1.done, "collapseRow result 1 is deferred");
-    assert.ok(collapseRowResult1.state(), "resolved", "collapseRow result state 1 is resolved");
+    assert.strictEqual(collapseRowResult1.state(), "resolved", "collapseRow result state 1 is resolved");
     assert.strictEqual(this.dataController.isRowExpanded(0), false);
     assert.strictEqual(this.dataController.isRowExpanded(1), false);
     assert.strictEqual(this.dataController.isRowExpanded(2), true);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -6581,7 +6581,7 @@ QUnit.test("Total summary row should be rendered if row rendering mode is virtua
 
     var $footerView = $dataGrid.find(".dx-datagrid-total-footer");
     assert.ok($footerView.is(":visible"), "footer view is visible");
-    assert.ok($footerView.find(".dx-row").length, 1, "one footer row is rendered");
+    assert.strictEqual($footerView.find(".dx-row").length, 1, "one footer row is rendered");
 });
 
 QUnit.test("Keep horizontal scroller position after refresh with native scrolling", function(assert) {
@@ -7800,7 +7800,7 @@ QUnit.test("updateDimensions during grouping when fixed to right column exists",
 
     // assert
     assert.ok(dataGrid.isReady(), "dataGrid is ready");
-    assert.ok($(dataGrid.$element()).find(".dx-group-row").length, 1, "one grouped row is rendered");
+    assert.strictEqual($(dataGrid.$element()).find(".dx-group-row").length, 1, "one grouped row is rendered");
 });
 
 // T334530
@@ -15708,7 +15708,7 @@ QUnit.test("Using watch in masterDetail template if repaintChangesOnly", functio
 
     // assert
     assert.ok($(dataGrid.element()).find(".detail").is($detail), "detail element isn't updated");
-    assert.ok($detail.text(), "changed", "detail text is changed");
+    assert.strictEqual($detail.text(), "changed", "detail text is changed");
 });
 
 // T800483

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -7800,7 +7800,7 @@ QUnit.test("updateDimensions during grouping when fixed to right column exists",
 
     // assert
     assert.ok(dataGrid.isReady(), "dataGrid is ready");
-    assert.strictEqual($(dataGrid.$element()).find(".dx-group-row").length, 1, "one grouped row is rendered");
+    assert.strictEqual($(dataGrid.$element()).find(".dx-group-row").length, 2, "grouped rows are rendered");
 });
 
 // T334530

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -2352,7 +2352,7 @@ QUnit.test("The first cell should not be switched to the editing state when clic
     // assert
     $mainTable = $(rowsView.element().children(".dx-datagrid-content").children("table"));
     assert.strictEqual($mainTable.find("input").length, 0, "hasn't input");
-    assert.notOk($mainTable.find("tbody > tr").first().children().first().hasClass("dx-editor-cell"), 0, "first cell isn't editable");
+    assert.notOk($mainTable.find("tbody > tr").first().children().first().hasClass("dx-editor-cell"), "first cell isn't editable");
 });
 
 // T531154
@@ -4484,7 +4484,7 @@ QUnit.test("Not highlight calculated column", function(assert) {
     that.clock.tick();
 
     assert.equal(testElement.find(".dx-row").first().find(".dx-cell-modified").length, 1, "one modified value");
-    assert.ok(testElement.find(".dx-row").first().children().eq(0).hasClass("dx-cell-modified"), 1, "first cell is modified");
+    assert.ok(testElement.find(".dx-row").first().children().eq(0).hasClass("dx-cell-modified"), "first cell is modified");
 });
 
 // T246535
@@ -11857,7 +11857,7 @@ QUnit.test("The validation message should not be overlapped by the fixed column 
 
     // assert
     overlayInstance = $(rowsView.getCellElement(0, 1)).find(".dx-overlay.dx-datagrid-invalid-message").dxOverlay("instance");
-    assert.ok(overlayInstance, 1, "has invalid message");
+    assert.ok(overlayInstance, "has invalid message");
     overlayPosition = overlayInstance.option("position");
     assert.strictEqual(overlayPosition.my, "top left", "position.my");
     assert.strictEqual(overlayPosition.at, "bottom left", "position.at");
@@ -11908,14 +11908,14 @@ QUnit.test("The validation message should not be overlapped by the fixed column 
 
     // assert
     overlayInstance = $(rowsView.getCellElement(0, 1)).find(".dx-overlay.dx-datagrid-invalid-message").dxOverlay("instance");
-    assert.ok(overlayInstance, 1, "has invalid message");
+    assert.ok(overlayInstance, "has invalid message");
     overlayPosition = overlayInstance.option("position");
     assert.strictEqual(overlayPosition.my, "top right", "position.my");
     assert.strictEqual(overlayPosition.at, "bottom right", "position.at");
     assert.strictEqual(overlayPosition.collision, "none flip", "position.collision");
 
     tooltipInstance = $(rowsView.getCellElement(0, 1)).find(".dx-overlay.dx-datagrid-revert-tooltip").dxTooltip("instance");
-    assert.ok(overlayInstance, 1, "has invalid message");
+    assert.ok(overlayInstance, "has invalid message");
     tooltipPosition = tooltipInstance.option("position");
     assert.strictEqual(tooltipPosition.my, "top right", "position.my");
     assert.strictEqual(tooltipPosition.at, "top left", "position.at");
@@ -11965,7 +11965,7 @@ QUnit.test("The validation message should be decreased when there is not enough 
 
     // assert
     overlayInstance = $(rowsView.getCellElement(0, 1)).find(".dx-overlay.dx-datagrid-invalid-message").dxOverlay("instance");
-    assert.ok(overlayInstance, 1, "has invalid message");
+    assert.ok(overlayInstance, "has invalid message");
     assert.strictEqual(overlayInstance.option("maxWidth"), 148, "maxWidth of the validation message");
     overlayPosition = overlayInstance.option("position");
     assert.strictEqual(overlayPosition.my, "top left", "position.my");

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
@@ -4706,7 +4706,7 @@ QUnit.test("Focused row should be visible if set focusedRowKey", function(assert
     rowsView = this.gridView.getView("rowsView");
     rowsView._scrollToElement = function($row) {
         ++counter;
-        assert.ok($row.find("td").eq(0).text(), "Smith", "Row");
+        assert.strictEqual($row.find("td").eq(0).text(), "Smith", "Row");
     };
     rowsView.height(100);
     this.gridView.component.updateDimensions();

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/chartIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/chartIntegration.tests.js
@@ -297,7 +297,7 @@ QUnit.test("Pass grandTotal text", function(assert) {
     var series = chart.getAllSeries();
 
     assert.strictEqual(series[series.length - 1].name, "GT");
-    assert.strictEqual(series[series.length - 1].getPoints()[0].arg);
+    assert.ok(series[series.length - 1].getPoints()[0].arg);
 });
 
 QUnit.test("Not redraw chart during virtual scrolling", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/chartIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/chartIntegration.tests.js
@@ -297,7 +297,7 @@ QUnit.test("Pass grandTotal text", function(assert) {
     var series = chart.getAllSeries();
 
     assert.strictEqual(series[series.length - 1].name, "GT");
-    assert.ok(series[series.length - 1].getPoints()[0].arg);
+    assert.ok(series[series.length - 1].getPoints()[0].argument);
 });
 
 QUnit.test("Not redraw chart during virtual scrolling", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
@@ -1473,7 +1473,7 @@ QUnit.test("Layout 2", function(assert) {
     assert.roughEqual($areas.eq(2).outerHeight(true), $areas.eq(3).outerHeight(true), 1.1, "area 2=3 outerHeight");
     assert.roughEqual($areas.eq(3).outerHeight(true), $areas.eq(4).outerHeight(true), 1.1, "area 3=4 outerHeight");
 
-    assert.equal($areas.eq(0).width(), $areas.eq(1).width(), "area 0>1 width");
+    assert.ok($areas.eq(0).width() > $areas.eq(1).width(), "area 0>1 width");
     assert.equal($areas.eq(1).width(), $areas.eq(2).width(), "area 1=2 width");
     assert.equal($areas.eq(2).width(), $areas.eq(3).width(), "area 2=3 width");
     assert.equal($areas.eq(3).width(), $areas.eq(4).width(), "area 3=4 width");

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
@@ -1473,7 +1473,7 @@ QUnit.test("Layout 2", function(assert) {
     assert.roughEqual($areas.eq(2).outerHeight(true), $areas.eq(3).outerHeight(true), 1.1, "area 2=3 outerHeight");
     assert.roughEqual($areas.eq(3).outerHeight(true), $areas.eq(4).outerHeight(true), 1.1, "area 3=4 outerHeight");
 
-    assert.ok($areas.eq(0).width(), $areas.eq(1).width(), "area 0>1 width");
+    assert.equal($areas.eq(0).width(), $areas.eq(1).width(), "area 0>1 width");
     assert.equal($areas.eq(1).width(), $areas.eq(2).width(), "area 1=2 width");
     assert.equal($areas.eq(2).width(), $areas.eq(3).width(), "area 2=3 width");
     assert.equal($areas.eq(3).width(), $areas.eq(4).width(), "area 3=4 width");

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/store.local.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/store.local.tests.js
@@ -1118,7 +1118,7 @@ QUnit.test("Expand row on several levels & column", function(assert) {
         assert.equal(data.rows[14].children.length, 3, 'Spain children count');
         assert.equal(data.rows[14].children[1].value, "Madrid", 'Spain Madrid value');
         assert.equal(data.rows[14].children[1].index, 14, 'Spain Madrid index');
-        assert.ok(data.rows[14].children[1].children, "Madrid", 'Spain - Madrid has children');
+        assert.ok(data.rows[14].children[1].children, 'Spain - Madrid has children');
         assert.equal(data.rows[14].children[1].children.length, 2, 'Spain - Madrid children count');
         assert.equal(data.rows[14].children[1].children[0].value, "Bolido Comidas preparadas", 'Spain - Madrid first children value');
         assert.equal(data.rows[14].children[1].children[0].index, 19, 'Spain - Madrid first children index');

--- a/testing/tests/DevExpress.ui.widgets.treeList/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/editing.tests.js
@@ -254,7 +254,7 @@ QUnit.test("Add row to child should call addRow method with parentId", function(
 
     // assert
     assert.ok(this.editingController.addRow.calledOnce, "addRow is called");
-    assert.ok(this.editingController.addRow.args[0], [1], "addRow arg is row key");
+    assert.deepEqual(this.editingController.addRow.args[0], [1], "addRow arg is row key");
 });
 
 QUnit.test("AddRow method should expand row and add item after parent", function(assert) {


### PR DESCRIPTION
Helps to enable the [assert-args](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md) rule of ESLint QUnit plugin (#10691).