### PR TITLE
ESLint: Add eslint-plugin-qunit

### DIFF
--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -8,7 +8,7 @@ export DEVEXTREME_DOCKER_CI=true
 export NUGET_PACKAGES=$PWD/dotnet_packages
 
 function run_lint {
-    npm i eslint eslint-plugin-spellcheck stylelint stylelint-config-standard npm-run-all
+    npm i eslint eslint-plugin-spellcheck eslint-plugin-qunit stylelint stylelint-config-standard npm-run-all
     npm run lint
 }
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "del": "^2.2.2",
     "devextreme-internal-tools": "~1.1.0",
     "eslint": "^6.0.0",
+    "eslint-plugin-qunit": "^4.0.0",
     "eslint-plugin-spellcheck": "0.0.11",
     "exceljs": "^1.7.0",
     "globalize": "^1.3.0",

--- a/testing/.eslintrc
+++ b/testing/.eslintrc
@@ -9,5 +9,11 @@
         "SystemJS": true,
         "DevExpress": true,
         "sinon": true
+    },
+    "plugins": [
+        "qunit"
+    ],
+    "rules": {
+        "qunit/assert-args": "error"
     }
 }


### PR DESCRIPTION
Adds the ESLint plugin for QUnit ([eslint-plugin-qunit](https://github.com/platinumazure/eslint-plugin-qunit)) with enabled [assert-args](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md) rule (based on #10682, #10683, #10684, #10685, #10686). We can add other [rules](https://github.com/platinumazure/eslint-plugin-qunit#available-rules) in future separate PRs.