### PR TITLE
ResponsiveBox - change default strategy for IE 11 and Edge browsers  (T823974)

### DIFF
--- a/js/ui/box.js
+++ b/js/ui/box.js
@@ -186,6 +186,7 @@ class FlexLayoutStrategy {
     }
 }
 
+// obsolete. Will be removed in 20.2
 class FallbackLayoutStrategy {
     constructor($element, option) {
         this._$element = $element;
@@ -527,7 +528,7 @@ class Box extends CollectionWidget {
                     return browser["msie"];
                 },
                 options: {
-                    _layoutStrategy: "fallback"
+                    _layoutStrategy: "flex"
                 }
             }
         ]);

--- a/js/ui/box.js
+++ b/js/ui/box.js
@@ -186,7 +186,7 @@ class FlexLayoutStrategy {
     }
 }
 
-// obsolete. Will be removed in 20.2
+// Deprecated in 19.2 (T823974)
 class FallbackLayoutStrategy {
     constructor($element, option) {
         this._$element = $element;

--- a/testing/tests/DevExpress.ui/defaultOptions.tests.js
+++ b/testing/tests/DevExpress.ui/defaultOptions.tests.js
@@ -155,7 +155,7 @@ testComponentDefaults(DateBox,
 
 testComponentDefaults(Box,
     {},
-    { _layoutStrategy: 'fallback' },
+    { _layoutStrategy: 'flex' },
     function() {
         this._origMSIE = browser.msie;
         browser.msie = true;


### PR DESCRIPTION
Use flex strategy as default for IE 11