### PR TITLE
UI widgets: Fix expected and actual args order in test assertions

### DIFF
--- a/testing/tests/DevExpress.core/utils.topOverlay.tests.js
+++ b/testing/tests/DevExpress.core/utils.topOverlay.tests.js
@@ -12,7 +12,7 @@ QUnit.test("hideTopOverlayCallback", function(assert) {
     assert.ok(navCallback.hasCallback());
     assert.ok(navCallback.fire());
     assert.ok(!navCallback.hasCallback());
-    assert.equal("0", res);
+    assert.equal(res, "0");
 
     navCallback.add(function() {
         res += "1";
@@ -22,7 +22,7 @@ QUnit.test("hideTopOverlayCallback", function(assert) {
     });
     navCallback.fire();
     navCallback.fire();
-    assert.equal("021", res);
+    assert.equal(res, "021");
     var callback = function() {
         res += "3";
     };
@@ -33,7 +33,7 @@ QUnit.test("hideTopOverlayCallback", function(assert) {
     navCallback.remove(callback);
     assert.ok(navCallback.fire());
     assert.ok(!navCallback.fire());
-    assert.equal("0214", res);
+    assert.equal(res, "0214");
 });
 
 QUnit.test("hideTopOverlay", function(assert) {
@@ -43,8 +43,8 @@ QUnit.test("hideTopOverlay", function(assert) {
     callback.add(function() {
         eventFiredCount++;
     });
-    assert.equal(0, eventFiredCount);
+    assert.equal(eventFiredCount, 0);
 
     hideTopOverlay();
-    assert.equal(1, eventFiredCount);
+    assert.equal(eventFiredCount, 1);
 });

--- a/testing/tests/DevExpress.ui.widgets/button.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/button.markup.tests.js
@@ -40,7 +40,7 @@ QUnit.test("markup init", function(assert) {
 
     var buttonContent = $(items[0]).hasClass(BUTTON_CONTENT_CLASS);
 
-    assert.equal(true, buttonContent);
+    assert.equal(buttonContent, true);
 });
 
 QUnit.test("init with options", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/button.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/button.markup.tests.js
@@ -38,9 +38,9 @@ QUnit.test("markup init", function(assert) {
 
     var items = element.children();
 
-    var buttonContent = $(items[0]).hasClass(BUTTON_CONTENT_CLASS);
+    var hasButtonContentClass = $(items[0]).hasClass(BUTTON_CONTENT_CLASS);
 
-    assert.equal(buttonContent, true);
+    assert.ok(hasButtonContentClass);
 });
 
 QUnit.test("init with options", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/dropDownMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownMenu.tests.js
@@ -419,7 +419,7 @@ QUnit.test("check default position", function(assert) {
         defaultPosition = { my: "top center", at: "bottom center", collision: "fit flip", offset: { v: 4 } };
 
     assert.deepEqual(defaultPosition, instance.option("popupPosition"));
-    assert.equal(false, instance.option("usePopover"));
+    assert.equal(instance.option("usePopover"), false);
 });
 
 QUnit.test("check position for LTR and RTL", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/dropDownMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownMenu.tests.js
@@ -419,7 +419,7 @@ QUnit.test("check default position", function(assert) {
         defaultPosition = { my: "top center", at: "bottom center", collision: "fit flip", offset: { v: 4 } };
 
     assert.deepEqual(defaultPosition, instance.option("popupPosition"));
-    assert.equal(instance.option("usePopover"), false);
+    assert.notOk(instance.option("usePopover"));
 });
 
 QUnit.test("check position for LTR and RTL", function(assert) {


### PR DESCRIPTION
`equal( actual, expected [, message ])`

name | description
-- | --
actual | Expression being tested
expected | Known comparison value
message (string) | A short description of the assertion

See https://api.qunitjs.com/assert/equal.