### PR TITLE
Collection widgets: Fix test assertion args

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
@@ -163,7 +163,7 @@ QUnit.test('Render item with icon path', function(assert) {
 
     assert.equal($menuItemContent.children().length, 1, 'there is 1 element inside item-content');
     assert.ok($($menuItemContent.children()[0]).hasClass(DX_ICON_CLASS), 'there is dx-icon class inside item-content');
-    assert.ok($($menuItemContent.children()[0]).attr('src'), '1.png', 'image is right');
+    assert.strictEqual($($menuItemContent.children()[0]).attr('src'), '1.png', 'image is right');
 });
 
 QUnit.test('Render item with expressions', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/pager.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/pager.tests.js
@@ -944,8 +944,8 @@ QUnit.test("Light mode when re-render", function(assert) {
     $pagesCount = $(".dx-pages-count");
     $pageInfoText = $(".dx-info-text"),
 
-    assert.ok($pageSizeChooser.dxSelectBox("instance").option("value"), 10, "page size");
-    assert.ok($pageIndex.dxNumberBox("instance").option("value"), 1, "page index");
+    assert.strictEqual($pageSizeChooser.dxSelectBox("instance").option("value"), 10, "page size");
+    assert.strictEqual($pageIndex.dxNumberBox("instance").option("value"), 1, "page index");
     assert.equal($pageInfoText.text(), "of", "pages info text");
     assert.equal($pagesCount.text(), "10", "pages count");
 });

--- a/testing/tests/DevExpress.ui.widgets/slideOut.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/slideOut.tests.js
@@ -252,7 +252,7 @@ QUnit.test("menu items should be rendered after change only one item", function(
 
     instance.option("items[0].text", "c");
     var $items = this.$element.find(".dx-list-item");
-    assert.ok($items.text(), "cb", "items rendered correctly");
+    assert.strictEqual($items.text(), "cb", "items rendered correctly");
 });
 
 QUnit.test("grouped options", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/sortable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/sortable.tests.js
@@ -1662,7 +1662,7 @@ QUnit.test("Dragging item to another the sortable widget with dropFeedbackMode i
     items2 = sortable2.$element().children();
     assert.strictEqual(items1.length, 3, "first list - item count");
     assert.strictEqual(items2.length, 3, "second list - item count");
-    assert.ok($("body").children(".dx-sortable-placeholder").length, 1, "placeholder is in body");
+    assert.strictEqual($("body").children(".dx-sortable-placeholder").length, 1, "placeholder is in body");
 });
 
 QUnit.test("Dropping item to another the sortable widget with dropFeedbackMode indicate", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/keyboardNavigation.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/keyboardNavigation.js
@@ -124,8 +124,8 @@ QUnit.test("'shift+home' key pressing extends selection up to the top-most node"
     $firstItem.trigger("dxpointerdown");
     $treeView.trigger($.Event("keydown", { key: "Home", shiftKey: true }));
 
-    assert.ok($topNodeCheckBox.dxCheckBox("instance").option("value"), true, "top node was selected");
-    assert.ok($secondNodeCheckBox.dxCheckBox("instance").option("value"), true, "node was selected");
+    assert.strictEqual($topNodeCheckBox.dxCheckBox("instance").option("value"), true, "top node was selected");
+    assert.strictEqual($secondNodeCheckBox.dxCheckBox("instance").option("value"), true, "node was selected");
 }),
 
 QUnit.test("'shift+home' key pressing without checkBoxes", function(assert) {
@@ -181,8 +181,8 @@ QUnit.test("'shift+end' key pressing extends selection up to the last node", fun
     $firstItem.trigger("dxpointerdown");
     $treeView.trigger($.Event("keydown", { key: "End", shiftKey: true }));
 
-    assert.ok($lastNodeCheckBox.dxCheckBox("instance").option("value"), true, "last node was selected");
-    assert.ok($secondNodeCheckBox.dxCheckBox("instance").option("value"), true, "node was selected");
+    assert.strictEqual($lastNodeCheckBox.dxCheckBox("instance").option("value"), true, "last node was selected");
+    assert.strictEqual($secondNodeCheckBox.dxCheckBox("instance").option("value"), true, "node was selected");
 }),
 
 QUnit.test("'shift+end' key pressing without checkBoxes", function(assert) {
@@ -491,7 +491,7 @@ QUnit.test("'minus' key test", function(assert) {
     $parentItem.trigger("dxpointerdown");
     $treeView.trigger($.Event("keydown", { key: "-" }));
 
-    assert.ok(collapseFired, 2, "onItemCollapsed was fired desired number of times");
+    assert.strictEqual(collapseFired, 2, "onItemCollapsed was fired desired number of times");
 }),
 
 QUnit.test("right arrow should update 'expanded' field of item and node", function(assert) {

--- a/testing/tests/DevExpress.ui/hierarchicalCollectionWidgetParts/hierarchicalDataAdapter.js
+++ b/testing/tests/DevExpress.ui/hierarchicalCollectionWidgetParts/hierarchicalDataAdapter.js
@@ -955,15 +955,15 @@ module("Search operation", moduleConfig, () => {
 
         var result = dataAdapter.search("X");
 
-        assert.ok(result[0].internalFields.expanded, "Cars", "The entry is OK");
-        assert.ok(result[1].internalFields.expanded, "BMWX", "The entry is OK");
-        assert.ok(!result[2].internalFields.expanded, "X1", "The entry is OK");
-        assert.ok(!result[3].internalFields.expanded, "X5", "The entry is OK");
-        assert.ok(!result[4].internalFields.expanded, "X6", "The entry is OK");
-        assert.ok(result[5].internalFields.expanded, "Motobikes", "The entry is OK");
-        assert.ok(result[6].internalFields.expanded, "Yamaha", "The entry is OK");
-        assert.ok(!result[7].internalFields.expanded, "YX 1", "The entry is OK");
-        assert.ok(!result[8].internalFields.expanded, "YX 2", "The entry is OK");
+        assert.ok(result[0].internalFields.expanded, "The 'Cars' entry is expanded");
+        assert.ok(result[1].internalFields.expanded, "The 'BMWX' entry is expanded");
+        assert.ok(!result[2].internalFields.expanded, "The 'X1' entry is not expanded");
+        assert.ok(!result[3].internalFields.expanded, "The 'X5' entry is not expanded");
+        assert.ok(!result[4].internalFields.expanded, "The 'X6' entry is not expanded");
+        assert.ok(result[5].internalFields.expanded, "The 'Motobikes' entry expanded");
+        assert.ok(result[6].internalFields.expanded, "The 'Yamaha' entry not expanded");
+        assert.ok(!result[7].internalFields.expanded, "The 'YX 1' entry is not expanded");
+        assert.ok(!result[8].internalFields.expanded, "The 'YX' The entry is not expanded");
     });
 
     test("Search should work with warning when the parent node is lost", function(assert) {


### PR DESCRIPTION
Helps to enable the [assert-args](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md) rule of ESLint QUnit plugin (#10691).