### PR TITLE
Diagram: Fix globals in tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/diagram.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/diagram.tests.js
@@ -21,7 +21,7 @@ const DX_MENU_ITEM_SELECTOR = ".dx-menu-item";
 const DIAGRAM_FULLSCREEN_CLASS = "dx-diagram-fullscreen";
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("#diagram").dxDiagram();
         this.instance = this.$element.dxDiagram("instance");
     }
@@ -33,22 +33,22 @@ function getToolbarIcon(button) {
 
 
 QUnit.module("Diagram DOM Layout", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
-        moduleConfig.beforeEach();
+        moduleConfig.beforeEach.apply(this, arguments);
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         this.clock.reset();
     }
 }, () => {
-    test("should return correct size of document container in default options", (assert) => {
+    test("should return correct size of document container in default options", function(assert) {
         assertSizes(assert,
             this.$element.find(".dxdi-control"),
             this.$element.find(".dx-diagram-drawer-wrapper"),
             this.instance);
     });
-    test("should return correct size of document container if options panel is hidden", (assert) => {
+    test("should return correct size of document container if options panel is hidden", function(assert) {
         this.instance.option("propertiesPanel.enabled", false);
         this.clock.tick(10000);
         assertSizes(assert,
@@ -57,7 +57,7 @@ QUnit.module("Diagram DOM Layout", {
             this.instance);
     });
 
-    test("should return correct size of document container if toolbox is hidden", (assert) => {
+    test("should return correct size of document container if toolbox is hidden", function(assert) {
         this.instance.option("toolbox.visible", false);
         this.clock.tick(10000);
         assertSizes(assert,
@@ -66,7 +66,7 @@ QUnit.module("Diagram DOM Layout", {
             this.instance);
     });
 
-    test("should return correct size of document container if toolbar is hidden", (assert) => {
+    test("should return correct size of document container if toolbar is hidden", function(assert) {
         this.instance.option("toolbar.visible", false);
         this.clock.tick(10000);
         assertSizes(assert,
@@ -75,7 +75,7 @@ QUnit.module("Diagram DOM Layout", {
             this.instance);
     });
 
-    test("should return correct size of document container if all UI is hidden", (assert) => {
+    test("should return correct size of document container if all UI is hidden", function(assert) {
         this.instance.option("toolbar.visible", false);
         this.instance.option("toolbox.visible", false);
         this.instance.option("propertiesPanel.enabled", false);
@@ -97,25 +97,25 @@ QUnit.module("Diagram DOM Layout", {
 });
 
 QUnit.module("Diagram Toolbar", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
-        moduleConfig.beforeEach();
+        moduleConfig.beforeEach.apply(this, arguments);
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         this.clock.reset();
     }
 }, () => {
-    test("should not render if toolbar.visible is false", (assert) => {
+    test("should not render if toolbar.visible is false", function(assert) {
         this.instance.option("toolbar.visible", false);
         let $toolbar = this.$element.find(TOOLBAR_SELECTOR);
         assert.equal($toolbar.length, 0);
     });
-    test("should fill toolbar with default items", (assert) => {
+    test("should fill toolbar with default items", function(assert) {
         let toolbar = this.$element.find(TOOLBAR_SELECTOR).dxToolbar("instance");
         assert.ok(toolbar.option("dataSource").length > 10);
     });
-    test("should fill toolbar with custom items", (assert) => {
+    test("should fill toolbar with custom items", function(assert) {
         this.instance.option("toolbar.commands", ["export"]);
         let toolbar = this.$element.find(TOOLBAR_SELECTOR).dxToolbar("instance");
         assert.equal(toolbar.option("dataSource").length, 2); // + show properties panel
@@ -128,45 +128,45 @@ QUnit.module("Diagram Toolbar", {
         toolbar = this.$element.find(TOOLBAR_SELECTOR).dxToolbar("instance");
         assert.equal(toolbar.option("dataSource").length, 1);
     });
-    test("should enable items on diagram request", (assert) => {
+    test("should enable items on diagram request", function(assert) {
         let undoButton = findToolbarItem(this.$element, "undo").dxButton("instance");
         assert.ok(undoButton.option("disabled"));
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.PageLandscape).execute(true);
         assert.notOk(undoButton.option("disabled"));
     });
-    test("should activate items on diagram request", (assert) => {
+    test("should activate items on diagram request", function(assert) {
         assert.ok(findToolbarItem(this.$element, "center").hasClass(TOOLBAR_ITEM_ACTIVE_CLASS));
         assert.notOk(findToolbarItem(this.$element, "left").hasClass(TOOLBAR_ITEM_ACTIVE_CLASS));
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.TextLeftAlign).execute(true);
         assert.notOk(findToolbarItem(this.$element, "center").hasClass(TOOLBAR_ITEM_ACTIVE_CLASS));
         assert.ok(findToolbarItem(this.$element, "left").hasClass(TOOLBAR_ITEM_ACTIVE_CLASS));
     });
-    test("button should raise diagram commands", (assert) => {
+    test("button should raise diagram commands", function(assert) {
         assert.notOk(this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.TextLeftAlign).getState().value);
         findToolbarItem(this.$element, "left").trigger("dxclick");
         assert.ok(this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.TextLeftAlign).getState().value);
     });
-    test("selectBox should raise diagram commands", (assert) => {
+    test("selectBox should raise diagram commands", function(assert) {
         assert.equal(this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.FontName).getState().value, "Arial");
         const fontSelectBox = this.$element.find(TOOLBAR_SELECTOR).find(".dx-selectbox").eq(0).dxSelectBox("instance");
         fontSelectBox.option("value", "Arial Black");
         assert.equal(this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.FontName).getState().value, "Arial Black");
     });
-    test("selectboxes with icon items should be replaced with select buttons", (assert) => {
+    test("selectboxes with icon items should be replaced with select buttons", function(assert) {
         const $selectButtonTemplates = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-select-b").find(".dx-dropdowneditor-field-template-wrapper");
         assert.ok($selectButtonTemplates.length > 0, "select buttons are rendered");
         const selectButtonsCount = $selectButtonTemplates.length;
         assert.equal($selectButtonTemplates.find(".dx-diagram-i").length, selectButtonsCount, "icons are rendered");
         assert.equal($selectButtonTemplates.find(".dx-textbox")[0].offsetWidth, 0, "textbox is hidden");
     });
-    test("colorboxes should be replaced with color buttons", (assert) => {
+    test("colorboxes should be replaced with color buttons", function(assert) {
         const $selectButtonTemplates = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-color-b").find(".dx-dropdowneditor-field-template-wrapper");
         assert.ok($selectButtonTemplates.length > 0, "color buttons are rendered");
         const selectButtonsCount = $selectButtonTemplates.length;
         assert.equal($selectButtonTemplates.find(".dx-diagram-i, .dx-icon").length, selectButtonsCount, "icons are rendered");
         assert.equal($selectButtonTemplates.find(".dx-textbox")[0].offsetWidth, 0, "textbox is hidden");
     });
-    test("colorbuttons should show an active color", (assert) => {
+    test("colorbuttons should show an active color", function(assert) {
         const colorButton = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-color-b").first();
         assert.equal(getToolbarIcon(colorButton).css("borderBottomColor"), "rgb(0, 0, 0)");
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.FontColor).execute("rgb(255, 0, 0)");
@@ -178,13 +178,13 @@ QUnit.module("Diagram Toolbar", {
         assert.equal(this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.FontColor).getState().value, "#00ff00", "color changed by color button");
         assert.equal(getToolbarIcon(colorButton).css("borderBottomColor"), "rgb(0, 255, 0)", "button changed via coloredit");
     });
-    test("colorbutton should show dropdown on icon click", (assert) => {
+    test("colorbutton should show dropdown on icon click", function(assert) {
         const colorButton = this.$element.find(TOOLBAR_SELECTOR).find(".dx-diagram-color-b").first();
         const colorBox = colorButton.find(".dx-colorbox").dxColorBox("instance");
         getToolbarIcon(colorButton).trigger("dxclick");
         assert.ok(colorBox.option("opened"), true);
     });
-    test("call .update() after accordion item collapsing/expanding", (assert) => {
+    test("call .update() after accordion item collapsing/expanding", function(assert) {
         const clock = sinon.useFakeTimers();
         const $leftPanel = this.$element.find(".dx-diagram-left-panel");
         const scrollView = $leftPanel.find(".dx-scrollview").dxScrollView("instance");
@@ -194,7 +194,7 @@ QUnit.module("Diagram Toolbar", {
         assert.equal(updateSpy.callCount, 1, "scrollView.update() called once");
         clock.restore();
     });
-    test("should toggle fullscreen class name on button click", (assert) => {
+    test("should toggle fullscreen class name on button click", function(assert) {
         assert.notOk(this.$element.hasClass(DIAGRAM_FULLSCREEN_CLASS));
         let fullScreenButton = findToolbarItem(this.$element, "full screen");
         fullScreenButton.trigger("dxclick");
@@ -202,7 +202,7 @@ QUnit.module("Diagram Toolbar", {
         fullScreenButton.trigger("dxclick");
         assert.notOk(this.$element.hasClass(DIAGRAM_FULLSCREEN_CLASS));
     });
-    test("diagram should be focused after change font family", (assert) => {
+    test("diagram should be focused after change font family", function(assert) {
         const fontSelectBox = this.$element.find(TOOLBAR_SELECTOR).find(".dx-selectbox").eq(0).dxSelectBox("instance");
         fontSelectBox.focus();
         fontSelectBox.open();
@@ -213,17 +213,17 @@ QUnit.module("Diagram Toolbar", {
         item.trigger("dxclick");
         assert.equal(document.activeElement, this.instance._diagramInstance.render.input.inputElement);
     });
-    test("diagram should be focused after set font bold", (assert) => {
+    test("diagram should be focused after set font bold", function(assert) {
         const boldButton = findToolbarItem(this.$element, "bold");
         assert.notEqual(document.activeElement, this.instance._diagramInstance.render.input.inputElement);
         boldButton.trigger("dxclick");
         assert.equal(document.activeElement, this.instance._diagramInstance.render.input.inputElement);
     });
-    test("Auto Layout button should be disabled when there is no selection", (assert) => {
+    test("Auto Layout button should be disabled when there is no selection", function(assert) {
         const button = findToolbarItem(this.$element, "auto layout").dxButton("instance");
         assert.ok(button.option("disabled"));
     });
-    test("Auto Layout button should be disabled in Read Only mode", (assert) => {
+    test("Auto Layout button should be disabled in Read Only mode", function(assert) {
         this.instance.option("contextMenu.commands", ["selectAll"]);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.Import).execute(SIMPLE_DIAGRAM);
         const contextMenu = this.$element.find(CONTEXT_MENU_SELECTOR).dxContextMenu("instance");
@@ -241,16 +241,16 @@ QUnit.module("Diagram Toolbar", {
 });
 
 QUnit.module("Diagram Toolbox", moduleConfig, () => {
-    test("should not render if toolbox.visible is false", (assert) => {
+    test("should not render if toolbox.visible is false", function(assert) {
         this.instance.option("toolbox.visible", false);
         let $accordion = this.$element.find(TOOBOX_ACCORDION_SELECTOR);
         assert.equal($accordion.length, 0);
     });
-    test("should fill toolbox with default items", (assert) => {
+    test("should fill toolbox with default items", function(assert) {
         let accordion = this.$element.find(TOOBOX_ACCORDION_SELECTOR).dxAccordion("instance");
         assert.ok(accordion.option("dataSource").length > 1);
     });
-    test("should fill toolbox with custom items", (assert) => {
+    test("should fill toolbox with custom items", function(assert) {
         this.instance.option("toolbox.groups", ["general"]);
         let accordion = this.$element.find(TOOBOX_ACCORDION_SELECTOR).dxAccordion("instance");
         assert.equal(accordion.option("dataSource").length, 1);
@@ -258,16 +258,16 @@ QUnit.module("Diagram Toolbox", moduleConfig, () => {
 });
 
 QUnit.module("Diagram Properties Panel", moduleConfig, () => {
-    test("should not render if propertiesPanel.enabled is false", (assert) => {
+    test("should not render if propertiesPanel.enabled is false", function(assert) {
         this.instance.option("propertiesPanel.enabled", false);
         let $accordion = this.$element.find(PROPERTIES_PANEL_ACCORDION_SELECTOR);
         assert.equal($accordion.length, 0);
     });
-    test("should fill properties panel with default items", (assert) => {
+    test("should fill properties panel with default items", function(assert) {
         let form = this.$element.find(PROPERTIES_PANEL_FORM_SELECTOR).dxForm("instance");
         assert.ok(form.option("items").length > 1);
     });
-    test("should fill toolbox with custom items", (assert) => {
+    test("should fill toolbox with custom items", function(assert) {
         this.instance.option("propertiesPanel.groups", [{ commands: ["units"] }]);
         let form = this.$element.find(PROPERTIES_PANEL_FORM_SELECTOR).dxForm("instance");
         assert.equal(form.option("items").length, 1);
@@ -275,32 +275,32 @@ QUnit.module("Diagram Properties Panel", moduleConfig, () => {
 });
 
 QUnit.module("Context Menu", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
-        moduleConfig.beforeEach();
+        moduleConfig.beforeEach.apply(this, arguments);
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         this.clock.reset();
     }
 }, () => {
-    test("should not render if contextMenu.enabled is false", (assert) => {
+    test("should not render if contextMenu.enabled is false", function(assert) {
         let $contextMenu = this.$element.find(CONTEXT_MENU_SELECTOR);
         assert.equal($contextMenu.length, 1);
         this.instance.option("contextMenu.enabled", false);
         $contextMenu = this.$element.children(CONTEXT_MENU_SELECTOR);
         assert.equal($contextMenu.length, 0);
     });
-    test("should load default items", (assert) => {
+    test("should load default items", function(assert) {
         const contextMenu = this.$element.find(CONTEXT_MENU_SELECTOR).dxContextMenu("instance");
         assert.ok(contextMenu.option("items").length > 1);
     });
-    test("should load custom items", (assert) => {
+    test("should load custom items", function(assert) {
         this.instance.option("contextMenu.commands", ["copy"]);
         const contextMenu = this.$element.find(CONTEXT_MENU_SELECTOR).dxContextMenu("instance");
         assert.equal(contextMenu.option("items").length, 1);
     });
-    test("should update items on showing", (assert) => {
+    test("should update items on showing", function(assert) {
         this.instance.option("contextMenu.commands", ["copy", "selectAll"]);
         const contextMenu = this.$element.find(CONTEXT_MENU_SELECTOR).dxContextMenu("instance");
         assert.notOk(contextMenu.option("visible"));
@@ -313,7 +313,7 @@ QUnit.module("Context Menu", {
         assert.ok(contextMenu.option("visible"));
         assert.ok(contextMenu.option("items")[0].text.indexOf("Select All") > -1);
     });
-    test("should execute commands on click", (assert) => {
+    test("should execute commands on click", function(assert) {
         this.instance.option("contextMenu.commands", ["selectAll"]);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.Import).execute(SIMPLE_DIAGRAM);
         const contextMenu = this.$element.find(CONTEXT_MENU_SELECTOR).dxContextMenu("instance");
@@ -329,26 +329,26 @@ QUnit.module("Context Menu", {
 });
 
 QUnit.module("Options", moduleConfig, () => {
-    test("should change readOnly property", (assert) => {
+    test("should change readOnly property", function(assert) {
         assert.notOk(this.instance._diagramInstance.settings.readOnly);
         this.instance.option("readOnly", true);
         assert.ok(this.instance._diagramInstance.settings.readOnly);
         this.instance.option("readOnly", false);
         assert.notOk(this.instance._diagramInstance.settings.readOnly);
     });
-    test("should change zoomLevel property", (assert) => {
+    test("should change zoomLevel property", function(assert) {
         assert.equal(this.instance._diagramInstance.settings.zoomLevel, 1);
         this.instance.option("zoomLevel", 1.5);
         assert.equal(this.instance._diagramInstance.settings.zoomLevel, 1.5);
         this.instance.option("zoomLevel", 1);
         assert.equal(this.instance._diagramInstance.settings.zoomLevel, 1);
     });
-    test("should sync zoomLevel property", (assert) => {
+    test("should sync zoomLevel property", function(assert) {
         assert.equal(this.instance.option("zoomLevel"), 1);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.ZoomLevel).execute(1.5);
         assert.equal(this.instance.option("zoomLevel"), 1.5);
     });
-    test("should change zoomLevel object property", (assert) => {
+    test("should change zoomLevel object property", function(assert) {
         assert.equal(this.instance._diagramInstance.settings.zoomLevel, 1);
         assert.equal(this.instance._diagramInstance.settings.zoomLevelItems.length, 7);
         this.instance.option("zoomLevel", { value: 1.5, items: [ 1, 1.5 ] });
@@ -358,13 +358,13 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal(this.instance._diagramInstance.settings.zoomLevel, 1);
         assert.equal(this.instance._diagramInstance.settings.zoomLevelItems.length, 2);
     });
-    test("should sync zoomLevel object property", (assert) => {
+    test("should sync zoomLevel object property", function(assert) {
         this.instance.option("zoomLevel", { value: 1.5, items: [ 1, 1.5, 2 ] });
         assert.equal(this.instance.option("zoomLevel.value"), 1.5);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.ZoomLevel).execute(2);
         assert.equal(this.instance.option("zoomLevel.value"), 2);
     });
-    test("should change autoZoom property", (assert) => {
+    test("should change autoZoom property", function(assert) {
         assert.equal(this.instance._diagramInstance.settings.autoZoom, 0);
         this.instance.option("autoZoom", "fitContent");
         assert.equal(this.instance._diagramInstance.settings.autoZoom, 1);
@@ -373,60 +373,60 @@ QUnit.module("Options", moduleConfig, () => {
         this.instance.option("autoZoom", "disabled");
         assert.equal(this.instance._diagramInstance.settings.autoZoom, 0);
     });
-    test("should sync autoZoom property", (assert) => {
+    test("should sync autoZoom property", function(assert) {
         assert.equal(this.instance.option("autoZoom"), "disabled");
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.SwitchAutoZoom).execute(1);
         assert.equal(this.instance.option("autoZoom"), "fitContent");
     });
-    test("should change fullScreen property", (assert) => {
+    test("should change fullScreen property", function(assert) {
         assert.notOk(this.instance._diagramInstance.settings.fullscreen);
         this.instance.option("fullScreen", true);
         assert.ok(this.instance._diagramInstance.settings.fullscreen);
         this.instance.option("fullScreen", false);
         assert.notOk(this.instance._diagramInstance.settings.fullscreen);
     });
-    test("should sync fullScreen property", (assert) => {
+    test("should sync fullScreen property", function(assert) {
         assert.equal(this.instance.option("fullScreen"), false);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.Fullscreen).execute(true);
         assert.equal(this.instance.option("fullScreen"), true);
     });
-    test("should change showGrid property", (assert) => {
+    test("should change showGrid property", function(assert) {
         assert.ok(this.instance._diagramInstance.settings.showGrid);
         this.instance.option("showGrid", false);
         assert.notOk(this.instance._diagramInstance.settings.showGrid);
         this.instance.option("showGrid", true);
         assert.ok(this.instance._diagramInstance.settings.showGrid);
     });
-    test("should sync showGrid property", (assert) => {
+    test("should sync showGrid property", function(assert) {
         assert.equal(this.instance.option("showGrid"), true);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.ShowGrid).execute(false);
         assert.equal(this.instance.option("showGrid"), false);
     });
-    test("should change snapToGrid property", (assert) => {
+    test("should change snapToGrid property", function(assert) {
         assert.ok(this.instance._diagramInstance.settings.snapToGrid);
         this.instance.option("snapToGrid", false);
         assert.notOk(this.instance._diagramInstance.settings.snapToGrid);
         this.instance.option("snapToGrid", true);
         assert.ok(this.instance._diagramInstance.settings.snapToGrid);
     });
-    test("should sync snapToGrid property", (assert) => {
+    test("should sync snapToGrid property", function(assert) {
         assert.equal(this.instance.option("snapToGrid"), true);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.SnapToGrid).execute(false);
         assert.equal(this.instance.option("snapToGrid"), false);
     });
-    test("should change gridSize property", (assert) => {
+    test("should change gridSize property", function(assert) {
         assert.equal(this.instance._diagramInstance.settings.gridSize, 180);
         this.instance.option("gridSize", 0.25);
         assert.equal(this.instance._diagramInstance.settings.gridSize, 360);
         this.instance.option("gridSize", 0.125);
         assert.equal(this.instance._diagramInstance.settings.gridSize, 180);
     });
-    test("should sync gridSize property", (assert) => {
+    test("should sync gridSize property", function(assert) {
         assert.equal(this.instance.option("gridSize"), 0.125);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.GridSize).execute(0.25);
         assert.equal(this.instance.option("gridSize"), 0.25);
     });
-    test("should change gridSize object property", (assert) => {
+    test("should change gridSize object property", function(assert) {
         assert.equal(this.instance._diagramInstance.settings.gridSize, 180);
         assert.equal(this.instance._diagramInstance.settings.gridSizeItems.length, 4);
         this.instance.option("gridSize", { value: 0.25, items: [0.25, 1] });
@@ -436,39 +436,39 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal(this.instance._diagramInstance.settings.gridSize, 180);
         assert.equal(this.instance._diagramInstance.settings.gridSizeItems.length, 2);
     });
-    test("should sync gridSize object property", (assert) => {
+    test("should sync gridSize object property", function(assert) {
         this.instance.option("gridSize", { value: 0.25, items: [0.125, 0.25, 1] });
         assert.equal(this.instance.option("gridSize.value"), 0.25);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.GridSize).execute(1);
         assert.equal(this.instance.option("gridSize.value"), 1);
     });
-    test("should change viewUnits property", (assert) => {
+    test("should change viewUnits property", function(assert) {
         assert.equal(this.instance._diagramInstance.settings.viewUnits, 0);
         this.instance.option("viewUnits", "cm");
         assert.equal(this.instance._diagramInstance.settings.viewUnits, 1);
         this.instance.option("viewUnits", "in");
         assert.equal(this.instance._diagramInstance.settings.viewUnits, 0);
     });
-    test("should sync viewUnits property", (assert) => {
+    test("should sync viewUnits property", function(assert) {
         assert.equal(this.instance.option("viewUnits"), "in");
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.ViewUnits).execute(1);
         assert.equal(this.instance.option("viewUnits"), "cm");
     });
-    test("should change units property", (assert) => {
+    test("should change units property", function(assert) {
         assert.equal(this.instance._diagramInstance.model.units, 0);
         this.instance.option("units", "cm");
         assert.equal(this.instance._diagramInstance.model.units, 1);
         this.instance.option("units", "in");
         assert.equal(this.instance._diagramInstance.model.units, 0);
     });
-    test("should change pageSize property", (assert) => {
+    test("should change pageSize property", function(assert) {
         assert.equal(this.instance._diagramInstance.model.pageSize.width, 8391);
         assert.equal(this.instance._diagramInstance.model.pageSize.height, 11906);
         this.instance.option("pageSize", { width: 3, height: 5 });
         assert.equal(this.instance._diagramInstance.model.pageSize.width, 4320);
         assert.equal(this.instance._diagramInstance.model.pageSize.height, 7200);
     });
-    test("should sync pageSize property", (assert) => {
+    test("should sync pageSize property", function(assert) {
         this.instance.option("pageSize", { width: 3, height: 5 });
         assert.equal(this.instance.option("pageSize.width"), 3);
         assert.equal(this.instance.option("pageSize.height"), 5);
@@ -476,7 +476,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal(this.instance.option("pageSize.width"), 4);
         assert.equal(this.instance.option("pageSize.height"), 6);
     });
-    test("should change pageSize object property", (assert) => {
+    test("should change pageSize object property", function(assert) {
         assert.equal(this.instance._diagramInstance.model.pageSize.width, 8391);
         assert.equal(this.instance._diagramInstance.model.pageSize.height, 11906);
         assert.equal(this.instance._diagramInstance.settings.pageSizeItems.length, 11);
@@ -485,7 +485,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal(this.instance._diagramInstance.model.pageSize.height, 7200);
         assert.equal(this.instance._diagramInstance.settings.pageSizeItems.length, 1);
     });
-    test("should sync pageSize object property", (assert) => {
+    test("should sync pageSize object property", function(assert) {
         this.instance.option("pageSize", { width: 3, height: 5, items: [{ width: 3, height: 5, text: "A10" }, { width: 4, height: 6, text: "A11" }] });
         assert.equal(this.instance.option("pageSize.width"), 3);
         assert.equal(this.instance.option("pageSize.height"), 5);
@@ -493,38 +493,38 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal(this.instance.option("pageSize.width"), 4);
         assert.equal(this.instance.option("pageSize.height"), 6);
     });
-    test("should change pageOrientation property", (assert) => {
+    test("should change pageOrientation property", function(assert) {
         assert.equal(this.instance._diagramInstance.model.pageLandscape, false);
         this.instance.option("pageOrientation", "landscape");
         assert.equal(this.instance._diagramInstance.model.pageLandscape, true);
         this.instance.option("pageOrientation", "portrait");
         assert.equal(this.instance._diagramInstance.model.pageLandscape, false);
     });
-    test("should sync pageOrientation property", (assert) => {
+    test("should sync pageOrientation property", function(assert) {
         assert.equal(this.instance.option("pageOrientation"), "portrait");
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.PageLandscape).execute(1);
         assert.equal(this.instance.option("pageOrientation"), "landscape");
     });
-    test("should change pageColor property", (assert) => {
+    test("should change pageColor property", function(assert) {
         assert.equal(this.instance._diagramInstance.model.pageColor, -1); // FFFFFF
         this.instance.option("pageColor", "red");
         assert.equal(this.instance._diagramInstance.model.pageColor, -65536); // FF0000
         this.instance.option("pageColor", "white");
         assert.equal(this.instance._diagramInstance.model.pageColor, -1); // FFFFFF
     });
-    test("should sync pageColor property", (assert) => {
+    test("should sync pageColor property", function(assert) {
         assert.equal(this.instance.option("pageColor"), "#ffffff");
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.PageColor).execute("red");
         assert.equal(this.instance.option("pageColor"), "#ff0000"); // FF0000
     });
-    test("should change simpleView property", (assert) => {
+    test("should change simpleView property", function(assert) {
         assert.equal(this.instance._diagramInstance.settings.simpleView, false);
         this.instance.option("simpleView", true);
         assert.equal(this.instance._diagramInstance.settings.simpleView, true);
         this.instance.option("simpleView", false);
         assert.equal(this.instance._diagramInstance.settings.simpleView, false);
     });
-    test("should sync simpleView property", (assert) => {
+    test("should sync simpleView property", function(assert) {
         assert.equal(this.instance.option("simpleView"), false);
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.ToggleSimpleView).execute(true);
         assert.equal(this.instance.option("simpleView"), true);
@@ -532,16 +532,16 @@ QUnit.module("Options", moduleConfig, () => {
 });
 
 QUnit.module("ClientSideEvents", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
-        moduleConfig.beforeEach();
+        moduleConfig.beforeEach.apply(this, arguments);
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         this.clock.reset();
     }
 }, () => {
-    test("click on unbound diagram", (assert) => {
+    test("click on unbound diagram", function(assert) {
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.Import).execute(SIMPLE_DIAGRAM);
         var clickedItem;
         this.instance.option("onItemClick", function(e) {
@@ -551,7 +551,7 @@ QUnit.module("ClientSideEvents", {
         assert.equal(clickedItem.id, "107");
         assert.equal(clickedItem.text, "A new ticket");
     });
-    test("selectionchanged on unbound diagram", (assert) => {
+    test("selectionchanged on unbound diagram", function(assert) {
         this.instance._diagramInstance.commandManager.getCommand(DiagramCommand.Import).execute(SIMPLE_DIAGRAM);
         var selectedItems;
         this.instance.option("onSelectionChanged", function(e) {
@@ -562,7 +562,7 @@ QUnit.module("ClientSideEvents", {
         assert.equal(selectedItems[0].id, "107");
         assert.equal(selectedItems[0].text, "A new ticket");
     });
-    test("click on bound diagram", (assert) => {
+    test("click on bound diagram", function(assert) {
         this.instance.option("nodes.keyExpr", "key");
         this.instance.option("nodes.textExpr", "text");
         this.instance.option("edges.keyExpr", "key");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1420883/69522389-4cf47900-0f72-11ea-853f-a9e032cdd307.png)

Clarification:
---

> QUnit test and module callbacks can share state by modifying properties of `this` within those callbacks.
> 
> This only works when using function expressions, which allow for dynamic binding of `this` by the QUnit library. Arrow function expressions will not work in this case, because arrow functions will always bind to whatever the value of `this` was in the enclosing scope (in QUnit tests, usually the global object). This means that developers who use arrow function expressions as test or module callbacks will not be able to share state and may encounter other problems.

See https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md