### PR TITLE
Lookup: Fix globals in test

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -2252,7 +2252,7 @@ QUnit.test("popup height should be stretch when data items are loaded asynchrono
     assert.ok($(".dx-overlay-content").outerHeight() > defaultHeight, "popup height is changed when data is loaded");
 });
 
-QUnit.test("popover height should be recalculated after async datasource load(T655040)", (assert) => {
+QUnit.test("popover height should be recalculated after async datasource load(T655040)", function(assert) {
     if(browser.mozilla && parseFloat(browser.version) < 71 || devices.real().deviceType !== "desktop") {
         assert.expect(0);
         return;
@@ -2261,7 +2261,6 @@ QUnit.test("popover height should be recalculated after async datasource load(T6
     const $rootLookup = $("<div>").appendTo("body");
 
     try {
-        this.clock = sinon.useFakeTimers();
         const items = ["item 1", "item 2", "item 3", "item 4"];
         const instance = $rootLookup.dxLookup({
             dataSource: new CustomStore({
@@ -2297,7 +2296,6 @@ QUnit.test("popover height should be recalculated after async datasource load(T6
         assert.ok($(instance.content()).height() >= $(instance.content()).find(".dx-scrollable-content").height(), $(instance.content()).height() + " >= " + $(instance.content()).find(".dx-scrollable-content").height());
     } finally {
         $rootLookup.remove();
-        this.clock.restore();
     }
 });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1420883/69441458-d41bd400-0d5b-11ea-954b-145658afb662.png)

Clarification:
---

> QUnit test and module callbacks can share state by modifying properties of `this` within those callbacks.
> 
> This only works when using function expressions, which allow for dynamic binding of `this` by the QUnit library. Arrow function expressions will not work in this case, because arrow functions will always bind to whatever the value of `this` was in the enclosing scope (in QUnit tests, usually the global object). This means that developers who use arrow function expressions as test or module callbacks will not be able to share state and may encounter other problems.

See https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md