### PR TITLE
HtmlEditor: Fix globals in tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
@@ -7,7 +7,7 @@ const { test } = QUnit;
 const TOOLBAR_FORMAT_WIDGET_CLASS = "dx-htmleditor-toolbar-format";
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
 
         this.options = {
@@ -20,13 +20,13 @@ const moduleConfig = {
                 .dxHtmlEditor("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 };
 
 QUnit.module("API", moduleConfig, () => {
-    test("get registered module", (assert) => {
+    test("get registered module", function(assert) {
         this.createEditor();
         const Bold = this.instance.get("formats/bold");
 
@@ -34,7 +34,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(Bold.blotName, "bold", "we get correct blot");
     });
 
-    test("get registered module on init", (assert) => {
+    test("get registered module on init", function(assert) {
         assert.expect(2);
         this.options.onInitialized = ({ component }) => {
             const Bold = component.get("formats/bold");
@@ -45,7 +45,7 @@ QUnit.module("API", moduleConfig, () => {
         this.createEditor();
     });
 
-    test("get quill instance", (assert) => {
+    test("get quill instance", function(assert) {
         this.createEditor();
         const quillInstance = this.instance.getQuillInstance();
 
@@ -53,7 +53,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.ok(quillInstance.format, "specific method isn't undefined");
     });
 
-    test("get/set selection", (assert) => {
+    test("get/set selection", function(assert) {
         this.createEditor();
         this.instance.setSelection(1, 2);
         const selection = this.instance.getSelection();
@@ -62,7 +62,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(selection.length, 2, "Correct length");
     });
 
-    test("format", (assert) => {
+    test("format", function(assert) {
         this.createEditor();
         this.instance.setSelection(1, 2);
         this.instance.format("bold", true);
@@ -70,7 +70,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), "<p>T<strong>es</strong>t 1</p><p>Test 2</p><p>Test 3</p>", "format applied");
     });
 
-    test("formatText", (assert) => {
+    test("formatText", function(assert) {
         this.createEditor();
         const expected = "<h1>T<strong>est 1</strong></h1><p><strong>Tes</strong>t 2</p><p>Test 3</p>";
         this.instance.formatText(1, 9, {
@@ -82,7 +82,7 @@ QUnit.module("API", moduleConfig, () => {
             this.instance.option("value"), expected, "block format applies for the first line only");
     });
 
-    test("formatLine", (assert) => {
+    test("formatLine", function(assert) {
         this.createEditor();
         this.instance.formatLine(1, 9, {
             bold: true, // inline format
@@ -92,7 +92,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), "<h1>Test 1</h1><h1>Test 2</h1><p>Test 3</p>", "just block format applied");
     });
 
-    test("getFormat", (assert) => {
+    test("getFormat", function(assert) {
         this.createEditor();
         this.instance.option("value", "<p><b>Test Test</b></p>");
 
@@ -100,7 +100,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.deepEqual(format, { bold: true }, "correct format");
     });
 
-    test("removeFormat", (assert) => {
+    test("removeFormat", function(assert) {
         this.createEditor();
         this.instance.option("value", "<p><b>Test Test</b></p>");
         this.instance.removeFormat(1, 2);
@@ -108,7 +108,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), "<p><strong>T</strong>es<strong>t Test</strong></p>", "remove format from specific range");
     });
 
-    test("getLength", (assert) => {
+    test("getLength", function(assert) {
         this.createEditor();
         const length = this.instance.getLength();
         const LINE_WIDTH = 7; // 6 chars + the new line char
@@ -116,14 +116,14 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(length, LINE_WIDTH * 3, "correct format");
     });
 
-    test("delete", (assert) => {
+    test("delete", function(assert) {
         this.createEditor();
         this.instance.delete(1, 7);
 
         assert.strictEqual(this.instance.option("value"), "<p>Test 2</p><p>Test 3</p>", "custom range removed");
     });
 
-    test("insertText", (assert) => {
+    test("insertText", function(assert) {
         this.createEditor();
         this.instance.insertText(1, "one");
         this.instance.insertText(6, "two", { italic: true });
@@ -131,7 +131,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), "<p>Tonees<em>two</em>t 1</p><p>Test 2</p><p>Test 3</p>", "insert simple and formatted text");
     });
 
-    test("insertEmbed", (assert) => {
+    test("insertEmbed", function(assert) {
         this.createEditor();
         const expected = '<p>T<span class="dx-variable" data-var-start-esc-char="#" data-var-end-esc-char="#"' +
             ' data-var-value="template"><span contenteditable="false">#template#</span></span>est 1</p><p>Test 2</p><p>Test 3</p>';
@@ -140,7 +140,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value").replace(/\uFEFF/g, ""), expected, "insert embed");
     });
 
-    test("undo/redo", (assert) => {
+    test("undo/redo", function(assert) {
         this.createEditor();
         this.instance.insertText(0, "a");
         this.clock.tick(1000);
@@ -157,7 +157,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), "<p>cbaTest 1</p><p>Test 2</p><p>Test 3</p>", "redo operation");
     });
 
-    test("clearHistory", (assert) => {
+    test("clearHistory", function(assert) {
         this.createEditor();
         this.instance.insertText(0, "a");
         this.clock.tick(1000);
@@ -172,7 +172,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), "<p>cbaTest 1</p><p>Test 2</p><p>Test 3</p>", "history is empty");
     });
 
-    test("registerModule", (assert) => {
+    test("registerModule", function(assert) {
         class Test {
             constructor(quillInstance, options) {
                 this._editorInstance = options.editorInstance;
@@ -195,7 +195,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(testModule.getEditor(), this.instance);
     });
 
-    test("registerModule on init", (assert) => {
+    test("registerModule on init", function(assert) {
         class Test {
             constructor(quillInstance, options) {
                 this._editorInstance = options.editorInstance;
@@ -221,7 +221,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(testModule.getEditor(), this.instance);
     });
 
-    test("'focus' method should call the quill's focus", (assert) => {
+    test("'focus' method should call the quill's focus", function(assert) {
         this.createEditor();
         const focusSpy = sinon.spy(this.instance.getQuillInstance(), "focus");
 
@@ -230,7 +230,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.ok(focusSpy.calledOnce, "Quill focus() should triggered on the editor's focus()");
     });
 
-    test("change value via 'option' method should correctly update content", (assert) => {
+    test("change value via 'option' method should correctly update content", function(assert) {
         this.createEditor();
         const valueChangeStub = sinon.stub();
         const updateContentSpy = sinon.spy(this.instance, "_updateHtmlContent");
@@ -246,7 +246,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual(updateContentSpy.lastCall.args[0], "New text", "Update content with the new value");
     });
 
-    test("customize module", (assert) => {
+    test("customize module", function(assert) {
         this.options.customizeModules = function({ toolbar }) {
             toolbar.items.push("italic");
         };
@@ -259,7 +259,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.strictEqual($toolbarItems.text(), "BoldItalic", "expected items order");
     });
 
-    test("customize custom module", (assert) => {
+    test("customize custom module", function(assert) {
         assert.expect(1);
         class Test {
             constructor(quillInstance, { customOption }) {
@@ -277,7 +277,7 @@ QUnit.module("API", moduleConfig, () => {
         this.instance.register({ "modules/testWithOptions": Test });
     });
 
-    test("onContentReady should trigger after processing transcluded content", (assert) => {
+    test("onContentReady should trigger after processing transcluded content", function(assert) {
         const initialMarkup = "<custom-tag></custom-tag><h1>Hi!</h1><p>Test         </p>";
         const expectedValue = "<h1>Hi!</h1><p>Test</p>";
 
@@ -292,7 +292,7 @@ QUnit.module("API", moduleConfig, () => {
         this.clock.tick();
     });
 
-    test("onContentReady event should trigger after editor without transcluded content rendered", (assert) => {
+    test("onContentReady event should trigger after editor without transcluded content rendered", function(assert) {
         this.options.onContentReady = sinon.stub();
         this.createEditor();
 
@@ -300,7 +300,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.ok(this.options.onContentReady.calledOnce, "onContentReady has been called once");
     });
 
-    test("empty editor should trigger onContentReady event", (assert) => {
+    test("empty editor should trigger onContentReady event", function(assert) {
         this.options = { onContentReady: sinon.stub() };
         this.createEditor();
 
@@ -308,7 +308,7 @@ QUnit.module("API", moduleConfig, () => {
         assert.ok(this.options.onContentReady.calledOnce, "onContentReady has been called once");
     });
 
-    test("editor with invalid transcluded content should trigger onContentReady event", (assert) => {
+    test("editor with invalid transcluded content should trigger onContentReady event", function(assert) {
         $("#htmlEditor").html("<test><custom-tag></custom-tag></test>");
         this.options = { onContentReady: sinon.stub() };
         this.createEditor();
@@ -319,7 +319,7 @@ QUnit.module("API", moduleConfig, () => {
 });
 
 QUnit.module("Private API", moduleConfig, () => {
-    test("cleanCallback should trigger on refresh", (assert) => {
+    test("cleanCallback should trigger on refresh", function(assert) {
         const cleanCallback = sinon.stub();
 
         this.createEditor();
@@ -336,7 +336,7 @@ QUnit.module("Private API", moduleConfig, () => {
         assert.ok(cleanCallback.calledTwice, "callback is called on dispose");
     });
 
-    test("contentInitialized callback should trigger after content was initialized by Quill but before ContentReady event", (assert) => {
+    test("contentInitialized callback should trigger after content was initialized by Quill but before ContentReady event", function(assert) {
         const contentInitializedCallback = () => {
             assert.ok(contentReadyHandler.notCalled, "ContentReady event isn't trigger yet");
         };
@@ -351,7 +351,7 @@ QUnit.module("Private API", moduleConfig, () => {
         this.instance.repaint();
     });
 
-    test("contentInitialized callback should been removed on widget repaint", (assert) => {
+    test("contentInitialized callback should been removed on widget repaint", function(assert) {
         const contentInitializedCallback = sinon.stub();
 
         this.options.onInitialized = ({ component }) => {

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/converterController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/converterController.tests.js
@@ -6,7 +6,7 @@ import ConverterController from "ui/html_editor/converterController";
 const { test } = QUnit;
 
 QUnit.module("Converter controller", () => {
-    test("Check registered converters", (assert) => {
+    test("Check registered converters", function(assert) {
         const deltaConverter = ConverterController.getConverter("delta");
         const markdownConverter = ConverterController.getConverter("markdown");
 
@@ -14,7 +14,7 @@ QUnit.module("Converter controller", () => {
         assert.notOk(markdownConverter, "Markdown converter isn't exists by default");
     });
 
-    test("Add new converter", (assert) => {
+    test("Add new converter", function(assert) {
         ConverterController.addConverter("custom", () => {});
         const customConverter = ConverterController.getConverter("custom");
 
@@ -23,7 +23,7 @@ QUnit.module("Converter controller", () => {
 });
 
 QUnit.module("Unknown converter", () => {
-    test("Editor throw an error if cannot find a converter", (assert) => {
+    test("Editor throw an error if cannot find a converter", function(assert) {
         assert.throws(
             function() { $("#htmlEditor").dxHtmlEditor({ valueType: "markdown" }); },
             function(e) {

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/converters.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/converters.tests.js
@@ -5,13 +5,13 @@ import { getQuill } from "ui/html_editor/quill_importer";
 const { test } = QUnit;
 
 QUnit.module("Delta converter", {
-    beforeEach: () => {
+    beforeEach: function() {
         const Quill = getQuill();
         this.deltaConverter = new DeltaConverter();
         this.quillInstance = new Quill(document.getElementById("htmlEditor"), {});
         this.deltaConverter.setQuillInstance(this.quillInstance);
     } }, () => {
-    test("it convert an editor content to semantic HTML markup", (assert) => {
+    test("it convert an editor content to semantic HTML markup", function(assert) {
         const deltaOps = [{
             insert: 'test',
             attributes: {
@@ -24,7 +24,7 @@ QUnit.module("Delta converter", {
         assert.strictEqual(this.deltaConverter.toHtml(), "<p><strong>test</strong></p>", "It converts delta operations");
     });
 
-    test("it should respect more the one level indent between list items", (assert) => {
+    test("it should respect more the one level indent between list items", function(assert) {
         const deltaOps = [{
             insert: "item1-1"
         }, {
@@ -53,7 +53,7 @@ QUnit.module("Delta converter", {
         assert.strictEqual(this.deltaConverter.toHtml(), expected, "convert list with indent more the one step");
     });
 
-    test("it should respect list item attributes", (assert) => {
+    test("it should respect list item attributes", function(assert) {
         const deltaOps = [
             { insert: "item1" },
             {
@@ -79,20 +79,20 @@ QUnit.module("Delta converter", {
         assert.strictEqual(this.deltaConverter.toHtml(), expected, "converted markup should contains inner styles");
     });
 
-    test("it should return an empty string when editor is empty", (assert) => {
+    test("it should return an empty string when editor is empty", function(assert) {
         assert.strictEqual(this.deltaConverter.toHtml(), "", "editor is empty and converter return an empty string");
     });
 });
 
 QUnit.module("Markdown converter", () => {
-    test("it convert a HTML to the Markdown", (assert) => {
+    test("it convert a HTML to the Markdown", function(assert) {
         const markdownConverter = new MarkdownConverter();
         const html = "<p>Te<strong>st</strong></p>";
 
         assert.equal(markdownConverter.toMarkdown(html), "Te**st**", "It converts a HTML to Markdown");
     });
 
-    test("it convert a Markdown to the HTML", (assert) => {
+    test("it convert a Markdown to the HTML", function(assert) {
         const markdownConverter = new MarkdownConverter();
         const markdown = "Te**st**";
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/dropImageModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/dropImageModule.tests.js
@@ -13,7 +13,7 @@ class DropImageMock extends DropImage {
 }
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("#htmlEditor");
 
         this.insertEmbedStub = sinon.stub();
@@ -39,7 +39,7 @@ const moduleConfig = {
 const { test } = QUnit;
 
 QUnit.module("DropImage module", moduleConfig, () => {
-    test("insert image on drop", (assert) => {
+    test("insert image on drop", function(assert) {
         new DropImageMock(this.quillMock, this.options);
 
         const event = $.Event($.Event("drop", { dataTransfer: { files: [this.file] } }));
@@ -50,7 +50,7 @@ QUnit.module("DropImage module", moduleConfig, () => {
         assert.deepEqual(this.insertEmbedStub.lastCall.args, [1, "extendedImage", IMAGE, "user"], "insert base64 image by user");
     });
 
-    test("check file type", (assert) => {
+    test("check file type", function(assert) {
         const dropImage = new DropImage(this.quillMock, this.options);
 
         const textFile = createBlobFile("test", 80, "text/html");
@@ -61,7 +61,7 @@ QUnit.module("DropImage module", moduleConfig, () => {
         assert.notOk(dropImage._isImage(unsupportedImage), "PSD is unsupported");
     });
 
-    test("insert image on paste", (assert) => {
+    test("insert image on paste", function(assert) {
         const clock = sinon.useFakeTimers();
         new DropImageMock(this.quillMock, this.options);
 
@@ -84,7 +84,7 @@ QUnit.module("DropImage module", moduleConfig, () => {
         clock.restore();
     });
 
-    test("Do not encode pasted image with URL", (assert) => {
+    test("Do not encode pasted image with URL", function(assert) {
         new DropImageMock(this.quillMock, this.options);
 
         const textFile = createBlobFile("test", 80, "text/html");
@@ -100,7 +100,7 @@ QUnit.module("DropImage module", moduleConfig, () => {
         assert.equal(this.insertEmbedStub.callCount, 0, "File isn't inserted");
     });
 
-    test("dragover event", (assert) => {
+    test("dragover event", function(assert) {
         new DropImage(this.quillMock, this.options);
 
         const event = $.Event("dragover");

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
@@ -20,7 +20,7 @@ function createPasteEvent() {
 }
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
 
         this.options = {
@@ -33,13 +33,13 @@ const moduleConfig = {
                 .dxHtmlEditor("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 };
 
 module("Events", moduleConfig, () => {
-    test("focusIn event by API", (assert) => {
+    test("focusIn event by API", function(assert) {
         this.createEditor();
 
         const focusInStub = sinon.stub();
@@ -60,7 +60,7 @@ module("Events", moduleConfig, () => {
         assert.strictEqual(focusOutStub.callCount, 1, "Editor is blurred");
     });
 
-    test("focus events should toggle 'dx-state-focused' class", (assert) => {
+    test("focus events should toggle 'dx-state-focused' class", function(assert) {
         this.createEditor();
         this.instance.focus();
         this.clock.tick(TIME_TO_WAIT);
@@ -78,7 +78,7 @@ module("Events", moduleConfig, () => {
         assert.notOk($focusTarget.hasClass(FOCUS_STATE_CLASS), "focusTarget doesn't have focused class");
     });
 
-    test("focus events should not trigger when content is pasted", (assert) => {
+    test("focus events should not trigger when content is pasted", function(assert) {
         const focusInStub = sinon.stub();
         const focusOutStub = sinon.stub();
 
@@ -104,7 +104,7 @@ module("Events", moduleConfig, () => {
         assert.strictEqual(focusOutStub.callCount, 1, "Editor is blurred one time");
     });
 
-    test("focus events listeners attached via 'on' should not trigger when content is pasted", (assert) => {
+    test("focus events listeners attached via 'on' should not trigger when content is pasted", function(assert) {
         const focusInStub = sinon.stub();
         const focusOutStub = sinon.stub();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/formDialog.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/formDialog.tests.js
@@ -13,7 +13,7 @@ const TEXTEDITOR_INPUT_CLASS = "dx-texteditor-input";
 const BUTTON_WITH_TEXT_CLASS = "dx-button-has-text";
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("#htmlEditor");
         this.componentMock = {
             _createComponent: ($container, Widget, options) => {
@@ -29,7 +29,7 @@ const moduleConfig = {
 const { test } = QUnit;
 
 QUnit.module("FormDialog", moduleConfig, () => {
-    test("render FormDialog", (assert) => {
+    test("render FormDialog", function(assert) {
         const formDialog = new FormDialog(this.componentMock);
         const $dialog = this.$element.find(`.${DIALOG_CLASS}`);
         const $form = $dialog.find(`.${FORM_CLASS}`);
@@ -39,13 +39,13 @@ QUnit.module("FormDialog", moduleConfig, () => {
         assert.equal($form.length, 1, "There is element with the Form class inside FormDialog");
     });
 
-    test("render FormDialog with popup options", (assert) => {
+    test("render FormDialog with popup options", function(assert) {
         const formDialog = new FormDialog(this.componentMock, { width: 155 });
 
         assert.equal(formDialog.popupOption("width"), 155, "Custom width should apply");
     });
 
-    test("show dialog", (assert) => {
+    test("show dialog", function(assert) {
         const formDialog = new FormDialog(this.componentMock, { container: this.$element });
         const promise = formDialog.show({ items: ["name", "age"] });
         const formItemsCount = this.$element.find(`.${FORM_CLASS} .${FIELD_ITEM_CLASS}`).length;
@@ -54,7 +54,7 @@ QUnit.module("FormDialog", moduleConfig, () => {
         assert.equal(formItemsCount, 2, "2 form items are rendered");
     });
 
-    test("confirm dialog by api", (assert) => {
+    test("confirm dialog by api", function(assert) {
         assert.expect(1);
 
         const EXPECTED_DATA = { name: "Test", age: 20 };
@@ -68,7 +68,7 @@ QUnit.module("FormDialog", moduleConfig, () => {
         formDialog.hide(EXPECTED_DATA);
     });
 
-    test("confirm dialog by Enter key press", (assert) => {
+    test("confirm dialog by Enter key press", function(assert) {
         assert.expect(1);
 
         const EXPECTED_DATA = { name: "Test" };
@@ -83,7 +83,7 @@ QUnit.module("FormDialog", moduleConfig, () => {
         keyboardMock($input).type("Test").change().press("enter");
     });
 
-    test("IE11 should reset active editor to update data", (assert) => {
+    test("IE11 should reset active editor to update data", function(assert) {
         const isIE11 = browser.msie && parseInt(browser.version) <= 11;
         if(!isIE11) {
             assert.ok("IE11 specific test");
@@ -108,7 +108,7 @@ QUnit.module("FormDialog", moduleConfig, () => {
         activeElements.push(getActiveElement());
     });
 
-    test("confirm dialog by button", (assert) => {
+    test("confirm dialog by button", function(assert) {
         assert.expect(1);
 
         const EXPECTED_DATA = { name: "Test" };
@@ -127,7 +127,7 @@ QUnit.module("FormDialog", moduleConfig, () => {
             .trigger("dxclick");
     });
 
-    test("decline dialog by button click", (assert) => {
+    test("decline dialog by button click", function(assert) {
         assert.expect(1);
 
         const formDialog = new FormDialog(this.componentMock, { container: this.$element });
@@ -145,7 +145,7 @@ QUnit.module("FormDialog", moduleConfig, () => {
             .trigger("dxclick");
     });
 
-    test("decline dialog on hiding", (assert) => {
+    test("decline dialog on hiding", function(assert) {
         assert.expect(1);
 
         const formDialog = new FormDialog(this.componentMock, { container: this.$element });
@@ -161,7 +161,7 @@ QUnit.module("FormDialog", moduleConfig, () => {
         formDialog._popup.hide();
     });
 
-    test("decline dialog by escape key press", (assert) => {
+    test("decline dialog by escape key press", function(assert) {
         assert.expect(1);
 
         const formDialog = new FormDialog(this.componentMock, { container: this.$element });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/markup.tests.js
@@ -11,7 +11,7 @@ const HTML_EDITOR_SUBMIT_ELEMENT_CLASS = "dx-htmleditor-submit-element";
 const { test } = QUnit;
 
 QUnit.module("Base markup", () => {
-    test("render markup", (assert) => {
+    test("render markup", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
             value: "<h1>Hi!</h1><p>Test</p>"
         }).dxHtmlEditor("instance");
@@ -30,7 +30,7 @@ QUnit.module("Base markup", () => {
         assert.equal(!!instance._quillRegistrator, isQuillRendered, "Quill registrator isn't initialized at SSR");
     });
 
-    test("name options should be applies to the submit element", (assert) => {
+    test("name options should be applies to the submit element", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
             name: "Test"
         }).dxHtmlEditor("instance");
@@ -43,7 +43,7 @@ QUnit.module("Base markup", () => {
         assert.equal($submitElement.attr("name"), "New", "It's the right new name");
     });
 
-    test("render markdown markup", (assert) => {
+    test("render markdown markup", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
                 value: "*Test* **text**",
                 valueType: "markdown"
@@ -62,7 +62,7 @@ QUnit.module("Base markup", () => {
         assert.equal(!!instance._quillRegistrator, isQuillRendered, "Quill registrator isn't initialized at SSR");
     });
 
-    test("change value", (assert) => {
+    test("change value", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
             value: "<h1>Hi!</h1><p>Test</p>"
         }).dxHtmlEditor("instance");

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/mentionIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/mentionIntegration.tests.js
@@ -42,7 +42,7 @@ const NAVIGATION_KEYS = [
 const KeyEventsMock = nativePointerMock();
 
 module("Mentions integration", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
 
         this.$element = $("#htmlEditor");
@@ -68,11 +68,11 @@ module("Mentions integration", {
 
         this.getItems = () => $(`.${SUGGESTION_LIST_CLASS} .${LIST_ITEM_CLASS}`);
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    test("insert mention after click on item", (assert) => {
+    test("insert mention after click on item", function(assert) {
         const done = assert.async();
         const expectedMention = `<p><span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="John" data-id="John"><span contenteditable="false"><span>@</span>John</span></span> </p>`;
         const valueChangeSpy = sinon.spy(({ value }) => {
@@ -94,7 +94,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("popup position", (assert) => {
+    test("popup position", function(assert) {
         const done = assert.async();
         const $fixture = $("#qunit-fixture");
         const fixtureLeft = $fixture.css("left");
@@ -124,7 +124,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("set up mentions for existed editor", (assert) => {
+    test("set up mentions for existed editor", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             const $items = this.getItems();
@@ -146,7 +146,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("reset mentions option for existed editor", (assert) => {
+    test("reset mentions option for existed editor", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             const $list = $(`.${SUGGESTION_LIST_CLASS}`);
@@ -165,7 +165,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("change mentions marker", (assert) => {
+    test("change mentions marker", function(assert) {
         const done = assert.async();
         const expectedMention = `<p><span class="dx-mention" spellcheck="false" data-marker="#" data-mention-value="Freddy" data-id="Freddy"><span contenteditable="false"><span>#</span>Freddy</span></span> </p>`;
         const valueChangeSpy = sinon.spy(({ value }) => {
@@ -189,7 +189,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("list isn't shown for wrong marker", (assert) => {
+    test("list isn't shown for wrong marker", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             const $list = $(`.${SUGGESTION_LIST_CLASS}`);
@@ -208,7 +208,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("several mention markers: first mention", (assert) => {
+    test("several mention markers: first mention", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             const $items = this.getItems();
@@ -233,7 +233,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("several mention markers: second mention", (assert) => {
+    test("several mention markers: second mention", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             const $items = this.getItems();
@@ -258,7 +258,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("reduce mention markers", (assert) => {
+    test("reduce mention markers", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             const $items = this.getItems();
@@ -289,7 +289,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("old marker doesn't work after reduce mention markers", (assert) => {
+    test("old marker doesn't work after reduce mention markers", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             const $list = $(`.${SUGGESTION_LIST_CLASS}`);
@@ -319,7 +319,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("new mention should be selected after press 'enter' key", (assert) => {
+    test("new mention should be selected after press 'enter' key", function(assert) {
         const done = assert.async();
         const expectedMention = `<p><span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="John" data-id="John"><span contenteditable="false"><span>@</span>John</span></span> </p>`;
         const valueChangeSpy = sinon.spy(({ value }) => {
@@ -342,7 +342,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("navigation keys don't change a caret position when suggestion list is visible", (assert) => {
+    test("navigation keys don't change a caret position when suggestion list is visible", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             if(valueChangeSpy.calledOnce) {
@@ -366,7 +366,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("list should show relevant items on typing text", (assert) => {
+    test("list should show relevant items on typing text", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(({ component }) => {
 
@@ -393,7 +393,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("first list item should be focused on filtering", (assert) => {
+    test("first list item should be focused on filtering", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(() => {
             if(valueChangeSpy.calledOnce) {
@@ -418,7 +418,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("input text should be removed after item select", (assert) => {
+    test("input text should be removed after item select", function(assert) {
         const done = assert.async();
         const expectedMention = `<p><span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="Freddy" data-id="Freddy"><span contenteditable="false"><span>@</span>Freddy</span></span> </p>`;
         const valueChangeSpy = sinon.spy(({ value }) => {
@@ -448,7 +448,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("search timeout", (assert) => {
+    test("search timeout", function(assert) {
         const done = assert.async();
         const TIMEOUT = 700;
         const valueChangeSpy = sinon.spy(({ value }) => {
@@ -477,7 +477,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("minimal search length", (assert) => {
+    test("minimal search length", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(({ component }) => {
             let $items;
@@ -507,7 +507,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("search expression", (assert) => {
+    test("search expression", function(assert) {
         const done = assert.async();
         const valueChangeSpy = sinon.spy(({ component }) => {
             let $items;
@@ -543,7 +543,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("template", (assert) => {
+    test("template", function(assert) {
         const done = assert.async();
         const expectedMention = `<p><span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="John" data-id="John"><span contenteditable="false">John!</span></span> </p>`;
         const valueChangeSpy = sinon.spy(({ value }) => {
@@ -568,7 +568,7 @@ module("Mentions integration", {
         this.clock.tick();
     });
 
-    test("template for existed value", (assert) => {
+    test("template for existed value", function(assert) {
         const expectedMention = `<span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="John" data-id="John"><span contenteditable="false">John!</span></span>`;
 
         this.options.mentions[0].template = (data, container) => {

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/mentionModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/mentionModule.tests.js
@@ -30,7 +30,7 @@ const INSERT_HASH_MENTION_DELTA = { ops: [{ insert: "#" }] };
 const INSERT_TEXT_DELTA = { ops: [{ insert: "Text" }] };
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
 
         this.$element = $("#htmlEditor");
@@ -118,7 +118,7 @@ const moduleConfig = {
             editorInstance: this.options.editorInstance
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.reset();
     }
 };
@@ -126,7 +126,7 @@ const moduleConfig = {
 const { test } = QUnit;
 
 QUnit.module("Mention format", () => {
-    test("Create an element by data", (assert) => {
+    test("Create an element by data", function(assert) {
         const data = {
             value: "John Smith",
             marker: "@",
@@ -140,7 +140,7 @@ QUnit.module("Mention format", () => {
         assert.strictEqual(element.innerText, "@John Smith", "correct inner text");
     });
 
-    test("Get data from element", (assert) => {
+    test("Get data from element", function(assert) {
         const markup = "<span class='dx-mention' data-marker=@ data-mention-value='John Smith' data-id='JohnSm'><span>@</span>John Smith</span>";
         const element = $(markup).get(0);
         const data = MentionFormat.value(element);
@@ -148,7 +148,7 @@ QUnit.module("Mention format", () => {
         assert.deepEqual(data, { value: "John Smith", marker: "@", id: "JohnSm" }, "Correct data");
     });
 
-    test("Change default marker", (assert) => {
+    test("Change default marker", function(assert) {
         const data = {
             value: "John Smith",
             marker: "#",
@@ -159,7 +159,7 @@ QUnit.module("Mention format", () => {
         assert.strictEqual(element.innerText, "#John Smith", "correct inner text");
     });
 
-    test("Change default content renderer", (assert) => {
+    test("Change default content renderer", function(assert) {
         const data = {
             value: "John Smith",
             marker: "@",
@@ -185,7 +185,7 @@ QUnit.module("Mention format", () => {
 });
 
 QUnit.module("Mentions module", moduleConfig, () => {
-    test("insert mention after click on item", (assert) => {
+    test("insert mention after click on item", function(assert) {
         const mention = new Mentions(this.quillMock, this.options);
 
         mention.savePosition(0);
@@ -206,7 +206,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         }, "Correct formatting");
     });
 
-    test("Display and value expression with complex data", (assert) => {
+    test("Display and value expression with complex data", function(assert) {
         const mention = new Mentions(this.quillMock, this.complexDataOptions);
 
         mention.savePosition(0);
@@ -226,7 +226,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         }, "Correct formatting");
     });
 
-    test("Insert embed content should remove marker before insert a mention and restore the selection", (assert) => {
+    test("Insert embed content should remove marker before insert a mention and restore the selection", function(assert) {
         const mention = new Mentions(this.quillMock, this.complexDataOptions);
 
         mention.savePosition(2);
@@ -257,7 +257,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         }]);
     });
 
-    test("changing text by user should trigger checkMentionRequest", (assert) => {
+    test("changing text by user should trigger checkMentionRequest", function(assert) {
         this.quillMock.getSelection = () => { return { index: 1, length: 0 }; };
 
         const mention = new Mentions(this.quillMock, this.complexDataOptions);
@@ -281,7 +281,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.ok(showPopupSpy.calledOnce, "Show popup with suggestion list");
     });
 
-    test("Should appear after type a marker that replaces a selected text (T730303)", (assert) => {
+    test("Should appear after type a marker that replaces a selected text (T730303)", function(assert) {
         const mention = new Mentions(this.quillMock, this.complexDataOptions);
         const showPopupSpy = sinon.spy(mention._popup, "show");
 
@@ -295,7 +295,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.ok(showPopupSpy.calledTwice);
     });
 
-    test("display expression should be used in the suggestion list", (assert) => {
+    test("display expression should be used in the suggestion list", function(assert) {
         const mention = new Mentions(this.quillMock, this.complexDataOptions);
 
         mention.savePosition(2);
@@ -306,7 +306,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.strictEqual(itemText, "Alex manager");
     });
 
-    test("item template", (assert) => {
+    test("item template", function(assert) {
         this.complexDataOptions.mentions[0].itemTemplate = (item, index, element) => {
             $(element).text(`${item.name}@`);
         };
@@ -319,7 +319,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.strictEqual(itemText, "Alex@");
     });
 
-    test("several markers using", (assert) => {
+    test("several markers using", function(assert) {
         const usersCount = this.severalMarkerOptions.mentions[0].dataSource.length;
         const issueCount = this.severalMarkerOptions.mentions[1].dataSource.length;
         const mention = new Mentions(this.quillMock, this.severalMarkerOptions);
@@ -363,7 +363,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         }, "insert issue mention");
     });
 
-    test("list shouldn't be focused on text input", (assert) => {
+    test("list shouldn't be focused on text input", function(assert) {
         const mention = new Mentions(this.quillMock, this.options);
 
         mention.savePosition(0);
@@ -378,7 +378,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.ok(isFirstListItemFocused);
     });
 
-    test("trigger 'arrow down' should focus next list item", (assert) => {
+    test("trigger 'arrow down' should focus next list item", function(assert) {
         const mention = new Mentions(this.quillMock, this.options);
 
         mention.savePosition(0);
@@ -396,7 +396,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.ok(isSecondListItemFocused);
     });
 
-    test("list should load next page on reach end of current page", (assert) => {
+    test("list should load next page on reach end of current page", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "desktop specific test");
             return;
@@ -445,7 +445,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.strictEqual($items.length, 60, "next page has loaded");
     });
 
-    test("trigger 'arrow up' should focus previous list item", (assert) => {
+    test("trigger 'arrow up' should focus previous list item", function(assert) {
         const mention = new Mentions(this.quillMock, this.options);
 
         mention.savePosition(0);
@@ -464,7 +464,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
     });
 
     APPLY_VALUE_KEYS.forEach(({ key, code }) => {
-        test(`trigger '${key}' key should select focused list item`, (assert) => {
+        test(`trigger '${key}' key should select focused list item`, function(assert) {
             const mention = new Mentions(this.quillMock, this.options);
 
             mention.savePosition(0);
@@ -486,7 +486,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         });
     });
 
-    test("trigger 'escape' should close list", (assert) => {
+    test("trigger 'escape' should close list", function(assert) {
         const mention = new Mentions(this.quillMock, this.options);
 
         mention.savePosition(0);
@@ -502,7 +502,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.notOk($list.is(":visible"));
     });
 
-    test("mention char shouldn't be a part of string (e.g. e-mail)", (assert) => {
+    test("mention char shouldn't be a part of string (e.g. e-mail)", function(assert) {
         let content = "d";
 
         this.quillMock.getContents = (index, length) => {
@@ -532,7 +532,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.deepEqual(this.log[2], { operation: "getContents", index: 0, length: 1 });
     });
 
-    test("popup position config", (assert) => {
+    test("popup position config", function(assert) {
         const mention = new Mentions(this.quillMock, this.options);
         mention.savePosition(0);
         const { collision, offset, of: positionTarget } = mention._popupPosition;
@@ -546,7 +546,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.ok(Object.prototype.hasOwnProperty.call(offset, "v"), "it has a vertical offset");
     });
 
-    test("popup shouldn't close on target scroll", (assert) => {
+    test("popup shouldn't close on target scroll", function(assert) {
         const mention = new Mentions(this.quillMock, this.options);
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, "user");
@@ -557,7 +557,7 @@ QUnit.module("Mentions module", moduleConfig, () => {
         assert.ok(mention._popup.option("visible"), "popup is visible after scrolling");
     });
 
-    test("popup should update position after search", (assert) => {
+    test("popup should update position after search", function(assert) {
         const mention = new Mentions(this.quillMock, this.options);
         const popupRepaintSpy = sinon.spy(mention._popup, "repaint");
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/paste.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/paste.tests.js
@@ -40,7 +40,7 @@ const MS_INVALID_LIST_PARAGRAPH = "<p class='MsoListParagraphCxSpFirst'><span>te
 const { module: testModule, test } = QUnit;
 
 testModule("Paste from MS Word", () => {
-    test("paste bullet list with indent", (assert) => {
+    test("paste bullet list with indent", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
@@ -55,7 +55,7 @@ testModule("Paste from MS Word", () => {
         instance._quillInstance.setContents(newDelta);
     });
 
-    test("paste ordered list with indent", (assert) => {
+    test("paste ordered list with indent", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
@@ -70,7 +70,7 @@ testModule("Paste from MS Word", () => {
         instance._quillInstance.setContents(newDelta);
     });
 
-    test("paste list paragraph without styles", (assert) => {
+    test("paste list paragraph without styles", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
@@ -87,7 +87,7 @@ testModule("Paste from MS Word", () => {
 });
 
 testModule("Text with decoration", () => {
-    test("paste text with text-decoration style", (assert) => {
+    test("paste text with text-decoration style", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/popupModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/popupModule.tests.js
@@ -10,7 +10,7 @@ const SUGGESTION_LIST_WRAPPER_CLASS = "dx-suggestion-list-wrapper";
 const MIN_HEIGHT = 100;
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("#htmlEditor");
         this.clock = sinon.useFakeTimers();
 
@@ -25,7 +25,7 @@ const moduleConfig = {
             }
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 };
@@ -33,7 +33,7 @@ const moduleConfig = {
 const { test } = QUnit;
 
 QUnit.module("Popup module", moduleConfig, () => {
-    test("Render Popup with a suggestion list", (assert) => {
+    test("Render Popup with a suggestion list", function(assert) {
         this.options.dataSource = ["Test1", "Test2"];
         new PopupModule({}, this.options);
 
@@ -46,7 +46,7 @@ QUnit.module("Popup module", moduleConfig, () => {
         assert.deepEqual(listDataSource, this.options.dataSource, "List has a correct dataSource");
     });
 
-    test("Show and hide popup on item selecting", (assert) => {
+    test("Show and hide popup on item selecting", function(assert) {
         this.options.dataSource = ["Test1", "Test2"];
         const popupModule = new PopupModule({}, this.options);
         const insertEmbedContent = sinon.spy(popupModule, "insertEmbedContent");
@@ -67,7 +67,7 @@ QUnit.module("Popup module", moduleConfig, () => {
         assert.notOk($suggestionList.is(":visible"), "list isn't visible");
     });
 
-    test("Save position and get position", (assert) => {
+    test("Save position and get position", function(assert) {
         const popupModule = new PopupModule({}, this.options);
 
         popupModule.savePosition(5);
@@ -75,7 +75,7 @@ QUnit.module("Popup module", moduleConfig, () => {
         assert.strictEqual(popupModule.getPosition(), 5, "correct position");
     });
 
-    test("Max height should be a half of the window height", (assert) => {
+    test("Max height should be a half of the window height", function(assert) {
         const windowStub = sinon.stub(windowUtils, "getWindow").returns($("<div>").height(240));
         const popupModule = new PopupModule({}, this.options);
 
@@ -83,7 +83,7 @@ QUnit.module("Popup module", moduleConfig, () => {
         windowStub.restore();
     });
 
-    test("Max height shouldn't less than a predefined threshold", (assert) => {
+    test("Max height shouldn't less than a predefined threshold", function(assert) {
         const windowStub = sinon.stub(windowUtils, "getWindow").returns($("<div>").height(80));
         const popupModule = new PopupModule({}, this.options);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/quillRegistrator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/quillRegistrator.tests.js
@@ -6,7 +6,7 @@ import Size from "ui/html_editor/formats/size";
 const { test } = QUnit;
 
 QUnit.module("Quill registrator", () => {
-    test("check defaults", (assert) => {
+    test("check defaults", function(assert) {
         const quillRegistrator = new QuillRegistrator();
         const quill = quillRegistrator.getQuill();
 
@@ -32,7 +32,7 @@ QUnit.module("Quill registrator", () => {
         assert.ok(baseTheme, "custom base theme");
     });
 
-    test("change format", (assert) => {
+    test("change format", function(assert) {
         const quillRegistrator = new QuillRegistrator();
         const quill = quillRegistrator.getQuill();
 
@@ -47,7 +47,7 @@ QUnit.module("Quill registrator", () => {
         assert.deepEqual(alignFormat, alignClassFormat, "Class attributor");
     });
 
-    test("create a quill editor instance", (assert) => {
+    test("create a quill editor instance", function(assert) {
         const element = document.getElementById("htmlEditor");
         const quillRegistrator = new QuillRegistrator();
 
@@ -56,7 +56,7 @@ QUnit.module("Quill registrator", () => {
         assert.equal(element.className, "ql-container");
     });
 
-    test("add a customModule", (assert) => {
+    test("add a customModule", function(assert) {
         const quillRegistrator = new QuillRegistrator();
 
         quillRegistrator.registerModules({

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/resizingIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/resizingIntegration.tests.js
@@ -14,7 +14,7 @@ const IMAGE = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcS
 const IMAGE_SIZE = 100;
 
 module("Resizing integration", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
 
         this.$element = $("#htmlEditor");
@@ -28,11 +28,11 @@ module("Resizing integration", {
                 .dxHtmlEditor("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    test("Click on an image with default resize module config", (assert) => {
+    test("Click on an image with default resize module config", function(assert) {
         this.createWidget();
 
         this.$element
@@ -44,7 +44,7 @@ module("Resizing integration", {
         assert.strictEqual($resizeFrame.length, 0, "There is no resize frame");
     });
 
-    test("Click on an image after enable resizing via optionChange", (assert) => {
+    test("Click on an image after enable resizing via optionChange", function(assert) {
         this.createWidget();
 
         this.instance.option("mediaResizing.enabled", true);
@@ -59,7 +59,7 @@ module("Resizing integration", {
         assert.ok($resizeFrame.is(":visible"), "Resize frame is visible");
     });
 
-    test("Click on an image with enabled resizing", (assert) => {
+    test("Click on an image with enabled resizing", function(assert) {
         this.options.mediaResizing = { enabled: true };
         this.createWidget();
 
@@ -73,7 +73,7 @@ module("Resizing integration", {
         assert.ok($resizeFrame.is(":visible"), "Resize frame is visible");
     });
 
-    test("Click on an image after disable resizing via optionChange", (assert) => {
+    test("Click on an image after disable resizing via optionChange", function(assert) {
         this.options.mediaResizing = { enabled: true };
         this.createWidget();
 
@@ -88,7 +88,7 @@ module("Resizing integration", {
         assert.strictEqual($resizeFrame.length, 0, "There is resize frame");
     });
 
-    test("Click on an image with enabled resizing but remove 'image' from allowed resizing targets", (assert) => {
+    test("Click on an image with enabled resizing but remove 'image' from allowed resizing targets", function(assert) {
         this.createWidget();
 
         this.instance.option("mediaResizing", {
@@ -106,7 +106,7 @@ module("Resizing integration", {
         assert.notOk($resizeFrame.is(":visible"), "Resize frame isn't visible, image isn't resizable");
     });
 
-    test("check editor value after resizing", (assert) => {
+    test("check editor value after resizing", function(assert) {
         const done = assert.async();
         const hOffset = 10;
         const vOffset = 5;

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/resizingModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/resizingModule.tests.js
@@ -17,7 +17,7 @@ const IMAGE_SIZE = 100;
 const BORDER_PADDING_WIDTH = 2;
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("#htmlEditor").css({ position: "relative", margin: "10px" });
         this.$image = $("<img>").attr({
             width: IMAGE_SIZE,
@@ -52,7 +52,7 @@ const moduleConfig = {
 const { test, module } = QUnit;
 
 module("Resizing module", moduleConfig, () => {
-    test("create module instance with default options", (assert) => {
+    test("create module instance with default options", function(assert) {
         const resizingInstance = new Resizing(this.quillMock, this.options);
 
         assert.strictEqual(this.$element.find(`.${RESIZE_FRAME_CLASS}`).length, 0, "There is no resize frame element");
@@ -60,7 +60,7 @@ module("Resizing module", moduleConfig, () => {
         assert.notOk(resizingInstance.enabled, "module disabled by default");
     });
 
-    test("create module instance with enabled equals to 'true'", (assert) => {
+    test("create module instance with enabled equals to 'true'", function(assert) {
         this.options.enabled = true;
         const resizingInstance = new Resizing(this.quillMock, this.options);
         const $resizeFrame = this.$element.find(`.${RESIZE_FRAME_CLASS}`);
@@ -70,7 +70,7 @@ module("Resizing module", moduleConfig, () => {
         assert.deepEqual(resizingInstance.allowedTargets, ["image"], "default allowed targets");
     });
 
-    test("module should detach events on clean", (assert) => {
+    test("module should detach events on clean", function(assert) {
         this.options.enabled = true;
         const resizingInstance = new Resizing(this.quillMock, this.options);
 
@@ -80,7 +80,7 @@ module("Resizing module", moduleConfig, () => {
         assert.ok(this.detachEventsSpy.calledOnce, "events has been detached on 'clean'");
     });
 
-    test("module should attach and detach events on the 'enabled' option changing", (assert) => {
+    test("module should attach and detach events on the 'enabled' option changing", function(assert) {
         const resizingInstance = new Resizing(this.quillMock, this.options);
 
         this.attachSpies(resizingInstance);
@@ -95,7 +95,7 @@ module("Resizing module", moduleConfig, () => {
         assert.ok(this.detachEventsSpy.calledOnce, "events has been detached");
     });
 
-    test("'allowedTargets' option should accept Array only", (assert) => {
+    test("'allowedTargets' option should accept Array only", function(assert) {
         const resizingInstance = new Resizing(this.quillMock, this.options);
 
         resizingInstance.option("allowedTargets", []);
@@ -107,7 +107,7 @@ module("Resizing module", moduleConfig, () => {
         assert.deepEqual(resizingInstance.allowedTargets, [], "Boolean value rejected");
     });
 
-    test("'option' can apply a set of options", (assert) => {
+    test("'option' can apply a set of options", function(assert) {
         const resizingInstance = new Resizing(this.quillMock, this.options);
 
         resizingInstance.option("mediaResizing", { allowedTargets: ["video"], enabled: true });
@@ -116,7 +116,7 @@ module("Resizing module", moduleConfig, () => {
         assert.deepEqual(resizingInstance.allowedTargets, ["video"], "'allowedTargets' option has been applied");
     });
 
-    test("click on an image with default module options", (assert) => {
+    test("click on an image with default module options", function(assert) {
         const resizingInstance = new Resizing(this.quillMock, this.options);
 
         this.attachSpies(resizingInstance);
@@ -127,7 +127,7 @@ module("Resizing module", moduleConfig, () => {
         assert.ok(this.showFrameSpy.notCalled, "Frame isn't shown");
     });
 
-    test("click on an image with enabled resizing", (assert) => {
+    test("click on an image with enabled resizing", function(assert) {
         this.options.enabled = true;
         const resizingInstance = new Resizing(this.quillMock, this.options);
         const $resizeFrame = this.$element.find(`.${RESIZE_FRAME_CLASS}`);
@@ -147,7 +147,7 @@ module("Resizing module", moduleConfig, () => {
         assert.strictEqual(frameClientRect.height, IMAGE_SIZE + BORDER_PADDING_WIDTH * 2, "Frame has a correct height");
     });
 
-    test("click on an div with enabled resizing", (assert) => {
+    test("click on an div with enabled resizing", function(assert) {
         this.options.enabled = true;
         const resizingInstance = new Resizing(this.quillMock, this.options);
         const $resizeFrame = this.$element.find(`.${RESIZE_FRAME_CLASS}`);
@@ -161,7 +161,7 @@ module("Resizing module", moduleConfig, () => {
         assert.notOk($resizeFrame.is(":visible"), "Frame element isn't visible");
     });
 
-    test("click on an image after disable image resizing", (assert) => {
+    test("click on an image after disable image resizing", function(assert) {
         const resizingInstance = new Resizing(this.quillMock, this.options);
 
         this.attachSpies(resizingInstance);
@@ -178,7 +178,7 @@ module("Resizing module", moduleConfig, () => {
         assert.notOk($resizeFrame.is(":visible"), "Frame element isn't visible");
     });
 
-    test("click outside the target should hide resize frame", (assert) => {
+    test("click outside the target should hide resize frame", function(assert) {
         this.options.enabled = true;
         const resizingInstance = new Resizing(this.quillMock, this.options);
         const $resizeFrame = this.$element.find(`.${RESIZE_FRAME_CLASS}`);
@@ -195,7 +195,7 @@ module("Resizing module", moduleConfig, () => {
         assert.notOk($resizeFrame.is(":visible"), "Frame element isn't visible");
     });
 
-    test("keydown event should hide resize frame", (assert) => {
+    test("keydown event should hide resize frame", function(assert) {
         this.options.enabled = true;
         const resizingInstance = new Resizing(this.quillMock, this.options);
         const $resizeFrame = this.$element.find(`.${RESIZE_FRAME_CLASS}`);
@@ -212,7 +212,7 @@ module("Resizing module", moduleConfig, () => {
         assert.notOk($resizeFrame.is(":visible"), "Frame element isn't visible");
     });
 
-    test("scroll event should update resize frame position", (assert) => {
+    test("scroll event should update resize frame position", function(assert) {
         this.options.enabled = true;
         const resizingInstance = new Resizing(this.quillMock, this.options);
         const $resizeFrame = this.$element.find(`.${RESIZE_FRAME_CLASS}`);
@@ -231,7 +231,7 @@ module("Resizing module", moduleConfig, () => {
         assert.ok(this.hideFrameSpy.notCalled, "Frame hasn't been hidden");
     });
 
-    test("resize frame should change an target size on the frame resizing", (assert) => {
+    test("resize frame should change an target size on the frame resizing", function(assert) {
         this.options.enabled = true;
         new Resizing(this.quillMock, this.options);
 
@@ -260,7 +260,7 @@ module("Resizing module", moduleConfig, () => {
         assert.strictEqual(imageClientRect.width, IMAGE_SIZE + 10, "Image width has been increased");
     });
 
-    test("check frame position", (assert) => {
+    test("check frame position", function(assert) {
         this.options.enabled = true;
         new Resizing(this.quillMock, this.options);
 
@@ -279,7 +279,7 @@ module("Resizing module", moduleConfig, () => {
         assert.strictEqual(frameClientRect.top + BORDER_PADDING_WIDTH, imageClientRect.top, "Frame positioned correctly by the top");
     });
 
-    test("resize frame should have specific class on mobile devices", (assert) => {
+    test("resize frame should have specific class on mobile devices", function(assert) {
         const currentDevice = devices.current();
 
         devices.current("iPad");
@@ -293,7 +293,7 @@ module("Resizing module", moduleConfig, () => {
         devices.current(currentDevice);
     });
 
-    test("resize frame shouldn't have specific class on desktop", (assert) => {
+    test("resize frame shouldn't have specific class on desktop", function(assert) {
         const currentDevice = devices.current();
 
         devices.current("desktop");

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/scrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/scrolling.tests.js
@@ -12,11 +12,11 @@ const { test } = QUnit;
 const MULTILINE_VALUE = "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n";
 
 QUnit.module("Scrolling", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         fx.off = false;
     }
@@ -99,7 +99,7 @@ QUnit.module("Scrolling", {
         }
     }
 
-    test(`editor + scrollView: editor scrollTop - start`, (assert) => {
+    test(`editor + scrollView: editor scrollTop - start`, function(assert) {
         const helper = new TestHelper();
         helper.initScrollViewTest();
 
@@ -118,7 +118,7 @@ QUnit.module("Scrolling", {
 
     });
 
-    test(`editor + scrollView: editor scrollTop - end`, (assert) => {
+    test(`editor + scrollView: editor scrollTop - end`, function(assert) {
         const helper = new TestHelper();
         helper.initScrollViewTest();
 
@@ -137,7 +137,7 @@ QUnit.module("Scrolling", {
         helper.checkAsserts(assert, 45);
     });
 
-    test(`editor + scrollView: editor scrollTop - middle`, (assert) => {
+    test(`editor + scrollView: editor scrollTop - middle`, function(assert) {
         const helper = new TestHelper();
         helper.initScrollViewTest();
 
@@ -156,7 +156,7 @@ QUnit.module("Scrolling", {
         helper.checkAsserts(assert, 50);
     });
 
-    test(`editor + popup: editor scrollTop - start`, (assert) => {
+    test(`editor + popup: editor scrollTop - start`, function(assert) {
         const helper = new TestHelper();
         helper.initPopupTest();
 
@@ -174,7 +174,7 @@ QUnit.module("Scrolling", {
         helper.checkAsserts(assert, 50);
     });
 
-    test(`editor + popup: editor scrollTop - end`, (assert) => {
+    test(`editor + popup: editor scrollTop - end`, function(assert) {
         const helper = new TestHelper();
         helper.initPopupTest();
 
@@ -193,7 +193,7 @@ QUnit.module("Scrolling", {
         helper.checkAsserts(assert, 25);
     });
 
-    test(`editor + popup: editor scrollTop - middle`, (assert) => {
+    test(`editor + popup: editor scrollTop - middle`, function(assert) {
         const helper = new TestHelper();
         helper.initPopupTest();
 
@@ -212,7 +212,7 @@ QUnit.module("Scrolling", {
         helper.checkAsserts(assert, 50);
     });
 
-    test(`editor + popup + scrollView: editor scrollTop - start`, (assert) => {
+    test(`editor + popup + scrollView: editor scrollTop - start`, function(assert) {
         const helper = new TestHelper();
         helper.initPopupWithScrollViewTest();
 
@@ -230,7 +230,7 @@ QUnit.module("Scrolling", {
         helper.checkAsserts(assert, 30);
     });
 
-    test(`editor + popup + scrollView: editor scrollTop - end`, (assert) => {
+    test(`editor + popup + scrollView: editor scrollTop - end`, function(assert) {
         const helper = new TestHelper();
         helper.initPopupWithScrollViewTest();
 
@@ -249,7 +249,7 @@ QUnit.module("Scrolling", {
         helper.checkAsserts(assert, 45);
     });
 
-    test(`editor + popup + scrollView: editor scrollTop - middle`, (assert) => {
+    test(`editor + popup + scrollView: editor scrollTop - middle`, function(assert) {
         const helper = new TestHelper();
         helper.initPopupWithScrollViewTest();
 
@@ -268,7 +268,7 @@ QUnit.module("Scrolling", {
         helper.checkAsserts(assert, 50);
     });
 
-    test(`editor + popup: wheel event should be passed for element with contenteditable=false`, (assert) => {
+    test(`editor + popup: wheel event should be passed for element with contenteditable=false`, function(assert) {
         const helper = new TestHelper();
         const labelClass = "test-label";
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarIntegration.tests.js
@@ -30,16 +30,16 @@ const ORANGE_PIXEL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYA
 const { test } = QUnit;
 
 QUnit.module("Toolbar integration", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         fx.off = false;
     }
 }, () => {
-    test("Apply simple format without focus", (assert) => {
+    test("Apply simple format without focus", function(assert) {
         const focusInStub = sinon.stub();
         const focusOutStub = sinon.stub();
 
@@ -62,7 +62,7 @@ QUnit.module("Toolbar integration", {
         assert.strictEqual(focusOutStub.callCount, 0, "editor isn't blurred");
     });
 
-    test("there is no extra focusout when applying toolbar formatting to the selected range", (assert) => {
+    test("there is no extra focusout when applying toolbar formatting to the selected range", function(assert) {
         const done = assert.async();
         const focusInStub = sinon.stub();
         const focusOutStub = sinon.stub();
@@ -86,7 +86,7 @@ QUnit.module("Toolbar integration", {
             .trigger("dxclick");
     });
 
-    test("Apply simple format with selection", (assert) => {
+    test("Apply simple format with selection", function(assert) {
         const done = assert.async();
         const expected = "<p><strong>te</strong>st</p>";
         const instance = $("#htmlEditor").dxHtmlEditor({
@@ -106,7 +106,7 @@ QUnit.module("Toolbar integration", {
             .trigger("dxclick");
     });
 
-    test("Apply format via color dialog located in the adaptive menu", (assert) => {
+    test("Apply format via color dialog located in the adaptive menu", function(assert) {
         const done = assert.async();
         const toolbarClickStub = sinon.stub();
         const expected = '<p><span style="color: rgb(250, 250, 250);">te</span>st</p>';
@@ -140,7 +140,7 @@ QUnit.module("Toolbar integration", {
             .trigger("dxclick");
     });
 
-    test("Add a link via dialog", (assert) => {
+    test("Add a link via dialog", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor").dxHtmlEditor({
             value: "<p>test</p>",
@@ -177,7 +177,7 @@ QUnit.module("Toolbar integration", {
             .trigger("dxclick");
     });
 
-    test("Overflow menu button should have a correct content", (assert) => {
+    test("Overflow menu button should have a correct content", function(assert) {
         $("#htmlEditor").html("<p>test</p>").dxHtmlEditor({
             toolbar: { items: ["bold", { text: "test", showInMenu: "always" }] }
         });
@@ -190,7 +190,7 @@ QUnit.module("Toolbar integration", {
         assert.equal(buttonContent, expectedContent);
     });
 
-    test("Editor disposing should dispose external toolbar", (assert) => {
+    test("Editor disposing should dispose external toolbar", function(assert) {
         const $toolbarContainer = $("<div>").addClass("external-container");
         $("#qunit-fixture").append($toolbarContainer);
 
@@ -210,7 +210,7 @@ QUnit.module("Toolbar integration", {
         assert.notOk($toolbarContainer.hasClass(TOOLBAR_WRAPPER_CLASS), "Container hasn't wrapper class");
     });
 
-    test("Editor should consider toolbar height", (assert => {
+    test("Editor should consider toolbar height", (function(assert) {
         const height = 100;
         const $container = $("#htmlEditor");
         let markup = "";
@@ -231,7 +231,7 @@ QUnit.module("Toolbar integration", {
         assert.roughEqual(quillContainerHeight + toolbarHeight + bordersWidth, height, 1, "Toolbar + editor equals to the predefined height");
     }));
 
-    test("Toolbar correctly disposed after repaint", (assert) => {
+    test("Toolbar correctly disposed after repaint", function(assert) {
         const $toolbarContainer = $("<div>").addClass("external-container");
         $("#qunit-fixture").append($toolbarContainer);
 
@@ -248,7 +248,7 @@ QUnit.module("Toolbar integration", {
         assert.equal($toolbarContainer.find(`.${TOOLBAR_CLASS}`).length, 1, "Toolbar container contains the htmlEditor's toolbar");
     });
 
-    test("Toolbar should be disabled once editor is read only", (assert) => {
+    test("Toolbar should be disabled once editor is read only", function(assert) {
         $("#htmlEditor").dxHtmlEditor({
             readOnly: true,
             toolbar: { items: ["bold"] }
@@ -258,7 +258,7 @@ QUnit.module("Toolbar integration", {
         assert.ok(isToolbarDisabled);
     });
 
-    test("Toolbar should be disabled once editor is disabled", (assert) => {
+    test("Toolbar should be disabled once editor is disabled", function(assert) {
         $("#htmlEditor").dxHtmlEditor({
             disabled: true,
             toolbar: { items: ["bold"] }
@@ -268,7 +268,7 @@ QUnit.module("Toolbar integration", {
         assert.ok(isToolbarDisabled);
     });
 
-    test("Toolbar should correctly update disabled state on the option changed", (assert) => {
+    test("Toolbar should correctly update disabled state on the option changed", function(assert) {
         const editor = $("#htmlEditor").dxHtmlEditor({
             disabled: true,
             readOnly: true,
@@ -286,7 +286,7 @@ QUnit.module("Toolbar integration", {
         assert.ok($toolbar.hasClass(STATE_DISABLED_CLASS));
     });
 
-    test("SelectBox should keep selected value after format applying", (assert) => {
+    test("SelectBox should keep selected value after format applying", function(assert) {
         $("#htmlEditor").dxHtmlEditor({
             toolbar: { items: [{ formatName: "size", formatValues: ["10px", "11px"] }] }
         });
@@ -306,8 +306,8 @@ QUnit.module("Toolbar integration", {
         assert.strictEqual(value, "11px", "SelectBox contain selected value");
     });
 
-    function prepareImageUpdateTest(context, caretPosition, selectionLength) {
-        return (assert) => {
+    function prepareImageUpdateTest(caretPosition, selectionLength) {
+        return function(assert) {
             const done = assert.async();
             const $container = $("#htmlEditor");
             const instance = $container.dxHtmlEditor({
@@ -326,7 +326,7 @@ QUnit.module("Toolbar integration", {
                 instance.setSelection(caretPosition, selectionLength);
             }, 100);
 
-            context.clock.tick(100);
+            this.clock.tick(100);
             $container
                 .find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`)
                 .trigger("dxclick");
@@ -340,15 +340,15 @@ QUnit.module("Toolbar integration", {
         };
     }
 
-    test("image should be correctly updated after change a source and caret placed after", prepareImageUpdateTest(this, 1, 0));
+    test("image should be correctly updated after change a source and caret placed after", prepareImageUpdateTest(1, 0));
 
-    test("image should be correctly updated after change a source and caret placed before an image", prepareImageUpdateTest(this, 0, 0));
+    test("image should be correctly updated after change a source and caret placed before an image", prepareImageUpdateTest(0, 0));
 
-    test("selected image should be correctly updated after change a source and caret placed after", prepareImageUpdateTest(this, 1, 1));
+    test("selected image should be correctly updated after change a source and caret placed after", prepareImageUpdateTest(1, 1));
 
-    test("selected image should be correctly updated after change a source and caret placed before an image", prepareImageUpdateTest(this, 0, 1));
+    test("selected image should be correctly updated after change a source and caret placed before an image", prepareImageUpdateTest(0, 1));
 
-    test("image should be correctly updated after change a source and caret placed between two images", (assert) => {
+    test("image should be correctly updated after change a source and caret placed between two images", function(assert) {
         const done = assert.async();
         const $container = $("#htmlEditor");
         const instance = $container.dxHtmlEditor({
@@ -386,7 +386,7 @@ QUnit.module("Toolbar integration", {
             .press("enter");
     });
 
-    test("link should be correctly set to an image", (assert) => {
+    test("link should be correctly set to an image", function(assert) {
         const done = assert.async();
         const $container = $("#htmlEditor");
         const link = "http://test.test";
@@ -418,7 +418,7 @@ QUnit.module("Toolbar integration", {
         $okDialogButton.trigger("dxclick");
     });
 
-    test("link should be correctly added for a third", (assert) => {
+    test("link should be correctly added for a third", function(assert) {
         const done = assert.async();
         const $container = $("#htmlEditor");
         let $urlInput;
@@ -480,7 +480,7 @@ QUnit.module("Toolbar integration", {
         this.clock.tick();
     });
 
-    test("Add a link with empty text", (assert) => {
+    test("Add a link with empty text", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor").dxHtmlEditor({
             value: "<p>test</p>",
@@ -513,7 +513,7 @@ QUnit.module("Toolbar integration", {
             .trigger("dxclick");
     });
 
-    test("Add a link and text without selection", (assert) => {
+    test("Add a link and text without selection", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor").dxHtmlEditor({
             value: "<p>test</p>",
@@ -551,7 +551,7 @@ QUnit.module("Toolbar integration", {
             .trigger("dxclick");
     });
 
-    test("Add a link with empty text and selected range", (assert) => {
+    test("Add a link with empty text and selected range", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor").dxHtmlEditor({
             value: "<p>test</p>",
@@ -589,7 +589,7 @@ QUnit.module("Toolbar integration", {
             .trigger("dxclick");
     });
 
-    test("format image and text", (assert) => {
+    test("format image and text", function(assert) {
         const done = assert.async();
         const $container = $("#htmlEditor");
         const link = "http://test.test";
@@ -621,7 +621,7 @@ QUnit.module("Toolbar integration", {
         $okDialogButton.trigger("dxclick");
     });
 
-    test("replace the text of the existed link", (assert) => {
+    test("replace the text of the existed link", function(assert) {
         const done = assert.async();
         const $container = $("#htmlEditor");
         const link = "http://test.test";
@@ -653,7 +653,7 @@ QUnit.module("Toolbar integration", {
         $okDialogButton.trigger("dxclick");
     });
 
-    test("history buttons are inactive after processing transcluded content", (assert) => {
+    test("history buttons are inactive after processing transcluded content", function(assert) {
         const done = assert.async();
         const $container = $("#htmlEditor").html("<p>test</p>");
 
@@ -671,7 +671,7 @@ QUnit.module("Toolbar integration", {
         this.clock.tick();
     });
 
-    test("history buttons are inactive when editor has initial value", (assert) => {
+    test("history buttons are inactive when editor has initial value", function(assert) {
         const done = assert.async();
         const $container = $("#htmlEditor");
 
@@ -688,7 +688,7 @@ QUnit.module("Toolbar integration", {
         }).dxHtmlEditor("instance");
     });
 
-    test("history buttons are inactive when editor hasn't initial value", (assert) => {
+    test("history buttons are inactive when editor hasn't initial value", function(assert) {
         const done = assert.async();
         const $container = $("#htmlEditor");
 
@@ -704,7 +704,7 @@ QUnit.module("Toolbar integration", {
         }).dxHtmlEditor("instance");
     });
 
-    test("Toolbar should correctly update its dimensions after changing the width of the HtmlEditor", (assert) => {
+    test("Toolbar should correctly update its dimensions after changing the width of the HtmlEditor", function(assert) {
         const $container = $("#htmlEditor");
         const instance = $container.dxHtmlEditor({
             width: 1000,

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -49,7 +49,7 @@ const IMAGE_FORMAT_CLASS = "dx-image-format";
 
 
 const simpleModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("#htmlEditor");
@@ -80,13 +80,13 @@ const simpleModuleConfig = {
             }
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 };
 
 const dialogModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("#htmlEditor");
@@ -135,7 +135,7 @@ const dialogModuleConfig = {
 
         this.formDialog = new FormDialog(this.options.editorInstance, { container: this.$element, position: null });
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 };
@@ -143,7 +143,7 @@ const dialogModuleConfig = {
 const { test } = QUnit;
 
 QUnit.module("Toolbar module", simpleModuleConfig, () => {
-    test("Render toolbar without any options", (assert) => {
+    test("Render toolbar without any options", function(assert) {
         new Toolbar(this.quillMock, this.options);
 
         assert.notOk(this.$element.hasClass(TOOLBAR_WRAPPER_CLASS), "Toolbar rendered not on the root element");
@@ -151,7 +151,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.equal(this.$element.find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`).length, 0, "There are no format widgets");
     });
 
-    test("Render toolbar with items", (assert) => {
+    test("Render toolbar with items", function(assert) {
         this.options.items = ["bold"];
         new Toolbar(this.quillMock, this.options);
 
@@ -167,7 +167,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.equal($formatWidget.find(".dx-icon-bold").length, 1, "It has a bold icon");
     });
 
-    test("Render toolbar on custom container", (assert) => {
+    test("Render toolbar on custom container", function(assert) {
         this.options.items = ["bold"];
         this.options.container = this.$element;
         new Toolbar(this.quillMock, this.options);
@@ -178,7 +178,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.ok($toolbar.hasClass(TOOLBAR_CLASS), "Toolbar rendered on the custom element");
     });
 
-    test("Render toolbar with simple formats", (assert) => {
+    test("Render toolbar with simple formats", function(assert) {
         this.options.items = ["bold", "strike"];
 
         new Toolbar(this.quillMock, this.options);
@@ -188,7 +188,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.ok($formatWidgets.first().hasClass("dx-button"), "Change simple format via Button");
     });
 
-    test("Simple format handling", (assert) => {
+    test("Simple format handling", function(assert) {
         let isHandlerTriggered;
         this.quillMock.getFormat = () => {
             return { bold: false };
@@ -240,7 +240,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.equal($homeIcon.length, 1, "last button has a custom icon");
     });
 
-    test("Enum format handling", (assert) => {
+    test("Enum format handling", function(assert) {
         this.quillMock.getFormat = () => {
             return {};
         };
@@ -267,7 +267,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         );
     });
 
-    test("Enum with custom options format handling", (assert) => {
+    test("Enum with custom options format handling", function(assert) {
         this.quillMock.getFormat = () => {
             return {};
         };
@@ -299,7 +299,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.equal(placeholder, "Test", "widget has a custom placeholder");
     });
 
-    test("handle align formatting", (assert) => {
+    test("handle align formatting", function(assert) {
         this.options.items = ["alignLeft", "alignCenter", "alignRight", "alignJustify"];
 
         new Toolbar(this.quillMock, this.options);
@@ -334,7 +334,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         );
     });
 
-    test("handle codeBlock formatting", (assert) => {
+    test("handle codeBlock formatting", function(assert) {
         this.options.items = ["codeBlock"];
 
         new Toolbar(this.quillMock, this.options);
@@ -357,7 +357,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             }]);
     });
 
-    test("handle orderedList formatting", (assert) => {
+    test("handle orderedList formatting", function(assert) {
         this.options.items = ["orderedList"];
 
         new Toolbar(this.quillMock, this.options);
@@ -380,7 +380,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             }]);
     });
 
-    test("handle bulletList formatting", (assert) => {
+    test("handle bulletList formatting", function(assert) {
         this.options.items = ["bulletList"];
 
         new Toolbar(this.quillMock, this.options);
@@ -403,7 +403,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             }]);
     });
 
-    test("Render toolbar with enum format", (assert) => {
+    test("Render toolbar with enum format", function(assert) {
         this.options.items = [{ formatName: "header", formatValues: [1, 2, 3, false] }];
 
         new Toolbar(this.quillMock, this.options);
@@ -412,7 +412,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.ok($formatWidget.hasClass(SELECTBOX_CLASS), "Change enum format via SelectBox");
     });
 
-    test("undo operation", (assert) => {
+    test("undo operation", function(assert) {
         const undoStub = sinon.stub();
         this.quillMock.history = {
             undo: undoStub,
@@ -430,7 +430,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.ok(undoStub.calledOnce, "call undo");
     });
 
-    test("redo operation", (assert) => {
+    test("redo operation", function(assert) {
         const redoStub = sinon.stub();
         this.quillMock.history = {
             redo: redoStub,
@@ -448,7 +448,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.ok(redoStub.calledOnce, "call redo");
     });
 
-    test("custom item without formatName shouldn't have format class", (assert) => {
+    test("custom item without formatName shouldn't have format class", function(assert) {
         this.options.items = ["bold", { widget: "dxButton", options: { text: "test" } }];
 
         new Toolbar(this.quillMock, this.options);
@@ -459,7 +459,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.notOk($buttons.eq(1).hasClass(TOOLBAR_FORMAT_WIDGET_CLASS), "Custom button");
     });
 
-    test("handle indent formatting", (assert) => {
+    test("handle indent formatting", function(assert) {
         this.options.items = ["decreaseIndent", "increaseIndent"];
 
         new Toolbar(this.quillMock, this.options);
@@ -479,7 +479,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             }]);
     });
 
-    test("handle script formatting", (assert) => {
+    test("handle script formatting", function(assert) {
         this.options.items = ["superscript", "subscript"];
 
         new Toolbar(this.quillMock, this.options);
@@ -511,7 +511,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             }]);
     });
 
-    test("separator item", (assert) => {
+    test("separator item", function(assert) {
         this.options.items = ["separator", { formatName: "separator", locateInMenu: "always" }];
 
         new Toolbar(this.quillMock, this.options);
@@ -527,7 +527,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
         assert.equal($menuSeparator.length, 1, "Toolbar has a menu separator item");
     });
 
-    test("toolbar should prevent default mousedown event", (assert) => {
+    test("toolbar should prevent default mousedown event", function(assert) {
         this.options.items = ["bold"];
 
         new Toolbar(this.quillMock, this.options);
@@ -541,7 +541,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             .trigger("mousedown");
     });
 
-    test("default click handler should correctly revert defined format", (assert) => {
+    test("default click handler should correctly revert defined format", function(assert) {
         this.options.items = ["bold"];
         this.quillMock.getFormat = () => { return { bold: "" }; };
 
@@ -558,7 +558,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
             }]);
     });
 
-    test("adaptive menu container", (assert) => {
+    test("adaptive menu container", function(assert) {
         this.options.items = [{ formatName: "strike", locateInMenu: "always" }];
 
         new Toolbar(this.quillMock, this.options);
@@ -575,7 +575,7 @@ QUnit.module("Toolbar module", simpleModuleConfig, () => {
 });
 
 QUnit.module("Active formats", simpleModuleConfig, () => {
-    test("without active formats", (assert) => {
+    test("without active formats", function(assert) {
         this.options.items = ["bold", "italic", "clear"];
 
         const toolbar = new Toolbar(this.quillMock, this.options);
@@ -586,7 +586,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.equal($activeFormats.length, 0, "There is no active formats");
     });
 
-    test("clear formatting", (assert) => {
+    test("clear formatting", function(assert) {
         this.quillMock.getFormat = () => { return { bold: true }; };
         this.options.items = ["clear"];
 
@@ -600,7 +600,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.notOk($clearFormat.hasClass(DISABLED_STATE_CLASS), "Clear formats button is active because there is active format");
     });
 
-    test("simple format", (assert) => {
+    test("simple format", function(assert) {
         this.quillMock.getFormat = () => { return { bold: true }; };
         this.options.items = ["bold", "italic", "strike"];
 
@@ -612,7 +612,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.ok($activeFormats.hasClass(BOLD_FORMAT_CLASS), "it's a bold button");
     });
 
-    test("several simple format", (assert) => {
+    test("several simple format", function(assert) {
         this.quillMock.getFormat = () => { return { bold: true, italic: true }; };
         this.options.items = ["bold", "italic", "strike"];
 
@@ -626,7 +626,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
 
     });
 
-    test("alias format", (assert) => {
+    test("alias format", function(assert) {
         this.quillMock.getFormat = () => { return { "code-block": true }; };
         this.options.items = ["codeBlock"];
 
@@ -638,7 +638,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.ok($activeFormats.hasClass(CODEBLOCK_FORMAT_CLASS), "it's a code block button");
     });
 
-    test("composite format", (assert) => {
+    test("composite format", function(assert) {
         this.quillMock.getFormat = () => { return { align: "center" }; };
         this.options.items = ["alignLeft", "alignCenter", "alignRight", "alignJustify"];
 
@@ -650,7 +650,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.ok($activeFormats.hasClass(ALIGNCENTER_FORMAT_CLASS), "it's an align center button");
     });
 
-    test("color format", (assert) => {
+    test("color format", function(assert) {
         this.quillMock.getFormat = () => { return { color: "#fafafa" }; };
         this.options.items = ["color", "background", "bold"];
 
@@ -668,7 +668,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.equal($icon.get(0).style.borderBottomColor, "transparent", "icon has correct color after reset format");
     });
 
-    test("background format", (assert) => {
+    test("background format", function(assert) {
         this.quillMock.getFormat = () => { return { background: "#fafafa" }; };
         this.options.items = ["color", "background", "bold"];
 
@@ -686,7 +686,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.equal($icon.get(0).style.borderBottomColor, "transparent", "icon has correct background after reset format");
     });
 
-    test("list format", (assert) => {
+    test("list format", function(assert) {
         this.quillMock.getFormat = () => { return { list: "ordered" }; };
         this.options.items = ["orderedList", "bulletList", "bold"];
 
@@ -706,7 +706,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.ok($activeFormats.hasClass(BULLETLIST_FORMAT_CLASS), "it's a bullet list button");
     });
 
-    test("undo/redo", (assert) => {
+    test("undo/redo", function(assert) {
         this.quillMock.history = { stack: { undo: [], redo: [] } };
         this.options.items = ["undo", "redo"];
 
@@ -729,7 +729,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.notOk($historyWidgets.eq(1).hasClass(DISABLED_STATE_CLASS), "Redo is enabled");
     });
 
-    test("SelectBox should display currently applied value", (assert) => {
+    test("SelectBox should display currently applied value", function(assert) {
         this.quillMock.getFormat = () => { return { size: "10px" }; };
         this.options.items = [{ formatName: "size", formatValues: ["10px", "11px"] }];
 
@@ -744,7 +744,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
         assert.strictEqual(value, "10px", "SelectBox contain selected value");
     });
 
-    test("Image format", (assert) => {
+    test("Image format", function(assert) {
         this.quillMock.getFormat = () => { return { imageSrc: "testImage" }; };
         this.options.items = ["image", "background", "bold"];
 
@@ -758,7 +758,7 @@ QUnit.module("Active formats", simpleModuleConfig, () => {
 });
 
 QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
-    test("show color dialog", (assert) => {
+    test("show color dialog", function(assert) {
         this.options.items = ["color"];
         new Toolbar(this.quillMock, this.options);
         this.$element
@@ -776,7 +776,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.strictEqual($boxItemContent.css("flexBasis"), "auto", "Box item content flex-basis is 'auto'");
     });
 
-    test("show color dialog when formatted text selected", (assert) => {
+    test("show color dialog when formatted text selected", function(assert) {
         this.options.items = ["color"];
         this.quillMock.getFormat = () => { return { color: "#fafafa" }; };
 
@@ -791,7 +791,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.equal($hexValueInput.val(), "fafafa", "Selected text color");
     });
 
-    test("change color", (assert) => {
+    test("change color", function(assert) {
         this.options.items = ["color"];
 
         new Toolbar(this.quillMock, this.options);
@@ -814,7 +814,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.deepEqual(this.log, [{ format: "color", value: "#fafafa" }], "format method with the right arguments");
     });
 
-    test("decline change color dialog", (assert) => {
+    test("decline change color dialog", function(assert) {
         this.options.items = ["color"];
 
         new Toolbar(this.quillMock, this.options);
@@ -830,7 +830,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.ok(this.focusStub.calledOnce, "focus method was called after closing the dialog");
     });
 
-    test("show background dialog", (assert) => {
+    test("show background dialog", function(assert) {
         this.options.items = ["background"];
         new Toolbar(this.quillMock, this.options);
         this.$element
@@ -846,7 +846,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.equal($hexValueInput.val(), "000000", "Base value");
     });
 
-    test("show background dialog when formatted text selected", (assert) => {
+    test("show background dialog when formatted text selected", function(assert) {
         this.options.items = ["background"];
         this.quillMock.getFormat = () => { return { background: "#fafafa" }; };
 
@@ -861,7 +861,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.equal($hexValueInput.val(), "fafafa", "Selected background color");
     });
 
-    test("change background", (assert) => {
+    test("change background", function(assert) {
         this.options.items = ["background"];
 
         new Toolbar(this.quillMock, this.options);
@@ -884,7 +884,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.deepEqual(this.log, [{ format: "background", value: "#fafafa" }], "format method with the right arguments");
     });
 
-    test("show image dialog", (assert) => {
+    test("show image dialog", function(assert) {
         this.options.items = ["image"];
         new Toolbar(this.quillMock, this.options);
         this.$element
@@ -900,7 +900,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
 
     });
 
-    test("show image dialog when an image selected", (assert) => {
+    test("show image dialog when an image selected", function(assert) {
         this.quillMock.getFormat = () => {
             return {
                 src: "http://test.com/test.jpg",
@@ -921,7 +921,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.equal($fieldInputs.eq(2).val(), "100", "Height");
     });
 
-    test("decline link dialog", (assert) => {
+    test("decline link dialog", function(assert) {
         this.options.items = ["link"];
 
         new Toolbar(this.quillMock, this.options);
@@ -939,7 +939,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.ok(this.focusStub.calledTwice, "focus method was called after closing the dialog");
     });
 
-    test("change an image formatting", (assert) => {
+    test("change an image formatting", function(assert) {
         this.options.items = ["image"];
         this.quillMock.getSelection = () => { return { index: 1, length: 0 }; };
         new Toolbar(this.quillMock, this.options);
@@ -982,7 +982,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         }, "caret position has been updated");
     });
 
-    test("caret position after update an image with selection", (assert) => {
+    test("caret position after update an image with selection", function(assert) {
         this.options.items = ["image"];
         this.quillMock.getSelection = () => { return { index: 4, length: 2 }; };
         this.quillMock.getFormat = () => { return { extendedImage: "oldImage" }; };
@@ -1003,7 +1003,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         }, "caret position has been correctly updated");
     });
 
-    test("show link dialog", (assert) => {
+    test("show link dialog", function(assert) {
         this.options.items = ["link"];
         new Toolbar(this.quillMock, this.options);
         this.$element
@@ -1018,7 +1018,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.equal(fieldsText, "URL:Text:Open link in new window", "Check labels");
     });
 
-    test("show link dialog when a link selected", (assert) => {
+    test("show link dialog when a link selected", function(assert) {
         this.quillMock.getFormat = () => {
             return {
                 link: "http://test.com",
@@ -1044,7 +1044,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.equal($targetField.find(`.${CHECKBOX_CHECKED_CLASS}`).length, 1, "It is contains a checked CheckBox");
     });
 
-    test("show link dialog when a link selected and didn't contain a target attribute", (assert) => {
+    test("show link dialog when a link selected and didn't contain a target attribute", function(assert) {
         this.quillMock.getFormat = () => {
             return {
                 link: "http://test.com",
@@ -1070,7 +1070,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         assert.equal($targetField.find(`.${CHECKBOX_CHECKED_CLASS}`).length, 0, "It isn't contains an checked CheckBox");
     });
 
-    test("change an link formatting", (assert) => {
+    test("change an link formatting", function(assert) {
         this.options.items = ["link"];
         new Toolbar(this.quillMock, this.options);
         this.$element
@@ -1098,7 +1098,7 @@ QUnit.module("Toolbar dialogs", dialogModuleConfig, () => {
         }], "expected format config");
     });
 
-    test("'Text' field should be hidden when formatting embed config with the 'link' dialog", (assert) => {
+    test("'Text' field should be hidden when formatting embed config with the 'link' dialog", function(assert) {
         this.options.items = ["link"];
         this.quillMock.getSelection = () => { return { index: 0, length: 10 }; };
         this.quillMock.getText = () => "Test";

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/valueRendering.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/valueRendering.tests.js
@@ -15,16 +15,16 @@ function getSelector(className) {
 const { test } = QUnit;
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 };
 
 QUnit.module("Value as HTML markup", moduleConfig, () => {
-    test("show placeholder is value undefined", (assert) => {
+    test("show placeholder is value undefined", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
                 placeholder: "test placeholder"
             }).dxHtmlEditor("instance"),
@@ -34,7 +34,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal($content.get(0).dataset.placeholder, "test placeholder");
     });
 
-    test("render default value", (assert) => {
+    test("render default value", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
                 value: "<h1>Hi!</h1><p>Test</p>"
             }).dxHtmlEditor("instance"),
@@ -45,7 +45,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal(markup, "<h1>Hi!</h1><p>Test</p>");
     });
 
-    test("render transclude content", (assert) => {
+    test("render transclude content", function(assert) {
         assert.expect(4);
         const instance = $("#htmlEditor")
             .html("<h1>Hi!</h1><p>Test</p>")
@@ -71,7 +71,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal(markup, "<h1>Hi!</h1><p>Test</p>");
     });
 
-    test("render transclude content and predefined value", (assert) => {
+    test("render transclude content and predefined value", function(assert) {
         const instance = $("#htmlEditor")
                 .html("<h1>Hi!</h1><p>Test</p>")
                 .dxHtmlEditor({
@@ -87,7 +87,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal(markup, "<p>Test1</p><p>Test2</p>");
     });
 
-    test("change value by user", (assert) => {
+    test("change value by user", function(assert) {
         const done = assert.async();
         const expectedValue = "<p>Hi! <strong>Test.</strong></p><p>New line</p>";
         const instance = $("#htmlEditor")
@@ -106,7 +106,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
             .html("<p>Hi! <strong>Test.</strong></p><p>New line</p>");
     });
 
-    test("value after change valueType", (assert) => {
+    test("value after change valueType", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
@@ -124,7 +124,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         instance.option("valueType", "html");
     });
 
-    test("render markup with a font-size style", (assert) => {
+    test("render markup with a font-size style", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
             value: '<span style="font-size: 20px">Test</span>'
         }).dxHtmlEditor("instance");
@@ -134,7 +134,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal(markup, '<p><span style="font-size: 20px;">Test</span></p>');
     });
 
-    test("render markup with a font-family style", (assert) => {
+    test("render markup with a font-family style", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
             value: '<span style="font-family: Terminal;">Test</span>'
         }).dxHtmlEditor("instance");
@@ -144,7 +144,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal(markup, '<p><span style="font-family: Terminal;">Test</span></p>');
     });
 
-    test("editor should preserve break lines", (assert) => {
+    test("editor should preserve break lines", function(assert) {
         const expectedMarkup = "<p><br></p><p><br></p><h1>Hi!</h1><p>Te</p><p>st</p>";
         const instance = $("#htmlEditor")
             .html("<br><br><h1>Hi!</h1><p>Te<br>st</p>")
@@ -160,7 +160,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal(markup, expectedMarkup);
     });
 
-    test("editor shouldn't create unexpected break lines", (assert) => {
+    test("editor shouldn't create unexpected break lines", function(assert) {
         const expectedMarkup = "<p>hi</p><ul><li>test</li></ul>";
         const instance = $("#htmlEditor")
             .html("<p>hi</p><ul><li>test</li></ul>")
@@ -176,7 +176,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal(markup, expectedMarkup);
     });
 
-    test("editor should respect attributes of the list item", (assert) => {
+    test("editor should respect attributes of the list item", function(assert) {
         const done = assert.async();
         const expectedMarkup = '<ul><li style="text-align: center;">test</li></ul>';
         const instance = $("#htmlEditor")
@@ -197,7 +197,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         this.clock.tick();
     });
 
-    test("editor should respect attributes of the single formatted line", (assert) => {
+    test("editor should respect attributes of the single formatted line", function(assert) {
         const done = assert.async();
         const expectedMarkup = '<p style="text-align: center;">test</p>';
         const instance = $("#htmlEditor")
@@ -218,7 +218,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         this.clock.tick();
     });
 
-    test("editor should have an empty string value when all content has been removed", (assert) => {
+    test("editor should have an empty string value when all content has been removed", function(assert) {
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
                 value: "test"
@@ -228,7 +228,7 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
         assert.equal(instance.option("value"), "", "value is empty line");
     });
 
-    test("editor should trigger the 'valueChanged' event after formatting a link", (assert) => {
+    test("editor should trigger the 'valueChanged' event after formatting a link", function(assert) {
         assert.expect(1);
 
         const done = assert.async();
@@ -250,14 +250,14 @@ QUnit.module("Value as HTML markup", moduleConfig, () => {
 
 
 QUnit.module("Value as Markdown markup", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    test("render default value", (assert) => {
+    test("render default value", function(assert) {
         const instance = $("#htmlEditor").dxHtmlEditor({
                 value: "Hi!\nIt's a **test**!",
                 valueType: "markdown"
@@ -269,7 +269,7 @@ QUnit.module("Value as Markdown markup", {
         assert.equal(markup, "<p>Hi!</p><p>It's a <strong>test</strong>!</p>");
     });
 
-    test("change value by user", (assert) => {
+    test("change value by user", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
@@ -287,7 +287,7 @@ QUnit.module("Value as Markdown markup", {
             .html("<p>Hi! <strong>Test.</strong></p>");
     });
 
-    test("value after change valueType", (assert) => {
+    test("value after change valueType", function(assert) {
         const done = assert.async();
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
@@ -306,14 +306,14 @@ QUnit.module("Value as Markdown markup", {
 });
 
 QUnit.module("Custom blots rendering", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    test("render image", (assert) => {
+    test("render image", function(assert) {
         const testTag = /<img([\w\W]+?)/;
         const testSrc = /src="http:\/\/test.test\/test.jpg"/g;
         const testAlt = /alt="altering"/g;
@@ -336,7 +336,7 @@ QUnit.module("Custom blots rendering", {
         this.clock.tick();
     });
 
-    test("render link", (assert) => {
+    test("render link", function(assert) {
         const instance = $("#htmlEditor")
             .dxHtmlEditor({
                 value: "test",
@@ -354,7 +354,7 @@ QUnit.module("Custom blots rendering", {
         instance.insertText(0, "test", "link", { href: "http://test.test", target: true });
     });
 
-    test("render variable", (assert) => {
+    test("render variable", function(assert) {
         const expected = '<p><span class="dx-variable" data-var-start-esc-char="#" data-var-end-esc-char="#" data-var-value="Test"><span contenteditable="false">#Test#</span></span></p>';
         const instance = $("#htmlEditor")
             .dxHtmlEditor({

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/variablesModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/variablesModule.tests.js
@@ -7,7 +7,7 @@ import { noop } from "core/utils/common";
 const SUGGESTION_LIST_CLASS = "dx-suggestion-list";
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
 
         this.$element = $("#htmlEditor");
@@ -43,7 +43,7 @@ const moduleConfig = {
             }
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.reset();
     }
 };
@@ -51,7 +51,7 @@ const moduleConfig = {
 const { test } = QUnit;
 
 QUnit.module("Variable format", () => {
-    test("Create an element by data", (assert) => {
+    test("Create an element by data", function(assert) {
         const data = {
             value: "TEST_NAME",
             escapeChar: "@"
@@ -64,7 +64,7 @@ QUnit.module("Variable format", () => {
         assert.equal(element.innerText, "@TEST_NAME@", "correct inner text");
     });
 
-    test("Create an element with default escape char", (assert) => {
+    test("Create an element with default escape char", function(assert) {
         const data = {
             value: "TEST_NAME",
             escapeChar: ""
@@ -77,7 +77,7 @@ QUnit.module("Variable format", () => {
         assert.equal(element.innerText, "TEST_NAME", "correct inner text");
     });
 
-    test("Create an element with start escaping char", (assert) => {
+    test("Create an element with start escaping char", function(assert) {
         const data = {
             value: "TEST_NAME",
             escapeChar: ["{", ""],
@@ -90,7 +90,7 @@ QUnit.module("Variable format", () => {
         assert.equal(element.innerText, "{TEST_NAME", "correct inner text");
     });
 
-    test("Create an element with end escaping char", (assert) => {
+    test("Create an element with end escaping char", function(assert) {
         const data = {
             value: "TEST_NAME",
             escapeChar: ["", "}"],
@@ -103,7 +103,7 @@ QUnit.module("Variable format", () => {
         assert.equal(element.innerText, "TEST_NAME}", "correct inner text");
     });
 
-    test("Create an element with start, end and default escaping char", (assert) => {
+    test("Create an element with start, end and default escaping char", function(assert) {
         const data = {
             value: "TEST_NAME",
             escapeChar: ["{", "}"]
@@ -116,7 +116,7 @@ QUnit.module("Variable format", () => {
         assert.equal(element.innerText, "{TEST_NAME}", "correct inner text");
     });
 
-    test("Get data from element", (assert) => {
+    test("Get data from element", function(assert) {
         const markup = "<span class='dx-variable' data-var-start-esc-char=## data-var-value=TEST_NAME><span>##TEST_NAME##</span></span>";
         const element = $(markup).get(0);
         const data = VariableFormat.value(element);
@@ -126,7 +126,7 @@ QUnit.module("Variable format", () => {
 });
 
 QUnit.module("Variables module", moduleConfig, () => {
-    test("insert variable after click on item", (assert) => {
+    test("insert variable after click on item", function(assert) {
         this.options.escapeChar = "#";
         const variables = new Variables(this.quillMock, this.options);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1420883/69521723-b2e00100-0f70-11ea-831d-5068fff60ce0.png)

Clarification:
---

> QUnit test and module callbacks can share state by modifying properties of `this` within those callbacks.
> 
> This only works when using function expressions, which allow for dynamic binding of `this` by the QUnit library. Arrow function expressions will not work in this case, because arrow functions will always bind to whatever the value of `this` was in the enclosing scope (in QUnit tests, usually the global object). This means that developers who use arrow function expressions as test or module callbacks will not be able to share state and may encounter other problems.

See https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md