### PR TITLE
Skip DateBox test for mobile devices after #10687

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -3808,6 +3808,11 @@ QUnit.module("keyboard navigation", {
     });
 
     QUnit.test("Pressing escape when focus 'today' button must hide the popup", (assert) => {
+        if(devices.real().deviceType !== "desktop") {
+            assert.ok(true, "test does not actual for mobile devices");
+            return;
+        }
+
         const escapeKeyDown = $.Event("keydown", { key: "Escape" });
         this.dateBox.option({
             type: "date",


### PR DESCRIPTION
Buttons aren't focusable on mobile devices