### PR TITLE
Editors: Fix globals in tests

### DIFF
--- a/testing/helpers/registerKeyHandlerTestHelper.js
+++ b/testing/helpers/registerKeyHandlerTestHelper.js
@@ -11,7 +11,7 @@ const registerKeyHandlerTestHelper = {
         const { createWidget, keyPressTargetElement, checkInitialize, testNamePrefix } = config;
 
         module("RegisterKeyHandler", {
-            beforeEach: () => {
+            beforeEach: function() {
                 this.handler = sinon.spy();
 
                 this.createWidget = (options = {}) => {
@@ -29,13 +29,13 @@ const registerKeyHandlerTestHelper = {
                     assert.ok(this.keyPressTargetElement.is(args.target), "event.target");
                 };
             },
-            afterEach: () => {
+            afterEach: function() {
                 this.$widget.remove();
             }
         }, () => {
             SUPPORTED_KEYS.forEach((key) => {
                 if(checkInitialize) {
-                    test(`${testNamePrefix || ''} RegisterKeyHandler -> onInitialize - "${key}"`, () => {
+                    test(`${testNamePrefix || ''} RegisterKeyHandler -> onInitialize - "${key}"`, function(assert) {
                         this.createWidget({ onInitialized: e => { e.component.registerKeyHandler(key, this.handler); } });
 
                         keyboardMock(this.keyPressTargetElement).press(key);
@@ -43,7 +43,7 @@ const registerKeyHandlerTestHelper = {
                     });
                 }
 
-                test(`${testNamePrefix || ''} RegisterKeyHandler -> "${key}"`, () => {
+                test(`${testNamePrefix || ''} RegisterKeyHandler -> "${key}"`, function() {
                     this.createWidget();
 
                     this.widget.registerKeyHandler(key, this.handler);

--- a/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
@@ -31,7 +31,7 @@ function isDropDownButton($element) {
 }
 
 module("button collection", () => {
-    test("should render default buttons if the 'buttons' option is not defined", (assert) => {
+    test("should render default buttons if the 'buttons' option is not defined", function(assert) {
         const $textBox = $("<div>").dxTextBox({ showClearButton: true });
         const { $before, $after } = getTextEditorButtons($textBox);
 
@@ -39,7 +39,7 @@ module("button collection", () => {
         assert.strictEqual($after.length, 1);
     });
 
-    test("should not render default buttons if the collection is defined", (assert) => {
+    test("should not render default buttons if the collection is defined", function(assert) {
         const $textBox = $("<div>").dxTextBox({ buttons: [], showClearButton: true });
         const { $before, $after } = getTextEditorButtons($textBox);
 
@@ -47,7 +47,7 @@ module("button collection", () => {
         assert.notOk($after.length);
     });
 
-    test("should be an array", (assert) => {
+    test("should be an array", function(assert) {
         const checkException = (value) => {
             const textBox = $("<div>").dxTextBox({}).dxTextBox("instance");
 
@@ -59,7 +59,7 @@ module("button collection", () => {
     });
 
     module("button", () => {
-        test("should be a string or an object only", (assert) => {
+        test("should be a string or an object only", function(assert) {
             const checkException = (value) => {
                 const textBox = $("<div>").dxTextBox({}).dxTextBox("instance");
 
@@ -70,17 +70,17 @@ module("button collection", () => {
             [0, [], true, null, void 0].forEach(checkException);
         });
 
-        test("should not have buttons with same names", (assert) => {
+        test("should not have buttons with same names", function(assert) {
             assert.throws(() => $("<div>").dxTextBox({ buttons: ["clear", "clear"] }), errors.Error("E1055", "clear"));
             assert.throws(() => $("<div>").dxTextBox({ buttons: [{ name: "name" }, { name: "name" }] }), errors.Error("E1055", "name"));
         });
 
         module("fields", () => {
-            test("'name' filed should be defined for custom buttons", (assert) => {
+            test("'name' filed should be defined for custom buttons", function(assert) {
                 assert.throws(() => $("<div>").dxTextBox({ buttons: [{}] }), errors.Error("E1054"));
             });
 
-            test("'name' filed should be a string", (assert) => {
+            test("'name' filed should be a string", function(assert) {
                 const checkException = (value) => {
                     const textBox = $("<div>").dxTextBox({}).dxTextBox("instance");
 
@@ -91,7 +91,7 @@ module("button collection", () => {
                 [1, [], {}, false, null, void 0].forEach(checkException);
             });
 
-            test("'location' field should be 'after' or 'before' string only", (assert) => {
+            test("'location' field should be 'after' or 'before' string only", function(assert) {
                 const $textBox = $("<div>").dxTextBox({ buttons: [{ name: "name", location: "incorrect" }] });
                 const { $before, $after } = getTextEditorButtons($textBox);
 
@@ -99,7 +99,7 @@ module("button collection", () => {
                 assert.strictEqual($after.length, 1);
             });
 
-            test("'options' and 'location' fields should not be required", (assert) => {
+            test("'options' and 'location' fields should not be required", function(assert) {
                 const $textBox = $("<div>").dxTextBox({ buttons: [{ name: "name1" }, { name: "name2" }] });
                 const { $before, $after } = getTextEditorButtons($textBox);
 
@@ -107,7 +107,7 @@ module("button collection", () => {
                 assert.strictEqual($after.length, 2);
             });
 
-            test("custom button should skip content template from the integrationOptions", (assert) => {
+            test("custom button should skip content template from the integrationOptions", function(assert) {
                 const $textBox = $("<div>").dxTextBox({ buttons: [{ name: "name1" }] });
                 const buttons = getTextEditorButtons($textBox);
                 const button = buttons.$after.eq(0).dxButton("instance");
@@ -119,7 +119,7 @@ module("button collection", () => {
 });
 
 module("API", () => {
-    test("'getButton' method should returns action button instance", (assert) => {
+    test("'getButton' method should returns action button instance", function(assert) {
         const selectBox = $("<div>")
             .dxSelectBox({
                 showClearButton: true,
@@ -146,7 +146,7 @@ module("rendering", () => {
     }
 
     module("textBox", () => {
-        test("custom button options should be applied", (assert) => {
+        test("custom button options should be applied", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: false,
                 buttons: [{
@@ -163,7 +163,7 @@ module("rendering", () => {
             assert.strictEqual($after.text(), "custom");
         });
 
-        test("editor with button should have smaller placeholder than the editor without buttons", (assert) => {
+        test("editor with button should have smaller placeholder than the editor without buttons", function(assert) {
             const $textBox = $("<div>").appendTo("body").dxTextBox({
                 width: 150,
                 placeholder: "Test long text example",
@@ -187,7 +187,7 @@ module("rendering", () => {
         });
 
 
-        test("should not render 'clear' button if showClearButton is false", (assert) => {
+        test("should not render 'clear' button if showClearButton is false", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: false,
                 buttons: ["clear"],
@@ -199,7 +199,7 @@ module("rendering", () => {
             assert.strictEqual(getButtonPlaceHolders($after).length, 1);
         });
 
-        test("should render 'clear' button only after it becomes visible", (assert) => {
+        test("should render 'clear' button only after it becomes visible", function(assert) {
             const $textBox = $("<div>").dxTextBox({});
             const textBox = $textBox.dxTextBox("instance");
             let { $before, $after } = getTextEditorButtons($textBox);
@@ -221,7 +221,7 @@ module("rendering", () => {
             assert.ok(isClearButton($after.eq(0)));
         });
 
-        test("should render predefined button ('clear')", (assert) => {
+        test("should render predefined button ('clear')", function(assert) {
             const $textBox = $("<div>").dxTextBox({ showClearButton: true, buttons: ["clear"] });
             const { $before, $after } = getTextEditorButtons($textBox);
 
@@ -230,17 +230,17 @@ module("rendering", () => {
             assert.notOk(getButtonPlaceHolders($after).length);
         });
 
-        test("should render predefined button ('clear') configurated as object", (assert) => {
+        test("should render predefined button ('clear') configurated as object", function(assert) {
             const $textBox = $("<div>").dxTextBox({ showClearButton: true, buttons: [{ name: "clear" }] });
             let $after = getTextEditorButtons($textBox).$after;
             assert.ok(isClearButton($after.eq(0)));
         });
 
-        test("should have only 'clear' predefined button", (assert) => {
+        test("should have only 'clear' predefined button", function(assert) {
             assert.throws(() => $("<div>").dxTextBox({ buttons: ["fakeButtonName"] }), errors.Error("E1056", "dxTextBox", "fakeButtonName"));
         });
 
-        test("predefined button should ignore 'location' or 'options' fields in predefined button configuration", (assert) => {
+        test("predefined button should ignore 'location' or 'options' fields in predefined button configuration", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 value: "text",
                 showClearButton: true,
@@ -255,7 +255,7 @@ module("rendering", () => {
             assert.strictEqual($after.eq(0).text(), "");
         });
 
-        test("custom button with location 'before' should be rendered", (assert) => {
+        test("custom button with location 'before' should be rendered", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: false,
                 value: "text",
@@ -273,7 +273,7 @@ module("rendering", () => {
             assert.strictEqual($after.length, 0);
         });
 
-        test("custom button with location 'after' should be rendered", (assert) => {
+        test("custom button with location 'after' should be rendered", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: false,
                 value: "text",
@@ -291,7 +291,7 @@ module("rendering", () => {
             assert.strictEqual($before.length, 0);
         });
 
-        test("custom button should not change the widget height", (assert) => {
+        test("custom button should not change the widget height", function(assert) {
             const $textBox = $("<div>").appendTo("#qunit-fixture").dxTextBox({
                 value: "text",
                 stylingMode: "underlined"
@@ -310,7 +310,7 @@ module("rendering", () => {
             assert.strictEqual($textBox.height(), startHeight);
         });
 
-        test("custom button should be disabled in readOnly state by default", (assert) => {
+        test("custom button should be disabled in readOnly state by default", function(assert) {
             const textBox = $("<div>").appendTo("#qunit-fixture").dxTextBox({
                 value: "text",
                 buttons: [
@@ -332,7 +332,7 @@ module("rendering", () => {
             assert.notOk(button.option("disabled"), "button is enabled");
         });
 
-        test("custom button should not be disabled in readOnly state if it was specified by a user", (assert) => {
+        test("custom button should not be disabled in readOnly state if it was specified by a user", function(assert) {
             const textBox = $("<div>").appendTo("#qunit-fixture").dxTextBox({
                 value: "text",
                 buttons: [
@@ -358,7 +358,7 @@ module("rendering", () => {
     });
 
     module("numberBox", () => {
-        test("widget should not render a clear button if 'buttons' option have no string for it", (assert) => {
+        test("widget should not render a clear button if 'buttons' option have no string for it", function(assert) {
             const $numberBox = $("<div>").dxNumberBox({
                 showClearButton: true,
                 showSpinButtons: true,
@@ -371,7 +371,7 @@ module("rendering", () => {
             assert.ok(isSpinButton($after.eq(0)));
         });
 
-        test("should render 'spins' buttons only after they become visible", (assert) => {
+        test("should render 'spins' buttons only after they become visible", function(assert) {
             const $numberBox = $("<div>").dxNumberBox({ showClearButton: true });
             const numberBox = $numberBox.dxNumberBox("instance");
             let { $before, $after } = getTextEditorButtons($numberBox);
@@ -393,7 +393,7 @@ module("rendering", () => {
             assert.notOk(getButtonPlaceHolders($after).length);
         });
 
-        test("should render predefined buttons ('clear', 'spins')", (assert) => {
+        test("should render predefined buttons ('clear', 'spins')", function(assert) {
             const $numberBox = $("<div>").dxNumberBox({
                 showClearButton: true,
                 showSpinButtons: true,
@@ -406,7 +406,7 @@ module("rendering", () => {
             assert.strictEqual(getButtonPlaceHolders($after).length, 0);
         });
 
-        test("should render predefined buttons ('clear', 'spins') configurated as object", (assert) => {
+        test("should render predefined buttons ('clear', 'spins') configurated as object", function(assert) {
             const $numberBox = $("<div>").dxNumberBox({
                 showClearButton: true,
                 showSpinButtons: true,
@@ -420,11 +420,11 @@ module("rendering", () => {
             assert.strictEqual(getButtonPlaceHolders($after).length, 0);
         });
 
-        test("should have only 'clear', 'spins' predefined buttons", (assert) => {
+        test("should have only 'clear', 'spins' predefined buttons", function(assert) {
             assert.throws(() => $("<div>").dxNumberBox({ buttons: ["fakeButtonName"] }), errors.Error("E1056", "dxNumberBox", "fakeButtonName"));
         });
 
-        test("predefined buttons should ignore 'location' or 'options' fields in predefined button configuration", (assert) => {
+        test("predefined buttons should ignore 'location' or 'options' fields in predefined button configuration", function(assert) {
             const $numberBox = $("<div>").dxNumberBox({
                 value: 1,
                 showClearButton: true,
@@ -443,7 +443,7 @@ module("rendering", () => {
     });
 
     module("dropDownEditors", () => {
-        test("should render drop down button", (assert) => {
+        test("should render drop down button", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({ buttons: ["dropDown"], items: ["1", "2"], value: "1" });
             const $after = getTextEditorButtons($selectBox).$after;
 
@@ -451,7 +451,7 @@ module("rendering", () => {
             assert.ok(isDropDownButton($after.eq(0)));
         });
 
-        test("should render 'dropDown' button only after it becomes visible", (assert) => {
+        test("should render 'dropDown' button only after it becomes visible", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({ showClearButton: true, showDropDownButton: false });
             const selectBox = $selectBox.dxSelectBox("instance");
             let { $before, $after } = getTextEditorButtons($selectBox);
@@ -473,7 +473,7 @@ module("rendering", () => {
             assert.notOk(getButtonPlaceHolders($after).length);
         });
 
-        test("should render predefined buttons ('clear', 'dropDown')", (assert) => {
+        test("should render predefined buttons ('clear', 'dropDown')", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({ showClearButton: true, buttons: ["clear", "dropDown"] });
             const { $before, $after } = getTextEditorButtons($selectBox);
 
@@ -482,7 +482,7 @@ module("rendering", () => {
             assert.strictEqual(getButtonPlaceHolders($after).length, 0);
         });
 
-        test("should render predefined buttons ('clear', 'dropDown') configurated as object", (assert) => {
+        test("should render predefined buttons ('clear', 'dropDown') configurated as object", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({
                 showClearButton: true,
                 buttons: [{ name: "clear" }, { name: "dropDown" }]
@@ -494,11 +494,11 @@ module("rendering", () => {
             assert.strictEqual(getButtonPlaceHolders($after).length, 0);
         });
 
-        test("should have only 'clear', 'dropDown' predefined button", (assert) => {
+        test("should have only 'clear', 'dropDown' predefined button", function(assert) {
             assert.throws(() => $("<div>").dxSelectBox({ buttons: ["fakeButtonName"] }), errors.Error("E1056", "dxSelectBox", "fakeButtonName"));
         });
 
-        test("predefined buttons should ignore 'location' or 'options' fields in predefined button configuration", (assert) => {
+        test("predefined buttons should ignore 'location' or 'options' fields in predefined button configuration", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({
                 items: ["1", "2"],
                 value: "1",
@@ -515,7 +515,7 @@ module("rendering", () => {
             assert.strictEqual($after.eq(1).text(), "");
         });
 
-        test("buttons is rendered with fieldTemplate", (assert) => {
+        test("buttons is rendered with fieldTemplate", function(assert) {
             const $selectBox = $("<div>").appendTo("#qunit-fixture").dxSelectBox({
                 showClearButton: true,
                 items: ["1", "2"],
@@ -539,7 +539,7 @@ module("rendering", () => {
             assert.ok(isDropDownButton($after.eq(2)));
         });
 
-        test("buttons should not be rendered for the textBox in the dropDownBox fieldTemplate by default", (assert) => {
+        test("buttons should not be rendered for the textBox in the dropDownBox fieldTemplate by default", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({
                 showClearButton: true,
                 buttons: [{
@@ -564,7 +564,7 @@ module("rendering", () => {
             assert.strictEqual(getButtonPlaceHolders($textBoxAfter).length, 1);
         });
 
-        test("buttons can be rendered for the textBox in the dropDownBox fieldTemplate", (assert) => {
+        test("buttons can be rendered for the textBox in the dropDownBox fieldTemplate", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({
                 showClearButton: true,
                 buttons: [{
@@ -597,7 +597,7 @@ module("rendering", () => {
 module("reordering", () => {
 
     module("textBox", () => {
-        test("custom button with location 'after' should be rendered after the clear button", (assert) => {
+        test("custom button with location 'after' should be rendered after the clear button", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: true,
                 buttons: [
@@ -618,7 +618,7 @@ module("reordering", () => {
             assert.strictEqual($after.eq(1).text(), "custom");
         });
 
-        test("the group of predefined and custom buttons should have correct order", (assert) => {
+        test("the group of predefined and custom buttons should have correct order", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: true,
                 buttons: [{
@@ -655,7 +655,7 @@ module("reordering", () => {
             assert.strictEqual($after.eq(2).text(), "after2");
         });
 
-        test("buttons should have correct order if 'before' custom button is after 'after' buttons in the 'buttons' array", (assert) => {
+        test("buttons should have correct order if 'before' custom button is after 'after' buttons in the 'buttons' array", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: true,
                 buttons: ["clear", {
@@ -687,7 +687,7 @@ module("reordering", () => {
 
     module("numberBox", () => {
 
-        test("buttons option can reorder predefined buttons", (assert) => {
+        test("buttons option can reorder predefined buttons", function(assert) {
             const $numberBox = $("<div>").dxNumberBox({
                 showClearButton: true,
                 showSpinButtons: true,
@@ -699,7 +699,7 @@ module("reordering", () => {
             assert.ok(isClearButton($after.eq(1)));
         });
 
-        test("widget should render custom and predefined buttons in the right order", (assert) => {
+        test("widget should render custom and predefined buttons in the right order", function(assert) {
             const $numberBox = $("<div>").dxNumberBox({
                 showClearButton: true,
                 showSpinButtons: true,
@@ -743,7 +743,7 @@ module("reordering", () => {
     });
 
     module("dropDownEditors", () => {
-        test("buttons option can reorder predefined buttons", (assert) => {
+        test("buttons option can reorder predefined buttons", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({
                 showClearButton: true,
                 buttons: ["dropDown", "clear"],
@@ -755,7 +755,7 @@ module("reordering", () => {
             assert.ok(isClearButton($after.eq(1)));
         });
 
-        test("widget should render custom and predefined buttons in the right order", (assert) => {
+        test("widget should render custom and predefined buttons in the right order", function(assert) {
             const $selectBox = $("<div>").dxSelectBox({
                 showClearButton: true,
                 buttons: [{
@@ -801,7 +801,7 @@ module("reordering", () => {
 module("collection updating", () => {
 
     module("textBox", () => {
-        test("it is able to change internal custom button option", (assert) => {
+        test("it is able to change internal custom button option", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: true,
                 buttons: ["clear", {
@@ -826,7 +826,7 @@ module("collection updating", () => {
             assert.ok(isClearButton($after.eq(0)));
         });
 
-        test("it is able to reorder buttons", (assert) => {
+        test("it is able to reorder buttons", function(assert) {
             const customButtonConfig = {
                 name: "custom",
                 location: "after",
@@ -849,7 +849,7 @@ module("collection updating", () => {
             assert.ok(isClearButton($after.eq(1)));
         });
 
-        test("it is able to change buttons", (assert) => {
+        test("it is able to change buttons", function(assert) {
             const customButtonConfig = {
                 name: "custom",
                 location: "after",
@@ -884,7 +884,7 @@ module("collection updating", () => {
             assert.ok(isClearButton($after.eq(0)));
         });
 
-        test("buttons and showClearButton options should control clear button visibility", (assert) => {
+        test("buttons and showClearButton options should control clear button visibility", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: true,
                 buttons: ["clear"],
@@ -909,7 +909,7 @@ module("collection updating", () => {
             assert.ok($after.eq(0).is(":hidden"));
         });
 
-        test("custom button should have 'text' styling mode by default if editor has stylingMode = 'underlined'", (assert) => {
+        test("custom button should have 'text' styling mode by default if editor has stylingMode = 'underlined'", function(assert) {
             const $textBox = $("<div>").dxTextBox({
                 showClearButton: false,
                 stylingMode: "underlined",
@@ -934,7 +934,7 @@ module("collection updating", () => {
     });
 
     module("numberBox", () => {
-        test("number box should work with 'buttons' option", (assert) => {
+        test("number box should work with 'buttons' option", function(assert) {
             const $numberBox = $("<div>").dxNumberBox({
                 showSpinButtons: true,
                 buttons: ["spins"],
@@ -962,7 +962,7 @@ module("collection updating", () => {
     });
 
     module("dropDownEditors", () => {
-        test("Drop button template should work with 'buttons' option", (assert) => {
+        test("Drop button template should work with 'buttons' option", function(assert) {
             const buttonTemplate = () => "<div>Template</div>";
             const $selectBox = $("<div>").dxSelectBox({
                 items: ["1", "2"]
@@ -993,7 +993,7 @@ module("collection updating", () => {
 
 
 module("events", () => {
-    test("should use CUSTOM_BUTTON_HOVERED_CLASS to prevent predefined button hover styling while custom button is hovered", (assert) => {
+    test("should use CUSTOM_BUTTON_HOVERED_CLASS to prevent predefined button hover styling while custom button is hovered", function(assert) {
         const $textBox = $("<div>").dxTextBox({
             value: "text",
             buttons: [{
@@ -1017,7 +1017,7 @@ module("events", () => {
         assert.notOk($textBox.hasClass(CUSTOM_BUTTON_HOVERED_CLASS));
     });
 
-    test("should not open dropDown editor after custom button click", (assert) => {
+    test("should not open dropDown editor after custom button click", function(assert) {
         const spy = sinon.spy();
         const selectBox = $("<div>").dxSelectBox({
             items: ["1", "2"],

--- a/testing/tests/DevExpress.ui.widgets.editors/autocomplete.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/autocomplete.markup.tests.js
@@ -123,7 +123,7 @@ QUnit.module("aria accessibility", {}, () => {
         assert.equal($input.attr("aria-autocomplete"), "inline");
     });
 
-    QUnit.test("aria role should not change to listbox after it's second rendering (T290859)", assert => {
+    QUnit.test("aria role should not change to listbox after it's second rendering (T290859)", function(assert) {
         assert.expect(2);
 
         const $element = $("#widget").dxAutocomplete({

--- a/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
@@ -52,7 +52,7 @@ const KEY_ESC = "Escape";
 const KEY_TAB = "Tab";
 
 QUnit.module("dxAutocomplete", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         executeAsyncMock.setup();
         Autocomplete.defaultOptions({ options: { deferRendering: false } });
@@ -69,21 +69,21 @@ QUnit.module("dxAutocomplete", {
         this.popup = this.instance._popup;
         this.keyboard = keyboardMock(this.$input);
     },
-    afterEach: () => {
+    afterEach: function() {
         executeAsyncMock.teardown();
         fx.off = false;
 
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("popup init", (assert) => {
+    QUnit.test("popup init", function(assert) {
         assert.ok(this.popup._wrapper().hasClass("dx-autocomplete-popup-wrapper"), "popup wrapper class set");
 
         this.instance.option("value", "i");
         assert.equal($(".dx-viewport " + "." + LIST_CLASS).length, 1, "Element has " + LIST_CLASS + " class");
     });
 
-    QUnit.test("dataSource init", assert => {
+    QUnit.test("dataSource init", function(assert) {
         const element = $("#autocomplete2").dxAutocomplete({
             value: "anotherText",
             dataSource: ["qwerty", "item 2", "item 3"]
@@ -94,7 +94,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(instance._dataSource.items()[0], "qwerty", "autocomplete-s dataSource initialization");
     });
 
-    QUnit.test("Resize by option", assert => {
+    QUnit.test("Resize by option", function(assert) {
         const setUpWidth = 456;
         const setUpHeight = 1000;
 
@@ -129,7 +129,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(dWidth, dPopupWidth + autocomplete.option("popupWidthExtension"), "Element and popup change width accordingly");
     });
 
-    QUnit.test("check textbox sizes", assert => {
+    QUnit.test("check textbox sizes", function(assert) {
         const element = $("#autocomplete2").dxAutocomplete({
             value: "anotherText",
             dataSource: ["qwerty", "item 2", "item 3"],
@@ -147,7 +147,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(element.height(), instance.option("height"), "textbox height is right");
     });
 
-    QUnit.test("dataSource support", (assert) => {
+    QUnit.test("dataSource support", function(assert) {
         const newData = ["item1", "item2"];
         this.instance.option("dataSource", newData);
         this.instance.option("minSearchLength", 0);
@@ -158,7 +158,7 @@ QUnit.module("dxAutocomplete", {
         assert.deepEqual(this.instance._list._dataSource.items(), ["item3", "item4"], "init with dx.data.ArrayStore");
     });
 
-    QUnit.testInActiveWindow("list showing/hiding", (assert) => {
+    QUnit.testInActiveWindow("list showing/hiding", function(assert) {
         const keyboard = this.keyboard;
         let $list;
 
@@ -188,7 +188,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal($list.is(":hidden"), true, "when we select list-s item with -enter- key, list is hidden");
     });
 
-    QUnit.test("Enter and escape key press prevent default when popup in opened", (assert) => {
+    QUnit.test("Enter and escape key press prevent default when popup in opened", function(assert) {
         assert.expect(1);
 
         let prevented = 0;
@@ -211,7 +211,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(prevented, 2, "defaults prevented on enter and escape keys");
     });
 
-    QUnit.test("Enter and escape key press does not prevent default when popup in not opened", (assert) => {
+    QUnit.test("Enter and escape key press does not prevent default when popup in not opened", function(assert) {
         assert.expect(1);
 
         let prevented = 0;
@@ -230,7 +230,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(prevented, 0, "defaults has not prevented on enter and escape keys");
     });
 
-    QUnit.test("item click sets value", (assert) => {
+    QUnit.test("item click sets value", function(assert) {
         let $list;
 
         $list = this.instance._list._$element;
@@ -243,7 +243,7 @@ QUnit.module("dxAutocomplete", {
         assert.ok(!this.$input.is(":focus"), "after select value we drop focus from input");
     });
 
-    QUnit.testInActiveWindow("open/close actions", (assert) => {
+    QUnit.testInActiveWindow("open/close actions", function(assert) {
         let openFired = 0;
         let closeFired = 0;
 
@@ -266,7 +266,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(closeFired, 1, "close fired once");
     });
 
-    QUnit.testInActiveWindow("should not open overlay if the focus has been lost (T712942)", (assert) => {
+    QUnit.testInActiveWindow("should not open overlay if the focus has been lost (T712942)", function(assert) {
         const done = assert.async();
         let isOpenFired = false;
 
@@ -298,7 +298,7 @@ QUnit.module("dxAutocomplete", {
         }, 20);
     });
 
-    QUnit.test("onEnterKey (T107163)", (assert) => {
+    QUnit.test("onEnterKey (T107163)", function(assert) {
         let enterKeyFired = 0;
 
         this.instance.option({
@@ -311,7 +311,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(enterKeyFired, 1, "onEnterKey fired once");
     });
 
-    QUnit.testInActiveWindow("minimal search length", (assert) => {
+    QUnit.testInActiveWindow("minimal search length", function(assert) {
         let $list;
 
         this.element.dxAutocomplete({
@@ -329,7 +329,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal($list.is(":hidden"), false, "when enter second char, list shows all items");
     });
 
-    QUnit.testInActiveWindow("Typing shows the list with async data source", (assert) => {
+    QUnit.testInActiveWindow("Typing shows the list with async data source", function(assert) {
         const instance = this.instance;
         const deferred = new $.Deferred();
         let searchValue;
@@ -360,7 +360,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(searchValue, "q");
     });
 
-    QUnit.test("'searchTimeout' sets interval between list filtering", (assert) => {
+    QUnit.test("'searchTimeout' sets interval between list filtering", function(assert) {
         const instance = this.instance;
 
         this.element.dxAutocomplete({
@@ -376,7 +376,7 @@ QUnit.module("dxAutocomplete", {
         assert.deepEqual(instance._dataSource.items(), ["qwerty"], "dataSource is filtered after timeout");
     });
 
-    QUnit.test("'change event' is called once", (assert) => {
+    QUnit.test("'change event' is called once", function(assert) {
         const instance = this.instance;
         this.element.dxAutocomplete({
             value: null,
@@ -392,7 +392,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(instance.option("value"), "item2");
     });
 
-    QUnit.testInActiveWindow("list is shown when key was pressed and there was items to show", (assert) => {
+    QUnit.testInActiveWindow("list is shown when key was pressed and there was items to show", function(assert) {
         const instance = this.instance;
         this.element.dxAutocomplete({
             value: null,
@@ -406,7 +406,7 @@ QUnit.module("dxAutocomplete", {
         assert.ok($list.is(":visible"), "when key press and input not empty, list is visible");
     });
 
-    QUnit.test("interrupt searchTimeout by new timer", (assert) => {
+    QUnit.test("interrupt searchTimeout by new timer", function(assert) {
         const instance = this.instance;
         const keyboard = this.keyboard;
         let time = 0;
@@ -438,7 +438,7 @@ QUnit.module("dxAutocomplete", {
         }
     });
 
-    QUnit.test("arrow_down/arrow_up/enter provide item navigation and selection", (assert) => {
+    QUnit.test("arrow_down/arrow_up/enter provide item navigation and selection", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -513,7 +513,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal($selectedItem.text(), "item 2", "when we press 'key_up', we select 'item 2'");
     });
 
-    QUnit.test("down arrow should move focus through the groups", assert => {
+    QUnit.test("down arrow should move focus through the groups", function(assert) {
         const $element = $("#widget").dxAutocomplete({
             searchExpr: "text",
             value: null,
@@ -546,7 +546,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(instance.option("value"), "Item 2", "value is correct");
     });
 
-    QUnit.testInActiveWindow("key_tab for autocomplete current value", (assert) => {
+    QUnit.testInActiveWindow("key_tab for autocomplete current value", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -568,7 +568,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(instance.option("value"), "item 1", "when press 'tab', replace input value with top list item");
     });
 
-    QUnit.test("key_up/key_down - prevent default", (assert) => {
+    QUnit.test("key_up/key_down - prevent default", function(assert) {
         assert.expect(2);
 
         const instance = this.instance;
@@ -589,7 +589,7 @@ QUnit.module("dxAutocomplete", {
             .keyDown(KEY_UP);
     });
 
-    QUnit.testInActiveWindow("enter - prevent default", (assert) => {
+    QUnit.testInActiveWindow("enter - prevent default", function(assert) {
         assert.expect(1);
 
         if(devices.real().deviceType !== "desktop") {
@@ -615,7 +615,7 @@ QUnit.module("dxAutocomplete", {
         keyboard.keyDown(KEY_ENTER);
     });
 
-    QUnit.test("try to autocomplete current value when type missing searchValue", (assert) => {
+    QUnit.test("try to autocomplete current value when type missing searchValue", function(assert) {
         const keyboard = this.keyboard;
 
         this.element.dxAutocomplete({
@@ -630,7 +630,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(this.instance.option("value"), "l", "when press 'tab' and list hidden, input value still unchanged");
     });
 
-    QUnit.testInActiveWindow("esc_key close list", (assert) => {
+    QUnit.testInActiveWindow("esc_key close list", function(assert) {
         let $list;
 
         $list = this.instance._list._$element;
@@ -643,7 +643,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal($list.is(":hidden"), true, "when press -esc- key, we hide list");
     });
 
-    QUnit.test("filter with non-default searchMode", (assert) => {
+    QUnit.test("filter with non-default searchMode", function(assert) {
         const instance = this.instance;
         const keyboard = this.keyboard;
 
@@ -657,7 +657,7 @@ QUnit.module("dxAutocomplete", {
         assert.deepEqual(instance._dataSource.items(), ["thing"], "element that starts with 't' letter was found");
     });
 
-    QUnit.test("search mode incorrect name raises exception", assert => {
+    QUnit.test("search mode incorrect name raises exception", function(assert) {
         assert.throws(() => {
             $("#autocomplete2").dxAutocomplete({
                 value: "",
@@ -679,7 +679,7 @@ QUnit.module("dxAutocomplete", {
         });
     });
 
-    QUnit.testInActiveWindow("using custom item template", assert => {
+    QUnit.testInActiveWindow("using custom item template", function(assert) {
         const element = $("#autocompleteTemplate").dxAutocomplete({
             value: "",
             dataSource: ["item 1", "item 2", "item 3"],
@@ -705,7 +705,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(instance.option("value"), "item 1", "send correct value to input when using custom template");
     });
 
-    QUnit.test("itemTemplate support", assert => {
+    QUnit.test("itemTemplate support", function(assert) {
         const instance = $("#autocomplete2").dxAutocomplete({
             dataSource: ["0", "1", "2"],
             itemTemplate(item) {
@@ -718,7 +718,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(items.text(), "item0item1item2");
     });
 
-    QUnit.test("valueExpr option", assert => {
+    QUnit.test("valueExpr option", function(assert) {
         const element = $("#autocomplete2").dxAutocomplete({
             value: "",
             searchTimeout: 0,
@@ -750,7 +750,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(items.eq(0).text(), "qa");
     });
 
-    QUnit.testInActiveWindow("using multifield datasource", assert => {
+    QUnit.testInActiveWindow("using multifield datasource", function(assert) {
         const element = $("#autocomplete2").dxAutocomplete({
             value: "",
             dataSource: [
@@ -785,7 +785,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(instance.option("value"), "ed", "send correct value to input when change 'valueExpr' option");
     });
 
-    QUnit.testInActiveWindow("using multifield datasource with template", assert => {
+    QUnit.testInActiveWindow("using multifield datasource with template", function(assert) {
         const element = $("#multifieldDS").dxAutocomplete({
             itemTemplate: "item",
             value: "",
@@ -817,7 +817,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(instance.option("value"), "item 1", "send correct value to input when using multifield datasource");
     });
 
-    QUnit.test("Manual datasource - search in datasource", (assert) => {
+    QUnit.test("Manual datasource - search in datasource", function(assert) {
         const keyboard = this.keyboard;
         let searchedString = null;
 
@@ -838,7 +838,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(searchedString, "t", "Search string should be passed to user-defined load method");
     });
 
-    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", assert => {
+    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         const autocomplete = $("#autocomplete2").dxAutocomplete({
             onValueChanged() {
                 assert.ok(true);
@@ -847,7 +847,7 @@ QUnit.module("dxAutocomplete", {
         autocomplete.option("value", true);
     });
 
-    QUnit.test("dxAutoComplete should not be opened when change the value from code (T141485)", (assert) => {
+    QUnit.test("dxAutoComplete should not be opened when change the value from code (T141485)", function(assert) {
         this.element.dxAutocomplete({
             dataSource: ["item1", "item2", "item3"],
             value: ""
@@ -858,7 +858,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(this.instance._popup.option("visible"), false, "drop down should not be shown");
     });
 
-    QUnit.testInActiveWindow("maxItemCount option test", assert => {
+    QUnit.testInActiveWindow("maxItemCount option test", function(assert) {
         assert.expect(2);
 
         const $autocomplete = $("#autocomplete2").dxAutocomplete({
@@ -884,7 +884,7 @@ QUnit.module("dxAutocomplete", {
         assert.equal(listItemsCount, autocompleteInstance.option("maxItemCount"), "drop down list items count is not equal to maxItemCount");
     });
 
-    QUnit.test("there should be no warnings after widget value is cleared (T386512)", assert => {
+    QUnit.test("there should be no warnings after widget value is cleared (T386512)", function(assert) {
         if(!window.console || !window.console.warn) {
             assert.ok(true, "the console object is not supported");
             return;
@@ -918,7 +918,7 @@ QUnit.module("dxAutocomplete", {
 });
 
 QUnit.module("Overlay integration", {
-    beforeEach: () => {
+    beforeEach: function() {
         executeAsyncMock.setup();
         fx.off = true;
         this.clock = sinon.useFakeTimers();
@@ -933,13 +933,13 @@ QUnit.module("Overlay integration", {
         this.popup = this.instance._popup.$element();
         this.keyboard = keyboardMock(this.$input);
     },
-    afterEach: () => {
+    afterEach: function() {
         executeAsyncMock.teardown();
         fx.off = false;
         this.clock.restore();
     }
 }, () => {
-    QUnit.testInActiveWindow("list animation jumps to end", (assert) => {
+    QUnit.testInActiveWindow("list animation jumps to end", function(assert) {
         const keyboard = this.keyboard;
         let $overlayContent;
 
@@ -956,7 +956,7 @@ QUnit.module("Overlay integration", {
         assert.equal($overlayContent.css("opacity"), 1, "when type, opacity is 1");
     });
 
-    QUnit.testInActiveWindow("popup height calculated correctly", (assert) => {
+    QUnit.testInActiveWindow("popup height calculated correctly", function(assert) {
         this.element.dxAutocomplete({
             value: "",
             dataSource: ["item 10", "item 20", "item 30"]
@@ -974,7 +974,7 @@ QUnit.module("Overlay integration", {
         assert.ok(popupHeightWithSingleItem < popupHeightWithAllItems, "height recalculated");
     });
 
-    QUnit.test("popup height is refreshed on window resize callback (B254555)", (assert) => {
+    QUnit.test("popup height is refreshed on window resize callback (B254555)", function(assert) {
         fx.off = true;
 
         const $popup = this.popup;
@@ -991,7 +991,7 @@ QUnit.module("Overlay integration", {
         assert.notEqual(testHeight, initialHeight, "initial height is restored after window resize callback");
     });
 
-    QUnit.test("popup showing calls list update (B254555)", (assert) => {
+    QUnit.test("popup showing calls list update (B254555)", function(assert) {
         fx.off = true;
         let listUpdated = 0;
 
@@ -1009,7 +1009,7 @@ QUnit.module("Overlay integration", {
         assert.equal(listUpdated, 1, "list updated once");
     });
 
-    QUnit.test("dxAutocomplete - popup list has vertical scroll when items count is small and scroll is not needed(T105434)", (assert) => {
+    QUnit.test("dxAutocomplete - popup list has vertical scroll when items count is small and scroll is not needed(T105434)", function(assert) {
         fx.off = true;
 
         const $popup = this.popup;
@@ -1025,7 +1025,7 @@ QUnit.module("Overlay integration", {
         assert.equal($scrollableContainer.outerHeight(), $popupContent.height());
     });
 
-    QUnit.testInActiveWindow("popup should not reopened on Enter key press", (assert) => {
+    QUnit.testInActiveWindow("popup should not reopened on Enter key press", function(assert) {
         assert.expect(1);
 
         fx.off = true;
@@ -1043,7 +1043,7 @@ QUnit.module("Overlay integration", {
         $(this.$input).trigger("change");
     });
 
-    QUnit.test("popup should be hidden after reset", (assert) => {
+    QUnit.test("popup should be hidden after reset", function(assert) {
         this.instance.option("value", "");
 
         this.keyboard.type("i");
@@ -1054,7 +1054,7 @@ QUnit.module("Overlay integration", {
 });
 
 QUnit.module("regressions", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         executeAsyncMock.setup();
         Autocomplete.defaultOptions({ options: { deferRendering: false } });
@@ -1077,14 +1077,14 @@ QUnit.module("regressions", {
         };
         this.popup = this.instance._popup;
     },
-    afterEach: () => {
+    afterEach: function() {
         executeAsyncMock.teardown();
         fx.off = false;
 
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("update input value on click", (assert) => {
+    QUnit.test("update input value on click", function(assert) {
         let $item;
         let mouse;
         let $list;
@@ -1100,7 +1100,7 @@ QUnit.module("regressions", {
         assert.equal(this.widgetValue(), "item 1", "widget value");
     });
 
-    QUnit.testInActiveWindow("update input value on press complete key", (assert) => {
+    QUnit.testInActiveWindow("update input value on press complete key", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1115,7 +1115,7 @@ QUnit.module("regressions", {
         assert.equal(this.widgetValue(), "item 1", "widget value");
     });
 
-    QUnit.testInActiveWindow("update input value on press enter key", (assert) => {
+    QUnit.testInActiveWindow("update input value on press enter key", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1130,7 +1130,7 @@ QUnit.module("regressions", {
         assert.equal(this.widgetValue(), "item 1", "widget value");
     });
 
-    QUnit.testInActiveWindow("when updating value option, input.val() do not updating twice", (assert) => {
+    QUnit.testInActiveWindow("when updating value option, input.val() do not updating twice", function(assert) {
         this.keyboard.type("i");
 
         assert.equal(this.inputValue(), "i", "input value");
@@ -1152,7 +1152,7 @@ QUnit.module("regressions", {
         assert.equal(this.widgetValue(), "ite", "widget value");
     });
 
-    QUnit.test("big dataSource loading", (assert) => {
+    QUnit.test("big dataSource loading", function(assert) {
         const instance = this.instance;
         const longArray = [];
         let arrayLength = 100;
@@ -1175,7 +1175,7 @@ QUnit.module("regressions", {
         assert.equal(instance._list.$element().find(".dx-list-item").length, 10);
     });
 
-    QUnit.test("B233605 autocomplete shows on short time", (assert) => {
+    QUnit.test("B233605 autocomplete shows on short time", function(assert) {
         executeAsyncMock.teardown();
 
         const instance = this.instance;
@@ -1194,7 +1194,7 @@ QUnit.module("regressions", {
         assert.equal(showCounter, 0, "autocomplete menu should not be shown");
     });
 
-    QUnit.testInActiveWindow("B233600 dxAutocomplete - Sometimes autocomplete shows redundant items", (assert) => {
+    QUnit.testInActiveWindow("B233600 dxAutocomplete - Sometimes autocomplete shows redundant items", function(assert) {
         assert.expect(5);
 
         executeAsyncMock.teardown();
@@ -1239,7 +1239,7 @@ QUnit.module("regressions", {
         this.clock.tick(1000);
     });
 
-    QUnit.test("B233813 dxAutocomplete - custom or non existing option change, cause additional autocomplete edit input instance.", (assert) => {
+    QUnit.test("B233813 dxAutocomplete - custom or non existing option change, cause additional autocomplete edit input instance.", function(assert) {
         executeAsyncMock.teardown();
         const instance = this.instance;
         const childrenCount = this.element.children().length;
@@ -1253,7 +1253,7 @@ QUnit.module("regressions", {
         assert.equal(numEditItems, 1, "we should have only one dx-texteditor-input in dxautocomplete instance");
     });
 
-    QUnit.test("B234608 check offset for iOS devices", assert => {
+    QUnit.test("B234608 check offset for iOS devices", function(assert) {
         let popup;
         let vOffset;
 
@@ -1271,7 +1271,7 @@ QUnit.module("regressions", {
         devices.current(null);
     });
 
-    QUnit.testInActiveWindow("B234649 if item not selected and pressed enter key - close popup", (assert) => {
+    QUnit.testInActiveWindow("B234649 if item not selected and pressed enter key - close popup", function(assert) {
         let $list;
         const keyboard = this.keyboard;
 
@@ -1283,7 +1283,7 @@ QUnit.module("regressions", {
         assert.equal($list.is(":hidden"), true, "when press enter key and item not selected - hide popup");
     });
 
-    QUnit.test("B238021", (assert) => {
+    QUnit.test("B238021", function(assert) {
         let $list;
         const $input = this.$input;
 
@@ -1297,7 +1297,7 @@ QUnit.module("regressions", {
         assert.ok($list.is(":hidden"), "close menu after input losts focus");
     });
 
-    QUnit.test("onValueChanged callback", (assert) => {
+    QUnit.test("onValueChanged callback", function(assert) {
         let called = 0;
 
         this.instance.option("valueChangeEvent", "change keyup");
@@ -1317,7 +1317,7 @@ QUnit.module("regressions", {
         assert.equal(called, 6);
     });
 
-    QUnit.test("clear button should save valueChangeEvent", (assert) => {
+    QUnit.test("clear button should save valueChangeEvent", function(assert) {
         const valueChangedHandler = sinon.spy();
 
         this.instance.option({
@@ -1334,7 +1334,7 @@ QUnit.module("regressions", {
         assert.equal(valueChangedHandler.getCall(0).args[0].event.type, "dxclick", "event is correct");
     });
 
-    QUnit.test("item initialization scenario", assert => {
+    QUnit.test("item initialization scenario", function(assert) {
         const instance = $("#autocomplete").dxAutocomplete({
             items: ["a", "b", "c"]
         }).dxAutocomplete("instance");
@@ -1344,7 +1344,7 @@ QUnit.module("regressions", {
         assert.equal(items.text(), "abc");
     });
 
-    QUnit.test("item option change scenario", assert => {
+    QUnit.test("item option change scenario", function(assert) {
         const instance = $("#autocomplete").dxAutocomplete({
             items: ["a", "b"]
         }).dxAutocomplete("instance");
@@ -1358,7 +1358,7 @@ QUnit.module("regressions", {
         assert.equal(items.text(), "abc");
     });
 
-    QUnit.test("B251208 - dxAutocomplete: cannot select text by keyboard", (assert) => {
+    QUnit.test("B251208 - dxAutocomplete: cannot select text by keyboard", function(assert) {
         $("#autocomplete").dxAutocomplete().dxAutocomplete("instance");
 
         this.$input.val("xxx");
@@ -1373,20 +1373,20 @@ QUnit.module("regressions", {
 });
 
 QUnit.module("widget sizing render", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("default", assert => {
+    QUnit.test("default", function(assert) {
         const $element = $("#widget").dxAutocomplete();
 
         assert.ok($element.outerWidth() > 0, "outer width of the element must be more than zero");
     });
 
-    QUnit.test("constructor", assert => {
+    QUnit.test("constructor", function(assert) {
         const $element = $("#widget").dxAutocomplete({ width: 400 });
         const instance = $element.dxAutocomplete("instance");
 
@@ -1394,12 +1394,12 @@ QUnit.module("widget sizing render", {
         assert.strictEqual($element.outerWidth(), 400, "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("root with custom width", assert => {
+    QUnit.test("root with custom width", function(assert) {
         const $element = $("#widthRootStyle").dxAutocomplete();
         assert.strictEqual($element.outerWidth(), 300, "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("change width", assert => {
+    QUnit.test("change width", function(assert) {
         const $element = $("#widget").dxAutocomplete();
         const instance = $element.dxAutocomplete("instance");
         const customWidth = 400;
@@ -1409,7 +1409,7 @@ QUnit.module("widget sizing render", {
         assert.strictEqual($element.outerWidth(), customWidth, "outer width of the element must be equal to custom width");
     });
 
-    QUnit.testInActiveWindow("filter is not reset", (assert) => {
+    QUnit.testInActiveWindow("filter is not reset", function(assert) {
         const $fixture = $("#qunit-fixture");
         const requiredCSS = $("<style>.dx-popup-content {padding: 0 !important;border: none !important;margin: 0 !important;</style>");
         requiredCSS.appendTo($fixture);

--- a/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
@@ -86,7 +86,7 @@ function triggerKeydown($element, key, ctrl) {
 }
 
 QUnit.module("Hidden input", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("<div>").appendTo("body");
@@ -98,12 +98,12 @@ QUnit.module("Hidden input", {
             return dateSerialization.serializeDate(value, "yyyy-MM-dd");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.$element.remove();
     }
 }, () => {
-    QUnit.test("Calendar should pass value to the hidden input on widget value change", (assert) => {
+    QUnit.test("Calendar should pass value to the hidden input on widget value change", function(assert) {
         const $input = this.$element.find("input");
 
         const date = new Date(2016, 6, 9);
@@ -114,19 +114,19 @@ QUnit.module("Hidden input", {
 
 
 QUnit.module("Navigator", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.$element = $("<div>").appendTo("body");
         this.calendar = this.$element.dxCalendar({
             value: new Date(2015, 5, 13)
         }).dxCalendar("instance");
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("Navigator links must prevent default click browser action", (assert) => {
+    QUnit.test("Navigator links must prevent default click browser action", function(assert) {
         const $window = $(window),
             brick = $("<div style='height:50000px;'></div>"),
             immediateClick = (element) => {
@@ -152,7 +152,7 @@ QUnit.module("Navigator", {
         }
     });
 
-    QUnit.test("Calendar must display the current month and year", (assert) => {
+    QUnit.test("Calendar must display the current month and year", function(assert) {
         const navigatorCaption = this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
         assert.equal(navigatorCaption.text(), "June 2015");
     });
@@ -160,7 +160,7 @@ QUnit.module("Navigator", {
 
 
 QUnit.module("Navigator integration", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.$element = $("<div>").appendTo("body");
         this.calendar = this.$element.dxCalendar({
@@ -181,13 +181,13 @@ QUnit.module("Navigator integration", {
             this.$navigatorPrev = this.$element.find(toSelector(CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS));
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
 
-    QUnit.test("calendar must change the current date when navigating to previous and next view", (assert) => {
+    QUnit.test("calendar must change the current date when navigating to previous and next view", function(assert) {
         const calendar = this.calendar,
             $navigatorPrev = this.$navigatorPrev,
             $navigatorNext = this.$navigatorNext;
@@ -204,7 +204,7 @@ QUnit.module("Navigator integration", {
         });
     });
 
-    QUnit.test("calendar must change the current date when navigating to previous and next view in RTL mode", (assert) => {
+    QUnit.test("calendar must change the current date when navigating to previous and next view in RTL mode", function(assert) {
         this.reinit({
             rtlEnabled: true
         });
@@ -226,7 +226,7 @@ QUnit.module("Navigator integration", {
     });
 
     // TODO: get rid of mocking private method
-    QUnit.test("when option.disabled = true, navigator links should do nothing", (assert) => {
+    QUnit.test("when option.disabled = true, navigator links should do nothing", function(assert) {
         this.reinit({
             disabled: true
         });
@@ -239,7 +239,7 @@ QUnit.module("Navigator integration", {
         $(this.$navigatorNext).trigger("dxclick");
     });
 
-    QUnit.test("Navigator caption should be changed after click on prev/next month button", (assert) => {
+    QUnit.test("Navigator caption should be changed after click on prev/next month button", function(assert) {
         this.reinit({
             value: new Date(2015, 4, 15)
         });
@@ -250,7 +250,7 @@ QUnit.module("Navigator integration", {
         assert.equal(newText, "July 2015", "correct navigation caption");
     });
 
-    QUnit.test("Navigator caption should be changed after click on prev/next month button in RTL", (assert) => {
+    QUnit.test("Navigator caption should be changed after click on prev/next month button in RTL", function(assert) {
         this.reinit({
             value: new Date(2015, 4, 15),
             rtlEnabled: true
@@ -262,7 +262,7 @@ QUnit.module("Navigator integration", {
         assert.equal(newText, "March 2015", "correct navigation caption");
     });
 
-    QUnit.test("navigator caption should be changed after the 'value' option change", (assert) => {
+    QUnit.test("navigator caption should be changed after the 'value' option change", function(assert) {
         this.reinit({
             value: new Date(2015, 5, 9)
         });
@@ -276,7 +276,7 @@ QUnit.module("Navigator integration", {
         assert.equal($navigatorCaption.text(), "July 2015", "navigator caption is correct");
     });
 
-    QUnit.test("navigator caption should be changed after the 'currentDate' option change", (assert) => {
+    QUnit.test("navigator caption should be changed after the 'currentDate' option change", function(assert) {
         this.reinit({
             value: new Date(2015, 5, 9),
             currentDate: new Date(2015, 5, 1)
@@ -291,7 +291,7 @@ QUnit.module("Navigator integration", {
         assert.equal($navigatorCaption.text(), "July 2015", "navigator caption is correct");
     });
 
-    QUnit.test("navigator caption should be changed during swipe", (assert) => {
+    QUnit.test("navigator caption should be changed during swipe", function(assert) {
         const $element = this.$element,
             $navigatorCaption = this.$navigatorCaption;
 
@@ -307,7 +307,7 @@ QUnit.module("Navigator integration", {
         assert.equal($navigatorCaption.text(), "May 2015", "navigator caption is changed to previous month");
     });
 
-    QUnit.test("navigator caption should be changed correctly during swipe in RTL (not reverted)", (assert) => {
+    QUnit.test("navigator caption should be changed correctly during swipe in RTL (not reverted)", function(assert) {
         this.reinit({
             rtlEnabled: true,
             value: new Date(2015, 5, 13)
@@ -325,7 +325,7 @@ QUnit.module("Navigator integration", {
         assert.equal($navigatorCaption.text(), "July 2015", "navigator caption is changed to next month");
     });
 
-    QUnit.test("navigator should be disabled after min/max option changed", (assert) => {
+    QUnit.test("navigator should be disabled after min/max option changed", function(assert) {
         this.reinit({
             value: new Date(2015, 3, 14)
         });
@@ -345,12 +345,12 @@ QUnit.module("Navigator integration", {
         assert.equal(prevButton.option("disabled"), true, "prev button is disabled");
     });
 
-    QUnit.test("navigator caption should be updated after 'zoomLevel' option change", (assert) => {
+    QUnit.test("navigator caption should be updated after 'zoomLevel' option change", function(assert) {
         this.calendar.option("zoomLevel", "year");
         assert.equal(this.$navigatorCaption.text(), "2015", "navigator caption is correct");
     });
 
-    QUnit.test("click on caption button should change 'zoomLevel'", (assert) => {
+    QUnit.test("click on caption button should change 'zoomLevel'", function(assert) {
         const calendar = this.calendar;
         const $navigatorCaption = this.$navigatorCaption;
 
@@ -360,7 +360,7 @@ QUnit.module("Navigator integration", {
         });
     });
 
-    QUnit.test("view change buttons should have feedback", (assert) => {
+    QUnit.test("view change buttons should have feedback", function(assert) {
         const prevChangeMonthButton = this.$navigatorPrev,
             nextChangeMonthButton = this.$navigatorNext,
             prevMouse = pointerMock(prevChangeMonthButton).start();
@@ -380,7 +380,7 @@ QUnit.module("Navigator integration", {
         assert.ok(!$(nextChangeMonthButton).hasClass(ACTIVE_STATE_CLASS));
     });
 
-    QUnit.test("view change buttons should be disabled if min/max has been reached", (assert) => {
+    QUnit.test("view change buttons should be disabled if min/max has been reached", function(assert) {
         this.reinit({
             value: new Date(2015, 8, 6),
             min: new Date(2015, 7, 1),
@@ -398,7 +398,7 @@ QUnit.module("Navigator integration", {
         assert.ok(this.$navigatorNext.hasClass(CALENDAR_DISABLED_NAVIGATOR_LINK_CLASS));
     });
 
-    QUnit.test("view change buttons should be disabled if min/max has been reached in RTL mode", (assert) => {
+    QUnit.test("view change buttons should be disabled if min/max has been reached in RTL mode", function(assert) {
         this.reinit({
             rtlEnabled: true,
             value: new Date(2015, 8, 6),
@@ -417,7 +417,7 @@ QUnit.module("Navigator integration", {
         assert.ok(this.$navigatorNext.hasClass(CALENDAR_DISABLED_NAVIGATOR_LINK_CLASS));
     });
 
-    QUnit.test("navigator caption is correct after fast right short swipe", (assert) => {
+    QUnit.test("navigator caption is correct after fast right short swipe", function(assert) {
         const currentDate = new Date(this.calendar.option("currentDate"));
         currentDate.setMonth(currentDate.getMonth() - 1);
 
@@ -430,7 +430,7 @@ QUnit.module("Navigator integration", {
         assert.equal(navigatorText, expectedText, "navigator caption is correct");
     });
 
-    QUnit.test("navigator caption is correct after fast left short swipe", (assert) => {
+    QUnit.test("navigator caption is correct after fast left short swipe", function(assert) {
         const currentDate = new Date(this.calendar.option("currentDate"));
         currentDate.setMonth(currentDate.getMonth() + 1);
 
@@ -443,7 +443,7 @@ QUnit.module("Navigator integration", {
         assert.equal(navigatorText, expectedText, "navigator caption is correct");
     });
 
-    QUnit.test("navigator buttons should displays correctly on short min/max range", (assert) => {
+    QUnit.test("navigator buttons should displays correctly on short min/max range", function(assert) {
         this.reinit({
             min: new Date(1522454400000),
             max: new Date(1523923200000),
@@ -457,7 +457,7 @@ QUnit.module("Navigator integration", {
 
 
 QUnit.module("Views initial positions", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("<div>").appendTo("body");
         this.instance = this.$element.dxCalendar().dxCalendar("instance");
 
@@ -468,11 +468,11 @@ QUnit.module("Views initial positions", {
         };
     },
 
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
     }
 }, () => {
-    QUnit.test("calendar views animation end position should be correct after width is changed", (assert) => {
+    QUnit.test("calendar views animation end position should be correct after width is changed", function(assert) {
         this.reinit({
             width: 400
         });
@@ -493,7 +493,7 @@ QUnit.module("Views initial positions", {
         }
     });
 
-    QUnit.test("calendar views position", (assert) => {
+    QUnit.test("calendar views position", function(assert) {
         const $view = $(getCurrentViewInstance(this.instance).$element()),
             viewWidth = $view.width();
 
@@ -502,7 +502,7 @@ QUnit.module("Views initial positions", {
         assert.equal(getAfterViewInstance(this.instance).$element().position().left, viewWidth, "main view is at the right");
     });
 
-    QUnit.test("calendar views position in RTL", (assert) => {
+    QUnit.test("calendar views position in RTL", function(assert) {
         if("chrome" in window && browser.msie) {
             // Chrome DevTools device emulation
             assert.ok(true, "This test is not relevant for chrome dev tools device emulation");
@@ -522,7 +522,7 @@ QUnit.module("Views initial positions", {
 
 
 QUnit.module("Views integration", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.$element = $("<div>").appendTo("body");
         this.calendar = this.$element.dxCalendar({
@@ -536,26 +536,26 @@ QUnit.module("Views integration", {
             this.calendar = this.$element.dxCalendar(options).dxCalendar("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("calendar should instantiate views with proper LTR-RTL mode", (assert) => {
+    QUnit.test("calendar should instantiate views with proper LTR-RTL mode", function(assert) {
         this.reinit({
             rtlEnabled: true
         });
         assert.ok(getCurrentViewInstance(this.calendar).option("rtl"));
     });
 
-    QUnit.test("calendar must pass disabled to the created views", (assert) => {
+    QUnit.test("calendar must pass disabled to the created views", function(assert) {
         this.reinit({
             disabled: true
         });
         assert.deepEqual(getCurrentViewInstance(this.calendar).option("disabled"), true);
     });
 
-    QUnit.test("calendar must render correct view depending on current zoom level", (assert) => {
+    QUnit.test("calendar must render correct view depending on current zoom level", function(assert) {
         const calendar = this.calendar;
 
         $.each(["month", "year", "decade", "century"], (_, type) => {
@@ -565,7 +565,7 @@ QUnit.module("Views integration", {
         });
     });
 
-    QUnit.test("view option 'value' should depend on calendar option 'value'", (assert) => {
+    QUnit.test("view option 'value' should depend on calendar option 'value'", function(assert) {
         const calendar = this.calendar;
         let value = new Date(2015, 5, 15);
 
@@ -577,7 +577,7 @@ QUnit.module("Views integration", {
         assert.deepEqual(getCurrentViewInstance(calendar).option("value"), value, "view option 'value' is changed correctly");
     });
 
-    QUnit.test("changing calendar 'value' option to the date of different view should change current view", (assert) => {
+    QUnit.test("changing calendar 'value' option to the date of different view should change current view", function(assert) {
         const calendar = this.calendar,
             oldMonthView = getCurrentViewInstance(calendar),
             newDate = new Date(2015, 8, 11),
@@ -591,7 +591,7 @@ QUnit.module("Views integration", {
         assert.deepEqual(newMonthView.option("date"), newMonthView.option("value"));
     });
 
-    QUnit.test("T277747 - only one selected cell may be present among all rendered views", (assert) => {
+    QUnit.test("T277747 - only one selected cell may be present among all rendered views", function(assert) {
         const $element = this.$element;
 
         this.calendar.option("value", new Date(2013, 9, 15));
@@ -601,7 +601,7 @@ QUnit.module("Views integration", {
         assert.equal($element.find(toSelector(CALENDAR_SELECTED_DATE_CLASS)).length, 1, "there is only one selected cell");
     });
 
-    QUnit.test("views should not be rerendered after other month cell click", (assert) => {
+    QUnit.test("views should not be rerendered after other month cell click", function(assert) {
         const calendar = this.calendar;
 
         calendar.option("value", new Date(2015, 9, 1));
@@ -615,7 +615,7 @@ QUnit.module("Views integration", {
         assert.ok(afterViewBeforeClick === currentViewAfterClick, "after view should become a current view after click on other month date cell");
     });
 
-    QUnit.test("selected value should be rendered correctly on views with different maxZoomLevel", (assert) => {
+    QUnit.test("selected value should be rendered correctly on views with different maxZoomLevel", function(assert) {
         const $element = this.$element;
         const calendar = this.calendar;
 
@@ -631,7 +631,7 @@ QUnit.module("Views integration", {
         });
     });
 
-    QUnit.test("click on cell should have UI feedback", (assert) => {
+    QUnit.test("click on cell should have UI feedback", function(assert) {
         this.reinit({
             firstDayOfWeek: 0,
             value: new Date(2013, 8, 9)
@@ -647,7 +647,7 @@ QUnit.module("Views integration", {
         assert.ok(!$dayElement.hasClass(ACTIVE_STATE_CLASS));
     });
 
-    QUnit.test("click on view cell changes calendar value", (assert) => {
+    QUnit.test("click on view cell changes calendar value", function(assert) {
         this.reinit({
             zoomLevel: "month",
             value: new Date(2015, 2, 15)
@@ -668,7 +668,7 @@ QUnit.module("Views integration", {
         });
     });
 
-    QUnit.test("view contouredDate should sync with calendar currentDate", (assert) => {
+    QUnit.test("view contouredDate should sync with calendar currentDate", function(assert) {
         this.reinit({
             value: new Date(2015, 2, 15),
             focusStateEnabled: true
@@ -689,7 +689,7 @@ QUnit.module("Views integration", {
         });
     });
 
-    QUnit.test("view contouredDate should be set on calendar focusin and should be removed on focusout", (assert) => {
+    QUnit.test("view contouredDate should be set on calendar focusin and should be removed on focusout", function(assert) {
         const view = getCurrentViewInstance(this.calendar);
 
         assert.equal(view.option("contouredDate"), null, "no currentDate is passed to view on calendar init");
@@ -701,7 +701,7 @@ QUnit.module("Views integration", {
         assert.equal(view.option("contouredDate"), null, "view contouredDate is set to null on focusout");
     });
 
-    QUnit.test("contouredDate should not be passed to view if widget is not in focus", (assert) => {
+    QUnit.test("contouredDate should not be passed to view if widget is not in focus", function(assert) {
         this.calendar.option("value", new Date(2013, 5, 16));
         assert.equal(getCurrentViewInstance(this.calendar).option("contouredDate"), null, "view contouredDate is null");
     });
@@ -709,7 +709,7 @@ QUnit.module("Views integration", {
 
 
 QUnit.module("Keyboard navigation", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("<div>").appendTo("body");
@@ -728,17 +728,17 @@ QUnit.module("Keyboard navigation", {
             this.calendar = this.$element.dxCalendar(options).dxCalendar("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("when a KeyboardProcessor instance is not passed into the constructor, rootElement must have a tabindex of 0", (assert) => {
+    QUnit.test("when a KeyboardProcessor instance is not passed into the constructor, rootElement must have a tabindex of 0", function(assert) {
         assert.equal(this.$element.attr("tabindex"), 0);
     });
 
-    QUnit.test("calendar should not dispose a keyDownProcessor passed via the constructor", (assert) => {
+    QUnit.test("calendar should not dispose a keyDownProcessor passed via the constructor", function(assert) {
         let disposeCount = 0;
         const disposeMock = () => {
             ++disposeCount;
@@ -755,7 +755,7 @@ QUnit.module("Keyboard navigation", {
         assert.strictEqual(disposeCount, 0);
     });
 
-    QUnit.test("when a KeyboardProcessor instance is passed into the constructor, the main table must not have tabindex", (assert) => {
+    QUnit.test("when a KeyboardProcessor instance is passed into the constructor, the main table must not have tabindex", function(assert) {
         this.reinit({
             keyDownProcessor: new KeyboardProcessor({})
         });
@@ -763,7 +763,7 @@ QUnit.module("Keyboard navigation", {
         assert.ok(!this.$element.find("table").attr("tabindex"));
     });
 
-    QUnit.test("click must not focus the main table if it does have tabindex", (assert) => {
+    QUnit.test("click must not focus the main table if it does have tabindex", function(assert) {
         this.reinit({
             keyDownProcessor: new KeyboardProcessor()
         });
@@ -775,7 +775,7 @@ QUnit.module("Keyboard navigation", {
         assert.notStrictEqual(document.activeElement, this.$element.find("table")[0]);
     });
 
-    QUnit.test("left/right key press should change currentDate correctly", (assert) => {
+    QUnit.test("left/right key press should change currentDate correctly", function(assert) {
         const params = {
             "month": { startDate: new Date(2013, 9, 13), movedDate: new Date(2013, 9, 14) },
             "year": { startDate: new Date(2013, 9, 13), movedDate: new Date(2013, 10, 13) },
@@ -797,7 +797,7 @@ QUnit.module("Keyboard navigation", {
         });
     });
 
-    QUnit.test("left/right key press should change currentDate correctly in RTL", (assert) => {
+    QUnit.test("left/right key press should change currentDate correctly in RTL", function(assert) {
         this.reinit({
             value: new Date(2023, 9, 13),
             focusStateEnabled: true,
@@ -825,7 +825,7 @@ QUnit.module("Keyboard navigation", {
         });
     });
 
-    QUnit.test("up/down key press should change currentDate correctly", (assert) => {
+    QUnit.test("up/down key press should change currentDate correctly", function(assert) {
         const expectedDates = {
             "month": new Date(2055, 6, 15),
             "year": new Date(2055, 2, 22),
@@ -851,7 +851,7 @@ QUnit.module("Keyboard navigation", {
         }, this));
     });
 
-    QUnit.test("pressing enter should change value", (assert) => {
+    QUnit.test("pressing enter should change value", function(assert) {
         const calendar = this.calendar;
         const keyboard = keyboardMock(this.$element);
 
@@ -866,7 +866,7 @@ QUnit.module("Keyboard navigation", {
         });
     });
 
-    QUnit.test("Event should be passed to the valueChanged action after selecting a cell via the keyboard", (assert) => {
+    QUnit.test("Event should be passed to the valueChanged action after selecting a cell via the keyboard", function(assert) {
         const keyboard = keyboardMock(this.$element),
             valueChangedHandler = sinon.stub();
 
@@ -883,7 +883,7 @@ QUnit.module("Keyboard navigation", {
         assert.ok(params.element, "Element should be passed");
     });
 
-    QUnit.test("pressing ctrl+arrows or pageup/pagedown keys must change view correctly", (assert) => {
+    QUnit.test("pressing ctrl+arrows or pageup/pagedown keys must change view correctly", function(assert) {
         const $element = this.$element,
             calendar = this.calendar;
 
@@ -917,7 +917,7 @@ QUnit.module("Keyboard navigation", {
         });
     });
 
-    QUnit.test("pressing ctrl+arrows must navigate in inverse direction in RTL mode", (assert) => {
+    QUnit.test("pressing ctrl+arrows must navigate in inverse direction in RTL mode", function(assert) {
         this.reinit({
             value: this.value,
             firstDayOfWeek: 1,
@@ -935,7 +935,7 @@ QUnit.module("Keyboard navigation", {
         assert.deepEqual(this.calendar.option("currentDate"), new Date(2013, 9, this.value.getDate()), "ctrl+right arrow navigates correctly");
     });
 
-    QUnit.test("correct currentDate change after navigating on other view cell by keyboard", (assert) => {
+    QUnit.test("correct currentDate change after navigating on other view cell by keyboard", function(assert) {
         this.reinit({
             value: new Date(2015, 2, 1),
             zoomLevel: "month",
@@ -967,7 +967,7 @@ QUnit.module("Keyboard navigation", {
         assert.deepEqual(calendar.option("currentDate"), new Date(2100, 0, 1), "century changed correctly");
     });
 
-    QUnit.test("view changing should be correct after keyboard navigation from boundary cell", (assert) => {
+    QUnit.test("view changing should be correct after keyboard navigation from boundary cell", function(assert) {
         this.reinit({
             value: new Date(2015, 8, 10),
             min: new Date(2015, 7, 20),
@@ -989,7 +989,7 @@ QUnit.module("Keyboard navigation", {
         assert.ok(dateUtils.sameMonth(getCurrentViewInstance(calendar).option("date"), new Date(2015, 9, 1)), "view is changed");
     });
 
-    QUnit.test("pressing ctrl+up/down arrow keys must call navigateUp/navigateDown", (assert) => {
+    QUnit.test("pressing ctrl+up/down arrow keys must call navigateUp/navigateDown", function(assert) {
         this.reinit({
             value: new Date(2013, 11, 15),
             zoomLevel: "month",
@@ -1010,7 +1010,7 @@ QUnit.module("Keyboard navigation", {
         });
     });
 
-    QUnit.test("Pressing home/end keys must contour first/last cell", (assert) => {
+    QUnit.test("Pressing home/end keys must contour first/last cell", function(assert) {
         this.reinit({
             focusStateEnabled: true,
             value: new Date(2013, 11, 15)
@@ -1040,7 +1040,7 @@ QUnit.module("Keyboard navigation", {
         });
     });
 
-    QUnit.test("home/end keypress must contoured first and last allowable cells", (assert) => {
+    QUnit.test("home/end keypress must contoured first and last allowable cells", function(assert) {
         const params = {
             "month": { value: new Date(2010, 10, 15), min: new Date(2010, 10, 5), max: new Date(2010, 10, 24) },
             "year": { value: new Date(2015, 4, 10), min: new Date(2015, 2, 18), max: new Date(2015, 8, 18) },
@@ -1065,7 +1065,7 @@ QUnit.module("Keyboard navigation", {
         }, this));
     });
 
-    QUnit.test("keydown event default behavior should be prevented by calendar keydown handlers for datebox integration", (assert) => {
+    QUnit.test("keydown event default behavior should be prevented by calendar keydown handlers for datebox integration", function(assert) {
         assert.expect(4);
 
         this.$element.remove();
@@ -1094,7 +1094,7 @@ QUnit.module("Keyboard navigation", {
             .off(".TEST");
     });
 
-    QUnit.test("correct view change after fast keyboard navigation", (assert) => {
+    QUnit.test("correct view change after fast keyboard navigation", function(assert) {
         this.reinit({
             value: new Date(2013, 9, 1),
             focusStateEnabled: true
@@ -1126,7 +1126,7 @@ QUnit.module("Keyboard navigation", {
 
 
 QUnit.module("Preserve time component on value change", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("<div>").appendTo("body");
@@ -1134,12 +1134,12 @@ QUnit.module("Preserve time component on value change", {
             focusStateEnabled: true
         }).dxCalendar("instance");
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("date time should not be changed after cell click", (assert) => {
+    QUnit.test("date time should not be changed after cell click", function(assert) {
         const calendar = this.calendar;
 
         calendar.option("value", new Date(2015, 4, 7, 18, 37));
@@ -1149,7 +1149,7 @@ QUnit.module("Preserve time component on value change", {
         assert.deepEqual(calendar.option("value"), new Date(2015, 4, 4, 18, 37), "value is correct");
     });
 
-    QUnit.test("T277555 - time should not be reset if keyboard is used", (assert) => {
+    QUnit.test("T277555 - time should not be reset if keyboard is used", function(assert) {
         const calendar = this.calendar,
             $calendar = this.$element;
 
@@ -1166,7 +1166,7 @@ QUnit.module("Preserve time component on value change", {
 
 
 QUnit.module("Calendar footer", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("<div>").appendTo("body");
@@ -1182,12 +1182,12 @@ QUnit.module("Calendar footer", {
             this.calendar = this.$element.dxCalendar(options).dxCalendar("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("today view are current after today button click", (assert) => {
+    QUnit.test("today view are current after today button click", function(assert) {
         const calendar = this.calendar;
 
         const $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
@@ -1206,7 +1206,7 @@ QUnit.module("Calendar footer", {
         assert.deepEqual(calendar.option("currentDate"), today, "current view is today view");
     });
 
-    QUnit.test("today view already has a current", (assert) => {
+    QUnit.test("today view already has a current", function(assert) {
         const calendar = this.calendar,
             $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
 
@@ -1220,7 +1220,7 @@ QUnit.module("Calendar footer", {
         assert.equal(getShortDate(calendar.option("value")), getShortDate(new Date()), "value is today date");
     });
 
-    QUnit.test("click on today button should change current view to 'month'", (assert) => {
+    QUnit.test("click on today button should change current view to 'month'", function(assert) {
         this.reinit({
             showTodayButton: true,
             value: new Date(2013, 3, 11),
@@ -1236,7 +1236,7 @@ QUnit.module("Calendar footer", {
         assert.deepEqual(getShortDate(calendar.option("value")), getShortDate(new Date()), "calendar value is correct");
     });
 
-    QUnit.test("today view is visible after 'today' button click", (assert) => {
+    QUnit.test("today view is visible after 'today' button click", function(assert) {
         const $element = this.$element,
             $todayButton = $element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
 
@@ -1250,7 +1250,7 @@ QUnit.module("Calendar footer", {
         assert.equal(view.$element().find(toSelector(CALENDAR_SELECTED_DATE_CLASS)).length, 1, "there is selected cell on the current view");
     });
 
-    QUnit.test("navigator caption should be changed after 'today' button click", (assert) => {
+    QUnit.test("navigator caption should be changed after 'today' button click", function(assert) {
         const $element = this.$element,
             $todayButton = $element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
 
@@ -1263,7 +1263,7 @@ QUnit.module("Calendar footer", {
         assert.notEqual(navigatorText, prevText, "navigator caption changed");
     });
 
-    QUnit.test("correct today view position before animation (currentDate < today)", (assert) => {
+    QUnit.test("correct today view position before animation (currentDate < today)", function(assert) {
         assert.expect(2);
 
         const fxState = fx.off,
@@ -1293,7 +1293,7 @@ QUnit.module("Calendar footer", {
         }
     });
 
-    QUnit.test("correct today view position before animation (currentDate > today)", (assert) => {
+    QUnit.test("correct today view position before animation (currentDate > today)", function(assert) {
         assert.expect(2);
 
         const fxState = fx.off,
@@ -1326,7 +1326,7 @@ QUnit.module("Calendar footer", {
         }
     });
 
-    QUnit.test("correct views are rendered after animation", (assert) => {
+    QUnit.test("correct views are rendered after animation", function(assert) {
         const calendar = this.calendar,
             $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
 
@@ -1342,7 +1342,7 @@ QUnit.module("Calendar footer", {
         assert.equal(afterViewDate.getMonth(), new Date(today.getFullYear(), today.getMonth() + 1).getMonth(), "after view month is correct");
     });
 
-    QUnit.test("correct animation after today button click on the different zoom level", (assert) => {
+    QUnit.test("correct animation after today button click on the different zoom level", function(assert) {
         this.calendar.option({
             zoomLevel: "century",
             value: new Date(1973, 4, 5),
@@ -1369,7 +1369,7 @@ QUnit.module("Calendar footer", {
 
 
 QUnit.module("Options", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("<div>").appendTo("body");
@@ -1381,12 +1381,12 @@ QUnit.module("Options", {
             this.calendar = this.$element.dxCalendar(options).dxCalendar("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("changing the 'value' option must invoke the 'onValueChanged' action", (assert) => {
+    QUnit.test("changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         this.reinit({
             onValueChanged: () => {
                 assert.ok(true);
@@ -1395,7 +1395,7 @@ QUnit.module("Options", {
         this.calendar.option("value", new Date(2002, 2, 2));
     });
 
-    QUnit.test("onCellClick return not 'undefined' after click on cell", (assert) => {
+    QUnit.test("onCellClick return not 'undefined' after click on cell", function(assert) {
         const clickHandler = sinon.spy(noop);
 
         this.reinit({
@@ -1416,7 +1416,7 @@ QUnit.module("Options", {
         assert.ok(params.element, "Element should be passed");
     });
 
-    QUnit.test("Event should be passed to the valueChanged action after click on a cell", (assert) => {
+    QUnit.test("Event should be passed to the valueChanged action after click on a cell", function(assert) {
         const valueChangedHandler = sinon.stub();
 
         this.reinit({
@@ -1434,7 +1434,7 @@ QUnit.module("Options", {
         assert.ok(params.element, "Element should be passed");
     });
 
-    QUnit.test("onCellClick should not be fired when zoomLevel change required (for datebox integration)", (assert) => {
+    QUnit.test("onCellClick should not be fired when zoomLevel change required (for datebox integration)", function(assert) {
         const clickSpy = sinon.spy();
 
         this.reinit({
@@ -1449,7 +1449,7 @@ QUnit.module("Options", {
         assert.equal(clickSpy.callCount, 0, "onCellClick was not fired");
     });
 
-    QUnit.test("Calendar should not allow to select date in disabled state changed in runtime (T196663)", (assert) => {
+    QUnit.test("Calendar should not allow to select date in disabled state changed in runtime (T196663)", function(assert) {
         this.reinit({
             value: new Date(2013, 11, 15),
             currentDate: new Date(2013, 11, 15)
@@ -1460,7 +1460,7 @@ QUnit.module("Options", {
         assert.deepEqual(this.calendar.option("value"), new Date(2013, 11, 15));
     });
 
-    QUnit.test("When initialized without currentDate, calendar must try to infer it from value", (assert) => {
+    QUnit.test("When initialized without currentDate, calendar must try to infer it from value", function(assert) {
         const date = new Date(2014, 11, 11);
 
         this.reinit({
@@ -1470,7 +1470,7 @@ QUnit.module("Options", {
         assert.deepEqual(this.calendar.option("currentDate"), date);
     });
 
-    QUnit.test("calendar view should be changed on the 'currentDate' option change", (assert) => {
+    QUnit.test("calendar view should be changed on the 'currentDate' option change", function(assert) {
         const calendar = this.calendar,
             oldDate = getCurrentViewInstance(calendar).option("date");
 
@@ -1478,7 +1478,7 @@ QUnit.module("Options", {
         assert.notDeepEqual(getCurrentViewInstance(calendar).option("date"), oldDate, "view is changed");
     });
 
-    QUnit.test("contoured date displaying should depend on 'hasFocus' option", (assert) => {
+    QUnit.test("contoured date displaying should depend on 'hasFocus' option", function(assert) {
         this.reinit({
             value: new Date(2015, 10, 18),
             hasFocus: () => {
@@ -1492,16 +1492,16 @@ QUnit.module("Options", {
 
 
 QUnit.module("ZoomLevel option", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.$element = $("<div>").appendTo("body");
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("'zoomLevel' should have correct value on init if 'maxZoomLevel' is specified", (assert) => {
+    QUnit.test("'zoomLevel' should have correct value on init if 'maxZoomLevel' is specified", function(assert) {
         const calendar = this.$element.dxCalendar({
             maxZoomLevel: "year",
             zoomLevel: "month"
@@ -1510,7 +1510,7 @@ QUnit.module("ZoomLevel option", {
         assert.equal(calendar.option("zoomLevel"), calendar.option("maxZoomLevel"), "'zoomLevel' is corrected");
     });
 
-    QUnit.test("view should not be changed down if specified maxZoomLevel is reached", (assert) => {
+    QUnit.test("view should not be changed down if specified maxZoomLevel is reached", function(assert) {
         const calendar = this.$element.dxCalendar({
             maxZoomLevel: "year",
             zoomLevel: "decade"
@@ -1523,7 +1523,7 @@ QUnit.module("ZoomLevel option", {
         assert.equal(calendar.option("zoomLevel"), "year", "'zoomLevel' did not change");
     });
 
-    QUnit.test("'zoomLevel' should be aligned after 'maxZoomLevel' option change if out of bounds", (assert) => {
+    QUnit.test("'zoomLevel' should be aligned after 'maxZoomLevel' option change if out of bounds", function(assert) {
         const calendar = this.$element.dxCalendar({
             maxZoomLevel: "month",
             value: new Date(2015, 2, 15)
@@ -1536,7 +1536,7 @@ QUnit.module("ZoomLevel option", {
         });
     });
 
-    QUnit.test("'zoomLevel' option should not be changed after 'maxZoomLevel' option change", (assert) => {
+    QUnit.test("'zoomLevel' option should not be changed after 'maxZoomLevel' option change", function(assert) {
         const calendar = this.$element.dxCalendar({
             maxZoomLevel: "century",
             value: new Date(2015, 2, 15)
@@ -1549,7 +1549,7 @@ QUnit.module("ZoomLevel option", {
         });
     });
 
-    QUnit.test("calendar should get correct value after click on cell of specified maxZoomLevel", (assert) => {
+    QUnit.test("calendar should get correct value after click on cell of specified maxZoomLevel", function(assert) {
         const calendar = this.$element.dxCalendar({
             maxZoomLevel: "year",
             value: new Date(2015, 2, 15)
@@ -1567,7 +1567,7 @@ QUnit.module("ZoomLevel option", {
         assert.deepEqual(calendar.option("value"), new Date(2040, 0, 1), "'zoomLevel' changed");
     });
 
-    QUnit.test("do not go up if minZoomLevel is reached", (assert) => {
+    QUnit.test("do not go up if minZoomLevel is reached", function(assert) {
         const $element = this.$element,
             instance = $element.dxCalendar().dxCalendar("instance");
 
@@ -1582,7 +1582,7 @@ QUnit.module("ZoomLevel option", {
         });
     });
 
-    QUnit.test("'zoomLevel' should be aligned after 'minZoomLevel' option change if out of bounds", (assert) => {
+    QUnit.test("'zoomLevel' should be aligned after 'minZoomLevel' option change if out of bounds", function(assert) {
         const $element = this.$element,
             instance = $element.dxCalendar({
                 minZoomLevel: "century",
@@ -1595,7 +1595,7 @@ QUnit.module("ZoomLevel option", {
         });
     });
 
-    QUnit.test("cancel change zoomLevel if there is only one cell on new view", (assert) => {
+    QUnit.test("cancel change zoomLevel if there is only one cell on new view", function(assert) {
         const calendar = this.$element.dxCalendar({
             maxZoomLevel: "month",
             min: new Date(2015, 3, 5),
@@ -1619,7 +1619,7 @@ QUnit.module("ZoomLevel option", {
         assert.equal(calendar.option("zoomLevel"), "decade", "view is not changed (decade)");
     });
 
-    QUnit.test("change ZoomLevel after click on view cell", (assert) => {
+    QUnit.test("change ZoomLevel after click on view cell", function(assert) {
         const $element = this.$element;
         const calendar = $element.dxCalendar({
             zoomLevel: "century",
@@ -1634,7 +1634,7 @@ QUnit.module("ZoomLevel option", {
         });
     });
 
-    QUnit.test("change ZoomLevel after pressing enter key on view cell", (assert) => {
+    QUnit.test("change ZoomLevel after pressing enter key on view cell", function(assert) {
         const $element = this.$element;
         const calendar = $element.dxCalendar({
             zoomLevel: "century",
@@ -1650,7 +1650,7 @@ QUnit.module("ZoomLevel option", {
         });
     });
 
-    QUnit.test("change ZoomLevel after click on other view cell", (assert) => {
+    QUnit.test("change ZoomLevel after click on other view cell", function(assert) {
         const $element = this.$element;
         const calendar = $element.dxCalendar({
             zoomLevel: "century",
@@ -1665,7 +1665,7 @@ QUnit.module("ZoomLevel option", {
         });
     });
 
-    QUnit.test("Current view should be set correctly, after click on other view cells", (assert) => {
+    QUnit.test("Current view should be set correctly, after click on other view cells", function(assert) {
 
         const $element = this.$element;
         const calendar = $element.dxCalendar({
@@ -1695,7 +1695,7 @@ QUnit.module("ZoomLevel option", {
         }
     });
 
-    QUnit.test("Month names should be shown in 'abbreviated' format when ZoomLevel is Year", (assert) => {
+    QUnit.test("Month names should be shown in 'abbreviated' format when ZoomLevel is Year", function(assert) {
         const getMonthNamesStub = sinon.stub(dateLocalization, "getMonthNames");
 
         getMonthNamesStub.returns(["leden", "únor", "březen", "duben", "květen", "červen", "červenec", "srpen", "září", "říjen", "listopad", "prosinec"]);
@@ -1717,7 +1717,7 @@ QUnit.module("ZoomLevel option", {
 
 
 QUnit.module("Min & Max options", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.value = new Date(2010, 10, 10);
@@ -1740,24 +1740,24 @@ QUnit.module("Min & Max options", {
             this.calendar = this.$element.dxCalendar(options).dxCalendar("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         this.clock.restore();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("calendar should not throw error if max date is null", (assert) => {
+    QUnit.test("calendar should not throw error if max date is null", function(assert) {
         assert.expect(0);
 
         new Calendar("<div>", { value: new Date(2013, 9, 15), firstDayOfWeek: 1, max: null });
     });
 
-    QUnit.test("calendar must pass min and max to the created views", (assert) => {
+    QUnit.test("calendar must pass min and max to the created views", function(assert) {
         assert.deepEqual(getCurrentViewInstance(this.calendar).option("min"), this.minDate);
         assert.deepEqual(getCurrentViewInstance(this.calendar).option("max"), this.maxDate);
     });
 
-    QUnit.test("calendar should not allow to navigate to a date earlier than min and later than max via keyboard events", (assert) => {
+    QUnit.test("calendar should not allow to navigate to a date earlier than min and later than max via keyboard events", function(assert) {
         const isAnimationOff = fx.off,
             animate = fx.animate;
 
@@ -1806,7 +1806,7 @@ QUnit.module("Min & Max options", {
         }
     });
 
-    QUnit.test("calendar should set currentDate to min when setting to an earlier date; and to max when setting to a later date", (assert) => {
+    QUnit.test("calendar should set currentDate to min when setting to an earlier date; and to max when setting to a later date", function(assert) {
         const calendar = this.calendar,
             min = calendar.option("min"),
             max = calendar.option("max"),
@@ -1819,7 +1819,7 @@ QUnit.module("Min & Max options", {
         assert.deepEqual(calendar.option("currentDate"), new Date(this.maxDate.getFullYear(), this.maxDate.getMonth(), max.getDate()));
     });
 
-    QUnit.test("calendar should properly initialize currentDate with respect to min and max", (assert) => {
+    QUnit.test("calendar should properly initialize currentDate with respect to min and max", function(assert) {
         this.reinit({
             min: this.minDate,
             max: this.maxDate
@@ -1829,7 +1829,7 @@ QUnit.module("Min & Max options", {
         assert.ok(dateUtils.sameView(calendar.option("zoomLevel"), calendar.option("currentDate"), this.minDate));
     });
 
-    QUnit.test("value should not be changed when min and max options are set", (assert) => {
+    QUnit.test("value should not be changed when min and max options are set", function(assert) {
         const calendar = this.calendar;
         const outOfRangeDate = new Date(2010, 12, 10);
 
@@ -1837,7 +1837,7 @@ QUnit.module("Min & Max options", {
         assert.equal(calendar.option("value"), outOfRangeDate, "value is not changed");
     });
 
-    QUnit.test("current date is max month if value is null and range is earlier than today", (assert) => {
+    QUnit.test("current date is max month if value is null and range is earlier than today", function(assert) {
         this.reinit({
             min: this.minDate,
             max: this.maxDate,
@@ -1851,7 +1851,7 @@ QUnit.module("Min & Max options", {
         assert.deepEqual(calendar.option("currentDate"), new Date(this.maxDate), "current date is max");
     });
 
-    QUnit.test("change currentDate without navigation if became out of range after max is set", (assert) => {
+    QUnit.test("change currentDate without navigation if became out of range after max is set", function(assert) {
         this.reinit({
             value: new Date(2015, 5, 16)
         });
@@ -1865,7 +1865,7 @@ QUnit.module("Min & Max options", {
         assert.equal(this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS)).text(), "May 2015", "navigator caption is changed");
     });
 
-    QUnit.test("change currentDate without navigation if became out of range after min is set", (assert) => {
+    QUnit.test("change currentDate without navigation if became out of range after min is set", function(assert) {
         this.reinit({
             value: new Date(2015, 5, 16)
         });
@@ -1879,7 +1879,7 @@ QUnit.module("Min & Max options", {
         assert.equal(this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS)).text(), "July 2015", "navigator caption is changed");
     });
 
-    QUnit.test("current date is not changed when min or max option is changed and current value is in range", (assert) => {
+    QUnit.test("current date is not changed when min or max option is changed and current value is in range", function(assert) {
         const value = new Date(2015, 0, 27);
 
         this.reinit({
@@ -1910,7 +1910,7 @@ QUnit.module("Min & Max options", {
         assert.deepEqual(calendar.option("value"), value, "value is not changed");
     });
 
-    QUnit.test("T278441 - min date should be 1/1/1000 if the 'min' option is null", (assert) => {
+    QUnit.test("T278441 - min date should be 1/1/1000 if the 'min' option is null", function(assert) {
         const value = new Date(988, 7, 17);
 
         this.reinit({
@@ -1921,7 +1921,7 @@ QUnit.module("Min & Max options", {
         assert.deepEqual(this.calendar.option("currentDate"), new Date(1000, 0), "current date is correct");
     });
 
-    QUnit.test("T278441 - max date should be 31/12/2999 if the 'max' option is null", (assert) => {
+    QUnit.test("T278441 - max date should be 31/12/2999 if the 'max' option is null", function(assert) {
         const value = new Date(3015, 7, 17);
 
         this.reinit({
@@ -1932,7 +1932,7 @@ QUnit.module("Min & Max options", {
         assert.deepEqual(this.calendar.option("currentDate"), new Date(3000, 0), "current date is correct");
     });
 
-    QUnit.test("T266658 - widget should have no views that are out of range", (assert) => {
+    QUnit.test("T266658 - widget should have no views that are out of range", function(assert) {
         this.reinit({
             value: new Date(2015, 8, 8),
             min: new Date(2015, 8, 2),
@@ -1951,7 +1951,7 @@ QUnit.module("Min & Max options", {
         assert.ok(!getAfterViewInstance(calendar), "there is no after view");
     });
 
-    QUnit.test("T266658 - widget should have no views that are out of range after navigation", (assert) => {
+    QUnit.test("T266658 - widget should have no views that are out of range after navigation", function(assert) {
         this.reinit({
             value: new Date(2015, 9, 8),
             min: new Date(2015, 8, 2),
@@ -1964,7 +1964,7 @@ QUnit.module("Min & Max options", {
         assert.equal($views.length, 2, "the number of views is correct when current view contain min date");
     });
 
-    QUnit.test("correct views rendering with min option", (assert) => {
+    QUnit.test("correct views rendering with min option", function(assert) {
         const params = {
             "year": { value: new Date(2015, 0, 8), min: new Date(2014, 11, 16) },
             "decade": { value: new Date(2010, 0, 8), min: new Date(2009, 11, 16) },
@@ -1979,7 +1979,7 @@ QUnit.module("Min & Max options", {
         }, this));
     });
 
-    QUnit.test("correct views rendering with max option", (assert) => {
+    QUnit.test("correct views rendering with max option", function(assert) {
         const params = {
             "year": { value: new Date(2015, 11, 8), max: new Date(2016, 0, 16) },
             "decade": { value: new Date(2019, 11, 8), max: new Date(2020, 0, 16) },
@@ -1997,7 +1997,7 @@ QUnit.module("Min & Max options", {
 
 
 QUnit.module("disabledDates option", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.value = new Date(2010, 10, 10);
@@ -2024,13 +2024,13 @@ QUnit.module("disabledDates option", {
             this.calendar = this.$element.dxCalendar(options).dxCalendar("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         this.clock.restore();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("calendar should not allow to navigate to a disabled date via keyboard events", (assert) => {
+    QUnit.test("calendar should not allow to navigate to a disabled date via keyboard events", function(assert) {
         const isAnimationOff = fx.off,
             animate = fx.animate;
 
@@ -2078,7 +2078,7 @@ QUnit.module("disabledDates option", {
         }
     });
 
-    QUnit.test("calendar should properly set the first and the last available cells", (assert) => {
+    QUnit.test("calendar should properly set the first and the last available cells", function(assert) {
         this.reinit({
             disabledDates: (args) => {
                 const disabledDays = [1, 2, 28, 30];
@@ -2099,7 +2099,7 @@ QUnit.module("disabledDates option", {
         assert.deepEqual(this.calendar.option("currentDate"), new Date(2010, 10, 29));
     });
 
-    QUnit.test("calendar should properly initialize currentDate when initial value is disabled", (assert) => {
+    QUnit.test("calendar should properly initialize currentDate when initial value is disabled", function(assert) {
         this.reinit({
             disabledDates: (args) => {
                 if(args.date.valueOf() === new Date(2010, 10, 10).valueOf()) {
@@ -2114,7 +2114,7 @@ QUnit.module("disabledDates option", {
         assert.ok(dateUtils.sameView(calendar.option("zoomLevel"), calendar.option("currentDate"), new Date(2010, 10, 11)));
     });
 
-    QUnit.test("value should not be changed when disabledDates option is set", (assert) => {
+    QUnit.test("value should not be changed when disabledDates option is set", function(assert) {
         const calendar = this.calendar;
         const disabledDate = new Date(2010, 9, 10);
 
@@ -2122,7 +2122,7 @@ QUnit.module("disabledDates option", {
         assert.equal(calendar.option("value"), disabledDate, "value is not changed");
     });
 
-    QUnit.test("disabledDates argument contains correct component parameter", (assert) => {
+    QUnit.test("disabledDates argument contains correct component parameter", function(assert) {
         const stub = sinon.stub();
 
         this.reinit({
@@ -2135,7 +2135,7 @@ QUnit.module("disabledDates option", {
         assert.equal(component.NAME, "dxCalendar", "Correct component");
     });
 
-    QUnit.test("current day is moved to a next day while it is less a max date when all days are disabled", (assert) => {
+    QUnit.test("current day is moved to a next day while it is less a max date when all days are disabled", function(assert) {
         this.reinit({
             max: new Date(2018, 0, 10),
             value: new Date(2018, 0, 2),
@@ -2147,7 +2147,7 @@ QUnit.module("disabledDates option", {
         assert.ok(this.calendar.option("currentDate") <= this.calendar.option("max"));
     });
 
-    QUnit.test("current day is moved to the next day when it is more a min date when all days are disabled", (assert) => {
+    QUnit.test("current day is moved to the next day when it is more a min date when all days are disabled", function(assert) {
         this.reinit({
             min: new Date(2018, 0, 10),
             value: new Date(2018, 1, 2),
@@ -2161,7 +2161,7 @@ QUnit.module("disabledDates option", {
         assert.ok(this.calendar.option("currentDate") >= this.calendar.option("min"));
     });
 
-    QUnit.test("current day should be moved to the closest available date on init", (assert) => {
+    QUnit.test("current day should be moved to the closest available date on init", function(assert) {
         const newDateMock = sinon.useFakeTimers(new Date(2017, 11, 30).valueOf());
         const maxAvailableDate = new Date(2017, 10, 25);
 
@@ -2182,7 +2182,7 @@ QUnit.module("disabledDates option", {
 
 
 QUnit.module("Current date", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.$element = $("<div>").appendTo("body");
 
@@ -2191,12 +2191,12 @@ QUnit.module("Current date", {
             this.$element = $("<div>").appendTo("body");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("calendar must contouring date on focusin", (assert) => {
+    QUnit.test("calendar must contouring date on focusin", function(assert) {
         const $element = this.$element;
         const calendar = $element.dxCalendar({
             value: new Date(2015, 11, 15),
@@ -2212,7 +2212,7 @@ QUnit.module("Current date", {
         });
     });
 
-    QUnit.test("click on cell should change current date", (assert) => {
+    QUnit.test("click on cell should change current date", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2015, 10, 8),
             focusStateEnabled: true
@@ -2224,7 +2224,7 @@ QUnit.module("Current date", {
         assert.deepEqual(calendar.option("currentDate"), new Date(2015, 10, 16), "current date is changed correctly");
     });
 
-    QUnit.test("correct currentDate with min and no value", (assert) => {
+    QUnit.test("correct currentDate with min and no value", function(assert) {
         const $element = this.$element;
         const calendar = $element.dxCalendar({
             focusStateEnabled: true
@@ -2248,7 +2248,7 @@ QUnit.module("Current date", {
         });
     });
 
-    QUnit.test("correct change contouredDate after view change if this cell is not present on new view", (assert) => {
+    QUnit.test("correct change contouredDate after view change if this cell is not present on new view", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2015, 0, 31),
             zoomLevel: "month",
@@ -2259,7 +2259,7 @@ QUnit.module("Current date", {
         assert.deepEqual(calendar.option("currentDate"), new Date(2015, 1, 28));
     });
 
-    QUnit.test("current date is correct when trying to navigate out of available range", (assert) => {
+    QUnit.test("current date is correct when trying to navigate out of available range", function(assert) {
         const params = {
             "month": { min: new Date(2015, 2, 14), max: new Date(2015, 2, 16), currentDate: new Date(2015, 2, 15) },
             "year": { min: new Date(2015, 1, 17), max: new Date(2015, 3, 20), currentDate: new Date(2015, 2, 15) },
@@ -2291,7 +2291,7 @@ QUnit.module("Current date", {
         }, this));
     });
 
-    QUnit.test("after pressing upArrow/downArrow button the current view should be changed and the contouredDate should be set correctly", (assert) => {
+    QUnit.test("after pressing upArrow/downArrow button the current view should be changed and the contouredDate should be set correctly", function(assert) {
         const params = {
             "month": { startDate: new Date(2015, 2, 3), expectedDate: new Date(2015, 1, 24) },
             "year": { startDate: new Date(2015, 2, 1), expectedDate: new Date(2014, 10, 1) },
@@ -2323,7 +2323,7 @@ QUnit.module("Current date", {
         }, this));
     });
 
-    QUnit.test("current date should be saved while navigating up and down", (assert) => {
+    QUnit.test("current date should be saved while navigating up and down", function(assert) {
         const $element = this.$element;
         const calendar = $element.dxCalendar({
             value: new Date(2015, 2, 10),
@@ -2352,7 +2352,7 @@ QUnit.module("Current date", {
         assert.deepEqual(calendar.option("currentDate"), new Date(2025, 2, 10), "contoured is correct on month view (down)");
     });
 
-    QUnit.test("contouredDate should not be rendered when focusStateEnabled is false(T196396)", (assert) => {
+    QUnit.test("contouredDate should not be rendered when focusStateEnabled is false(T196396)", function(assert) {
         const $calendar = this.$element.dxCalendar({
             focusStateEnabled: false,
             value: new Date(2013, 11, 15)
@@ -2365,16 +2365,16 @@ QUnit.module("Current date", {
 
 
 QUnit.module("Navigation - click on other view cell", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.$element = $("<div>").appendTo("body");
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("go to neighbor view after click on view cell with class 'CALENDAR_OTHER_VIEW_CLASS'", (assert) => {
+    QUnit.test("go to neighbor view after click on view cell with class 'CALENDAR_OTHER_VIEW_CLASS'", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2015, 2, 15)
         }).dxCalendar("instance");
@@ -2394,7 +2394,7 @@ QUnit.module("Navigation - click on other view cell", {
         });
     });
 
-    QUnit.test("click on other view cell forces view change", (assert) => {
+    QUnit.test("click on other view cell forces view change", function(assert) {
         const calendar = this.$element.dxCalendar({
                 maxZoomLevel: "month",
                 value: new Date(2015, 3, 15)
@@ -2410,7 +2410,7 @@ QUnit.module("Navigation - click on other view cell", {
         assert.deepEqual(calendar.option("currentDate"), expectedDate, "view is changed");
     });
 
-    QUnit.test("click on other view cell must set value and contoured date on boundary view ", (assert) => {
+    QUnit.test("click on other view cell must set value and contoured date on boundary view ", function(assert) {
         const calendar = this.$element.dxCalendar({
                 zoomLevel: "month",
                 value: new Date(2015, 3, 15),
@@ -2429,7 +2429,7 @@ QUnit.module("Navigation - click on other view cell", {
         assert.deepEqual(calendar._view.option("contouredDate"), expectedDate, "view is changed");
     });
 
-    QUnit.test("Click on other view cell must set value correctly", (assert) => {
+    QUnit.test("Click on other view cell must set value correctly", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2015, 11, 1),
             currentDate: new Date(2015, 11, 1)
@@ -2453,7 +2453,7 @@ QUnit.module("Navigation - click on other view cell", {
 
 
 QUnit.module("Navigation - swiping", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("<div>").appendTo("body");
@@ -2471,19 +2471,19 @@ QUnit.module("Navigation - swiping", {
             this.pointer = pointerMock(this.$element).start();
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("views count on continuous swipe", (assert) => {
+    QUnit.test("views count on continuous swipe", function(assert) {
         assert.expect(1);
 
         this.pointer.swipeStart().swipe(0.01);
         assert.equal(this.$element.find("table").length, 3, "Month views count is equal to 3");
     });
 
-    QUnit.test("views offset on continuous right swipe", (assert) => {
+    QUnit.test("views offset on continuous right swipe", function(assert) {
         const width = this.$element.width(),
             offset = 0.5 * width;
 
@@ -2497,7 +2497,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(translator.locate($tables.eq(1)).left, -width, "Second view position is correct");
     });
 
-    QUnit.test("views offset on continuous left swipe", (assert) => {
+    QUnit.test("views offset on continuous left swipe", function(assert) {
         const width = this.$element.width(),
             offset = 0.5 * width;
 
@@ -2512,7 +2512,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(translator.locate($tables.eq(2)).left, width, "Third view position is correct");
     });
 
-    QUnit.test("views after canceled right swipe", (assert) => {
+    QUnit.test("views after canceled right swipe", function(assert) {
         const currentDate = new Date(this.calendar.option("currentDate"));
 
         this.pointer.swipeStart().swipeEnd(0, 0.4);
@@ -2523,7 +2523,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(this.calendar.option("currentDate").getMonth(), currentDate.getMonth(), "Current month is correct");
     });
 
-    QUnit.test("views after canceled left swipe", (assert) => {
+    QUnit.test("views after canceled left swipe", function(assert) {
         const currentDate = new Date(this.calendar.option("currentDate"));
 
         this.pointer.swipeStart().swipeEnd(0, -0.4);
@@ -2534,7 +2534,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(this.calendar.option("currentDate").getMonth(), currentDate.getMonth(), "Current month is correct");
     });
 
-    QUnit.test("views after right long swipe end", (assert) => {
+    QUnit.test("views after right long swipe end", function(assert) {
         const currentDate = new Date(this.calendar.option("currentDate"));
         currentDate.setMonth(currentDate.getMonth() - 1);
 
@@ -2546,7 +2546,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(this.calendar.option("currentDate").getMonth(), currentDate.getMonth(), "Current month is correct");
     });
 
-    QUnit.test("views after left long swipe end", (assert) => {
+    QUnit.test("views after left long swipe end", function(assert) {
         const currentDate = new Date(this.calendar.option("currentDate"));
         currentDate.setMonth(currentDate.getMonth() + 1);
 
@@ -2558,12 +2558,12 @@ QUnit.module("Navigation - swiping", {
         assert.equal(this.calendar.option("currentDate").getMonth(), currentDate.getMonth(), "Current month is correct");
     });
 
-    QUnit.test("views after fast long swipe end", (assert) => {
+    QUnit.test("views after fast long swipe end", function(assert) {
         this.pointer.down().move(-100).move(-1000).up();
         assert.ok(true, "test must pass");
     });
 
-    QUnit.test("views after right short swipe end", (assert) => {
+    QUnit.test("views after right short swipe end", function(assert) {
         const currentDate = new Date(this.calendar.option("currentDate"));
 
         currentDate.setMonth(currentDate.getMonth() - 1);
@@ -2575,7 +2575,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(this.calendar.option("currentDate").getMonth(), currentDate.getMonth(), "Current month is correct");
     });
 
-    QUnit.test("views after left short swipe end", (assert) => {
+    QUnit.test("views after left short swipe end", function(assert) {
         const currentDate = new Date(this.calendar.option("currentDate"));
         currentDate.setMonth(currentDate.getMonth() + 1);
 
@@ -2587,7 +2587,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(this.calendar.option("currentDate").getMonth(), currentDate.getMonth(), "Current month is correct");
     });
 
-    QUnit.test("should not overlap during multidirectional swipe", (assert) => {
+    QUnit.test("should not overlap during multidirectional swipe", function(assert) {
         this.pointer.swipeStart().swipe(-0.1).swipe(0.01);
 
         const $views = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + " .dx-widget");
@@ -2597,7 +2597,7 @@ QUnit.module("Navigation - swiping", {
         assert.ok($views.eq(2).position().left > 0, "second additional view located at left");
     });
 
-    QUnit.test("views after right swipe end in rtl mode", (assert) => {
+    QUnit.test("views after right swipe end in rtl mode", function(assert) {
         this.reinit({
             currentDate: new Date(2013, 9, 15),
             firstDayOfWeek: 1,
@@ -2615,7 +2615,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(calendar.option("currentDate").getMonth(), newDate.getMonth(), "Current month is correct");
     });
 
-    QUnit.test("views after left swipe end in rtl mode", (assert) => {
+    QUnit.test("views after left swipe end in rtl mode", function(assert) {
         assert.expect(2);
 
         this.reinit({
@@ -2635,7 +2635,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(calendar.option("currentDate").getMonth(), newDate.getMonth(), "Current month is correct");
     });
 
-    QUnit.test("calendar must not leak views when navigating by swipe gesture", (assert) => {
+    QUnit.test("calendar must not leak views when navigating by swipe gesture", function(assert) {
         this.pointer.swipeStart().swipe(-0.6).swipeEnd(-1);
         this.pointer.swipeStart().swipe(-0.6).swipeEnd(-1);
         this.pointer.swipeStart().swipe(-0.6).swipeEnd(-1);
@@ -2643,7 +2643,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal(this.$element.find("table").length, 3, "correct views count");
     });
 
-    QUnit.test("correct end position for animation after long left swipe end", (assert) => {
+    QUnit.test("correct end position for animation after long left swipe end", function(assert) {
         assert.expect(1);
 
         const origAnimate = fx.animate;
@@ -2664,7 +2664,7 @@ QUnit.module("Navigation - swiping", {
         }
     });
 
-    QUnit.test("correct end position for animation after long right swipe end", (assert) => {
+    QUnit.test("correct end position for animation after long right swipe end", function(assert) {
         assert.expect(1);
 
         const origAnimate = fx.animate;
@@ -2685,7 +2685,7 @@ QUnit.module("Navigation - swiping", {
         }
     });
 
-    QUnit.test("correct views wrapper position after swiping from boundary view", (assert) => {
+    QUnit.test("correct views wrapper position after swiping from boundary view", function(assert) {
         this.reinit({
             currentDate: new Date(2015, 8, 15),
             min: new Date(2015, 8, 8),
@@ -2701,7 +2701,7 @@ QUnit.module("Navigation - swiping", {
         assert.equal($viewsWrapper.position().left, 0, "views wrapper position is correct");
     });
 
-    QUnit.test("correct views wrapper position after canceled swipe", (assert) => {
+    QUnit.test("correct views wrapper position after canceled swipe", function(assert) {
         this.reinit({
             currentDate: new Date(2015, 8, 15),
             min: new Date(2015, 8, 8),
@@ -2718,7 +2718,7 @@ QUnit.module("Navigation - swiping", {
     });
 
     // TODO: get rid of mocking private method
-    QUnit.test("performing a micro-swipe should not make the calendar jump by navigating to the same month", (assert) => {
+    QUnit.test("performing a micro-swipe should not make the calendar jump by navigating to the same month", function(assert) {
         const swipeEnd = $.Event(swipeEvents.end, { offset: 0, targetOffset: 0 });
         this.calendar._navigate = () => {
             assert.ok(false);
@@ -2728,7 +2728,7 @@ QUnit.module("Navigation - swiping", {
         $(this.$element).trigger(swipeEnd);
     });
 
-    QUnit.test("maxRightOffset and maxLeftOffset are correct when rltEnabled=true (T322033)", (assert) => {
+    QUnit.test("maxRightOffset and maxLeftOffset are correct when rltEnabled=true (T322033)", function(assert) {
         this.reinit({
             rtlEnabled: true,
             min: new Date(2015, 10, 10),
@@ -2750,16 +2750,16 @@ QUnit.module("Navigation - swiping", {
 
 
 QUnit.module("Aria accessibility", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.$element = $("<div>").appendTo("body");
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("role for calendar widget", (assert) => {
+    QUnit.test("role for calendar widget", function(assert) {
         const $element = this.$element;
 
         $element.dxCalendar();
@@ -2768,7 +2768,7 @@ QUnit.module("Aria accessibility", {
         assert.equal($element.attr("aria-label"), "Calendar", "label is correct");
     });
 
-    QUnit.test("aria-activedescendant on widget should point to the focused cell", (assert) => {
+    QUnit.test("aria-activedescendant on widget should point to the focused cell", function(assert) {
         const $element = this.$element;
 
         $element.dxCalendar({
@@ -2783,7 +2783,7 @@ QUnit.module("Aria accessibility", {
         assert.equal($element.attr("aria-activedescendant"), $cell.attr("id"), "cell's id and element's activedescendant are equal");
     });
 
-    QUnit.test("onContouredChanged action on init", (assert) => {
+    QUnit.test("onContouredChanged action on init", function(assert) {
         assert.expect(2);
 
         this.$element.dxCalendar({
@@ -2798,7 +2798,7 @@ QUnit.module("Aria accessibility", {
         $(this.$element).trigger("focusin");
     });
 
-    QUnit.test("onContouredChanged action on option change", (assert) => {
+    QUnit.test("onContouredChanged action on option change", function(assert) {
         assert.expect(2);
 
         this.$element.dxCalendar({
@@ -2811,7 +2811,7 @@ QUnit.module("Aria accessibility", {
         });
     });
 
-    QUnit.test("element should have correct aria-activedescendant attribute (T310017)", (assert) => {
+    QUnit.test("element should have correct aria-activedescendant attribute (T310017)", function(assert) {
         const $element = this.$element;
 
         $element.dxCalendar({
@@ -2837,14 +2837,14 @@ QUnit.module("Aria accessibility", {
         assert.equal($element.attr("aria-activedescendant"), $cell.attr("id"), "selected cell id and activedescendant are equal");
     });
 
-    QUnit.test("role for calendar cells", (assert) => {
+    QUnit.test("role for calendar cells", function(assert) {
         const calendar = this.$element.dxCalendar().dxCalendar("instance");
         const $cell = $(getCurrentViewInstance(calendar).$element().find(toSelector(CALENDAR_CELL_CLASS)).first());
 
         assert.equal($cell.attr("role"), "option", "aria role is correct");
     });
 
-    QUnit.test("aria id on contoured date cell", (assert) => {
+    QUnit.test("aria id on contoured date cell", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2015, 5, 1),
             focusStateEnabled: true
@@ -2874,7 +2874,7 @@ QUnit.module("Aria accessibility", {
         assert.notEqual($cell.attr("id"), newCellId, "id was refreshed again");
     });
 
-    QUnit.test("aria-selected on selected date cell", (assert) => {
+    QUnit.test("aria-selected on selected date cell", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2015, 5, 1),
             focusStateEnabled: true
@@ -2895,7 +2895,7 @@ QUnit.module("Aria accessibility", {
         assert.equal($cell.attr("aria-selected"), "true", "aria-selected was added to the new cell");
     });
 
-    QUnit.test("cell id should be set before widget activedescendant attribute", (assert) => {
+    QUnit.test("cell id should be set before widget activedescendant attribute", function(assert) {
         const calendar = this.$element.dxCalendar({
             focusStateEnabled: true
         }).dxCalendar("instance");
@@ -2916,7 +2916,7 @@ QUnit.module("Aria accessibility", {
         }
     });
 
-    QUnit.test("aria id on contoured cell after zoom level change (T321824)", (assert) => {
+    QUnit.test("aria id on contoured cell after zoom level change (T321824)", function(assert) {
         const calendar = this.$element.dxCalendar({
             focusStateEnabled: true,
             zoomLevel: "month"
@@ -2931,7 +2931,7 @@ QUnit.module("Aria accessibility", {
         assert.equal($contouredDateCell.attr("id"), this.$element.attr("aria-activedescendant"), "cell has correct id");
     });
 
-    QUnit.test("aria id on contoured cell after view change (T321824)", (assert) => {
+    QUnit.test("aria id on contoured cell after view change (T321824)", function(assert) {
         try {
             fx.off = false;
 
@@ -2960,7 +2960,7 @@ QUnit.module("Aria accessibility", {
 
 
 QUnit.module("Regression", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.$element = $("<div>").appendTo("body");
 
@@ -2969,12 +2969,12 @@ QUnit.module("Regression", {
             this.$element = $("<div>").appendTo("body");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("T182880: dxDateBox - Can not list to next month in Firefox", (assert) => {
+    QUnit.test("T182880: dxDateBox - Can not list to next month in Firefox", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2013, 11, 31)
         }).dxCalendar("instance");
@@ -2985,7 +2985,7 @@ QUnit.module("Regression", {
         assert.equal(calendar.option("currentDate").getMonth(), 0);
     });
 
-    QUnit.test("T182866: dxCalendar shows 31 Dec. 2013 twice in Firefox and Yandex browsers", (assert) => {
+    QUnit.test("T182866: dxCalendar shows 31 Dec. 2013 twice in Firefox and Yandex browsers", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2013, 11, 31)
         }).dxCalendar("instance");
@@ -2997,7 +2997,7 @@ QUnit.module("Regression", {
         }).length, 1);
     });
 
-    QUnit.test("T190112: dxCalendar - month is not changed when click on cell in Firefox (December 2013 -> January 2014)", (assert) => {
+    QUnit.test("T190112: dxCalendar - month is not changed when click on cell in Firefox (December 2013 -> January 2014)", function(assert) {
         const calendar = this.$element.dxCalendar({
             currentDate: new Date(2013, 11, 31)
         }).dxCalendar("instance");
@@ -3006,7 +3006,7 @@ QUnit.module("Regression", {
         assert.equal(calendar.option("currentDate").getMonth(), 0);
     });
 
-    QUnit.test("T190814: dxCalendar - unable to navigate by keyboard from December 2013 to January 2013 in Firefox", (assert) => {
+    QUnit.test("T190814: dxCalendar - unable to navigate by keyboard from December 2013 to January 2013 in Firefox", function(assert) {
         const calendar = this.$element.dxCalendar({
             value: new Date(2013, 11, 31),
             currentDate: new Date(2013, 11, 31),
@@ -3020,16 +3020,16 @@ QUnit.module("Regression", {
 
 
 QUnit.module("dxCalendar number and string value support", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("<div>").appendTo("body");
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("widget should work correct if the 'value', 'min' and 'max' options have string type", (assert) => {
+    QUnit.test("widget should work correct if the 'value', 'min' and 'max' options have string type", function(assert) {
         this.$element.dxCalendar({
             value: "2016/04/11",
             min: "2016/03/11",
@@ -3039,7 +3039,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.ok(true, "it's ok");
     });
 
-    QUnit.test("widget should work correct if the 'value', 'min' and 'max' options have number type", (assert) => {
+    QUnit.test("widget should work correct if the 'value', 'min' and 'max' options have number type", function(assert) {
         const value = new Date(2016, 3, 11),
             min = new Date(2016, 2, 11),
             max = new Date(2016, 4, 11);
@@ -3053,7 +3053,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.ok(true, "it's ok");
     });
 
-    QUnit.test("widget should work correct if the only 'min' and 'max' options have number type", (assert) => {
+    QUnit.test("widget should work correct if the only 'min' and 'max' options have number type", function(assert) {
         const min = new Date(2016, 2, 11),
             max = new Date(2016, 4, 11);
 
@@ -3065,7 +3065,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.ok(true, "it's ok");
     });
 
-    QUnit.test("selected cell is correct if the 'value' has string type", (assert) => {
+    QUnit.test("selected cell is correct if the 'value' has string type", function(assert) {
         this.$element.dxCalendar({
             value: "2016/04/11"
         });
@@ -3074,7 +3074,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.deepEqual(cellValue, "2016/04/11", "cell value is correct");
     });
 
-    QUnit.test("selected cell is correct if the 'value' has number type", (assert) => {
+    QUnit.test("selected cell is correct if the 'value' has number type", function(assert) {
         const numberValue = (new Date(2016, 3, 11)).getTime();
 
         this.$element.dxCalendar({
@@ -3085,7 +3085,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.deepEqual(cellValue, "2016/04/11", "cell value is correct");
     });
 
-    QUnit.test("new cell selection should change value correct if the value type is string", (assert) => {
+    QUnit.test("new cell selection should change value correct if the value type is string", function(assert) {
         this.$element.dxCalendar({
             value: "2016/04/11"
         });
@@ -3098,7 +3098,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.equal(this.$element.dxCalendar("option", "value"), "2016/04/12", "value is correct");
     });
 
-    QUnit.test("new cell selection should change value correct if the value type is string", (assert) => {
+    QUnit.test("new cell selection should change value correct if the value type is string", function(assert) {
         this.$element.dxCalendar({
             value: (new Date(2016, 3, 11)).getTime()
         });
@@ -3111,7 +3111,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.equal(this.$element.dxCalendar("option", "value"), (new Date(2016, 3, 12)).getTime(), "value is correct");
     });
 
-    QUnit.test("datetime value should work correct if the value type is string", (assert) => {
+    QUnit.test("datetime value should work correct if the value type is string", function(assert) {
         this.$element.dxCalendar({
             value: "2016/04/11 17:29"
         });
@@ -3119,7 +3119,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.ok(true, "it's ok");
     });
 
-    QUnit.test("datetime value should be changed without time changing if the value type is string", (assert) => {
+    QUnit.test("datetime value should be changed without time changing if the value type is string", function(assert) {
         this.$element.dxCalendar({
             value: "2016/04/11 17:29:00"
         });
@@ -3132,7 +3132,7 @@ QUnit.module("dxCalendar number and string value support", {
         assert.equal(this.$element.dxCalendar("option", "value"), "2016/04/12 17:29:00", "value is correct");
     });
 
-    QUnit.test("datetime value should be changed without time changing if the value type is ISO string", (assert) => {
+    QUnit.test("datetime value should be changed without time changing if the value type is ISO string", function(assert) {
         const defaultForceIsoDateParsing = config().forceIsoDateParsing;
         config().forceIsoDateParsing = true;
 
@@ -3154,7 +3154,7 @@ QUnit.module("dxCalendar number and string value support", {
         }
     });
 
-    QUnit.test("datetime value should be changed without time changing if the value type is ISO string with dateSerializationFormat", (assert) => {
+    QUnit.test("datetime value should be changed without time changing if the value type is ISO string with dateSerializationFormat", function(assert) {
         this.$element.dxCalendar({
             value: "2016-04-11T00:00:00Z",
             dateSerializationFormat: "yyyy-MM-ddTHH:mm:ssZ"

--- a/testing/tests/DevExpress.ui.widgets.editors/checkbox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/checkbox.tests.js
@@ -108,7 +108,7 @@ QUnit.test("onContentReady fired after setting the value", function(assert) {
 QUnit.module("validation");
 
 if(devices.real().deviceType === "desktop") {
-    QUnit.test("the click should be processed before the validation message is shown (T570458)", (assert) => {
+    QUnit.test("the click should be processed before the validation message is shown (T570458)", function(assert) {
         const $checkbox = $("#checkbox")
             .dxCheckBox({})
             .dxValidator({
@@ -137,7 +137,7 @@ if(devices.real().deviceType === "desktop") {
         assert.ok(isValidationMessageVisible());
     });
 
-    QUnit.test("should show validation message after focusing", (assert) => {
+    QUnit.test("should show validation message after focusing", function(assert) {
         const clock = sinon.useFakeTimers();
         const $checkbox = $("#checkbox")
             .dxCheckBox({})

--- a/testing/tests/DevExpress.ui.widgets.editors/colorBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/colorBox.tests.js
@@ -790,7 +790,7 @@ QUnit.test("Value should not be changed by 'up' key when colorbox was opened and
     assert.equal(colorBox.option("value"), "#326b8a");
 });
 
-QUnit.test("value should be reseted after popup closing when 'applyValueMode' is 'useButtons' (T806577)", (assert) => {
+QUnit.test("value should be reseted after popup closing when 'applyValueMode' is 'useButtons' (T806577)", function(assert) {
     const colorBox = $("#color-box").dxColorBox({
             value: "#aabbcc",
             applyValueMode: "useButtons",

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
@@ -16,7 +16,7 @@ QUnit.testStart(() => {
 
 if(devices.real().deviceType === "desktop") {
     let setupModule = {
-        beforeEach: () => {
+        beforeEach: function() {
             this.parts = renderDateParts("Tuesday, July 2, 2024 16:19 PM", dateParser.getRegExpInfo("EEEE, MMMM d, yyyy HH:mm a", dateLocalization));
             this.$element = $("#dateBox").dxDateBox({
                 value: new Date("10/10/2012 13:07"),
@@ -32,30 +32,30 @@ if(devices.real().deviceType === "desktop") {
             this.clock = sinon.useFakeTimers(new Date(2015, 3, 14).getTime());
         },
 
-        afterEach: () => {
+        afterEach: function() {
             this.clock.restore();
         }
     };
 
     module("Rendering", setupModule, () => {
-        test("Text option should depend on the input value", (assert) => {
+        test("Text option should depend on the input value", function(assert) {
             this.keyboard.press("up");
             assert.strictEqual(this.instance.option("text"), "November 10 2012", "text is correct");
         });
 
-        test("Masks should be enabled when displayFormat is not specified", (assert) => {
+        test("Masks should be enabled when displayFormat is not specified", function(assert) {
             this.instance.option("displayFormat", undefined);
             this.keyboard.press("up");
             assert.strictEqual(this.instance.option("text"), "11/10/2012", "mask behavior works");
         });
 
-        test("Masks should not be enabled when mode is not text", (assert) => {
+        test("Masks should not be enabled when mode is not text", function(assert) {
             this.instance.option("mode", "date");
             this.keyboard.press("up");
             assert.strictEqual(this.instance.option("text"), "October 10 2012", "mask behavior does not work");
         });
 
-        test("Rendering with non-ldml format", (assert) => {
+        test("Rendering with non-ldml format", function(assert) {
             this.instance.option("displayFormat", "shortdate");
             assert.strictEqual(this.instance.option("text"), "10/10/2012", "format works");
         });
@@ -78,11 +78,11 @@ if(devices.real().deviceType === "desktop") {
             delete part.limits;
         };
 
-        test("Check parts length", (assert) => {
+        test("Check parts length", function(assert) {
             assert.strictEqual(this.parts.length, 13);
         });
 
-        test("Day of week", (assert) => {
+        test("Day of week", function(assert) {
             checkAndRemoveLimits(this.parts[0], { min: 0, max: 6 }, assert);
 
             let date = new Date(2012, 1, 4, 15, 6);
@@ -100,7 +100,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Month", (assert) => {
+        test("Month", function(assert) {
             checkAndRemoveLimits(this.parts[2], { min: 1, max: 12 }, assert);
 
             let date = new Date(2012, 2, 30);
@@ -120,7 +120,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Day", (assert) => {
+        test("Day", function(assert) {
             checkAndRemoveLimits(this.parts[4], { min: 1, max: 31 }, assert);
 
             let date = new Date(2012, 1, 4, 15, 6);
@@ -138,7 +138,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Year", (assert) => {
+        test("Year", function(assert) {
             checkAndRemoveLimits(this.parts[6], { min: 0, max: 9999 }, assert);
 
             let date = new Date(2012, 1, 4, 15, 6);
@@ -156,7 +156,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Hours", (assert) => {
+        test("Hours", function(assert) {
             checkAndRemoveLimits(this.parts[8], { min: 0, max: 23 }, assert);
 
             assert.deepEqual(this.parts[8], {
@@ -170,7 +170,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Minutes", (assert) => {
+        test("Minutes", function(assert) {
             checkAndRemoveLimits(this.parts[10], { min: 0, max: 59 }, assert);
 
             assert.deepEqual(this.parts[10], {
@@ -184,7 +184,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Seconds", (assert) => {
+        test("Seconds", function(assert) {
             const dateString = "Tuesday, July 2, 2024 16:19:22";
             const regExpInfo = dateParser.getRegExpInfo("EEEE, MMMM d, yyyy HH:mm:ss", dateLocalization);
 
@@ -202,7 +202,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Milliseconds", (assert) => {
+        test("Milliseconds", function(assert) {
             const dateString = "Tuesday, July 2, 2024 16:19:22:333";
             const regExpInfo = dateParser.getRegExpInfo("EEEE, MMMM d, yyyy HH:mm:ss:SSS", dateLocalization);
 
@@ -220,7 +220,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Time indication", (assert) => {
+        test("Time indication", function(assert) {
             checkAndRemoveLimits(this.parts[12], { min: 0, max: 1 }, assert);
 
             let date = new Date(2012, 1, 4, 15, 6);
@@ -242,7 +242,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Comma stub", (assert) => {
+        test("Comma stub", function(assert) {
             checkAndRemoveAccessors(this.parts[1], ",", assert);
 
             assert.deepEqual(this.parts[1], {
@@ -254,7 +254,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Space stub", (assert) => {
+        test("Space stub", function(assert) {
             checkAndRemoveAccessors(this.parts[3], " ", assert);
 
             assert.deepEqual(this.parts[3], {
@@ -266,7 +266,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Colon stub", (assert) => {
+        test("Colon stub", function(assert) {
             checkAndRemoveAccessors(this.parts[9], ":", assert);
 
             assert.deepEqual(this.parts[9], {
@@ -278,7 +278,7 @@ if(devices.real().deviceType === "desktop") {
             });
         });
 
-        test("Pattern stub", (assert) => {
+        test("Pattern stub", function(assert) {
             const parts = renderDateParts("dd 2016", dateParser.getRegExpInfo("'dd' yyyy", dateLocalization));
 
             assert.strictEqual(parts.length, 2, "there are 2 parts rendered");
@@ -288,42 +288,42 @@ if(devices.real().deviceType === "desktop") {
     });
 
     module("Date parts find", setupModule, () => {
-        test("Find day of week", (assert) => {
+        test("Find day of week", function(assert) {
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 0), 0, "start position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 3), 0, "middle position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 7), 0, "end position of the group");
         });
 
-        test("Find month", (assert) => {
+        test("Find month", function(assert) {
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 9), 2, "start position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 10), 2, "middle position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 13), 2, "end position of the group");
         });
 
-        test("Find day", (assert) => {
+        test("Find day", function(assert) {
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 14), 4, "start position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 15), 4, "end position of the group");
         });
 
-        test("Find year", (assert) => {
+        test("Find year", function(assert) {
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 17), 6, "start position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 19), 6, "middle position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 21), 6, "end position of the group");
         });
 
-        test("Find hours", (assert) => {
+        test("Find hours", function(assert) {
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 22), 8, "start position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 23), 8, "middle position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 24), 8, "end position of the group");
         });
 
-        test("Find minutes", (assert) => {
+        test("Find minutes", function(assert) {
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 25), 10, "start position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 26), 10, "middle position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 27), 10, "end position of the group");
         });
 
-        test("Find time indicator", (assert) => {
+        test("Find time indicator", function(assert) {
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 28), 12, "start position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 29), 12, "middle position of the group");
             assert.strictEqual(getDatePartIndexByPosition(this.parts, 30), 12, "end position of the group");
@@ -331,7 +331,7 @@ if(devices.real().deviceType === "desktop") {
     });
 
     module("Keyboard navigation", setupModule, () => {
-        test("RegisterKeyHandler should work", (assert) => {
+        test("RegisterKeyHandler should work", function(assert) {
             const handler = sinon.spy();
             this.instance.registerKeyHandler("del", handler);
 
@@ -339,7 +339,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(handler.callCount, 1, "registerKeyHandler works");
         });
 
-        test("original keyboard handlers should work after 'registerKeyHandler'", (assert) => {
+        test("original keyboard handlers should work after 'registerKeyHandler'", function(assert) {
             this.instance.option("pickerType", "calendar");
             this.instance.registerKeyHandler("space", sinon.stub());
             this.instance.open();
@@ -354,7 +354,7 @@ if(devices.real().deviceType === "desktop") {
             assert.notOk($contouredDate.is($selectedDate), "Contoured date isn't a selected");
         });
 
-        test("mask handler should be used instead of the default for delete key when widget is opened (T832885)", (assert) => {
+        test("mask handler should be used instead of the default for delete key when widget is opened (T832885)", function(assert) {
             this.instance.open();
 
             for(let i = 0; i < 3; ++i) {
@@ -364,7 +364,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "January 1 2000", "value has been reverted");
         });
 
-        test("mask handler should be used instead of the default for backspace key when widget is opened (T832885)", (assert) => {
+        test("mask handler should be used instead of the default for backspace key when widget is opened (T832885)", function(assert) {
             this.keyboard
                 .press("right")
                 .press("right");
@@ -377,7 +377,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "January 1 2000", "value has been reverted");
         });
 
-        test("Right and left arrows should move the selection", (assert) => {
+        test("Right and left arrows should move the selection", function(assert) {
             this.keyboard.press("right");
             assert.deepEqual(this.keyboard.caret(), { start: 8, end: 10 }, "next group is selected");
 
@@ -385,7 +385,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 0, end: 7 }, "previous group is selected");
         });
 
-        test("Home and end keys should move selection to boundaries", (assert) => {
+        test("Home and end keys should move selection to boundaries", function(assert) {
             this.keyboard.focus();
             this.keyboard.press("end");
             assert.deepEqual(this.keyboard.caret(), { start: 11, end: 15 }, "last group is selected");
@@ -394,7 +394,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 0, end: 7 }, "first group is selected");
         });
 
-        test("Up and down arrows should increase and decrease current group value", (assert) => {
+        test("Up and down arrows should increase and decrease current group value", function(assert) {
             const groups = [
                 { pattern: "EEEE", up: "Thursday", down: "Wednesday" },
                 { pattern: "d", up: "11", down: "10" },
@@ -419,7 +419,7 @@ if(devices.real().deviceType === "desktop") {
             }.bind(this));
         });
 
-        test("Hours switching should not switch am/pm", (assert) => {
+        test("Hours switching should not switch am/pm", function(assert) {
             this.instance.option("displayFormat", "h a");
             this.instance.option("value", new Date(2012, 3, 4, 23, 55, 0));
 
@@ -429,7 +429,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "12 PM", "am/pm was not switched");
         });
 
-        test("Moving through the february should not break day value", (assert) => {
+        test("Moving through the february should not break day value", function(assert) {
             this.instance.option({
                 value: new Date(2015, 0, 29),
                 displayFormat: "MMMM, dd"
@@ -442,7 +442,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "January, 29");
         });
 
-        test("Day reducing by down arrow key should use max date for the current month", (assert) => {
+        test("Day reducing by down arrow key should use max date for the current month", function(assert) {
             this.instance.option({
                 value: new Date(2015, 1, 1),
                 displayFormat: "dd/MM/yyyy"
@@ -460,7 +460,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "February, 28", "the date is correct for 'd' date format");
         });
 
-        test("Day increasing by up arrow key should use max date for the current month", (assert) => {
+        test("Day increasing by up arrow key should use max date for the current month", function(assert) {
             this.instance.option({
                 value: new Date(2015, 1, 28),
                 displayFormat: "dd/MM/yyyy"
@@ -470,7 +470,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "01/02/2015");
         });
 
-        test("Month changing should adjust days to limits", (assert) => {
+        test("Month changing should adjust days to limits", function(assert) {
             this.instance.option("value", new Date(2018, 2, 30));
             assert.strictEqual(this.$input.val(), "March 30 2018", "initial text is correct");
 
@@ -478,7 +478,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "February 28 2018", "text is correct");
         });
 
-        test("Esc should restore the value", (assert) => {
+        test("Esc should restore the value", function(assert) {
             this.keyboard.press("up");
             assert.strictEqual(this.$input.val(), "November 10 2012", "text was changed");
             assert.strictEqual(this.instance.option("value").getMonth(), 9, "month did not changed in the value");
@@ -487,7 +487,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "October 10 2012", "text was reverted");
         });
 
-        test("Enter should commit the value", (assert) => {
+        test("Enter should commit the value", function(assert) {
             this.keyboard.press("up");
             assert.strictEqual(this.instance.option("value").getMonth(), 9, "month did not changed in the value");
 
@@ -499,7 +499,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value").getDate(), 10, "day did not changed in the value after commit");
         });
 
-        test("Mask should not catch arrows on opened dateBox", (assert) => {
+        test("Mask should not catch arrows on opened dateBox", function(assert) {
             this.instance.open();
             this.keyboard.press("up");
             this.keyboard.press("right");
@@ -507,18 +507,18 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "October 10 2012", "text was not changed");
         });
 
-        test("Mask should catch char input on opened dateBox", (assert) => {
+        test("Mask should catch char input on opened dateBox", function(assert) {
             this.instance.open();
             this.keyboard.type("3");
             assert.strictEqual(this.$input.val(), "March 10 2012", "text has been changed");
         });
 
-        test("alt+down should open dxDateBox", (assert) => {
+        test("alt+down should open dxDateBox", function(assert) {
             this.keyboard.keyDown("down", { altKey: true });
             assert.ok(this.instance.option("opened"), "datebox is opened");
         });
 
-        test("delete should revert group to an empty date and go to the next part", (assert) => {
+        test("delete should revert group to an empty date and go to the next part", function(assert) {
             this.keyboard.press("up");
             assert.strictEqual(this.instance.option("text"), "November 10 2012", "text has been changed");
 
@@ -536,7 +536,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 10, end: 14 }, "caret is good");
         });
 
-        test("search value should be cleared after part is reverted", (assert) => {
+        test("search value should be cleared after part is reverted", function(assert) {
             this.instance.option("displayFormat", "dd, yyyy");
 
             this.keyboard.press("right");
@@ -547,13 +547,13 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("text"), "10, 2044", "text is correct");
         });
 
-        test("search value should be cleared if number was entered after the letter", (assert) => {
+        test("search value should be cleared if number was entered after the letter", function(assert) {
             this.instance.option("displayFormat", "dd-MMM-yyyy");
             this.keyboard.type("11m12y2015");
             assert.strictEqual(this.instance.option("text"), "11-Dec-2015", "date is correct");
         });
 
-        test("search value should be cleared after part is reverted when all text is selected", (assert) => {
+        test("search value should be cleared after part is reverted when all text is selected", function(assert) {
             this.instance.option("displayFormat", "yyyy");
 
             this.keyboard.type("33");
@@ -563,7 +563,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("text"), "2044", "text is correct");
         });
 
-        test("delete should revert a part when the value is null", (assert) => {
+        test("delete should revert a part when the value is null", function(assert) {
             this.instance.option({
                 displayFormat: "MMM yyyy",
                 value: null
@@ -577,7 +577,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 4, end: 8 }, "next group is selected");
         });
 
-        test("backspace should revert group to an empty date and go to the previous part", (assert) => {
+        test("backspace should revert group to an empty date and go to the previous part", function(assert) {
             this.keyboard.press("right");
             this.keyboard.press("up");
             assert.strictEqual(this.instance.option("text"), "October 11 2012", "text has been changed");
@@ -588,7 +588,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 0, end: 7 }, "caret is good");
         });
 
-        test("emptyDateValue option should work", (assert) => {
+        test("emptyDateValue option should work", function(assert) {
             this.instance.option("emptyDateValue", new Date(2015, 5, 4));
             this.keyboard.press("up");
             assert.strictEqual(this.instance.option("text"), "November 10 2012", "text has been changed");
@@ -599,7 +599,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 5, end: 7 }, "caret is good");
         });
 
-        test("removing all text should be possible", (assert) => {
+        test("removing all text should be possible", function(assert) {
             this.keyboard
                 .caret({ start: 0, end: 15 })
                 .press("del")
@@ -609,7 +609,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value"), null, "value has been cleared");
         });
 
-        test("focusout should clear search value", (assert) => {
+        test("focusout should clear search value", function(assert) {
             this.keyboard.type("1");
             assert.strictEqual(this.instance.option("text"), "January 10 2012", "text has been changed");
 
@@ -619,7 +619,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 9, end: 11 }, "first group has been filled again");
         });
 
-        test("enter should clear search value", (assert) => {
+        test("enter should clear search value", function(assert) {
             this.keyboard.type("1");
             assert.strictEqual(this.instance.option("text"), "January 10 2012", "text has been changed");
 
@@ -629,12 +629,12 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 8, end: 9 }, "next group has been selected");
         });
 
-        test("incorrect input should clear search value", (assert) => {
+        test("incorrect input should clear search value", function(assert) {
             this.keyboard.type("jqwed");
             assert.strictEqual(this.instance.option("text"), "December 10 2012", "text has been changed");
         });
 
-        test("first part should be active if select all parts and type new date", (assert) => {
+        test("first part should be active if select all parts and type new date", function(assert) {
             this.keyboard.press("right");
 
             assert.deepEqual(this.keyboard.caret(), { start: 8, end: 10 }, "next group has been selected");
@@ -646,7 +646,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 0, end: 7 }, "next group has been selected");
         });
 
-        test("first part should be active if select all parts, delete and type new", (assert) => {
+        test("first part should be active if select all parts, delete and type new", function(assert) {
             this.keyboard.press("right");
 
             assert.deepEqual(this.keyboard.caret(), { start: 8, end: 10 }, "next group has been selected");
@@ -659,21 +659,21 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 0, end: 7 }, "next group has been selected");
         });
 
-        test("keydown event shouldn't be prevented on 'Esc' key press", (assert) => {
+        test("keydown event shouldn't be prevented on 'Esc' key press", function(assert) {
             this.keyboard.press("esc");
             assert.notOk(this.keyboard.event.isDefaultPrevented(), "event should not be prevented");
         });
     });
 
     module("Events", setupModule, () => {
-        test("Select date part on click", (assert) => {
+        test("Select date part on click", function(assert) {
             this.keyboard.caret(9);
             this.$input.trigger("dxclick");
 
             assert.deepEqual(this.keyboard.caret(), { start: 8, end: 10 }, "caret position is good");
         });
 
-        test("Increment and decrement date part by mouse wheel", (assert) => {
+        test("Increment and decrement date part by mouse wheel", function(assert) {
             this.$input.get(0).focus();
 
             this.pointer.wheel(10);
@@ -683,7 +683,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "October 10 2012", "decrement works");
         });
 
-        test("it should not be possible to drag text in the editor", (assert) => {
+        test("it should not be possible to drag text in the editor", function(assert) {
             this.keyboard.type("3");
             assert.strictEqual(this.$input.val(), "March 10 2012", "text has been changed");
 
@@ -692,7 +692,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 6, end: 8 }, "caret is good");
         });
 
-        test("paste should be possible when pasting data matches the format", (assert) => {
+        test("paste should be possible when pasting data matches the format", function(assert) {
             this.instance.option("value", null);
 
             this.keyboard.paste("123456");
@@ -702,7 +702,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "November 10 2018", "pasting correct value is allowed");
         });
 
-        test("exception should not be thrown when the widget disposed on valueChange", (assert) => {
+        test("exception should not be thrown when the widget disposed on valueChange", function(assert) {
             this.instance.option({
                 value: new Date(2019, 11, 31),
                 onValueChanged: function(e) {
@@ -719,7 +719,7 @@ if(devices.real().deviceType === "desktop") {
 
 
     module("Search", setupModule, () => {
-        test("Time indication", (assert) => {
+        test("Time indication", function(assert) {
             this.instance.option("displayFormat", "a");
 
             this.keyboard.type("a");
@@ -729,7 +729,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "PM", "revert incorrect changes");
         });
 
-        test("Hour", (assert) => {
+        test("Hour", function(assert) {
             this.instance.option("displayFormat", "hh");
 
             this.keyboard.type("31");
@@ -739,7 +739,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "12", "set new value");
         });
 
-        test("Day of week", (assert) => {
+        test("Day of week", function(assert) {
             this.instance.option("displayFormat", "EEEE");
 
             this.keyboard.type("monda");
@@ -749,7 +749,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "Saturday", "revert incorrect changes");
         });
 
-        test("Day of week by a number", (assert) => {
+        test("Day of week by a number", function(assert) {
             this.instance.option("displayFormat", "EEEE");
 
             this.keyboard.type("0");
@@ -762,7 +762,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "Saturday", "out-of-limit values does not supported");
         });
 
-        test("Day", (assert) => {
+        test("Day", function(assert) {
             this.instance.option("displayFormat", "MMM, dd");
 
             this.keyboard
@@ -780,7 +780,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "Mar, 05", "out-of-limit values should clear search value");
         });
 
-        test("Month", (assert) => {
+        test("Month", function(assert) {
             this.instance.option("displayFormat", "MMMM");
 
             this.keyboard.type("janu");
@@ -791,7 +791,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "December", "revert incorrect chars");
         });
 
-        test("Month by char step over February", (assert) => {
+        test("Month by char step over February", function(assert) {
             this.instance.option({
                 value: new Date(2015, 0, 29),
                 displayFormat: "MMMM, dd"
@@ -804,7 +804,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "January, 29", "move backward, text is correct");
         });
 
-        test("Short month", (assert) => {
+        test("Short month", function(assert) {
             this.instance.option("displayFormat", "MMM");
 
             this.keyboard.type("jan");
@@ -814,7 +814,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "Dec", "revert incorrect chars");
         });
 
-        test("Month by a number", (assert) => {
+        test("Month by a number", function(assert) {
             this.instance.option("displayFormat", "MMMM");
 
             this.keyboard.type("1");
@@ -827,7 +827,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "May");
         });
 
-        test("Year", (assert) => {
+        test("Year", function(assert) {
             this.instance.option("displayFormat", "yyyy");
 
             this.keyboard.type("1995");
@@ -849,7 +849,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "0000");
         });
 
-        test("Short Year", (assert) => {
+        test("Short Year", function(assert) {
             this.instance.option({
                 value: new Date(1990, 4, 2),
                 displayFormat: "yy"
@@ -862,7 +862,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value").getFullYear(), 1921, "only 2 last digits of the year should be changed");
         });
 
-        test("Hotkeys should not be handled by the search", (assert) => {
+        test("Hotkeys should not be handled by the search", function(assert) {
             this.instance.option("displayFormat", "EEEE");
 
             this.keyboard.keyDown("s", { altKey: true });
@@ -872,7 +872,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "Wednesday", "ctrl was not handled");
         });
 
-        test("Typing a letter in the year section should not lead to an infinite loop", (assert) => {
+        test("Typing a letter in the year section should not lead to an infinite loop", function(assert) {
             this.instance.option("displayFormat", "yyyy");
 
             sinon.stub(this.instance, "_partIncrease").throws(new Error);
@@ -887,18 +887,18 @@ if(devices.real().deviceType === "desktop") {
     });
 
     module("Empty dateBox", {
-        beforeEach: () => {
+        beforeEach: function() {
             setupModule.beforeEach.call(this);
             this.instance.option("value", null);
         },
         afterEach: setupModule.afterEach
     }, () => {
-        test("Current date should be rendered on first input", (assert) => {
+        test("Current date should be rendered on first input", function(assert) {
             this.keyboard.type("1");
             assert.strictEqual(this.$input.val(), "January 14 2015", "first part was changed, other parts is from the current date");
         });
 
-        test("Bluring the input after first input should update the value", (assert) => {
+        test("Bluring the input after first input should update the value", function(assert) {
             this.keyboard.type("1");
             this.instance.blur();
 
@@ -906,7 +906,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value").getMonth(), 0, "value is correct");
         });
 
-        test("Clear button should work", (assert) => {
+        test("Clear button should work", function(assert) {
             this.instance.option({
                 showClearButton: true,
                 value: new Date(2018, 6, 19)
@@ -928,14 +928,14 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "January 14 2015", "text is correct after clearing");
         });
 
-        test("Incorrect search on empty input should render current date", (assert) => {
+        test("Incorrect search on empty input should render current date", function(assert) {
             this.keyboard.type("qq");
 
             assert.strictEqual(this.$input.val(), "April 14 2015", "text is correct");
             assert.strictEqual(this.instance.option("value"), null, "value is correct");
         });
 
-        test("focus and blur empty input should not change it's value", (assert) => {
+        test("focus and blur empty input should not change it's value", function(assert) {
             this.$input.trigger("focusin");
             this.$input.trigger("focusout");
 
@@ -943,7 +943,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value"), null, "value is correct");
         });
 
-        test("focusing datebox by click should work", (assert) => {
+        test("focusing datebox by click should work", function(assert) {
             this.$input.trigger("dxclick");
             this.keyboard.type("2");
 
@@ -951,7 +951,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value"), null, "value is correct");
         });
 
-        test("focusing datebox by mousewheel should work", (assert) => {
+        test("focusing datebox by mousewheel should work", function(assert) {
             this.pointer.wheel(10);
             this.keyboard.type("2");
 
@@ -959,7 +959,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value"), null, "value is correct");
         });
 
-        test("moving between groups should work with empty dateBox", (assert) => {
+        test("moving between groups should work with empty dateBox", function(assert) {
             ["up", "down", "right", "left", "home", "end", "esc"].forEach((arrow) => {
                 this.instance.option("value", null);
                 this.keyboard.press(arrow);
@@ -970,7 +970,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value"), null, "value is correct");
         });
 
-        test("Short Year should use current date", (assert) => {
+        test("Short Year should use current date", function(assert) {
             this.instance.option("displayFormat", "yy");
 
             let dateStart = new Date().getFullYear().toString().substr(0, 2);
@@ -982,7 +982,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value").getFullYear(), parseInt(dateStart + "21"), "only 2 last digits of the year should be changed");
         });
 
-        test("Click and leave empty datebox should not change the value", (assert) => {
+        test("Click and leave empty datebox should not change the value", function(assert) {
             this.instance.option("displayFormat", "yy");
 
             this.$input.trigger("dxclick");
@@ -992,7 +992,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "", "value is correct");
         });
 
-        test("navigation keys should do nothing in an empty datebox", (assert) => {
+        test("navigation keys should do nothing in an empty datebox", function(assert) {
             this.keyboard.press("home");
             this.keyboard.press("end");
             this.keyboard.press("del");
@@ -1009,7 +1009,7 @@ if(devices.real().deviceType === "desktop") {
     });
 
     module("Options changed", setupModule, () => {
-        test("The 'useMaskBehavior' option is changed to false", (assert) => {
+        test("The 'useMaskBehavior' option is changed to false", function(assert) {
             this.keyboard.caret(9);
             this.$input.trigger("dxclick");
 
@@ -1028,7 +1028,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.$input.val(), "October 10 2012", "date is not changed on mouse wheel");
         });
 
-        test("onValueChanged should have event", (assert) => {
+        test("onValueChanged should have event", function(assert) {
             const valueChangedHandler = sinon.spy();
 
             this.instance.option({
@@ -1045,7 +1045,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(valueChangedHandler.getCall(1).args[0].event, undefined, "event has been cleared");
         });
 
-        test("It should be possible to set a value via calendar", (assert) => {
+        test("It should be possible to set a value via calendar", function(assert) {
             this.instance.option({
                 opened: true
             });
@@ -1056,7 +1056,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 0, end: 7 }, "caret is good");
         });
 
-        test("Internal _maskValue and public value should be different objects", (assert) => {
+        test("Internal _maskValue and public value should be different objects", function(assert) {
             assert.ok(this.instance._maskValue !== this.instance.option("value"), "objects are different on init");
 
             this.instance.option("value", new Date(2012, 1, 2));
@@ -1076,7 +1076,7 @@ if(devices.real().deviceType === "desktop") {
             assert.ok(this.instance._maskValue !== this.instance.option("value"), "objects are different after change event");
         });
 
-        test("performance - value change should not lead to recreate regexp and format pattern", (assert) => {
+        test("performance - value change should not lead to recreate regexp and format pattern", function(assert) {
             const regExpInfo = sinon.spy(dateParser, "getRegExpInfo");
 
             this.instance.option("displayFormat", "dd.MM");
@@ -1088,7 +1088,7 @@ if(devices.real().deviceType === "desktop") {
     });
 
     module("Regression", () => {
-        QUnit.test("should paste text if value was not initialized (T715236)", (assert) => {
+        QUnit.test("should paste text if value was not initialized (T715236)", function(assert) {
             const $input = $("#dateBox")
                 .dxDateBox({ useMaskBehavior: true })
                 .dxDateBox("instance")
@@ -1098,7 +1098,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual($input.get(0).value, "2/15/2019");
         });
 
-        QUnit.test("selected date should be in 1970 when it was set from user's input (T758357)", (assert) => {
+        QUnit.test("selected date should be in 1970 when it was set from user's input (T758357)", function(assert) {
             const $dateBox = $("#dateBox").dxDateBox({
                 value: null,
                 displayFormat: "HH:mm",
@@ -1116,7 +1116,7 @@ if(devices.real().deviceType === "desktop") {
     });
 
     module("Advanced caret", setupModule, () => {
-        test("Move caret to the next group", (assert) => {
+        test("Move caret to the next group", function(assert) {
             this.instance.option({
                 advanceCaret: true,
                 displayFormat: "dd.MM"
@@ -1127,7 +1127,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, "caret was moved");
         });
 
-        test("Move caret to the next group when next digit will overflow", (assert) => {
+        test("Move caret to the next group when next digit will overflow", function(assert) {
             this.instance.option({
                 advanceCaret: true,
                 displayFormat: "MM.dd"
@@ -1138,7 +1138,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, "caret was moved");
         });
 
-        test("Move caret to the next group after limit overflow", (assert) => {
+        test("Move caret to the next group after limit overflow", function(assert) {
             this.instance.option({
                 advanceCaret: true,
                 displayFormat: "dd.MM"
@@ -1148,7 +1148,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, "caret was moved to month");
         });
 
-        test("Move caret to the next group after format length overflow", (assert) => {
+        test("Move caret to the next group after format length overflow", function(assert) {
             this.instance.option({
                 advanceCaret: true,
                 displayFormat: "yy MM"
@@ -1159,7 +1159,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, "caret was moved to month");
         });
 
-        test("Don't move caret to next group when format length is less than limit length", (assert) => {
+        test("Don't move caret to next group when format length is less than limit length", function(assert) {
             this.instance.option({
                 advanceCaret: true,
                 displayFormat: "y MM"
@@ -1170,7 +1170,7 @@ if(devices.real().deviceType === "desktop") {
             assert.deepEqual(this.keyboard.caret(), { start: 5, end: 7 }, "caret was moved to month");
         });
 
-        test("Typed year and value should be in the same century when short year format is used", (assert) => {
+        test("Typed year and value should be in the same century when short year format is used", function(assert) {
             this.instance.option({
                 advanceCaret: true,
                 displayFormat: "yy MM",
@@ -1192,7 +1192,7 @@ if(devices.real().deviceType === "desktop") {
             assert.strictEqual(this.instance.option("value").getFullYear(), 2014, "year is correct");
         });
 
-        test("Move caret to the next group after string length overflow", (assert) => {
+        test("Move caret to the next group after string length overflow", function(assert) {
             this.instance.option({
                 advanceCaret: true,
                 displayFormat: "dd.MM"

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -74,14 +74,14 @@ const getInstanceWidget = instance => {
 };
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers(new Date().valueOf());
 
         this.$element = $("#dateBox")[widgetName]({ pickerType: "native" });
         this.instance = this.$element[widgetName]("instance");
         this.$input = $.proxy(this.instance._input, this.instance);
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 };
@@ -106,7 +106,7 @@ const getExpectedResult = (date, mode, stringDate) => {
 };
 
 QUnit.module("datebox tests", moduleConfig, () => {
-    QUnit.test("value is null after reset", (assert) => {
+    QUnit.test("value is null after reset", function(assert) {
         const date = new Date(2012, 10, 26, 16, 40, 23);
 
         this.instance.option("value", date);
@@ -115,7 +115,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal(this.instance.option("value"), null, "value is null after reset");
     });
 
-    QUnit.test("render valueChangeEvent", (assert) => {
+    QUnit.test("render valueChangeEvent", function(assert) {
         this.instance.option({
             type: "date"
         });
@@ -132,7 +132,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal(value.getDate(), 26);
     });
 
-    QUnit.test("simulated date picker should not be opened if pickerType is 'native'", assert => {
+    QUnit.test("simulated date picker should not be opened if pickerType is 'native'", function(assert) {
         const originalInputType = support.inputType;
         support.inputType = () => {
             return true;
@@ -152,7 +152,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         support.inputType = originalInputType;
     });
 
-    QUnit.test("simulated datepicker should not be draggable, T231481", assert => {
+    QUnit.test("simulated datepicker should not be draggable, T231481", function(assert) {
         const $dateBox = $("#dateBoxWithPicker").dxDateBox({
             pickerType: "native",
             deferRendering: false,
@@ -165,7 +165,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.ok(!popup.option("dragEnabled"), "popup is not draggable");
     });
 
-    QUnit.test("T204185 - dxDateBox input should be editable when pickerType is 'calendar'", assert => {
+    QUnit.test("T204185 - dxDateBox input should be editable when pickerType is 'calendar'", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             pickerType: "calendar"
         });
@@ -175,7 +175,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.ok(!$input.prop("readOnly"), "correct readOnly value");
     });
 
-    QUnit.test("readonly property should not be applied to the native picker on real ios", assert => {
+    QUnit.test("readonly property should not be applied to the native picker on real ios", function(assert) {
         const deviceStub = sinon.stub(devices, "real").returns({
             deviceType: "mobile",
             version: [],
@@ -196,7 +196,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         }
     });
 
-    QUnit.test("dateBox with readOnly option enabled should not raise exception", assert => {
+    QUnit.test("dateBox with readOnly option enabled should not raise exception", function(assert) {
         try {
             $("#dateBox").dxDateBox({
                 type: "date",
@@ -210,7 +210,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         }
     });
 
-    QUnit.test("T204179 - dxDateBox should not render dropDownButton only for generic device when pickerType is 'native'", assert => {
+    QUnit.test("T204179 - dxDateBox should not render dropDownButton only for generic device when pickerType is 'native'", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             pickerType: "native"
         });
@@ -221,7 +221,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal($dropDownButton.length, expectedButtonsNumber, "correct readOnly value");
     });
 
-    QUnit.test("Datebox should set min and max attributes to the native input (T258860) after option changed", assert => {
+    QUnit.test("Datebox should set min and max attributes to the native input (T258860) after option changed", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "native",
@@ -242,7 +242,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal($input.attr("max"), "2015-08-03", "maximum date changed correctly");
     });
 
-    QUnit.test("T195971 - popup is not showing after click on the 'clear' button", assert => {
+    QUnit.test("T195971 - popup is not showing after click on the 'clear' button", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "rollers",
@@ -257,7 +257,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.ok(!dateBox.option("opened"), "popup is still closed after click on clear button");
     });
 
-    QUnit.test("invalid value should be cleared after clear button click", assert => {
+    QUnit.test("invalid value should be cleared after clear button click", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -275,7 +275,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal($input.val(), "", "dateBox input is empty");
     });
 
-    QUnit.test("clear button press should save value change event", assert => {
+    QUnit.test("clear button press should save value change event", function(assert) {
         const onValueChanged = sinon.spy();
 
         const $dateBox = $("#dateBox").dxDateBox({
@@ -294,7 +294,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.ok(onValueChanged.getCall(1).args[0].event, "event was saved");
     });
 
-    QUnit.test("out of range value should not be marked as invalid on init", assert => {
+    QUnit.test("out of range value should not be marked as invalid on init", function(assert) {
         const $dateBox = $("#widthRootStyle").dxDateBox({
             value: new Date(2015, 3, 20),
             min: new Date(2014, 3, 20),
@@ -306,7 +306,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.ok(dateBox.option("isValid"), "widget is valid on init");
     });
 
-    QUnit.test("it shouild be impossible to set out of range time to dxDateBox using ui (T394206)", assert => {
+    QUnit.test("it shouild be impossible to set out of range time to dxDateBox using ui (T394206)", function(assert) {
         const $dateBox = $("#widthRootStyle").dxDateBox({
             opened: true,
             type: "datetime",
@@ -325,7 +325,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.notOk(dateBox.option("isValid"), "widget is invalid");
     });
 
-    QUnit.test("clear button should change validation state to valid", assert => {
+    QUnit.test("clear button should change validation state to valid", function(assert) {
         const $dateBox = $("#widthRootStyle").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -345,7 +345,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.ok(dateBox.option("isValid"), "widget is valid");
     });
 
-    QUnit.test("type change should raise validation", assert => {
+    QUnit.test("type change should raise validation", function(assert) {
         const now = new Date();
         const $dateBox = $("#widthRootStyle").dxDateBox({
             type: "date",
@@ -366,7 +366,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.deepEqual(dateBox.option("value"), now, "value has been reset");
     });
 
-    QUnit.test("T252737 - the 'acceptCustomValue' option correct behavior", assert => {
+    QUnit.test("T252737 - the 'acceptCustomValue' option correct behavior", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             acceptCustomValue: false,
             valueChangeEvent: "change keyup",
@@ -381,7 +381,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal($input.val(), "", "text is not rendered");
     });
 
-    QUnit.test(`After typing while calendar is opened the typed data should be saved`, assert => {
+    QUnit.test(`After typing while calendar is opened the typed data should be saved`, function(assert) {
         const optionsSet = [];
         [true, false].forEach(useMaskBehavior => {
             ["date", "datetime"].forEach(type => {
@@ -419,7 +419,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         });
     });
 
-    QUnit.test("T278148 - picker type should be 'rollers' if the real device is phone in generic theme", assert => {
+    QUnit.test("T278148 - picker type should be 'rollers' if the real device is phone in generic theme", function(assert) {
         const realDevice = devices.real();
         const currentDevice = devices.current();
 
@@ -437,7 +437,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         }
     });
 
-    QUnit.test("Customize 'Done' and 'Cancel' buttons", assert => {
+    QUnit.test("Customize 'Done' and 'Cancel' buttons", function(assert) {
         const expectedDoneText = "newDoneText";
         const expectedCancelText = "newCancelText";
 
@@ -459,7 +459,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal(realCancelText, expectedCancelText, "cancel text customized correctly");
     });
 
-    QUnit.test("T378630 - the displayFormat should not be changed if the type option is set", assert => {
+    QUnit.test("T378630 - the displayFormat should not be changed if the type option is set", function(assert) {
         const displayFormat = "Y";
 
         const instance = $("#dateBox").dxDateBox({
@@ -472,7 +472,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal(instance.option("displayFormat"), displayFormat, "the displayFormat option is not changed");
     });
 
-    QUnit.test("set maxWidth for time view when fallback strategy is used", assert => {
+    QUnit.test("set maxWidth for time view when fallback strategy is used", function(assert) {
         if(!browser.msie) {
             assert.ok(true);
             return;
@@ -491,7 +491,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal(maxWidth, $("." + TIMEVIEW_CLOCK_CLASS).css("minWidth"), "minWidth of time view clock should be equal maxWidth");
     });
 
-    QUnit.test("the 'displayFormat' option should accept format objects (T378753)", assert => {
+    QUnit.test("the 'displayFormat' option should accept format objects (T378753)", function(assert) {
         const date = new Date(2016, 4, 13, 22, 5);
         const format = {
             type: "longDate"
@@ -506,7 +506,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal($element.find("." + TEXTEDITOR_INPUT_CLASS).val(), expectedDisplayValue, "correct display value");
     });
 
-    QUnit.test("T437211: Custom dxDateBox value formatter is not called if the same value is typed twice", assert => {
+    QUnit.test("T437211: Custom dxDateBox value formatter is not called if the same value is typed twice", function(assert) {
         const date = new Date(2016, 4, 13, 22, 5);
 
         const format = {
@@ -535,7 +535,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
         assert.equal(instance.option("text"), expectedDisplayValue, "input value was formatted");
     });
 
-    QUnit.test("onPopupInitialized handler calls with the calendar picker type", assert => {
+    QUnit.test("onPopupInitialized handler calls with the calendar picker type", function(assert) {
         assert.expect(1);
 
         $("#dateBoxWithPicker").dxDateBox({
@@ -548,7 +548,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
 
     });
 
-    QUnit.test("onPopupInitialized handler calls with the rollers picker type", assert => {
+    QUnit.test("onPopupInitialized handler calls with the rollers picker type", function(assert) {
         assert.expect(1);
 
         $("#dateBoxWithPicker").dxDateBox({
@@ -561,7 +561,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
 
     });
 
-    QUnit.test("onPopupInitialized handler calls with the list picker type", assert => {
+    QUnit.test("onPopupInitialized handler calls with the list picker type", function(assert) {
         assert.expect(1);
 
         $("#dateBoxWithPicker").dxDateBox({
@@ -576,7 +576,7 @@ QUnit.module("datebox tests", moduleConfig, () => {
 });
 
 QUnit.module("hidden input", {}, () => {
-    QUnit.test("the value should be passed to the hidden input in the correct format", assert => {
+    QUnit.test("the value should be passed to the hidden input in the correct format", function(assert) {
         const dateValue = new Date(2016, 6, 15, 14, 30);
         const types = ["datetime", "date", "time"];
 
@@ -593,7 +593,7 @@ QUnit.module("hidden input", {}, () => {
         });
     });
 
-    QUnit.test("the value should be passed to the hidden input on widget value change", assert => {
+    QUnit.test("the value should be passed to the hidden input on widget value change", function(assert) {
         const type = "date";
 
         const $element = $("#dateBox").dxDateBox({
@@ -609,7 +609,7 @@ QUnit.module("hidden input", {}, () => {
         assert.equal($hiddenInput.val(), expectedStringValue, "input value is correct after widget value change");
     });
 
-    QUnit.test("click on drop-down button should call click on input to show native picker (T824701)", assert => {
+    QUnit.test("click on drop-down button should call click on input to show native picker (T824701)", function(assert) {
         const clickSpy = sinon.spy();
         const $element = $("#dateBox").dxDateBox({
             pickerType: "native",
@@ -629,7 +629,7 @@ QUnit.module("hidden input", {}, () => {
 });
 
 QUnit.module("focus policy", {}, () => {
-    QUnit.test("dateBox should stay focused after value selecting in date strategy", assert => {
+    QUnit.test("dateBox should stay focused after value selecting in date strategy", function(assert) {
         assert.expect(1);
 
         if(devices.real().deviceType !== "desktop") {
@@ -653,7 +653,7 @@ QUnit.module("focus policy", {}, () => {
         $($popupContent).trigger("mousedown");
     });
 
-    QUnit.test("dateBox should stay focused after value selecting in time strategy", assert => {
+    QUnit.test("dateBox should stay focused after value selecting in time strategy", function(assert) {
         assert.expect(1);
 
         if(devices.real().deviceType !== "desktop") {
@@ -678,7 +678,7 @@ QUnit.module("focus policy", {}, () => {
         $($popupContent).trigger("mousedown");
     });
 
-    QUnit.test("dateBox should stay focused after value selecting in datetime strategy", assert => {
+    QUnit.test("dateBox should stay focused after value selecting in datetime strategy", function(assert) {
         assert.expect(1);
 
         if(devices.real().deviceType !== "desktop") {
@@ -703,7 +703,7 @@ QUnit.module("focus policy", {}, () => {
         $($popupContent).trigger("mousedown");
     });
 
-    QUnit.test("calendar in datebox should not have tabIndex attribute", assert => {
+    QUnit.test("calendar in datebox should not have tabIndex attribute", function(assert) {
         assert.expect(1);
 
         if(devices.real().deviceType !== "desktop") {
@@ -723,7 +723,7 @@ QUnit.module("focus policy", {}, () => {
         assert.equal($calendar.attr("tabindex"), null, "calendar has not tabindex");
     });
 
-    QUnit.testInActiveWindow("set focus on 'tab' key from editor to overlay and inversely", assert => {
+    QUnit.testInActiveWindow("set focus on 'tab' key from editor to overlay and inversely", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -751,7 +751,7 @@ QUnit.module("focus policy", {}, () => {
         assert.ok($dateBox.hasClass(STATE_FOCUSED_CLASS), "dateBox on focus reset focus to element");
     });
 
-    QUnit.test("mousewheel action should not work if dateBox is not focused", (assert) => {
+    QUnit.test("mousewheel action should not work if dateBox is not focused", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "desktop specific test");
             return;
@@ -774,7 +774,7 @@ QUnit.module("focus policy", {}, () => {
 });
 
 QUnit.module("options changed callbacks", moduleConfig, () => {
-    QUnit.test("value", (assert) => {
+    QUnit.test("value", function(assert) {
         let date = new Date(2012, 10, 26);
         const mode = this.instance.option("mode");
 
@@ -787,7 +787,7 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
         assert.equal(this.$input().val(), getExpectedResult(date, mode, "2012-12-26"));
     });
 
-    QUnit.test("type", (assert) => {
+    QUnit.test("type", function(assert) {
         const date = new Date(2012, 10, 26, 16, 40, 23);
 
         this.instance.option({
@@ -800,14 +800,14 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
         assert.equal(this.$input().val(), getExpectedResult(date, this.instance.option("mode"), "16:40"));
     });
 
-    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", (assert) => {
+    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         this.instance.option("onValueChanged", () => {
             assert.ok(true);
         });
         this.instance.option("value", new Date(2015, 6, 14));
     });
 
-    QUnit.test("empty class toggle depending on value", assert => {
+    QUnit.test("empty class toggle depending on value", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: null,
             pickerType: "calendar",
@@ -822,7 +822,7 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
         assert.ok(!$dateBox.hasClass("dx-texteditor-empty"), "empty class removed when value is not empty");
     });
 
-    QUnit.test("T188238 - changing of type leads to strategy changing", assert => {
+    QUnit.test("T188238 - changing of type leads to strategy changing", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: new Date(),
             type: "date",
@@ -844,7 +844,7 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
         assert.equal($(".dx-timeview").length, 1, "there is timeview in popup when type is 'datetime'");
     });
 
-    QUnit.test("dxDateBox calendar popup should be closed after value is changed if applyValueMode='instantly' (T189022)", assert => {
+    QUnit.test("dxDateBox calendar popup should be closed after value is changed if applyValueMode='instantly' (T189022)", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             pickerType: "calendar",
             applyValueMode: "instantly"
@@ -858,7 +858,7 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
         assert.ok(!dateBox._popup.option("visible"), "popup is not visible");
     });
 
-    QUnit.test("dxDateBox's value change doesn't lead to strategy's widget value change until popup is opened", assert => {
+    QUnit.test("dxDateBox's value change doesn't lead to strategy's widget value change until popup is opened", function(assert) {
         const firstValue = new Date(2015, 0, 20);
         const secondValue = new Date(2014, 4, 15);
 
@@ -882,7 +882,7 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
         assert.deepEqual(secondValue, calendar.option("value"), "value in calendar is changed");
     });
 
-    QUnit.test("dxDateBox's value change leads to strategy's widget value change if popup is opened", assert => {
+    QUnit.test("dxDateBox's value change leads to strategy's widget value change if popup is opened", function(assert) {
         const firstValue = new Date(2015, 0, 20);
         const secondValue = new Date(2014, 4, 15);
 
@@ -905,7 +905,7 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
         assert.deepEqual(secondValue, calendar.option("value"), "value in calendar is changed");
     });
 
-    QUnit.test("buttons are removed after applyValueMode option is changed", assert => {
+    QUnit.test("buttons are removed after applyValueMode option is changed", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             type: "date",
             applyValueMode: "useButtons",
@@ -926,7 +926,7 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
         assert.equal($buttons.length, 0, "no buttons are rendered");
     });
 
-    QUnit.test("closeOnValueChange option still affects on buttons rendering", assert => {
+    QUnit.test("closeOnValueChange option still affects on buttons rendering", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             type: "date",
             closeOnValueChange: false,
@@ -949,7 +949,7 @@ QUnit.module("options changed callbacks", moduleConfig, () => {
 });
 
 QUnit.module("merging dates", moduleConfig, () => {
-    QUnit.test("dates should be merged correctly", assert => {
+    QUnit.test("dates should be merged correctly", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             value: new Date(2014, 10, 1, 11, 22),
             type: "date",
@@ -968,7 +968,7 @@ QUnit.module("merging dates", moduleConfig, () => {
         assert.equal(instance.option("value").valueOf(), new Date(2014, 10, 1, 11, 22).valueOf(), "date merged correctly");
     });
 
-    QUnit.test("incorrect work of mergeDates function (B237850)", (assert) => {
+    QUnit.test("incorrect work of mergeDates function (B237850)", function(assert) {
         this.instance.option("type", "date");
         this.instance.option("value", new Date(2000, 6, 31, 1, 1, 1));
 
@@ -979,7 +979,7 @@ QUnit.module("merging dates", moduleConfig, () => {
         assert.deepEqual(this.instance.option("value"), new Date(2000, 8, 10, 1, 1, 1));
     });
 
-    QUnit.test("incorrect work of mergeDates function if previous value not valid (Q568689)", (assert) => {
+    QUnit.test("incorrect work of mergeDates function if previous value not valid (Q568689)", function(assert) {
         this.instance.option("type", "time");
 
         $(this.$input())
@@ -997,7 +997,7 @@ QUnit.module("merging dates", moduleConfig, () => {
         assert.deepEqual(this.instance.option("value"), date);
     });
 
-    QUnit.test("if value isn't specified then Unix Epoch is default for an editor with type 'time'", (assert) => {
+    QUnit.test("if value isn't specified then Unix Epoch is default for an editor with type 'time'", function(assert) {
         this.instance.option({
             type: "time",
             pickerType: "list",
@@ -1016,7 +1016,7 @@ QUnit.module("merging dates", moduleConfig, () => {
         assert.equal(value.getDate(), defaultDate.getDate(), "correct date");
     });
 
-    QUnit.test("mergeDates must merge seconds when type is 'time'", (assert) => {
+    QUnit.test("mergeDates must merge seconds when type is 'time'", function(assert) {
         this.instance.option({
             type: "time",
             value: new Date(2000, 6, 31, 1, 1, 1),
@@ -1032,7 +1032,7 @@ QUnit.module("merging dates", moduleConfig, () => {
         assert.deepEqual(this.instance.option("value"), date);
     });
 
-    QUnit.test("mergeDates must merge milliseconds when type is 'time'", (assert) => {
+    QUnit.test("mergeDates must merge milliseconds when type is 'time'", function(assert) {
         this.instance.option({
             type: "time",
             value: new Date(2000, 6, 31, 1, 1, 1),
@@ -1051,7 +1051,7 @@ QUnit.module("merging dates", moduleConfig, () => {
 });
 
 QUnit.module("dateView integration", {
-    beforeEach: (...args) => {
+    beforeEach: function(...args) {
         fx.off = true;
         this.originalInputType = support.inputType;
         support.inputType = () => {
@@ -1074,13 +1074,13 @@ QUnit.module("dateView integration", {
             return getInstanceWidget(this.instance);
         };
     },
-    afterEach: (...args) => {
+    afterEach: function(...args) {
         moduleConfig.afterEach.apply(this, args);
         support.inputType = this.originalInputType;
         fx.off = false;
     }
 }, () => {
-    QUnit.test("check DateView default config", (assert) => {
+    QUnit.test("check DateView default config", function(assert) {
         const { value, minDate, maxDate } = this.dateView().option();
         const FIFTY_YEARS = uiDateUtils.ONE_YEAR * 50;
         const defaultDate = new Date();
@@ -1094,20 +1094,20 @@ QUnit.module("dateView integration", {
         assert.deepEqual(maxDate, new Date(), "default max date is current date + 50 years");
     });
 
-    QUnit.test("dateView renders", (assert) => {
+    QUnit.test("dateView renders", function(assert) {
         assert.equal(this.popup().$content().find(".dx-dateview").length, 1);
     });
 
-    QUnit.test("readOnly input prop should be always true to prevent keyboard open if simulated dateView is using", (assert) => {
+    QUnit.test("readOnly input prop should be always true to prevent keyboard open if simulated dateView is using", function(assert) {
         this.instance.option("readOnly", false);
         assert.ok(this.$element.find("." + TEXTEDITOR_INPUT_CLASS).prop("readOnly"), "readonly prop specified correctly");
     });
 
-    QUnit.test("dateView shows on field click", (assert) => {
+    QUnit.test("dateView shows on field click", function(assert) {
         assert.ok(this.instance.option("openOnFieldClick"));
     });
 
-    QUnit.test("dateView 'minDate' and 'maxDate' matches dateBox 'min' and 'max' respectively", (assert) => {
+    QUnit.test("dateView 'minDate' and 'maxDate' matches dateBox 'min' and 'max' respectively", function(assert) {
         this.instance.option("min", new Date(2000, 1, 1));
         assert.deepEqual(this.dateView().option("minDate"), new Date(2000, 1, 1));
 
@@ -1115,7 +1115,7 @@ QUnit.module("dateView integration", {
         assert.deepEqual(this.dateView().option("maxDate"), new Date(2001, 2, 2));
     });
 
-    QUnit.test("dateView 'value' and 'type' matches dateBox 'value' and 'type' respectively", (assert) => {
+    QUnit.test("dateView 'value' and 'type' matches dateBox 'value' and 'type' respectively", function(assert) {
         this.instance.option("value", new Date(2000, 1, 1));
         this.instance.open();
         assert.deepEqual(this.dateView().option("value"), new Date(2000, 1, 1));
@@ -1126,7 +1126,7 @@ QUnit.module("dateView integration", {
         assert.deepEqual(this.dateView().option("value"), new Date(2000, 2, 2));
     });
 
-    QUnit.test("dateView 'type' option matches dateBox 'type' option", (assert) => {
+    QUnit.test("dateView 'type' option matches dateBox 'type' option", function(assert) {
         this.instance.option("type", "datetime");
         this.instance.open();
         assert.equal(getInstanceWidget(this.instance).option("type"), "datetime");
@@ -1136,7 +1136,7 @@ QUnit.module("dateView integration", {
         assert.equal(getInstanceWidget(this.instance).option("type"), "time");
     });
 
-    QUnit.test("dateView should be updated on popup opening and closing (T578764)", (assert) => {
+    QUnit.test("dateView should be updated on popup opening and closing (T578764)", function(assert) {
         this.instance.close();
         this.instance.option("value", new Date(2000, 2, 2));
 
@@ -1148,7 +1148,7 @@ QUnit.module("dateView integration", {
         assert.deepEqual(this.dateView().option("value"), new Date(2000, 2, 2), "update on closing when value was not applied");
     });
 
-    QUnit.test("dateView should not update dateBox value after closing using 'close' method", (assert) => {
+    QUnit.test("dateView should not update dateBox value after closing using 'close' method", function(assert) {
         this.instance.option("value", new Date(2000, 1, 1));
         this.instance.open();
 
@@ -1159,7 +1159,7 @@ QUnit.module("dateView integration", {
         assert.deepEqual(this.instance.option("value"), new Date(2000, 1, 1));
     });
 
-    QUnit.test("render simulated dateView title when using option 'placeholder'", (assert) => {
+    QUnit.test("render simulated dateView title when using option 'placeholder'", function(assert) {
         this.instance.option({
             placeholder: "test"
         });
@@ -1175,7 +1175,7 @@ QUnit.module("dateView integration", {
         assert.equal(this.popupTitle(), "new title", "option changed successfully");
     });
 
-    QUnit.test("specify dataPicker title, dependent from 'type' option, when 'placeholder' option is not defined", (assert) => {
+    QUnit.test("specify dataPicker title, dependent from 'type' option, when 'placeholder' option is not defined", function(assert) {
         this.instance.option({
             type: "date",
             placeholder: ""
@@ -1202,7 +1202,7 @@ QUnit.module("dateView integration", {
         assert.equal(this.popupTitle(), messageLocalization.format("dxDateBox-simulatedDataPickerTitleDate"), "title changed successfully when type set in 'date'");
     });
 
-    QUnit.test("cancel & done button action", (assert) => {
+    QUnit.test("cancel & done button action", function(assert) {
         const date = new Date(2012, 9, 10);
         const minDate = new Date(2000, 1);
 
@@ -1227,7 +1227,7 @@ QUnit.module("dateView integration", {
         assert.deepEqual(this.instance.option("value"), new Date(2002, 10, 13));
     });
 
-    QUnit.test("specify dataPicker title, independent from 'type' option, when 'placeholder' option is defined", (assert) => {
+    QUnit.test("specify dataPicker title, independent from 'type' option, when 'placeholder' option is defined", function(assert) {
         this.instance.option({
             type: "date",
             placeholder: "custom title"
@@ -1244,7 +1244,7 @@ QUnit.module("dateView integration", {
         assert.equal(this.popupTitle(), messageLocalization.format("dxDateBox-simulatedDataPickerTitleTime"), "title set successfully when 'placeholder' option set to ''");
     });
 
-    QUnit.test("Native datebox should have specific class", assert => {
+    QUnit.test("Native datebox should have specific class", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             pickerType: "native"
         });
@@ -1253,7 +1253,7 @@ QUnit.module("dateView integration", {
         assert.equal($element.dxDateBox("instance")._strategy.NAME, "Native", "correct strategy is chosen");
     });
 
-    QUnit.test("pickerType should be 'rollers' on android < 4.4 (Q588373, Q588012)", (assert) => {
+    QUnit.test("pickerType should be 'rollers' on android < 4.4 (Q588373, Q588012)", function(assert) {
         support.inputType = () => {
             return true;
         };
@@ -1272,7 +1272,7 @@ QUnit.module("dateView integration", {
         }
     });
 
-    QUnit.test("pickerType should be 'native' on android >= 4.4 (Q588373, Q588012)", (assert) => {
+    QUnit.test("pickerType should be 'native' on android >= 4.4 (Q588373, Q588012)", function(assert) {
         support.inputType = () => {
             return true;
         };
@@ -1293,7 +1293,7 @@ QUnit.module("dateView integration", {
         }
     });
 
-    QUnit.test("B230631 - Can not clear datebox field", (assert) => {
+    QUnit.test("B230631 - Can not clear datebox field", function(assert) {
         this.instance.option({
             value: new Date(),
             type: "datetime"
@@ -1311,7 +1311,7 @@ QUnit.module("dateView integration", {
         assert.equal(this.instance.option("value"), undefined);
     });
 
-    QUnit.test("B236537 - onValueChanged event does not fire", (assert) => {
+    QUnit.test("B236537 - onValueChanged event does not fire", function(assert) {
         let valueUpdated = false;
 
         this.instance.option({
@@ -1327,7 +1327,7 @@ QUnit.module("dateView integration", {
         assert.ok(valueUpdated);
     });
 
-    QUnit.test("B251997 - date picker is shown in spite of 'readOnly' is true", (assert) => {
+    QUnit.test("B251997 - date picker is shown in spite of 'readOnly' is true", function(assert) {
         const originalSupportInputType = support.inputType;
 
         support.inputType = () => {
@@ -1356,11 +1356,11 @@ QUnit.module("dateView integration", {
         }
     });
 
-    QUnit.test("Q559762 - input does not clear input value Samsung Android 4.1 devices", (assert) => {
+    QUnit.test("Q559762 - input does not clear input value Samsung Android 4.1 devices", function(assert) {
         assert.equal(this.$input().attr("autocomplete"), "off");
     });
 
-    QUnit.test("T170478 - no picker rollers should be chosen after click on 'cancel' button", (assert) => {
+    QUnit.test("T170478 - no picker rollers should be chosen after click on 'cancel' button", function(assert) {
         const pointer = pointerMock($(".dx-dateviewroller").eq(0).find(".dx-scrollable-container"));
 
         assert.equal($(".dx-dateviewroller-current").length, 0, "no rollers are chosen after widget is opened first time");
@@ -1373,7 +1373,7 @@ QUnit.module("dateView integration", {
         assert.equal($(".dx-dateviewroller-current").length, 0, "no rollers are chosen after widget is opened second time");
     });
 
-    QUnit.test("T207178 - error should not be thrown if value is null", assert => {
+    QUnit.test("T207178 - error should not be thrown if value is null", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: null,
             pickerType: "rollers"
@@ -1389,7 +1389,7 @@ QUnit.module("dateView integration", {
         }
     });
 
-    QUnit.test("T319042 - input value should be correct if picker type is 'rollers' and 'type' is 'time'", assert => {
+    QUnit.test("T319042 - input value should be correct if picker type is 'rollers' and 'type' is 'time'", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: new Date(0, 0, 0, 15, 32),
             pickerType: "rollers",
@@ -1401,7 +1401,7 @@ QUnit.module("dateView integration", {
         assert.equal($input.val(), "3:32 PM", "input value is correct");
     });
 
-    QUnit.test("the next value after null should have zero time components when type = 'date' (T407518)", assert => {
+    QUnit.test("the next value after null should have zero time components when type = 'date' (T407518)", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             value: null,
             pickerType: "rollers",
@@ -1418,7 +1418,7 @@ QUnit.module("dateView integration", {
         assert.equal(value.getMilliseconds(), 0, "milliseconds component is 0");
     });
 
-    QUnit.test("Gesture cover should be hidden after wheel event processed by Overlay emitter (T820405)", (assert) => {
+    QUnit.test("Gesture cover should be hidden after wheel event processed by Overlay emitter (T820405)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "gesture cover element is specific for desktop");
             return;
@@ -1449,13 +1449,13 @@ QUnit.module("dateView integration", {
 });
 
 QUnit.module("widget sizing render", {}, () => {
-    QUnit.test("default", assert => {
+    QUnit.test("default", function(assert) {
         const $element = $("#dateBox").dxDateBox();
 
         assert.ok($element.outerWidth() > 0, "outer width of the element must be more than zero");
     });
 
-    QUnit.test("widget shouldn't be wider than a container", assert => {
+    QUnit.test("widget shouldn't be wider than a container", function(assert) {
         const $element = $("#innerDateBox").dxDateBox();
         const instance = $element.dxDateBox("instance");
 
@@ -1463,7 +1463,7 @@ QUnit.module("widget sizing render", {}, () => {
         assert.ok($element.outerWidth() <= 100, "outer width of the element must be less or equal to a container width");
     });
 
-    QUnit.test("validation icon should hide if container size is too small", assert => {
+    QUnit.test("validation icon should hide if container size is too small", function(assert) {
         const $element = $("#innerDateBox").dxDateBox({
             "showClearButton": true,
             "pickerType": "calendar",
@@ -1479,7 +1479,7 @@ QUnit.module("widget sizing render", {}, () => {
         assert.ok($element.hasClass('dx-show-invalid-badge'), "validation icon's visible");
     });
 
-    QUnit.test("component should have correct width when it was rendered in a scaled container (T584097)", assert => {
+    QUnit.test("component should have correct width when it was rendered in a scaled container (T584097)", function(assert) {
         const $parent = $("#parent-div");
         $parent.css("width", 200);
 
@@ -1499,7 +1499,7 @@ QUnit.module("widget sizing render", {}, () => {
         assert.strictEqual(actualWidth, initialWidth, "component has correct width");
     });
 
-    QUnit.test("component width calculation should consider buttons containers element", assert => {
+    QUnit.test("component width calculation should consider buttons containers element", function(assert) {
         const $parent = $("#parent-div");
         $parent.css("width", 200);
 
@@ -1518,7 +1518,7 @@ QUnit.module("widget sizing render", {}, () => {
         assert.strictEqual(actualWidth, initialWidth + buttonWidth);
     });
 
-    QUnit.test("change width", assert => {
+    QUnit.test("change width", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             pickerType: "rollers"
         });
@@ -1533,13 +1533,13 @@ QUnit.module("widget sizing render", {}, () => {
 });
 
 QUnit.module("datebox and calendar integration", () => {
-    QUnit.test("default", assert => {
+    QUnit.test("default", function(assert) {
         const $element = $("#dateBox").dxDateBox({ pickerType: "calendar" });
 
         assert.ok($element.outerWidth() > 0, "outer width of the element must be more than zero");
     });
 
-    QUnit.test("change width", assert => {
+    QUnit.test("change width", function(assert) {
         const $element = $("#dateBox").dxDateBox({ pickerType: "calendar" });
         const instance = $element.dxDateBox("instance");
         const customWidth = 258;
@@ -1549,7 +1549,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.strictEqual($element.outerWidth(), customWidth, "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("change input value should change calendar value", assert => {
+    QUnit.test("change input value should change calendar value", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             pickerType: "calendar",
             type: "date",
@@ -1573,7 +1573,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.strictEqual(dateBox.option("validationError"), null, "No validation error should be specified for valid input");
     });
 
-    QUnit.test("wrong value in input should mark datebox as invalid", assert => {
+    QUnit.test("wrong value in input should mark datebox as invalid", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: null,
             type: "date",
@@ -1593,7 +1593,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.ok(validationError.editorSpecific, "editorSpecific flag should be added");
     });
 
-    QUnit.test("datebox should not be revalidated when readOnly option changed", assert => {
+    QUnit.test("datebox should not be revalidated when readOnly option changed", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             readOnly: false
         }).dxValidator({
@@ -1610,7 +1610,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.notOk($("#dateBox").hasClass("dx-invalid"), "dateBox is not marked as invalid");
     });
 
-    QUnit.test("wrong value in input should mark time datebox as invalid", assert => {
+    QUnit.test("wrong value in input should mark time datebox as invalid", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: null,
             type: "time",
@@ -1631,7 +1631,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.ok(validationError.editorSpecific, "editorSpecific flag should be added");
     });
 
-    QUnit.test("wrong value in input should mark pre-filled datebox as invalid", assert => {
+    QUnit.test("wrong value in input should mark pre-filled datebox as invalid", function(assert) {
         const value = new Date(2013, 2, 2);
 
         const $dateBox = $("#dateBox").dxDateBox({
@@ -1656,7 +1656,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.ok(validationError.editorSpecific, "editorSpecific flag should be added");
     });
 
-    QUnit.test("correct value in input should mark datebox as valid but keep text", assert => {
+    QUnit.test("correct value in input should mark datebox as valid but keep text", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: null,
             type: "date",
@@ -1682,7 +1682,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.strictEqual(dateBox.option("validationError"), null, "No validation error should be specified for valid input");
     });
 
-    QUnit.test("calendar picker should be used on generic device by default and 'type' is 'date'", assert => {
+    QUnit.test("calendar picker should be used on generic device by default and 'type' is 'date'", function(assert) {
         const currentDevice = devices.current();
         const realDevice = devices.real();
 
@@ -1701,7 +1701,7 @@ QUnit.module("datebox and calendar integration", () => {
         }
     });
 
-    QUnit.test("calendar picker should not be used on generic device by default and 'type' is not 'date'", assert => {
+    QUnit.test("calendar picker should not be used on generic device by default and 'type' is not 'date'", function(assert) {
         const currentDevice = devices.current();
         devices.current({ platform: "generic", deviceType: "desktop" });
 
@@ -1716,7 +1716,7 @@ QUnit.module("datebox and calendar integration", () => {
         }
     });
 
-    QUnit.test("calendar picker should not be used on mobile device by default", assert => {
+    QUnit.test("calendar picker should not be used on mobile device by default", function(assert) {
         const realDevice = devices.real();
         devices.real({ platform: "android" });
 
@@ -1728,7 +1728,7 @@ QUnit.module("datebox and calendar integration", () => {
         }
     });
 
-    QUnit.test("correct default value for 'minZoomLevel' option", assert => {
+    QUnit.test("correct default value for 'minZoomLevel' option", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -1740,7 +1740,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.equal(calendar.option("minZoomLevel"), "century", "'minZoomLevel' option value is correct");
     });
 
-    QUnit.test("correct default value for 'maxZoomLevel' option", assert => {
+    QUnit.test("correct default value for 'maxZoomLevel' option", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -1752,7 +1752,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.equal(calendar.option("maxZoomLevel"), "month", "'maxZoomLevel' option value is correct");
     });
 
-    QUnit.test("DateBox 'minZoomLevel' option should affect on Calendar 'minZoomLevel' option", assert => {
+    QUnit.test("DateBox 'minZoomLevel' option should affect on Calendar 'minZoomLevel' option", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -1772,7 +1772,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.equal(calendar.option("minZoomLevel"), "month", "calendar 'minZoomLevel' option after dateBox option change");
     });
 
-    QUnit.test("DateBox 'maxZoomLevel' option should affect on Calendar 'maxZoomLevel' option", assert => {
+    QUnit.test("DateBox 'maxZoomLevel' option should affect on Calendar 'maxZoomLevel' option", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -1792,7 +1792,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.equal(calendar.option("maxZoomLevel"), "year", "calendar 'maxZoomLevel' option after dateBox option change");
     });
 
-    QUnit.test("T208534 - calendar value should depend on datebox text option", assert => {
+    QUnit.test("T208534 - calendar value should depend on datebox text option", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -1811,7 +1811,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.deepEqual(new Date(2014, 4, 12), instance._strategy._widget.option("value"), "calendar value is correct");
     });
 
-    QUnit.test("calendar value should depend on datebox text option when calendar is opened", assert => {
+    QUnit.test("calendar value should depend on datebox text option when calendar is opened", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -1837,7 +1837,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.deepEqual(new Date(2013, 4, 12), calendar.option("value"), "calendar value is correct");
     });
 
-    QUnit.test("changing 'displayFormat' should update input value", assert => {
+    QUnit.test("changing 'displayFormat' should update input value", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: new Date('03/10/2015'),
             pickerType: 'calendar',
@@ -1849,7 +1849,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.equal($dateBox.find("." + TEXTEDITOR_INPUT_CLASS).val(), "3/10/2015, 12:00 AM", "input value is updated");
     });
 
-    QUnit.test("displayFormat should affect on timeView", assert => {
+    QUnit.test("displayFormat should affect on timeView", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: new Date('03/10/2015'),
             displayFormat: 'shortdateshorttime',
@@ -1868,7 +1868,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.ok(timeView.option("use24HourFormat"), "using 24 hour format");
     });
 
-    QUnit.test("disabledDates correctly displays", assert => {
+    QUnit.test("disabledDates correctly displays", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -1884,7 +1884,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.equal($disabledCell.text(), "13", "Correct cell is disabled");
     });
 
-    QUnit.test("disabledDates correctly displays after optionChanged", assert => {
+    QUnit.test("disabledDates correctly displays after optionChanged", function(assert) {
         const instance = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -1906,7 +1906,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.equal($disabledCell.text(), "14", "Correct cell is disabled");
     });
 
-    QUnit.test("disabledDates argument contains correct component parameter", assert => {
+    QUnit.test("disabledDates argument contains correct component parameter", function(assert) {
         const stub = sinon.stub();
 
         $("#dateBox").dxDateBox({
@@ -1921,7 +1921,7 @@ QUnit.module("datebox and calendar integration", () => {
         assert.equal(component.NAME, "dxDateBox", "Correct component");
     });
 
-    QUnit.test("datebox with the 'datetime' type should keep event subscriptions", assert => {
+    QUnit.test("datebox with the 'datetime' type should keep event subscriptions", function(assert) {
         const stub = sinon.stub();
 
         const dateBox = $("#dateBox").dxDateBox({
@@ -1943,7 +1943,7 @@ QUnit.module("datebox and calendar integration", () => {
 });
 
 QUnit.module("datebox w/ calendar", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers(new Date().valueOf());
         fx.off = true;
 
@@ -1960,50 +1960,50 @@ QUnit.module("datebox w/ calendar", {
             this.fixture = new DevExpress.ui.testing.DateBoxFixture("#dateBox", options);
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.fixture.dispose();
         fx.off = false;
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("DateBox is defined", (assert) => {
+    QUnit.test("DateBox is defined", function(assert) {
         assert.ok(this.fixture.dateBox);
     });
 
-    QUnit.test("DateBox can be instantiated", (assert) => {
+    QUnit.test("DateBox can be instantiated", function(assert) {
         assert.ok(this.fixture.dateBox instanceof DateBox);
     });
 
-    QUnit.test("DateBox must render an input", (assert) => {
+    QUnit.test("DateBox must render an input", function(assert) {
         assert.ok(this.fixture.input.length);
     });
 
-    QUnit.test("open must set 'opened' option", (assert) => {
+    QUnit.test("open must set 'opened' option", function(assert) {
         assert.ok(!this.fixture.dateBox.option("opened"));
         this.fixture.dateBox.open();
         assert.ok(this.fixture.dateBox.option("opened"));
     });
 
-    QUnit.test("calendarOptions must be passed to dxCalendar on initialization", (assert) => {
+    QUnit.test("calendarOptions must be passed to dxCalendar on initialization", function(assert) {
         this.fixture.dateBox.open();
         currentDate.setDate(1);
         assert.deepEqual(getInstanceWidget(this.fixture.dateBox).option("currentDate"), currentDate);
         assert.deepEqual(getInstanceWidget(this.fixture.dateBox).option("firstDayOfWeek"), firstDayOfWeek);
     });
 
-    QUnit.test("Clicking _calendarContainer must not close dropDown", (assert) => {
+    QUnit.test("Clicking _calendarContainer must not close dropDown", function(assert) {
         this.fixture.dateBox.open();
         pointerMock(this.fixture.dateBox._calendarContainer).click();
         assert.ok(this.fixture.dateBox.option("opened"));
     });
 
-    QUnit.test("DateBox must update the input value when the value option changes", (assert) => {
+    QUnit.test("DateBox must update the input value when the value option changes", function(assert) {
         const date = new Date(2011, 11, 11);
         this.fixture.dateBox.option("value", date);
         assert.deepEqual(this.fixture.input.val(), dateLocalization.format(date, this.fixture.format));
     });
 
-    QUnit.test("DateBox must immediately display 'value' passed via the constructor on rendering", (assert) => {
+    QUnit.test("DateBox must immediately display 'value' passed via the constructor on rendering", function(assert) {
         const date = new Date(2010, 10, 10);
 
         this.reinitFixture({
@@ -2015,7 +2015,7 @@ QUnit.module("datebox w/ calendar", {
         assert.deepEqual(this.fixture.input.val(), dateLocalization.format(date, this.fixture.format));
     });
 
-    QUnit.test("DateBox must pass value to calendar correctly if value is empty string", (assert) => {
+    QUnit.test("DateBox must pass value to calendar correctly if value is empty string", function(assert) {
         this.reinitFixture({
             value: '',
             pickerType: 'calendar',
@@ -2025,14 +2025,14 @@ QUnit.module("datebox w/ calendar", {
         assert.equal(this.fixture.dateBox._strategy._widget.option("value"), null, "value is correctly");
     });
 
-    QUnit.test("DateBox must show the calendar with a proper date selected", (assert) => {
+    QUnit.test("DateBox must show the calendar with a proper date selected", function(assert) {
         const date = new Date(2011, 11, 11);
         this.fixture.dateBox.option("value", date);
         this.fixture.dateBox.open();
         assert.deepEqual(getInstanceWidget(this.fixture.dateBox).option("value"), date);
     });
 
-    QUnit.test("DateBox must update its value when a date is selected in the calendar when applyValueMode='instantly'", (assert) => {
+    QUnit.test("DateBox must update its value when a date is selected in the calendar when applyValueMode='instantly'", function(assert) {
         const date = new Date(2011, 11, 11);
 
         this.reinitFixture({
@@ -2046,7 +2046,7 @@ QUnit.module("datebox w/ calendar", {
         assert.strictEqual(this.fixture.dateBox.option("value"), date);
     });
 
-    QUnit.test("DateBox must update the calendar value when the CalendarPicker.option('value') changes", (assert) => {
+    QUnit.test("DateBox must update the calendar value when the CalendarPicker.option('value') changes", function(assert) {
         this.reinitFixture({
             applyValueMode: "useButtons",
             pickerType: "calendar",
@@ -2058,7 +2058,7 @@ QUnit.module("datebox w/ calendar", {
         assert.deepEqual(getInstanceWidget(this.fixture.dateBox).option("value"), date);
     });
 
-    QUnit.test("When typing a correct date, dateBox must not make a redundant _setInputValue call", (assert) => {
+    QUnit.test("When typing a correct date, dateBox must not make a redundant _setInputValue call", function(assert) {
         let _setInputValueCallCount = 0;
 
         const mockSetInputValue = () => {
@@ -2071,14 +2071,14 @@ QUnit.module("datebox w/ calendar", {
         assert.strictEqual(_setInputValueCallCount, 0);
     });
 
-    QUnit.test("Swiping must not close the calendar", (assert) => {
+    QUnit.test("Swiping must not close the calendar", function(assert) {
         $(this.fixture.dateBox._input()).focus();
         this.fixture.dateBox.open();
         pointerMock(this.fixture.dateBox._strategy._calendarContainer).start().swipeStart().swipeEnd(1);
         assert.ok(this.fixture.dateBox._input()[0] === document.activeElement);
     });
 
-    QUnit.test("Pressing escape must hide the calendar and clean focus", (assert) => {
+    QUnit.test("Pressing escape must hide the calendar and clean focus", function(assert) {
         const escapeKeyDown = $.Event("keydown", { key: "Escape" });
         this.fixture.dateBox.option("focusStateEnabled", true);
         this.fixture.dateBox.open();
@@ -2087,13 +2087,13 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(!this.fixture.dateBox._input().is(":focus"));
     });
 
-    QUnit.test("dateBox must show the calendar with proper LTR-RTL mode", (assert) => {
+    QUnit.test("dateBox must show the calendar with proper LTR-RTL mode", function(assert) {
         this.fixture.dateBox.option("rtlEnabled", true);
         this.fixture.dateBox.open();
         assert.ok(getInstanceWidget(this.fixture.dateBox).option("rtlEnabled"));
     });
 
-    QUnit.test("dateBox should not reposition the calendar icon in RTL mode", (assert) => {
+    QUnit.test("dateBox should not reposition the calendar icon in RTL mode", function(assert) {
         let iconRepositionCount = 0;
 
         const _repositionCalendarIconMock = () => {
@@ -2105,26 +2105,26 @@ QUnit.module("datebox w/ calendar", {
         assert.strictEqual(iconRepositionCount, 0);
     });
 
-    QUnit.test("dateBox must apply the wrapper class with appropriate picker type to the drop-down overlay wrapper", (assert) => {
+    QUnit.test("dateBox must apply the wrapper class with appropriate picker type to the drop-down overlay wrapper", function(assert) {
         const dateBox = this.fixture.dateBox;
         dateBox.open();
         assert.ok(this.fixture.dateBox._popup._wrapper().hasClass(DATEBOX_WRAPPER_CLASS + "-" + dateBox.option("pickerType")));
     });
 
-    QUnit.test("dateBox must correctly reopen the calendar after refreshing when it was not hidden beforehand", (assert) => {
+    QUnit.test("dateBox must correctly reopen the calendar after refreshing when it was not hidden beforehand", function(assert) {
         this.fixture.dateBox.open();
         this.fixture.dateBox._refresh();
         assert.ok(this.fixture.dateBox._$popup.dxPopup("instance").option("visible"));
     });
 
-    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", (assert) => {
+    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         this.fixture.dateBox.option("onValueChanged", () => {
             assert.ok(true);
         });
         this.fixture.dateBox.option("value", new Date(2015, 6, 14));
     });
 
-    QUnit.test("ValueChanged action should have jQuery event as a parameter when value was changed by user interaction", (assert) => {
+    QUnit.test("ValueChanged action should have jQuery event as a parameter when value was changed by user interaction", function(assert) {
         const valueChangedHandler = sinon.stub();
 
         this.fixture.dateBox.option({
@@ -2138,7 +2138,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(valueChangedHandler.getCall(0).args[0].event, "Event is defined");
     });
 
-    QUnit.test("valueChangeEvent cache should be cleared after the value changing", (assert) => {
+    QUnit.test("valueChangeEvent cache should be cleared after the value changing", function(assert) {
         const valueChangedHandler = sinon.stub();
 
         this.fixture.dateBox.option({
@@ -2154,12 +2154,12 @@ QUnit.module("datebox w/ calendar", {
         assert.notOk(valueChangedHandler.getCall(1).args[0].event, "Event does not exist in second call via api");
     });
 
-    QUnit.test("dateBox's 'min' and 'max' options equal to undefined (T171537)", (assert) => {
+    QUnit.test("dateBox's 'min' and 'max' options equal to undefined (T171537)", function(assert) {
         assert.strictEqual(this.fixture.dateBox.option("min"), undefined);
         assert.strictEqual(this.fixture.dateBox.option("max"), undefined);
     });
 
-    QUnit.test("dateBox must pass min and max to the created calendar", (assert) => {
+    QUnit.test("dateBox must pass min and max to the created calendar", function(assert) {
         const min = new Date(2010, 9, 10);
         const max = new Date(2010, 11, 10);
         this.reinitFixture({
@@ -2171,7 +2171,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(dateUtils.dateInRange(getInstanceWidget(this.fixture.dateBox).option("currentDate"), min, max));
     });
 
-    QUnit.test("dateBox should not change value when setting to an earlier date than min; and setting to a later date than max", (assert) => {
+    QUnit.test("dateBox should not change value when setting to an earlier date than min; and setting to a later date than max", function(assert) {
         const min = new Date(2010, 10, 5);
         const max = new Date(2010, 10, 25);
         const earlyDate = new Date(min.getFullYear(), min.getMonth(), min.getDate() - 1);
@@ -2190,7 +2190,7 @@ QUnit.module("datebox w/ calendar", {
         assert.deepEqual(this.fixture.dateBox.option("value"), lateDate);
     });
 
-    QUnit.test("should execute custom validator while validation state reevaluating", (assert) => {
+    QUnit.test("should execute custom validator while validation state reevaluating", function(assert) {
         this.reinitFixture({ opened: true });
 
         const dateBox = this.fixture.dateBox;
@@ -2213,7 +2213,7 @@ QUnit.module("datebox w/ calendar", {
         assert.notStrictEqual(dateBox.option("text"), "");
     });
 
-    QUnit.test("should rise validation event once after value is changed by calendar (T714599)", (assert) => {
+    QUnit.test("should rise validation event once after value is changed by calendar (T714599)", function(assert) {
         const validationCallbackStub = sinon.stub().returns(false);
         const dateBox = $("#dateBoxWithPicker")
             .dxDateBox({
@@ -2237,7 +2237,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(validationCallbackStub.calledOnce);
     });
 
-    QUnit.test("Editor should reevaluate validation state after change text to the current value", (assert) => {
+    QUnit.test("Editor should reevaluate validation state after change text to the current value", function(assert) {
         this.reinitFixture({
             min: new Date(2010, 10, 5),
             value: new Date(2010, 10, 10),
@@ -2263,7 +2263,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal(dateBox.option("text"), "11/10/2010");
     });
 
-    QUnit.test("In dateTime strategy buttons should be placed in popup bottom", (assert) => {
+    QUnit.test("In dateTime strategy buttons should be placed in popup bottom", function(assert) {
         this.reinitFixture({
             type: "datetime",
             applyValueMode: "useButtons",
@@ -2275,7 +2275,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal($(".dx-popup-bottom .dx-button").length, 3, "two buttons is in popup bottom");
     });
 
-    QUnit.test("Click on apply button", (assert) => {
+    QUnit.test("Click on apply button", function(assert) {
         const onValueChangedHandler = sinon.spy(noop);
         const newDate = new Date(2010, 10, 10);
 
@@ -2292,7 +2292,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(onValueChangedHandler.calledOnce);
     });
 
-    QUnit.test("Click on cancel button", (assert) => {
+    QUnit.test("Click on cancel button", function(assert) {
         const onValueChangedHandler = sinon.spy(noop);
         const oldDate = new Date(2008, 8, 8);
         const newDate = new Date(2010, 10, 10);
@@ -2313,14 +2313,14 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(!onValueChangedHandler.calledOnce);
     });
 
-    QUnit.test("calendar does not open on field click (T189394)", (assert) => {
+    QUnit.test("calendar does not open on field click (T189394)", function(assert) {
         assert.ok(!this.fixture.dateBox.option("openOnFieldClick"));
     });
 
     const getLongestCaptionIndex = uiDateUtils.getLongestCaptionIndex;
     const getLongestDate = uiDateUtils.getLongestDate;
 
-    QUnit.test("getLongestDate must consider the possibility of overflowing to the next month from its 28th day and thus losing the longest month name when calculating widths for formats containing day and month names", assert => {
+    QUnit.test("getLongestDate must consider the possibility of overflowing to the next month from its 28th day and thus losing the longest month name when calculating widths for formats containing day and month names", function(assert) {
         const someLanguageMonthNames = ["1", "1", "1", "1", "1", "1", "1", "1", "1", "22", "1", "1"];
         const someLanguageDayNames = ["1", "1", "1", "1", "22", "1", "1"];
         const longestMonthNameIndex = getLongestCaptionIndex(someLanguageMonthNames);
@@ -2328,7 +2328,7 @@ QUnit.module("datebox w/ calendar", {
         assert.strictEqual(longestDate.getMonth(), longestMonthNameIndex);
     });
 
-    QUnit.test("Calendar should update it value accordingly 'text' option if it is valid (T189474)", (assert) => {
+    QUnit.test("Calendar should update it value accordingly 'text' option if it is valid (T189474)", function(assert) {
         const date = new Date(2014, 5, 10);
 
         this.reinitFixture({
@@ -2350,7 +2350,7 @@ QUnit.module("datebox w/ calendar", {
         assert.deepEqual(calendar.option("value"), new Date(2015, 5, 10));
     });
 
-    QUnit.test("Calendar should not be closed after datebox value has been changed by input", (assert) => {
+    QUnit.test("Calendar should not be closed after datebox value has been changed by input", function(assert) {
         const date = new Date(2014, 5, 10);
 
         this.reinitFixture({
@@ -2373,7 +2373,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(this.fixture.dateBox.option("opened"));
     });
 
-    QUnit.test("Value should be changed only after click on 'Apply' button if the 'applyValueMode' options is changed to 'useButtons'", (assert) => {
+    QUnit.test("Value should be changed only after click on 'Apply' button if the 'applyValueMode' options is changed to 'useButtons'", function(assert) {
         const value = new Date(2015, 0, 20);
         const newValue = new Date(2015, 0, 30);
 
@@ -2395,7 +2395,7 @@ QUnit.module("datebox w/ calendar", {
         assert.deepEqual(dateBox.option("value"), newValue, "value is changed after click");
     });
 
-    QUnit.test("Value should be changed if it was entered from keyboard and it is out of range", (assert) => {
+    QUnit.test("Value should be changed if it was entered from keyboard and it is out of range", function(assert) {
         const value = new Date(2015, 0, 15);
         const min = new Date(2015, 0, 10);
         const max = new Date(2015, 0, 20);
@@ -2423,7 +2423,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(validationError.editorSpecific, "editorSpecific flag should be added");
     });
 
-    QUnit.test("Empty value should not be marked as 'out of range'", (assert) => {
+    QUnit.test("Empty value should not be marked as 'out of range'", function(assert) {
         const value = new Date(2015, 0, 15);
         const min = new Date(2015, 0, 10);
         const max = new Date(2015, 0, 20);
@@ -2445,7 +2445,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(!dateBox.option("validationError"), "validationError should not be set");
     });
 
-    QUnit.test("Popup should not be hidden after value change using keyboard", (assert) => {
+    QUnit.test("Popup should not be hidden after value change using keyboard", function(assert) {
         const value = new Date(2015, 0, 29);
 
         this.reinitFixture({
@@ -2472,7 +2472,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(dateBox.option("opened"), "popup is still opened");
     });
 
-    QUnit.test("T196443 - dxDateBox should not hide popup after erase date in input field", (assert) => {
+    QUnit.test("T196443 - dxDateBox should not hide popup after erase date in input field", function(assert) {
         const value = new Date(2015, 0, 30);
 
         this.reinitFixture({
@@ -2498,7 +2498,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(dateBox.option("opened"), "popup is still opened");
     });
 
-    QUnit.test("T203457 - popup should be closed when selected date is clicked", (assert) => {
+    QUnit.test("T203457 - popup should be closed when selected date is clicked", function(assert) {
         const value = new Date(2015, 1, 1);
 
         this.reinitFixture({
@@ -2517,7 +2517,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(!dateBox.option("opened"), "popup is closed");
     });
 
-    QUnit.test("T208825 - tapping on the 'enter' should change value if popup is opened", (assert) => {
+    QUnit.test("T208825 - tapping on the 'enter' should change value if popup is opened", function(assert) {
         const value = new Date(2015, 2, 13);
 
         this.reinitFixture({
@@ -2542,7 +2542,7 @@ QUnit.module("datebox w/ calendar", {
         assert.deepEqual(dateBox.option("value"), new Date(2014, 2, 13), "value is changed");
     });
 
-    QUnit.test("Close popup on the 'enter' press after input value is changed", (assert) => {
+    QUnit.test("Close popup on the 'enter' press after input value is changed", function(assert) {
         const value = new Date(2015, 2, 10);
 
         this.reinitFixture({
@@ -2564,7 +2564,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal(dateBox.option("opened"), false, "popup is still opened");
     });
 
-    QUnit.test("repaint was fired if strategy is fallback", (assert) => {
+    QUnit.test("repaint was fired if strategy is fallback", function(assert) {
         this.reinitFixture({
             useNative: false,
             useCalendar: true,
@@ -2582,7 +2582,7 @@ QUnit.module("datebox w/ calendar", {
         assert.ok(repaintSpy.called, "repaint was fired on opened");
     });
 
-    QUnit.test("changing type from 'datetime' to 'date' should lead to strategy changing", (assert) => {
+    QUnit.test("changing type from 'datetime' to 'date' should lead to strategy changing", function(assert) {
         this.reinitFixture({
             type: "datetime",
             pickerType: "calendar"
@@ -2595,7 +2595,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal(dateBox._strategy.NAME, "Calendar", "correct strategy for the 'date' type");
     });
 
-    QUnit.test("T247493 - value is cleared when text is changed to invalid date and popup is opened", (assert) => {
+    QUnit.test("T247493 - value is cleared when text is changed to invalid date and popup is opened", function(assert) {
         const date = new Date(2015, 5, 9);
 
         this.reinitFixture({
@@ -2617,7 +2617,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal($input.val(), "6/9/201", "input value is correct");
     });
 
-    QUnit.test("T252170 - date time should be the same with set value after calendar value is changed", (assert) => {
+    QUnit.test("T252170 - date time should be the same with set value after calendar value is changed", function(assert) {
         const date = new Date(2015, 5, 9, 15, 54, 13);
 
         this.reinitFixture({
@@ -2636,7 +2636,7 @@ QUnit.module("datebox w/ calendar", {
         assert.deepEqual(dateBox.option("value"), new Date(2015, 5, 10, 15, 54, 13), "new datebox value saves set value time");
     });
 
-    QUnit.test("calendar views should be positioned correctly", assert => {
+    QUnit.test("calendar views should be positioned correctly", function(assert) {
         $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -2652,7 +2652,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal($calendarViews.eq(2).position().left, viewWidth, "after view is at the right");
     });
 
-    QUnit.test("Popup with calendar strategy should be use 'flipfit flip' strategy", assert => {
+    QUnit.test("Popup with calendar strategy should be use 'flipfit flip' strategy", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "date",
             pickerType: "calendar",
@@ -2670,7 +2670,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal(popup.option("position").my, "bottom left", "position is saved");
     });
 
-    QUnit.test("Popup with calendarWithTime strategy should be use 'flipfit flip' strategy", assert => {
+    QUnit.test("Popup with calendarWithTime strategy should be use 'flipfit flip' strategy", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -2681,7 +2681,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal($dateBox.find(".dx-popup").dxPopup("option", "position").collision, "flipfit flip", "collision set correctly");
     });
 
-    QUnit.test("DateBox should not take current date value at the opening if value is null", assert => {
+    QUnit.test("DateBox should not take current date value at the opening if value is null", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: null,
             pickerType: "calendar"
@@ -2695,7 +2695,7 @@ QUnit.module("datebox w/ calendar", {
         assert.equal(instance.option("value"), null, "value shouldn't be dropped after opening");
     });
 
-    QUnit.test("time component should not be changed if editing value with the help of keyboard (T398429)", (assert) => {
+    QUnit.test("time component should not be changed if editing value with the help of keyboard (T398429)", function(assert) {
         this.reinitFixture({
             type: "date",
             pickerType: "calendar",
@@ -2717,14 +2717,14 @@ QUnit.module("datebox w/ calendar", {
 });
 
 QUnit.module("datebox with time component", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.test("date box should contain calendar and time view inside box in large screen", assert => {
+    QUnit.test("date box should contain calendar and time view inside box in large screen", function(assert) {
         const originalWidthFunction = renderer.fn.width;
 
         try {
@@ -2751,7 +2751,7 @@ QUnit.module("datebox with time component", {
         }
     });
 
-    QUnit.test("date box should contain calendar and time view inside box in small screen", assert => {
+    QUnit.test("date box should contain calendar and time view inside box in small screen", function(assert) {
         const originalWidthFunction = renderer.fn.width;
 
         try {
@@ -2778,7 +2778,7 @@ QUnit.module("datebox with time component", {
         }
     });
 
-    QUnit.test("date box should have compact view when showAnalogClock option is false", assert => {
+    QUnit.test("date box should have compact view when showAnalogClock option is false", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar"
@@ -2799,7 +2799,7 @@ QUnit.module("datebox with time component", {
         assert.equal($clock.length, 0, "clock was not rendered");
     });
 
-    QUnit.test("date box wrapper adaptivity class depends on the screen size", assert => {
+    QUnit.test("date box wrapper adaptivity class depends on the screen size", function(assert) {
         const LARGE_SCREEN_SIZE = 2000;
         const SMALL_SCREEN_SIZE = 300;
 
@@ -2827,7 +2827,7 @@ QUnit.module("datebox with time component", {
         }
     });
 
-    QUnit.test("dateBox with datetime strategy should be rendered once on init", assert => {
+    QUnit.test("dateBox with datetime strategy should be rendered once on init", function(assert) {
         const contentReadyHandler = sinon.spy();
 
         $("#dateBox").dxDateBox({
@@ -2839,7 +2839,7 @@ QUnit.module("datebox with time component", {
         assert.equal(contentReadyHandler.callCount, 1, "contentReady has been called once");
     });
 
-    QUnit.test("date box popup should have maximum 100% width", assert => {
+    QUnit.test("date box popup should have maximum 100% width", function(assert) {
         const currentDevice = sinon.stub(devices, "current").returns({
             platform: "generic",
             phone: true
@@ -2859,7 +2859,7 @@ QUnit.module("datebox with time component", {
         }
     });
 
-    QUnit.test("datebox value is bound to time view value", assert => {
+    QUnit.test("datebox value is bound to time view value", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -2882,7 +2882,7 @@ QUnit.module("datebox with time component", {
         assert.equal(instance.option("value").toString(), date.toString(), "dateBox value is set");
     });
 
-    QUnit.test("time value should be updated after select date", assert => {
+    QUnit.test("time value should be updated after select date", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -2902,7 +2902,7 @@ QUnit.module("datebox with time component", {
         assert.equal(dateBox.option("value").toString(), (new Date(2014, 2, 1, 12, 16)).toString(), "dateBox value is set");
     });
 
-    QUnit.test("buttons are rendered after 'type' option was changed", assert => {
+    QUnit.test("buttons are rendered after 'type' option was changed", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             pickerType: "calendar",
             type: "datetime",
@@ -2926,7 +2926,7 @@ QUnit.module("datebox with time component", {
         assert.equal($buttons.length, 3, "buttons are rendered after option was changed");
     });
 
-    QUnit.test("T208853 - time is reset when calendar value is changed", assert => {
+    QUnit.test("T208853 - time is reset when calendar value is changed", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             pickerType: "calendar",
             type: "datetime",
@@ -2948,7 +2948,7 @@ QUnit.module("datebox with time component", {
         assert.deepEqual(dateBox.option("value"), new Date(2014, 1, 16, 11, 20), "date and time are correct");
     });
 
-    QUnit.test("T231015 - widget should set default date or time if only one widget's value is chosen", assert => {
+    QUnit.test("T231015 - widget should set default date or time if only one widget's value is chosen", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             pickerType: "calendar",
             type: "datetime",
@@ -2978,7 +2978,7 @@ QUnit.module("datebox with time component", {
         assert.equal(Math.floor(dateBox.option("value").getTime() / 1000 / 10), Math.floor(date.getTime() / 1000 / 10), "value is correct if only timeView value is changed");
     });
 
-    QUnit.test("T253298 - widget should set default date and time if value is null and the 'OK' button is clicked", assert => {
+    QUnit.test("T253298 - widget should set default date and time if value is null and the 'OK' button is clicked", function(assert) {
         const $element = $("#dateBox").dxDateBox({
             pickerType: "calendar",
             type: "datetime",
@@ -2997,7 +2997,7 @@ QUnit.module("datebox with time component", {
         assert.equal(Math.round(value.getTime() / 1000 / 10), Math.round(date.getTime() / 1000 / 10), "value is correct");
     });
 
-    QUnit.test("DateBox should have time part when pickerType is rollers", assert => {
+    QUnit.test("DateBox should have time part when pickerType is rollers", function(assert) {
         const date = new Date(2015, 1, 1, 12, 13, 14);
         const dateBox = $("#dateBox").dxDateBox({
             pickerType: "rollers",
@@ -3011,7 +3011,7 @@ QUnit.module("datebox with time component", {
         assert.equal($input.val(), dateLocalization.format(date, format), "input value is correct");
     });
 
-    QUnit.test("DateBox with time should be rendered correctly in IE, templatesRenderAsynchronously=true", assert => {
+    QUnit.test("DateBox with time should be rendered correctly in IE, templatesRenderAsynchronously=true", function(assert) {
         const clock = sinon.useFakeTimers();
         try {
             const dateBox = $("#dateBox").dxDateBox({
@@ -3032,7 +3032,7 @@ QUnit.module("datebox with time component", {
         }
     });
 
-    QUnit.test("Reset seconds and milliseconds when DateBox has no value for datetime view", assert => {
+    QUnit.test("Reset seconds and milliseconds when DateBox has no value for datetime view", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -3049,7 +3049,7 @@ QUnit.module("datebox with time component", {
         assert.equal(dateBox.option("value").getMilliseconds(), 0, "milliseconds has zero value");
     });
 
-    QUnit.test("Submit value should not be changed when apply button clicked and an invalid (by internal validation) value is selected", assert => {
+    QUnit.test("Submit value should not be changed when apply button clicked and an invalid (by internal validation) value is selected", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -3067,7 +3067,7 @@ QUnit.module("datebox with time component", {
         assert.equal($submitElement.val(), "2015-01-25T13:00:00", "submit element has correct value");
     });
 
-    QUnit.test("Submit value should be changed when apply button clicked and an invalid (by validator) value is selected", assert => {
+    QUnit.test("Submit value should be changed when apply button clicked and an invalid (by validator) value is selected", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -3094,7 +3094,7 @@ QUnit.module("datebox with time component", {
         assert.equal($submitElement.val(), "2015-01-25T12:00:00", "submit element has correct value");
     });
 
-    QUnit.test("Reset seconds and milliseconds when DateBox has no value for time view", assert => {
+    QUnit.test("Reset seconds and milliseconds when DateBox has no value for time view", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             pickerType: "list",
             type: "time"
@@ -3108,7 +3108,7 @@ QUnit.module("datebox with time component", {
         assert.equal(dateBox.option("value").getMilliseconds(), 0, "milliseconds has zero value");
     });
 
-    QUnit.test("DateBox renders the right stylingMode for editors in time view overlay (default)", assert => {
+    QUnit.test("DateBox renders the right stylingMode for editors in time view overlay (default)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3129,7 +3129,7 @@ QUnit.module("datebox with time component", {
         assert.ok(amPmEditor.hasClass("dx-editor-outlined"));
     });
 
-    QUnit.test("DateBox renders the right stylingMode for editors in time view overlay (custom)", assert => {
+    QUnit.test("DateBox renders the right stylingMode for editors in time view overlay (custom)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3151,7 +3151,7 @@ QUnit.module("datebox with time component", {
         assert.ok(amPmEditor.hasClass("dx-editor-underlined"));
     });
 
-    QUnit.test("datebox with the 'datetime' type should have an 'event' parameter of the ValueChanged event", assert => {
+    QUnit.test("datebox with the 'datetime' type should have an 'event' parameter of the ValueChanged event", function(assert) {
         $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -3168,7 +3168,7 @@ QUnit.module("datebox with time component", {
 });
 
 QUnit.module("datebox w/ time list", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$dateBox = $("#dateBox");
@@ -3180,29 +3180,29 @@ QUnit.module("datebox w/ time list", {
             })
             .dxDateBox("instance");
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.test("rendered markup", (assert) => {
+    QUnit.test("rendered markup", function(assert) {
         this.dateBox.option("opened", true);
         assert.ok($(DATEBOX_LIST_POPUP_SELECTOR).length, "Popup has dx-timebox-popup-wrapper class");
     });
 
-    QUnit.test("rendered popup markup", (assert) => {
+    QUnit.test("rendered popup markup", function(assert) {
         this.dateBox.option("opened", true);
 
         assert.ok(this.dateBox._popup, "popup exist");
     });
 
-    QUnit.test("rendered list markup", (assert) => {
+    QUnit.test("rendered list markup", function(assert) {
         this.dateBox.option("opened", true);
 
         assert.ok(getInstanceWidget(this.dateBox), "list exist");
         assert.ok(getInstanceWidget(this.dateBox).$element().hasClass("dx-list"), "list initialized");
     });
 
-    QUnit.test("width option test", (assert) => {
+    QUnit.test("width option test", function(assert) {
         this.dateBox.option("opened", false);
         this.dateBox.option("width", "auto");
         this.dateBox.option("opened", true);
@@ -3217,7 +3217,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(this.$dateBox.outerWidth(), popup.option("width"), "timebox popup has equal width with timebox with option width in pixels");
     });
 
-    QUnit.test("list should contain correct values if min/max does not specified", (assert) => {
+    QUnit.test("list should contain correct values if min/max does not specified", function(assert) {
         this.dateBox.option({
             min: null,
             max: null
@@ -3232,7 +3232,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal($listItems.last().text(), "11:30 PM", "max value is right");
     });
 
-    QUnit.test("min/max option test", (assert) => {
+    QUnit.test("min/max option test", function(assert) {
         this.dateBox.option({
             min: new Date(2008, 7, 8, 4, 0),
             max: new Date(2008, 7, 8, 8, 59)
@@ -3247,7 +3247,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal($listItems.last().text(), "8:30 AM", "max value is right");
     });
 
-    QUnit.test("min/max overflow test", (assert) => {
+    QUnit.test("min/max overflow test", function(assert) {
         this.dateBox.option({
             min: new Date(2008, 7, 8, 4, 0),
             max: new Date(2008, 7, 9, 9, 0)
@@ -3262,7 +3262,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal($listItems.last().text(), "3:30 AM", "max value is right");
     });
 
-    QUnit.test("interval option", (assert) => {
+    QUnit.test("interval option", function(assert) {
         this.dateBox.option({
             min: new Date(2008, 7, 8, 4, 0),
             value: new Date(2008, 7, 8, 5, 0),
@@ -3286,7 +3286,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(items.length, 1, "interval option works");
     });
 
-    QUnit.test("T240639 - correct list item should be highlighted if appropriate datebox value is set", (assert) => {
+    QUnit.test("T240639 - correct list item should be highlighted if appropriate datebox value is set", function(assert) {
         this.dateBox.option({
             type: "time",
             pickerType: "list",
@@ -3305,7 +3305,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(list.option("selectedItem"), null, "there is no selected list item");
     });
 
-    QUnit.test("T351678 - the date is reset after item click", (assert) => {
+    QUnit.test("T351678 - the date is reset after item click", function(assert) {
         this.dateBox.option({
             type: "time",
             pickerType: "list",
@@ -3319,7 +3319,7 @@ QUnit.module("datebox w/ time list", {
         assert.deepEqual(this.dateBox.option("value"), new Date(2020, 4, 13, 1, 30), "date is correct");
     });
 
-    QUnit.test("the date should be in range after the selection", (assert) => {
+    QUnit.test("the date should be in range after the selection", function(assert) {
         this.dateBox.option({
             type: "time",
             pickerType: "list",
@@ -3335,7 +3335,7 @@ QUnit.module("datebox w/ time list", {
         assert.deepEqual(this.dateBox.option("value"), new Date(2016, 10, 5, 12, 0, 0), "date is correct");
     });
 
-    QUnit.test("list should have items if the 'min' option is specified (T395529)", (assert) => {
+    QUnit.test("list should have items if the 'min' option is specified (T395529)", function(assert) {
         this.dateBox.option({
             min: new Date(new Date(null).setHours(15)),
             opened: true
@@ -3345,7 +3345,7 @@ QUnit.module("datebox w/ time list", {
         assert.ok(list.option("items").length > 0, "list is not empty");
     });
 
-    QUnit.test("selected date should be in 1970 when it was set from the null value", (assert) => {
+    QUnit.test("selected date should be in 1970 when it was set from the null value", function(assert) {
         this.dateBox.option({
             opened: true,
             value: null
@@ -3357,7 +3357,7 @@ QUnit.module("datebox w/ time list", {
         assert.strictEqual(this.dateBox.option("value").getFullYear(), new Date(null).getFullYear(), "year is correct");
     });
 
-    QUnit.test("selected date should be in value year when value is specified", (assert) => {
+    QUnit.test("selected date should be in value year when value is specified", function(assert) {
         this.dateBox.option({
             opened: true,
             value: new Date(2018, 5, 6, 14, 12)
@@ -3369,7 +3369,7 @@ QUnit.module("datebox w/ time list", {
         assert.strictEqual(this.dateBox.option("value").getFullYear(), 2018, "year is correct");
     });
 
-    QUnit.test("selected date should be in 1970 when it was set from user's input", (assert) => {
+    QUnit.test("selected date should be in 1970 when it was set from user's input", function(assert) {
         this.dateBox.option({
             value: null,
             displayFormat: "HH:mm"
@@ -3383,7 +3383,7 @@ QUnit.module("datebox w/ time list", {
         assert.strictEqual(this.dateBox.option("value").getFullYear(), new Date(null).getFullYear(), "year is correct");
     });
 
-    QUnit.test("the value's date part should not be changed if editing input's text by keyboard (T395685)", (assert) => {
+    QUnit.test("the value's date part should not be changed if editing input's text by keyboard (T395685)", function(assert) {
         this.dateBox.option({
             focusStateEnabled: true,
             value: new Date(2016, 5, 25, 14, 22)
@@ -3401,7 +3401,7 @@ QUnit.module("datebox w/ time list", {
         assert.deepEqual(this.dateBox.option("value"), new Date(2016, 5, 25, 14, 44), "value is correct");
     });
 
-    QUnit.test("List of items should be refreshed after value is changed", (assert) => {
+    QUnit.test("List of items should be refreshed after value is changed", function(assert) {
         this.dateBox.option({
             min: new Date(2016, 1, 1, 10, 0),
             value: new Date(2016, 1, 2, 14, 45),
@@ -3421,7 +3421,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(items.length, 14, "14 items should be find from min to finish of day");
     });
 
-    QUnit.test("All items in list should be present if value and min options are belong to different days", (assert) => {
+    QUnit.test("All items in list should be present if value and min options are belong to different days", function(assert) {
         this.dateBox.option({
             min: new Date(2016, 1, 1, 13, 45),
             value: new Date(2016, 1, 1, 14, 45),
@@ -3442,7 +3442,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(items.eq(0).text(), "12:45 AM", "start time is correct");
     });
 
-    QUnit.test("The situation when value and max options are belong to one day", (assert) => {
+    QUnit.test("The situation when value and max options are belong to one day", function(assert) {
         this.dateBox.option({
             value: new Date(2016, 1, 1, 13, 45),
             max: new Date(2016, 1, 1, 15, 0),
@@ -3456,7 +3456,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(items.length, 15, "list should be contain right count of items");
     });
 
-    QUnit.test("value and max are belong to one day", (assert) => {
+    QUnit.test("value and max are belong to one day", function(assert) {
         this.dateBox.option({
             min: new Date(2016, 1, 1, 0, 11),
             value: new Date(2016, 1, 3, 14, 45),
@@ -3473,7 +3473,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(items.eq(items.length - 1).text(), "6:11 PM", "last item in list is correct");
     });
 
-    QUnit.test("List items should be started with minimal possible value", (assert) => {
+    QUnit.test("List items should be started with minimal possible value", function(assert) {
         this.dateBox.option({
             min: new Date(2016, 1, 1, 0, 17),
             value: new Date(2016, 1, 3, 14, 45),
@@ -3488,7 +3488,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(items.eq(items.length - 1).text(), "11:47 PM", "last item in list is correct");
     });
 
-    QUnit.test("dxDateBox with list strategy automatically scrolls to selected item on opening", (assert) => {
+    QUnit.test("dxDateBox with list strategy automatically scrolls to selected item on opening", function(assert) {
         this.dateBox.option({
             value: new Date(2016, 1, 3, 14, 45),
             interval: 15,
@@ -3503,7 +3503,7 @@ QUnit.module("datebox w/ time list", {
         assert.ok($popupContent.offset().top + $popupContent.height() > $selectedItem.offset().top, "selected item is visible");
     });
 
-    QUnit.test("min/max settings should be work if value option is null", (assert) => {
+    QUnit.test("min/max settings should be work if value option is null", function(assert) {
         this.dateBox.option({
             value: null,
             min: new Date(2008, 7, 8, 8, 0),
@@ -3519,7 +3519,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal($listItems.last().text(), "7:30 PM", "max value is right");
     });
 
-    QUnit.test("min/max settings should be work if value option is undefined", (assert) => {
+    QUnit.test("min/max settings should be work if value option is undefined", function(assert) {
         this.dateBox.option({
             value: undefined,
             min: new Date(2008, 7, 8, 8, 0),
@@ -3535,7 +3535,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal($listItems.last().text(), "7:30 PM", "max value is right");
     });
 
-    QUnit.test("validator correctly check value with 'time' format", assert => {
+    QUnit.test("validator correctly check value with 'time' format", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "time",
             pickerType: "list",
@@ -3557,7 +3557,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(dateBox.option("isValid"), true, "Editor should be marked as valid");
     });
 
-    QUnit.testInActiveWindow("select a new value via the Enter key", (assert) => {
+    QUnit.testInActiveWindow("select a new value via the Enter key", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "time",
             value: new Date(2018, 2, 2, 12, 0, 13),
@@ -3581,7 +3581,7 @@ QUnit.module("datebox w/ time list", {
         assert.equal(value.getMinutes(), 0, "Correct minutes");
     });
 
-    QUnit.test("items are rendered when value is 'undefined' (T805931)", (assert) => {
+    QUnit.test("items are rendered when value is 'undefined' (T805931)", function(assert) {
         this.dateBox.option({
             value: undefined
         });
@@ -3594,7 +3594,7 @@ QUnit.module("datebox w/ time list", {
 });
 
 QUnit.module("keyboard navigation", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$dateBox = $("#dateBox");
@@ -3613,11 +3613,11 @@ QUnit.module("keyboard navigation", {
         this.$input = this.$dateBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         this.keyboard = keyboardMock(this.$input);
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.testInActiveWindow("popup hides on tab", (assert) => {
+    QUnit.testInActiveWindow("popup hides on tab", function(assert) {
         this.dateBox.focus();
         assert.ok(this.$dateBox.hasClass(STATE_FOCUSED_CLASS), "element is focused");
         this.dateBox.option("opened", true);
@@ -3627,7 +3627,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(this.dateBox.option("opened"), false, "popup is hidden");
     });
 
-    QUnit.testInActiveWindow("home/end should not be handled", (assert) => {
+    QUnit.testInActiveWindow("home/end should not be handled", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3644,7 +3644,7 @@ QUnit.module("keyboard navigation", {
         assert.ok(!$timeList.find(LIST_ITEM_SELECTOR).eq(0).hasClass(STATE_FOCUSED_CLASS), "element is not focused");
     });
 
-    QUnit.testInActiveWindow("arrow keys control", (assert) => {
+    QUnit.testInActiveWindow("arrow keys control", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3675,7 +3675,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(selectedDate.getMinutes(), 30, "minutes is right");
     });
 
-    QUnit.test("apply contoured date on enter for date and datetime mode", (assert) => {
+    QUnit.test("apply contoured date on enter for date and datetime mode", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3707,7 +3707,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(selectedDate.getDate(), 1, "day is right");
     });
 
-    QUnit.testInActiveWindow("valueChangeEvent should have Event when enter key was pressed", assert => {
+    QUnit.testInActiveWindow("valueChangeEvent should have Event when enter key was pressed", function(assert) {
         let $dateBox;
 
         try {
@@ -3732,7 +3732,7 @@ QUnit.module("keyboard navigation", {
         }
     });
 
-    QUnit.testInActiveWindow("onValueChanged fires after clearing and enter key press", (assert) => {
+    QUnit.testInActiveWindow("onValueChanged fires after clearing and enter key press", function(assert) {
         const valueChanged = sinon.stub();
 
         this.dateBox = this.$dateBox
@@ -3760,7 +3760,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(valueChanged.callCount, 2, "valueChanged is called");
     });
 
-    QUnit.test("Enter key press prevents default when popup in opened", assert => {
+    QUnit.test("Enter key press prevents default when popup in opened", function(assert) {
         assert.expect(1);
 
         let prevented = 0;
@@ -3790,7 +3790,7 @@ QUnit.module("keyboard navigation", {
         }
     });
 
-    QUnit.testInActiveWindow("the 'shift+tab' key press leads to the cancel button focus if the input is focused", (assert) => {
+    QUnit.testInActiveWindow("the 'shift+tab' key press leads to the cancel button focus if the input is focused", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "desktop specific test");
             return;
@@ -3816,7 +3816,7 @@ QUnit.module("keyboard navigation", {
         assert.ok($cancelButton.hasClass("dx-state-focused"), "cancel button is focused");
     });
 
-    QUnit.testInActiveWindow("Unsupported key handlers must be processed correctly", (assert) => {
+    QUnit.testInActiveWindow("Unsupported key handlers must be processed correctly", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3847,7 +3847,7 @@ QUnit.module("keyboard navigation", {
         assert.ok(isNoError, "key handlers processed without errors");
     });
 
-    QUnit.test("Pressing escape when focus 'today' button must hide the popup", (assert) => {
+    QUnit.test("Pressing escape when focus 'today' button must hide the popup", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3874,7 +3874,7 @@ QUnit.module("keyboard navigation", {
         { editorName: "minute", editorIndex: 1 },
         { editorName: "period", editorIndex: 2 }
     ].forEach(({ editorName, editorIndex }) => {
-        QUnit.test(`Pressing escape when focus the ${editorName} editor must hide the popup`, (assert) => {
+        QUnit.test(`Pressing escape when focus the ${editorName} editor must hide the popup`, function(assert) {
             const escapeKeyDown = $.Event("keydown", { key: "Escape" });
             this.dateBox.option({
                 pickerType: "calendar",
@@ -3893,7 +3893,7 @@ QUnit.module("keyboard navigation", {
 });
 
 QUnit.module("aria accessibility", {}, () => {
-    QUnit.test("aria-activedescendant on combobox should point to the active list item (date view)", assert => {
+    QUnit.test("aria-activedescendant on combobox should point to the active list item (date view)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3915,7 +3915,7 @@ QUnit.module("aria accessibility", {}, () => {
         assert.equal($input.attr("aria-activedescendant"), $contouredCell.attr("id"), "aria-activedescendant equals contoured cell's id");
     });
 
-    QUnit.test("aria-activedescendant on combobox should point to the active list item (time view)", assert => {
+    QUnit.test("aria-activedescendant on combobox should point to the active list item (time view)", function(assert) {
         const isDesktop = devices.real().deviceType === "desktop";
 
         if(isDesktop) {
@@ -3942,7 +3942,7 @@ QUnit.module("aria accessibility", {}, () => {
 });
 
 QUnit.module("pickerType", {}, () => {
-    QUnit.test("T319039 - classes on DateBox should be correct after the 'pickerType' option changed", assert => {
+    QUnit.test("T319039 - classes on DateBox should be correct after the 'pickerType' option changed", function(assert) {
         const pickerTypes = ["rollers", "calendar", "native", "list"];
         const $dateBox = $("#dateBox").dxDateBox();
         const dateBox = $dateBox.dxDateBox("instance");
@@ -3973,7 +3973,7 @@ QUnit.module("pickerType", {}, () => {
         }
     });
 
-    QUnit.test("Calendar pickerType and time type should use time list (T248089)", assert => {
+    QUnit.test("Calendar pickerType and time type should use time list (T248089)", function(assert) {
         const currentDevice = devices.real();
         devices.real({ platform: "android" });
 
@@ -3993,7 +3993,7 @@ QUnit.module("pickerType", {}, () => {
 });
 
 QUnit.module("datebox validation", {}, () => {
-    QUnit.test("validation should be correct when max value is chosen (T266206)", assert => {
+    QUnit.test("validation should be correct when max value is chosen (T266206)", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             min: new Date(2015, 6, 10),
             max: new Date(2015, 6, 14),
@@ -4005,7 +4005,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "datebox is valid");
     });
 
-    QUnit.test("datebox should create validation error if user set isValid = false", (assert) => {
+    QUnit.test("datebox should create validation error if user set isValid = false", function(assert) {
         const dateBox = $("#widthRootStyle").dxDateBox({
             type: "datetime",
             isValid: false,
@@ -4021,7 +4021,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.notOk(dateBox.option("isValid"), "set isValid = false by API");
     });
 
-    QUnit.test("datebox should be invalid after out of range value was setted", (assert) => {
+    QUnit.test("datebox should be invalid after out of range value was setted", function(assert) {
         const dateBox = $("#widthRootStyle").dxDateBox({
             type: "datetime",
             min: new Date(2019, 1, 1),
@@ -4037,7 +4037,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "widget is valid");
     });
 
-    QUnit.test("datebox should change validation state if value was changed by keyboard", (assert) => {
+    QUnit.test("datebox should change validation state if value was changed by keyboard", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "date",
             value: null,
@@ -4057,7 +4057,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "widget is valid");
     });
 
-    QUnit.test("required validator should not block valuechange in datetime strategy", (assert) => {
+    QUnit.test("required validator should not block valuechange in datetime strategy", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -4077,7 +4077,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("value"), "value is not empty");
     });
 
-    QUnit.test("widget is still valid after drop down is opened", assert => {
+    QUnit.test("widget is still valid after drop down is opened", function(assert) {
         const startDate = new Date(2015, 1, 1, 8, 12);
 
         const $dateBox = $("#dateBox").dxDateBox({
@@ -4106,7 +4106,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "value is valid too");
     });
 
-    QUnit.test("datebox with 'date' type should ignore time in min/max options", assert => {
+    QUnit.test("datebox with 'date' type should ignore time in min/max options", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: new Date(2015, 0, 31, 10),
             focusStateEnabled: true,
@@ -4116,7 +4116,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(!$dateBox.hasClass("dx-invalid"), "datebox should stay valid");
     });
 
-    QUnit.test("time works correct when value is invalid", assert => {
+    QUnit.test("time works correct when value is invalid", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "time",
             pickerType: "list",
@@ -4135,7 +4135,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(popup.option("visible"), "popup is opened");
     });
 
-    QUnit.test("invalidDateMessage", assert => {
+    QUnit.test("invalidDateMessage", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.expect(0);
             return;
@@ -4154,7 +4154,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.equal(validationError, "A lorem ipsum...", "validation message is correct");
     });
 
-    QUnit.test("dateOutOfRangeMessage", assert => {
+    QUnit.test("dateOutOfRangeMessage", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             dateOutOfRangeMessage: "A lorem ipsum...",
             min: new Date(2015, 5, 5),
@@ -4170,7 +4170,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.equal(validationError, "A lorem ipsum...", "validation message is correct");
     });
 
-    QUnit.test("year is too big", assert => {
+    QUnit.test("year is too big", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             displayFormat: "d/M/y",
             valueChangeEvent: "change",
@@ -4185,7 +4185,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.equal($input.val(), "01/01/999999999", "value is not changed");
     });
 
-    QUnit.test("datebox should not ignore the time component in validation when it is changed by timeview (T394206)", assert => {
+    QUnit.test("datebox should not ignore the time component in validation when it is changed by timeview (T394206)", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             type: "datetime",
             pickerType: "calendar",
@@ -4207,7 +4207,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok($dateBox.hasClass("dx-invalid"), "datebox should be marked as invalid");
     });
 
-    QUnit.test("datebox should be valid if value was changed in the onValueChanged handle(T413553)", assert => {
+    QUnit.test("datebox should be valid if value was changed in the onValueChanged handle(T413553)", function(assert) {
         const date = new Date();
 
         const $dateBox = $("#dateBox").dxDateBox({
@@ -4228,7 +4228,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(!$dateBox.hasClass("dx-invalid"), "datebox should be marked as valid");
     });
 
-    QUnit.test("custom validation should be more important than internal", assert => {
+    QUnit.test("custom validation should be more important than internal", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: new Date(2016, 1, 1)
         }).dxValidator({
@@ -4248,7 +4248,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok($dateBox.hasClass("dx-invalid"), "datebox should be marked as invalid");
     });
 
-    QUnit.test("Internal validation should be valid when null value was set to null", assert => {
+    QUnit.test("Internal validation should be valid when null value was set to null", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             value: new Date(2016, 1, 1)
         });
@@ -4260,7 +4260,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(!$dateBox.hasClass("dx-invalid"), "datebox should not be marked as invalid");
     });
 
-    QUnit.test("Internal validation shouldn't be reset value if localization return null for invalid value", assert => {
+    QUnit.test("Internal validation shouldn't be reset value if localization return null for invalid value", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             pickerType: "calendar",
             value: new Date(2016, 1, 1)
@@ -4278,7 +4278,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.equal(dateBox.option("text"), "abc2/1/2016", "text option shouldn't be reset");
     });
 
-    QUnit.test("Validation should be correct when year of the value less than 100", assert => {
+    QUnit.test("Validation should be correct when year of the value less than 100", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             min: new Date(2015, 6, 10),
             max: new Date(2015, 6, 14),
@@ -4298,7 +4298,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.equal(validationError, "Value is out of range", "validation message is correct");
     });
 
-    QUnit.test("dxDateBox should validate value after change 'max' option", assert => {
+    QUnit.test("dxDateBox should validate value after change 'max' option", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             max: new Date(2015, 6, 14),
             value: new Date(2015, 6, 12),
@@ -4311,7 +4311,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "datebox is valid");
     });
 
-    QUnit.test("dxDateBox should validate value after change 'min' option", assert => {
+    QUnit.test("dxDateBox should validate value after change 'min' option", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             min: new Date(2015, 6, 14),
             value: new Date(2015, 6, 18),
@@ -4324,7 +4324,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "datebox is valid");
     });
 
-    QUnit.test("dxDateBox should become invalid if min/max options changed", (assert) => {
+    QUnit.test("dxDateBox should become invalid if min/max options changed", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             min: new Date(2015, 6, 14),
             value: new Date(2015, 6, 18),
@@ -4345,7 +4345,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "datebox is valid");
     });
 
-    QUnit.test("required validator should not be triggered when another validation rule has been changed", (assert) => {
+    QUnit.test("required validator should not be triggered when another validation rule has been changed", function(assert) {
         const dateBox = $("#dateBox").dxDateBox({
             min: new Date(2015, 6, 14),
             value: null,
@@ -4363,7 +4363,7 @@ QUnit.module("datebox validation", {}, () => {
         assert.ok(dateBox.option("isValid"), "datebox is valid");
     });
 
-    QUnit.testInActiveWindow("DateBox should validate value after remove an invalid characters", assert => {
+    QUnit.testInActiveWindow("DateBox should validate value after remove an invalid characters", function(assert) {
         const $element = $("#dateBox");
         const dateBox = $element.dxDateBox({
             value: new Date(2015, 6, 18),
@@ -4388,14 +4388,14 @@ QUnit.module("datebox validation", {}, () => {
 });
 
 QUnit.module("DateBox number and string value support", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.test("string value should be supported", assert => {
+    QUnit.test("string value should be supported", function(assert) {
         assert.expect(1);
 
         $("#dateBox").dxDateBox({
@@ -4406,7 +4406,7 @@ QUnit.module("DateBox number and string value support", {
         });
     });
 
-    QUnit.test("number value should be supported", assert => {
+    QUnit.test("number value should be supported", function(assert) {
         assert.expect(1);
 
         const date = new Date(2015, 7, 7);
@@ -4418,7 +4418,7 @@ QUnit.module("DateBox number and string value support", {
         });
     });
 
-    QUnit.test("date should be displayed correctly", assert => {
+    QUnit.test("date should be displayed correctly", function(assert) {
         const date = new Date(2015, 7, 14);
         const $dateBox = $("#dateBox").dxDateBox({
             type: "date",
@@ -4436,7 +4436,7 @@ QUnit.module("DateBox number and string value support", {
         assert.equal($input.text(), expectedText, "date is displayed correctly when specified by string");
     });
 
-    QUnit.test("value should save its type after picker was used (type = 'date')", assert => {
+    QUnit.test("value should save its type after picker was used (type = 'date')", function(assert) {
         const date = new Date(2015, 7, 9);
         const dateString = "2015/08/09";
         const newDate = new Date(2015, 7, 21);
@@ -4463,7 +4463,7 @@ QUnit.module("DateBox number and string value support", {
         assert.equal(instance.option("value"), newDate.valueOf(), "value is correct");
     });
 
-    QUnit.test("value should remain correct after picker was used (type = 'datetime')", assert => {
+    QUnit.test("value should remain correct after picker was used (type = 'datetime')", function(assert) {
         const dateString = "2015/08/09 18:33:00";
         const newDate = new Date(2015, 7, 21, 18, 33);
 
@@ -4481,7 +4481,7 @@ QUnit.module("DateBox number and string value support", {
         assert.deepEqual(new Date(instance.option("value")), newDate, "value is correct");
     });
 
-    QUnit.test("value should remain correct after picker was used (type = 'time')", assert => {
+    QUnit.test("value should remain correct after picker was used (type = 'time')", function(assert) {
         const $dateBox = $("#dateBox").dxDateBox({
             pickerType: "calendar",
             applyValueMode: "instantly",
@@ -4499,7 +4499,7 @@ QUnit.module("DateBox number and string value support", {
         assert.equal(time, expectedTime, "value is correct");
     });
 
-    QUnit.test("string value for the 'min' option should be supported", assert => {
+    QUnit.test("string value for the 'min' option should be supported", function(assert) {
         assert.expect(1);
 
         $("#dateBox").dxDateBox({
@@ -4511,7 +4511,7 @@ QUnit.module("DateBox number and string value support", {
         });
     });
 
-    QUnit.test("number value for the 'min' option should be supported", assert => {
+    QUnit.test("number value for the 'min' option should be supported", function(assert) {
         assert.expect(1);
 
         $("#dateBox").dxDateBox({
@@ -4523,7 +4523,7 @@ QUnit.module("DateBox number and string value support", {
         });
     });
 
-    QUnit.test("string value for the 'max' option should be supported", assert => {
+    QUnit.test("string value for the 'max' option should be supported", function(assert) {
         assert.expect(1);
 
         $("#dateBox").dxDateBox({
@@ -4535,7 +4535,7 @@ QUnit.module("DateBox number and string value support", {
         });
     });
 
-    QUnit.test("number value for the 'max' option should be supported", assert => {
+    QUnit.test("number value for the 'max' option should be supported", function(assert) {
         assert.expect(1);
 
         $("#dateBox").dxDateBox({
@@ -4547,7 +4547,7 @@ QUnit.module("DateBox number and string value support", {
         });
     });
 
-    QUnit.test("ISO strings support", assert => {
+    QUnit.test("ISO strings support", function(assert) {
         const defaultForceIsoDateParsing = config().forceIsoDateParsing;
         config().forceIsoDateParsing = true;
 
@@ -4570,7 +4570,7 @@ QUnit.module("DateBox number and string value support", {
         }
     });
 
-    QUnit.test("ISO strings support dateSerializationFormat", assert => {
+    QUnit.test("ISO strings support dateSerializationFormat", function(assert) {
         const defaultForceIsoDateParsing = config().forceIsoDateParsing;
         config().forceIsoDateParsing = true;
 
@@ -4596,7 +4596,7 @@ QUnit.module("DateBox number and string value support", {
     });
 
     // T506146
-    QUnit.test("enter value with big year if dateSerializationFormat is defined", assert => {
+    QUnit.test("enter value with big year if dateSerializationFormat is defined", function(assert) {
         const defaultForceIsoDateParsing = config().forceIsoDateParsing;
         config().forceIsoDateParsing = true;
 
@@ -4616,7 +4616,7 @@ QUnit.module("DateBox number and string value support", {
         }
     });
 
-    QUnit.test("enter value with big year if dateSerializationFormat is defined and forceIsoDateParsing is disabled", assert => {
+    QUnit.test("enter value with big year if dateSerializationFormat is defined and forceIsoDateParsing is disabled", function(assert) {
         const defaultForceIsoDateParsing = config().forceIsoDateParsing;
         config().forceIsoDateParsing = false;
 
@@ -4636,7 +4636,7 @@ QUnit.module("DateBox number and string value support", {
         }
     });
 
-    QUnit.test("onValueChanged should not be fired when on popup opening", assert => {
+    QUnit.test("onValueChanged should not be fired when on popup opening", function(assert) {
         let isValueChangedCalled = false;
 
         const dateBox = $("#dateBox").dxDateBox({
@@ -4654,7 +4654,7 @@ QUnit.module("DateBox number and string value support", {
         assert.ok(!isValueChangedCalled, "onValueChanged is not called");
     });
 
-    QUnit.test("value should be changed on cell click in calendar with defined dateSerializationFormat via defaultOptions", assert => {
+    QUnit.test("value should be changed on cell click in calendar with defined dateSerializationFormat via defaultOptions", function(assert) {
         Calendar.defaultOptions({
             options: { dateSerializationFormat: 'yyyy-MM-dd' }
         });

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
@@ -27,7 +27,7 @@ const DX_STATE_FOCUSED_CLASS = "dx-state-focused";
 const OVERLAY_CONTENT_CLASS = "dx-overlay-content";
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
         this.$element = $("#dropDownBox");
@@ -37,7 +37,7 @@ const moduleConfig = {
             { id: 3, name: "Item 3" }
         ];
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.clock.restore();
     }
@@ -46,7 +46,7 @@ const moduleConfig = {
 const isIE11 = (browser.msie && parseInt(browser.version) === 11);
 
 QUnit.module("common", moduleConfig, () => {
-    QUnit.test("the widget should work without the dataSource", (assert) => {
+    QUnit.test("the widget should work without the dataSource", function(assert) {
         this.$element.dxDropDownBox({ value: 1 });
         const $input = this.$element.find(".dx-texteditor-input");
         const instance = this.$element.dxDropDownBox("instance");
@@ -61,7 +61,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "Test", "input value is correct");
     });
 
-    QUnit.test("the widget should work when dataSource is set to null", (assert) => {
+    QUnit.test("the widget should work when dataSource is set to null", function(assert) {
         this.$element.dxDropDownBox({ value: 1, dataSource: [1, 2, 3] });
 
         const instance = this.$element.dxDropDownBox("instance");
@@ -71,7 +71,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.ok(true, "widget works correctly");
     });
 
-    QUnit.test("array value should be supported", (assert) => {
+    QUnit.test("array value should be supported", function(assert) {
         this.$element.dxDropDownBox({
             items: this.simpleItems,
             valueExpr: "id",
@@ -83,7 +83,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "Item 2", "array value works");
     });
 
-    QUnit.test("it should be possible to restore value after reset", (assert) => {
+    QUnit.test("it should be possible to restore value after reset", function(assert) {
         const instance = new DropDownBox(this.$element, {
             value: 2
         });
@@ -96,7 +96,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "Test", "value has been applied");
     });
 
-    QUnit.test("array value changing", (assert) => {
+    QUnit.test("array value changing", function(assert) {
         const instance = new DropDownBox(this.$element, {
             items: this.simpleItems,
             valueExpr: "id",
@@ -113,7 +113,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "Item 2", "value has been changed correctly from primitive to array");
     });
 
-    QUnit.test("multiple selection should work", (assert) => {
+    QUnit.test("multiple selection should work", function(assert) {
         this.$element.dxDropDownBox({
             items: this.simpleItems,
             valueExpr: "id",
@@ -125,7 +125,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "Item 1, Item 3", "multiple selection works");
     });
 
-    QUnit.test("multiple selection value changing", (assert) => {
+    QUnit.test("multiple selection value changing", function(assert) {
         const instance = new DropDownBox(this.$element, {
             items: this.simpleItems,
             valueExpr: "id",
@@ -139,7 +139,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "Item 1, Item 3", "correct values are selected");
     });
 
-    QUnit.test("value clearing", (assert) => {
+    QUnit.test("value clearing", function(assert) {
         const instance = new DropDownBox(this.$element, {
             items: this.simpleItems,
             valueExpr: "id",
@@ -153,7 +153,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "", "input was cleared");
     });
 
-    QUnit.test("clear button should save valueChangeEvent", (assert) => {
+    QUnit.test("clear button should save valueChangeEvent", function(assert) {
         const valueChangedHandler = sinon.spy();
 
         new DropDownBox(this.$element, {
@@ -172,7 +172,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal(valueChangedHandler.getCall(0).args[0].event.type, "dxclick", "event is correct");
     });
 
-    QUnit.test("content template should work", (assert) => {
+    QUnit.test("content template should work", function(assert) {
         assert.expect(4);
 
         const instance = new DropDownBox(this.$element, {
@@ -193,7 +193,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($(instance.content()).text(), "Test content", "content template has been rendered");
     });
 
-    QUnit.test("anonymous content template should work", assert => {
+    QUnit.test("anonymous content template should work", function(assert) {
         const $inner = $("#dropDownBoxAnonymous #inner");
         const instance = new DropDownBox($("#dropDownBoxAnonymous"), { opened: true });
         const $content = $(instance.content());
@@ -202,7 +202,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($content.find("#inner")[0], $inner[0], "Markup is equal by the link");
     });
 
-    QUnit.test("anonymous template should not be passed to the custom button", assert => {
+    QUnit.test("anonymous template should not be passed to the custom button", function(assert) {
         const instance = new DropDownBox($("#dropDownBoxAnonymous"), {
             buttons: [
                 { name: "test", location: "after", options: { text: "Button text" } }
@@ -216,7 +216,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($("#dropDownBoxAnonymous").find(".dx-button").text(), "Button text", "Button text is correct");
     });
 
-    QUnit.test("popup and editor width should be equal", (assert) => {
+    QUnit.test("popup and editor width should be equal", function(assert) {
         const instance = new DropDownBox(this.$element, {
             items: this.simpleItems,
             opened: true,
@@ -237,7 +237,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($(instance.content()).outerWidth(), 700, "width are equal after option change");
     });
 
-    QUnit.test("popup and editor width should be equal when container resizes after runtime width change", (assert) => {
+    QUnit.test("popup and editor width should be equal when container resizes after runtime width change", function(assert) {
         const instance = new DropDownBox(this.$element, {
             width: "100%",
             opened: true
@@ -252,7 +252,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($(instance.content()).outerWidth(), 810, "width are equal after option change");
     });
 
-    QUnit.test("popup and editor width should be eual when the editor rendered in the hidden content", (assert) => {
+    QUnit.test("popup and editor width should be eual when the editor rendered in the hidden content", function(assert) {
         this.$element.hide();
         const instance = new DropDownBox(this.$element, {
             deferRendering: false,
@@ -266,7 +266,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($(instance.content()).outerWidth(), this.$element.outerWidth(), "width are equal");
     });
 
-    QUnit.test("dropDownBox should work with the slow dataSource", (assert) => {
+    QUnit.test("dropDownBox should work with the slow dataSource", function(assert) {
         const items = [{ key: 1, text: "Item 1" }, { key: 2, text: "Item 2" }];
 
         const instance = new DropDownBox(this.$element, {
@@ -297,7 +297,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal(instance.option("value"), 2, "value was applied");
     });
 
-    QUnit.test("dropDownBox should update display text after dataSource changed", (assert) => {
+    QUnit.test("dropDownBox should update display text after dataSource changed", function(assert) {
         const items = [{ id: 1, name: "item 1" }, { id: 2, name: "item 2" }, { id: 3, name: "item 3" }];
 
         const instance = new DropDownBox(this.$element, {
@@ -314,7 +314,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "item 2, item 3", "input text has been updated");
     });
 
-    QUnit.test("dropDownBox should update display text after displayExpr changed", (assert) => {
+    QUnit.test("dropDownBox should update display text after displayExpr changed", function(assert) {
         const items = [{ id: 1, name: "item 1", text: "text 1" }];
 
         const instance = new DropDownBox(this.$element, {
@@ -330,7 +330,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "text 1", "input text has been updated");
     });
 
-    QUnit.test("dropDownBox should update display text when displayExpr was changed on initialization", (assert) => {
+    QUnit.test("dropDownBox should update display text when displayExpr was changed on initialization", function(assert) {
         this.$element.dxDropDownBox({
             items: [{ id: 1, name: "item 1", text: "text 1" }],
             onInitialized(e) {
@@ -345,14 +345,14 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal($input.val(), "item 1", "input text is correct");
     });
 
-    QUnit.test("text option should follow the displayValue option", (assert) => {
+    QUnit.test("text option should follow the displayValue option", function(assert) {
         const instance = new DropDownBox(this.$element, {});
         instance.option("displayValue", "test");
 
         assert.equal(instance.option("text"), "test", "text option has been changed");
     });
 
-    QUnit.test("displayValue option should be correct after value option changed, acceptCustomValue = true", (assert) => {
+    QUnit.test("displayValue option should be correct after value option changed, acceptCustomValue = true", function(assert) {
         const instance = new DropDownBox(this.$element,
             {
                 acceptCustomValue: true,
@@ -365,7 +365,7 @@ QUnit.module("common", moduleConfig, () => {
         assert.equal(instance.option("displayValue"), "12", "displayValue option has been changed");
     });
 
-    QUnit.test("displayValue option should be correct after value option changed, acceptCustomValue = true, initial value = null", (assert) => {
+    QUnit.test("displayValue option should be correct after value option changed, acceptCustomValue = true, initial value = null", function(assert) {
         const instance = new DropDownBox(this.$element,
             {
                 acceptCustomValue: true,
@@ -380,7 +380,7 @@ QUnit.module("common", moduleConfig, () => {
 });
 
 QUnit.module("popup options", moduleConfig, () => {
-    QUnit.test("customize width and height", (assert) => {
+    QUnit.test("customize width and height", function(assert) {
         const instance = new DropDownBox(this.$element, {
             width: 200,
             dropDownOptions: {
@@ -399,7 +399,7 @@ QUnit.module("popup options", moduleConfig, () => {
         assert.equal($popupContent.outerWidth(), 200, "popup width customization has been cancelled");
     });
 
-    QUnit.test("two way binding should work with dropDownOptions", (assert) => {
+    QUnit.test("two way binding should work with dropDownOptions", function(assert) {
         const instance = new DropDownBox(this.$element, { opened: true });
         const popup = instance._popup;
 
@@ -409,7 +409,7 @@ QUnit.module("popup options", moduleConfig, () => {
         assert.strictEqual(instance.option("dropDownOptions.resizeEnabled"), true, "popup option change leads to dropDownOptions change");
     });
 
-    QUnit.test("popup should not be draggable by default", (assert) => {
+    QUnit.test("popup should not be draggable by default", function(assert) {
         this.$element.dxDropDownBox({
             opened: true
         });
@@ -419,7 +419,7 @@ QUnit.module("popup options", moduleConfig, () => {
         assert.strictEqual(popup.option("dragEnabled"), false, "dragging is disabled");
     });
 
-    QUnit.test("popup should be flipped when container size is smaller than content size", assert => {
+    QUnit.test("popup should be flipped when container size is smaller than content size", function(assert) {
         const $dropDownBox = $("<div>").appendTo("body");
         try {
             $dropDownBox.css({ position: "fixed", bottom: 0 });
@@ -438,7 +438,7 @@ QUnit.module("popup options", moduleConfig, () => {
         }
     });
 
-    QUnit.test("maxHeight should be 90% of maximum of top or bottom offsets including page scroll", (assert) => {
+    QUnit.test("maxHeight should be 90% of maximum of top or bottom offsets including page scroll", function(assert) {
         this.$element.dxDropDownBox({
             items: [1, 2, 3],
             value: 2
@@ -463,7 +463,7 @@ QUnit.module("popup options", moduleConfig, () => {
         }
     });
 
-    QUnit.test("Dropdownbox popup should change height according to the content", assert => {
+    QUnit.test("Dropdownbox popup should change height according to the content", function(assert) {
         if(isIE11) {
             assert.expect(0);
             return;
@@ -485,7 +485,7 @@ QUnit.module("popup options", moduleConfig, () => {
 });
 
 QUnit.module("keyboard navigation", moduleConfig, () => {
-    QUnit.testInActiveWindow("first focusable element inside of content should get focused after tab pressing", (assert) => {
+    QUnit.testInActiveWindow("first focusable element inside of content should get focused after tab pressing", function(assert) {
         const $input1 = $("<input>", { id: "input1", type: "text" });
         const $input2 = $("<input>", { id: "input2", type: "text" });
 
@@ -507,7 +507,7 @@ QUnit.module("keyboard navigation", moduleConfig, () => {
         assert.ok($input1.is(":focus"), "first focusable content element got focused");
     });
 
-    QUnit.testInActiveWindow("last focusable element inside of content should get focused after shift+tab pressing", (assert) => {
+    QUnit.testInActiveWindow("last focusable element inside of content should get focused after shift+tab pressing", function(assert) {
         const $input1 = $("<input>", { id: "input1", type: "text" });
         const $input2 = $("<input>", { id: "input2", type: "text" });
 
@@ -528,7 +528,7 @@ QUnit.module("keyboard navigation", moduleConfig, () => {
         assert.ok($input2.is(":focus"), "first focusable content element got focused");
     });
 
-    QUnit.testInActiveWindow("widget should be closed after tab pressing on the last content element", (assert) => {
+    QUnit.testInActiveWindow("widget should be closed after tab pressing on the last content element", function(assert) {
         const $input1 = $("<input>", { id: "input1", type: "text" });
         const $input2 = $("<input>", { id: "input2", type: "text" });
 
@@ -548,7 +548,7 @@ QUnit.module("keyboard navigation", moduleConfig, () => {
         assert.notOk(instance.option("opened"), "popup was closed");
     });
 
-    QUnit.testInActiveWindow("input should get focused when shift+tab pressed on first content element", (assert) => {
+    QUnit.testInActiveWindow("input should get focused when shift+tab pressed on first content element", function(assert) {
         const $input1 = $("<input>", { id: "input1", type: "text" });
         const $input2 = $("<input>", { id: "input2", type: "text" });
 
@@ -569,7 +569,7 @@ QUnit.module("keyboard navigation", moduleConfig, () => {
         assert.ok(event.isDefaultPrevented(), "prevent default for focusing it's own input but not an input of the previous editor on the page");
     });
 
-    QUnit.testInActiveWindow("inner input should be focused after popup opening", (assert) => {
+    QUnit.testInActiveWindow("inner input should be focused after popup opening", function(assert) {
         const inputFocusedHandler = sinon.stub();
         const $input = $("<input>", { id: "input1", type: "text" }).on("focusin", inputFocusedHandler);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.markup.tests.js
@@ -23,44 +23,44 @@ const DROP_DOWN_EDITOR_FIELD_TEMPLATE_WRAPPER = "dx-dropdowneditor-field-templat
 const TEXTEDITOR_INPUT_CLASS = "dx-texteditor-input";
 
 module("DropDownEditor markup", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.rootElement = $("<div id='dropDownEditor'></div>");
         this.rootElement.appendTo($("#qunit-fixture"));
         this.$dropDownEditor = $("#dropDownEditor").dxDropDownEditor();
         this.dropDownEditor = this.$dropDownEditor.dxDropDownEditor("instance");
     },
-    afterEach: () => {
+    afterEach: function() {
         this.rootElement.remove();
         this.dropDownEditor = null;
     }
 }, () => {
-    test("root element must be decorated with DROP_DOWN_EDITOR_CLASS", (assert) => {
+    test("root element must be decorated with DROP_DOWN_EDITOR_CLASS", function(assert) {
         assert.ok(this.rootElement.hasClass(DROP_DOWN_EDITOR_CLASS));
     });
 
-    test("dxDropDownEditor must have a button which must be decorated with DROP_DOWN_EDITOR_BUTTON_CLASS", (assert) => {
+    test("dxDropDownEditor must have a button which must be decorated with DROP_DOWN_EDITOR_BUTTON_CLASS", function(assert) {
         const $dropDownButton = this.rootElement.find(`.${DROP_DOWN_EDITOR_BUTTON_CLASS}`);
         assert.strictEqual($dropDownButton.length, 1);
         assert.ok($dropDownButton.hasClass(DROP_DOWN_EDITOR_BUTTON_CLASS));
     });
 
-    test("dxDropDownEditor button should have correct aria-label attribute", (assert) => {
+    test("dxDropDownEditor button should have correct aria-label attribute", function(assert) {
         const $dropDownButton = this.rootElement.find(`.${DROP_DOWN_EDITOR_BUTTON_CLASS}`);
         assert.strictEqual($dropDownButton.attr("aria-label"), "Select", "'aria-label' is correct");
     });
 
-    test("input wrapper must be upper than button", (assert) => {
+    test("input wrapper must be upper than button", function(assert) {
         const $inputWrapper = this.rootElement.children();
 
         assert.strictEqual(this.rootElement.find(`.${DROP_DOWN_EDITOR_INPUT_WRAPPER}`)[0], $inputWrapper[0]);
         assert.strictEqual(this.rootElement.find(`.${DROP_DOWN_EDITOR_BUTTON_CLASS}`)[0], $inputWrapper.find(`.${DROP_DOWN_EDITOR_BUTTON_CLASS}`)[0]);
     });
 
-    test("input must be wrapped for proper event handling", (assert) => {
+    test("input must be wrapped for proper event handling", function(assert) {
         assert.ok(this.dropDownEditor._input().parents().find(`.${DROP_DOWN_EDITOR_INPUT_WRAPPER}`).hasClass(DROP_DOWN_EDITOR_INPUT_WRAPPER));
     });
 
-    test("DROP_DOWN_EDITOR_BUTTON_VISIBLE class should depend on drop down button visibility", (assert) => {
+    test("DROP_DOWN_EDITOR_BUTTON_VISIBLE class should depend on drop down button visibility", function(assert) {
         assert.ok(this.rootElement.hasClass(DROP_DOWN_EDITOR_BUTTON_VISIBLE), "class present by default");
 
         this.dropDownEditor.option("showDropDownButton", false);
@@ -70,7 +70,7 @@ module("DropDownEditor markup", {
         assert.ok(this.rootElement.hasClass(DROP_DOWN_EDITOR_BUTTON_VISIBLE), "class appears when the button shows");
     });
 
-    test("correct buttons order after rendering", (assert) => {
+    test("correct buttons order after rendering", function(assert) {
         const $dropDownEditor = this.rootElement.dxDropDownEditor({
                 showClearButton: true
             }),
@@ -82,7 +82,7 @@ module("DropDownEditor markup", {
         assert.ok($buttons.eq(1).hasClass(DROP_DOWN_EDITOR_BUTTON_CLASS), "drop button is the second one");
     });
 
-    test("fieldTemplate as render", (assert) => {
+    test("fieldTemplate as render", function(assert) {
         const $dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor({
             fieldTemplate: function(value) {
                 const $textBox = $("<div>").dxTextBox();
@@ -95,7 +95,7 @@ module("DropDownEditor markup", {
         assert.equal($.trim($dropDownEditor.text()), "testtest", "field rendered");
     });
 
-    test("field should be rendered after input value rendering", (assert) => {
+    test("field should be rendered after input value rendering", function(assert) {
         const dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor({
             value: "test"
         }).dxDropDownEditor("instance");
@@ -113,7 +113,7 @@ module("DropDownEditor markup", {
 
 
 module("aria accessibility", () => {
-    test("aria role", (assert) => {
+    test("aria role", function(assert) {
         const $dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor(),
             $input = $dropDownEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
@@ -121,7 +121,7 @@ module("aria accessibility", () => {
         assert.strictEqual($dropDownEditor.attr("role"), undefined, "aria role on element is not exist");
     });
 
-    test("aria-autocomplete property on input", (assert) => {
+    test("aria-autocomplete property on input", function(assert) {
         const $input = $("#dropDownEditorLazy").dxDropDownEditor().find(`.${TEXTEDITOR_INPUT_CLASS}`);
         assert.equal($input.attr("aria-autocomplete"), "list", "haspopup attribute exists");
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -927,7 +927,7 @@ QUnit.test("popup is rendered only when open editor when deferRendering is true"
 
 QUnit.module("Templates");
 
-QUnit.test("should not render placeholder if the fieldTemplate is used", (assert) => {
+QUnit.test("should not render placeholder if the fieldTemplate is used", function(assert) {
     const $dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor({
         items: [0, 1, 2, 3, 4, 5],
         placeholder: "placeholder",
@@ -1036,7 +1036,7 @@ QUnit.test("events should be rendered for input after value is changed when fiel
     });
 });
 
-QUnit.test("should have no errors after value change if text editor buttons were directly removed (T743479)", (assert) => {
+QUnit.test("should have no errors after value change if text editor buttons were directly removed (T743479)", function(assert) {
     const $dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor({
         items: [0, 1, 2, 3, 4, 5],
         value: 1,
@@ -1057,7 +1057,7 @@ QUnit.test("should have no errors after value change if text editor buttons were
     }
 });
 
-QUnit.testInActiveWindow("widget should detach focus events before fieldTemplate rerender", (assert) => {
+QUnit.testInActiveWindow("widget should detach focus events before fieldTemplate rerender", function(assert) {
     const focusOutSpy = sinon.stub();
     const $dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor({
         dataSource: [1, 2],
@@ -1083,7 +1083,7 @@ QUnit.testInActiveWindow("widget should detach focus events before fieldTemplate
     assert.strictEqual(focusOutSpy.callCount, 0, "there's no focus outs from deleted field container");
 });
 
-QUnit.test("fieldTemplate item element should have 100% width (T826516)", (assert) => {
+QUnit.test("fieldTemplate item element should have 100% width (T826516)", function(assert) {
     const $dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor({
         dataSource: [1, 2],
         width: 500,
@@ -1099,7 +1099,7 @@ QUnit.test("fieldTemplate item element should have 100% width (T826516)", (asser
     assert.roughEqual($fieldTemplateWrapper.outerWidth(), $input.outerWidth(), 1);
 });
 
-QUnit.test("fieldTemplate item element should have 100% width with field template wrapper (T826516)", (assert) => {
+QUnit.test("fieldTemplate item element should have 100% width with field template wrapper (T826516)", function(assert) {
     const $dropDownEditor = $("#dropDownEditorLazy").dxDropDownEditor({
         dataSource: [1, 2],
         width: 500,

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -32,18 +32,18 @@ const POPUP_CONTENT_CLASS = "dx-popup-content";
 const LIST_CLASS = "dx-list";
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         fx.off = false;
     }
 };
 
 QUnit.module("focus policy", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
 
@@ -55,12 +55,12 @@ QUnit.module("focus policy", {
         this.$input = this.$element.find("." + TEXTEDITOR_INPUT_CLASS);
         this.keyboard = keyboardMock(this.$input);
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("focus removed from list on type some text", (assert) => {
+    QUnit.test("focus removed from list on type some text", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -77,7 +77,7 @@ QUnit.module("focus policy", {
         assert.ok(!$firstItem.hasClass(STATE_FOCUSED_CLASS), "first list element is not focused");
     });
 
-    QUnit.testInActiveWindow("popup should not focus when we selecting an item", (assert) => {
+    QUnit.testInActiveWindow("popup should not focus when we selecting an item", function(assert) {
         this.instance.option("opened", true);
 
         const mouseDownStub = sinon.stub();
@@ -95,7 +95,7 @@ QUnit.module("focus policy", {
         }
     });
 
-    QUnit.test("hover and focus states for list should be initially disabled on mobile devices only", (assert) => {
+    QUnit.test("hover and focus states for list should be initially disabled on mobile devices only", function(assert) {
         this.instance.option("opened", true);
 
         const list = $(`.${LIST_CLASS}`).dxList("instance");
@@ -109,7 +109,7 @@ QUnit.module("focus policy", {
         }
     });
 
-    QUnit.test("changing hover and focus states for list should be enabled on desktop only", (assert) => {
+    QUnit.test("changing hover and focus states for list should be enabled on desktop only", function(assert) {
         this.instance.option("opened", true);
 
         const list = $(`.${LIST_CLASS}`).dxList("instance");
@@ -127,7 +127,7 @@ QUnit.module("focus policy", {
         }
     });
 
-    QUnit.test("setFocusPolicy should correctly renew subscription", (assert) => {
+    QUnit.test("setFocusPolicy should correctly renew subscription", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -144,7 +144,7 @@ QUnit.module("focus policy", {
 });
 
 QUnit.module("keyboard navigation", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.$element = $("#dropDownList").dxDropDownList({
@@ -159,12 +159,12 @@ QUnit.module("keyboard navigation", {
         this.$list = this.instance._$list;
         this.keyboard = keyboardMock(this.$input);
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("focusout should not be fired on input element", (assert) => {
+    QUnit.test("focusout should not be fired on input element", function(assert) {
         const onFocusOutStub = sinon.stub();
         this.instance.option("onFocusOut", onFocusOutStub);
 
@@ -174,7 +174,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(onFocusOutStub.callCount, 0, "onFocusOut wasn't fired");
     });
 
-    QUnit.test("focusout should be prevented when list clicked", (assert) => {
+    QUnit.test("focusout should be prevented when list clicked", function(assert) {
         assert.expect(1);
 
         this.instance.open();
@@ -190,7 +190,7 @@ QUnit.module("keyboard navigation", {
         $list.trigger("mousedown");
     });
 
-    QUnit.test("list should not have tab index to prevent its focusing when scrollbar clicked", (assert) => {
+    QUnit.test("list should not have tab index to prevent its focusing when scrollbar clicked", function(assert) {
         this.instance.option({
             items: [1, 2, 3, 4, 5, 6],
             opened: true,
@@ -203,7 +203,7 @@ QUnit.module("keyboard navigation", {
         assert.notOk($list.attr("tabIndex"), "list have no tabindex");
     });
 
-    QUnit.testInActiveWindow("popup hides on tab", (assert) => {
+    QUnit.testInActiveWindow("popup hides on tab", function(assert) {
         this.instance.focus();
         assert.ok(this.$element.hasClass(STATE_FOCUSED_CLASS), "element is focused");
 
@@ -212,7 +212,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(this.instance.option("opened"), false, "popup is hidden");
     });
 
-    QUnit.test("event should be a parameter for onValueChanged function after select an item via tab", (assert) => {
+    QUnit.test("event should be a parameter for onValueChanged function after select an item via tab", function(assert) {
         const valueChangedHandler = sinon.spy();
 
         this.instance.option({
@@ -230,7 +230,7 @@ QUnit.module("keyboard navigation", {
         assert.ok(valueChangedHandler.getCall(0).args[0].event, "event is defined");
     });
 
-    QUnit.test("No item should be chosen after pressing tab", (assert) => {
+    QUnit.test("No item should be chosen after pressing tab", function(assert) {
         this.instance.option("opened", true);
 
         this.$input.focusin();
@@ -239,7 +239,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(this.instance.option("value"), null, "value was set correctly");
     });
 
-    QUnit.test("DropDownList does not crushed after pressing pageup, pagedown keys when list doesn't have focused item", (assert) => {
+    QUnit.test("DropDownList does not crushed after pressing pageup, pagedown keys when list doesn't have focused item", function(assert) {
         assert.expect(0);
 
         this.instance.option("opened", true);
@@ -255,7 +255,7 @@ QUnit.module("keyboard navigation", {
 });
 
 QUnit.module("displayExpr", moduleConfig, () => {
-    QUnit.test("displayExpr has item in argument", (assert) => {
+    QUnit.test("displayExpr has item in argument", function(assert) {
         const args = [];
 
         const dataSource = [1, 2, 3];
@@ -274,7 +274,7 @@ QUnit.module("displayExpr", moduleConfig, () => {
         assert.deepEqual(args, [2].concat(dataSource), "displayExpr args is correct");
     });
 
-    QUnit.test("submit value should be equal to the displayExpr in case value is object and valueExpr isn't an object field", assert => {
+    QUnit.test("submit value should be equal to the displayExpr in case value is object and valueExpr isn't an object field", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [{ text: "test" }],
             deferRendering: false,
@@ -287,7 +287,7 @@ QUnit.module("displayExpr", moduleConfig, () => {
         assert.equal($submitInput.val(), "test", "the submit value is correct");
     });
 
-    QUnit.test("submit value should be equal to the primitive value type", assert => {
+    QUnit.test("submit value should be equal to the primitive value type", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: ["test"],
             deferRendering: false,
@@ -306,14 +306,14 @@ QUnit.module("displayExpr", moduleConfig, () => {
 });
 
 QUnit.module("items & dataSource", moduleConfig, () => {
-    QUnit.test("default value is null", assert => {
+    QUnit.test("default value is null", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList();
         const instance = $dropDownList.dxDropDownList("instance");
 
         assert.strictEqual(instance.option("value"), null, "value is null on default");
     });
 
-    QUnit.test("wrapItemText option", (assert) => {
+    QUnit.test("wrapItemText option", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             items: [1],
             deferRendering: false,
@@ -328,7 +328,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.notOk($itemContainer.hasClass("dx-wrap-item-text"), "class was removed");
     });
 
-    QUnit.test("widget should render with empty items", assert => {
+    QUnit.test("widget should render with empty items", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             items: null,
             opened: true
@@ -339,7 +339,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.ok(instance, "widget was rendered");
     });
 
-    QUnit.test("items option contains items from dataSource after load", (assert) => {
+    QUnit.test("items option contains items from dataSource after load", function(assert) {
         const dataSource = [1, 2, 3];
 
         const $dropDownList = $("#dropDownList").dxDropDownList({
@@ -351,7 +351,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.deepEqual($dropDownList.dxDropDownList("option", "items"), dataSource, "displayExpr args is correct");
     });
 
-    QUnit.test("all items", (assert) => {
+    QUnit.test("all items", function(assert) {
         const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21];
         const $dropDownList = $("#dropDownList").dxDropDownList({
             items,
@@ -362,7 +362,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.deepEqual($dropDownList.dxDropDownList("option", "items"), items, "rendered all items");
     });
 
-    QUnit.test("calcNextItem private method should work", assert => {
+    QUnit.test("calcNextItem private method should work", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [1, 2, 3, 4],
             opened: true,
@@ -375,7 +375,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.strictEqual(dropDownList._calcNextItem(-1), 1, "step backward");
     });
 
-    QUnit.test("items private method should work", assert => {
+    QUnit.test("items private method should work", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [1, 2, 3, 4],
             opened: true,
@@ -387,7 +387,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.deepEqual(dropDownList._items(), [1, 2, 3, 4], "items are correct");
     });
 
-    QUnit.test("fitIntoRange private method should work", assert => {
+    QUnit.test("fitIntoRange private method should work", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [1, 2, 3, 4],
             opened: true,
@@ -401,7 +401,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.deepEqual(dropDownList._fitIntoRange(5, 2, 4), 2, "larger than max");
     });
 
-    QUnit.test("getSelectedIndex private method should work", assert => {
+    QUnit.test("getSelectedIndex private method should work", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [{ id: 1 }, { id: 2 }],
             opened: true,
@@ -414,7 +414,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.deepEqual(dropDownList._getSelectedIndex(), 1, "index is correct");
     });
 
-    QUnit.test("widget should be openable if dataSource is null", assert => {
+    QUnit.test("widget should be openable if dataSource is null", function(assert) {
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [1]
         }).dxDropDownList("instance");
@@ -424,7 +424,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.ok(true, "Widget works correctly");
     });
 
-    QUnit.test("itemTemplate accepts template", (assert) => {
+    QUnit.test("itemTemplate accepts template", function(assert) {
         const $template = $("<div>").text("test");
         $("#dropDownList").dxDropDownList({
             items: [1],
@@ -438,7 +438,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal($.trim($(".dx-list-item").text()), "test", "template rendered");
     });
 
-    QUnit.test("contentReady action fires when dataSource loaded", (assert) => {
+    QUnit.test("contentReady action fires when dataSource loaded", function(assert) {
         let contentReadyFired = 0;
 
         const $dropDownList = $("#dropDownList").dxDropDownList({
@@ -461,7 +461,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal(contentReadyFired, 1, "content ready not fired when reopen dropdown");
     });
 
-    QUnit.test("contentReady action fires when readOnly=true", assert => {
+    QUnit.test("contentReady action fires when readOnly=true", function(assert) {
         const contentReadyActionStub = sinon.stub();
 
         const $dropDownList = $("#dropDownList").dxDropDownList({
@@ -476,7 +476,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.ok(contentReadyActionStub.called, "content ready fired when content is rendered");
     });
 
-    QUnit.test("contentReady action fires when disabled=true", assert => {
+    QUnit.test("contentReady action fires when disabled=true", function(assert) {
         const contentReadyActionStub = sinon.stub();
 
         const $dropDownList = $("#dropDownList").dxDropDownList({
@@ -491,7 +491,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.ok(contentReadyActionStub.called, "content ready fired when content is rendered");
     });
 
-    QUnit.test("dataSource with Guid key", assert => {
+    QUnit.test("dataSource with Guid key", function(assert) {
         const guidKey1 = "bd330029-8106-6d2d-5371-f27325155e99";
         const dataSource = new DataSource({
             load() {
@@ -515,7 +515,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal($dropDownList.dxDropDownList("option", "text"), "one", "value displayed");
     });
 
-    QUnit.test("set item when key is 0", (assert) => {
+    QUnit.test("set item when key is 0", function(assert) {
         const data = [{ key: 0, value: "one" }];
         const store = new CustomStore({
             load() {
@@ -543,7 +543,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal($input.val(), "one", "item displayed");
     });
 
-    QUnit.test("composite keys should be supported (T431267)", assert => {
+    QUnit.test("composite keys should be supported (T431267)", function(assert) {
         const data = [
             { a: 1, b: 1, value: "one" },
             { a: 1, b: 2, value: "two" }
@@ -569,7 +569,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.deepEqual(dropDownList.option("selectedItem"), data[1], "the selected item is set correctly");
     });
 
-    QUnit.test("T321572: dxSelectBox - Use clear button with custom store leads to duplicate items", assert => {
+    QUnit.test("T321572: dxSelectBox - Use clear button with custom store leads to duplicate items", function(assert) {
         const productSample = [{
             "ID": 1,
             "Name": "HD Video Player"
@@ -632,7 +632,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.ok(dataSource.isLastPage(), "last page is not changed");
     });
 
-    QUnit.test("items value should be escaped", assert => {
+    QUnit.test("items value should be escaped", function(assert) {
         const $element = $("#dropDownList").dxDropDownList({
             dataSource: [{
                 "CustId": -1,
@@ -648,7 +648,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal($.trim($(".dx-list-item").text()), "<None>", "template rendered");
     });
 
-    QUnit.test("searchTimeout should be refreshed after next symbol entered", (assert) => {
+    QUnit.test("searchTimeout should be refreshed after next symbol entered", function(assert) {
         const loadHandler = sinon.spy();
 
         const $element = $("#dropDownList").dxDropDownList({
@@ -677,7 +677,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal(loadHandler.callCount, 2, "dataSource loaded when full time is over after last input character");
     });
 
-    QUnit.test("dropDownList should search for a pasted value", (assert) => {
+    QUnit.test("dropDownList should search for a pasted value", function(assert) {
         const $element = $("#dropDownList").dxDropDownList({
             searchEnabled: true,
             dataSource: ["1", "2", "3"]
@@ -694,7 +694,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal(searchSpy.callCount, 1, "widget searched for a suitable values");
     });
 
-    QUnit.test("dropDownList should search in grouped DataSource", (assert) => {
+    QUnit.test("dropDownList should search in grouped DataSource", function(assert) {
         const $element = $("#dropDownList").dxDropDownList({
             grouped: true,
             searchEnabled: true,
@@ -715,7 +715,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.deepEqual(instance.option("items")[0], expectedValue, "widget searched for a suitable values");
     });
 
-    QUnit.test("valueExpr should not be passed to the list if it is 'this'", assert => {
+    QUnit.test("valueExpr should not be passed to the list if it is 'this'", function(assert) {
         // note: selection can not work with this and function as keyExpr.
         // Allowing of this breaks the case when store key is specified and deferred datasource is used
         $("#dropDownList").dxDropDownList({
@@ -730,7 +730,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal(list.option("keyExpr"), null, "keyExpr is correct");
     });
 
-    QUnit.test("valueExpr should be passed to the list's keyExpr option", assert => {
+    QUnit.test("valueExpr should be passed to the list's keyExpr option", function(assert) {
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [{ id: 1, text: "Item 1" }],
             displayExpr: 'text',
@@ -749,7 +749,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal(list.option("keyExpr"), "text", "keyExpr should be passed on optionChanged");
     });
 
-    QUnit.test("value option should be case-sensitive", assert => {
+    QUnit.test("value option should be case-sensitive", function(assert) {
         const $element = $("#dropDownList").dxDropDownList({
             dataSource: [{ text: "first" }, { text: "First" }],
             displayExpr: "text",
@@ -765,7 +765,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
         assert.equal($input.val(), "First");
     });
 
-    QUnit.test("set items on init when items of a data source are loaded", assert => {
+    QUnit.test("set items on init when items of a data source are loaded", function(assert) {
         const arrayStore = new ArrayStore({
             data: [{ id: 1, text: "first" }, { id: 2, text: "second" }],
             key: "id"
@@ -813,7 +813,7 @@ QUnit.module("items & dataSource", moduleConfig, () => {
 });
 
 QUnit.module("selectedItem", moduleConfig, () => {
-    QUnit.test("selectedItem", (assert) => {
+    QUnit.test("selectedItem", function(assert) {
         const items = [
             { key: 1, value: "one" },
             { key: 2, value: "two" }
@@ -831,7 +831,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
         assert.deepEqual(dropDownList.option("selectedItem"), items[0], "selected item");
     });
 
-    QUnit.test("selectedItem and value should be reset on loading new items", (assert) => {
+    QUnit.test("selectedItem and value should be reset on loading new items", function(assert) {
         const dropDownList = $("#dropDownList").dxDropDownList({
             items: [1, 2, 3, 4],
             value: 1,
@@ -847,7 +847,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
         assert.strictEqual(dropDownList.option("selectedItem"), null, "selected item was reset");
     });
 
-    QUnit.test("selectedItem and value should be reset on loading new dataSource", (assert) => {
+    QUnit.test("selectedItem and value should be reset on loading new dataSource", function(assert) {
 
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: ["1", "2", "3", "4"],
@@ -864,7 +864,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
         assert.strictEqual(dropDownList.option("selectedItem"), null, "selected item was reset");
     });
 
-    QUnit.test("selectedItem and value should not be reset on loading new dataSource, if the same element is contained in new dataSource", (assert) => {
+    QUnit.test("selectedItem and value should not be reset on loading new dataSource, if the same element is contained in new dataSource", function(assert) {
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [],
             value: 2,
@@ -880,7 +880,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
         assert.strictEqual(dropDownList.option("selectedItem"), 2, "selected item was not reset");
     });
 
-    QUnit.test("'null' value processed correctly", assert => {
+    QUnit.test("'null' value processed correctly", function(assert) {
         const store = new ArrayStore({
             key: "k",
             data: [
@@ -906,7 +906,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
 
     });
 
-    QUnit.test("onSelectionChanged args should provide selectedItem (T193115)", (assert) => {
+    QUnit.test("onSelectionChanged args should provide selectedItem (T193115)", function(assert) {
         assert.expect(2);
 
         const $dropDownList = $("#dropDownList").dxDropDownList({
@@ -941,7 +941,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
         this.clock.tick();
     });
 
-    QUnit.test("selectedItem should be chosen synchronously if item is already loaded", (assert) => {
+    QUnit.test("selectedItem should be chosen synchronously if item is already loaded", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: {
                 store: new CustomStore({
@@ -973,7 +973,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
         assert.equal($dropDownList.dxDropDownList("option", "selectedItem"), 0, "selectedItem is fetched");
     });
 
-    QUnit.test("selectedItem should be chosen correctly if deferRendering = false and dataSource is async", (assert) => {
+    QUnit.test("selectedItem should be chosen correctly if deferRendering = false and dataSource is async", function(assert) {
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: {
                 store: new CustomStore({
@@ -1004,7 +1004,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
         assert.equal(dropDownList._list.option("selectedItem"), 1, "selectedItem is correct");
     });
 
-    QUnit.test("reset()", assert => {
+    QUnit.test("reset()", function(assert) {
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [1, 2, 3, 4],
             value: 2,
@@ -1018,7 +1018,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
         assert.strictEqual(dropDownList.option("selectedItem"), null, "Value should be reset");
     });
 
-    QUnit.test("onSelectionChanged action should not be fired when selectedItem was not changed", assert => {
+    QUnit.test("onSelectionChanged action should not be fired when selectedItem was not changed", function(assert) {
         const selectionChangedHandler = sinon.spy();
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [],
@@ -1036,7 +1036,7 @@ QUnit.module("selectedItem", moduleConfig, () => {
 });
 
 QUnit.module("popup", moduleConfig, () => {
-    QUnit.test("popup max height should fit in the window", assert => {
+    QUnit.test("popup max height should fit in the window", function(assert) {
         const items = ["item 1", "item 2", "item 3", "item 1", "item 2", "item 3", "item 1", "item 2", "item 3",
             "item 1", "item 2", "item 3", "item 1", "item 2", "item 3", "item 1", "item 2", "item 3", "item 1", "item 2", "item 3",
             "item 1", "item 2", "item 3", "item 1", "item 2", "item 3", "item 1", "item 2", "item 3",
@@ -1050,7 +1050,7 @@ QUnit.module("popup", moduleConfig, () => {
         assert.ok($('.dx-overlay-content').height() <= Math.ceil($(window).height() * 0.5));
     });
 
-    QUnit.test("popup max height are limited by container bounds", assert => {
+    QUnit.test("popup max height are limited by container bounds", function(assert) {
         const items = ["item 1", "item 2", "item 3", "item 1", "item 2", "item 3", "item 1", "item 2", "item 3"];
         const parentContainer = $("<div>").attr("id", "specific-container").height(80).appendTo("#qunit-fixture");
         const childContainer = $("<div>").attr("id", "child-container").height(60).appendTo(parentContainer);
@@ -1077,7 +1077,7 @@ QUnit.module("popup", moduleConfig, () => {
         parentContainer.remove();
     });
 
-    QUnit.test("skip gesture event class attach only when popup is opened", assert => {
+    QUnit.test("skip gesture event class attach only when popup is opened", function(assert) {
         const SKIP_GESTURE_EVENT_CLASS = "dx-skip-gesture-event";
         const $dropDownList = $("#dropDownList").dxDropDownList({
             items: [1, 2, 3]
@@ -1092,7 +1092,7 @@ QUnit.module("popup", moduleConfig, () => {
         assert.equal($dropDownList.hasClass(SKIP_GESTURE_EVENT_CLASS), false, "skip gesture event class was removed after popup was closed");
     });
 
-    QUnit.test("After load new page scrollTop should not be changed", (assert) => {
+    QUnit.test("After load new page scrollTop should not be changed", function(assert) {
         this.clock.restore();
 
         const data = [];
@@ -1133,7 +1133,7 @@ QUnit.module("popup", moduleConfig, () => {
         });
     });
 
-    QUnit.testInActiveWindow("After search and load new page scrollTop should not be changed", (assert) => {
+    QUnit.testInActiveWindow("After search and load new page scrollTop should not be changed", function(assert) {
         if(browser.msie) {
             assert.ok(true, "test does not actual for IE");
             return;
@@ -1186,7 +1186,7 @@ QUnit.module("popup", moduleConfig, () => {
         });
     });
 
-    QUnit.test("popup should be configured with templatesRenderAsynchronously=false (T470619)", assert => {
+    QUnit.test("popup should be configured with templatesRenderAsynchronously=false (T470619)", function(assert) {
         const data = ["item-1", "item-2", "item-3"];
 
         $("#dropDownList").dxDropDownList({
@@ -1200,7 +1200,7 @@ QUnit.module("popup", moduleConfig, () => {
         assert.strictEqual(popup.option("templatesRenderAsynchronously"), false, "templatesRenderAsynchronously should have false value");
     });
 
-    QUnit.test("popup should be configured with autoResizeEnabled=false (to prevent issues with pushBackValue and scrolling in IOS)", (assert) => {
+    QUnit.test("popup should be configured with autoResizeEnabled=false (to prevent issues with pushBackValue and scrolling in IOS)", function(assert) {
         const data = ["item-1"];
 
         $("#dropDownList").dxDropDownList({
@@ -1214,7 +1214,7 @@ QUnit.module("popup", moduleConfig, () => {
         assert.strictEqual(popup.option("autoResizeEnabled"), false, "autoResizeEnabled should have false value");
     });
 
-    QUnit.test("no exception when 'container' is empty jQuery set (T831152)", assert => {
+    QUnit.test("no exception when 'container' is empty jQuery set (T831152)", function(assert) {
         let exception = null;
 
         try {
@@ -1236,7 +1236,7 @@ QUnit.module("popup", moduleConfig, () => {
 });
 
 QUnit.module("dataSource integration", moduleConfig, () => {
-    QUnit.test("guid integration", (assert) => {
+    QUnit.test("guid integration", function(assert) {
         const value = "6fd3d2c5-904d-4e6f-a302-3e277ef36630";
         const data = [new Guid(value)];
         const dataSource = new DataSource(data);
@@ -1252,7 +1252,7 @@ QUnit.module("dataSource integration", moduleConfig, () => {
 });
 
 QUnit.module("action options", moduleConfig, () => {
-    QUnit.test("onItemClick action", (assert) => {
+    QUnit.test("onItemClick action", function(assert) {
         assert.expect(3);
 
         const items = ["item 1", "item 2", "item 3"];
@@ -1279,7 +1279,7 @@ QUnit.module("action options", moduleConfig, () => {
 });
 
 QUnit.module("render input addons", moduleConfig, () => {
-    QUnit.test("dropDownButton rendered correctly when dataSource is async", (assert) => {
+    QUnit.test("dropDownButton rendered correctly when dataSource is async", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: {
                 load() {
@@ -1309,7 +1309,7 @@ QUnit.module("render input addons", moduleConfig, () => {
 });
 
 QUnit.module("aria accessibility", moduleConfig, () => {
-    QUnit.test("aria-owns should point to list", assert => {
+    QUnit.test("aria-owns should point to list", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({ opened: true });
         const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
 
@@ -1331,7 +1331,7 @@ QUnit.module("aria accessibility", moduleConfig, () => {
         assert.strictEqual($input.attr("aria-controls"), undefined, "controls does not exist");
     });
 
-    QUnit.test("input's aria-activedescendant attribute should point to the focused item", assert => {
+    QUnit.test("input's aria-activedescendant attribute should point to the focused item", function(assert) {
         const $dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: [1, 2, 3],
             opened: true,
@@ -1349,7 +1349,7 @@ QUnit.module("aria accessibility", moduleConfig, () => {
         assert.equal($input.attr("aria-activedescendant"), $item.attr("id"), "aria-activedescendant and id of the focused item are equals");
     });
 
-    QUnit.test("list's aria-target should point to the widget's input (T247414)", assert => {
+    QUnit.test("list's aria-target should point to the widget's input (T247414)", function(assert) {
         assert.expect(2);
 
         const dropDownList = $("#dropDownList").dxDropDownList({ opened: true }).dxDropDownList("instance");
@@ -1362,7 +1362,7 @@ QUnit.module("aria accessibility", moduleConfig, () => {
 });
 
 QUnit.module("dropdownlist with groups", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.dataSource = new DataSource({
             store: [{ id: 1, group: "first" }, { id: 2, group: "second" }],
             key: "id",
@@ -1370,7 +1370,7 @@ QUnit.module("dropdownlist with groups", {
         });
     }
 }, () => {
-    QUnit.test("grouped option", (assert) => {
+    QUnit.test("grouped option", function(assert) {
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: this.dataSource,
             opened: true,
@@ -1386,7 +1386,7 @@ QUnit.module("dropdownlist with groups", {
         assert.strictEqual(list.option("grouped"), false, "grouped option is passed to the list");
     });
 
-    QUnit.test("groupTemplate option", (assert) => {
+    QUnit.test("groupTemplate option", function(assert) {
         const groupTemplate1 = new Template("<div>Test</div>");
 
         const dropDownList = $("#dropDownList").dxDropDownList({
@@ -1405,7 +1405,7 @@ QUnit.module("dropdownlist with groups", {
         assert.strictEqual(list.option("groupTemplate"), groupTemplate2, "groupTemplate has been passed on option changing");
     });
 
-    QUnit.test("itemElement argument of groupTemplate option is correct", (assert) => {
+    QUnit.test("itemElement argument of groupTemplate option is correct", function(assert) {
         $("#dropDownList").dxDropDownList({
             dataSource: this.dataSource,
             opened: true,
@@ -1417,7 +1417,7 @@ QUnit.module("dropdownlist with groups", {
         }).dxDropDownList("instance");
     });
 
-    QUnit.test("selectedItem for grouped dropdownlist", (assert) => {
+    QUnit.test("selectedItem for grouped dropdownlist", function(assert) {
         const dropDownList = $("#dropDownList").dxDropDownList({
             dataSource: this.dataSource,
             opened: true,
@@ -1434,7 +1434,7 @@ QUnit.module("dropdownlist with groups", {
 QUnit.module(
     "data source from url",
     {
-        afterEach: () => {
+        afterEach: function() {
             ajaxMock.clear();
         }
     },
@@ -1454,7 +1454,7 @@ QUnit.module(
             return $("#qunit-fixture").append("<div id=test-drop-down></div>");
         };
 
-        QUnit.test("initial value", assert => {
+        QUnit.test("initial value", function(assert) {
             const done = assert.async();
 
             appendWidgetContainer();
@@ -1479,7 +1479,7 @@ QUnit.module(
                 });
         });
 
-        QUnit.test("search", assert => {
+        QUnit.test("search", function(assert) {
             const done = assert.async();
 
             appendWidgetContainer();

--- a/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
@@ -28,30 +28,30 @@ const Fixture = Class.inherit({
 });
 
 QUnit.module("Editor", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.fixture = new Fixture();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.fixture.teardown();
     }
 }, () => {
-    QUnit.test("Editor can be instantiated", (assert) => {
+    QUnit.test("Editor can be instantiated", function(assert) {
         const editor = this.fixture.createEditor();
         assert.ok(editor instanceof Editor);
     });
 
-    QUnit.test("rendering", (assert) => {
+    QUnit.test("rendering", function(assert) {
         const editor = this.fixture.createEditor();
         assert.ok(editor);
     });
 
-    QUnit.test("'readOnly' option has 'false' value by default", (assert) => {
+    QUnit.test("'readOnly' option has 'false' value by default", function(assert) {
         const editor = this.fixture.createEditor();
 
         assert.strictEqual(editor.option("readOnly"), false);
     });
 
-    QUnit.test("Changing the 'value' option invokes the onValueChanged and passes the old and new values as arguments", (assert) => {
+    QUnit.test("Changing the 'value' option invokes the onValueChanged and passes the old and new values as arguments", function(assert) {
         const oldValue = "old";
         const newValue = "new";
 
@@ -67,7 +67,7 @@ QUnit.module("Editor", {
         editor.option("value", newValue);
     });
 
-    QUnit.test("Changing the 'value' option invokes the onValueChanged and passes the old and new values as arguments, 'readOnly' editor", (assert) => {
+    QUnit.test("Changing the 'value' option invokes the onValueChanged and passes the old and new values as arguments, 'readOnly' editor", function(assert) {
         const oldValue = "old";
         const newValue = "new";
 
@@ -83,7 +83,7 @@ QUnit.module("Editor", {
         editor.option("value", newValue);
     });
 
-    QUnit.test("Changing the 'value' option invokes the onValueChanged and passes the old and new values as arguments, 'disabled' editor", (assert) => {
+    QUnit.test("Changing the 'value' option invokes the onValueChanged and passes the old and new values as arguments, 'disabled' editor", function(assert) {
         const oldValue = "old";
         const newValue = "new";
 
@@ -99,7 +99,7 @@ QUnit.module("Editor", {
         editor.option("value", newValue);
     });
 
-    QUnit.test("keyboardProcessor is not defined for readOnly editor", (assert) => {
+    QUnit.test("keyboardProcessor is not defined for readOnly editor", function(assert) {
         const editor = this.fixture.createEditor({ focusStateEnabled: true, readOnly: true });
 
         assert.strictEqual(editor._keyboardProcessor, undefined, "keyboardProcessor is not defined after init");
@@ -109,7 +109,7 @@ QUnit.module("Editor", {
         assert.ok(editor._keyboardProcessor, "keyboardProcessor is defined");
     });
 
-    QUnit.test("If _valueChangeEventInstance is present, the onValueChanged must receive it as a Event argument; and then _valueChangeEventInstance must be reset", (assert) => {
+    QUnit.test("If _valueChangeEventInstance is present, the onValueChanged must receive it as a Event argument; and then _valueChangeEventInstance must be reset", function(assert) {
         const newValue = "new";
         const _valueChangeEventInstance = "something";
 
@@ -124,7 +124,7 @@ QUnit.module("Editor", {
         assert.strictEqual(editor._valueChangeEventInstance, undefined, "_valueChangeEventInstance is reset");
     });
 
-    QUnit.test("_suppressValueChangeAction should suppress invoking _suppressValueChangeAction", (assert) => {
+    QUnit.test("_suppressValueChangeAction should suppress invoking _suppressValueChangeAction", function(assert) {
         assert.expect(0);
 
         const editor = this.fixture.createEditor();
@@ -135,7 +135,7 @@ QUnit.module("Editor", {
         editor.option("value", true);
     });
 
-    QUnit.test("_resumeValueChangeAction should resume invoking _suppressValueChangeAction", (assert) => {
+    QUnit.test("_resumeValueChangeAction should resume invoking _suppressValueChangeAction", function(assert) {
         const value = "value";
 
         const onValueChanged = options => {
@@ -151,7 +151,7 @@ QUnit.module("Editor", {
         editor.option("value", value);
     });
 
-    QUnit.test("onValueChanged should work correctly when it passed on onInitialized (T314007)", (assert) => {
+    QUnit.test("onValueChanged should work correctly when it passed on onInitialized (T314007)", function(assert) {
         let valueChangeCounter = 0;
         const editor = this.fixture.createEditor({
             onInitialized(e) {
@@ -166,7 +166,7 @@ QUnit.module("Editor", {
         assert.equal(valueChangeCounter, 1, "onValueChanged was fired");
     });
 
-    QUnit.test("Editor can be reset()", (assert) => {
+    QUnit.test("Editor can be reset()", function(assert) {
         const editor = this.fixture.createEditor({ value: "123" });
 
         editor.reset();
@@ -174,7 +174,7 @@ QUnit.module("Editor", {
         assert.strictEqual(editor.option("value"), null);
     });
 
-    QUnit.test("T359215 - the hover class should be added on hover event if widget has read only state", (assert) => {
+    QUnit.test("T359215 - the hover class should be added on hover event if widget has read only state", function(assert) {
         const editor = this.fixture.createEditor({
             hoverStateEnabled: true,
             readOnly: true
@@ -188,7 +188,7 @@ QUnit.module("Editor", {
 
     [false, true].forEach((readOnly) => {
         const substring = readOnly ? "" : "not";
-        QUnit.test(`"backspace" key press event should ${substring} be prevented when editor is ${substring} read only`, (assert) => {
+        QUnit.test(`"backspace" key press event should ${substring} be prevented when editor is ${substring} read only`, function(assert) {
             const editor = this.fixture.createEditor({
                 readOnly
             });
@@ -208,7 +208,7 @@ QUnit.module("Editor", {
 });
 
 QUnit.module("the 'name' option", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("<div>").appendTo("body");
         this.EditorInheritor = Editor.inherit({
             _initMarkup() {
@@ -220,11 +220,11 @@ QUnit.module("the 'name' option", {
             }
         });
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
     }
 }, () => {
-    QUnit.test("editor inheritor input should get the 'name' attribute with a correct value", (assert) => {
+    QUnit.test("editor inheritor input should get the 'name' attribute with a correct value", function(assert) {
         const expectedName = "some_name";
 
         new this.EditorInheritor(this.$element, {
@@ -235,7 +235,7 @@ QUnit.module("the 'name' option", {
         assert.equal($input.attr("name"), expectedName, "the input 'name' attribute has correct value");
     });
 
-    QUnit.test("editor inheritor input should get correct 'name' attribute after the 'name' option is changed", (assert) => {
+    QUnit.test("editor inheritor input should get correct 'name' attribute after the 'name' option is changed", function(assert) {
         const expectedName = "new_name";
 
         const instance = new this.EditorInheritor(this.$element, {
@@ -248,14 +248,14 @@ QUnit.module("the 'name' option", {
         assert.equal($input.attr("name"), expectedName, "the input 'name' attribute has correct value ");
     });
 
-    QUnit.test("the 'name' attribute should not be rendered if name is an empty string", (assert) => {
+    QUnit.test("the 'name' attribute should not be rendered if name is an empty string", function(assert) {
         new this.EditorInheritor(this.$element);
 
         const input = this.$element.find("input[type='hidden']").get(0);
         assert.notOk(input.hasAttribute("name"), "there should be no 'name' attribute for hidden input");
     });
 
-    QUnit.test("the 'name' attribute should be removed after name is changed to an empty string", (assert) => {
+    QUnit.test("the 'name' attribute should be removed after name is changed to an empty string", function(assert) {
         const instance = new this.EditorInheritor(this.$element, {
             name: "some_name"
         });
@@ -268,16 +268,16 @@ QUnit.module("the 'name' option", {
 });
 
 QUnit.module("Validation - UI", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.fixture = new Fixture();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.fixture.teardown();
     }
 }, () => {
     const INVALID_VALIDATION_CLASS = "dx-invalid";
 
-    QUnit.test("Widget can be created as invalid", (assert) => {
+    QUnit.test("Widget can be created as invalid", function(assert) {
         // assign
         const message = "That is very bad editor";
 
@@ -295,7 +295,7 @@ QUnit.module("Validation - UI", {
         assert.ok(editor.$element().hasClass(INVALID_VALIDATION_CLASS), "Editor main element should be marked as invalid");
     });
 
-    QUnit.test("Widget can be set in invalid state through options", (assert) => {
+    QUnit.test("Widget can be set in invalid state through options", function(assert) {
         // assign
         const message = "That is very bad editor";
 
@@ -315,7 +315,7 @@ QUnit.module("Validation - UI", {
         assert.ok(editor.$element().hasClass(INVALID_VALIDATION_CLASS), "Editor main element should be marked as invalid");
     });
 
-    QUnit.test("Widget message should be created", (assert) => {
+    QUnit.test("Widget message should be created", function(assert) {
         const message = "That is very bad editor";
         const editor = this.fixture.createEditor({});
 
@@ -333,7 +333,7 @@ QUnit.module("Validation - UI", {
         assert.equal(editor._$validationMessage.dxOverlay("instance").$content().text(), message, "Correct message should be set");
     });
 
-    QUnit.test("Widget message (tooltip) should be created and always shown", (assert) => {
+    QUnit.test("Widget message (tooltip) should be created and always shown", function(assert) {
         // assign
         const message = "That is very bad editor";
 
@@ -356,7 +356,7 @@ QUnit.module("Validation - UI", {
         assert.ok(!editor._$validationMessage.hasClass("dx-invalid-message-auto"), "Tooltip should not be marked with auto");
     });
 
-    QUnit.test("Widget message (tooltip) should be created but never shown", (assert) => {
+    QUnit.test("Widget message (tooltip) should be created but never shown", function(assert) {
         // assign
         const message = "That is very bad editor";
 
@@ -379,7 +379,7 @@ QUnit.module("Validation - UI", {
         assert.ok(!editor._$validationMessage.hasClass("dx-invalid-message-always"), "Tooltip should not be marked as always");
     });
 
-    QUnit.test("Widget message (tooltip) should be destroyed after editor become valid", (assert) => {
+    QUnit.test("Widget message (tooltip) should be destroyed after editor become valid", function(assert) {
         // assign
         const message = "That is very bad editor";
 
@@ -401,7 +401,7 @@ QUnit.module("Validation - UI", {
         assert.ok(!editor._$validationMessage, "Tooltip should be destroyed; reference should be removed");
     });
 
-    QUnit.test("Validation message should flip if it is out of boundary validationBoundary", (assert) => {
+    QUnit.test("Validation message should flip if it is out of boundary validationBoundary", function(assert) {
         const $parent = this.fixture.createOnlyElement().css({
             paddingTop: "100px"
         });
@@ -423,7 +423,7 @@ QUnit.module("Validation - UI", {
         assert.ok($validationMessage.offset().top < $element.offset().top, "validation message was flipped");
     });
 
-    QUnit.test("Validation message should have the same with editor width", (assert) => {
+    QUnit.test("Validation message should have the same with editor width", function(assert) {
         const width = 100;
         const $element = this.fixture.createOnlyElement();
 
@@ -440,7 +440,7 @@ QUnit.module("Validation - UI", {
         assert.equal($validationMessage.outerWidth(), width, "validation message width is correct");
     });
 
-    QUnit.test("Validation message should have the same with editor width after option change", (assert) => {
+    QUnit.test("Validation message should have the same with editor width after option change", function(assert) {
         const width = 200;
         const $element = this.fixture.createOnlyElement();
 
@@ -458,7 +458,7 @@ QUnit.module("Validation - UI", {
         assert.equal($validationMessage.outerWidth(), width, "validation message width is correct");
     });
 
-    QUnit.test("Overlay content width should be less or equal message width", (assert) => {
+    QUnit.test("Overlay content width should be less or equal message width", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         new Editor($element, {
@@ -476,7 +476,7 @@ QUnit.module("Validation - UI", {
         assert.ok($content.outerWidth() <= $validationMessage.outerWidth(), "validation message width is correct");
     });
 
-    QUnit.test("Validation message text should not be wrapped", (assert) => {
+    QUnit.test("Validation message text should not be wrapped", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         new Editor($element, {
@@ -491,7 +491,7 @@ QUnit.module("Validation - UI", {
         assert.equal($content.css("whiteSpace"), "normal", "text is not wrapped");
     });
 
-    QUnit.test("Validation message should have correct width for small content", (assert) => {
+    QUnit.test("Validation message should have correct width for small content", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         new Editor($element, {
@@ -509,7 +509,7 @@ QUnit.module("Validation - UI", {
         assert.equal($content.css("width", "auto").outerWidth(), contentWidth, "validation message width is correct");
     });
 
-    QUnit.test("T376114 - Validation message should have the 100px max height if the editor has smaller size", (assert) => {
+    QUnit.test("T376114 - Validation message should have the 100px max height if the editor has smaller size", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         new Editor($element, {
@@ -526,7 +526,7 @@ QUnit.module("Validation - UI", {
         assert.equal($content.outerWidth(), 100, "the validation message width is correct");
     });
 
-    QUnit.test("Validation overlay should have the 'propagateOutsideClick' with true ", (assert) => {
+    QUnit.test("Validation overlay should have the 'propagateOutsideClick' with true ", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         new Editor($element, {
@@ -540,7 +540,7 @@ QUnit.module("Validation - UI", {
         assert.equal($element.find(`.${INVALID_MESSAGE_CLASS}.dx-widget`).dxOverlay("option", "propagateOutsideClick"), true, "'propagateOutsideClick' option has correct value");
     });
 
-    QUnit.test("Validation overlay should not inherit templates from the editor", (assert) => {
+    QUnit.test("Validation overlay should not inherit templates from the editor", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         new Editor($element, {
@@ -563,7 +563,7 @@ QUnit.module("Validation - UI", {
         assert.equal($element.find(`.${INVALID_MESSAGE_CLASS}.dx-widget #editorContentTemplate`).length, 0, "overlay does not inherit templates from the editor");
     });
 
-    QUnit.test("Validation overlay should be render correctly in hidden area", (assert) => {
+    QUnit.test("Validation overlay should be render correctly in hidden area", function(assert) {
         const $element = this.fixture.createOnlyElement();
         const $hiddenDiv = $("<div>").css("display", "none");
 
@@ -581,7 +581,7 @@ QUnit.module("Validation - UI", {
         assert.equal(editor._$validationMessage.text(), validationMessage, "validation overlay text was render correctly");
     });
 
-    QUnit.test("Validation overlay width after render in hidden area should be equal width in visible area", (assert) => {
+    QUnit.test("Validation overlay width after render in hidden area should be equal width in visible area", function(assert) {
         const $element = this.fixture.createOnlyElement();
         const $hiddenDiv = $("<div>").css("display", "none");
 
@@ -605,14 +605,14 @@ QUnit.module("Validation - UI", {
 });
 
 QUnit.module("Validation overlay options", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.fixture = new Fixture();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.fixture.teardown();
     }
 }, () => {
-    QUnit.test("it should be possible to redefine validation overlay options", (assert) => {
+    QUnit.test("it should be possible to redefine validation overlay options", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         new Editor($element, {
@@ -633,7 +633,7 @@ QUnit.module("Validation overlay options", {
         assert.equal(overlay.option("width"), 200, "a default option has been redefined");
     });
 
-    QUnit.test("editor's overlay options should be changed when validation overlay's options changed", (assert) => {
+    QUnit.test("editor's overlay options should be changed when validation overlay's options changed", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         const instance = new Editor($element, {
@@ -652,7 +652,7 @@ QUnit.module("Validation overlay options", {
         assert.equal(instance.option("validationTooltipOptions.width"), 150, "option has ben changed");
     });
 
-    QUnit.test("it should be possible to set validationTooltipOptions dynamically", (assert) => {
+    QUnit.test("it should be possible to set validationTooltipOptions dynamically", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         const instance = new Editor($element, {
@@ -674,7 +674,7 @@ QUnit.module("Validation overlay options", {
         assert.equal(instance.option("validationTooltipOptions.shading"), false, "default object's fields was not changed");
     });
 
-    QUnit.test("it should be possible to set null or undefined to the validationTooltipOptions", (assert) => {
+    QUnit.test("it should be possible to set null or undefined to the validationTooltipOptions", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         const instance = new Editor($element, {
@@ -697,7 +697,7 @@ QUnit.module("Validation overlay options", {
         assert.strictEqual(overlay.option("test2"), null, "option has ben changed");
     });
 
-    QUnit.test("default validation options should not be redefined on revalidation", (assert) => {
+    QUnit.test("default validation options should not be redefined on revalidation", function(assert) {
         const $element = this.fixture.createOnlyElement();
 
         const instance = new Editor($element, {
@@ -722,14 +722,14 @@ QUnit.module("Validation overlay options", {
 });
 
 QUnit.module("Validation Events", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.fixture = new Fixture();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.fixture.teardown();
     }
 }, () => {
-    QUnit.test("validationRequest event should fire on value change", (assert) => {
+    QUnit.test("validationRequest event should fire on value change", function(assert) {
         const value = "test123";
         const handler = sinon.stub();
 
@@ -748,7 +748,7 @@ QUnit.module("Validation Events", {
         assert.equal(params.editor, editor, "Editor was passed");
     });
 
-    QUnit.test("T220137: validationRequest event should NOT fire on value change", (assert) => {
+    QUnit.test("T220137: validationRequest event should NOT fire on value change", function(assert) {
         const nullValue = null;
         const handler = sinon.stub();
 
@@ -766,14 +766,14 @@ QUnit.module("Validation Events", {
 });
 
 QUnit.module("aria accessibility", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.fixture = new Fixture();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.fixture.teardown();
     }
 }, () => {
-    QUnit.test("readonly state", (assert) => {
+    QUnit.test("readonly state", function(assert) {
         const editor = this.fixture.createEditor({ readOnly: true });
 
         assert.equal(editor.$element().attr("aria-readonly"), "true", "aria-readonly is correct");
@@ -782,7 +782,7 @@ QUnit.module("aria accessibility", {
         assert.equal(editor.$element().attr("aria-readonly"), undefined, "aria-readonly does not exist in not readonly state");
     });
 
-    QUnit.test("invalid state", (assert) => {
+    QUnit.test("invalid state", function(assert) {
         const editor = this.fixture.createEditor({
             isValid: false,
             validationError: {

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.markup.tests.js
@@ -25,7 +25,7 @@ testStart(() => {
 const LOOKUP_FIELD_CLASS = "dx-lookup-field";
 
 module("Lookup", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         executeAsyncMock.setup();
         this.clock = sinon.useFakeTimers();
@@ -34,20 +34,20 @@ module("Lookup", {
         this.instance = this.element.dxLookup({ fullScreen: false }).dxLookup("instance");
         this.$field = $(this.instance._$field);
     },
-    afterEach: () => {
+    afterEach: function() {
         executeAsyncMock.teardown();
         this.clock.restore();
         fx.off = false;
     }
 }, () => {
-    test("render dxLookup", (assert) => {
+    test("render dxLookup", function(assert) {
         assert.ok(this.instance instanceof Lookup);
         assert.ok(this.element.hasClass("dx-lookup"), "widget has class dx-lookup");
         assert.ok($(`.${LOOKUP_FIELD_CLASS}`, this.element).length, "widget contents field");
         assert.ok($(".dx-lookup-arrow", this.element).length, "widget contents arrow");
     });
 
-    test("regression: value is out of range (B231783)", (assert) => {
+    test("regression: value is out of range (B231783)", function(assert) {
         this.instance.option({
             dataSource: [1, 2, 3],
             value: "wrongValue"
@@ -56,18 +56,18 @@ module("Lookup", {
         assert.equal(this.$field.text(), "Select...");
     });
 
-    test("regression: B232016 - Lookup element has no 'dx-widget' CSS class", (assert) => {
+    test("regression: B232016 - Lookup element has no 'dx-widget' CSS class", function(assert) {
         assert.ok(this.element.hasClass("dx-widget"));
     });
 
-    test("lookup empty class is attached when no item is selected", (assert) => {
+    test("lookup empty class is attached when no item is selected", function(assert) {
         const $lookup = this.element.dxLookup({ dataSource: [1, 2, 3], showClearButton: true, placeholder: "placeholder" });
         const LOOKUP_EMPTY_CLASS = "dx-lookup-empty";
 
         assert.ok($lookup.hasClass(LOOKUP_EMPTY_CLASS), "Lookup without preselected value has empty class");
     });
 
-    test("data source should be paginated by default", (assert) => {
+    test("data source should be paginated by default", function(assert) {
         assert.expect(1);
 
         const $element = $("#lookup").dxLookup({
@@ -78,7 +78,7 @@ module("Lookup", {
         assert.equal(instance._dataSource.paginate(), true, "pagination enabled by default");
     });
 
-    test("T373464 - the 'fieldTemplate' should be used for rendering if the item is get asynchronously", (assert) => {
+    test("T373464 - the 'fieldTemplate' should be used for rendering if the item is get asynchronously", function(assert) {
         const fieldTemplateText = "Field template";
         const items = ["1", "2"];
         const $element = $("#lookup").dxLookup({
@@ -105,7 +105,7 @@ module("Lookup", {
     });
 
 
-    test("field template should be render one time per value rendering", (assert) => {
+    test("field template should be render one time per value rendering", function(assert) {
         const fieldTemplateStub = sinon.stub().returns($("<div>"));
         $("#widthRootStyle").dxLookup({
             fieldTemplate: fieldTemplateStub,
@@ -116,7 +116,7 @@ module("Lookup", {
         assert.ok(fieldTemplateStub.calledOnce, "field template called once");
     });
 
-    test("value should be rendered correctly when async data source has been used", (assert) => {
+    test("value should be rendered correctly when async data source has been used", function(assert) {
         const value = "last name";
 
         this.element.dxLookup({
@@ -143,14 +143,14 @@ module("Lookup", {
 
 
 module("hidden input", () => {
-    test("a hidden input should be rendered", (assert) => {
+    test("a hidden input should be rendered", function(assert) {
         const $element = $("#lookup").dxLookup();
         const $input = $element.find("input[type='hidden']");
 
         assert.equal($input.length, 1, "a hidden input is rendered");
     });
 
-    test("the hidden input should have correct value on widget init", (assert) => {
+    test("the hidden input should have correct value on widget init", function(assert) {
         const $element = $("#lookup").dxLookup({
             items: [1, 2, 3],
             value: 2
@@ -160,7 +160,7 @@ module("hidden input", () => {
         assert.equal($input.val(), "2", "input value is correct");
     });
 
-    test("the hidden input should get display text as value if widget value is an object", (assert) => {
+    test("the hidden input should get display text as value if widget value is an object", function(assert) {
         const items = [{ id: 1, text: "one" }];
         const $element = $("#lookup").dxLookup({
             items: items,
@@ -173,7 +173,7 @@ module("hidden input", () => {
         assert.equal($input.val(), items[0].text, "input value is correct");
     });
 
-    test("the submit value must be equal to the value of the widget", (assert) => {
+    test("the submit value must be equal to the value of the widget", function(assert) {
         const items = ["test"];
         const $element = $("#lookup").dxLookup({
             items: items,
@@ -190,7 +190,7 @@ module("hidden input", () => {
         assert.deepEqual($input.val(), items[0], "input value is correct");
     });
 
-    test("the hidden input should get value in respect of the 'valueExpr' option", (assert) => {
+    test("the hidden input should get value in respect of the 'valueExpr' option", function(assert) {
         const items = [{ id: 1, text: "one" }];
         const $element = $("#lookup").dxLookup({
             items: items,
@@ -206,18 +206,18 @@ module("hidden input", () => {
 
 
 module("options", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         executeAsyncMock.setup();
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         executeAsyncMock.teardown();
         fx.off = false;
         this.clock.restore();
     }
 }, () => {
-    test("hidden input should get the 'name' attribute with a correct value", (assert) => {
+    test("hidden input should get the 'name' attribute with a correct value", function(assert) {
         const expectedName = "lookup";
         const $element = $("#lookup").dxLookup({
             name: expectedName
@@ -227,7 +227,7 @@ module("options", {
         assert.equal($input.attr("name"), expectedName, "input has correct 'name' attribute");
     });
 
-    test("displayExpr, valueExpr as functions (regression B230600)", (assert) => {
+    test("displayExpr, valueExpr as functions (regression B230600)", function(assert) {
         const instance = $("#lookup").dxLookup({
             dataSource: [1, 2],
             valueExpr: function(item) {
@@ -243,7 +243,7 @@ module("options", {
         assert.equal($field.text(), "number 1");
     });
 
-    test("value", (assert) => {
+    test("value", function(assert) {
         const items = [1, 2, 3];
         const instance = $("#lookup").dxLookup({ dataSource: items, value: 1 }).dxLookup("instance");
         const $field = $(instance._$field);
@@ -252,7 +252,7 @@ module("options", {
         assert.equal(instance.option("displayValue"), 1, "displayValue is selected item value");
     });
 
-    test("value should be assigned by reference", (assert) => {
+    test("value should be assigned by reference", function(assert) {
         const items = [{ name: "name" }];
         const instance = $("#lookup").dxLookup({
             dataSource: items,
@@ -264,7 +264,7 @@ module("options", {
         assert.equal($field.text(), "name", "item was found in items by reference");
     });
 
-    test("placeholder", (assert) => {
+    test("placeholder", function(assert) {
         const instance = $("#lookup").dxLookup({
             dataSource: []
         }).dxLookup("instance");
@@ -272,13 +272,13 @@ module("options", {
         assert.equal($(instance._$field).text(), "Select...", "default value");
     });
 
-    test("fieldTemplate should be rendered", (assert) => {
+    test("fieldTemplate should be rendered", function(assert) {
         $("#lookupFieldTemplate").dxLookup({ fieldTemplate: "field" });
 
         assert.equal($.trim($("#lookupFieldTemplate").text()), "test", "test was be rendered");
     });
 
-    test("selected item should be passed as first argument if fieldTemplate is a function", (assert) => {
+    test("selected item should be passed as first argument if fieldTemplate is a function", function(assert) {
         const items = [{ id: 1, text: "one", data: 11 }, { id: 2, text: "two", data: 22 }];
 
         $("#lookup").dxLookup({
@@ -297,7 +297,7 @@ module("options", {
 
 
 module("widget sizing render", () => {
-    test("constructor", (assert) => {
+    test("constructor", function(assert) {
         const $element = $("#lookup").dxLookup({ width: 400 });
         const instance = $element.dxLookup("instance");
 
@@ -305,7 +305,7 @@ module("widget sizing render", () => {
         assert.strictEqual($element.get(0).style.width, "400px", "outer width of the element must be equal to custom width");
     });
 
-    test("root with custom width", (assert) => {
+    test("root with custom width", function(assert) {
         const $element = $("#widthRootStyle").dxLookup();
         const instance = $element.dxLookup("instance");
 
@@ -316,7 +316,7 @@ module("widget sizing render", () => {
 
 
 module("aria accessibility", () => {
-    test("aria role", (assert) => {
+    test("aria role", function(assert) {
         const $element = $("#lookup").dxLookup();
         const $field = $element.find(`.${LOOKUP_FIELD_CLASS}:first`);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -3042,7 +3042,7 @@ var helper;
 if(devices.real().deviceType === "desktop") {
     [true, false].forEach((searchEnabled) => {
         QUnit.module(`Aria accessibility, searchEnabled: ${searchEnabled}`, {
-            beforeEach: () => {
+            beforeEach: function() {
                 helper = new ariaAccessibilityTestHelper({
                     createWidget: ($element, options) => new Lookup($element,
                         $.extend({
@@ -3050,11 +3050,11 @@ if(devices.real().deviceType === "desktop") {
                         }, options))
                 });
             },
-            afterEach: () => {
+            afterEach: function() {
                 helper.$widget.remove();
             }
         }, () => {
-            QUnit.test(`opened: true, searchEnabled: ${searchEnabled}`, () => {
+            QUnit.test(`opened: true, searchEnabled: ${searchEnabled}`, function() {
                 helper.createWidget({ opened: true });
 
                 const $field = helper.$widget.find(`.${LOOKUP_FIELD_CLASS}`);
@@ -3079,7 +3079,7 @@ if(devices.real().deviceType === "desktop") {
                 }
             });
 
-            QUnit.test(`Opened: false, searchEnabled: ${searchEnabled}`, () => {
+            QUnit.test(`Opened: false, searchEnabled: ${searchEnabled}`, function() {
                 helper.createWidget({ opened: false });
 
                 const $field = helper.$widget.find(`.${LOOKUP_FIELD_CLASS}`);

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/common.tests.js
@@ -25,7 +25,7 @@ const ACTIVE_STATE_CLASS = "dx-state-active";
 const CLEAR_BUTTON_CLASS = "dx-clear-button-area";
 
 QUnit.module("basics", {}, () => {
-    QUnit.test("markup init", (assert) => {
+    QUnit.test("markup init", function(assert) {
         const element = $("#numberbox").dxNumberBox();
 
         assert.ok(element.hasClass(NUMBERBOX_CLASS));
@@ -35,7 +35,7 @@ QUnit.module("basics", {}, () => {
         assert.equal(element.find("." + CONTAINER_CLASS).length, 1);
     });
 
-    QUnit.test("input should have correct type", (assert) => {
+    QUnit.test("input should have correct type", function(assert) {
         const $element = $("#numberbox").dxNumberBox();
         const instance = $element.dxNumberBox("instance");
 
@@ -65,7 +65,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($element.find("." + INPUT_CLASS).attr("inputmode"), "decimal", "inputmode is correct");
     });
 
-    QUnit.test("onContentReady fired after the widget is fully ready", (assert) => {
+    QUnit.test("onContentReady fired after the widget is fully ready", function(assert) {
         assert.expect(2);
 
         $("#numberbox").dxNumberBox({
@@ -77,7 +77,7 @@ QUnit.module("basics", {}, () => {
         });
     });
 
-    QUnit.test("init with options", (assert) => {
+    QUnit.test("init with options", function(assert) {
         assert.expect(2);
 
         const element = $("#numberbox").dxNumberBox({
@@ -91,7 +91,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($input.prop("max"), 100);
     });
 
-    QUnit.test("typing value by keyboard update 'value' option", (assert) => {
+    QUnit.test("typing value by keyboard update 'value' option", function(assert) {
         assert.expect(2);
 
         const element = $("#numberbox").dxNumberBox({
@@ -113,7 +113,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual(instance.option("value"), 100200);
     });
 
-    QUnit.test("validate value on focusout", (assert) => {
+    QUnit.test("validate value on focusout", function(assert) {
         assert.expect(2);
 
         const element = $("#numberbox").dxNumberBox({
@@ -136,7 +136,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual(instance.option("value"), 100, "validate value on focusout");
     });
 
-    QUnit.test("trigger invalid event", (assert) => {
+    QUnit.test("trigger invalid event", function(assert) {
         assert.expect(2);
 
         const element = $("#numberbox").dxNumberBox({
@@ -159,7 +159,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual(instance.option("value"), 100, "validate value on invalid event");
     });
 
-    QUnit.test("validate value on keyup", (assert) => {
+    QUnit.test("validate value on keyup", function(assert) {
         const element = $("#numberbox").dxNumberBox({
             value: 100,
             valueChangeEvent: "keyup"
@@ -180,7 +180,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual(instance.option("value"), expectedResult, "value is correct");
     });
 
-    QUnit.test("Validate value on keyup when 0 typing after a comma", (assert) => {
+    QUnit.test("Validate value on keyup when 0 typing after a comma", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             value: null,
             valueChangeEvent: "keyup",
@@ -209,7 +209,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual(instance.option("value"), expectedValue++, "value is correct");
     });
 
-    QUnit.test("validate 'plus' char typing", (assert) => {
+    QUnit.test("validate 'plus' char typing", function(assert) {
         const element = $("#numberbox").dxNumberBox({
             value: 1,
             valueChangeEvent: "change"
@@ -237,7 +237,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual(instance.option("value"), 1, "value is correct");
     });
 
-    QUnit.test("validate 'minus' char typing", (assert) => {
+    QUnit.test("validate 'minus' char typing", function(assert) {
         const element = $("#numberbox").dxNumberBox({
             value: 1,
             valueChangeEvent: "change"
@@ -265,7 +265,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual(instance.option("value"), -11, "value is correct");
     });
 
-    QUnit.test("jQuery event should be specified on value change when value is not valid", (assert) => {
+    QUnit.test("jQuery event should be specified on value change when value is not valid", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             value: 1,
             valueChangeEvent: "keyup",
@@ -283,7 +283,7 @@ QUnit.module("basics", {}, () => {
             .keyUp("backspace");
     });
 
-    QUnit.test("regression test. Change value used option", (assert) => {
+    QUnit.test("regression test. Change value used option", function(assert) {
         assert.expect(1);
 
         const element = $("#numberbox").dxNumberBox({
@@ -297,7 +297,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($input.val(), 200);
     });
 
-    QUnit.test("'text' option should be correct", (assert) => {
+    QUnit.test("'text' option should be correct", function(assert) {
         assert.expect(2);
 
         const element = $("#numberbox").dxNumberBox({
@@ -312,7 +312,7 @@ QUnit.module("basics", {}, () => {
         assert.equal(instance.option("text"), "200", "Text is OK");
     });
 
-    QUnit.test("placeholder is visible when value is invalid", (assert) => {
+    QUnit.test("placeholder is visible when value is invalid", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             placeholder: "Placeholder",
             value: ""
@@ -328,7 +328,7 @@ QUnit.module("basics", {}, () => {
         assert.ok($element.find("." + PLACEHOLDER_CLASS).is(":visible"), "placeholder is visible with invalid value");
     });
 
-    QUnit.test("init with option useLargeSpinButtons", (assert) => {
+    QUnit.test("init with option useLargeSpinButtons", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showSpinButtons: true,
             useLargeSpinButtons: true
@@ -337,7 +337,7 @@ QUnit.module("basics", {}, () => {
         assert.ok($element.hasClass(SPIN_TOUCH_FRIENDLY_CLASS), "element has touchFriendly class");
     });
 
-    QUnit.test("widget's width does not increase after buttons hover in FF (T806555)", (assert) => {
+    QUnit.test("widget's width does not increase after buttons hover in FF (T806555)", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showSpinButtons: true,
             useLargeSpinButtons: true
@@ -350,7 +350,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual($element.height(), startHeight, "widget's width does not change");
     });
 
-    QUnit.testInActiveWindow("input is focused when spin buttons are clicked if useLargeSpinButtons = false", (assert) => {
+    QUnit.testInActiveWindow("input is focused when spin buttons are clicked if useLargeSpinButtons = false", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showSpinButtons: true,
             useLargeSpinButtons: false
@@ -366,7 +366,7 @@ QUnit.module("basics", {}, () => {
         assert.ok($input.is(":focus"), "input is focused after click on spin button");
     });
 
-    QUnit.test("spin button should have feedback after click on it", (assert) => {
+    QUnit.test("spin button should have feedback after click on it", function(assert) {
         const FEEDBACK_SHOW_TIMEOUT = 30;
         this.clock = sinon.useFakeTimers();
 
@@ -387,7 +387,7 @@ QUnit.module("basics", {}, () => {
         }
     });
 
-    QUnit.test("spin button should change value after long click on it", (assert) => {
+    QUnit.test("spin button should change value after long click on it", function(assert) {
         const FEEDBACK_SHOW_TIMEOUT = 500;
         this.clock = sinon.useFakeTimers();
 
@@ -414,7 +414,7 @@ QUnit.module("basics", {}, () => {
         }
     });
 
-    QUnit.test("hoverStateEnabled option", (assert) => {
+    QUnit.test("hoverStateEnabled option", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             hoverStateEnabled: true
         });
@@ -426,7 +426,7 @@ QUnit.module("basics", {}, () => {
         assert.ok(!$element.hasClass("dx-state-hover"), "dxNumberBox has not hover class");
     });
 
-    QUnit.test("hoverStateEnabled option for spinButton", (assert) => {
+    QUnit.test("hoverStateEnabled option for spinButton", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             hoverStateEnabled: true,
             showSpinButtons: true
@@ -441,7 +441,7 @@ QUnit.module("basics", {}, () => {
         assert.ok(!$spinButton.hasClass("dx-state-hover"), "Spin button has not hover class after mouse enter on it");
     });
 
-    QUnit.testInActiveWindow("input value is greeter or less after mousewheel action", (assert) => {
+    QUnit.testInActiveWindow("input value is greeter or less after mousewheel action", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: 100.6
         });
@@ -464,7 +464,7 @@ QUnit.module("basics", {}, () => {
         assert.roughEqual(numberBox.option("value"), 100.6, 1.001);
     });
 
-    QUnit.test("mousewheel action should not work in disabled state", (assert) => {
+    QUnit.test("mousewheel action should not work in disabled state", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: 100.6,
             disabled: true
@@ -480,7 +480,7 @@ QUnit.module("basics", {}, () => {
         assert.equal(numberBox.option("value"), 100.6, "value is not changed");
     });
 
-    QUnit.test("mousewheel action should not work if widget is not focused", (assert) => {
+    QUnit.test("mousewheel action should not work if widget is not focused", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({ value: 100 });
         const numberBox = $numberBox.dxNumberBox("instance");
         const input = $(`.${INPUT_CLASS}`, $numberBox).get(0);
@@ -495,7 +495,7 @@ QUnit.module("basics", {}, () => {
         assert.notStrictEqual(numberBox.option("value"), 100);
     });
 
-    QUnit.testInActiveWindow("input is not focused when spin buttons are clicked if useLargeSpinButtons = true", (assert) => {
+    QUnit.testInActiveWindow("input is not focused when spin buttons are clicked if useLargeSpinButtons = true", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showSpinButtons: true,
             useLargeSpinButtons: true
@@ -519,7 +519,7 @@ QUnit.module("basics", {}, () => {
         assert.ok($input.is(":focus"), "input is still focused");
     });
 
-    QUnit.test("correct order of buttons when widget is rendered", (assert) => {
+    QUnit.test("correct order of buttons when widget is rendered", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showSpinButtons: true,
             showClearButton: true
@@ -530,7 +530,7 @@ QUnit.module("basics", {}, () => {
         assert.ok($buttons.eq(1).hasClass("dx-numberbox-spin-container"), "spin buttons are the second");
     });
 
-    QUnit.test("correct order of buttons when clear button option is set after rendering", (assert) => {
+    QUnit.test("correct order of buttons when clear button option is set after rendering", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showSpinButtons: true
         });
@@ -545,7 +545,7 @@ QUnit.module("basics", {}, () => {
         assert.ok($buttons.eq(1).hasClass("dx-numberbox-spin-container"), "spin buttons are the second");
     });
 
-    QUnit.test("correct order of buttons when spin buttons option is set after rendering", (assert) => {
+    QUnit.test("correct order of buttons when spin buttons option is set after rendering", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showClearButton: true
         });
@@ -559,7 +559,7 @@ QUnit.module("basics", {}, () => {
         assert.ok($buttons.eq(1).hasClass("dx-numberbox-spin-container"), "spin buttons are the second");
     });
 
-    QUnit.test("clear button should save valueChangeEvent", (assert) => {
+    QUnit.test("clear button should save valueChangeEvent", function(assert) {
         const valueChangedHandler = sinon.spy();
 
         const $element = $("#numberbox").dxNumberBox({
@@ -574,7 +574,7 @@ QUnit.module("basics", {}, () => {
         assert.equal(valueChangedHandler.getCall(0).args[0].event.type, "dxclick", "event is correct");
     });
 
-    QUnit.test("clearButton should clear the text even if the value was not changed", (assert) => {
+    QUnit.test("clearButton should clear the text even if the value was not changed", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showClearButton: true,
             value: null
@@ -592,7 +592,7 @@ QUnit.module("basics", {}, () => {
         assert.strictEqual($input.val(), "", "value is still cleared");
     });
 
-    QUnit.test("clearButton should clear the text and reset incorrect value (T818673)", (assert) => {
+    QUnit.test("clearButton should clear the text and reset incorrect value (T818673)", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             showClearButton: true,
             value: null
@@ -614,7 +614,7 @@ QUnit.module("basics", {}, () => {
         }
     });
 
-    QUnit.test("T220209 - the 'displayValueFormatter' option", (assert) => {
+    QUnit.test("T220209 - the 'displayValueFormatter' option", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: 5,
             displayValueFormatter(value) {
@@ -626,7 +626,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($numberBox.find(`.${INPUT_CLASS}`).val(), "05", "input value is correct");
     });
 
-    QUnit.test("T220209 - the 'displayValueFormatter' option when value is changed using keyboard", (assert) => {
+    QUnit.test("T220209 - the 'displayValueFormatter' option when value is changed using keyboard", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "this test is actual only for desktop ");
             return;
@@ -653,7 +653,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($numberBox.find(`.${INPUT_CLASS}`).val(), "50", "input value is correct");
     });
 
-    QUnit.test("T220209 - the 'displayValueFormatter' option when value is changed using spin buttons", (assert) => {
+    QUnit.test("T220209 - the 'displayValueFormatter' option when value is changed using spin buttons", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: 5,
             displayValueFormatter(value) {
@@ -670,7 +670,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($numberBox.find(`.${INPUT_CLASS}`).val(), "06", "input value is correct");
     });
 
-    QUnit.test("T351846 - the value should not be changed after the 'change' input event is fired if value is null", (assert) => {
+    QUnit.test("T351846 - the value should not be changed after the 'change' input event is fired if value is null", function(assert) {
         let valueChangedCount = 0;
 
         const $numberBox = $("#numberbox").dxNumberBox({
@@ -690,7 +690,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($numberBox.dxNumberBox("option", "value"), null, "value is correct");
     });
 
-    QUnit.test("T351846 - the value should be reset to null if input is cleared", (assert) => {
+    QUnit.test("T351846 - the value should be reset to null if input is cleared", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: 0
         });
@@ -706,7 +706,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($numberBox.dxNumberBox("option", "value"), null, "value is correct");
     });
 
-    QUnit.test("the value should be reset to null if reset method called", (assert) => {
+    QUnit.test("the value should be reset to null if reset method called", function(assert) {
         const numberBox = $("#numberbox").dxNumberBox({
             value: 0
         }).dxNumberBox("instance");
@@ -716,7 +716,7 @@ QUnit.module("basics", {}, () => {
         assert.equal(numberBox.option("value"), null, "value is correct");
     });
 
-    QUnit.test("The value option should not be changed if it is invalid", (assert) => {
+    QUnit.test("The value option should not be changed if it is invalid", function(assert) {
         const value = "any invalid value";
 
         const $numberBox = $("#numberbox").dxNumberBox({
@@ -731,7 +731,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($input.val(), "", "input value is cleared");
     });
 
-    QUnit.test("The value option should not be reset if it is invalid", (assert) => {
+    QUnit.test("The value option should not be reset if it is invalid", function(assert) {
         const value = "any invalid value";
 
         const $numberBox = $("#numberbox").dxNumberBox({
@@ -747,7 +747,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($input.val(), "", "input value is cleared");
     });
 
-    QUnit.test("The value option should not be reset if it is invalid", (assert) => {
+    QUnit.test("The value option should not be reset if it is invalid", function(assert) {
         const value = "any invalid value";
 
         const $numberBox = $("#numberbox").dxNumberBox({
@@ -763,7 +763,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($input.val(), "", "input value is cleared");
     });
 
-    QUnit.test("The widget should be valid if the value option is undefined", (assert) => {
+    QUnit.test("The widget should be valid if the value option is undefined", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: undefined
         });
@@ -775,7 +775,7 @@ QUnit.module("basics", {}, () => {
         assert.equal($input.val(), "", "input value is correct");
     });
 
-    QUnit.test("The widget should be invalid if isValid option is false on init but value format is correct", (assert) => {
+    QUnit.test("The widget should be invalid if isValid option is false on init but value format is correct", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: 0,
             isValid: false
@@ -786,14 +786,14 @@ QUnit.module("basics", {}, () => {
 });
 
 QUnit.module("submit element", {}, () => {
-    QUnit.test("a hidden input should be rendered", (assert) => {
+    QUnit.test("a hidden input should be rendered", function(assert) {
         const $element = $("#numberbox").dxNumberBox();
         const $hiddenInput = $element.find("input[type='hidden']");
 
         assert.equal($hiddenInput.length, 1, "a hidden input is created");
     });
 
-    QUnit.test("the hidden input should get correct value on init", (assert) => {
+    QUnit.test("the hidden input should get correct value on init", function(assert) {
         const expectedValue = 24.8;
 
         const $element = $("#numberbox").dxNumberBox({
@@ -805,7 +805,7 @@ QUnit.module("submit element", {}, () => {
         assert.equal(parseFloat($hiddenInput.val()), expectedValue, "the hidden input has correct value after init");
     });
 
-    QUnit.test("the hidden input gets correct value after widget value is changed", (assert) => {
+    QUnit.test("the hidden input gets correct value after widget value is changed", function(assert) {
         const expectedValue = 13;
 
         const $element = $("#numberbox").dxNumberBox({
@@ -819,7 +819,7 @@ QUnit.module("submit element", {}, () => {
         assert.equal(parseInt($hiddenInput.val()), expectedValue, "the hidden input value is correct");
     });
 
-    QUnit.test("the hidden input should use the decimal separator specified in DevExpress.config", (assert) => {
+    QUnit.test("the hidden input should use the decimal separator specified in DevExpress.config", function(assert) {
         const originalConfig = config();
         try {
             config({ serverDecimalSeparator: "|" });
@@ -838,7 +838,7 @@ QUnit.module("submit element", {}, () => {
 });
 
 QUnit.module("the 'name' option", {}, () => {
-    QUnit.test("hidden input should get the 'name' attribute", (assert) => {
+    QUnit.test("hidden input should get the 'name' attribute", function(assert) {
         const expectedName = "name";
 
         $("#numberbox").dxNumberBox({
@@ -850,7 +850,7 @@ QUnit.module("the 'name' option", {}, () => {
         assert.equal($hiddenInput.attr("name"), expectedName, "hidden input has correct 'name' attribute");
     });
 
-    QUnit.test("editor input should not get the 'name' attribute", (assert) => {
+    QUnit.test("editor input should not get the 'name' attribute", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             name: "name"
         });
@@ -862,7 +862,7 @@ QUnit.module("the 'name' option", {}, () => {
 });
 
 QUnit.module("input value updating", {}, () => {
-    QUnit.test("value should not be redrawn if it equals previous value", (assert) => {
+    QUnit.test("value should not be redrawn if it equals previous value", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             value: 0
         });
@@ -878,7 +878,7 @@ QUnit.module("input value updating", {}, () => {
         assert.equal($input.val(), "00");
     });
 
-    QUnit.test("value should not be redrawn if it does not equals previous value", (assert) => {
+    QUnit.test("value should not be redrawn if it does not equals previous value", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             value: 1
         });
@@ -894,7 +894,7 @@ QUnit.module("input value updating", {}, () => {
         assert.equal($input.val(), "00");
     });
 
-    QUnit.test("value should not be redrawn if it is incomplete and valueChangeEvent is set to keyup", (assert) => {
+    QUnit.test("value should not be redrawn if it is incomplete and valueChangeEvent is set to keyup", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             value: null,
             valueChangeEvent: "keyup",
@@ -951,7 +951,7 @@ QUnit.module("input value updating", {}, () => {
         instance.blur();
     });
 
-    QUnit.test("T378082 - value should be null if the incorrect value is entered", (assert) => {
+    QUnit.test("T378082 - value should be null if the incorrect value is entered", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             value: null,
             mode: "text"
@@ -966,7 +966,7 @@ QUnit.module("input value updating", {}, () => {
         assert.equal($element.dxNumberBox("option", "value"), null, "value is correct");
     });
 
-    QUnit.test("value should be updated when it was incomplete", (assert) => {
+    QUnit.test("value should be updated when it was incomplete", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             value: null,
             mode: "text"
@@ -988,12 +988,12 @@ QUnit.module("input value updating", {}, () => {
 });
 
 QUnit.module("options changed callbacks", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.element = $("#numberbox");
         this.instance = this.element.dxNumberBox().dxNumberBox("instance");
     }
 }, () => {
-    QUnit.test("min/max", (assert) => {
+    QUnit.test("min/max", function(assert) {
         assert.expect(2);
 
         this.instance.option("min", 123);
@@ -1003,14 +1003,14 @@ QUnit.module("options changed callbacks", {
         assert.equal(this.element.find("." + INPUT_CLASS).prop("max"), "321");
     });
 
-    QUnit.test("step", (assert) => {
+    QUnit.test("step", function(assert) {
         assert.expect(1);
 
         this.instance.option("step", 123);
         assert.equal(this.element.find("." + INPUT_CLASS).prop("step"), "123");
     });
 
-    QUnit.test("min/max: value changes to limited value", (assert) => {
+    QUnit.test("min/max: value changes to limited value", function(assert) {
         assert.expect(4);
 
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1038,7 +1038,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), 203, "set value more than min with option");
     });
 
-    QUnit.test("min/max: value changes when max wasn't set", (assert) => {
+    QUnit.test("min/max: value changes when max wasn't set", function(assert) {
         const $input = this.element.find("." + INPUT_CLASS);
 
         this.instance.option("min", 100);
@@ -1051,7 +1051,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), 100);
     });
 
-    QUnit.test("min/max: value changes when min wasn't set", (assert) => {
+    QUnit.test("min/max: value changes when min wasn't set", function(assert) {
         const $input = this.element.find("." + INPUT_CLASS);
 
         this.instance.option("min", undefined);
@@ -1065,7 +1065,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), 100);
     });
 
-    QUnit.test("changing min limit should lead to value change in base numberbox", (assert) => {
+    QUnit.test("changing min limit should lead to value change in base numberbox", function(assert) {
         this.instance.option({
             value: 5,
             min: 1
@@ -1075,7 +1075,7 @@ QUnit.module("options changed callbacks", {
         assert.equal(this.instance.option("value"), 6, "value has been updated");
     });
 
-    QUnit.test("changing max limit should lead to value change in base numberbox", (assert) => {
+    QUnit.test("changing max limit should lead to value change in base numberbox", function(assert) {
         this.instance.option({
             value: 5,
             max: 6
@@ -1085,7 +1085,7 @@ QUnit.module("options changed callbacks", {
         assert.equal(this.instance.option("value"), 4, "value has been updated");
     });
 
-    QUnit.test("min/max: value changes to limited value with number mode", (assert) => {
+    QUnit.test("min/max: value changes to limited value with number mode", function(assert) {
         this.instance.option({
             mode: "number",
             valueChangeEvent: "keyup",
@@ -1109,7 +1109,7 @@ QUnit.module("options changed callbacks", {
         assert.equal(this.instance.option("value"), 20, "widget's value was changed to the maximum after changing via input");
     });
 
-    QUnit.test("min/max: value changes if value is negative", (assert) => {
+    QUnit.test("min/max: value changes if value is negative", function(assert) {
         const $input = this.element.find("." + INPUT_CLASS);
 
         this.instance.option("min", -30);
@@ -1136,7 +1136,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), -5, "set value more than min with option");
     });
 
-    QUnit.test("value starts from decimal", (assert) => {
+    QUnit.test("value starts from decimal", function(assert) {
         assert.expect(1);
 
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1152,7 +1152,7 @@ QUnit.module("options changed callbacks", {
         assert.equal(this.instance.option("value"), 0.1, "value is right");
     });
 
-    QUnit.test("showSpinButtons", (assert) => {
+    QUnit.test("showSpinButtons", function(assert) {
         assert.expect(5);
 
         assert.ok(!this.element.hasClass(SPIN_CLASS), "on default spin classes aren't applied");
@@ -1169,7 +1169,7 @@ QUnit.module("options changed callbacks", {
         $spinContainer = this.element.find("." + SPIN_CONTAINER_CLASS);
     });
 
-    QUnit.test("spin edit handling", (assert) => {
+    QUnit.test("spin edit handling", function(assert) {
         assert.expect(3);
 
         this.instance.option("showSpinButtons", true);
@@ -1190,7 +1190,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), "-1");
     });
 
-    QUnit.test("interactions with spin buttons do not change value if the readOnly option was set to true", (assert) => {
+    QUnit.test("interactions with spin buttons do not change value if the readOnly option was set to true", function(assert) {
         this.instance.option("showSpinButtons", true);
         this.instance.option("value", 100);
         this.instance.option("readOnly", true);
@@ -1204,7 +1204,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), "100");
     });
 
-    QUnit.test("correct round value with integer step", (assert) => {
+    QUnit.test("correct round value with integer step", function(assert) {
         this.instance.option("showSpinButtons", true);
         this.instance.option("value", 0.2);
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1229,7 +1229,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), "-0.8");
     });
 
-    QUnit.test("correct round value with float step", (assert) => {
+    QUnit.test("correct round value with float step", function(assert) {
         this.instance.option("showSpinButtons", true);
         this.instance.option("value", 1.4);
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1253,7 +1253,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), "-2.22");
     });
 
-    QUnit.test("keep null value with 0 step", (assert) => {
+    QUnit.test("keep null value with 0 step", function(assert) {
         this.instance.option("showSpinButtons", true);
         this.instance.option("value", null);
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1268,7 +1268,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), "");
     });
 
-    QUnit.test("spin edit min/max", (assert) => {
+    QUnit.test("spin edit min/max", function(assert) {
         assert.expect(2);
 
         this.instance.option({
@@ -1290,7 +1290,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), "0", "min value is right");
     });
 
-    QUnit.test("spin edit min/max onValueChanged action", (assert) => {
+    QUnit.test("spin edit min/max onValueChanged action", function(assert) {
         assert.expect(2);
 
         this.instance.option({
@@ -1321,7 +1321,7 @@ QUnit.module("options changed callbacks", {
         $spinDown.trigger("dxpointerdown");
     });
 
-    QUnit.test("spin edit long click handling", (assert) => {
+    QUnit.test("spin edit long click handling", function(assert) {
         assert.expect(1);
 
         this.clock = sinon.useFakeTimers();
@@ -1345,7 +1345,7 @@ QUnit.module("options changed callbacks", {
         }
     });
 
-    QUnit.test("spin edit long click handling", (assert) => {
+    QUnit.test("spin edit long click handling", function(assert) {
         assert.expect(2);
 
         this.clock = sinon.useFakeTimers();
@@ -1367,7 +1367,7 @@ QUnit.module("options changed callbacks", {
         }
     });
 
-    QUnit.test("spin button should not catch dxhold event from parent dom elements", (assert) => {
+    QUnit.test("spin button should not catch dxhold event from parent dom elements", function(assert) {
         this.instance.option("showSpinButtons", true);
         this.instance.option("value", 100);
 
@@ -1387,7 +1387,7 @@ QUnit.module("options changed callbacks", {
         }
     });
 
-    QUnit.test("spin edit immediately after keyboard input", (assert) => {
+    QUnit.test("spin edit immediately after keyboard input", function(assert) {
         this.instance.option("showSpinButtons", true);
 
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1407,7 +1407,7 @@ QUnit.module("options changed callbacks", {
         assert.equal($input.val(), 29, "displayed value is correct after spinDown click");
     });
 
-    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", (assert) => {
+    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         this.instance.option({
             onValueChanged() {
                 assert.ok(true);
@@ -1416,7 +1416,7 @@ QUnit.module("options changed callbacks", {
         this.instance.option("value", true);
     });
 
-    QUnit.test("Placeholder must not be visible after setting value by option", (assert) => {
+    QUnit.test("Placeholder must not be visible after setting value by option", function(assert) {
         this.instance.option({ placeholder: "1", value: "" });
         assert.ok(this.element.find(".dx-placeholder").is(":visible"), "placeholder is visible");
 
@@ -1424,7 +1424,7 @@ QUnit.module("options changed callbacks", {
         assert.ok(this.element.find(".dx-placeholder").is(":hidden"), "placeholder is hidden");
     });
 
-    QUnit.test("useLargeSpinButtons option changed", (assert) => {
+    QUnit.test("useLargeSpinButtons option changed", function(assert) {
         this.instance.option({
             showSpinButtons: true,
             useLargeSpinButtons: false
@@ -1436,7 +1436,7 @@ QUnit.module("options changed callbacks", {
         assert.ok(this.element.hasClass(SPIN_TOUCH_FRIENDLY_CLASS), "element has touchFriendly class");
     });
 
-    QUnit.test("onValueChanged option should get jQuery event as a parameter when spin buttons are clicked", (assert) => {
+    QUnit.test("onValueChanged option should get jQuery event as a parameter when spin buttons are clicked", function(assert) {
         let jQueryEvent;
 
         this.instance.option({
@@ -1456,7 +1456,7 @@ QUnit.module("options changed callbacks", {
         assert.equal(jQueryEvent.target, $spinDown.get(0), "jQuery event is defined when spindown click used");
     });
 
-    QUnit.testInActiveWindow("onValueChanged option should get jQuery event as a parameter when mouse wheel is used", (assert) => {
+    QUnit.testInActiveWindow("onValueChanged option should get jQuery event as a parameter when mouse wheel is used", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "this test is actual only for desktop ");
             return;
@@ -1484,7 +1484,7 @@ QUnit.module("options changed callbacks", {
         assert.equal(jQueryEvent.delta, -10, "jQuery event is defined when mousewheel down");
     });
 
-    QUnit.test("onValueChanged option should get jQuery event as a parameter when up/down arrows are used", (assert) => {
+    QUnit.test("onValueChanged option should get jQuery event as a parameter when up/down arrows are used", function(assert) {
         let jQueryEvent;
 
         this.instance.option({
@@ -1506,12 +1506,12 @@ QUnit.module("options changed callbacks", {
 });
 
 QUnit.module("regressions", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.element = $("#numberbox").dxNumberBox();
         this.instance = this.element.dxNumberBox("instance");
     }
 }, () => {
-    QUnit.test("B230398", (assert) => {
+    QUnit.test("B230398", function(assert) {
         assert.expect(3);
 
         const element = $("#numberbox").dxNumberBox({ value: "", placeholder: "auto" });
@@ -1535,7 +1535,7 @@ QUnit.module("regressions", {
         assert.equal(instance.option("value"), null);
     });
 
-    QUnit.test("B234644 - break value update handler in google chrome at desktop and android", (assert) => {
+    QUnit.test("B234644 - break value update handler in google chrome at desktop and android", function(assert) {
         if(!/chrome/i.test(navigator.userAgent)) {
             assert.ok(true);
             return;
@@ -1568,7 +1568,7 @@ QUnit.module("regressions", {
         assert.equal(this.instance.option("value") || '', $input.val(), "check that input value equal option value after incorrect value");
     });
 
-    QUnit.test("B233615 dxNumberbox UI value reset after 'type' option changing in Opera", (assert) => {
+    QUnit.test("B233615 dxNumberbox UI value reset after 'type' option changing in Opera", function(assert) {
         assert.expect(3);
 
         this.instance.option("value", 100);
@@ -1578,7 +1578,7 @@ QUnit.module("regressions", {
         assert.equal(this.element.find("." + INPUT_CLASS).val(), 100, "find and check that value from jQuery is ok too");
     });
 
-    QUnit.test("B235175 - add additional test cases for various numbers", (assert) => {
+    QUnit.test("B235175 - add additional test cases for various numbers", function(assert) {
         assert.expect(10);
 
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1633,7 +1633,7 @@ QUnit.module("regressions", {
         assert.equal($input.val(), "11", "check input value 1");
     });
 
-    QUnit.test("B235175 - one case for minmax numberbox", (assert) => {
+    QUnit.test("B235175 - one case for minmax numberbox", function(assert) {
         assert.expect(4);
 
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1658,7 +1658,7 @@ QUnit.module("regressions", {
         assert.equal($input.val(), "50", "check input value 50");
     });
 
-    QUnit.test("numberbox should correctly process 'undefined' value", (assert) => {
+    QUnit.test("numberbox should correctly process 'undefined' value", function(assert) {
         const instance = this.instance;
 
         instance.option("value", undefined);
@@ -1666,7 +1666,7 @@ QUnit.module("regressions", {
         assert.equal(instance.option("value"), null, "value was reset correctly");
     });
 
-    QUnit.test("B236651 - when we try set zero value that do not change", (assert) => {
+    QUnit.test("B236651 - when we try set zero value that do not change", function(assert) {
         assert.expect(4);
 
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1692,7 +1692,7 @@ QUnit.module("regressions", {
         assert.equal($input.val(), "0", "check input value 0");
     });
 
-    QUnit.test("Both comma and dot can be used as float separator (Q561267)", (assert) => {
+    QUnit.test("Both comma and dot can be used as float separator (Q561267)", function(assert) {
         assert.expect(4);
 
         const $input = this.element.find("." + INPUT_CLASS);
@@ -1723,12 +1723,12 @@ QUnit.module("regressions", {
         assert.equal($input.val(), "1.2");
     });
 
-    QUnit.test("Complete dispose dxNumberBox", (assert) => {
+    QUnit.test("Complete dispose dxNumberBox", function(assert) {
         this.instance._dispose();
         assert.ok(!this.element.children().length);
     });
 
-    QUnit.test("T282446 - widget disabled state change should lead to spin buttons disabled state change", (assert) => {
+    QUnit.test("T282446 - widget disabled state change should lead to spin buttons disabled state change", function(assert) {
         const $element = $("#widget").dxNumberBox({
             disabled: true,
             showSpinButtons: true
@@ -1744,13 +1744,13 @@ QUnit.module("regressions", {
 });
 
 QUnit.module("widget sizing render", {}, () => {
-    QUnit.test("default", (assert) => {
+    QUnit.test("default", function(assert) {
         const $element = $("#widget").dxNumberBox();
 
         assert.ok($element.outerWidth() > 0, "outer width of the element must be more than zero");
     });
 
-    QUnit.test("constructor", (assert) => {
+    QUnit.test("constructor", function(assert) {
         const $element = $("#widget").dxNumberBox({ width: 400 });
         const instance = $element.dxNumberBox("instance");
 
@@ -1758,7 +1758,7 @@ QUnit.module("widget sizing render", {}, () => {
         assert.strictEqual($element.outerWidth(), 400, "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("root with custom width", (assert) => {
+    QUnit.test("root with custom width", function(assert) {
         const $element = $("#widthRootStyle").dxNumberBox();
         const instance = $element.dxNumberBox("instance");
 
@@ -1766,7 +1766,7 @@ QUnit.module("widget sizing render", {}, () => {
         assert.strictEqual($element.outerWidth(), 300, "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("change width", (assert) => {
+    QUnit.test("change width", function(assert) {
         const $element = $("#widget").dxNumberBox();
         const instance = $element.dxNumberBox("instance");
         const customWidth = 400;
@@ -1778,7 +1778,7 @@ QUnit.module("widget sizing render", {}, () => {
 });
 
 QUnit.module("keyboard navigation", {}, () => {
-    QUnit.test("control keys test", (assert) => {
+    QUnit.test("control keys test", function(assert) {
         const element = $("#numberbox").dxNumberBox({
             focusStateEnabled: true,
             value: 100
@@ -1805,7 +1805,7 @@ QUnit.module("keyboard navigation", {}, () => {
         assert.equal(instance.option("value"), 100, "value is correct after upArrow press");
     });
 
-    QUnit.test("it is impossible to change value by keyboard in readonly editor", (assert) => {
+    QUnit.test("it is impossible to change value by keyboard in readonly editor", function(assert) {
         const element = $("#numberbox").dxNumberBox({
             focusStateEnabled: true,
             readOnly: true,
@@ -1825,7 +1825,7 @@ QUnit.module("keyboard navigation", {}, () => {
         assert.equal(instance.option("value"), 100, "value is correct after downArrow press");
     });
 
-    QUnit.test("keypress with meta key should not be prevented", (assert) => {
+    QUnit.test("keypress with meta key should not be prevented", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             focusStateEnabled: true
         });
@@ -1841,7 +1841,7 @@ QUnit.module("keyboard navigation", {}, () => {
         assert.equal(isKeyPressPrevented, false, "keypress with meta is not prevented");
     });
 
-    QUnit.test("keypress with ctrl key should not be prevented", (assert) => {
+    QUnit.test("keypress with ctrl key should not be prevented", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             focusStateEnabled: true
         });
@@ -1857,7 +1857,7 @@ QUnit.module("keyboard navigation", {}, () => {
         assert.equal(isKeyPressPrevented, false, "keypress with meta is not prevented");
     });
 
-    QUnit.test("control keys should not be prevented", (assert) => {
+    QUnit.test("control keys should not be prevented", function(assert) {
         const controlKeys = ["Tab", "Del", "Delete", "Backspace", "Left", "ArrowLeft", "Right", "ArrowRight", "Home", "End"];
 
         let isKeyPressPrevented = false;
@@ -1879,7 +1879,7 @@ QUnit.module("keyboard navigation", {}, () => {
         });
     });
 
-    QUnit.test("Subtract key is not prevented", (assert) => {
+    QUnit.test("Subtract key is not prevented", function(assert) {
         const keyPressStub = sinon.stub();
         const $numberBox = $("#numberbox").dxNumberBox({
             focusStateEnabled: true
@@ -1896,7 +1896,7 @@ QUnit.module("keyboard navigation", {}, () => {
 });
 
 QUnit.module("number validation", {}, () => {
-    QUnit.test("decimal is not removed on valueChangeEvent", (assert) => {
+    QUnit.test("decimal is not removed on valueChangeEvent", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             valueChangeEvent: "keyup"
         });
@@ -1912,7 +1912,7 @@ QUnit.module("number validation", {}, () => {
         assert.equal($input.val(), inputValue, "decimal not removed");
     });
 
-    QUnit.test("T277051 - the 'e' letter entered in the center of text should not be ignored", (assert) => {
+    QUnit.test("T277051 - the 'e' letter entered in the center of text should not be ignored", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: 95
         });
@@ -1931,7 +1931,7 @@ QUnit.module("number validation", {}, () => {
         assert.equal(numberBox.option("value"), 900000, "value is correct");
     });
 
-    QUnit.test("T303827: Delete last number in scientific notation with valueChangeEvent:'keyup'", (assert) => {
+    QUnit.test("T303827: Delete last number in scientific notation with valueChangeEvent:'keyup'", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             valueChangeEvent: 'keyup'
         });
@@ -1965,7 +1965,7 @@ QUnit.module("number validation", {}, () => {
         assert.equal(numberBox.option("value"), expectedOptionValue, "value vas changed");
     });
 
-    QUnit.test("Value shouldn't be reset after point remove", (assert) => {
+    QUnit.test("Value shouldn't be reset after point remove", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             valueChangeEvent: "keyup",
             value: 55.3
@@ -1984,7 +1984,7 @@ QUnit.module("number validation", {}, () => {
         assert.equal($input.val(), "55", "value is correct");
     });
 
-    QUnit.test("When is type 'number' set entered characters should be saved", (assert) => {
+    QUnit.test("When is type 'number' set entered characters should be saved", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             valueChangeEvent: "keyup",
             value: null
@@ -2012,7 +2012,7 @@ QUnit.module("number validation", {}, () => {
         assert.equal(numberBox.option("value"), "0.5", "value is correct");
     });
 
-    QUnit.test("the validation message should be shown if value is invalid", (assert) => {
+    QUnit.test("the validation message should be shown if value is invalid", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             value: "abc"
         });
@@ -2022,7 +2022,7 @@ QUnit.module("number validation", {}, () => {
         assert.equal($numberBox.find(".dx-invalid-message .dx-overlay-content").text(), instance.option("invalidValueMessage"), "validation message is rendered");
     });
 
-    QUnit.test("the validation message should be shown if value is invalid after 'enter' key was pressed", (assert) => {
+    QUnit.test("the validation message should be shown if value is invalid after 'enter' key was pressed", function(assert) {
         const $numberBox = $("#numberbox").dxNumberBox({
             valueChangeEvent: "input"
         }).dxValidator({
@@ -2049,7 +2049,7 @@ QUnit.module("number validation", {}, () => {
         assert.equal($numberBox.find(".dx-invalid-message .dx-overlay-content").text(), "Value is not in range", "validation message is not empty");
     });
 
-    QUnit.test("onValueChanged should be fired after 'enter' key was pressed", (assert) => {
+    QUnit.test("onValueChanged should be fired after 'enter' key was pressed", function(assert) {
         const onValueChangedStub = sinon.stub();
 
         const $numberBox = $("#numberbox").dxNumberBox({
@@ -2068,7 +2068,7 @@ QUnit.module("number validation", {}, () => {
 });
 
 QUnit.module("aria accessibility", {}, () => {
-    QUnit.test("default render", (assert) => {
+    QUnit.test("default render", function(assert) {
         const $element = $("#numberbox").dxNumberBox({});
         const $input = $element.find(`.${INPUT_CLASS}`);
         const inputElement = $input.get(0);
@@ -2080,7 +2080,7 @@ QUnit.module("aria accessibility", {}, () => {
         assert.ok(inputElement.hasAttribute("aria-valuemax"), "required 'aria-valuemax' attribute is defined");
     });
 
-    QUnit.test("aria-valuenow is defined for numberBox with null value (T801129)", (assert) => {
+    QUnit.test("aria-valuenow is defined for numberBox with null value (T801129)", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             value: null
         });
@@ -2090,7 +2090,7 @@ QUnit.module("aria accessibility", {}, () => {
         assert.strictEqual($input.attr("aria-valuetext"), "No data", "'aria-valuetext' attribute is defined when the value isn't defined");
     });
 
-    QUnit.test("'aria-valuetext' attribute must be correctly updated after changing the value", (assert) => {
+    QUnit.test("'aria-valuetext' attribute must be correctly updated after changing the value", function(assert) {
         const $element = $("#numberbox").dxNumberBox({});
         const instance = $element.dxNumberBox("instance");
         const $input = $element.find(`.${INPUT_CLASS}`);
@@ -2106,7 +2106,7 @@ QUnit.module("aria accessibility", {}, () => {
         assert.notOk($input.get(0).hasAttribute("aria-valuetext"), "'aria-valuetext' attribute isn't defined");
     });
 
-    QUnit.test("aria properties", (assert) => {
+    QUnit.test("aria properties", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             min: 12,
             max: 30,
@@ -2120,7 +2120,7 @@ QUnit.module("aria accessibility", {}, () => {
         assert.equal($input.attr("aria-valuenow"), 25, "aria now is correct");
     });
 
-    QUnit.test("aria-valuemin and valuemax attributes should be set when min/max option is 0", (assert) => {
+    QUnit.test("aria-valuemin and valuemax attributes should be set when min/max option is 0", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             min: 0,
             max: 0
@@ -2132,7 +2132,7 @@ QUnit.module("aria accessibility", {}, () => {
         assert.strictEqual($input.attr("aria-valuemax"), "0", "aria max is correct");
     });
 
-    QUnit.test("the dxNumberBox should have value[min/max] when max or min only is specified", (assert) => {
+    QUnit.test("the dxNumberBox should have value[min/max] when max or min only is specified", function(assert) {
         const $element = $("#numberbox").dxNumberBox({
             max: 30,
             value: 25

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -13,7 +13,7 @@ const IE_NUMPAD_MINUS_KEY = "Subtract";
 const CARET_TIMEOUT_DURATION = browser.msie ? 300 : 0; // IE prevent browser text selection on double click if caret was moved
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("#numberbox").dxNumberBox({
             format: "#0.##",
             value: "",
@@ -26,13 +26,13 @@ const moduleConfig = {
         this.keyboard = keyboardMock(this.input, true);
     },
 
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 };
 
 QUnit.module("format: api value changing", moduleConfig, () => {
-    QUnit.test("number type of input should be converted to tel on mobile device when inputMode is unsupported", assert => {
+    QUnit.test("number type of input should be converted to tel on mobile device when inputMode is unsupported", function(assert) {
         const realDeviceMock = sinon.stub(devices, "real").returns({ deviceType: "mobile" });
         const realBrowser = browser;
         const $element = $("<div>").appendTo("body");
@@ -64,7 +64,7 @@ QUnit.module("format: api value changing", moduleConfig, () => {
         }
     });
 
-    QUnit.test("number type of input should be converted to text on desktop device", assert => {
+    QUnit.test("number type of input should be converted to text on desktop device", function(assert) {
         const realDeviceMock = sinon.stub(devices, "real").returns({ deviceType: "desktop" });
         const $element = $("<div>").appendTo("body");
 
@@ -85,12 +85,12 @@ QUnit.module("format: api value changing", moduleConfig, () => {
         }
     });
 
-    QUnit.test("empty value should not be formatted", (assert) => {
+    QUnit.test("empty value should not be formatted", function(assert) {
         this.instance.option("value", "");
         assert.equal(this.input.val(), "", "value is empty");
     });
 
-    QUnit.test("placeholder should disappear when an empty value has been changed", (assert) => {
+    QUnit.test("placeholder should disappear when an empty value has been changed", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: null,
@@ -102,12 +102,12 @@ QUnit.module("format: api value changing", moduleConfig, () => {
         assert.notOk(this.$element.find(".dx-placeholder").is(":visible"), "placeholder is hidden");
     });
 
-    QUnit.test("format should be applied on value change", (assert) => {
+    QUnit.test("format should be applied on value change", function(assert) {
         this.instance.option("value", 12.34);
         assert.equal(this.input.val(), "12.34", "value is correct");
     });
 
-    QUnit.test("value should be reformatted when format option changed", (assert) => {
+    QUnit.test("value should be reformatted when format option changed", function(assert) {
         this.instance.option("value", 123);
         assert.equal(this.input.val(), "123", "value is correct");
 
@@ -115,7 +115,7 @@ QUnit.module("format: api value changing", moduleConfig, () => {
         assert.equal(this.input.val(), "123.00", "value was reformatted");
     });
 
-    QUnit.test("setting value to undefined should work correctly", (assert) => {
+    QUnit.test("setting value to undefined should work correctly", function(assert) {
         this.instance.option({
             format: "#0",
             value: 667
@@ -128,7 +128,7 @@ QUnit.module("format: api value changing", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), undefined, "value is correct");
     });
 
-    QUnit.test("widget should not crash when it is disposing on change (T578115)", (assert) => {
+    QUnit.test("widget should not crash when it is disposing on change (T578115)", function(assert) {
         this.instance.option({
             value: 1,
             onValueChanged(e) {
@@ -141,7 +141,7 @@ QUnit.module("format: api value changing", moduleConfig, () => {
         assert.ok(true, "there was no exceptions");
     });
 
-    QUnit.test("api value changing should hide a placeholder", (assert) => {
+    QUnit.test("api value changing should hide a placeholder", function(assert) {
         this.instance.option({
             format: "$ #0",
             placeholder: "Enter number"
@@ -157,7 +157,7 @@ QUnit.module("format: api value changing", moduleConfig, () => {
         assert.notOk($placeholder.is(":visible"), "placeholder is hidden");
     });
 
-    QUnit.test("text option should be changed after format option change", (assert) => {
+    QUnit.test("text option should be changed after format option change", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 1.23
@@ -169,7 +169,7 @@ QUnit.module("format: api value changing", moduleConfig, () => {
         assert.equal(this.instance.option("text"), "1", "text has been changed");
     });
 
-    QUnit.test("should not update value if the formated text has not been changed", (assert) => {
+    QUnit.test("should not update value if the formated text has not been changed", function(assert) {
         const done = assert.async();
 
         this.instance.option({
@@ -193,7 +193,7 @@ QUnit.module("format: api value changing", moduleConfig, () => {
 });
 
 QUnit.module("format: sign and minus button", moduleConfig, () => {
-    QUnit.test("pressing '-' button should revert the number", (assert) => {
+    QUnit.test("pressing '-' button should revert the number", function(assert) {
         this.instance.option({
             format: "#.000",
             value: 123.456
@@ -228,7 +228,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 123.456, "value has been changed after valueChange event");
     });
 
-    QUnit.test("pressing numpad minus button should revert the number", (assert) => {
+    QUnit.test("pressing numpad minus button should revert the number", function(assert) {
         const isIE = browser.msie;
         const keyName = isIE ? IE_NUMPAD_MINUS_KEY : "-";
 
@@ -254,7 +254,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.equal(this.instance.option("value"), -123.456, "value has been changed after valueChange event");
     });
 
-    QUnit.test("pressing minus with fireFox keyCode should revert the number", (assert) => {
+    QUnit.test("pressing minus with fireFox keyCode should revert the number", function(assert) {
         this.instance.option({
             format: "#.000",
             value: 123.456
@@ -264,7 +264,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.equal(this.input.val(), "-123.456", "value is correct");
     });
 
-    QUnit.test("pressing '-' button should revert zero number", (assert) => {
+    QUnit.test("pressing '-' button should revert zero number", function(assert) {
         this.instance.option({
             format: "#0",
             value: 0
@@ -279,7 +279,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.equal(1 / this.instance.option("value"), Infinity, "value is positive");
     });
 
-    QUnit.test("pressing '-' with different positive and negative parts", (assert) => {
+    QUnit.test("pressing '-' with different positive and negative parts", function(assert) {
         this.instance.option({
             format: "$ #0;($ #0)",
             value: 123
@@ -294,7 +294,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 123, "value is positive");
     });
 
-    QUnit.test("focusout after inverting sign should not lead to value changing", (assert) => {
+    QUnit.test("focusout after inverting sign should not lead to value changing", function(assert) {
         this.instance.option("value", -123);
 
         // note: keyboard mock keyDown send wrong key for '-' and can not be used here
@@ -306,7 +306,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 123, "value is correct");
     });
 
-    QUnit.test("pressing minus button should revert selected number", (assert) => {
+    QUnit.test("pressing minus button should revert selected number", function(assert) {
         if(!browser.msie) {
             this.clock.restore();
         }
@@ -322,7 +322,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 3, end: 6 }, "caret is good");
     });
 
-    QUnit.test("pressing '-' should keep selection", (assert) => {
+    QUnit.test("pressing '-' should keep selection", function(assert) {
         this.instance.option({
             format: "#0.#",
             value: 123.456
@@ -351,7 +351,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret is good");
     });
 
-    QUnit.test("pressing '-' correctly remove the selected part of previous value", (assert) => {
+    QUnit.test("pressing '-' correctly remove the selected part of previous value", function(assert) {
         this.instance.option({
             format: "#0.#",
             value: 123.4
@@ -366,7 +366,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.equal(this.instance.option("value"), -123.4, "value has been changed after valueChange event");
     });
 
-    QUnit.test("NumberBox keeps correct selection after revert the sign", (assert) => {
+    QUnit.test("NumberBox keeps correct selection after revert the sign", function(assert) {
         this.instance.option({
             format: "#0.#;<<#0.#>>",
             value: 123.4
@@ -379,7 +379,7 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 3, end: 4 }, "caret is good");
     });
 
-    QUnit.test("NumberBox should keep selected range after the ValueChange event", (assert) => {
+    QUnit.test("NumberBox should keep selected range after the ValueChange event", function(assert) {
         this.instance.option({
             format: "#0.#;<<#0.#>>",
             value: 123.4
@@ -394,14 +394,14 @@ QUnit.module("format: sign and minus button", moduleConfig, () => {
 });
 
 QUnit.module("format: fixed point format", moduleConfig, () => {
-    QUnit.test("value should be formatted on first input", (assert) => {
+    QUnit.test("value should be formatted on first input", function(assert) {
         this.instance.option("format", "#0.00");
 
         this.keyboard.type("1");
         assert.equal(this.input.val(), "1.00", "required digits was added on first input");
     });
 
-    QUnit.test("value option should have right value after typing when format is enabled (T829935)", (assert) => {
+    QUnit.test("value option should have right value after typing when format is enabled (T829935)", function(assert) {
         this.instance.option("format", "000.00");
 
         this.keyboard.type("1234").change();
@@ -409,7 +409,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 234, "value option is right");
     });
 
-    QUnit.test("value option should have right value after inserting when format is enabled (T829935)", (assert) => {
+    QUnit.test("value option should have right value after inserting when format is enabled (T829935)", function(assert) {
         this.instance.option("format", "000.00");
 
         this.keyboard.caret({ start: 0, end: 6 }).type("12345678").change();
@@ -417,7 +417,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 678, "value option is right");
     });
 
-    QUnit.test("value option should have right value after inserting when format is enabled and decimalSeparator is ',' (T829935)", (assert) => {
+    QUnit.test("value option should have right value after inserting when format is enabled and decimalSeparator is ',' (T829935)", function(assert) {
         const oldDecimalSeparator = config().decimalSeparator;
         config({ decimalSeparator: "," });
 
@@ -432,7 +432,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         }
     });
 
-    QUnit.test("extra decimal points should be ignored", (assert) => {
+    QUnit.test("extra decimal points should be ignored", function(assert) {
         this.instance.option("format", "#0.00");
 
         this.keyboard.type("2..05");
@@ -442,7 +442,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.input.val(), "2.05", "extra point should be prevented");
     });
 
-    QUnit.test("value should be rounded to the low digit on input an extra float digits", (assert) => {
+    QUnit.test("value should be rounded to the low digit on input an extra float digits", function(assert) {
         this.instance.option("format", "#0.00");
 
         this.keyboard.type("2.057").change();
@@ -450,7 +450,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 2.05, "value is correct");
     });
 
-    QUnit.test("required digits should be replaced on input", (assert) => {
+    QUnit.test("required digits should be replaced on input", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 1.23
@@ -460,7 +460,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.input.val(), "1.45", "text is correct");
     });
 
-    QUnit.test("should ignore backspace/delete key down when the caret in the start/end of input (T713045)", (assert) => {
+    QUnit.test("should ignore backspace/delete key down when the caret in the start/end of input (T713045)", function(assert) {
         this.instance.option({
             valueChangeEvent: "keyup",
             format: "#,##0",
@@ -480,7 +480,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.strictEqual(this.input.val(), "1,234");
     });
 
-    QUnit.test("removing required value should replace it to 0", (assert) => {
+    QUnit.test("removing required value should replace it to 0", function(assert) {
         this.instance.option({
             format: "#0.000",
             value: 1.234
@@ -493,7 +493,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.input.val(), "1.400", "delete works");
     });
 
-    QUnit.test("removing decimal point should move the caret", (assert) => {
+    QUnit.test("removing decimal point should move the caret", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 1.23
@@ -503,7 +503,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret().start, 1, "caret was moved");
     });
 
-    QUnit.test("removing last integer should replace it to 0", (assert) => {
+    QUnit.test("removing last integer should replace it to 0", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 1.23
@@ -513,7 +513,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.input.val(), "0.23", "integer was replaced to 0");
     });
 
-    QUnit.test("input with non-required digit", (assert) => {
+    QUnit.test("input with non-required digit", function(assert) {
         this.instance.option("format", "#0.##");
 
         this.keyboard.type("1");
@@ -529,7 +529,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.input.val(), "1.05", "extra digit should be rounded");
     });
 
-    QUnit.test("extra zeros in the end should be prevented from input", (assert) => {
+    QUnit.test("extra zeros in the end should be prevented from input", function(assert) {
         this.instance.option({
             format: "#.##",
             value: 1.52
@@ -540,7 +540,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.input.val(), "1.52", "extra zero input has been prevented");
     });
 
-    QUnit.test("removed digits should not be replaced to 0 when they are not required", (assert) => {
+    QUnit.test("removed digits should not be replaced to 0 when they are not required", function(assert) {
         this.instance.option({
             format: "#0.##",
             value: 1.23
@@ -553,7 +553,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.input.val(), "1", "decimal point was removed together with last float digit");
     });
 
-    QUnit.test("value is not changed when using the big float part", (assert) => {
+    QUnit.test("value is not changed when using the big float part", function(assert) {
         this.instance.option({
             format: "#,##0.##############################",
             value: ""
@@ -567,7 +567,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
         assert.equal(this.instance.option("value"), "3.4");
     });
 
-    QUnit.test("precision should correctly round the value", (assert) => {
+    QUnit.test("precision should correctly round the value", function(assert) {
         this.instance.option({
             format: {
                 type: "fixedPoint",
@@ -581,7 +581,7 @@ QUnit.module("format: fixed point format", moduleConfig, () => {
 });
 
 QUnit.module("format: minimum and maximum", moduleConfig, () => {
-    QUnit.test("value should be fitted into min and max range on change", (assert) => {
+    QUnit.test("value should be fitted into min and max range on change", function(assert) {
         this.instance.option({
             format: "#0.0",
             min: 10,
@@ -596,7 +596,7 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
         assert.equal(this.input.val(), "20.0", "value is fitted after the change event");
     });
 
-    QUnit.test("value removing should be possible when min is specified and stubs are in the format", (assert) => {
+    QUnit.test("value removing should be possible when min is specified and stubs are in the format", function(assert) {
         this.instance.option({
             format: "#,##0 d",
             min: 5,
@@ -614,7 +614,7 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), 7, "value is correct");
     });
 
-    QUnit.test("changing min limit should lead to value change in masked numberbox", (assert) => {
+    QUnit.test("changing min limit should lead to value change in masked numberbox", function(assert) {
         this.instance.option({
             format: "$ #0",
             value: 5,
@@ -626,7 +626,7 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 6", "text has been updated");
     });
 
-    QUnit.test("changing max limit should lead to value change in masked numberbox", (assert) => {
+    QUnit.test("changing max limit should lead to value change in masked numberbox", function(assert) {
         this.instance.option({
             format: "$ #0",
             value: 5,
@@ -638,7 +638,7 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 4", "text has been updated");
     });
 
-    QUnit.test("invert sign should be prevented if minimum is larger than 0", (assert) => {
+    QUnit.test("invert sign should be prevented if minimum is larger than 0", function(assert) {
         this.instance.option({
             min: 0,
             value: 4
@@ -648,14 +648,14 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
         assert.equal(this.input.val(), "4", "reverting was prevented");
     });
 
-    QUnit.test("integer should not be longer than 15 digit", (assert) => {
+    QUnit.test("integer should not be longer than 15 digit", function(assert) {
         this.instance.option("value", 999999999999999);
         this.keyboard.caret(15).type("5");
 
         assert.equal(this.input.val(), "999999999999999", "input was prevented");
     });
 
-    QUnit.test("trailing zeros should not affect 15 digits limit", (assert) => {
+    QUnit.test("trailing zeros should not affect 15 digits limit", function(assert) {
         this.instance.option("format", "#,##0.000000");
         this.instance.option("value", 222222222.120000);
         this.keyboard.caret(12).type("8");
@@ -663,7 +663,7 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
         assert.equal(this.input.val(), "222,222,222.812000", "input was not prevented");
     });
 
-    QUnit.test("leading zeros should not affect 15 digits limit", (assert) => {
+    QUnit.test("leading zeros should not affect 15 digits limit", function(assert) {
         this.instance.option("format", "000000000000000#.00");
         this.instance.option("value", 1);
         this.keyboard.caret(12).type("8");
@@ -671,14 +671,14 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
         assert.equal(this.input.val(), "000000000008001.00", "input was not prevented");
     });
 
-    QUnit.test("negative integer should not be longer than 15 digit", (assert) => {
+    QUnit.test("negative integer should not be longer than 15 digit", function(assert) {
         this.instance.option("value", -999999999999999);
         this.keyboard.caret(16).type("5");
 
         assert.equal(this.input.val(), "-999999999999999", "input was prevented");
     });
 
-    QUnit.test("15-digit value with decimal part should be parsed", (assert) => {
+    QUnit.test("15-digit value with decimal part should be parsed", function(assert) {
         this.instance.option("format", "#0.####");
         this.instance.option("value", 9999999999.999);
         this.keyboard.caret(14).type("9");
@@ -686,7 +686,7 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
         assert.equal(this.input.val(), "9999999999.9999", "input was not prevented");
     });
 
-    QUnit.test("boundary value should correctly apply after second try to set overflow value", (assert) => {
+    QUnit.test("boundary value should correctly apply after second try to set overflow value", function(assert) {
         this.instance.option({
             min: 1,
             max: 4,
@@ -723,7 +723,7 @@ QUnit.module("format: minimum and maximum", moduleConfig, () => {
 });
 
 QUnit.module("format: arabic digit shaping", {
-    beforeEach: () => {
+    beforeEach: function() {
         moduleConfig.beforeEach.call(this);
 
         const arabicDigits = "٠١٢٣٤٥٦٧٨٩";
@@ -757,12 +757,12 @@ QUnit.module("format: arabic digit shaping", {
         });
     },
 
-    afterEach: () => {
+    afterEach: function() {
         moduleConfig.afterEach.call(this);
         numberLocalization.resetInjection();
     }
 }, () => {
-    QUnit.test("mask should work with arabic digit shaping", (assert) => {
+    QUnit.test("mask should work with arabic digit shaping", function(assert) {
         this.keyboard
             .type("١٢٣٤٥")
             .press("backspace")
@@ -776,14 +776,14 @@ QUnit.module("format: arabic digit shaping", {
         assert.equal(this.input.val(), "-١٢٣٤", "arabic minus should work");
     });
 
-    QUnit.test("getFormatPattern should return correct format with arabic digit shaping", (assert) => {
+    QUnit.test("getFormatPattern should return correct format with arabic digit shaping", function(assert) {
         this.instance.option("format", "currency");
         assert.equal(this.instance._getFormatPattern(), "#0.##############");
     });
 });
 
 QUnit.module("format: text input", moduleConfig, () => {
-    QUnit.test("clearing numberbox via keyboard should be possible if non required format is used", (assert) => {
+    QUnit.test("clearing numberbox via keyboard should be possible if non required format is used", function(assert) {
         this.instance.option({
             format: "$ #.##",
             value: 1
@@ -798,19 +798,19 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.equal(this.instance.option("value"), null, "value is correct");
     });
 
-    QUnit.test("invalid chars should be prevented on keydown", (assert) => {
+    QUnit.test("invalid chars should be prevented on keydown", function(assert) {
         this.keyboard.type("12e*3.456");
         assert.equal(this.input.val(), "123.45", "value is correct");
     });
 
-    QUnit.test("input should be correct with group separators", (assert) => {
+    QUnit.test("input should be correct with group separators", function(assert) {
         this.instance.option("format", "$ #,##0.00 d");
 
         this.keyboard.type("1234567.894");
         assert.equal(this.input.val(), "$ 1,234,567.89 d", "input is correct");
     });
 
-    QUnit.test("select and replace all text", (assert) => {
+    QUnit.test("select and replace all text", function(assert) {
         this.instance.option({
             format: "$ #.000 d",
             value: 123
@@ -824,7 +824,7 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 3, end: 3 }, "caret position is correct");
     });
 
-    QUnit.test("don't replace selected text after enter pressed", (assert) => {
+    QUnit.test("don't replace selected text after enter pressed", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 123.45
@@ -838,7 +838,7 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.equal(this.input.val(), "123.45");
     });
 
-    QUnit.test("don't replace selected text after focusOut", (assert) => {
+    QUnit.test("don't replace selected text after focusOut", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 123.45
@@ -852,7 +852,7 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.equal(this.input.val(), "123.45");
     });
 
-    QUnit.test("decimal point should move the caret before float part only", (assert) => {
+    QUnit.test("decimal point should move the caret before float part only", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 123.45
@@ -867,7 +867,7 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 4, end: 4 }, "caret was moved to the float part");
     });
 
-    QUnit.test("input after 0 should not move caret to float part", (assert) => {
+    QUnit.test("input after 0 should not move caret to float part", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 0
@@ -878,12 +878,12 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.equal(this.keyboard.caret().start, 1, "caret is good");
     });
 
-    QUnit.test("ctrl+v should not be prevented", (assert) => {
+    QUnit.test("ctrl+v should not be prevented", function(assert) {
         this.keyboard.keyDown("v", { ctrlKey: true });
         assert.strictEqual(this.keyboard.event.isDefaultPrevented(), false, "keydown event is not prevented");
     });
 
-    QUnit.test("decimal point input should be prevented when it is restricted by the format", (assert) => {
+    QUnit.test("decimal point input should be prevented when it is restricted by the format", function(assert) {
         this.instance.option({
             format: "#0",
             value: 123
@@ -895,7 +895,7 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.equal(this.keyboard.caret().start, 1, "caret should not be moved");
     });
 
-    QUnit.test("leading zeros should be replaced on input", (assert) => {
+    QUnit.test("leading zeros should be replaced on input", function(assert) {
         this.instance.option("format", "$ #0 d");
         this.instance.option("value", 0);
 
@@ -906,7 +906,7 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 12 d", "value is correct");
     });
 
-    QUnit.test("leading zeros should not be replaced if input is before them", (assert) => {
+    QUnit.test("leading zeros should not be replaced if input is before them", function(assert) {
         this.instance.option("format", "#0 d");
         this.instance.option("value", 0);
 
@@ -917,14 +917,14 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.equal(this.input.val(), "120 d", "value is correct");
     });
 
-    QUnit.test("it should be possible to input decimal point when valueChangeEvent is input (T580162)", (assert) => {
+    QUnit.test("it should be possible to input decimal point when valueChangeEvent is input (T580162)", function(assert) {
         this.instance.option("valueChangeEvent", "input");
         this.keyboard.type("1.5");
 
         assert.equal(this.input.val(), "1.5", "value is correct");
     });
 
-    QUnit.test("valueChanged event fires on value apply", (assert) => {
+    QUnit.test("valueChanged event fires on value apply", function(assert) {
         if(!browser.msie) {
             // You can remove this test once issue noted below will resolved
             // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15181565/
@@ -940,7 +940,7 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.ok(valueChangedSpy.calledOnce, "valueChanged event called once");
     });
 
-    QUnit.test("onValueChanged should have change event as a parameter", (assert) => {
+    QUnit.test("onValueChanged should have change event as a parameter", function(assert) {
         const valueChangedHandler = sinon.spy();
         this.instance.option("onValueChanged", valueChangedHandler);
 
@@ -948,7 +948,7 @@ QUnit.module("format: text input", moduleConfig, () => {
         assert.equal(valueChangedHandler.getCall(0).args[0].event.type, "change", "event is correct");
     });
 
-    QUnit.testInActiveWindow("caret position is not changed when the focus out event has occurred", (assert) => {
+    QUnit.testInActiveWindow("caret position is not changed when the focus out event has occurred", function(assert) {
         const _caret = this.instance._caret;
         let caretIsUpdatedOnFocusOut;
         const $input = $(this.instance.element()).find(".dx-texteditor-input");
@@ -969,7 +969,7 @@ QUnit.module("format: text input", moduleConfig, () => {
 });
 
 QUnit.module("format: incomplete value", moduleConfig, () => {
-    QUnit.test("incomplete values should not be reformatted on input", (assert) => {
+    QUnit.test("incomplete values should not be reformatted on input", function(assert) {
         this.instance.option({
             format: "#0.####",
             value: null
@@ -979,7 +979,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "0.0005", "value was typed");
     });
 
-    QUnit.test("incomplete values with stubs should not be reformatted on input", (assert) => {
+    QUnit.test("incomplete values with stubs should not be reformatted on input", function(assert) {
         this.instance.option({
             format: "$ #0.#### kg",
             value: null
@@ -989,7 +989,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 0.0005 kg", "value was typed");
     });
 
-    QUnit.test("incomplete values should not be reformatted on paste", (assert) => {
+    QUnit.test("incomplete values should not be reformatted on paste", function(assert) {
         this.instance.option({
             format: "$ #0.#### kg",
             value: null
@@ -1006,7 +1006,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 0.0005 kg", "walue has been reformatted");
     });
 
-    QUnit.test("paste of value should call valueChanged event on keyup", (assert) => {
+    QUnit.test("paste of value should call valueChanged event on keyup", function(assert) {
         const valueChangedStub = sinon.stub();
         const originalIE = browser.msie;
         const $element = $("<div>").appendTo("body");
@@ -1035,7 +1035,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
     });
 
 
-    QUnit.test("paste of value should call valueChanged event on keyup in IE", (assert) => {
+    QUnit.test("paste of value should call valueChanged event on keyup in IE", function(assert) {
         const valueChangedStub = sinon.stub();
         const originalIE = browser.msie;
         const originalVersion = browser.version;
@@ -1066,7 +1066,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         }
     });
 
-    QUnit.test("incomplete values should be limited by max precision", (assert) => {
+    QUnit.test("incomplete values should be limited by max precision", function(assert) {
         this.instance.option({
             format: "$ #0.### kg",
             value: null
@@ -1079,7 +1079,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 0 kg", "value was reformatted on enter");
     });
 
-    QUnit.test("value can be incomplete after removing via backspace", (assert) => {
+    QUnit.test("value can be incomplete after removing via backspace", function(assert) {
         this.instance.option({
             format: "$ #0.### kg",
             value: 1.2
@@ -1089,7 +1089,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 1. kg", "value has not been reformatted");
     });
 
-    QUnit.test("value can be incomplete after removing via delete", (assert) => {
+    QUnit.test("value can be incomplete after removing via delete", function(assert) {
         this.instance.option({
             format: "$ #0.### kg",
             value: 1.2
@@ -1099,7 +1099,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 1. kg", "value has not been reformatted");
     });
 
-    QUnit.test("value without float part should never be incomplete", (assert) => {
+    QUnit.test("value without float part should never be incomplete", function(assert) {
         this.instance.option({
             format: "$ #0.####",
             value: null
@@ -1110,7 +1110,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 10", "value has been reformatted");
     });
 
-    QUnit.test("zero should not be incomplete", (assert) => {
+    QUnit.test("zero should not be incomplete", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 12.34
@@ -1121,7 +1121,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "0.00", "zero has been formatted");
     });
 
-    QUnit.test("value without an integer part is supported", (assert) => {
+    QUnit.test("value without an integer part is supported", function(assert) {
         this.instance.option({
             format: "$ #.#",
             value: null
@@ -1131,7 +1131,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ .5", "point should be prevented");
     });
 
-    QUnit.test("value with more than one point should not be incomplete", (assert) => {
+    QUnit.test("value with more than one point should not be incomplete", function(assert) {
         this.instance.option({
             format: "$ #0.###",
             value: null
@@ -1141,7 +1141,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 1", "value was reformatted");
     });
 
-    QUnit.test("entering any stub in incomplete value should reformat the value", (assert) => {
+    QUnit.test("entering any stub in incomplete value should reformat the value", function(assert) {
         this.instance.option({
             format: "$ #0.###",
             value: null
@@ -1151,7 +1151,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 1.0", "stub was prevented");
     });
 
-    QUnit.test("incomplete value should be limited by min precision", (assert) => {
+    QUnit.test("incomplete value should be limited by min precision", function(assert) {
         this.instance.option({
             format: "#0.0##",
             value: 1
@@ -1161,25 +1161,25 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "1.0", "zero has not been removed");
     });
 
-    QUnit.test("incomplete values should be reformatted on enter", (assert) => {
+    QUnit.test("incomplete values should be reformatted on enter", function(assert) {
         this.keyboard.type("123.").press("enter");
         assert.equal(this.input.val(), "123", "input was reformatted");
     });
 
-    QUnit.test("incomplete value should be reformatted on enter after paste", (assert) => {
+    QUnit.test("incomplete value should be reformatted on enter after paste", function(assert) {
         this.instance.option("value", null);
         this.input.val("123.");
         this.keyboard.press("enter");
         assert.equal(this.input.val(), "123", "input was reformatted");
     });
 
-    QUnit.testInActiveWindow("incomplete values should be reformatted on focusout", (assert) => {
+    QUnit.testInActiveWindow("incomplete values should be reformatted on focusout", function(assert) {
         this.instance.option("value", 123);
         this.keyboard.caret(3).type(".").blur();
         assert.equal(this.input.val(), "123", "input was reformatted");
     });
 
-    QUnit.test("incomplete value should be reformatted on focusout after paste", (assert) => {
+    QUnit.test("incomplete value should be reformatted on focusout after paste", function(assert) {
         this.instance.option("value", null);
         this.instance.focus();
         this.input.val("123.");
@@ -1188,7 +1188,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
         assert.equal(this.input.val(), "123", "input was reformatted");
     });
 
-    QUnit.test("minus sign typed to the end of the incomplete value should revert sign", (assert) => {
+    QUnit.test("minus sign typed to the end of the incomplete value should revert sign", function(assert) {
         this.instance.option({
             format: "#0.##",
             value: 0
@@ -1204,7 +1204,7 @@ QUnit.module("format: incomplete value", moduleConfig, () => {
 });
 
 QUnit.module("format: percent format", moduleConfig, () => {
-    QUnit.test("percent format should work properly on value change", (assert) => {
+    QUnit.test("percent format should work properly on value change", function(assert) {
         this.instance.option("format", "#0%");
         this.keyboard.type("45").change();
 
@@ -1212,7 +1212,7 @@ QUnit.module("format: percent format", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 0.45, "value is correct");
     });
 
-    QUnit.test("escaped percent should be parsed correctly", (assert) => {
+    QUnit.test("escaped percent should be parsed correctly", function(assert) {
         this.instance.option("format", "#0'%'");
         this.keyboard.type("123").change();
 
@@ -1220,7 +1220,7 @@ QUnit.module("format: percent format", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 123, "value is correct");
     });
 
-    QUnit.test("non-ldml percent format should work properly on value change", (assert) => {
+    QUnit.test("non-ldml percent format should work properly on value change", function(assert) {
         this.instance.option("value", "");
         this.instance.option("format", "percent");
         this.keyboard.type("45").change();
@@ -1229,7 +1229,7 @@ QUnit.module("format: percent format", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 0.45, "value is correct");
     });
 
-    QUnit.test("input before leading zero in percent format", (assert) => {
+    QUnit.test("input before leading zero in percent format", function(assert) {
         this.instance.option("format", "#0%");
         this.instance.option("value", 0);
 
@@ -1238,7 +1238,7 @@ QUnit.module("format: percent format", moduleConfig, () => {
         assert.equal(this.input.val(), "450%", "text is correct");
     });
 
-    QUnit.test("dot should not be ignored in percent format when the value has been parsed correctly", (assert) => {
+    QUnit.test("dot should not be ignored in percent format when the value has been parsed correctly", function(assert) {
         const oldDecimalSeparator = config().decimalSeparator;
 
         config({ decimalSeparator: "," });
@@ -1257,7 +1257,7 @@ QUnit.module("format: percent format", moduleConfig, () => {
 });
 
 QUnit.module("format: removing", moduleConfig, () => {
-    QUnit.test("delete key", (assert) => {
+    QUnit.test("delete key", function(assert) {
         this.instance.option({
             format: "$ #0.00 d",
             value: 123.45
@@ -1281,7 +1281,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 23.50 d", "required digit should be replaced to 0 after removing");
     });
 
-    QUnit.test("backspace key", (assert) => {
+    QUnit.test("backspace key", function(assert) {
         this.instance.option({
             format: "$ #0.00 d",
             value: 123.45
@@ -1305,7 +1305,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 23.50 d", "required digit should be replaced to 0 after removing");
     });
 
-    QUnit.test("removing non required char with negative value", (assert) => {
+    QUnit.test("removing non required char with negative value", function(assert) {
         this.instance.option("value", -123.45);
 
         this.keyboard.caret(6).press("del");
@@ -1315,7 +1315,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "-123", "value is correct");
     });
 
-    QUnit.test("last non required zero should not be typed", (assert) => {
+    QUnit.test("last non required zero should not be typed", function(assert) {
         this.instance.option("format", "#.##");
         this.keyboard.type("1.50");
 
@@ -1325,7 +1325,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "1.5", "value was reformatted on value change");
     });
 
-    QUnit.test("removing with group separators using delete key", (assert) => {
+    QUnit.test("removing with group separators using delete key", function(assert) {
         this.instance.option({
             format: "$ #,##0.## d",
             value: 1234567890
@@ -1346,7 +1346,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 5, end: 5 }, "caret is good after selection removing");
     });
 
-    QUnit.test("removing with group separators using backspace key", (assert) => {
+    QUnit.test("removing with group separators using backspace key", function(assert) {
         this.instance.option({
             format: "$ #,##0.## d",
             value: 1234567890
@@ -1367,7 +1367,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 2,390 d", "value is correct");
     });
 
-    QUnit.test("removing required last char should replace it to 0", (assert) => {
+    QUnit.test("removing required last char should replace it to 0", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 1
@@ -1378,7 +1378,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret is good");
     });
 
-    QUnit.test("removing required last char should replace it to 0 if there are stubs before", (assert) => {
+    QUnit.test("removing required last char should replace it to 0 if there are stubs before", function(assert) {
         this.instance.option({
             format: "$#0.00",
             value: 1
@@ -1389,7 +1389,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.keyboard.caret().start, 2, "caret is good");
     });
 
-    QUnit.test("removing required last char should replace it to 0 if percent format", (assert) => {
+    QUnit.test("removing required last char should replace it to 0 if percent format", function(assert) {
         this.instance.option("format", "#0%");
         this.instance.option("value", 0.01);
         this.keyboard.caret(1).press("backspace");
@@ -1398,7 +1398,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret position is correct");
     });
 
-    QUnit.test("removing required decimal digit should replace it to 0 and move caret", (assert) => {
+    QUnit.test("removing required decimal digit should replace it to 0 and move caret", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 1.23
@@ -1414,7 +1414,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, "caret position is correct");
     });
 
-    QUnit.test("removing integer digit using backspace if group separator is hiding", (assert) => {
+    QUnit.test("removing integer digit using backspace if group separator is hiding", function(assert) {
         this.instance.option({
             format: "#,##0",
             value: 1234
@@ -1425,7 +1425,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, "caret position is correct");
     });
 
-    QUnit.test("removing all characters should change value to 0", (assert) => {
+    QUnit.test("removing all characters should change value to 0", function(assert) {
         this.instance.option({
             format: "$#0",
             value: 1
@@ -1437,7 +1437,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), 0, "value is reseted");
     });
 
-    QUnit.test("removing all digits but not all characters should change value to 0", (assert) => {
+    QUnit.test("removing all digits but not all characters should change value to 0", function(assert) {
         this.instance.option({
             format: "#0.0 kg",
             value: 1
@@ -1449,7 +1449,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.strictEqual(this.instance.option("value"), 0, "value is reseted");
     });
 
-    QUnit.test("removing all digits with backspace should be possible when required zeros are in the end", (assert) => {
+    QUnit.test("removing all digits with backspace should be possible when required zeros are in the end", function(assert) {
         this.instance.option({
             format: "#0.00",
             value: 1
@@ -1464,7 +1464,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "0.00", "value is correct");
     });
 
-    QUnit.test("removing all digits should save the sign", (assert) => {
+    QUnit.test("removing all digits should save the sign", function(assert) {
         this.instance.option({
             format: "#0 kg",
             value: -1
@@ -1475,7 +1475,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.strictEqual(this.input.val(), "-0 kg", "text is correct");
     });
 
-    QUnit.test("removing last digit 0 should save the sign", (assert) => {
+    QUnit.test("removing last digit 0 should save the sign", function(assert) {
         this.instance.option({
             format: "#0 kg",
             value: -0
@@ -1486,7 +1486,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.strictEqual(this.input.val(), "-0 kg", "text is correct");
     });
 
-    QUnit.test("removing digit if decimal format", (assert) => {
+    QUnit.test("removing digit if decimal format", function(assert) {
         this.instance.option({
             format: "00000",
             value: 1234
@@ -1499,7 +1499,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 5, end: 5 }, "caret is correct");
     });
 
-    QUnit.test("removing digit if decimal format with prefix", (assert) => {
+    QUnit.test("removing digit if decimal format with prefix", function(assert) {
         this.instance.option({
             format: "$00000",
             value: 1234
@@ -1512,7 +1512,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 6, end: 6 }, "caret is correct");
     });
 
-    QUnit.test("removing decimal separator should be possible if float part is not required", (assert) => {
+    QUnit.test("removing decimal separator should be possible if float part is not required", function(assert) {
         this.instance.option({
             format: "#0.## kg",
             value: "12.3"
@@ -1525,7 +1525,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "12 kg", "decimal separator has been removed");
     });
 
-    QUnit.test("removing decimal separator if decimal separator is not default", (assert) => {
+    QUnit.test("removing decimal separator if decimal separator is not default", function(assert) {
         const oldDecimalSeparator = config().decimalSeparator;
 
         config({ decimalSeparator: "," });
@@ -1545,7 +1545,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         }
     });
 
-    QUnit.test("caret should be moved to the float part by '.' even when decimal separator is not '.'", (assert) => {
+    QUnit.test("caret should be moved to the float part by '.' even when decimal separator is not '.'", function(assert) {
         const oldDecimalSeparator = config().decimalSeparator;
 
         config({ decimalSeparator: "," });
@@ -1565,7 +1565,7 @@ QUnit.module("format: removing", moduleConfig, () => {
     });
 
     [",", "."].forEach((separator) => {
-        QUnit.test(`caret should be moved to the float part by "${separator}"`, (assert) => {
+        QUnit.test(`caret should be moved to the float part by "${separator}"`, function(assert) {
             this.instance.option({
                 format: {
                     type: 'fixedPoint',
@@ -1583,7 +1583,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         });
     });
 
-    QUnit.test("should parse float numbers with the ',' separator", (assert) => {
+    QUnit.test("should parse float numbers with the ',' separator", function(assert) {
         const oldDecimalSeparator = config().decimalSeparator;
         const input = this.input;
 
@@ -1604,7 +1604,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         }
     });
 
-    QUnit.test("removing a stub in the end or begin of the text should lead to remove minus sign", (assert) => {
+    QUnit.test("removing a stub in the end or begin of the text should lead to remove minus sign", function(assert) {
         this.instance.option({
             format: "$ #0.00;<<$ #0.00>>",
             value: -5
@@ -1624,7 +1624,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "$ 6.00", "value has not been inverted after second removing");
     });
 
-    QUnit.test("minus zero should be reverted after removing minus via backspace", (assert) => {
+    QUnit.test("minus zero should be reverted after removing minus via backspace", function(assert) {
         this.instance.option({
             format: "#0.00 kg",
             value: -0
@@ -1637,7 +1637,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "0.00 kg", "value has not been reverted again");
     });
 
-    QUnit.test("removing a stub should be prevented when it leads to revert sign", (assert) => {
+    QUnit.test("removing a stub should be prevented when it leads to revert sign", function(assert) {
         this.instance.option({
             format: "#0.00 kg",
             value: -0
@@ -1647,7 +1647,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.input.val(), "0.00 kg", "value has been reverted");
     });
 
-    QUnit.test("change event should be fired after stub removed and sign reverted", (assert) => {
+    QUnit.test("change event should be fired after stub removed and sign reverted", function(assert) {
         const changeHandler = sinon.spy();
 
         this.instance.option({
@@ -1664,7 +1664,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(changeHandler.callCount, 1, "change event has not been fired if value is not changed");
     });
 
-    QUnit.test("change event should be fired after extra digits have been entered (IE bug)", (assert) => {
+    QUnit.test("change event should be fired after extra digits have been entered (IE bug)", function(assert) {
         const changeHandler = sinon.spy();
 
         this.instance.option({
@@ -1678,7 +1678,7 @@ QUnit.module("format: removing", moduleConfig, () => {
         assert.equal(this.instance.option("value"), 123.45, "value is correct");
     });
 
-    QUnit.test("change event should not be rised when value has not been changed", (assert) => {
+    QUnit.test("change event should not be rised when value has not been changed", function(assert) {
         const changeHandler = sinon.spy();
 
         this.instance.option("value", null);
@@ -1694,7 +1694,7 @@ QUnit.module("format: removing", moduleConfig, () => {
 });
 
 QUnit.module("format: caret boundaries", moduleConfig, () => {
-    QUnit.test("right arrow limitation", (assert) => {
+    QUnit.test("right arrow limitation", function(assert) {
         this.instance.option({
             format: "#d",
             value: 1
@@ -1706,7 +1706,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.ok(this.keyboard.event.isDefaultPrevented(), "event is prevented");
     });
 
-    QUnit.test("right arrow after select all", (assert) => {
+    QUnit.test("right arrow after select all", function(assert) {
         this.instance.option({
             format: "# d",
             value: 1
@@ -1719,7 +1719,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret is after last digit");
     });
 
-    QUnit.test("left arrow limitation", (assert) => {
+    QUnit.test("left arrow limitation", function(assert) {
         this.instance.option({
             format: "$#",
             value: 1
@@ -1731,7 +1731,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.ok(this.keyboard.event.isDefaultPrevented(), "event is prevented");
     });
 
-    QUnit.test("left arrow after select all", (assert) => {
+    QUnit.test("left arrow after select all", function(assert) {
         this.instance.option({
             format: "$ #0",
             value: 1
@@ -1744,7 +1744,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, "caret is before first digit");
     });
 
-    QUnit.test("home button limitation", (assert) => {
+    QUnit.test("home button limitation", function(assert) {
         this.instance.option({
             format: "$#",
             value: 1
@@ -1756,7 +1756,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret is on the boundary");
     });
 
-    QUnit.test("end button limitation", (assert) => {
+    QUnit.test("end button limitation", function(assert) {
         this.instance.option({
             format: "#d",
             value: 1
@@ -1768,7 +1768,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret is on the boundary");
     });
 
-    QUnit.test("shift+home and shift+end should have default behavior", (assert) => {
+    QUnit.test("shift+home and shift+end should have default behavior", function(assert) {
         this.keyboard.keyDown("home", { shiftKey: true });
         assert.strictEqual(this.keyboard.event.isDefaultPrevented(), false);
 
@@ -1776,12 +1776,12 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.strictEqual(this.keyboard.event.isDefaultPrevented(), false);
     });
 
-    QUnit.test("ctrl+a should have default behavior", (assert) => {
+    QUnit.test("ctrl+a should have default behavior", function(assert) {
         this.keyboard.keyDown("a", { ctrlKey: true });
         assert.deepEqual(this.keyboard.event.isDefaultPrevented(), false);
     });
 
-    QUnit.test("moving caret to closest non stub on click - forward direction", (assert) => {
+    QUnit.test("moving caret to closest non stub on click - forward direction", function(assert) {
         this.instance.option({
             format: "$ #",
             value: 1
@@ -1797,7 +1797,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, "caret was adjusted");
     });
 
-    QUnit.test("moving caret to closest non stub on click - backward direction", (assert) => {
+    QUnit.test("moving caret to closest non stub on click - backward direction", function(assert) {
         this.instance.option({
             format: "#d",
             value: 1
@@ -1810,7 +1810,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret was adjusted");
     });
 
-    QUnit.test("move caret to the end when only stubs remain in the input", (assert) => {
+    QUnit.test("move caret to the end when only stubs remain in the input", function(assert) {
         this.instance.option({
             format: "$ #",
             value: 1
@@ -1826,7 +1826,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, "caret was adjusted");
     });
 
-    QUnit.test("move caret to the start when only stubs remain in the input", (assert) => {
+    QUnit.test("move caret to the start when only stubs remain in the input", function(assert) {
         this.instance.option({
             format: "# p",
             value: 1
@@ -1842,7 +1842,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 0, end: 0 }, "caret was adjusted");
     });
 
-    QUnit.test("caret should not move out of the boundaries when decimal separator was typed in percent format", (assert) => {
+    QUnit.test("caret should not move out of the boundaries when decimal separator was typed in percent format", function(assert) {
         this.instance.option({
             format: "#0%",
             value: 0.01
@@ -1853,7 +1853,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.equal(this.keyboard.caret().start, 1, "caret should not move when decimal part is disabled");
     });
 
-    QUnit.test("caret should not move out of the boundaries when non-available digit was typed", (assert) => {
+    QUnit.test("caret should not move out of the boundaries when non-available digit was typed", function(assert) {
         this.instance.option({
             format: "#0.00 kg",
             value: 1.23
@@ -1864,7 +1864,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.equal(this.keyboard.caret().start, 4, "caret should not move");
     });
 
-    QUnit.testInActiveWindow("caret should be before decimal separator on focusin", (assert) => {
+    QUnit.testInActiveWindow("caret should be before decimal separator on focusin", function(assert) {
         this.instance.option({
             format: "$ #0.## kg",
             value: 1.23
@@ -1880,7 +1880,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 3, end: 3 }, "caret is just before decimal separator");
     });
 
-    QUnit.testInActiveWindow("caret should not change position on focus after fast double click for IE", (assert) => {
+    QUnit.testInActiveWindow("caret should not change position on focus after fast double click for IE", function(assert) {
         if(!browser.msie) {
             assert.expect(0);
             return;
@@ -1912,7 +1912,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
         }, "caret is right after focus by click and dblclick");
     });
 
-    QUnit.testInActiveWindow("numberbox should not prevent all value selection after focus by keyboard navigation for IE", (assert) => {
+    QUnit.testInActiveWindow("numberbox should not prevent all value selection after focus by keyboard navigation for IE", function(assert) {
         if(!browser.msie) {
             assert.expect(0);
             return;
@@ -1931,7 +1931,7 @@ QUnit.module("format: caret boundaries", moduleConfig, () => {
 });
 
 QUnit.module("format: custom parser and formatter", moduleConfig, () => {
-    QUnit.test("custom parser and formatter should work", (assert) => {
+    QUnit.test("custom parser and formatter should work", function(assert) {
         this.instance.option({
             value: null,
             format: {

--- a/testing/tests/DevExpress.ui.widgets.editors/radioButton.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/radioButton.markup.tests.js
@@ -14,13 +14,13 @@ QUnit.testStart(() => {
 const toSelector = cssClass => "." + cssClass;
 
 QUnit.module("button rendering", () => {
-    QUnit.test("widget should be rendered", (assert) => {
+    QUnit.test("widget should be rendered", function(assert) {
         const $radioButton = $("#radioButton").dxRadioButton();
 
         assert.ok($radioButton.hasClass(RADIO_BUTTON_CLASS), "widget class added");
     });
 
-    QUnit.test("icon should be rendered", (assert) => {
+    QUnit.test("icon should be rendered", function(assert) {
         const $radioButton = $("#radioButton").dxRadioButton(),
             $icon = $radioButton.children(toSelector(RADIO_BUTTON_ICON_CLASS));
 
@@ -29,7 +29,7 @@ QUnit.module("button rendering", () => {
 });
 
 QUnit.module("value changing", () => {
-    QUnit.test("widget should be selected if value is set to true", (assert) => {
+    QUnit.test("widget should be selected if value is set to true", function(assert) {
         const $radioButton = $("#radioButton").dxRadioButton({
             value: true
         });
@@ -37,7 +37,7 @@ QUnit.module("value changing", () => {
         assert.ok($radioButton.hasClass(RADIO_BUTTON_CHECKED_CLASS), "selected class added");
     });
 
-    QUnit.test("widget should not be selected if value is set to false", (assert) => {
+    QUnit.test("widget should not be selected if value is set to false", function(assert) {
         const $radioButton = $("#radioButton").dxRadioButton({
             value: false
         });
@@ -47,12 +47,12 @@ QUnit.module("value changing", () => {
 });
 
 QUnit.module("aria accessibility", () => {
-    QUnit.test("aria role", (assert) => {
+    QUnit.test("aria role", function(assert) {
         const $element = $("#radioButton").dxRadioButton();
         assert.equal($element.attr("role"), "radio", "aria role is correct");
     });
 
-    QUnit.test("aria properties if value is set to true", (assert) => {
+    QUnit.test("aria properties if value is set to true", function(assert) {
         const $element = $("#radioButton").dxRadioButton({ value: true });
 
         $element.dxRadioButton("instance");
@@ -60,7 +60,7 @@ QUnit.module("aria accessibility", () => {
         assert.equal($element.attr("aria-checked"), "true", "aria checked true is correct");
     });
 
-    QUnit.test("aria properties if value is set to false", (assert) => {
+    QUnit.test("aria properties if value is set to false", function(assert) {
         const $element = $("#radioButton").dxRadioButton({ value: false });
 
         $element.dxRadioButton("instance");

--- a/testing/tests/DevExpress.ui.widgets.editors/radioButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/radioButton.tests.js
@@ -89,7 +89,7 @@ QUnit.test("state changes on space press", function(assert) {
 QUnit.module("validation");
 
 if(devices.real().deviceType === "desktop") {
-    QUnit.test("the click should be processed before the validation message is shown (T570458)", (assert) => {
+    QUnit.test("the click should be processed before the validation message is shown (T570458)", function(assert) {
         const $radioButton = $("#radioButton")
             .dxRadioButton({})
             .dxValidator({
@@ -114,7 +114,7 @@ if(devices.real().deviceType === "desktop") {
         assert.notOk(isValidationMessageVisible());
     });
 
-    QUnit.test("should show validation message after focusing", (assert) => {
+    QUnit.test("should show validation message after focusing", function(assert) {
         const clock = sinon.useFakeTimers();
         const $radioButton = $("#radioButton")
             .dxRadioButton({})

--- a/testing/tests/DevExpress.ui.widgets.editors/radioGroup.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/radioGroup.markup.tests.js
@@ -20,22 +20,22 @@ const RADIO_GROUP_CLASS = "dx-radiogroup",
 const toSelector = cssClass => "." + cssClass;
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         executeAsyncMock.setup();
     },
-    afterEach: () => {
+    afterEach: function() {
         executeAsyncMock.teardown();
     }
 };
 
 QUnit.module("buttons group rendering", moduleConfig, () => {
-    QUnit.test("widget should be rendered", (assert) => {
+    QUnit.test("widget should be rendered", function(assert) {
         const $radioGroup = $("#radioGroup").dxRadioGroup();
 
         assert.ok($radioGroup.hasClass(RADIO_GROUP_CLASS), "widget class added");
     });
 
-    QUnit.test("widget should generate buttons", (assert) => {
+    QUnit.test("widget should generate buttons", function(assert) {
         const $radioGroup = $("#radioGroup").dxRadioGroup({
             items: [
                 { text: "0" },
@@ -47,13 +47,13 @@ QUnit.module("buttons group rendering", moduleConfig, () => {
         assert.equal($radioGroup.find(toSelector(RADIO_BUTTON_CLASS)).length, 3, "buttons generated");
     });
 
-    QUnit.test("empty message should not be generated if no items", (assert) => {
+    QUnit.test("empty message should not be generated if no items", function(assert) {
         const $radioGroup = $("#radioGroup").dxRadioGroup();
 
         assert.equal($radioGroup.find(".dx-scrollview-content").text(), "", "empty message is not shown");
     });
 
-    QUnit.test("widget should correctly process 'disabled' option changed", (assert) => {
+    QUnit.test("widget should correctly process 'disabled' option changed", function(assert) {
         const $radioGroup = $("#radioGroup").dxRadioGroup({
             items: [
                 { text: "0" },
@@ -73,7 +73,7 @@ QUnit.module("buttons group rendering", moduleConfig, () => {
 });
 
 QUnit.module("buttons rendering", moduleConfig, () => {
-    QUnit.test("button markup item if item.value is specified", (assert) => {
+    QUnit.test("button markup item if item.value is specified", function(assert) {
         const $radioGroup = $("#radioGroup").dxRadioGroup({
             items: [
                 { text: "0", value: "0" }
@@ -85,7 +85,7 @@ QUnit.module("buttons rendering", moduleConfig, () => {
         assert.equal($radioButton.text(), "0", "text rendered correctly");
     });
 
-    QUnit.test("button markup item if item.value is not specified", (assert) => {
+    QUnit.test("button markup item if item.value is not specified", function(assert) {
         const $radioGroup = $("#radioGroup").dxRadioGroup({
             items: [
                 { text: "0" }
@@ -97,7 +97,7 @@ QUnit.module("buttons rendering", moduleConfig, () => {
         assert.equal($radioButton.text(), "0", "text rendered correctly");
     });
 
-    QUnit.test("button markup item if item is primitive string", (assert) => {
+    QUnit.test("button markup item if item is primitive string", function(assert) {
         const $radioGroup = $("#radioGroup").dxRadioGroup({
             items: [
                 "0"
@@ -108,7 +108,7 @@ QUnit.module("buttons rendering", moduleConfig, () => {
         assert.equal($radioButton.text(), "0", "text rendered correctly");
     });
 
-    QUnit.test("button markup item if item has html", (assert) => {
+    QUnit.test("button markup item if item has html", function(assert) {
         const $radioGroup = $("#radioGroup").dxRadioGroup({
             items: [
                 { html: "<input type='radio' value='foo'>" }
@@ -123,7 +123,7 @@ QUnit.module("buttons rendering", moduleConfig, () => {
 });
 
 QUnit.module("hidden input", () => {
-    QUnit.test("a hidden input should be rendered", (assert) => {
+    QUnit.test("a hidden input should be rendered", function(assert) {
         const $element = $("#radioGroup").dxRadioGroup(),
             $input = $element.find("input");
 
@@ -131,7 +131,7 @@ QUnit.module("hidden input", () => {
         assert.equal($input.attr("type"), "hidden", "the input type is 'hidden'");
     });
 
-    QUnit.test("the hidden input should have correct value on widget init", (assert) => {
+    QUnit.test("the hidden input should have correct value on widget init", function(assert) {
         const $element = $("#radioGroup").dxRadioGroup({
                 items: [1, 2, 3],
                 value: 2
@@ -141,7 +141,7 @@ QUnit.module("hidden input", () => {
         assert.equal($input.val(), "2", "input value is correct");
     });
 
-    QUnit.test("the hidden input should get display text as value if widget value is an object", (assert) => {
+    QUnit.test("the hidden input should get display text as value if widget value is an object", function(assert) {
         const items = [{ id: 1, text: "one" }],
             $element = $("#radioGroup").dxRadioGroup({
                 items: items,
@@ -153,7 +153,7 @@ QUnit.module("hidden input", () => {
         assert.equal($input.val(), items[0].text, "input value is correct");
     });
 
-    QUnit.test("the hidden input should get value in respect of the 'valueExpr' option", (assert) => {
+    QUnit.test("the hidden input should get value in respect of the 'valueExpr' option", function(assert) {
         const items = [{ id: 1, text: "one" }],
             $element = $("#radioGroup").dxRadioGroup({
                 items: items,
@@ -168,7 +168,7 @@ QUnit.module("hidden input", () => {
 });
 
 QUnit.module("the 'name' option", () => {
-    QUnit.test("widget hidden input should get the 'name' attribute with a correct value", (assert) => {
+    QUnit.test("widget hidden input should get the 'name' attribute with a correct value", function(assert) {
         const expectedName = "some_name",
             $element = $("#radioGroup").dxRadioGroup({
                 name: expectedName
@@ -180,7 +180,7 @@ QUnit.module("the 'name' option", () => {
 });
 
 QUnit.module("value", moduleConfig, () => {
-    QUnit.test("item checked on start", (assert) => {
+    QUnit.test("item checked on start", function(assert) {
         const done = assert.async();
 
         executeAsyncMock.teardown();
@@ -201,7 +201,7 @@ QUnit.module("value", moduleConfig, () => {
 });
 
 QUnit.module("valueExpr", moduleConfig, () => {
-    QUnit.test("value should be correct if valueExpr is a string", (assert) => {
+    QUnit.test("value should be correct if valueExpr is a string", function(assert) {
         const items = [
             { number: 0, caption: "zero" },
             { number: 1, caption: "one" }
@@ -225,7 +225,7 @@ QUnit.module("valueExpr", moduleConfig, () => {
 });
 
 QUnit.module("widget sizing render", moduleConfig, () => {
-    QUnit.test("default", (assert) => {
+    QUnit.test("default", function(assert) {
         const $element = $("#widget").dxRadioGroup({
             items: [
                 { text: "0" },
@@ -238,7 +238,7 @@ QUnit.module("widget sizing render", moduleConfig, () => {
         assert.ok($element[0].offsetWidth > 0, "outer width of the element must be more than zero");
     });
 
-    QUnit.test("constructor", (assert) => {
+    QUnit.test("constructor", function(assert) {
         const $element = $("#widget").dxRadioGroup({
                 items: [
                     { text: "0" },
@@ -254,7 +254,7 @@ QUnit.module("widget sizing render", moduleConfig, () => {
         assert.strictEqual($element[0].style.width, "400px", "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("root with custom width", (assert) => {
+    QUnit.test("root with custom width", function(assert) {
         const $element = $("#widthRootStyle").dxRadioGroup({
                 items: [
                     { text: "0" },
@@ -272,7 +272,7 @@ QUnit.module("widget sizing render", moduleConfig, () => {
 
 var helper;
 QUnit.module(`Aria accessibility`, {
-    beforeEach: () => {
+    beforeEach: function() {
         helper = new ariaAccessibilityTestHelper({
             createWidget: ($element, options) => new RadioGroup($element,
                 $.extend({
@@ -280,24 +280,24 @@ QUnit.module(`Aria accessibility`, {
                 }, options))
         });
     },
-    afterEach: () => {
+    afterEach: function() {
         helper.$widget.remove();
     }
 }, () => {
-    QUnit.test(`Items: []`, () => {
+    QUnit.test(`Items: []`, function() {
         helper.createWidget({ });
 
         helper.checkAttributes(helper.$widget, { role: "radiogroup", tabindex: "0" }, "widget");
     });
 
-    QUnit.test(`Items: [1, 2, 3], Item.selected: true`, () => {
+    QUnit.test(`Items: [1, 2, 3], Item.selected: true`, function() {
         helper.createWidget({ items: [1, 2, 3], value: 1 });
 
         helper.checkAttributes(helper.$widget, { role: "radiogroup", tabindex: "0" }, "widget");
         helper.checkItemsAttributes([0], { attributes: ["aria-selected", "aria-checked"], role: "radio" });
     });
 
-    QUnit.test(`Items: [1, 2, 3], Item.selected: true, set focusedElement -> clean focusedElement`, () => {
+    QUnit.test(`Items: [1, 2, 3], Item.selected: true, set focusedElement -> clean focusedElement`, function() {
         helper.createWidget({ items: [1, 2, 3], value: 1 });
 
         helper.widget.option("focusedElement", helper.getItems().eq(0));

--- a/testing/tests/DevExpress.ui.widgets.editors/radioGroup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/radioGroup.tests.js
@@ -23,10 +23,10 @@ const RADIO_BUTTON_CHECKED_CLASS = "dx-radiobutton-checked";
 const FOCUSED_CLASS = "dx-state-focused";
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         executeAsyncMock.setup();
     },
-    afterEach: () => {
+    afterEach: function() {
         executeAsyncMock.teardown();
     }
 };
@@ -35,7 +35,7 @@ const createRadioGroup = options => $("#radioGroup").dxRadioGroup(options);
 const getInstance = $element => $element.dxRadioGroup("instance");
 
 module("nested radio group", moduleConfig, () => {
-    test("T680199 - click on nested radio group in template should not affect on contaier parent radio group", assert => {
+    test("T680199 - click on nested radio group in template should not affect on contaier parent radio group", function(assert) {
         let $nestedRadioGroup;
 
         const $radioGroup = createRadioGroup({
@@ -65,7 +65,7 @@ module("nested radio group", moduleConfig, () => {
         assert.ok(parentItemElement.hasClass(RADIO_BUTTON_CHECKED_CLASS), "item of parent radio group is not changed");
     });
 
-    test("T680199 - click on one nested radio group doesn't change another nested group", assert => {
+    test("T680199 - click on one nested radio group doesn't change another nested group", function(assert) {
         let $nestedRadioGroup1,
             $nestedRadioGroup2;
 
@@ -94,7 +94,7 @@ module("nested radio group", moduleConfig, () => {
         assert.notOk(firstNestedItemElement2.hasClass(RADIO_BUTTON_CHECKED_CLASS), "item of second nested radio group is not changed");
     });
 
-    QUnit.test("item template can return default template name", (assert) => {
+    QUnit.test("item template can return default template name", function(assert) {
         const instance = $("#radioGroup").dxRadioGroup({
             items: [1, 2, 3],
             itemTemplate: function() {
@@ -108,7 +108,7 @@ module("nested radio group", moduleConfig, () => {
 });
 
 module("buttons group rendering", () => {
-    test("onContentReady fired after the widget is fully ready", assert => {
+    test("onContentReady fired after the widget is fully ready", function(assert) {
         assert.expect(2);
 
         createRadioGroup({
@@ -122,7 +122,7 @@ module("buttons group rendering", () => {
         });
     });
 
-    test("onContentReady should rise after changing dataSource (T697809)", assert => {
+    test("onContentReady should rise after changing dataSource (T697809)", function(assert) {
         const onContentReadyHandler = sinon.stub(),
             instance = getInstance(
                 createRadioGroup({
@@ -138,7 +138,7 @@ module("buttons group rendering", () => {
 });
 
 module("layout", moduleConfig, () => {
-    test("should be generated proper class with vertical layout", assert => {
+    test("should be generated proper class with vertical layout", function(assert) {
         const $radioGroup = createRadioGroup({
             layout: "vertical"
         });
@@ -146,7 +146,7 @@ module("layout", moduleConfig, () => {
         assert.ok($radioGroup.hasClass(RADIO_GROUP_VERTICAL_CLASS), "class set correctly");
     });
 
-    test("should be generated proper class with horizontal layout", assert => {
+    test("should be generated proper class with horizontal layout", function(assert) {
         const $radioGroup = createRadioGroup({
             layout: "horizontal"
         });
@@ -154,7 +154,7 @@ module("layout", moduleConfig, () => {
         assert.ok($radioGroup.hasClass(RADIO_GROUP_HORIZONTAL_CLASS), "class set correctly");
     });
 
-    test("should be generated proper class when layout is changed", assert => {
+    test("should be generated proper class when layout is changed", function(assert) {
         const $radioGroup = createRadioGroup({
             layout: "horizontal"
         });
@@ -164,7 +164,7 @@ module("layout", moduleConfig, () => {
         assert.ok($radioGroup.hasClass(RADIO_GROUP_VERTICAL_CLASS), "class set correctly");
     });
 
-    test("On the tablet radio group must use a horizontal layout", assert => {
+    test("On the tablet radio group must use a horizontal layout", function(assert) {
         devices.current("iPad");
 
         const $radioGroup = createRadioGroup(),
@@ -173,7 +173,7 @@ module("layout", moduleConfig, () => {
         assert.ok(isHorizontalLayout, "radio group on tablet have horizontal layout");
     });
 
-    test("RadioGroup items should have the 'dx-radio-button' class after render on deferUpdate (T820582)", (assert) => {
+    test("RadioGroup items should have the 'dx-radio-button' class after render on deferUpdate (T820582)", function(assert) {
         const items = [
             { text: "test 1" },
             { text: "test 2" }
@@ -190,7 +190,7 @@ module("layout", moduleConfig, () => {
 });
 
 module("hidden input", () => {
-    test("the hidden input should get correct value on widget value change", assert => {
+    test("the hidden input should get correct value on widget value change", function(assert) {
         const $element = createRadioGroup({
                 items: [1, 2, 3],
                 value: 2
@@ -205,7 +205,7 @@ module("hidden input", () => {
 
 module("value", moduleConfig, () => {
 
-    test("should throw the W1002 error when the value is unknown key", assert => {
+    test("should throw the W1002 error when the value is unknown key", function(assert) {
         const errorLogStub = sinon.stub(errors, "log");
 
         createRadioGroup({
@@ -218,7 +218,7 @@ module("value", moduleConfig, () => {
         errorLogStub.restore();
     });
 
-    test("should not throw the W1002 error when the value is 'null' (T823478)", assert => {
+    test("should not throw the W1002 error when the value is 'null' (T823478)", function(assert) {
         const errorLogStub = sinon.stub(errors, "log");
 
         createRadioGroup({
@@ -230,7 +230,7 @@ module("value", moduleConfig, () => {
         errorLogStub.restore();
     });
 
-    test("should not throw the W1002 error when the value is changed to 'null' (T823478)", assert => {
+    test("should not throw the W1002 error when the value is changed to 'null' (T823478)", function(assert) {
         const errorLogStub = sinon.stub(errors, "log");
 
         const instance = getInstance(
@@ -246,7 +246,7 @@ module("value", moduleConfig, () => {
         errorLogStub.restore();
     });
 
-    test("should not throw the W1002 error when the reset method is called (T823478)", assert => {
+    test("should not throw the W1002 error when the reset method is called (T823478)", function(assert) {
         const errorLogStub = sinon.stub(errors, "log");
 
         createRadioGroup({
@@ -258,7 +258,7 @@ module("value", moduleConfig, () => {
         errorLogStub.restore();
     });
 
-    test("should have correct initialized selection", assert => {
+    test("should have correct initialized selection", function(assert) {
         let radioGroupInstance = null;
         const isItemChecked = index => radioGroupInstance.itemElements().eq(index).hasClass(RADIO_BUTTON_CHECKED_CLASS);
 
@@ -284,7 +284,7 @@ module("value", moduleConfig, () => {
         assert.notOk(isItemChecked(2));
     });
 
-    QUnit.test("null item should be selectable", (assert) => {
+    QUnit.test("null item should be selectable", function(assert) {
         const radioGroupInstance = getInstance(
             createRadioGroup({
                 items: [
@@ -312,7 +312,7 @@ module("value", moduleConfig, () => {
         assert.ok($radioButtons.eq(3).hasClass("dx-radiobutton-checked"), "undefined item is selected");
     });
 
-    test("repaint of widget shouldn't reset value option", assert => {
+    test("repaint of widget shouldn't reset value option", function(assert) {
         const items = [{ text: "0" }, { text: "1" }];
         const $radioGroup = createRadioGroup({
                 items: items,
@@ -324,7 +324,7 @@ module("value", moduleConfig, () => {
         assert.strictEqual(radioGroup.option("value"), items[1]);
     });
 
-    test("value is changed on item click", assert => {
+    test("value is changed on item click", function(assert) {
         assert.expect(1);
 
         let value;
@@ -341,7 +341,7 @@ module("value", moduleConfig, () => {
         assert.equal(value, 1, "value changed");
     });
 
-    test("onValueChanged option should get jQuery event as a parameter", assert => {
+    test("onValueChanged option should get jQuery event as a parameter", function(assert) {
         let jQueryEvent,
             $radioGroup = createRadioGroup({
                 items: [1, 2, 3],
@@ -360,7 +360,7 @@ module("value", moduleConfig, () => {
 });
 
 module("valueExpr", moduleConfig, () => {
-    test("value should be correct if valueExpr is a string", assert => {
+    test("value should be correct if valueExpr is a string", function(assert) {
         const items = [
             { number: 1, caption: "one" },
             { number: 2, caption: "two" }
@@ -394,7 +394,7 @@ module("valueExpr", moduleConfig, () => {
         assert.equal($(radioGroup.itemElements()).find(`.${RADIO_BUTTON_CHECKED_CLASS}`).length, 0, "no items selected");
     });
 
-    test("value should be correct if valueExpr is a function", assert => {
+    test("value should be correct if valueExpr is a function", function(assert) {
         const items = [
             { text: "text1", value: true },
             { text: "text2", value: false }
@@ -416,7 +416,7 @@ module("valueExpr", moduleConfig, () => {
         assert.ok(itemElement.hasClass(RADIO_BUTTON_CHECKED_CLASS));
     });
 
-    test("displayExpr option should work", assert => {
+    test("displayExpr option should work", function(assert) {
         const radioGroup = getInstance(
             createRadioGroup({
                 dataSource: [{ id: 1, name: "Item 1" }],
@@ -432,7 +432,7 @@ module("valueExpr", moduleConfig, () => {
 });
 
 module("widget sizing render", moduleConfig, () => {
-    test("change width", assert => {
+    test("change width", function(assert) {
         const $element = createRadioGroup({
                 items: [
                     { text: "0" },
@@ -451,7 +451,7 @@ module("widget sizing render", moduleConfig, () => {
 });
 
 module("keyboard navigation", moduleConfig, () => {
-    test("keys tests", assert => {
+    test("keys tests", function(assert) {
         assert.expect(3);
 
         const items = [{ text: "0" }, { text: "1" }, { text: "2" }, { text: "3" }],
@@ -474,7 +474,7 @@ module("keyboard navigation", moduleConfig, () => {
         assert.equal(instance.option("value"), items[0], "first item chosen");
     });
 
-    test("control keys should be prevented", assert => {
+    test("control keys should be prevented", function(assert) {
         const items = [{ text: "0" }, { text: "1" }];
         const $element = createRadioGroup({
             focusStateEnabled: true,
@@ -501,7 +501,7 @@ module("keyboard navigation", moduleConfig, () => {
         assert.ok(isDefaultPrevented, "space is default prevented");
     });
 
-    test("keyboard navigation does not work in disabled widget", assert => {
+    test("keyboard navigation does not work in disabled widget", function(assert) {
         const items = [{ text: "0" }, { text: "1" }, { text: "2" }, { text: "3" }],
             $element = createRadioGroup({
                 focusStateEnabled: true,
@@ -512,7 +512,7 @@ module("keyboard navigation", moduleConfig, () => {
         assert.ok($element.attr('tabindex') === undefined, "collection of radio group has not tabindex");
     });
 
-    test("radio group items should not have tabIndex(T674238)", assert => {
+    test("radio group items should not have tabIndex(T674238)", function(assert) {
         const items = [{ text: "0" }, { text: "1" }],
             $element = createRadioGroup({
                 focusStateEnabled: true,
@@ -535,7 +535,7 @@ if(devices.current().deviceType === "desktop") {
 }
 
 module("focus policy", moduleConfig, () => {
-    test("focused-state set up on radio group after focusing on any item", assert => {
+    test("focused-state set up on radio group after focusing on any item", function(assert) {
         assert.expect(2);
 
         const $radioGroup = createRadioGroup({
@@ -553,7 +553,7 @@ module("focus policy", moduleConfig, () => {
         assert.ok($radioGroup.hasClass(FOCUSED_CLASS), "radio group was focused after focusing on item");
     });
 
-    test("radioGroup item has not dx-state-focused class after radioGroup lose focus", assert => {
+    test("radioGroup item has not dx-state-focused class after radioGroup lose focus", function(assert) {
         assert.expect(2);
 
         const $radioGroup = createRadioGroup({
@@ -573,7 +573,7 @@ module("focus policy", moduleConfig, () => {
         assert.ok(!$firstRButton.hasClass(FOCUSED_CLASS), "radio group item lost focus after focusout on radio group");
     });
 
-    test("radioGroup item has not dx-state-focused class after radioGroup lose focus", assert => {
+    test("radioGroup item has not dx-state-focused class after radioGroup lose focus", function(assert) {
         assert.expect(2);
 
         const $radioGroup = createRadioGroup({
@@ -590,7 +590,7 @@ module("focus policy", moduleConfig, () => {
         assert.ok($firstRButton.hasClass(FOCUSED_CLASS), "radioGroup item is not focused");
     });
 
-    test("radioGroup element should get 'dx-state-focused' class", assert => {
+    test("radioGroup element should get 'dx-state-focused' class", function(assert) {
         const $radioGroup = createRadioGroup({
             items: [1, 2, 3],
             focusStateEnabled: true
@@ -601,7 +601,7 @@ module("focus policy", moduleConfig, () => {
         assert.ok($radioGroup.hasClass(FOCUSED_CLASS), "element got 'dx-state-focused' class");
     });
 
-    test("option 'accessKey' has effect", assert => {
+    test("option 'accessKey' has effect", function(assert) {
         const $radioGroup = createRadioGroup({
                 items: [1, 2, 3],
                 focusStateEnabled: true,
@@ -615,7 +615,7 @@ module("focus policy", moduleConfig, () => {
         assert.equal($radioGroup.attr("accessKey"), "o", "access key is correct after change");
     });
 
-    test("option 'tabIndex' has effect", assert => {
+    test("option 'tabIndex' has effect", function(assert) {
         const $radioGroup = createRadioGroup({
                 items: [1, 2, 3],
                 focusStateEnabled: true,
@@ -628,7 +628,7 @@ module("focus policy", moduleConfig, () => {
         assert.equal($radioGroup.attr("tabIndex"), 7, "tab index is correct after change");
     });
 
-    testInActiveWindow("the 'focus()' method should set focused class to widget", assert => {
+    testInActiveWindow("the 'focus()' method should set focused class to widget", function(assert) {
         const $radioGroup = createRadioGroup({
             focusStateEnabled: true
         });
@@ -640,7 +640,7 @@ module("focus policy", moduleConfig, () => {
 });
 
 module("option changed", () => {
-    test("items from the getDataSource method are wrong when the dataSource option is changed", assert => {
+    test("items from the getDataSource method are wrong when the dataSource option is changed", function(assert) {
         const instance = getInstance(
             createRadioGroup({
                 dataSource: [1, 2, 3]
@@ -652,7 +652,7 @@ module("option changed", () => {
         assert.deepEqual(instance.getDataSource().items(), [4, 5, 6], "items from data source");
     });
 
-    test("items from the getDataSource method are wrong when the dataSource option is changed if uses an instance of dataSource", assert => {
+    test("items from the getDataSource method are wrong when the dataSource option is changed if uses an instance of dataSource", function(assert) {
         const instance = getInstance(
             createRadioGroup({
                 dataSource: new DataSource({ store: [1, 2, 3] })

--- a/testing/tests/DevExpress.ui.widgets.editors/rangeSlider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/rangeSlider.tests.js
@@ -1166,7 +1166,7 @@ QUnit.test("reset method should set value to default", function(assert) {
 
 QUnit.module("Validation", () => {
     [false, true].forEach((isValid) => {
-        QUnit.test(`initial state - isValid = ${isValid}, change the "value" option`, (assert) => {
+        QUnit.test(`initial state - isValid = ${isValid}, change the "value" option`, function(assert) {
             const instance = $("#slider").dxRangeSlider({
                 value: [10, 30],
                 isValid
@@ -1188,7 +1188,7 @@ QUnit.module("Validation", () => {
             assert.deepEqual(value, [15, 20], "'value' argument of the validation callback is correct");
         });
 
-        QUnit.test(`initial state - isValid = ${isValid}, change the "start" option`, (assert) => {
+        QUnit.test(`initial state - isValid = ${isValid}, change the "start" option`, function(assert) {
             const instance = $("#slider").dxRangeSlider({
                 value: [10, 30],
                 isValid
@@ -1209,7 +1209,7 @@ QUnit.module("Validation", () => {
             assert.deepEqual(value, [15, 30], "'value' argument of the validation callback is correct");
         });
 
-        QUnit.test(`initial state - isValid = ${isValid}, change the "end" option`, (assert) => {
+        QUnit.test(`initial state - isValid = ${isValid}, change the "end" option`, function(assert) {
             const instance = $("#slider").dxRangeSlider({
                 value: [10, 30],
                 isValid

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -73,19 +73,19 @@ const toSelector = (className) => {
 };
 
 const moduleSetup = {
-    beforeEach: () => {
+    beforeEach: function() {
         SelectBox.defaultOptions({ options: { deferRendering: false } });
         fx.off = true;
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.clock.restore();
     }
 };
 
 QUnit.module("rendering with css", {}, () => {
-    QUnit.test("Right width of popup", (assert) => {
+    QUnit.test("Right width of popup", function(assert) {
         let $element, instance, $popup;
 
         $element = $("#selectBox").dxSelectBox({ width: 100 });
@@ -101,7 +101,7 @@ QUnit.module("rendering with css", {}, () => {
 
 QUnit.module("hidden input", moduleSetup, () => {
 
-    QUnit.test("the hidden input should get correct value on widget value change", (assert) => {
+    QUnit.test("the hidden input should get correct value on widget value change", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [1, 2, 3],
                 value: 2
@@ -113,7 +113,7 @@ QUnit.module("hidden input", moduleSetup, () => {
         assert.equal($input.val(), "1", "input value is correct");
     });
 
-    QUnit.test("the hidden input should get correct values if async data source is used", (assert) => {
+    QUnit.test("the hidden input should get correct values if async data source is used", function(assert) {
         const data = [0, 1, 2, 3, 4],
             initialValue = 2,
             newValue = 4,
@@ -154,7 +154,7 @@ QUnit.module("hidden input", moduleSetup, () => {
 
 QUnit.module("functionality", moduleSetup, () => {
 
-    QUnit.test("value can be set to 'null'", (assert) => {
+    QUnit.test("value can be set to 'null'", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: ["first", "second", "third"],
                 value: "first",
@@ -174,7 +174,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($input.val() === "second", "new value displayed correct");
     });
 
-    QUnit.test("selectBox doesn't select item with value type is mismatch", (assert) => {
+    QUnit.test("selectBox doesn't select item with value type is mismatch", function(assert) {
         const dataSource = [{ ID: 1 }, { ID: 2 }, { ID: 3 }];
 
         $("#selectBox").dxSelectBox({
@@ -195,7 +195,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.notEqual($("#selectBox").dxSelectBox("option", "selectedItem"), dataSource[0], "item was not selected");
     });
 
-    QUnit.test("click on list item sets value", (assert) => {
+    QUnit.test("click on list item sets value", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: ["first", "second", "third"] }),
             instance = $element.dxSelectBox("instance"),
             $list = $element.find(".dx-list");
@@ -212,7 +212,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.is(":hidden"), "when click on lists item, list is hidden");
     });
 
-    QUnit.test("click on list item set 'selected' class", (assert) => {
+    QUnit.test("click on list item set 'selected' class", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: ["first", "second", "third"]
             }),
@@ -229,7 +229,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(2).hasClass(LIST_ITEM_SELECTED_CLASS), "selected item has selected class, after click on it");
     });
 
-    QUnit.test("changing the 'value' option must invoke the 'onValueChanged' action", (assert) => {
+    QUnit.test("changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         const selectBox = $("#selectBox").dxSelectBox({
             items: ["first", "second", "third"],
             onValueChanged: () => {
@@ -239,7 +239,7 @@ QUnit.module("functionality", moduleSetup, () => {
         selectBox.option("value", "first");
     });
 
-    QUnit.test("changing the 'value' option must set 'selected' class on correct item", (assert) => {
+    QUnit.test("changing the 'value' option must set 'selected' class on correct item", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: ["first", "second", "third"],
                 value: "first"
@@ -256,7 +256,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), "second item has selected class, after change value on it");
     });
 
-    QUnit.test("click on 0 in list [\"\", 0] sets value 0", (assert) => {
+    QUnit.test("click on 0 in list [\"\", 0] sets value 0", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: ["", 0], value: "" }),
             instance = $element.dxSelectBox("instance");
 
@@ -267,7 +267,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.strictEqual(instance.option("value"), 0, "click on list item, and its value replaces widget value");
     });
 
-    QUnit.test("click on textbox toggle popup visibility", (assert) => {
+    QUnit.test("click on textbox toggle popup visibility", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: [0, 1, 2] }),
             $list = $element.find(".dx-list"),
             $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
@@ -279,7 +279,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.is(':hidden'), "when we click on input once again - hide list");
     });
 
-    QUnit.test("click on arrow toggle popup visibility", (assert) => {
+    QUnit.test("click on arrow toggle popup visibility", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: [0, 1, 2] }),
             popup = $element.dxSelectBox("instance")._popup,
             $arrow = $element.find(".dx-dropdowneditor-icon");
@@ -293,7 +293,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.notOk(popup.option("visible"), "when we click on arrow once again - hide popup");
     });
 
-    QUnit.test("click on disabled selectbox doesn't toggle popup visibility", (assert) => {
+    QUnit.test("click on disabled selectbox doesn't toggle popup visibility", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: [0, 1, 2], disabled: true }),
             $list = $element.find(".dx-dropdowneditor-overlay"),
             $textBox = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
@@ -304,7 +304,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.is(':hidden'), "when we click on input - list is still hidden");
     });
 
-    QUnit.test("click on disabled selectbox arrow doesn't toggle popup visibility", (assert) => {
+    QUnit.test("click on disabled selectbox arrow doesn't toggle popup visibility", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: [0, 1, 2], disabled: true }),
             $list = $element.find(".dx-dropdowneditor-overlay"),
             $arrow = $element.find(toSelector(TEXTEDITOR_BUTTONS_CONTAINER_CLASS));
@@ -315,7 +315,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.is(':hidden'), "when we click on arrow - list is still hidden");
     });
 
-    QUnit.test("click on readOnly selectbox doesn't toggle popup visibility", (assert) => {
+    QUnit.test("click on readOnly selectbox doesn't toggle popup visibility", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: [0, 1, 2], readOnly: true }),
             $list = $element.find(".dx-dropdowneditor-overlay"),
             $textBox = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
@@ -326,7 +326,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.is(':hidden'), "when we click on input - list is still hidden");
     });
 
-    QUnit.test("click on readOnly selectbox arrow doesn't toggle popup visibility", (assert) => {
+    QUnit.test("click on readOnly selectbox arrow doesn't toggle popup visibility", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: [0, 1, 2], readOnly: true }),
             $list = $element.find(".dx-dropdowneditor-overlay"),
             $arrow = $element.find(toSelector(TEXTEDITOR_BUTTONS_CONTAINER_CLASS));
@@ -337,7 +337,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.is(':hidden'), "when we click on arrow - list is still hidden");
     });
 
-    QUnit.test("select box should not hide popup after focusout", (assert) => {
+    QUnit.test("select box should not hide popup after focusout", function(assert) {
         const $element = $("#selectBox").dxSelectBox({ items: [0, 1, 2] }),
             $list = $element.find(".dx-list"),
             $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
@@ -351,7 +351,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.is(':visible'), "when we click on input once again - hide list");
     });
 
-    QUnit.test("do not show tooltip if it is not enabled", (assert) => {
+    QUnit.test("do not show tooltip if it is not enabled", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: ["very very very long value", 2, 3, 4],
             value: "very very very long value",
@@ -361,7 +361,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.strictEqual($element.attr("title"), undefined, "tooltip should not be added");
     });
 
-    QUnit.test("show hint when tooltip is not enabled", (assert) => {
+    QUnit.test("show hint when tooltip is not enabled", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: ["very very very long value", 2, 3, 4],
             value: "very very very long value",
@@ -372,7 +372,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.strictEqual($element.attr("title"), "some text", "hint correct");
     });
 
-    QUnit.test("show tooltip when widget was created longer than values's width", (assert) => {
+    QUnit.test("show tooltip when widget was created longer than values's width", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: ["very very very long value", 2, 3, 4],
             value: "very very very long value",
@@ -383,7 +383,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.strictEqual($element.attr("title"), "very very very long value", "tooltip should be added");
     });
 
-    QUnit.test("show tooltip for object item", (assert) => {
+    QUnit.test("show tooltip for object item", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: [{ key: 1, value: "very very very long value" }],
             valueExpr: "key",
@@ -396,7 +396,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal($element.prop("title"), "very very very long value", "tooltip shown display value");
     });
 
-    QUnit.test("selectbox should not hide when selected item longer than first item", (assert) => {
+    QUnit.test("selectbox should not hide when selected item longer than first item", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: ["first", "longer than first"],
             value: "longer than first"
@@ -408,7 +408,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal($selectBox.dxSelectBox("option", "opened"), true, "selectbox is opened");
     });
 
-    QUnit.testInActiveWindow("input focused after click on drop button", (assert) => {
+    QUnit.testInActiveWindow("input focused after click on drop button", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "focus is not actual for mobile devices");
             return;
@@ -421,7 +421,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).is(":focus"), "input focused");
     });
 
-    QUnit.test("dataSource loaded after create dxSelectBox", (assert) => {
+    QUnit.test("dataSource loaded after create dxSelectBox", function(assert) {
         const timeout = 1000;
         const dataSource = new DataSource({
             load: () => {
@@ -447,7 +447,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal(listItems.length, 0, "items is not yet loaded");
     });
 
-    QUnit.test("Items list should be empty after dataSource reseting", (assert) => {
+    QUnit.test("Items list should be empty after dataSource reseting", function(assert) {
         const data = ["one", "two"];
         const $element = $("#selectBox");
         const selectBox = $element.dxSelectBox({
@@ -473,7 +473,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.deepEqual(selectBox._list.option("items"), []);
     });
 
-    QUnit.test("list item obtained focus only after press on control key", (assert) => {
+    QUnit.test("list item obtained focus only after press on control key", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -497,7 +497,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($firstItemList.hasClass(STATE_FOCUSED_CLASS), "first list item obtained focus");
     });
 
-    QUnit.test("items is not changed after value changing when displayExpr is not set", (assert) => {
+    QUnit.test("items is not changed after value changing when displayExpr is not set", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             items: [{ index: "1", text: "1" }, { index: "2", text: "2" }, { index: "3", text: "3" }],
             opened: true
@@ -517,7 +517,7 @@ QUnit.module("functionality", moduleSetup, () => {
         }, { index: "3", text: "3" }]);
     });
 
-    QUnit.test("dxSelectBox automatically scrolls to selected item on opening", (assert) => {
+    QUnit.test("dxSelectBox automatically scrolls to selected item on opening", function(assert) {
         const items = [];
         for(let i = 0; i <= 100; i++) {
             items.push(i);
@@ -539,7 +539,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($popupContent.offset().top + $popupContent.height() > $selectedItem.offset().top, "selected item is visible");
     });
 
-    QUnit.test("dxSelectBox automatically scrolls to selected item on opening after item search", (assert) => {
+    QUnit.test("dxSelectBox automatically scrolls to selected item on opening after item search", function(assert) {
         const items = [];
         for(let i = 0; i <= 100; i++) {
             items.push(i);
@@ -567,7 +567,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($popupContent.offset().top + $popupContent.height() > $selectedItem.offset().top, "selected item is visible after search");
     });
 
-    QUnit.test("Widget selects current value in the dropDownList if dxSelectBox with async data is opened on initialization (T822930)", (assert) => {
+    QUnit.test("Widget selects current value in the dropDownList if dxSelectBox with async data is opened on initialization (T822930)", function(assert) {
         const selectBox = $("#selectBox").dxSelectBox({
             deferRendering: true,
             dataSource: {
@@ -600,7 +600,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok(list.option("selectedItem") === 1, "list item is selected");
     });
 
-    QUnit.test("dxSelectBox scrolls to the top when paging is enabled and selectbox is editable and item is out of page", (assert) => {
+    QUnit.test("dxSelectBox scrolls to the top when paging is enabled and selectbox is editable and item is out of page", function(assert) {
         const items = [];
         for(let i = 0; i <= 200; i++) {
             items.push(i);
@@ -626,7 +626,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($popupContent.offset().top <= $firstItem.offset().top, "first item is visible");
     });
 
-    QUnit.test("dxSelectBox scroll to selected item when paging is enabled and selectbox is editable and item is not out of page", (assert) => {
+    QUnit.test("dxSelectBox scroll to selected item when paging is enabled and selectbox is editable and item is not out of page", function(assert) {
         const items = [];
         for(let i = 0; i <= 200; i++) {
             items.push(i);
@@ -655,7 +655,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok(itemBottom <= contentBottom, "selected item is visible");
     });
 
-    QUnit.test("selectedItem is readonly option", (assert) => {
+    QUnit.test("selectedItem is readonly option", function(assert) {
         const items = [
             "one",
             "two"
@@ -675,7 +675,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.strictEqual(selectBox.option("selectedItem"), null, "selected item");
     });
 
-    QUnit.test("display value should rendered when value is 0", (assert) => {
+    QUnit.test("display value should rendered when value is 0", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             items: [{ key: 0, value: "zero" }],
             value: 0,
@@ -687,7 +687,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal(displayValue, "zero", "value is rendered correctly");
     });
 
-    QUnit.test("selectBox should display value when item is 0 or boolean false", (assert) => {
+    QUnit.test("selectBox should display value when item is 0 or boolean false", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 dataSource: [null, 0, true, false],
                 displayExpr: (value) => {
@@ -718,7 +718,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal($input.val(), "None", "Null value is shown correctly");
     });
 
-    QUnit.test("dxList has empty message", (assert) => {
+    QUnit.test("dxList has empty message", function(assert) {
         $("#selectBox").dxSelectBox({
             deferRendering: false
         });
@@ -728,7 +728,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.notEqual($list.dxList("option", "noDataText"), "", "list has noDataText");
     });
 
-    QUnit.test("dxList should be have a customer's noDataText value after search", (assert) => {
+    QUnit.test("dxList should be have a customer's noDataText value after search", function(assert) {
         const simpleProducts = [],
             customersNoDataText = 'Customer string';
 
@@ -752,7 +752,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal(noDataText, customersNoDataText, "empty message is correct");
     });
 
-    QUnit.test("dxList has not empty message", (assert) => {
+    QUnit.test("dxList has not empty message", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: ["a", "b", "c"],
             searchEnabled: true,
@@ -769,7 +769,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal($list.dxList("option", "noDataText"), "No data to display", "list has default noDataText");
     });
 
-    QUnit.test("SelectBox should not load data twice on open", (assert) => {
+    QUnit.test("SelectBox should not load data twice on open", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             dataSource: [1, 2, 3, 4, 5],
@@ -786,7 +786,7 @@ QUnit.module("functionality", moduleSetup, () => {
         }
     });
 
-    QUnit.test("selectbox should load first page after filtering reset", (assert) => {
+    QUnit.test("selectbox should load first page after filtering reset", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             dataSource: {
@@ -846,7 +846,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal($.trim($(".dx-item").first().text()), "0", "filter was cleared when focusout even if item was not selected");
     });
 
-    QUnit.testInActiveWindow("SelectBox drop down should not blink on open after setting value with the help of search", (assert) => {
+    QUnit.testInActiveWindow("SelectBox drop down should not blink on open after setting value with the help of search", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             dataSource: [1, 2, 3, 4, 5, 6, 7],
@@ -864,7 +864,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.equal(instance.option("opened"), true, "selectbox is opened");
     });
 
-    QUnit.test("the selected item should be focused after popup is opened", (assert) => {
+    QUnit.test("the selected item should be focused after popup is opened", function(assert) {
         const items = [1, 2, 3],
             item = items[1],
             selectBox = $("#selectBox").dxSelectBox({
@@ -883,7 +883,7 @@ QUnit.module("functionality", moduleSetup, () => {
         assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(0).hasClass(STATE_FOCUSED_CLASS), "the selected item is focused after popup is opened second time");
     });
 
-    QUnit.test("no items should be focused if input value is changed", (assert) => {
+    QUnit.test("no items should be focused if input value is changed", function(assert) {
         const items = ["aaa", "aa"],
             item = items[1],
             $selectBox = $("#selectBox").dxSelectBox({
@@ -910,7 +910,7 @@ QUnit.module("functionality", moduleSetup, () => {
 
 QUnit.module("widget options", moduleSetup, () => {
 
-    QUnit.test("option onValueChanged", (assert) => {
+    QUnit.test("option onValueChanged", function(assert) {
         assert.expect(4);
 
         let count = 0;
@@ -942,7 +942,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal(count, 4);
     });
 
-    QUnit.test("options displayExpr, valueExpr", (assert) => {
+    QUnit.test("options displayExpr, valueExpr", function(assert) {
         assert.expect(5);
 
         const items = [
@@ -978,7 +978,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal(instance.option("value"), 1);
     });
 
-    QUnit.test("options displayExpr, valueExpr as functions", (assert) => {
+    QUnit.test("options displayExpr, valueExpr as functions", function(assert) {
         assert.expect(3);
 
         const $element = $("#selectBox")
@@ -1005,7 +1005,7 @@ QUnit.module("widget options", moduleSetup, () => {
 
     });
 
-    QUnit.test("option value", (assert) => {
+    QUnit.test("option value", function(assert) {
         const items = [{ text: "txt1", value: 1 }, { text: "txt2", value: 2 }];
 
         const $element = $("#selectBox")
@@ -1027,7 +1027,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal(instance._input().val(), "txt2");
     });
 
-    QUnit.test("valueExpr change should clear displayValue", (assert) => {
+    QUnit.test("valueExpr change should clear displayValue", function(assert) {
         const $element = $("#selectBox")
             .dxSelectBox({
                 items: [{ value: 1, text: "one" }, { value: 2, text: "two" }],
@@ -1043,7 +1043,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal(instance.option("displayValue"), null, "displayValue empty");
     });
 
-    QUnit.test("option displayValue", (assert) => {
+    QUnit.test("option displayValue", function(assert) {
         const items = [{ text: "txt1", value: 1 }, { text: "txt2", value: 2 }];
 
         const $element = $("#selectBox")
@@ -1065,7 +1065,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal(instance.option("displayValue"), "txt2");
     });
 
-    QUnit.test("placeholder option change", (assert) => {
+    QUnit.test("placeholder option change", function(assert) {
         const $element = $("#selectBox")
                 .dxSelectBox({
                     placeholder: "John Doe"
@@ -1078,7 +1078,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($element.find(toSelector(PLACEHOLDER_CLASS)).attr("data-dx_placeholder"), "John Jr. Doe");
     });
 
-    QUnit.test("the 'fieldTemplate' function should be called only once on init and value change", (assert) => {
+    QUnit.test("the 'fieldTemplate' function should be called only once on init and value change", function(assert) {
         let callCount = 0;
         const instance = $("#selectBoxWithItemTemplate").dxSelectBox({
             items: [1, 2],
@@ -1097,7 +1097,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal(callCount, 1, "the 'fieldTemplate; called only one on value change");
     });
 
-    QUnit.test("popup should not prevent closing when fieldTemplate is used", (assert) => {
+    QUnit.test("popup should not prevent closing when fieldTemplate is used", function(assert) {
         const $selectBox = $("#selectBoxFieldTemplate").dxSelectBox({
                 items: [1, 2],
                 fieldTemplate: () => {
@@ -1123,7 +1123,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.notOk(instance.option("opened"), "popup had been closed");
     });
 
-    QUnit.test("Field should be updated if fieldTemplate is used", (assert) => {
+    QUnit.test("Field should be updated if fieldTemplate is used", function(assert) {
         const $element = $("#selectBoxFieldTemplate").dxSelectBox({
             dataSource: [
                 { ID: 1, name: 'First' },
@@ -1164,7 +1164,7 @@ QUnit.module("widget options", moduleSetup, () => {
 
     });
 
-    QUnit.test("Field should be updated if value was changed and fieldTemplate is used (T568546)", (assert) => {
+    QUnit.test("Field should be updated if value was changed and fieldTemplate is used (T568546)", function(assert) {
         const $element = $("#selectBoxFieldTemplate").dxSelectBox({
             dataSource: [
                 { name: 'First' },
@@ -1194,7 +1194,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), "First", "value is correct");
     });
 
-    QUnit.test("dropdown button should not be hidden after the focusout when fieldTemplate and searchEnabled is used", (assert) => {
+    QUnit.test("dropdown button should not be hidden after the focusout when fieldTemplate and searchEnabled is used", function(assert) {
         const $element = $("#selectBoxFieldTemplate").dxSelectBox({
                 items: [1, 2, 3],
                 focusStateEnabled: true,
@@ -1215,7 +1215,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($element.find(toSelector(DX_DROP_DOWN_BUTTON)).length, 1, "dropdown button was not hidden");
     });
 
-    QUnit.test("item template", (assert) => {
+    QUnit.test("item template", function(assert) {
         const $selectBox = $("#selectBoxWithItemTemplate").dxSelectBox({
             items: [1]
         });
@@ -1225,7 +1225,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($.trim($container.text()), "itemTemplate", "items rendered with item template");
     });
 
-    QUnit.test("selectbox loads first page after first opening when paging is enabled", (assert) => {
+    QUnit.test("selectbox loads first page after first opening when paging is enabled", function(assert) {
         const items = [];
         for(let i = 0; i < 30; i++) {
             items.push(i);
@@ -1248,7 +1248,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($.trim($(toSelector(LIST_ITEM_CLASS)).first().text()), "0", "first item is loaded");
     });
 
-    QUnit.test("change displayCustomValue", (assert) => {
+    QUnit.test("change displayCustomValue", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             items: [1, 2, 3],
             displayCustomValue: true,
@@ -1262,7 +1262,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), "test2", "custom value displayed after value changed");
     });
 
-    QUnit.test("displayCustomValue should not reset selected value on dataSource change", (assert) => {
+    QUnit.test("displayCustomValue should not reset selected value on dataSource change", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: [1, 2, 3],
             displayCustomValue: true,
@@ -1274,7 +1274,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($selectBox.dxSelectBox("option", "value"), 1, "custom value displayed after dataSource change");
     });
 
-    QUnit.test("value should reset", (assert) => {
+    QUnit.test("value should reset", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: [1, 2, 3],
             value: 1
@@ -1289,7 +1289,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($input.val(), "", "input value is reset");
     });
 
-    QUnit.test("value changed runtime should not be displayed when it is not in dataSource", (assert) => {
+    QUnit.test("value changed runtime should not be displayed when it is not in dataSource", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: [1, 2, 3],
             value: 1
@@ -1304,7 +1304,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($input.val(), "", "input value is reset");
     });
 
-    QUnit.test("onValueChanged option should get jQuery event as a parameter", (assert) => {
+    QUnit.test("onValueChanged option should get jQuery event as a parameter", function(assert) {
         let jQueryEvent;
         const $selectBox = $("#selectBox").dxSelectBox({
                 dataSource: [1, 2, 3],
@@ -1324,7 +1324,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.notOk(jQueryEvent, "jQuery event is not defined when api used");
     });
 
-    QUnit.testInActiveWindow("it should be possible to clear the value via keyboard on focusout by default", (assert) => {
+    QUnit.testInActiveWindow("it should be possible to clear the value via keyboard on focusout by default", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [1, 2, 3],
                 searchEnabled: true,
@@ -1341,7 +1341,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($input.val(), "", "input text has been cleared");
     });
 
-    QUnit.testInActiveWindow("don't rise valueChange event on focusout in readonly state with searchEnabled", (assert) => {
+    QUnit.testInActiveWindow("don't rise valueChange event on focusout in readonly state with searchEnabled", function(assert) {
         const valueChangedMock = sinon.spy();
         const $element = $("#selectBox").dxSelectBox({
                 items: [1, 2, 3],
@@ -1361,7 +1361,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.notOk(valueChangedMock.called, "valueChange event should not be rised");
     });
 
-    QUnit.testInActiveWindow("allowClearing option on init", (assert) => {
+    QUnit.testInActiveWindow("allowClearing option on init", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [1, 2, 3],
                 searchEnabled: true,
@@ -1379,7 +1379,7 @@ QUnit.module("widget options", moduleSetup, () => {
         assert.equal($input.val(), "1", "input text has been restored");
     });
 
-    QUnit.testInActiveWindow("allowClearing option changing", (assert) => {
+    QUnit.testInActiveWindow("allowClearing option changing", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [1, 2, 3],
                 searchEnabled: true,
@@ -1402,7 +1402,7 @@ QUnit.module("widget options", moduleSetup, () => {
 
 QUnit.module("clearButton", moduleSetup, () => {
 
-    QUnit.test("'clear' button click should not open selectbox", (assert) => {
+    QUnit.test("'clear' button click should not open selectbox", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: [1, 2, 3],
             showClearButton: true,
@@ -1420,7 +1420,7 @@ QUnit.module("clearButton", moduleSetup, () => {
         assert.equal(selectBox.option("opened"), false, "selectbox is closed after click on clear button if searchEnabled = true");
     });
 
-    QUnit.test("drop down list should be still opened if click 'clear' during the search", (assert) => {
+    QUnit.test("drop down list should be still opened if click 'clear' during the search", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: [1, 2, 3],
             showClearButton: true,
@@ -1440,7 +1440,7 @@ QUnit.module("clearButton", moduleSetup, () => {
         assert.ok(selectBox.option("opened"), "selectbox is opened");
     });
 
-    QUnit.test("'clear' button should clear value when items is object and searchEnabled is true", (assert) => {
+    QUnit.test("'clear' button should clear value when items is object and searchEnabled is true", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             items: [{ key: 1, value: "one" }],
             valueExpr: "key",
@@ -1457,7 +1457,7 @@ QUnit.module("clearButton", moduleSetup, () => {
         assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), "", "text is cleared");
     });
 
-    QUnit.test("clear button should save valueChangeEvent", (assert) => {
+    QUnit.test("clear button should save valueChangeEvent", function(assert) {
         const valueChangedHandler = sinon.spy(),
             $selectBox = $("#selectBox").dxSelectBox({
                 items: [1],
@@ -1473,7 +1473,7 @@ QUnit.module("clearButton", moduleSetup, () => {
         assert.equal(valueChangedHandler.getCall(0).args[0].event.type, "dxclick", "event is correct");
     });
 
-    QUnit.test("selectedItem should be reset on 'clear' button", (assert) => {
+    QUnit.test("selectedItem should be reset on 'clear' button", function(assert) {
         const $selectBox = $("#selectBox");
 
         const selectBox = $selectBox.dxSelectBox({
@@ -1496,7 +1496,7 @@ QUnit.module("clearButton", moduleSetup, () => {
         assert.strictEqual(selectBox.option("selectedItem"), null, "selected item");
     });
 
-    QUnit.test("'clear' button should reset selectedValue if 'acceptCustomValue' is set to true", (assert) => {
+    QUnit.test("'clear' button should reset selectedValue if 'acceptCustomValue' is set to true", function(assert) {
         const data = [{ id: '1', text: 'text 1' }, { id: '2', text: 'text 2' }, { id: '3', text: 'text 3' }];
         const $selectBox = $("#selectBox");
 
@@ -1527,7 +1527,7 @@ QUnit.module("clearButton", moduleSetup, () => {
 
 QUnit.module("showSelectionControls", moduleSetup, () => {
 
-    QUnit.test("showSelectionControls is true", (assert) => {
+    QUnit.test("showSelectionControls is true", function(assert) {
         $("#selectBox").dxSelectBox({
             items: [1],
             opened: true,
@@ -1539,7 +1539,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal($(".dx-radiobutton").length, 1, "checkbox added");
     });
 
-    QUnit.test("click on item changes value", (assert) => {
+    QUnit.test("click on item changes value", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             items: [1, 2],
             opened: true,
@@ -1558,7 +1558,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
 
 QUnit.module("editing", moduleSetup, () => {
 
-    QUnit.test("readOnly option with searchEnabled", (assert) => {
+    QUnit.test("readOnly option with searchEnabled", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 items: ["item1", "item2", "text3"],
                 searchEnabled: true,
@@ -1579,7 +1579,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.ok($list.is(":hidden"), "list should not appear in readonly state (T265362)");
     });
 
-    QUnit.test("readOnly option with acceptCustomValue", (assert) => {
+    QUnit.test("readOnly option with acceptCustomValue", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 items: ["item1", "item2", "text3"],
                 acceptCustomValue: true,
@@ -1595,7 +1595,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.prop("readonly"), true, "input is readonly");
     });
 
-    QUnit.test("keyboardNavigation for readOnly widget", (assert) => {
+    QUnit.test("keyboardNavigation for readOnly widget", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 items: ["item1", "item2", "text3"],
                 value: "item1"
@@ -1609,7 +1609,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(selectBox.option("value"), "item1", "value was not changed");
     });
 
-    QUnit.test("searchEnabled", (assert) => {
+    QUnit.test("searchEnabled", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             items: ["item1", "item2", "text3"],
@@ -1629,7 +1629,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($selectBox.dxSelectBox("option", "value"), null, "value was not set");
     });
 
-    QUnit.testInActiveWindow("input value is reset on focusOut when searchEnabled is true and acceptCustomValue is false", (assert) => {
+    QUnit.testInActiveWindow("input value is reset on focusOut when searchEnabled is true and acceptCustomValue is false", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             acceptCustomValue: false,
@@ -1647,7 +1647,7 @@ QUnit.module("editing", moduleSetup, () => {
         $selectBox.dxSelectBox("blur");
     });
 
-    QUnit.testInActiveWindow("input value is reset on pressing enter key when searchEnabled is true and acceptCustomValue is false", (assert) => {
+    QUnit.testInActiveWindow("input value is reset on pressing enter key when searchEnabled is true and acceptCustomValue is false", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             acceptCustomValue: false,
@@ -1672,7 +1672,7 @@ QUnit.module("editing", moduleSetup, () => {
         $selectBox.dxSelectBox("blur");
     });
 
-    QUnit.test("Enter key press prevent default when popup is opened or acceptCustomValue is true", (assert) => {
+    QUnit.test("Enter key press prevent default when popup is opened or acceptCustomValue is true", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [0, 1, 2],
                 value: 1,
@@ -1707,7 +1707,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(prevented, 1, "defaults prevented on enter key when acceptCustomValue is true");
     });
 
-    QUnit.test("selectBox should save custom value after outside click", (assert) => {
+    QUnit.test("selectBox should save custom value after outside click", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: ["item 1", "item 2"],
                 acceptCustomValue: true
@@ -1720,7 +1720,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "custom", "initial value");
     });
 
-    QUnit.test("selectBox should restore initial value after press 'down' and outside click", (assert) => {
+    QUnit.test("selectBox should restore initial value after press 'down' and outside click", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: ["item 1", "item 2"],
                 value: "item 1",
@@ -1737,7 +1737,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "item 1", "value has been reverted");
     });
 
-    QUnit.test("selectBox should restore old value after esc if custom value is accepted", (assert) => {
+    QUnit.test("selectBox should restore old value after esc if custom value is accepted", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: ["item 1", "item 2"],
                 value: "item 1",
@@ -1753,7 +1753,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "item 1", "value has been reverted");
     });
 
-    QUnit.test("list should not be rendered on each open", (assert) => {
+    QUnit.test("list should not be rendered on each open", function(assert) {
         let dataSourceLoadedCount = 0;
         const $selectBox = $("#selectBox").dxSelectBox({
                 dataSource: new CustomStore({
@@ -1776,7 +1776,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(dataSourceLoadedCount, 1, "content ready not fired when reopen dropdown");
     });
 
-    QUnit.test("object value is restored after field focusout", (assert) => {
+    QUnit.test("object value is restored after field focusout", function(assert) {
         const dataSource = [{ key: 1, text: "one" }];
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
@@ -1800,7 +1800,7 @@ QUnit.module("editing", moduleSetup, () => {
         $selectBox.dxSelectBox("blur");
     });
 
-    QUnit.testInActiveWindow("input value should be restored on focusout if clearing is manually prevented", (assert) => {
+    QUnit.testInActiveWindow("input value should be restored on focusout if clearing is manually prevented", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             items: [1, 2],
@@ -1827,7 +1827,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(instance.option("value"), 1, "value have been restored");
     });
 
-    QUnit.test("byKey should not be called on focusout if text was not changed", (assert) => {
+    QUnit.test("byKey should not be called on focusout if text was not changed", function(assert) {
         const byKeyMock = sinon.stub().returnsArg(0),
             loadMock = sinon.stub().returns(["Item 1", "Item 2", "Item 3"]),
             $element = $("#selectBox").dxSelectBox({
@@ -1848,7 +1848,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(byKeyMock.callCount, 1, "byKey should not be called after input text restoring");
     });
 
-    QUnit.test("acceptCustomValue", (assert) => {
+    QUnit.test("acceptCustomValue", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             items: ["item1", "item2", "text3"],
@@ -1869,7 +1869,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($selectBox.dxSelectBox("option", "value"), "it", "value was set");
     });
 
-    QUnit.test("set existing item is succeeded value when acceptCustomValue is true", (assert) => {
+    QUnit.test("set existing item is succeeded value when acceptCustomValue is true", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             searchEnabled: false,
@@ -1891,7 +1891,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "20", "value was set");
     });
 
-    QUnit.test("set non existing item is succeeded value when acceptCustomValue is true", (assert) => {
+    QUnit.test("set non existing item is succeeded value when acceptCustomValue is true", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             searchEnabled: false,
@@ -1906,7 +1906,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(selectBox.option("displayValue"), "3", "value was set");
     });
 
-    QUnit.test("selectionChanged should not fire if selectedItem was not changed", (assert) => {
+    QUnit.test("selectionChanged should not fire if selectedItem was not changed", function(assert) {
         const selectionChangedHandler = sinon.spy(),
             items = [{ name: "item1" }, { name: "item2" }],
             $element = $("#selectBox").dxSelectBox({
@@ -1924,7 +1924,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(selectionChangedHandler.callCount, 1, "selectionChanged should not fire twice");
     });
 
-    QUnit.test("selectionChanged should not fire if selectedItem was not changed and displayValue is a number", (assert) => {
+    QUnit.test("selectionChanged should not fire if selectedItem was not changed and displayValue is a number", function(assert) {
         const selectionChangedHandler = sinon.spy(),
             $element = $("#selectBox").dxSelectBox({
                 dataSource: {
@@ -1949,7 +1949,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(selectionChangedHandler.callCount, 1, "selectionChanged does not rise twice");
     });
 
-    QUnit.test("set non existing item is not reset after dataSource changing", (assert) => {
+    QUnit.test("set non existing item is not reset after dataSource changing", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             searchEnabled: false,
@@ -1965,7 +1965,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(selectBox.option("displayValue"), "3", "value was not reset");
     });
 
-    QUnit.test("set non existing item is succeeded value when acceptCustomValue is true and displayExpr is set", (assert) => {
+    QUnit.test("set non existing item is succeeded value when acceptCustomValue is true and displayExpr is set", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             searchEnabled: false,
@@ -1984,7 +1984,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "three", "value was set");
     });
 
-    QUnit.test("drop button is not rendered after input blur", (assert) => {
+    QUnit.test("drop button is not rendered after input blur", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             acceptCustomValue: false,
@@ -1999,7 +1999,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.ok($selectBox.find(toSelector(DX_DROP_DOWN_BUTTON)).hasClass("test"), "button is not rendered again");
     });
 
-    QUnit.test("T316005 - mousedown on inputWrapper should not be prevented if openOnFieldClick is true", (assert) => {
+    QUnit.test("T316005 - mousedown on inputWrapper should not be prevented if openOnFieldClick is true", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 openOnFieldClick: true
             }),
@@ -2014,7 +2014,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.ok(!event.isDefaultPrevented(), "default event is not prevented");
     });
 
-    QUnit.test("The 'onCustomItemCreating' option should throw a warning if handler returns an item", (assert) => {
+    QUnit.test("The 'onCustomItemCreating' option should throw a warning if handler returns an item", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
                 displayExpr: "display",
@@ -2041,7 +2041,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.deepEqual(logStub.firstCall.args, ["W0015", "onCustomItemCreating", "customItem"], "Check warning parameters");
     });
 
-    QUnit.test("onCustomItemCreating should not be called when existing item selecting", (assert) => {
+    QUnit.test("onCustomItemCreating should not be called when existing item selecting", function(assert) {
         const onCustomItemCreating = sinon.stub().returns("Custom item"),
             $selectBox = $("#selectBox").dxSelectBox({
                 items: ["Item 11", "Item 22", "Item 33"],
@@ -2062,7 +2062,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal(onCustomItemCreating.callCount, 0, "action has not been called");
     });
 
-    QUnit.test("creating custom item via the 'customItem' event parameter", (assert) => {
+    QUnit.test("creating custom item via the 'customItem' event parameter", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
                 displayExpr: "display",
@@ -2086,7 +2086,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "display " + customValue, "displayed value is correct");
     });
 
-    QUnit.test("create custom item by subscribe on event via 'on' method", (assert) => {
+    QUnit.test("create custom item by subscribe on event via 'on' method", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
                 displayExpr: "display",
@@ -2113,7 +2113,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "display " + customValue, "displayed value is correct");
     });
 
-    QUnit.test("The 'onCustomItemCreating' option with Deferred", (assert) => {
+    QUnit.test("The 'onCustomItemCreating' option with Deferred", function(assert) {
         const deferred = $.Deferred(),
             $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
@@ -2143,7 +2143,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "display " + customValue, "displayed value is changed");
     });
 
-    QUnit.test("The 'onCustomItemCreating' option with Promise", (assert) => {
+    QUnit.test("The 'onCustomItemCreating' option with Promise", function(assert) {
         assert.expect(4);
 
         let resolve;
@@ -2182,7 +2182,7 @@ QUnit.module("editing", moduleSetup, () => {
         return promise;
     });
 
-    QUnit.test("Value should be reset if the 'onCustomItemCreating' deferred is rejected", (assert) => {
+    QUnit.test("Value should be reset if the 'onCustomItemCreating' deferred is rejected", function(assert) {
         const deferred = $.Deferred(),
             $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
@@ -2206,7 +2206,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "", "input value is reset after deferred is rejected");
     });
 
-    QUnit.test("Filter should be cleared if the 'onCustomItemCreating' deferred is rejected", (assert) => {
+    QUnit.test("Filter should be cleared if the 'onCustomItemCreating' deferred is rejected", function(assert) {
         const deferred = $.Deferred(),
             $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
@@ -2233,7 +2233,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 3, "filter was cleared");
     });
 
-    QUnit.test("filter should be cleared if all text was removed using backspace", (assert) => {
+    QUnit.test("filter should be cleared if all text was removed using backspace", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 searchEnabled: true,
                 opened: true,
@@ -2256,7 +2256,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 3, "filter was cleared");
     });
 
-    QUnit.test("search timer should not be cleared when the widget is opening", (assert) => {
+    QUnit.test("search timer should not be cleared when the widget is opening", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 searchEnabled: true,
                 searchTimeout: 100,
@@ -2279,7 +2279,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 3, "filter was cleared");
     });
 
-    QUnit.test("Custom value should be selected in the list", (assert) => {
+    QUnit.test("Custom value should be selected in the list", function(assert) {
         const ds = new DataSource({
                 store: ["1", "2", "3"]
             }),
@@ -2304,7 +2304,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.deepEqual(list.option("selectedItems"), ["Custom value"], "selected item is correct");
     });
 
-    QUnit.test("Custom value should be selected in list if items were modified on custom item creation", (assert) => {
+    QUnit.test("Custom value should be selected in list if items were modified on custom item creation", function(assert) {
         const items = [1, 2, 3],
             $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
@@ -2333,7 +2333,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.deepEqual(list.option("selectedItems"), [customValue], "selected item is correct");
     });
 
-    QUnit.test("Selection should not be cleared if the user select existing item after the search", (assert) => {
+    QUnit.test("Selection should not be cleared if the user select existing item after the search", function(assert) {
         const items = [{ id: 1, text: "Item 1" }, { id: 2, text: "Item 2" }],
             $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
@@ -2359,7 +2359,7 @@ QUnit.module("editing", moduleSetup, () => {
         assert.equal($input.val(), "Item 2", "input text is correct");
     });
 
-    QUnit.test("The error should be thrown if the 'onCustomItemCreating' option returns nothing", (assert) => {
+    QUnit.test("The error should be thrown if the 'onCustomItemCreating' option returns nothing", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
                 onCustomItemCreating: noop
@@ -2376,7 +2376,7 @@ QUnit.module("editing", moduleSetup, () => {
         }
     });
 
-    QUnit.test("Value is reset to previous one after error is thrown", (assert) => {
+    QUnit.test("Value is reset to previous one after error is thrown", function(assert) {
         const items = ["1"],
             $selectBox = $("#selectBox").dxSelectBox({
                 acceptCustomValue: true,
@@ -2402,7 +2402,7 @@ QUnit.module("editing", moduleSetup, () => {
 
 QUnit.module("search", moduleSetup, () => {
 
-    QUnit.test("data is not displayed before min search length is exceeded", (assert) => {
+    QUnit.test("data is not displayed before min search length is exceeded", function(assert) {
         $("#selectBox").dxSelectBox({
             dataSource: ["one", "two", "three"],
             showDataBeforeSearch: false,
@@ -2416,7 +2416,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($items.length, 0, "items is not rendered");
     });
 
-    QUnit.test("no data to display is not displayed after change option 'showDataBeforeSearch' with empty input", (assert) => {
+    QUnit.test("no data to display is not displayed after change option 'showDataBeforeSearch' with empty input", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: ["one", "two", "three"],
             showDataBeforeSearch: false,
@@ -2431,7 +2431,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.ok($items.length, "items is shown");
     });
 
-    QUnit.test("data is displayed before min search length is exceeded when showData='true'", (assert) => {
+    QUnit.test("data is displayed before min search length is exceeded when showData='true'", function(assert) {
         $("#selectBox").dxSelectBox({
             dataSource: ["one", "two", "three"],
             showDataBeforeSearch: true,
@@ -2445,7 +2445,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($items.length, 3, "items is not rendered");
     });
 
-    QUnit.test("data is filtered when min search length is exceeded", (assert) => {
+    QUnit.test("data is filtered when min search length is exceeded", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: ["one", "two", "three"],
             showDataBeforeSearch: false,
@@ -2465,7 +2465,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($items.length, 1, "items was filtered");
     });
 
-    QUnit.test("data is filtered when min search length is exceeded", (assert) => {
+    QUnit.test("data is filtered when min search length is exceeded", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: ["one", "two", "three"],
             showDataBeforeSearch: true,
@@ -2485,7 +2485,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($items.length, 1, "items was filtered");
     });
 
-    QUnit.test("data is filtered correctly for grouped items", (assert) => {
+    QUnit.test("data is filtered correctly for grouped items", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: {
                 store: [{ "value": "one", "groupName": "group1" }, { "value": "two", "groupName": "group1" }],
@@ -2509,7 +2509,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($items.length, 1, "items was filtered");
     });
 
-    QUnit.test("data is reset to first page after reset filter", (assert) => {
+    QUnit.test("data is reset to first page after reset filter", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: ["one", "two", "three"],
             showDataBeforeSearch: true,
@@ -2533,7 +2533,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($items.length, 3, "items are not filtered");
     });
 
-    QUnit.test("data is reset to first page fully after string < 'minSearchLength'", (assert) => {
+    QUnit.test("data is reset to first page fully after string < 'minSearchLength'", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: ["one", "two", "tree"],
             showDataBeforeSearch: true,
@@ -2558,7 +2558,7 @@ QUnit.module("search", moduleSetup, () => {
 
     });
 
-    QUnit.test("data should not be filtering before than string.length < 'minSearchLength'", (assert) => {
+    QUnit.test("data should not be filtering before than string.length < 'minSearchLength'", function(assert) {
         const $selectBox = $('#selectBox').dxSelectBox({
             dataSource: ["one", "two", "tree"],
             showDataBeforeSearch: true,
@@ -2592,7 +2592,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal(items.length, 1, "one item shown");
     });
 
-    QUnit.test("dataSource load is not called when showDataBeforeSearch is false", (assert) => {
+    QUnit.test("dataSource load is not called when showDataBeforeSearch is false", function(assert) {
         const dataSource = new DataSource(["one", "two", "three"]);
         const $selectBox = $("#selectBox").dxSelectBox({
             dataSource: dataSource,
@@ -2618,7 +2618,7 @@ QUnit.module("search", moduleSetup, () => {
         }
     });
 
-    QUnit.test("Widget should works correctly after setting dataSource to null", (assert) => {
+    QUnit.test("Widget should works correctly after setting dataSource to null", function(assert) {
         const dataSource = new DataSource(["one", "two", "three"]);
         const selectBox = $("#selectBox").dxSelectBox({
             dataSource: dataSource,
@@ -2631,7 +2631,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($list.dxList("option", "noDataText"), "No data to display", "SelectBox works correctly");
     });
 
-    QUnit.test("search should stay opened after the search when focus state is disabled", (assert) => {
+    QUnit.test("search should stay opened after the search when focus state is disabled", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 items: ["item 1"],
                 focusStateEnabled: false,
@@ -2646,7 +2646,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.ok(selectBox.option("opened"), "selectBox should be opened");
     });
 
-    QUnit.testInActiveWindow("widget with fieldTemplate and remote data source should display right value after search and selection (T668290)", (assert) => {
+    QUnit.testInActiveWindow("widget with fieldTemplate and remote data source should display right value after search and selection (T668290)", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 dataSource: {
                     store: new CustomStore({
@@ -2689,7 +2689,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), "Name 2", "selectBox displays right value");
     });
 
-    QUnit.testInActiveWindow("Value should be null after input is cleared and enter key is tapped", (assert) => {
+    QUnit.testInActiveWindow("Value should be null after input is cleared and enter key is tapped", function(assert) {
         const items = [1, 2],
             $selectBox = $("#selectBox").dxSelectBox({
                 searchEnabled: true,
@@ -2716,7 +2716,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.ok(!selectBox.option("opened"), "popup is closed");
     });
 
-    QUnit.testInActiveWindow("Value should not be null after focusOut during loading (T600537)", (assert) => {
+    QUnit.testInActiveWindow("Value should not be null after focusOut during loading (T600537)", function(assert) {
         const clock = sinon.useFakeTimers();
 
         try {
@@ -2764,7 +2764,7 @@ QUnit.module("search", moduleSetup, () => {
     });
 
     // T494140
-    QUnit.testInActiveWindow("Value should not be changed after input is cleared and enter key is tapped if allowClearing is false", (assert) => {
+    QUnit.testInActiveWindow("Value should not be changed after input is cleared and enter key is tapped if allowClearing is false", function(assert) {
         const items = [1, 2],
             valueChangedHandler = sinon.spy(),
             $selectBox = $("#selectBox").dxSelectBox({
@@ -2798,7 +2798,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($input.val(), "1", "input value is restored");
     });
 
-    QUnit.test("search should not be performed after control key press on substituted input value", (assert) => {
+    QUnit.test("search should not be performed after control key press on substituted input value", function(assert) {
         const item = "aaa",
             $selectBox = $("#selectBox").dxSelectBox({
                 items: [item],
@@ -2819,7 +2819,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.notOk(selectBox.option("opened"), "popup is opened after filtering");
     });
 
-    QUnit.test("item should not be reset on the 'tab' key press after popup is opened", (assert) => {
+    QUnit.test("item should not be reset on the 'tab' key press after popup is opened", function(assert) {
         const item = "aaa",
             $selectBox = $("#selectBox").dxSelectBox({
                 searchEnabled: true,
@@ -2842,7 +2842,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal(selectBox.option("value"), item, "value is correct");
     });
 
-    QUnit.test("filter should be cleared after item selection via tab", (assert) => {
+    QUnit.test("filter should be cleared after item selection via tab", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
                 searchEnabled: true,
                 dataSource: ["aaa", "bbb"],
@@ -2860,7 +2860,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal(selectBox.getDataSource().searchValue(), null, "filter was cleared");
     });
 
-    QUnit.test("Opening selectBox after search should not load data if the 'showDataBeforeSearch' option is false", (assert) => {
+    QUnit.test("Opening selectBox after search should not load data if the 'showDataBeforeSearch' option is false", function(assert) {
         const dataSource = new DataSource({
             load: () => {
                 return ["aaa", "aab", "bbb"];
@@ -2897,7 +2897,7 @@ QUnit.module("search", moduleSetup, () => {
         assert.equal($emptyMessage.length, 1, "empty message is rendered");
     });
 
-    QUnit.test("Input value should not be changed after dropdown click when 'startswith' search mode is enabled", (assert) => {
+    QUnit.test("Input value should not be changed after dropdown click when 'startswith' search mode is enabled", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "the test is not actual for non-desktop devices");
             return;
@@ -2927,7 +2927,7 @@ QUnit.module("search", moduleSetup, () => {
 
 
 QUnit.module("search substitution", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.testItem = "abc";
 
         this.$selectBox = $("#selectBox").dxSelectBox({
@@ -2959,7 +2959,7 @@ QUnit.module("search substitution", {
     }
 }, () => {
     // T434197
-    QUnit.test("search timeout should be cleared if new search have been initiated", (assert) => {
+    QUnit.test("search timeout should be cleared if new search have been initiated", function(assert) {
         const loadHandler = sinon.spy(),
             clock = sinon.useFakeTimers(),
             $selectBox = $("<div>").appendTo("body");
@@ -2992,7 +2992,7 @@ QUnit.module("search substitution", {
         }
     });
 
-    QUnit.test("caret should be at the end of the input if search is used with 'startswith' mode and items are numbers", (assert) => {
+    QUnit.test("caret should be at the end of the input if search is used with 'startswith' mode and items are numbers", function(assert) {
         this.reinit({
             dataSource: [1, 2, 3],
             value: null,
@@ -3005,7 +3005,7 @@ QUnit.module("search substitution", {
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 1 }, "caret is good");
     });
 
-    QUnit.test("search value should not be substituted if the 'autocompletionEnabled' is false", (assert) => {
+    QUnit.test("search value should not be substituted if the 'autocompletionEnabled' is false", function(assert) {
         this.reinit({
             items: [this.testItem],
             searchTimeout: 0,
@@ -3022,7 +3022,7 @@ QUnit.module("search substitution", {
         assert.equal(this.$input.val(), this.testItem[0], "search value is not substituted");
     });
 
-    QUnit.test("search value is substituted while typing", (assert) => {
+    QUnit.test("search value is substituted while typing", function(assert) {
         const itemLength = this.testItem.length,
             inputElement = this.$input.get(0);
 
@@ -3037,7 +3037,7 @@ QUnit.module("search substitution", {
         }
     });
 
-    QUnit.test("search value substitution is applied on the 'right' key press", (assert) => {
+    QUnit.test("search value substitution is applied on the 'right' key press", function(assert) {
         this.keyboard
             .focus()
             .type(this.testItem[0])
@@ -3047,7 +3047,7 @@ QUnit.module("search substitution", {
         assert.notOk(this.hasSelection(), "there is no input value selection");
     });
 
-    QUnit.test("items should not be loaded after substitution is removed on the 'backspace' key press", (assert) => {
+    QUnit.test("items should not be loaded after substitution is removed on the 'backspace' key press", function(assert) {
         const loadMock = sinon.stub().returns([this.testItem]);
 
         this.reinit({
@@ -3065,7 +3065,7 @@ QUnit.module("search substitution", {
         assert.equal(loadMock.callCount, 0, "items are not loaded");
     });
 
-    QUnit.test("there is no search value substitution if no items are found", (assert) => {
+    QUnit.test("there is no search value substitution if no items are found", function(assert) {
         const newValue = this.testItem[0] + "d";
 
         this.keyboard
@@ -3076,7 +3076,7 @@ QUnit.module("search substitution", {
         assert.notOk(this.hasSelection(), "there is no input value selection");
     });
 
-    QUnit.test("the value chars deleting using the 'backspace' key do not lead to the search value substitution", (assert) => {
+    QUnit.test("the value chars deleting using the 'backspace' key do not lead to the search value substitution", function(assert) {
         const itemLength = this.testItem.length;
 
         this.keyboard
@@ -3093,7 +3093,7 @@ QUnit.module("search substitution", {
         assert.notOk(this.hasSelection(), "there is no selection");
     });
 
-    QUnit.test("the 'left', 'right', 'home' and 'end' keys press should lead to the list dataSource filtering", (assert) => {
+    QUnit.test("the 'left', 'right', 'home' and 'end' keys press should lead to the list dataSource filtering", function(assert) {
         const keys = ["left", "right", "home", "end"],
             items = ["item1", "item2"];
 
@@ -3114,7 +3114,7 @@ QUnit.module("search substitution", {
         }
     });
 
-    QUnit.test("the 'left', 'right', 'home' and 'end' keys press should lead to the list dataSource filtering", (assert) => {
+    QUnit.test("the 'left', 'right', 'home' and 'end' keys press should lead to the list dataSource filtering", function(assert) {
         const keys = ["left", "right", "home", "end"],
             item = "item1";
 
@@ -3145,7 +3145,7 @@ QUnit.module("search substitution", {
         }
     });
 
-    QUnit.test("substitution should not be rendered if the 'searchMode' is 'contains' only", (assert) => {
+    QUnit.test("substitution should not be rendered if the 'searchMode' is 'contains' only", function(assert) {
         this.reinit({
             searchMode: "contains"
         });
@@ -3154,7 +3154,7 @@ QUnit.module("search substitution", {
         assert.notOk(this.hasSelection(), "there is no selection");
     });
 
-    QUnit.test("the list item value should be displayed in input while navigating without substitution", (assert) => {
+    QUnit.test("the list item value should be displayed in input while navigating without substitution", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "the test is not actual for non-desktop devices");
             return;
@@ -3178,7 +3178,7 @@ QUnit.module("search substitution", {
         }, this));
     });
 
-    QUnit.test("the list item value should not be displayed in input after click on item", (assert) => {
+    QUnit.test("the list item value should not be displayed in input after click on item", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "the test is not actual for non-desktop devices");
             return;
@@ -3222,7 +3222,7 @@ QUnit.module("search substitution", {
         }
     });
 
-    QUnit.testInActiveWindow("the first list item should be focused while searching", (assert) => {
+    QUnit.testInActiveWindow("the first list item should be focused while searching", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "the test is not actual for non-desktop devices");
             return;
@@ -3248,7 +3248,7 @@ QUnit.module("search substitution", {
         assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(0).hasClass(STATE_FOCUSED_CLASS), "the focused element is correct after the first searching");
     });
 
-    QUnit.test("There is no substitution if the 'acceptCustomValue' option is true", (assert) => {
+    QUnit.test("There is no substitution if the 'acceptCustomValue' option is true", function(assert) {
         this.reinit({
             acceptCustomValue: true
         });
@@ -3260,7 +3260,7 @@ QUnit.module("search substitution", {
         assert.notOk(this.hasSelection(), "the input value has no selection");
     });
 
-    QUnit.test("No items should be focused while searching if the 'acceptCustomValue' option is true", (assert) => {
+    QUnit.test("No items should be focused while searching if the 'acceptCustomValue' option is true", function(assert) {
         this.reinit({
             acceptCustomValue: true
         });
@@ -3277,20 +3277,20 @@ QUnit.module("search substitution", {
 
 
 QUnit.module("Scrolling", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
 
         this.container = $("<div>").addClass("selectBoxScrolling").appendTo("#qunit-fixture");
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         fx.off = false;
 
         this.container.remove();
     }
 }, () => {
-    QUnit.test("After load new page list should not be scrolled to selected item", (assert) => {
+    QUnit.test("After load new page list should not be scrolled to selected item", function(assert) {
         this.clock.restore();
 
         const data = [],
@@ -3332,7 +3332,7 @@ QUnit.module("Scrolling", {
 });
 
 QUnit.module("Async tests", {}, () => {
-    QUnit.testInActiveWindow("Value should be reset after on selectedItem after focusout", (assert) => {
+    QUnit.testInActiveWindow("Value should be reset after on selectedItem after focusout", function(assert) {
         const done = assert.async(),
             items = [1, 2],
             $selectBox = $("#selectBox").dxSelectBox({
@@ -3363,7 +3363,7 @@ QUnit.module("Async tests", {}, () => {
         }, 0);
     });
 
-    QUnit.test("the selected item should be visible if the data source is loaded after the delay (T386513)", (assert) => {
+    QUnit.test("the selected item should be visible if the data source is loaded after the delay (T386513)", function(assert) {
         const done = assert.async(),
             dataSourceLoadedDeferred = $.Deferred(),
             itemsCount = 100,
@@ -3402,7 +3402,7 @@ QUnit.module("Async tests", {}, () => {
         });
     });
 
-    QUnit.test("selectbox should not render own components if it was disposed (T517486)", (assert) => {
+    QUnit.test("selectbox should not render own components if it was disposed (T517486)", function(assert) {
         this.clock = sinon.useFakeTimers();
 
         try {
@@ -3435,7 +3435,7 @@ QUnit.module("Async tests", {}, () => {
 
 QUnit.module("regressions", moduleSetup, () => {
 
-    QUnit.test("dataSource null reference error", (assert) => {
+    QUnit.test("dataSource null reference error", function(assert) {
         assert.expect(0);
 
         const $element = $("#selectBox").dxSelectBox({ items: [0, 1, 2], value: 0 }),
@@ -3445,7 +3445,7 @@ QUnit.module("regressions", moduleSetup, () => {
         $($input).trigger("keyup", { key: KEY_DOWN });
     });
 
-    QUnit.test("dataSource option", (assert) => {
+    QUnit.test("dataSource option", function(assert) {
         assert.expect(1);
 
         const $element = $("#selectBox").dxSelectBox({ dataSource: [0, 1, 2], value: 0 }),
@@ -3458,7 +3458,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.equal($list.find(toSelector(LIST_ITEM_CLASS)).length, 3, "all items rendered");
     });
 
-    QUnit.test("incorrect list items count after press key_down", (assert) => {
+    QUnit.test("incorrect list items count after press key_down", function(assert) {
         assert.expect(1);
 
         const $element = $("#selectBox").dxSelectBox({ dataSource: [0, 1, 2], value: 0 }),
@@ -3474,7 +3474,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).length === 3);
     });
 
-    QUnit.test("B251138 disabled", (assert) => {
+    QUnit.test("B251138 disabled", function(assert) {
         const instance = $("#selectBox").dxSelectBox({
             dataSource: [0, 1, 2],
             disabled: false
@@ -3489,7 +3489,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.ok(!instance.option("disabled"), "Disabled state should be propagated to texteditor");
     });
 
-    QUnit.test("option value should be assigned by reference", (assert) => {
+    QUnit.test("option value should be assigned by reference", function(assert) {
         const items = [
             { name: "item1" },
             { name: "item2" }
@@ -3513,7 +3513,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.equal(instance._input().val(), "item1", "item was found in items by reference");
     });
 
-    QUnit.test("select box doesn't load first element when value isn't set", (assert) => {
+    QUnit.test("select box doesn't load first element when value isn't set", function(assert) {
         let loadAttempts = 0;
         $("#selectBox").dxSelectBox({
             dataSource: new DataSource({
@@ -3539,7 +3539,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.equal(loadAttempts, 0, "there were no attempts of loading");
     });
 
-    QUnit.test("press 'enter' key sets option value (T100679)", (assert) => {
+    QUnit.test("press 'enter' key sets option value (T100679)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3569,7 +3569,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.deepEqual(selectBox.option("value"), value, "value selected");
     });
 
-    QUnit.test("press 'space' key sets option value", (assert) => {
+    QUnit.test("press 'space' key sets option value", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3599,7 +3599,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.deepEqual(selectBox.option("value"), value, "value selected");
     });
 
-    QUnit.test("press 'space' key shouldn't sets option value if SelectBox accept custom value", (assert) => {
+    QUnit.test("press 'space' key shouldn't sets option value if SelectBox accept custom value", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3630,7 +3630,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.deepEqual(selectBox.option("value"), null, "There is no value");
     });
 
-    QUnit.test("press 'space' key shouldn't sets option value if search is enabled", (assert) => {
+    QUnit.test("press 'space' key shouldn't sets option value if search is enabled", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -3661,7 +3661,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.deepEqual(selectBox.option("value"), null, "There is no value");
     });
 
-    QUnit.test("error occurred while using the remote dataSource (T119856)", (assert) => {
+    QUnit.test("error occurred while using the remote dataSource (T119856)", function(assert) {
         assert.expect(0);
         const done = assert.async();
 
@@ -3689,7 +3689,7 @@ QUnit.module("regressions", moduleSetup, () => {
         });
     });
 
-    QUnit.test("onValueChanged should not be triggered while keyboard navigation in drop-down list (T116287)", (assert) => {
+    QUnit.test("onValueChanged should not be triggered while keyboard navigation in drop-down list (T116287)", function(assert) {
         let valueChangeFired = 0;
         const $element = $("#selectBox").dxSelectBox({
                 dataSource: [
@@ -3713,7 +3713,7 @@ QUnit.module("regressions", moduleSetup, () => {
         assert.strictEqual(instance.option("value"), null);
     });
 
-    QUnit.test("dxSelectBox's value should not be changed on keyup (T134612)", (assert) => {
+    QUnit.test("dxSelectBox's value should not be changed on keyup (T134612)", function(assert) {
         let valueChanged = 0;
         const $element = $("#selectBox").dxSelectBox({
                 dataSource: [
@@ -3747,7 +3747,7 @@ QUnit.module("regressions", moduleSetup, () => {
 
     });
 
-    QUnit.test("value change should select correct list item with the 'acceptCustomValue' set to true", (assert) => {
+    QUnit.test("value change should select correct list item with the 'acceptCustomValue' set to true", function(assert) {
         const selectBox = $("#selectBox").dxSelectBox({
             items: [1, 2, 3],
             acceptCustomValue: true
@@ -3762,7 +3762,7 @@ QUnit.module("regressions", moduleSetup, () => {
 
 QUnit.module("hide on blur", moduleSetup, () => {
 
-    QUnit.testInActiveWindow("selectbox does not hide self after input blur", (assert) => {
+    QUnit.testInActiveWindow("selectbox does not hide self after input blur", function(assert) {
         const $selectBox = $("#selectBoxWithoutScroll").dxSelectBox({
             dataSource: [100, 200, 300]
         });
@@ -3779,7 +3779,7 @@ QUnit.module("hide on blur", moduleSetup, () => {
 
 QUnit.module("keyboard navigation", moduleSetup, () => {
 
-    QUnit.test("upArrow and downArrow on textbox change value", (assert) => {
+    QUnit.test("upArrow and downArrow on textbox change value", function(assert) {
 
         const $element = $("#selectBox").dxSelectBox({
                 dataSource: [0, 1, 2],
@@ -3802,7 +3802,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.strictEqual(instance.option("value"), 1, "upArrow");
     });
 
-    QUnit.test("upArrow and downArrow on textbox change value after change dataSource", (assert) => {
+    QUnit.test("upArrow and downArrow on textbox change value after change dataSource", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 dataSource: [0, 1, 2],
                 value: 1,
@@ -3823,7 +3823,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.strictEqual(instance.option("value"), 4, "downArrow");
     });
 
-    QUnit.test("downArrow should load next page", (assert) => {
+    QUnit.test("downArrow should load next page", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 dataSource: {
                     store: [1, 2, 3, 4, 5, 6],
@@ -3851,7 +3851,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.strictEqual($list.find(".dx-list-item").text(), "1234", "all previous list items are loaded");
     });
 
-    QUnit.test("downArrow should not add new items", (assert) => {
+    QUnit.test("downArrow should not add new items", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: [1, 2, 3],
             opened: false
@@ -3872,7 +3872,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
     });
 
     [144, 145].forEach((testHeight) => {
-        QUnit.test(`downArrow should load next page if popup container has ${testHeight % 2 ? "odd" : "even"} height`, (assert) => {
+        QUnit.test(`downArrow should load next page if popup container has ${testHeight % 2 ? "odd" : "even"} height`, function(assert) {
             this.clock.restore();
             assert.expect(1);
             const done = assert.async();
@@ -3912,7 +3912,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         });
     });
 
-    QUnit.test("value should be correctly changed via arrow keys when grouped datasource is used", (assert) => {
+    QUnit.test("value should be correctly changed via arrow keys when grouped datasource is used", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             dataSource: new DataSource({
                 store: [{ id: 1, text: "item 1", Category: 1 }, { id: 2, text: "item 2", Category: 2 }],
@@ -3935,7 +3935,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal($input.val(), "item 2", "navigation is correct");
     });
 
-    QUnit.test("disabled item should not be selected via keyboard if the widget is closed", (assert) => {
+    QUnit.test("disabled item should not be selected via keyboard if the widget is closed", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [
                     { text: "Item 1" },
@@ -3958,7 +3958,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(instance.option("value"), "Item 1", "disabled item was skipped when up button was pressed");
     });
 
-    QUnit.test("Enter and escape key press prevent default when popup is opened", (assert) => {
+    QUnit.test("Enter and escape key press prevent default when popup is opened", function(assert) {
         assert.expect(1);
 
         const $element = $("#selectBox").dxSelectBox({
@@ -3987,7 +3987,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(prevented, 2, "defaults prevented on enter and escape keys");
     });
 
-    QUnit.test("Enter and escape key press does not prevent default when popup is not opened", (assert) => {
+    QUnit.test("Enter and escape key press does not prevent default when popup is not opened", function(assert) {
         assert.expect(1);
 
         const $element = $("#selectBox").dxSelectBox({
@@ -4013,7 +4013,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(prevented, 0, "defaults has not prevented on enter and escape keys");
     });
 
-    QUnit.test("Escape key press does not throw any errors when popup is not opened", (assert) => {
+    QUnit.test("Escape key press does not throw any errors when popup is not opened", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [0, 1, 2],
                 value: 1,
@@ -4029,7 +4029,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.ok(true, "SelectBox works correctly");
     });
 
-    QUnit.test("T243237: dxSelectBox keyboard navigation: up arrow can not circulate through the values, as down arrow", (assert) => {
+    QUnit.test("T243237: dxSelectBox keyboard navigation: up arrow can not circulate through the values, as down arrow", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [0, 1, 2],
                 value: 0,
@@ -4047,7 +4047,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(instance.option("value"), 0, "down arrow can circulate");
     });
 
-    QUnit.test("clearing selectbox with delete and backspace when showClearButton enabled (T243231)", (assert) => {
+    QUnit.test("clearing selectbox with delete and backspace when showClearButton enabled (T243231)", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [0, 1, 2],
                 value: 0,
@@ -4071,7 +4071,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(instance.option("value"), 2, "selectbox was not cleared on delete and backspace when showClearButton is false");
     });
 
-    QUnit.test("no clearing with delete and backspace when showClearButton enabled and searchEnabled is true (T257202)", (assert) => {
+    QUnit.test("no clearing with delete and backspace when showClearButton enabled and searchEnabled is true (T257202)", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: [0, 1, 2],
             value: 0,
@@ -4091,7 +4091,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(instance.option("value"), 0, "value preserved on delete");
     });
 
-    QUnit.test("no clearing with delete and backspace when showClearButton enabled and acceptCustomValue is true (T257202)", (assert) => {
+    QUnit.test("no clearing with delete and backspace when showClearButton enabled and acceptCustomValue is true (T257202)", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             items: [0, 1, 2],
             value: 0,
@@ -4111,7 +4111,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(instance.option("value"), 0, "value preserved on delete");
     });
 
-    QUnit.test("list should have selected value after it was selected in selectBox (T242349)", (assert) => {
+    QUnit.test("list should have selected value after it was selected in selectBox (T242349)", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
                 items: [0, 1, 2],
                 showSelectionControls: false,
@@ -4122,7 +4122,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(list.option("selectedIndex"), 1);
     });
 
-    QUnit.test("selectBox should select next value when used async dataSource (T298201)", (assert) => {
+    QUnit.test("selectBox should select next value when used async dataSource (T298201)", function(assert) {
         const items = [
             { id: 0, value: 'Item 0' },
             { id: 1, value: 'Item 1' }
@@ -4160,7 +4160,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.deepEqual(instance.option("value"), items[1], "upArrow");
     });
 
-    QUnit.test("selectBox should select next value when used async dataSource and values is set (T298201)", (assert) => {
+    QUnit.test("selectBox should select next value when used async dataSource and values is set (T298201)", function(assert) {
         const items = [
             { id: 0, value: 'Item 0' },
             { id: 1, value: 'Item 1' }
@@ -4199,7 +4199,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.deepEqual(instance.option("selectedItem"), items[1], "downArrow");
     });
 
-    QUnit.test("T323427 - item should be chosen after focus on it if input is empty", (assert) => {
+    QUnit.test("T323427 - item should be chosen after focus on it if input is empty", function(assert) {
         const items = [1, 2],
             $selectBox = $("#selectBox").dxSelectBox({
                 items: items,
@@ -4225,7 +4225,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(selectBox.option("value"), 1, "value should be changed to the selected item");
     });
 
-    QUnit.test("value can be cleared from keyboard when the list is not rendered yet", (assert) => {
+    QUnit.test("value can be cleared from keyboard when the list is not rendered yet", function(assert) {
         const items = [1, 2],
             $selectBox = $("#selectBox").dxSelectBox({
                 items: items,
@@ -4245,7 +4245,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal($input.val(), "", "input stay cleared");
     });
 
-    QUnit.test("T321249: SelectBox: Up/down keys loops only in last dataSource load result", (assert) => {
+    QUnit.test("T321249: SelectBox: Up/down keys loops only in last dataSource load result", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             dataSource: ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
             pageSize: 5,
@@ -4264,7 +4264,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal($input.val(), 1, "chosen value is correct");
     });
 
-    QUnit.test("Down key should not loop if dataSource is loading", (assert) => {
+    QUnit.test("Down key should not loop if dataSource is loading", function(assert) {
         const ds = new DataSource(["1", "2", "3", "4", "5", "6", "7", "8", "9"]);
         const $element = $("#selectBox").dxSelectBox({
             dataSource: ds,
@@ -4281,7 +4281,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal($input.val(), "9", "chosen value is correct");
     });
 
-    QUnit.testInActiveWindow("value should be reset to the previous one on the 'tab' press if popup is closed", (assert) => {
+    QUnit.testInActiveWindow("value should be reset to the previous one on the 'tab' press if popup is closed", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "not actual");
             return;
@@ -4309,7 +4309,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(selectBox.option("value"), items[0], "widget value is reset");
     });
 
-    QUnit.testInActiveWindow("input value should be reset to the previous one on the 'esc' press", (assert) => {
+    QUnit.testInActiveWindow("input value should be reset to the previous one on the 'esc' press", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "not actual");
             return;
@@ -4331,7 +4331,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal($input.val(), items[0], "input value is reset");
     });
 
-    QUnit.testInActiveWindow("value should be reset on the 'tab' press after input value was cleared", (assert) => {
+    QUnit.testInActiveWindow("value should be reset on the 'tab' press after input value was cleared", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "not actual");
             return;
@@ -4358,7 +4358,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal(selectBox.option("value"), null, "widget value is reset");
     });
 
-    QUnit.testInActiveWindow("value should be restored after the focusout when selection was not changed", (assert) => {
+    QUnit.testInActiveWindow("value should be restored after the focusout when selection was not changed", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "not actual");
             return;
@@ -4381,7 +4381,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal($input.val(), "first", "value has been restored");
     });
 
-    QUnit.test("value should be restored after the drop down button pressed when selection was not changed", (assert) => {
+    QUnit.test("value should be restored after the drop down button pressed when selection was not changed", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "not actual");
             return;
@@ -4404,7 +4404,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
         assert.equal($input.val(), "first", "value has been restored");
     });
 
-    QUnit.test("Escape key press should be handled by a children keyboard processor", (assert) => {
+    QUnit.test("Escape key press should be handled by a children keyboard processor", function(assert) {
 
         const $element = $("#selectBox").dxSelectBox({
             dataSource: [0, 1, 2],
@@ -4431,7 +4431,7 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
 
 QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
 
-    QUnit.test("T309987 - item should not be changed on the 'tab' press", (assert) => {
+    QUnit.test("T309987 - item should not be changed on the 'tab' press", function(assert) {
         const items = ["first", "second"],
             value = items[1],
             $selectBox = $("#selectBox").dxSelectBox({
@@ -4449,7 +4449,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
         assert.equal(instance.option("value"), value);
     });
 
-    QUnit.test("First item is not selected when edit is disabled", (assert) => {
+    QUnit.test("First item is not selected when edit is disabled", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: false,
             searchEnabled: false,
@@ -4465,7 +4465,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
         assert.equal($selectBox.dxSelectBox("option", "value"), null, "was selected first item and be set");
     });
 
-    QUnit.test("If no influence on selectBox, 'input' should be empty after 'tab' key pressed", (assert) => {
+    QUnit.test("If no influence on selectBox, 'input' should be empty after 'tab' key pressed", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             dataSource: ["a", "b", "c"],
             searchEnabled: true,
@@ -4485,7 +4485,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
         assert.equal(instance.option("value"), null, "value is empty");
     });
 
-    QUnit.test("After typing a couple letters of search criteria value should be set to input text (searchEnabled='true' acceptCustomValue='true')", (assert) => {
+    QUnit.test("After typing a couple letters of search criteria value should be set to input text (searchEnabled='true' acceptCustomValue='true')", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             dataSource: ["United States of America", "Uruguay", "Uzbekistan", "Vanuatu"],
             searchEnabled: true,
@@ -4508,7 +4508,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
         assert.equal(instance.option("value"), "an", "value is correct");
     });
 
-    QUnit.test("After highlighting item and pressing 'tab' it should be chosen", (assert) => {
+    QUnit.test("After highlighting item and pressing 'tab' it should be chosen", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -4536,7 +4536,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
         assert.equal(instance.option("value"), "Uzbekistan", "value is correct");
     });
 
-    QUnit.test("Text should not be reset after press tab", (assert) => {
+    QUnit.test("Text should not be reset after press tab", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             dataSource: ["United States of America", "Uruguay", "Uzbekistan", "Vanuatu"],
             acceptCustomValue: false,
@@ -4553,7 +4553,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
         assert.equal(instance.option("value"), "Uruguay", "value is correct");
     });
 
-    QUnit.test("Text should not be reset after press tab if popup is opened", (assert) => {
+    QUnit.test("Text should not be reset after press tab if popup is opened", function(assert) {
         const $element = $("#selectBox").dxSelectBox({
             dataSource: ["United States of America", "Uruguay", "Uzbekistan", "Vanuatu"],
             acceptCustomValue: false,
@@ -4573,7 +4573,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
         assert.equal(instance.option("value"), "Uruguay", "value is correct");
     });
 
-    QUnit.test("the 'Tab' key press should clear input selection", (assert) => {
+    QUnit.test("the 'Tab' key press should clear input selection", function(assert) {
         const items = ["aaa", "aab", "acc"];
         const $element = $("#selectBox").dxSelectBox({
             dataSource: items,
@@ -4592,7 +4592,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
         assert.equal(caret.start, caret.end, "the input has no selection");
     });
 
-    QUnit.testInActiveWindow("the 'tab' key press should focus the 'apply' button if the input is focused", (assert) => {
+    QUnit.testInActiveWindow("the 'tab' key press should focus the 'apply' button if the input is focused", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "desktop specific test");
             return;
@@ -4617,7 +4617,7 @@ QUnit.module("keyboard navigation 'TAB' button", moduleSetup, () => {
 });
 
 QUnit.module("acceptCustomValue mode", moduleSetup, () => {
-    QUnit.test("All items should be displayed when widget focused out before search completion", (assert) => {
+    QUnit.test("All items should be displayed when widget focused out before search completion", function(assert) {
         const items = ["aaa", "bbb"];
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
@@ -4646,7 +4646,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.equal($listItems.text(), items.join(''), "items are displayed correctly");
     });
 
-    QUnit.test("input value can be edited when acceptCustomValue=true", (assert) => {
+    QUnit.test("input value can be edited when acceptCustomValue=true", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true
         });
@@ -4656,7 +4656,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.equal($input.val(), "test", "value typed in input");
     });
 
-    QUnit.test("value set to custom value in input", (assert) => {
+    QUnit.test("value set to custom value in input", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true
         });
@@ -4666,7 +4666,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.equal($selectBox.dxSelectBox("option", "value"), "test", "value typed in input");
     });
 
-    QUnit.testInActiveWindow("searching values in selectbox when acceptCustomValue=true", (assert) => {
+    QUnit.testInActiveWindow("searching values in selectbox when acceptCustomValue=true", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             searchEnabled: true,
@@ -4684,7 +4684,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.deepEqual($(".dx-list").dxList("option", "items"), ["a", "ab", "ac"], "items filtered");
     });
 
-    QUnit.test("press enter key sets value when acceptCustomValue=true", (assert) => {
+    QUnit.test("press enter key sets value when acceptCustomValue=true", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             dataSource: ["1", "2", "3"]
@@ -4700,7 +4700,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.equal($selectBox.dxSelectBox("option", "value"), "0", "0 value was be set");
     });
 
-    QUnit.test("press on tab should close popup after custom value input if search is enabled", (assert) => {
+    QUnit.test("press on tab should close popup after custom value input if search is enabled", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             acceptCustomValue: true,
@@ -4716,7 +4716,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.notOk(instance.option("opened"), "popup is closed");
     });
 
-    QUnit.test("custom value should be added on enter key when acceptCustomValue=true", (assert) => {
+    QUnit.test("custom value should be added on enter key when acceptCustomValue=true", function(assert) {
         const onCustomItemCreating = sinon.stub().returns("Custom item");
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
@@ -4734,7 +4734,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.equal(onCustomItemCreating.callCount, 1, "action was called");
     });
 
-    QUnit.test("custom value should be added on enter key when acceptCustomValue=true and dd is initially closed", (assert) => {
+    QUnit.test("custom value should be added on enter key when acceptCustomValue=true and dd is initially closed", function(assert) {
         const onCustomItemCreating = sinon.stub().returns("Custom item");
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
@@ -4752,7 +4752,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.equal(onCustomItemCreating.callCount, 1, "action was called");
     });
 
-    QUnit.test("drop list should contain all items when input value is not empty", (assert) => {
+    QUnit.test("drop list should contain all items when input value is not empty", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             acceptCustomValue: true,
             dataSource: ["a", "b"],
@@ -4768,7 +4768,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.deepEqual($(".dx-list").dxList("option", "items"), ["a", "b"], "all items");
     });
 
-    QUnit.test("value must appear in the INPUT ​​after removal of value with searchEnabled='true'", (assert) => {
+    QUnit.test("value must appear in the INPUT ​​after removal of value with searchEnabled='true'", function(assert) {
         const $selectBox = $("#selectBox").dxSelectBox({
             searchEnabled: true,
             dataSource: ["a", "b", "c"],
@@ -4793,7 +4793,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
         assert.equal($input.val(), "b", "item should be choose after click on list item");
     });
 
-    QUnit.testInActiveWindow("dxSelectBox should not filter a dataSource when the widget disposing (T535861)", (assert) => {
+    QUnit.testInActiveWindow("dxSelectBox should not filter a dataSource when the widget disposing (T535861)", function(assert) {
         const instance = $("#selectBox").dxSelectBox({
                 dataSource: [1, 2],
                 acceptCustomValue: true,
@@ -4818,7 +4818,7 @@ QUnit.module("acceptCustomValue mode", moduleSetup, () => {
 
 
 QUnit.module("focus policy", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
         fx.off = true;
 
@@ -4830,12 +4830,12 @@ QUnit.module("focus policy", {
         this.$input = this.$element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
         this.keyboard = keyboardMock(this.$input);
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("filtering is reset when open control with keyboard", (assert) => {
+    QUnit.test("filtering is reset when open control with keyboard", function(assert) {
         this.instance.option({
             searchEnabled: true,
             searchTimeout: 0,
@@ -4857,7 +4857,7 @@ QUnit.module("focus policy", {
         assert.equal($.trim($(toSelector(LIST_ITEM_CLASS)).text()), "abc", "no filtering");
     });
 
-    QUnit.test("input keep focus when popup is opened by click on button", (assert) => {
+    QUnit.test("input keep focus when popup is opened by click on button", function(assert) {
         const $arrow = this.$element.find(toSelector(TEXTEDITOR_BUTTONS_CONTAINER_CLASS));
 
         this.instance.focus();
@@ -4869,7 +4869,7 @@ QUnit.module("focus policy", {
     });
 
     // T409774
-    QUnit.test("widget disposing in focusOut event handler", (assert) => {
+    QUnit.test("widget disposing in focusOut event handler", function(assert) {
         let focusOutCallCount = 0;
 
         this.instance.option({
@@ -4889,7 +4889,7 @@ QUnit.module("focus policy", {
         assert.equal(focusOutCallCount, 1, "onFocusOut called once");
     });
 
-    QUnit.test("selectbox should not focus disabled item after the search", (assert) => {
+    QUnit.test("selectbox should not focus disabled item after the search", function(assert) {
         this.instance.option({
             searchEnabled: true,
             opened: true,
@@ -4909,7 +4909,7 @@ QUnit.module("focus policy", {
         assert.ok($item.hasClass(STATE_FOCUSED_CLASS), "first non disabled item is focused");
     });
 
-    QUnit.test("After focus a selectBox and type a char exception should not be throw", (assert) => {
+    QUnit.test("After focus a selectBox and type a char exception should not be throw", function(assert) {
         this.instance.option({
             dataSource: [1, 2, 3],
             searchEnabled: true,
@@ -4929,7 +4929,7 @@ QUnit.module("focus policy", {
         }
     });
 
-    QUnit.testInActiveWindow("dxSelectBox should save focus after inner buttons were clicked", (assert) => {
+    QUnit.testInActiveWindow("dxSelectBox should save focus after inner buttons were clicked", function(assert) {
         const focusStub = sinon.stub();
         const blurStub = sinon.stub();
         const clickStub = sinon.stub();
@@ -4959,7 +4959,7 @@ QUnit.module("focus policy", {
         assert.strictEqual(clickStub.callCount, 1, "action button clicked");
     });
 
-    QUnit.testInActiveWindow("dxSelectBox should save focus after inner buttons were focused", (assert) => {
+    QUnit.testInActiveWindow("dxSelectBox should save focus after inner buttons were focused", function(assert) {
         const focusStub = sinon.stub();
         const blurStub = sinon.stub();
 
@@ -4990,7 +4990,7 @@ var helper;
 if(devices.real().deviceType === "desktop") {
     [true, false].forEach((searchEnabled) => {
         QUnit.module(`Aria accessibility, searchEnabled: ${searchEnabled}`, {
-            beforeEach: () => {
+            beforeEach: function() {
                 helper = new ariaAccessibilityTestHelper({
                     createWidget: ($element, options) => new SelectBox($element,
                         $.extend({
@@ -4998,11 +4998,11 @@ if(devices.real().deviceType === "desktop") {
                         }, options))
                 });
             },
-            afterEach: () => {
+            afterEach: function() {
                 helper.$widget.remove();
             }
         }, () => {
-            QUnit.test(`opened: true -> searchEnabled: ${!searchEnabled}`, () => {
+            QUnit.test(`opened: true -> searchEnabled: ${!searchEnabled}`, function() {
                 helper.createWidget({ opened: true });
 
                 helper.checkAttributes(helper.widget._list.$element(), { id: helper.widget._listId, "aria-label": "No data to display", role: "listbox" }, "list");
@@ -5044,7 +5044,7 @@ if(devices.real().deviceType === "desktop") {
                 helper.checkAttributes(helper.widget._popup.$content(), { id: helper.widget._popupContentId }, "popupContent");
             });
 
-            QUnit.test(`opened: false -> searchEnabled: ${!searchEnabled}`, () => {
+            QUnit.test(`opened: false -> searchEnabled: ${!searchEnabled}`, function() {
                 helper.createWidget({ opened: false });
 
                 let inputAttributes = {

--- a/testing/tests/DevExpress.ui.widgets.editors/slider.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/slider.markup.tests.js
@@ -23,7 +23,7 @@ testStart(function() {
 });
 
 module("slider markup", () => {
-    test("default", assert => {
+    test("default", function(assert) {
         const $sliderElement = $("#slider").dxSlider({
             useInkRipple: false
         });
@@ -43,7 +43,7 @@ module("slider markup", () => {
         assert.ok($bar.length, "bar is rendered");
     });
 
-    test("'showRange' option should toggle class to range element", assert => {
+    test("'showRange' option should toggle class to range element", function(assert) {
         const slider = $("#slider").dxSlider({
             showRange: true,
             useInkRipple: false
@@ -55,7 +55,7 @@ module("slider markup", () => {
         assert.ok(!$("." + SLIDER_RANGE_CLASS).hasClass(SLIDER_RANGE_VISIBLE_CLASS));
     });
 
-    test("labels visibility", assert => {
+    test("labels visibility", function(assert) {
         const $slider = $("#slider").dxSlider({
             min: 0,
             max: 100,
@@ -69,7 +69,7 @@ module("slider markup", () => {
         assert.equal($sliderLabels.length, 2, "labels are rendered");
     });
 
-    test("labels visiility - format", assert => {
+    test("labels visiility - format", function(assert) {
         const $slider = $("#slider").dxSlider({
             label: {
                 visible: true,
@@ -91,7 +91,7 @@ module("slider markup", () => {
         assert.equal($sliderLabels.eq(1).html(), "(100)");
     });
 
-    test("labels visiility - position", assert => {
+    test("labels visiility - position", function(assert) {
         const $slider = $("#slider").dxSlider({
             label: {
                 visible: true,
@@ -112,7 +112,7 @@ module("slider markup", () => {
         assert.ok(!$slider.hasClass("dx-slider-label-position-top"));
     });
 
-    test("set the validationMessageOffset for the Generic theme", assert => {
+    test("set the validationMessageOffset for the Generic theme", function(assert) {
         const slider = $("#slider").dxSlider({
             useInkRipple: false
         }).dxSlider("instance");
@@ -120,7 +120,7 @@ module("slider markup", () => {
         assert.deepEqual(slider.option("validationMessageOffset"), { h: 7, v: 4 });
     });
 
-    test("set the validationMessageOffset for the Material theme", assert => {
+    test("set the validationMessageOffset for the Material theme", function(assert) {
         const origIsMaterial = themes.isMaterial;
         themes.isMaterial = function() { return true; };
 
@@ -135,7 +135,7 @@ module("slider markup", () => {
 });
 
 module("widget sizing render", () => {
-    test("constructor", assert => {
+    test("constructor", function(assert) {
         const $element = $("#widget").dxSlider({
                 width: 400,
                 useInkRipple: false
@@ -146,7 +146,7 @@ module("widget sizing render", () => {
         assert.strictEqual($element[0].style.width, "400px", "outer width of the element must be equal to custom width");
     });
 
-    test("root with custom width", assert => {
+    test("root with custom width", function(assert) {
         const $element = $("#widthRootStyle").dxSlider({
                 useInkRipple: false
             }),
@@ -156,7 +156,7 @@ module("widget sizing render", () => {
         assert.strictEqual($element[0].style.width, "300px", "outer width of the element must be equal to custom width");
     });
 
-    test("change width", assert => {
+    test("change width", function(assert) {
         const $element = $("#widget").dxSlider({
                 useInkRipple: false
             }),
@@ -170,7 +170,7 @@ module("widget sizing render", () => {
 });
 
 module("hidden input", () => {
-    test("a hidden input should be rendered", assert => {
+    test("a hidden input should be rendered", function(assert) {
         const $slider = $("#slider").dxSlider(),
             $input = $slider.find("input");
 
@@ -178,7 +178,7 @@ module("hidden input", () => {
         assert.equal($input.attr("type"), "hidden", "the input type is 'hidden'");
     });
 
-    test("the hidden input should have correct value on widget init", assert => {
+    test("the hidden input should have correct value on widget init", function(assert) {
         const expectedValue = 30,
             $slider = $("#slider").dxSlider({
                 value: expectedValue
@@ -188,7 +188,7 @@ module("hidden input", () => {
         assert.equal(parseInt($input.val()), expectedValue, "the hidden input value is correct");
     });
 
-    test("the hidden input should get correct value on widget value change", assert => {
+    test("the hidden input should get correct value on widget value change", function(assert) {
         const expectedValue = 77,
             $slider = $("#slider").dxSlider(),
             instance = $slider.dxSlider("instance"),
@@ -201,7 +201,7 @@ module("hidden input", () => {
 });
 
 module("aria accessibility", () => {
-    test("aria role", assert => {
+    test("aria role", function(assert) {
         const $element = $("#widget").dxSlider({
                 useInkRipple: false
             }),
@@ -210,7 +210,7 @@ module("aria accessibility", () => {
         assert.equal($handle.attr("role"), "slider", "aria role is correct");
     });
 
-    test("aria properties", assert => {
+    test("aria properties", function(assert) {
         const $element = $("#widget").dxSlider({
                 min: 20,
                 max: 50,
@@ -224,7 +224,7 @@ module("aria accessibility", () => {
         assert.equal($handle.attr("aria-valuenow"), 35, "aria now is correct");
     });
 
-    test("change aria properties on option changing", assert => {
+    test("change aria properties on option changing", function(assert) {
         const $element = $("#widget").dxSlider({
                 min: 20,
                 max: 50,

--- a/testing/tests/DevExpress.ui.widgets.editors/slider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/slider.tests.js
@@ -57,7 +57,7 @@ const moduleOptions = {
 };
 
 module("render", moduleOptions, () => {
-    test("default size", assert => {
+    test("default size", function(assert) {
         const $element = $("#widget").dxSlider({
             useInkRipple: false
         });
@@ -65,7 +65,7 @@ module("render", moduleOptions, () => {
         assert.ok($element.outerWidth() > 0, "outer width of the element must be more than zero");
     });
 
-    test("onContentReady fired after the widget is fully ready", assert => {
+    test("onContentReady fired after the widget is fully ready", function(assert) {
         assert.expect(2);
         const position = "top";
 
@@ -81,7 +81,7 @@ module("render", moduleOptions, () => {
         });
     });
 
-    test("Resize by option", assert => {
+    test("Resize by option", function(assert) {
         const setUpWidth = 11,
             setUpHeight = 22,
             increment = 123,
@@ -106,7 +106,7 @@ module("render", moduleOptions, () => {
         assert.equal($slider.height() - initialHeight, increment, "Element's height was set properly on resize");
     });
 
-    test("check range-slide width after resize", assert => {
+    test("check range-slide width after resize", function(assert) {
         const setUpWidth = 100,
             decrement = 0.7 * setUpWidth,
             $slider = $("#slider").dxSlider({
@@ -123,7 +123,7 @@ module("render", moduleOptions, () => {
         assert.ok($range.width() < $slider.width(), "range width is correct");
     });
 
-    test("mousedown/touchstart on slider set new value (B233178)", assert => {
+    test("mousedown/touchstart on slider set new value (B233178)", function(assert) {
         const $element = $("#slider").dxSlider({
             max: 500,
             min: 0,
@@ -236,7 +236,7 @@ module("render", moduleOptions, () => {
         assert.ok(!$handle.hasClass(ACTIVE_STATE_CLASS), "feedback turned off");
     });
 
-    test("drag handler", assert => {
+    test("drag handler", function(assert) {
         const $element = $("#slider").dxSlider({
             max: 500,
             min: 0,
@@ -260,7 +260,7 @@ module("render", moduleOptions, () => {
 
     });
 
-    test("smooth drag of handler", assert => {
+    test("smooth drag of handler", function(assert) {
         const $element = $("#slider").dxSlider({
             max: 500,
             min: 0,
@@ -279,7 +279,7 @@ module("render", moduleOptions, () => {
         pointer.up();
     });
 
-    test("value should be updated on swipestart on mobile devices", assert => {
+    test("value should be updated on swipestart on mobile devices", function(assert) {
         const $element = $("#slider").dxSlider({
                 max: 500,
                 min: 0,
@@ -296,7 +296,7 @@ module("render", moduleOptions, () => {
         assert.equal(instance.option("value"), 300, "value set after dxswipestart");
     });
 
-    test("value should be updated on click on mobile devices", assert => {
+    test("value should be updated on click on mobile devices", function(assert) {
         const $element = $("#slider").dxSlider({
                 max: 500,
                 min: 0,
@@ -313,7 +313,7 @@ module("render", moduleOptions, () => {
         assert.equal(instance.option("value"), 300, "value set after dxclick");
     });
 
-    test("value should be correctly updated on swipestart with the step that exceeds the maximum (T831727)", assert => {
+    test("value should be correctly updated on swipestart with the step that exceeds the maximum (T831727)", function(assert) {
         const $element = $("#slider").dxSlider({
             max: 500,
             min: 0,
@@ -342,7 +342,7 @@ module("render", moduleOptions, () => {
 });
 
 module("hidden input", () => {
-    test("the hidden input should use the decimal separator specified in DevExpress.config", assert => {
+    test("the hidden input should use the decimal separator specified in DevExpress.config", function(assert) {
         const originalConfig = config();
         try {
             config({ serverDecimalSeparator: "|" });
@@ -360,7 +360,7 @@ module("hidden input", () => {
 });
 
 module("the 'name' option", () => {
-    test("widget input should get the 'name' attribute with a correct value", assert => {
+    test("widget input should get the 'name' attribute with a correct value", function(assert) {
         const expectedName = "some_name",
             $element = $("#slider").dxSlider({
                 name: expectedName
@@ -372,7 +372,7 @@ module("the 'name' option", () => {
 });
 
 module("slider with tooltip", () => {
-    test("tooltip default rendering", assert => {
+    test("tooltip default rendering", function(assert) {
         const $slider = $("#slider").dxSlider({
                 tooltip: {
                     enabled: true,
@@ -388,7 +388,7 @@ module("slider with tooltip", () => {
         assert.ok(Tooltip.getInstance($tooltip));
     });
 
-    test("'tooltip.enabled' option renders or remove tooltip", assert => {
+    test("'tooltip.enabled' option renders or remove tooltip", function(assert) {
         const $slider = $("#slider").dxSlider({
                 tooltip: {
                     enabled: false,
@@ -414,7 +414,7 @@ module("slider with tooltip", () => {
         assert.ok(!$slider.hasClass("dx-slider-tooltip-position-top") && !$slider.hasClass("dx-slider-tooltip-position-bottom"));
     });
 
-    test("tooltip displays current value", assert => {
+    test("tooltip displays current value", function(assert) {
         const $slider = $("#slider").dxSlider({
                 min: 0,
                 value: 50,
@@ -434,7 +434,7 @@ module("slider with tooltip", () => {
         assert.equal($.trim($tooltip.text()), 75);
     });
 
-    test("'tooltip.position' option", assert => {
+    test("'tooltip.position' option", function(assert) {
         const $slider = $("#slider");
 
         positionUtils.setup($slider, {
@@ -478,7 +478,7 @@ module("slider with tooltip", () => {
         assert.ok(tooltipTop > sliderBottom, "tooltip top = " + tooltipTop + ", slider bottom = " + sliderBottom + " - tooltip should be display on bottom");
     });
 
-    test("tooltip should be centered after render", assert => {
+    test("tooltip should be centered after render", function(assert) {
         const $slider = $("#slider").dxSlider({
             max: 100,
             min: 0,
@@ -493,7 +493,7 @@ module("slider with tooltip", () => {
         assert.equal(Math.floor(($tooltip.outerWidth() - $arrow.outerWidth()) / 2), -$tooltip.position().left + parseInt($arrow.css("margin-left").replace("px", "")), "tooltip position is centered");
     });
 
-    test("tooltip should be fitted into slide right and left bounds", assert => {
+    test("tooltip should be fitted into slide right and left bounds", function(assert) {
         const $slider = $("#slider");
 
         positionUtils.setup($slider, {
@@ -529,7 +529,7 @@ module("slider with tooltip", () => {
         assert.ok(tooltipRight <= sliderRight, "tooltip right = " + tooltipRight + ", slider right = " + sliderRight);
     });
 
-    test("'tooltip.showMode' option", assert => {
+    test("'tooltip.showMode' option", function(assert) {
         const $slider = $("#slider").dxSlider({
                 min: 0,
                 value: 50,
@@ -548,7 +548,7 @@ module("slider with tooltip", () => {
         assert.ok(!$handle.hasClass("dx-slider-tooltip-on-hover"));
     });
 
-    test("tooltip was not created before slider hanlde has focus", assert => {
+    test("tooltip was not created before slider hanlde has focus", function(assert) {
         const $slider = $("#slider").dxSlider({
                 min: 0,
                 value: 50,
@@ -572,7 +572,7 @@ module("slider with tooltip", () => {
         assert.ok(!!Tooltip.getInstance($tooltip), "tooltip was created");
     });
 
-    test("'rtlEnabled' changing should not leads to error", assert => {
+    test("'rtlEnabled' changing should not leads to error", function(assert) {
         assert.expect(0);
 
         const $slider = $("#slider").dxSlider({
@@ -589,7 +589,7 @@ module("slider with tooltip", () => {
         });
     });
 
-    test("tooltip option changing when slider 'visible' = false", assert => {
+    test("tooltip option changing when slider 'visible' = false", function(assert) {
         const $slider = $("#slider");
 
         positionUtils.setup($slider, {
@@ -624,7 +624,7 @@ module("slider with tooltip", () => {
         assert.ok(tooltipBottom < sliderTop, "tooltip bottom = " + tooltipBottom + ", slider top = " + sliderTop + " - tooltip should be display on top");
     });
 
-    test("slider tooltip should not add hideTopOverlayCallback (T104070)", assert => {
+    test("slider tooltip should not add hideTopOverlayCallback (T104070)", function(assert) {
         const $slider = $("#slider");
 
         $slider.dxSlider({
@@ -638,7 +638,7 @@ module("slider with tooltip", () => {
         assert.ok(!hideTopOverlayCallback.hasCallback());
     });
 
-    test("tooltip renders correct after value length changed", assert => {
+    test("tooltip renders correct after value length changed", function(assert) {
         if(browser.msie) {
             assert.expect(0);
             return;
@@ -674,7 +674,7 @@ module("slider with tooltip", () => {
         }
     });
 
-    test("tooltip should repaints when repaint function called (T260971)", assert => {
+    test("tooltip should repaints when repaint function called (T260971)", function(assert) {
         $("#slider").hide();
 
         const $slider = $("#slider").dxSlider({
@@ -697,7 +697,7 @@ module("slider with tooltip", () => {
         assert.ok($slider.find(".dx-tooltip .dx-overlay-content").length, "tooltip is exist");
     });
 
-    test("slider in scrollable should not show scroll in max position (T315618)", assert => {
+    test("slider in scrollable should not show scroll in max position (T315618)", function(assert) {
         const sliderWidth = 400,
             $slider = $("#slider").dxSlider({
                 min: 0,
@@ -718,7 +718,7 @@ module("slider with tooltip", () => {
         assert.equal(boundaryOffset, 2, "tooltip content should have correct boundary offset");
     });
 
-    test("arrow should be centered after dimension was changed", assert => {
+    test("arrow should be centered after dimension was changed", function(assert) {
         const $slider = $("#slider").dxSlider({
             min: 0,
             max: 100,
@@ -738,7 +738,7 @@ module("slider with tooltip", () => {
         assert.equal($arrow.offset().left + $arrow.outerWidth() / 2, $sliderHandle.offset().left + $sliderHandle.outerWidth() / 2, "arrow centered");
     });
 
-    test("arrow should not go outside of the content overlay", assert => {
+    test("arrow should not go outside of the content overlay", function(assert) {
         const $slider = $("#slider").dxSlider({
             min: 0,
             max: 100,
@@ -762,7 +762,7 @@ module("slider with tooltip", () => {
 });
 
 module("'tooltip.format' option", () => {
-    test("'tooltip.format' option as function", assert => {
+    test("'tooltip.format' option as function", function(assert) {
         const $slider = $("#slider").dxSlider({
                 min: 0,
                 value: 50,
@@ -785,7 +785,7 @@ module("'tooltip.format' option", () => {
         assert.equal($.trim($tooltip.text()), "$75");
     });
 
-    test("'tooltip.format' option as FormatHelper format", assert => {
+    test("'tooltip.format' option as FormatHelper format", function(assert) {
         const $slider = $("#slider").dxSlider({
                 min: 0,
                 value: 0.12345,
@@ -808,7 +808,7 @@ module("'tooltip.format' option", () => {
         assert.equal($.trim($tooltip.text()), "0.12");
     });
 
-    test("'tooltip.format' changing should re-render tooltip content", assert => {
+    test("'tooltip.format' changing should re-render tooltip content", function(assert) {
         const $slider = $("#slider").dxSlider({
                 min: 0,
                 value: 1,
@@ -837,7 +837,7 @@ module("'tooltip.format' option", () => {
         assert.equal($.trim($tooltip.text()), "[1]");
     });
 
-    test("'tooltip.format' as undefined (null, false) should render value as is", assert => {
+    test("'tooltip.format' as undefined (null, false) should render value as is", function(assert) {
         const $slider = $("#slider").dxSlider({
                 min: 0,
                 value: 1,
@@ -855,7 +855,7 @@ module("'tooltip.format' option", () => {
         assert.equal($.trim($tooltip.text()), "1");
     });
 
-    test("Update tooltip width when value is formatted", assert => {
+    test("Update tooltip width when value is formatted", function(assert) {
         const values = ["first", "second value", "third"],
             $slider = $("#slider").dxSlider({
                 min: 0,
@@ -879,7 +879,7 @@ module("'tooltip.format' option", () => {
 });
 
 module("labels", moduleOptions, () => {
-    test("'label.visible' option toggles label visibility", assert => {
+    test("'label.visible' option toggles label visibility", function(assert) {
         const $slider = $("#slider").dxSlider({
             min: 0,
             max: 100,
@@ -899,7 +899,7 @@ module("labels", moduleOptions, () => {
         assert.equal($sliderLabels.length, 0, "labels are removed");
     });
 
-    test("labels should re-rendered if 'min' or/and 'max' options changed", assert => {
+    test("labels should re-rendered if 'min' or/and 'max' options changed", function(assert) {
         const $slider = $("#slider").dxSlider({
             label: {
                 visible: true
@@ -933,7 +933,7 @@ module("labels", moduleOptions, () => {
 });
 
 module("events", () => {
-    test("value change should cause value change action call", assert => {
+    test("value change should cause value change action call", function(assert) {
         assert.expect(1);
 
         const $slider = $("#slider").dxSlider({
@@ -949,7 +949,7 @@ module("events", () => {
         pointerMock($slider).start().move(250 + $slider.offset().left).down();
     });
 
-    test("Changing the 'value' option must invoke the 'onValueChanged' action", assert => {
+    test("Changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         const slider = $("#slider").dxSlider({
             onValueChanged: function() { assert.ok(true); },
             useInkRipple: false
@@ -957,7 +957,7 @@ module("events", () => {
         slider.option("value", true);
     });
 
-    test("T269867 - handle should not have active state if the 'activeStateEnabled' option is false", assert => {
+    test("T269867 - handle should not have active state if the 'activeStateEnabled' option is false", function(assert) {
         const $element = $("#slider").dxSlider({
                 activeStateEnabled: false,
                 useInkRipple: false
@@ -970,7 +970,7 @@ module("events", () => {
 });
 
 module("focus policy", moduleOptions, () => {
-    testInActiveWindow("Handle focus by click on track bar (T249311)", assert => {
+    testInActiveWindow("Handle focus by click on track bar (T249311)", function(assert) {
         assert.expect(1);
 
         const $slider = $("#slider").dxSlider({
@@ -985,7 +985,7 @@ module("focus policy", moduleOptions, () => {
 });
 
 module("keyboard navigation", moduleOptions, () => {
-    test("control keys test", assert => {
+    test("control keys test", function(assert) {
         assert.expect(2);
 
         const $slider = $("#slider").dxSlider({
@@ -1008,7 +1008,7 @@ module("keyboard navigation", moduleOptions, () => {
         assert.equal(slider.option("value"), 50, "value is correct after leftArrow press");
     });
 
-    test("control keys test with step", assert => {
+    test("control keys test with step", function(assert) {
         assert.expect(4);
 
         const $slider = $("#slider").dxSlider({
@@ -1038,7 +1038,7 @@ module("keyboard navigation", moduleOptions, () => {
         assert.equal(slider.option("value"), 90, "value is correct after end press");
     });
 
-    test("pageUp/pageDown keys test", assert => {
+    test("pageUp/pageDown keys test", function(assert) {
         assert.expect(4);
 
         const $slider = $("#slider").dxSlider({
@@ -1071,7 +1071,7 @@ module("keyboard navigation", moduleOptions, () => {
         assert.equal(slider.option("value"), 50, "value is correct after pageDown press");
     });
 
-    test("control keys test for rtl", assert => {
+    test("control keys test for rtl", function(assert) {
         assert.expect(4);
 
         const $slider = $("#slider").dxSlider({
@@ -1102,7 +1102,7 @@ module("keyboard navigation", moduleOptions, () => {
         assert.equal(slider.option("value"), 90, "value is correct after end press");
     });
 
-    test("pageUp/pageDown keys test for rtl", assert => {
+    test("pageUp/pageDown keys test for rtl", function(assert) {
         assert.expect(4);
 
         const $slider = $("#slider").dxSlider({
@@ -1135,7 +1135,7 @@ module("keyboard navigation", moduleOptions, () => {
         assert.equal(slider.option("value"), 50, "value is correct after pageDown press");
     });
 
-    test("T380070 - the value should not be changed on the 'left' key press if the value is min", assert => {
+    test("T380070 - the value should not be changed on the 'left' key press if the value is min", function(assert) {
         const spy = sinon.spy(),
             $slider = $("#slider").dxSlider({
                 min: 10,
@@ -1149,7 +1149,7 @@ module("keyboard navigation", moduleOptions, () => {
         assert.ok(spy.called === false, "the onValueChanged is not called");
     });
 
-    test("T380070 - the value should not be changed on the 'right' key press if the value is max", assert => {
+    test("T380070 - the value should not be changed on the 'right' key press if the value is max", function(assert) {
         const spy = sinon.spy(),
             $slider = $("#slider").dxSlider({
                 max: 10,
@@ -1165,7 +1165,7 @@ module("keyboard navigation", moduleOptions, () => {
 });
 
 module("regression tests", moduleOptions, () => {
-    test("change value of invisible element", assert => {
+    test("change value of invisible element", function(assert) {
         const $element = $("#slider").dxSlider({
                 max: 100,
                 min: 0,
@@ -1182,7 +1182,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal(range.width(), 40, "range width is right");
     });
 
-    test("min value behaviour", assert => {
+    test("min value behaviour", function(assert) {
         const $element = $("#slider").dxSlider({
             max: 600,
             min: 100,
@@ -1196,7 +1196,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal(slider.option("value"), 350);
     });
 
-    test("B230095 - value is set to '0' after click on the handle", assert => {
+    test("B230095 - value is set to '0' after click on the handle", function(assert) {
         const $element = $("#slider").dxSlider({
             max: 10,
             min: 0,
@@ -1211,7 +1211,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal($element.dxSlider("option", "value"), 5);
     });
 
-    test("B232111, B233180 - disabled state doesn't work", assert => {
+    test("B232111, B233180 - disabled state doesn't work", function(assert) {
         const $element = $("#slider").dxSlider({
                 min: 0,
                 value: 50,
@@ -1226,7 +1226,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal(slider.option("value"), 50);
     });
 
-    test("B233256 - incorrect options", assert => {
+    test("B233256 - incorrect options", function(assert) {
         const $element = $("#slider").dxSlider({
                 min: 0,
                 value: 50,
@@ -1240,7 +1240,7 @@ module("regression tests", moduleOptions, () => {
         assert.expect(0);
     });
 
-    test("B233288 - incorrect behavior when swipe on handle", assert => {
+    test("B233288 - incorrect behavior when swipe on handle", function(assert) {
         const $element = $("#slider")
             .css("width", 500)
             .dxSlider({
@@ -1259,7 +1259,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal(instance.option("value"), 252);
     });
 
-    test("B234545 dxRangeSlider/dxSlider - incorrect behavior with negative min and max values.", assert => {
+    test("B234545 dxRangeSlider/dxSlider - incorrect behavior with negative min and max values.", function(assert) {
         const $element = $("#slider").css("width", 960);
 
         $element.dxSlider({
@@ -1280,7 +1280,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal($range.width(), 0);
     });
 
-    test("B234766 dxSlider - incorrect value calculation with fractional step", assert => {
+    test("B234766 dxSlider - incorrect value calculation with fractional step", function(assert) {
         const $element = $("#slider").css("width", 960);
 
         $element.dxSlider({
@@ -1309,7 +1309,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal($range.width(), 960 / 20);
     });
 
-    test("incorrect when step is NAN or empty string", assert => {
+    test("incorrect when step is NAN or empty string", function(assert) {
         const $element = $("#slider")
                 .css("width", 500)
                 .dxSlider({
@@ -1337,7 +1337,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal(slider.option("value"), 300);
     });
 
-    test("Q374462 dxSlider - It is impossible to set the step option to the float value", assert => {
+    test("Q374462 dxSlider - It is impossible to set the step option to the float value", function(assert) {
         const $element = $("#slider")
                 .css("width", 100)
                 .dxSlider({
@@ -1368,7 +1368,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal(slider.option("value"), 0.3, "step should be reset to default");
     });
 
-    test("step depends on min value after swipe", assert => {
+    test("step depends on min value after swipe", function(assert) {
         const $element = $("#slider")
                 .css("width", 150)
                 .dxSlider({
@@ -1387,7 +1387,7 @@ module("regression tests", moduleOptions, () => {
         assert.equal(slider.option("value"), 1.5, "step depends min value");
     });
 
-    test("'repaint' method should not leads to error if 'tooltip.enabled' is true", assert => {
+    test("'repaint' method should not leads to error if 'tooltip.enabled' is true", function(assert) {
         assert.expect(0);
 
         const $element = $("#slider"),
@@ -1402,7 +1402,7 @@ module("regression tests", moduleOptions, () => {
         slider.repaint();
     });
 
-    test("The error should not be thrown if value is null", assert => {
+    test("The error should not be thrown if value is null", function(assert) {
         try {
             const slider = $("#slider").dxSlider({
                 value: null
@@ -1446,7 +1446,7 @@ module("regression tests", moduleOptions, () => {
 });
 
 module("RTL", moduleOptions, () => {
-    test("render value", assert => {
+    test("render value", function(assert) {
         const $element = $("#slider").css("width", 960);
 
         $element.dxSlider({
@@ -1467,7 +1467,7 @@ module("RTL", moduleOptions, () => {
         assert.equal($range.position().left, 0);
     });
 
-    test("mousedown/touchstart on slider set new value", assert => {
+    test("mousedown/touchstart on slider set new value", function(assert) {
         const $element = $("#slider").dxSlider({
             max: 500,
             min: 0,
@@ -1487,7 +1487,7 @@ module("RTL", moduleOptions, () => {
 });
 
 module("visibility change", () => {
-    test("tooltip should be centered after visibility changed", assert => {
+    test("tooltip should be centered after visibility changed", function(assert) {
         const $slider = $("#slider");
         const $parent = $slider.parent();
 
@@ -1511,7 +1511,7 @@ module("visibility change", () => {
 });
 
 module("validation", () => {
-    testInActiveWindow("add the CSS class on the focusIn event for show a validation message", assert => {
+    testInActiveWindow("add the CSS class on the focusIn event for show a validation message", function(assert) {
         const $slider = $("#slider");
         $slider.dxSlider({
             max: 100,
@@ -1527,7 +1527,7 @@ module("validation", () => {
         assert.equal($(".dx-overlay-wrapper.dx-invalid-message").css("visibility"), "visible", "validation message is shown");
     });
 
-    testInActiveWindow("remove the CSS class on the focusOut event for hide a validation message", assert => {
+    testInActiveWindow("remove the CSS class on the focusOut event for hide a validation message", function(assert) {
         const $slider = $("#slider");
         $slider.dxSlider({
             max: 100,
@@ -1545,7 +1545,7 @@ module("validation", () => {
         assert.equal($(".dx-overlay-wrapper.dx-invalid-message").css("visibility"), "hidden", "validation message is hidden");
     });
 
-    testInActiveWindow("validation message should be hidden once focusStateEnabled option switch off", assert => {
+    testInActiveWindow("validation message should be hidden once focusStateEnabled option switch off", function(assert) {
         const $slider = $("#slider");
         const instance = $slider.dxSlider({
             max: 100,

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -52,19 +52,19 @@ const CLEAR_BUTTON_AREA = "dx-clear-button-area";
 const TIME_TO_WAIT = 500;
 
 const moduleSetup = {
-    beforeEach: () => {
+    beforeEach: function() {
         TagBox.defaultOptions({ options: { deferRendering: false } });
         fx.off = true;
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.clock.restore();
     }
 };
 
 QUnit.module("rendering", moduleSetup, () => {
-    QUnit.test("popup wrapper gets the 'dx-tagbox-popup-wrapper' class", assert => {
+    QUnit.test("popup wrapper gets the 'dx-tagbox-popup-wrapper' class", function(assert) {
         $("#tagBox").dxTagBox({
             opened: true
         }).dxTagBox("instance");
@@ -73,7 +73,7 @@ QUnit.module("rendering", moduleSetup, () => {
         assert.ok($popupWrapper.hasClass(TAGBOX_POPUP_WRAPPER_CLASS), "the class is added");
     });
 
-    QUnit.test("empty class should be added if no one tags selected", assert => {
+    QUnit.test("empty class should be added if no one tags selected", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3]
         });
@@ -86,7 +86,7 @@ QUnit.module("rendering", moduleSetup, () => {
         assert.ok($tagBox.hasClass(EMPTY_INPUT_CLASS), "empty class present");
     });
 
-    QUnit.test("skip gesture event class attach only when popup is opened", assert => {
+    QUnit.test("skip gesture event class attach only when popup is opened", function(assert) {
         const SKIP_GESTURE_EVENT_CLASS = "dx-skip-gesture-event";
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3]
@@ -103,14 +103,14 @@ QUnit.module("rendering", moduleSetup, () => {
 });
 
 QUnit.module("select element", () => {
-    QUnit.test("the select element should be invisible", assert => {
+    QUnit.test("the select element should be invisible", function(assert) {
         const $select = $("#tagBox").dxTagBox()
             .find("select");
 
         assert.notOk($select.is(":visible"), "select in not visible");
     });
 
-    QUnit.test("option elements should be updated on value change", assert => {
+    QUnit.test("option elements should be updated on value change", function(assert) {
         const items = [{ id: 1, text: "eins" }, { id: 2, text: "zwei" }, { id: 3, text: "drei" }];
         const initialValue = [1];
         const newValue = [2, 3];
@@ -134,7 +134,7 @@ QUnit.module("select element", () => {
         });
     });
 
-    QUnit.test("unselect item with value '0'", assert => {
+    QUnit.test("unselect item with value '0'", function(assert) {
         const items = [{ id: 0, text: "eins" }, { id: 1, text: "zwei" }, { id: 2, text: "drei" }];
         const value = [0, 1];
         const $tagBox = $("#tagBox");
@@ -157,7 +157,7 @@ QUnit.module("select element", () => {
 });
 
 QUnit.module("list selection", moduleSetup, () => {
-    QUnit.test("selected item class", (assert) => {
+    QUnit.test("selected item class", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
             value: [1, 4]
@@ -172,7 +172,7 @@ QUnit.module("list selection", moduleSetup, () => {
         assert.equal($listItems.eq(3).hasClass(LIST_ITEM_SELECTED_CLASS), true, "fourth item has selected class");
     });
 
-    QUnit.test("Selected item should be unselected on click", assert => {
+    QUnit.test("Selected item should be unselected on click", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: [1, 2, 3],
             value: [1, 2],
@@ -186,7 +186,7 @@ QUnit.module("list selection", moduleSetup, () => {
         assert.deepEqual(tagBox.option("value"), [2], "value is correct");
     });
 
-    QUnit.test("Selected item should be removed from list if 'hideSelectedItems' option is true", assert => {
+    QUnit.test("Selected item should be removed from list if 'hideSelectedItems' option is true", function(assert) {
         const dataSource = [1, 2, 3, 4, 5];
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -221,7 +221,7 @@ QUnit.module("list selection", moduleSetup, () => {
         assert.equal($list.find("." + LIST_ITEM_CLASS).length, dataSource.length - 1, "items count is correct after the second tag is removed");
     });
 
-    QUnit.test("Selected item tag should be correct if hideSelectedItems is set (T580639)", assert => {
+    QUnit.test("Selected item tag should be correct if hideSelectedItems is set (T580639)", function(assert) {
         const dataSource = [{
             "ID": 1,
             "Name": "Item 1"
@@ -251,7 +251,7 @@ QUnit.module("list selection", moduleSetup, () => {
         assert.equal($tagBox.find("." + TAGBOX_TAG_CLASS).eq(1).text(), "Item 2", "tag is correct after selection");
     });
 
-    QUnit.test("Items should be hidden on init if hideSelectedItems is true", assert => {
+    QUnit.test("Items should be hidden on init if hideSelectedItems is true", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4, 5],
             opened: true,
@@ -264,7 +264,7 @@ QUnit.module("list selection", moduleSetup, () => {
         assert.equal(tagBox._list.option("items").length, 2, "items was restored");
     });
 
-    QUnit.test("Items should not be changed if one of them is hidden", assert => {
+    QUnit.test("Items should not be changed if one of them is hidden", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4, 5],
             opened: true,
@@ -282,7 +282,7 @@ QUnit.module("list selection", moduleSetup, () => {
         assert.equal(tagBox.option("items").length, 5, "items was restored");
     });
 
-    QUnit.test("added and removed items should be correct with hideSelecterdItems option and dataSource (T589590)", assert => {
+    QUnit.test("added and removed items should be correct with hideSelecterdItems option and dataSource (T589590)", function(assert) {
         const spy = sinon.spy();
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -305,7 +305,7 @@ QUnit.module("list selection", moduleSetup, () => {
         assert.deepEqual(spy.args[2][0].removedItems, [], "removed items is empty");
     });
 
-    QUnit.test("selected items should be correct after item click with hideSelecterdItems option (T606462)", assert => {
+    QUnit.test("selected items should be correct after item click with hideSelecterdItems option (T606462)", function(assert) {
         const tagBox = $("#tagBox").dxTagBox({
             dataSource: [1, 2, 3],
             value: [1],
@@ -323,7 +323,7 @@ QUnit.module("list selection", moduleSetup, () => {
 });
 
 QUnit.module("tags", moduleSetup, () => {
-    QUnit.test("add/delete tags", (assert) => {
+    QUnit.test("add/delete tags", function(assert) {
         const items = [1, 2, 3];
 
         const $element = $("#tagBox").dxTagBox({
@@ -347,7 +347,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($element.find("." + TAGBOX_TAG_CLASS).length, 0, "tag is removed");
     });
 
-    QUnit.test("tags should remove after clear values", assert => {
+    QUnit.test("tags should remove after clear values", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: [1, 2, 3],
             value: [1]
@@ -359,7 +359,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($tagBox.find(".dx-tag").length, 0, "zero item rendered");
     });
 
-    QUnit.testInActiveWindow("tags should not be rerendered when editor looses focus", assert => {
+    QUnit.testInActiveWindow("tags should not be rerendered when editor looses focus", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             focusStateEnabled: true
@@ -375,7 +375,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal(renderTagsStub.callCount, 0, "tags weren't rerendered");
     });
 
-    QUnit.test("tagBox field is not cleared on blur", (assert) => {
+    QUnit.test("tagBox field is not cleared on blur", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             value: [1]
@@ -390,7 +390,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($tags.is(":visible"), true, "tag is rendered");
     });
 
-    QUnit.test("list item with zero value should be selectable", (assert) => {
+    QUnit.test("list item with zero value should be selectable", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [0, 1, 2, 3],
             opened: true
@@ -405,7 +405,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($.trim($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text()), "01", "selected first and second items");
     });
 
-    QUnit.test("'text' option should have correct value when item value is zero", assert => {
+    QUnit.test("'text' option should have correct value when item value is zero", function(assert) {
         const tagBox = $("#tagBox").dxTagBox({
             value: [0],
             items: [0, 1]
@@ -414,7 +414,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal(tagBox.option("text"), "0");
     });
 
-    QUnit.test("tag should have correct value when item value is an empty string", (assert) => {
+    QUnit.test("tag should have correct value when item value is an empty string", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["", 1, 2, 3],
             opened: true
@@ -428,7 +428,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($tagBox.find("." + TAGBOX_TAG_CLASS).length, 1, "empty string value was successfully selected");
     });
 
-    QUnit.test("TagBox has right content after items setting", assert => {
+    QUnit.test("TagBox has right content after items setting", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             value: [1],
             valueExpr: "id",
@@ -442,7 +442,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal(content.text(), "First", "tags has right content");
     });
 
-    QUnit.test("TagBox has right tag order if byKey return value in wrong order", (assert) => {
+    QUnit.test("TagBox has right tag order if byKey return value in wrong order", function(assert) {
         const data = [1, 2];
         const timeToWait = 500;
         let count = 2;
@@ -476,7 +476,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal(content.eq(1).text(), "2", "second tag has right content");
     });
 
-    QUnit.test("removing tags after clicking the 'clear' button", assert => {
+    QUnit.test("removing tags after clicking the 'clear' button", function(assert) {
         const $element = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             showClearButton: true,
@@ -493,7 +493,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($element.find("." + TAGBOX_TAG_CLASS).length, 1, "one item is chosen");
     });
 
-    QUnit.test("clear button should save valueChangeEvent", assert => {
+    QUnit.test("clear button should save valueChangeEvent", function(assert) {
         const valueChangedHandler = sinon.spy();
 
         const $element = $("#tagBox").dxTagBox({
@@ -510,7 +510,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal(valueChangedHandler.getCall(0).args[0].event.type, "dxclick", "event is correct");
     });
 
-    QUnit.test("clear button should also clear the input value", assert => {
+    QUnit.test("clear button should also clear the input value", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1],
             showClearButton: true,
@@ -531,7 +531,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($input.val(), "", "input is also cleared");
     });
 
-    QUnit.test("clear button should have sizes similar as the other editors have", assert => {
+    QUnit.test("clear button should have sizes similar as the other editors have", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             showClearButton: true,
             dataSource: ['1'],
@@ -551,7 +551,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal(tagBoxClearButtonWidth, textBoxClearButtonWidth, "clear button's width is ok");
     });
 
-    QUnit.test("Tag should have empty text if display value is empty", assert => {
+    QUnit.test("Tag should have empty text if display value is empty", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [{ name: "", value: 1 }, { name: "two", value: 2 }],
             displayExpr: "name",
@@ -563,7 +563,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($tag.text(), "", "tag has empty text");
     });
 
-    QUnit.test("Tag should have correct text if display value is '0'", assert => {
+    QUnit.test("Tag should have correct text if display value is '0'", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [{ name: 0, value: 1 }, { name: "two", value: 2 }],
             displayExpr: "name",
@@ -575,7 +575,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($tag.text(), 0, "tag has correct text");
     });
 
-    QUnit.test("Tag should have correct text if display value is 'null'", assert => {
+    QUnit.test("Tag should have correct text if display value is 'null'", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [{ name: null, value: 1 }, { name: "two", value: 2 }],
             displayExpr: "name",
@@ -587,7 +587,7 @@ QUnit.module("tags", moduleSetup, () => {
         assert.equal($tag.text(), "", "tag has correct text");
     });
 
-    QUnit.test("onValueChanged has dxclick event on remove button click", assert => {
+    QUnit.test("onValueChanged has dxclick event on remove button click", function(assert) {
         const $element = $("#tagBox").dxTagBox({
             value: ["123"],
             onValueChanged: function(e) {
@@ -602,7 +602,7 @@ QUnit.module("tags", moduleSetup, () => {
 });
 
 QUnit.module("multi tag support", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.getTexts = $tags => {
             return $tags.map((_, tag) => {
                 return $(tag).text();
@@ -616,11 +616,11 @@ QUnit.module("multi tag support", {
             }
         });
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("tagBox should display one tag after new tags was added", assert => {
+    QUnit.test("tagBox should display one tag after new tags was added", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
             value: [1, 2, 4],
@@ -639,7 +639,7 @@ QUnit.module("multi tag support", {
         assert.equal($tag.text(), "3 selected", "tag has correct text");
     });
 
-    QUnit.test("tagBox should display multiple tags after value was changed", (assert) => {
+    QUnit.test("tagBox should display multiple tags after value was changed", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
             value: [1, 2, 4],
@@ -655,7 +655,7 @@ QUnit.module("multi tag support", {
         assert.deepEqual(this.getTexts($tag), ["1", "2"], "tags have correct text");
     });
 
-    QUnit.test("multi tag should work with data expressions", (assert) => {
+    QUnit.test("multi tag should work with data expressions", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [{ id: 1, name: "item 1" }, { id: 2, name: "item 2" }, { id: 3, name: "item 3" }],
             value: [1, 2, 3],
@@ -668,7 +668,7 @@ QUnit.module("multi tag support", {
         assert.deepEqual(this.getTexts($tag), ["3 selected"], "multi tag works");
     });
 
-    QUnit.test("tagBox should deselect all items after multi tag removed", assert => {
+    QUnit.test("tagBox should deselect all items after multi tag removed", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
             value: [1, 2, 4],
@@ -687,7 +687,7 @@ QUnit.module("multi tag support", {
         assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CLASS).length, 0, "there are no tags in the field");
     });
 
-    QUnit.test("tags should be recalculated after maxDisplayedTags option changed", assert => {
+    QUnit.test("tags should be recalculated after maxDisplayedTags option changed", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
             value: [1, 2, 4]
@@ -708,7 +708,7 @@ QUnit.module("multi tag support", {
         assert.equal($tagBox.find("." + TAGBOX_TAG_CLASS).length, 4, "4 tags when option was disabled");
     });
 
-    QUnit.test("onMultitagPreparing option change", assert => {
+    QUnit.test("onMultitagPreparing option change", function(assert) {
         assert.expect(4);
 
         const onMultiTagPreparing = e => {
@@ -732,7 +732,7 @@ QUnit.module("multi tag support", {
         assert.deepEqual($tag.text(), "custom text", "custom text is displayed");
     });
 
-    QUnit.test("tags should be rerendered after showMultiTagOnly option changed", assert => {
+    QUnit.test("tags should be rerendered after showMultiTagOnly option changed", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
             value: [1, 2, 4],
@@ -750,7 +750,7 @@ QUnit.module("multi tag support", {
         assert.deepEqual($tag.text(), "3 selected", "text is correct");
     });
 
-    QUnit.test("multi tag should deselect overflow tags only when showMultiTagOnly is false", (assert) => {
+    QUnit.test("multi tag should deselect overflow tags only when showMultiTagOnly is false", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
             value: [1, 2, 4],
@@ -768,7 +768,7 @@ QUnit.module("multi tag support", {
         assert.deepEqual(this.getTexts($tagBox.find("." + TAGBOX_TAG_CLASS)), ["1", "2"], "tags have correct text");
     });
 
-    QUnit.test("only one multi tag should be rendered when selectAll checked and value changind on runtime", assert => {
+    QUnit.test("only one multi tag should be rendered when selectAll checked and value changind on runtime", function(assert) {
         let suppressSelectionChanged = false;
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -788,7 +788,7 @@ QUnit.module("multi tag support", {
         assert.equal($multiTag.length, 1, "only 1 tag rendered");
     });
 
-    QUnit.test("tagbox should show count of selected items when only first page is loaded", (assert) => {
+    QUnit.test("tagbox should show count of selected items when only first page is loaded", function(assert) {
         const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: {
@@ -811,7 +811,7 @@ QUnit.module("multi tag support", {
 });
 
 QUnit.module("the 'value' option", moduleSetup, () => {
-    QUnit.test("value should be passed by value (not by reference)", assert => {
+    QUnit.test("value should be passed by value (not by reference)", function(assert) {
         const value = ["item1"];
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["item1", "item2"],
@@ -823,7 +823,7 @@ QUnit.module("the 'value' option", moduleSetup, () => {
         assert.deepEqual(value, ["item1"], "outer value is not changed");
     });
 
-    QUnit.test("reset()", assert => {
+    QUnit.test("reset()", function(assert) {
         const tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             value: [1]
@@ -833,7 +833,7 @@ QUnit.module("the 'value' option", moduleSetup, () => {
         assert.deepEqual(tagBox.option("value"), [], "Value should be reset");
     });
 
-    QUnit.test("displayExpr change at runtime", assert => {
+    QUnit.test("displayExpr change at runtime", function(assert) {
         const items = [{ name: "one", value: 1 },
             { name: "two", value: 2 }];
 
@@ -854,7 +854,7 @@ QUnit.module("the 'value' option", moduleSetup, () => {
 });
 
 QUnit.module("the 'onValueChanged' option", moduleSetup, () => {
-    QUnit.test("onValueChanged provides selected values", (assert) => {
+    QUnit.test("onValueChanged provides selected values", function(assert) {
         let value;
 
         const $element = $("#tagBox").dxTagBox({
@@ -873,7 +873,7 @@ QUnit.module("the 'onValueChanged' option", moduleSetup, () => {
         assert.deepEqual(value, [1, 3], "two items are selected");
     });
 
-    QUnit.test("onValueChanged should not be fired on first render", (assert) => {
+    QUnit.test("onValueChanged should not be fired on first render", function(assert) {
         const valueChangeActionSpy = sinon.spy();
         $("#tagBox").dxTagBox({
             items: [1, 2, 3],
@@ -886,7 +886,7 @@ QUnit.module("the 'onValueChanged' option", moduleSetup, () => {
         assert.equal(valueChangeActionSpy.called, false, "onValueChanged was not fired");
     });
 
-    QUnit.test("onValueChanged should be fired when dxTagBox is readOnly", assert => {
+    QUnit.test("onValueChanged should be fired when dxTagBox is readOnly", function(assert) {
         const valueChangeActionSpy = sinon.spy();
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -901,7 +901,7 @@ QUnit.module("the 'onValueChanged' option", moduleSetup, () => {
         assert.ok(valueChangeActionSpy.called, "onValueChanged was fired");
     });
 
-    QUnit.test("onValueChanged should be fired when dxTagBox is disabled", assert => {
+    QUnit.test("onValueChanged should be fired when dxTagBox is disabled", function(assert) {
         const valueChangeActionSpy = sinon.spy();
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -916,7 +916,7 @@ QUnit.module("the 'onValueChanged' option", moduleSetup, () => {
         assert.ok(valueChangeActionSpy.called, "onValueChanged was fired");
     });
 
-    QUnit.test("onValueChanged provide selected value after removing values", (assert) => {
+    QUnit.test("onValueChanged provide selected value after removing values", function(assert) {
         let value;
 
         const $element = $("#tagBox").dxTagBox({
@@ -934,7 +934,7 @@ QUnit.module("the 'onValueChanged' option", moduleSetup, () => {
         assert.deepEqual(value, [3], "item is deleted");
     });
 
-    QUnit.test("T338728 - onValueChanged action should contain correct previousValues", assert => {
+    QUnit.test("T338728 - onValueChanged action should contain correct previousValues", function(assert) {
         const spy = sinon.spy();
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -949,7 +949,7 @@ QUnit.module("the 'onValueChanged' option", moduleSetup, () => {
         assert.deepEqual(spy.args[0][0].previousValue, [1, 2], "the 'previousValue' argument is correct");
     });
 
-    QUnit.test("onValueChanged should not be fired on the 'backspace' key press if the editor is already empty (T385450)", assert => {
+    QUnit.test("onValueChanged should not be fired on the 'backspace' key press if the editor is already empty (T385450)", function(assert) {
         const spy = sinon.spy();
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -964,7 +964,7 @@ QUnit.module("the 'onValueChanged' option", moduleSetup, () => {
 });
 
 QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
-    QUnit.test("using the 'onCustomItemCreating' option should throw a warning if handler returns an item", assert => {
+    QUnit.test("using the 'onCustomItemCreating' option should throw a warning if handler returns an item", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             acceptCustomValue: true,
             displayExpr: "display",
@@ -995,7 +995,7 @@ QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
         assert.deepEqual(logStub.firstCall.args, ["W0015", "onCustomItemCreating", "customItem"], "Check warning parameters");
     });
 
-    QUnit.test("creating custom item via the 'customItem' event parameter", assert => {
+    QUnit.test("creating custom item via the 'customItem' event parameter", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             acceptCustomValue: true,
             displayExpr: "display",
@@ -1023,7 +1023,7 @@ QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
         assert.equal($tags.eq(0).text(), "display " + customValue);
     });
 
-    QUnit.test("create custom item by subscribe on event via 'on' method", assert => {
+    QUnit.test("create custom item by subscribe on event via 'on' method", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             acceptCustomValue: true,
             displayExpr: "display",
@@ -1056,7 +1056,7 @@ QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
         assert.equal($tags.eq(0).text(), "display " + customValue);
     });
 
-    QUnit.test("the 'onCustomItemCreating' option with Deferred", assert => {
+    QUnit.test("the 'onCustomItemCreating' option with Deferred", function(assert) {
         const deferred = $.Deferred();
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -1091,7 +1091,7 @@ QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
         assert.equal($tags.eq(0).text(), "display " + customValue, "added tag text is correct");
     });
 
-    QUnit.test("the selected list items should be correct if custom item is in list", assert => {
+    QUnit.test("the selected list items should be correct if custom item is in list", function(assert) {
         const items = [1, 2, 3];
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -1121,7 +1121,7 @@ QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
         assert.deepEqual(list.option("selectedItems"), [customValue], "selected items are correct");
     });
 
-    QUnit.test("tags should have a right display texts for acceptCustomValue and preset value", assert => {
+    QUnit.test("tags should have a right display texts for acceptCustomValue and preset value", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [],
             value: ["one"],
@@ -1143,7 +1143,7 @@ QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
         assert.equal($tags.eq(1).text(), "two");
     });
 
-    QUnit.test("custom item should be selected in list but tag should not be rendered in useButtons mode", (assert) => {
+    QUnit.test("custom item should be selected in list but tag should not be rendered in useButtons mode", function(assert) {
         const store = new ArrayStore([{ id: 1, name: "Alex" }]);
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -1178,7 +1178,7 @@ QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
         assert.equal($listItems.length, 1, "list item should be selected after enter press");
     });
 
-    QUnit.test("custom item should be selected in list but tag should not be rendered in useButtons mode with checkboxes", (assert) => {
+    QUnit.test("custom item should be selected in list but tag should not be rendered in useButtons mode with checkboxes", function(assert) {
         const store = new ArrayStore([{ id: 1, name: "Alex" }]);
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -1218,7 +1218,7 @@ QUnit.module("the 'onCustomItemCreating' option", moduleSetup, () => {
 });
 
 QUnit.module("placeholder", () => {
-    QUnit.test("placeholder should appear after tag deleted", assert => {
+    QUnit.test("placeholder should appear after tag deleted", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: ['item1', 'item2', 'item3'],
             value: ['item1']
@@ -1234,7 +1234,7 @@ QUnit.module("placeholder", () => {
         assert.equal($placeholder.is(":visible"), true, "placeholder was appear");
     });
 
-    QUnit.test("placeholder is hidden after tag is removed if the search value is exist", assert => {
+    QUnit.test("placeholder is hidden after tag is removed if the search value is exist", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             value: [1],
@@ -1249,7 +1249,7 @@ QUnit.module("placeholder", () => {
         assert.notOk($placeholder.is(":visible"), "placeholder is hidden");
     });
 
-    QUnit.test("placeholder should be restored after focusout in Angular", assert => {
+    QUnit.test("placeholder should be restored after focusout in Angular", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             searchEnabled: true
@@ -1267,7 +1267,7 @@ QUnit.module("placeholder", () => {
 });
 
 QUnit.module("tag template", moduleSetup, () => {
-    QUnit.test("tag template should have correct arguments", assert => {
+    QUnit.test("tag template should have correct arguments", function(assert) {
         const items = [{ text: 1 }, { text: 2 }];
 
         $("#tagBox").dxTagBox({
@@ -1282,7 +1282,7 @@ QUnit.module("tag template", moduleSetup, () => {
         });
     });
 
-    QUnit.test("tag template should get item in arguments even if the 'displayExpr' option is specified", assert => {
+    QUnit.test("tag template should get item in arguments even if the 'displayExpr' option is specified", function(assert) {
         const items = [{ id: 1, text: "one" }, { id: 2, text: "two" }];
 
         $("#tagBox").dxTagBox({
@@ -1295,7 +1295,7 @@ QUnit.module("tag template", moduleSetup, () => {
         });
     });
 
-    QUnit.test("displayExpr as function should work", assert => {
+    QUnit.test("displayExpr as function should work", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [{ name: "Item 1", id: 1 }],
             displayExpr(item) {
@@ -1310,7 +1310,7 @@ QUnit.module("tag template", moduleSetup, () => {
         assert.equal($tags.text(), "Item 1", "tags are correct");
     });
 
-    QUnit.test("tag template should be applied correctly after item selection (T589269)", assert => {
+    QUnit.test("tag template should be applied correctly after item selection (T589269)", function(assert) {
         const items = [{ id: 1, text: "one" }, { id: 2, text: "two" }];
 
         const $element = $("#tagBox").dxTagBox({
@@ -1334,7 +1334,7 @@ QUnit.module("tag template", moduleSetup, () => {
         assert.equal($.trim($tagContainer.text()), "onetwo", "selected values are rendered correctly");
     });
 
-    QUnit.test("value should be correct if the default tag template is used and the displayExpr is specified", assert => {
+    QUnit.test("value should be correct if the default tag template is used and the displayExpr is specified", function(assert) {
         const items = [{ id: 1, text: "one" }];
 
         const $element = $("#tagBox").dxTagBox({
@@ -1351,7 +1351,7 @@ QUnit.module("tag template", moduleSetup, () => {
         assert.deepEqual(instance.option("value"), [items[0]], "the 'value' option is correct");
     });
 
-    QUnit.test("selected list items should be correct if the default tag template is used and the displayExpr is specified", assert => {
+    QUnit.test("selected list items should be correct if the default tag template is used and the displayExpr is specified", function(assert) {
         const items = [{ id: 1, text: "one" }];
 
         const $element = $("#tagBox").dxTagBox({
@@ -1368,7 +1368,7 @@ QUnit.module("tag template", moduleSetup, () => {
         assert.deepEqual(list.option("selectedItems"), [items[0]], "the 'selectedItems' list option is correct");
     });
 
-    QUnit.test("user can return default tag template from the custom function", assert => {
+    QUnit.test("user can return default tag template from the custom function", function(assert) {
         const $element = $("#tagBox").dxTagBox({
             items: [{ id: 1, text: "item 1" }],
             valueExpr: "id",
@@ -1386,7 +1386,7 @@ QUnit.module("tag template", moduleSetup, () => {
 });
 
 QUnit.module("showSelectionControls", moduleSetup, () => {
-    QUnit.test("showSelectionControls", (assert) => {
+    QUnit.test("showSelectionControls", function(assert) {
         $("#tagBox").dxTagBox({
             items: [1],
             opened: true,
@@ -1398,7 +1398,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal($(".dx-checkbox").length, 2, "selectAll checkbox and checkbox on item added");
     });
 
-    QUnit.test("click on selected item causes item uncheck", (assert) => {
+    QUnit.test("click on selected item causes item uncheck", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             opened: true,
@@ -1415,7 +1415,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.deepEqual($tagBox.dxTagBox("option", "value"), [2], "value is reset");
     });
 
-    QUnit.test("click on selected item causes item uncheck", (assert) => {
+    QUnit.test("click on selected item causes item uncheck", function(assert) {
         $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             value: [1, 2],
@@ -1428,7 +1428,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal($(".dx-checkbox-checked").length, 2, "values selected on render");
     });
 
-    QUnit.test("selectAll element should be rendered correctly when opening tagBox", (assert) => {
+    QUnit.test("selectAll element should be rendered correctly when opening tagBox", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: {
                 store: new ArrayStore([1, 2, 3]),
@@ -1445,7 +1445,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal($(".dx-list-select-all").length, 1, "selectAll item is rendered");
     });
 
-    QUnit.test("changing selectAll state with selectAllMode 'allPages'", (assert) => {
+    QUnit.test("changing selectAll state with selectAllMode 'allPages'", function(assert) {
         const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: {
@@ -1466,7 +1466,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.deepEqual($tagBox.dxTagBox("option", "value"), items, "items is selected");
     });
 
-    QUnit.test("items check state reset after deleting of the value", assert => {
+    QUnit.test("items check state reset after deleting of the value", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
             value: [1, 2],
@@ -1482,7 +1482,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal($checkedItems.length, 1, "only one item highlighted");
     });
 
-    QUnit.test("onValueChanged should be fired once when showSelectionControls is true", (assert) => {
+    QUnit.test("onValueChanged should be fired once when showSelectionControls is true", function(assert) {
         let fired = 0;
         $("#tagBox").dxTagBox({
             items: [1, 2, 3, 4],
@@ -1501,7 +1501,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal(fired, 1, "event fired once");
     });
 
-    QUnit.test("correct value after deselecting all items", (assert) => {
+    QUnit.test("correct value after deselecting all items", function(assert) {
         const items = [1, 2, 3, 4];
         const tagBox = $("#tagBox").dxTagBox({
             items,
@@ -1515,7 +1515,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.deepEqual(tagBox.option("value"), [], "value is an empty array");
     });
 
-    QUnit.test("onValueChanged was not raised when time after time popup opening (showSelectionControls = true)", (assert) => {
+    QUnit.test("onValueChanged was not raised when time after time popup opening (showSelectionControls = true)", function(assert) {
         let fired = 0;
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -1539,7 +1539,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal(fired, 1, "event was fired once");
     });
 
-    QUnit.test("tag rendered after click on selections control", (assert) => {
+    QUnit.test("tag rendered after click on selections control", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             showSelectionControls: true,
@@ -1555,7 +1555,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal($tagBox.find(".dx-tag").length, 1, "tag rendered");
     });
 
-    QUnit.testInActiveWindow("tag should not be removed when editor looses focus", assert => {
+    QUnit.testInActiveWindow("tag should not be removed when editor looses focus", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             showSelectionControls: true,
@@ -1572,7 +1572,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal($tagBox.find(".dx-tag").length, 1, "tag is present");
     });
 
-    QUnit.test("list 'select all' checkbox state should be correct if all items are selected on init and data source paging is enabled", assert => {
+    QUnit.test("list 'select all' checkbox state should be correct if all items are selected on init and data source paging is enabled", function(assert) {
         const items = (() => {
             const items = [];
             for(let i = 0, n = 200; i < n; i++) {
@@ -1597,7 +1597,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
         assert.equal(selectAllCheck.option("value"), true, "the 'select all' checkbox is checked");
     });
 
-    QUnit.test("T378748 - the tab key press should not lead to error while navigating in list", assert => {
+    QUnit.test("T378748 - the tab key press should not lead to error while navigating in list", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2, 3],
             showSelectionControls: true,
@@ -1616,7 +1616,7 @@ QUnit.module("showSelectionControls", moduleSetup, () => {
 });
 
 QUnit.module("keyboard navigation", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
 
@@ -1640,13 +1640,13 @@ QUnit.module("keyboard navigation", {
             this._init(options);
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         this.clock.restore();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("backspace", (assert) => {
+    QUnit.test("backspace", function(assert) {
         assert.expect(2);
 
         this.keyboard
@@ -1659,7 +1659,7 @@ QUnit.module("keyboard navigation", {
         assert.deepEqual(this.instance.option("value"), [], "values is empty");
     });
 
-    QUnit.test("backspace UI", (assert) => {
+    QUnit.test("backspace UI", function(assert) {
         assert.expect(2);
 
         this.keyboard
@@ -1672,7 +1672,7 @@ QUnit.module("keyboard navigation", {
         assert.equal($("." + LIST_ITEM_SELECTED_CLASS).length, 0, "there are no selected items in list");
     });
 
-    QUnit.test("TagBox should not select items when list is not shown", (assert) => {
+    QUnit.test("TagBox should not select items when list is not shown", function(assert) {
         assert.expect(1);
 
         this.instance.option({
@@ -1686,7 +1686,7 @@ QUnit.module("keyboard navigation", {
         assert.deepEqual(this.instance.option("value"), [], "downArrow should not select value when the list is hidden");
     });
 
-    QUnit.test("T309987 - value should not be changed when moving focus by the 'tab' key", (assert) => {
+    QUnit.test("T309987 - value should not be changed when moving focus by the 'tab' key", function(assert) {
         const items = ["first", "second", "third", "fourth"];
         const value = [items[1], items[3]];
 
@@ -1703,7 +1703,7 @@ QUnit.module("keyboard navigation", {
         assert.deepEqual(this.instance.option("value"), value, "the value is correct");
     });
 
-    QUnit.testInActiveWindow("Value should be correct when not last item is focused and the 'tab' key pressed", (assert) => {
+    QUnit.testInActiveWindow("Value should be correct when not last item is focused and the 'tab' key pressed", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "desktop specific test");
             return;
@@ -1726,7 +1726,7 @@ QUnit.module("keyboard navigation", {
         assert.deepEqual(this.instance.option("value"), [items[0], items[2]], "value is still the same");
     });
 
-    QUnit.test("First item is not selected when edit is disabled", (assert) => {
+    QUnit.test("First item is not selected when edit is disabled", function(assert) {
         this.reinit({
             value: [],
             acceptCustomValue: false,
@@ -1740,7 +1740,7 @@ QUnit.module("keyboard navigation", {
         assert.deepEqual(this.instance.option("value"), [], "was selected first item and be set");
     });
 
-    QUnit.test("Enter and escape key press prevent default when popup is opened", (assert) => {
+    QUnit.test("Enter and escape key press prevent default when popup is opened", function(assert) {
         this.reinit({
             items: [0, 1, 2],
             value: [1],
@@ -1769,7 +1769,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(prevented, 1, "defaults prevented on escape keys");
     });
 
-    QUnit.test("Enter and escape key press prevent default when popup is opened and field edit enabled is not set", (assert) => {
+    QUnit.test("Enter and escape key press prevent default when popup is opened and field edit enabled is not set", function(assert) {
         this.reinit({
             items: [0, 1, 2],
             value: [1],
@@ -1797,7 +1797,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(prevented, 0, "defaults not prevented on enter when popup is closed");
     });
 
-    QUnit.test("input value should be cleared", (assert) => {
+    QUnit.test("input value should be cleared", function(assert) {
         this.reinit({
             items: [1, 2],
             opened: true
@@ -1810,7 +1810,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(this.$input.val(), "", "value was not rendered");
     });
 
-    QUnit.test("tagBox selects item on enter key", (assert) => {
+    QUnit.test("tagBox selects item on enter key", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1831,7 +1831,7 @@ QUnit.module("keyboard navigation", {
         assert.equal($tags.text(), "1", "rendered first item");
     });
 
-    QUnit.test("control keys test", (assert) => {
+    QUnit.test("control keys test", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1854,7 +1854,7 @@ QUnit.module("keyboard navigation", {
         assert.notOk(this.instance.option("opened"), "overlay is invisible on alt+up press");
     });
 
-    QUnit.test("up and down keys should work correctly in dxTagBox", (assert) => {
+    QUnit.test("up and down keys should work correctly in dxTagBox", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1870,7 +1870,7 @@ QUnit.module("keyboard navigation", {
         assert.ok(true, "there is no exceptions");
     });
 
-    QUnit.test("tagBox selects item on space key", (assert) => {
+    QUnit.test("tagBox selects item on space key", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1891,7 +1891,7 @@ QUnit.module("keyboard navigation", {
         assert.equal($tags.text(), "1", "rendered first item");
     });
 
-    QUnit.test("tagBox didn't selects item on space key if it acceptCustomValue", (assert) => {
+    QUnit.test("tagBox didn't selects item on space key if it acceptCustomValue", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1913,7 +1913,7 @@ QUnit.module("keyboard navigation", {
         assert.equal($tags.length, 0, "there are no tags");
     });
 
-    QUnit.test("tagBox didn't selects item on space key if search is enabled", (assert) => {
+    QUnit.test("tagBox didn't selects item on space key if search is enabled", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1935,7 +1935,7 @@ QUnit.module("keyboard navigation", {
         assert.equal($tags.length, 0, "there are no tags");
     });
 
-    QUnit.test("the 'enter' key should not add/remove tags if the editor is closed (T378292)", (assert) => {
+    QUnit.test("the 'enter' key should not add/remove tags if the editor is closed (T378292)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1957,7 +1957,7 @@ QUnit.module("keyboard navigation", {
         assert.deepEqual(this.instance.option("value"), [], "value is not changed");
     });
 
-    QUnit.test("onValueChanged shouldn't be fired on the 'tab' key press", (assert) => {
+    QUnit.test("onValueChanged shouldn't be fired on the 'tab' key press", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1975,7 +1975,7 @@ QUnit.module("keyboard navigation", {
         assert.equal(spy.callCount, 0, "onValueChanged event isn't fired");
     });
 
-    QUnit.test("value shouldn't be changed on 'tab' if there is a focused item in the drop down list", (assert) => {
+    QUnit.test("value shouldn't be changed on 'tab' if there is a focused item in the drop down list", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -1992,7 +1992,7 @@ QUnit.module("keyboard navigation", {
         assert.deepEqual(this.instance.option("value"), expectedValue, "the value is correct");
     });
 
-    QUnit.testInActiveWindow("the 'apply' button should be focused on the 'tab' key press if the input is focused and showSelectionControls if false (T389453)", (assert) => {
+    QUnit.testInActiveWindow("the 'apply' button should be focused on the 'tab' key press if the input is focused and showSelectionControls if false (T389453)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "desktop specific test");
             return;
@@ -2013,7 +2013,7 @@ QUnit.module("keyboard navigation", {
 });
 
 QUnit.module("keyboard navigation through tags", {
-    beforeEach: () => {
+    beforeEach: function() {
         const items = [1, 2, 3, 4];
 
         this.$element = $("#tagBox").dxTagBox({
@@ -2044,7 +2044,7 @@ QUnit.module("keyboard navigation through tags", {
         this._init();
     },
 }, () => {
-    QUnit.test("the last rendered tag should get 'focused' class after the 'leftArrow' key press", (assert) => {
+    QUnit.test("the last rendered tag should get 'focused' class after the 'leftArrow' key press", function(assert) {
         this.keyboard
             .focus()
             .press("left");
@@ -2053,7 +2053,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($lastTag.hasClass(FOCUSED_CLASS), "the last tag got the 'focused' class");
     });
 
-    QUnit.test("the last rendered tag should get 'focused' class after the 'leftArrow' key press if field is editable", (assert) => {
+    QUnit.test("the last rendered tag should get 'focused' class after the 'leftArrow' key press if field is editable", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2070,7 +2070,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($lastTag.hasClass(FOCUSED_CLASS), "the last tag got the 'focused' class");
     });
 
-    QUnit.test("the first rendered tag should get 'focused' class after the 'rightArrow' key press", (assert) => {
+    QUnit.test("the first rendered tag should get 'focused' class after the 'rightArrow' key press", function(assert) {
         this.keyboard
             .focus()
             .press("right");
@@ -2079,7 +2079,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($firstTag.hasClass(FOCUSED_CLASS), "the first tag got the 'focused' class");
     });
 
-    QUnit.test("the 'focused' class should be moved to the previous tag after the 'leftArrow' key press", (assert) => {
+    QUnit.test("the 'focused' class should be moved to the previous tag after the 'leftArrow' key press", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2092,7 +2092,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($penultTag.hasClass(FOCUSED_CLASS), "the penult tag has the 'focused' class");
     });
 
-    QUnit.test("the 'focused' should remain on the first tag if the 'leftArrow' key is pressed", (assert) => {
+    QUnit.test("the 'focused' should remain on the first tag if the 'leftArrow' key is pressed", function(assert) {
         this.instance.option({
             items: [1],
             value: [1]
@@ -2107,7 +2107,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($firstTag.hasClass(FOCUSED_CLASS), "the first tag has the 'focused' class");
     });
 
-    QUnit.test("the 'focused' class should be moved to the next tag after the 'rightArrow' key press", (assert) => {
+    QUnit.test("the 'focused' class should be moved to the next tag after the 'rightArrow' key press", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2121,7 +2121,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.notOk($penultTag.hasClass(FOCUSED_CLASS), "the penult tag does not have the 'focused' class");
     });
 
-    QUnit.test("the 'focused' class should remain on the last tag if the 'rightArrow' key is pressed", (assert) => {
+    QUnit.test("the 'focused' class should remain on the last tag if the 'rightArrow' key is pressed", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2133,7 +2133,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.notOk(this.$input.hasClass(FOCUSED_CLASS), "the 'tag focused' class should not be set on the input");
     });
 
-    QUnit.test("the 'focused' class should be removed from the last tag if the 'rightArrow' key is pressed is field is editable", (assert) => {
+    QUnit.test("the 'focused' class should be removed from the last tag if the 'rightArrow' key is pressed is field is editable", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2153,7 +2153,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.notOk(this.$input.hasClass(FOCUSED_CLASS), "the 'tag focused' class should not be set on the input");
     });
 
-    QUnit.test("it should be possible to move input caret after navigating through tags", (assert) => {
+    QUnit.test("it should be possible to move input caret after navigating through tags", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2181,7 +2181,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.notOk(event.isDefaultPrevented(), "the event default is not prevented, so the input caret move");
     });
 
-    QUnit.test("typing symbols should not remove the 'focused' class from currently focused tag", (assert) => {
+    QUnit.test("typing symbols should not remove the 'focused' class from currently focused tag", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2191,7 +2191,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($lastTag.hasClass(FOCUSED_CLASS), "the last tag has the 'focused' class");
     });
 
-    QUnit.test("typing symbols should remove the 'focused' class from currently focused tag if the field is editable", (assert) => {
+    QUnit.test("typing symbols should remove the 'focused' class from currently focused tag if the field is editable", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2209,7 +2209,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal($focusedTags.length, 0, "no tags have the 'focused' class");
     });
 
-    QUnit.test("the last tag should not be selected after the 'leftArrow' key press if the input caret is not at the start position", (assert) => {
+    QUnit.test("the last tag should not be selected after the 'leftArrow' key press if the input caret is not at the start position", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2227,7 +2227,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal($focusedTags.length, 0, "there are no focused tags");
     });
 
-    QUnit.test("the input caret should not move while navigating through tags", (assert) => {
+    QUnit.test("the input caret should not move while navigating through tags", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2254,7 +2254,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok(event.isDefaultPrevented(), "the event default is prevented, so the input caret did not move");
     });
 
-    QUnit.test("the focused tag should be removed after pressing the 'backspace' key", (assert) => {
+    QUnit.test("the focused tag should be removed after pressing the 'backspace' key", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2272,7 +2272,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.deepEqual(value, expectedValue, "the widget's value is correct");
     });
 
-    QUnit.test("backspace should remove selected search text but not tag if any text is selected", (assert) => {
+    QUnit.test("backspace should remove selected search text but not tag if any text is selected", function(assert) {
         this.reinit({
             items: ["item 1", "item 2"],
             value: ["item 1"],
@@ -2287,7 +2287,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal(this.instance.option("value"), "item 1", "tag was not removed");
     });
 
-    QUnit.test("the focused tag should be removed after pressing the 'delete' key", (assert) => {
+    QUnit.test("the focused tag should be removed after pressing the 'delete' key", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2305,7 +2305,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.deepEqual(value, expectedValue, "the widget's value is correct");
     });
 
-    QUnit.test("pressing any of 'backspace' or 'delete' keys while tag is focused should not affect on input value", (assert) => {
+    QUnit.test("pressing any of 'backspace' or 'delete' keys while tag is focused should not affect on input value", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2340,7 +2340,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok(event.isDefaultPrevented(), "the default is prevented after the 'delete' key press, so the input value is not modified");
     });
 
-    QUnit.test("continuously removing tags with the 'backspace' key while input is focused", (assert) => {
+    QUnit.test("continuously removing tags with the 'backspace' key while input is focused", function(assert) {
         const expectedTagsCount = this.instance.option("value").length - 2;
 
         this.keyboard
@@ -2351,7 +2351,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal(this.instance.option("value").length, expectedTagsCount, "tags are removed correctly");
     });
 
-    QUnit.test("the previous tag is focused after the 'backspace' key press", (assert) => {
+    QUnit.test("the previous tag is focused after the 'backspace' key press", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2365,7 +2365,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($expectedFocusedTag.hasClass(FOCUSED_CLASS), "the previous tag is focused");
     });
 
-    QUnit.test("there are no focused tags after removing the first tag with the help of the 'backspace' key", (assert) => {
+    QUnit.test("there are no focused tags after removing the first tag with the help of the 'backspace' key", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2378,7 +2378,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal(focusedTagsCount, 0, "there are no focused tags");
     });
 
-    QUnit.test("there are no focused tags after pressing the 'backspace' key while input is focused", (assert) => {
+    QUnit.test("there are no focused tags after pressing the 'backspace' key while input is focused", function(assert) {
         this.keyboard
             .focus()
             .press("backspace");
@@ -2387,7 +2387,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal(focusedTagsCount, 0, "there are no focused tags");
     });
 
-    QUnit.test("keyboard navigation should work after removing the last tag with the help of the 'backspace' key (T378397)", (assert) => {
+    QUnit.test("keyboard navigation should work after removing the last tag with the help of the 'backspace' key (T378397)", function(assert) {
         this.keyboard
             .focus()
             .press("right")
@@ -2398,7 +2398,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($lastTag.hasClass(FOCUSED_CLASS), "the last tag is focused");
     });
 
-    QUnit.test("the next tag is focused after the 'del' key press", (assert) => {
+    QUnit.test("the next tag is focused after the 'del' key press", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2412,7 +2412,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($expectedFocusedTag.hasClass(FOCUSED_CLASS), "the next tag is focused");
     });
 
-    QUnit.test("there are no focused tags after removing the last tag with the help of the 'del' key", (assert) => {
+    QUnit.test("there are no focused tags after removing the last tag with the help of the 'del' key", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2422,7 +2422,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal(focusedTagsCount, 0, "there are no focused tags");
     });
 
-    QUnit.test("keyboard navigation should work after removing the last tag with the help of the 'del' key (T378397)", (assert) => {
+    QUnit.test("keyboard navigation should work after removing the last tag with the help of the 'del' key (T378397)", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -2433,7 +2433,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.ok($lastTag.hasClass(FOCUSED_CLASS), "the last tag is focused");
     });
 
-    QUnit.testInActiveWindow("the 'focused' class should be removed from the focused tag when the widget loses focus", (assert) => {
+    QUnit.testInActiveWindow("the 'focused' class should be removed from the focused tag when the widget loses focus", function(assert) {
         this.instance.focus();
         this.keyboard
             .press("left");
@@ -2444,7 +2444,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal(focusedTagsCount, 0, "there are no focused tags");
     });
 
-    QUnit.testInActiveWindow("the should be no focused tags on when the widget gets focus", (assert) => {
+    QUnit.testInActiveWindow("the should be no focused tags on when the widget gets focus", function(assert) {
         this.instance.focus();
 
         this.keyboard
@@ -2457,7 +2457,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal(focusedTagsCount, 0, "there are no focused tags");
     });
 
-    QUnit.test("there should be no focused tags after changing value not by keyboard", (assert) => {
+    QUnit.test("there should be no focused tags after changing value not by keyboard", function(assert) {
         this.keyboard
             .focus()
             .press("right");
@@ -2469,7 +2469,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal(focusedTagsCount, 0, "there are no focused tags");
     });
 
-    QUnit.test("navigating through tags in the RTL mode", (assert) => {
+    QUnit.test("navigating through tags in the RTL mode", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2498,7 +2498,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal($focusedTag.index(), 3, "correct tag is focused after the 'left' key press");
     });
 
-    QUnit.test("navigating through tags in the RTL mode if the field is editable", (assert) => {
+    QUnit.test("navigating through tags in the RTL mode if the field is editable", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2528,7 +2528,7 @@ QUnit.module("keyboard navigation through tags", {
         assert.equal($focusedTag.index(), 3, "correct tag is focused after the 'left' key press");
     });
 
-    QUnit.test("the input caret should not move while navigating through tags in the RTL mode", (assert) => {
+    QUnit.test("the input caret should not move while navigating through tags in the RTL mode", function(assert) {
         const items = [1, 2, 3, 4];
         this.reinit({
             items,
@@ -2558,7 +2558,7 @@ QUnit.module("keyboard navigation through tags", {
 });
 
 QUnit.module("searchEnabled", moduleSetup, () => {
-    QUnit.test("searchEnabled allows searching", (assert) => {
+    QUnit.test("searchEnabled allows searching", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["test", "custom"],
             searchEnabled: true,
@@ -2576,7 +2576,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($.trim($listItems.text()), "test", "items filtered");
     });
 
-    QUnit.test("renders all tags after search", (assert) => {
+    QUnit.test("renders all tags after search", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["Moscow", "London"],
             searchEnabled: true,
@@ -2599,7 +2599,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($.trim($tagContainer.text()), "MoscowLondon", "selected values are rendered");
     });
 
-    QUnit.test("input is positioned on the right of last tag", (assert) => {
+    QUnit.test("input is positioned on the right of last tag", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["Moscow"],
             searchEnabled: true,
@@ -2615,7 +2615,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.ok($input.offset().left > inputLeft, "input is moved to the right");
     });
 
-    QUnit.test("size of input changes depending on search value length", assert => {
+    QUnit.test("size of input changes depending on search value length", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             searchEnabled: true
         });
@@ -2629,7 +2629,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
     });
 
     ["searchEnabled", "acceptCustomValue"].forEach((option) => {
-        QUnit.test(`width of input is enougth for all content with ${option} option (T807069)`, assert => {
+        QUnit.test(`width of input is enougth for all content with ${option} option (T807069)`, function(assert) {
             const $tagBox = $("#tagBox").dxTagBox({
                 width: 300,
                 [option]: true
@@ -2650,7 +2650,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         });
     });
 
-    QUnit.test("size of input is reset after selecting item", assert => {
+    QUnit.test("size of input is reset after selecting item", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             searchEnabled: true,
             items: ["test1", "test2"]
@@ -2663,7 +2663,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.roughEqual($tagBox.find(`.${TEXTBOX_CLASS}`).width(), initInputWidth, 0.1, "input width is not changed after selecting item");
     });
 
-    QUnit.test("size of input is 1 when searchEnabled and acceptCustomValue is false", assert => {
+    QUnit.test("size of input is 1 when searchEnabled and acceptCustomValue is false", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             searchEnabled: false,
             acceptCustomValue: false
@@ -2674,7 +2674,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.roughEqual($input.width(), 0.1, 0.101, "input has correct width");
     });
 
-    QUnit.test("no placeholder when textbox is not empty", assert => {
+    QUnit.test("no placeholder when textbox is not empty", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             searchEnabled: true,
             placeholder: "placeholder"
@@ -2687,7 +2687,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.ok($placeholder.is(":hidden"), "placeholder is hidden");
     });
 
-    QUnit.test("the 'backspace' key press should remove text and preserve the widget's value", assert => {
+    QUnit.test("the 'backspace' key press should remove text and preserve the widget's value", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             searchEnabled: true,
             dataSource: [1, 2, 3],
@@ -2708,7 +2708,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal(tagBox.option("value").length, 2, "tags are not removed");
     });
 
-    QUnit.test("deleting tag when input is not empty", (assert) => {
+    QUnit.test("deleting tag when input is not empty", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: [1, 2, 3],
             searchEnabled: true,
@@ -2731,7 +2731,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($tagContainer.text(), "1", "tags is refreshed correctly");
     });
 
-    QUnit.test("list item obtained focus only after press on control key", (assert) => {
+    QUnit.test("list item obtained focus only after press on control key", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -2756,7 +2756,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.ok($firstItemList.hasClass(FOCUSED_CLASS), "first list item obtained focus");
     });
 
-    QUnit.test("tagBox should not be opened after selecting item", (assert) => {
+    QUnit.test("tagBox should not be opened after selecting item", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: [1, 2, 3],
             searchEnabled: true
@@ -2776,7 +2776,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal(tagBox.option("opened"), false, "widget closed");
     });
 
-    QUnit.test("tagBox removeTag with searchEnabled when input is focused", assert => {
+    QUnit.test("tagBox removeTag with searchEnabled when input is focused", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: [1, 2, 3],
             searchEnabled: true,
@@ -2795,7 +2795,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.deepEqual(tagBox.option("value"), [], "tag was removed");
     });
 
-    QUnit.test("tagBox set focused class with searchEnabled after press 'delete' key", (assert) => {
+    QUnit.test("tagBox set focused class with searchEnabled after press 'delete' key", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -2828,7 +2828,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.ok($focusedItemList.hasClass(FOCUSED_CLASS), "list item save focus after press 'delete' key");
     });
 
-    QUnit.test("remove tag by backspace", (assert) => {
+    QUnit.test("remove tag by backspace", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["one", "two", "three"],
             value: ["one", "two"],
@@ -2850,7 +2850,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($tagBox.find("." + TAGBOX_TAG_CLASS).length, 0, "all tags removed");
     });
 
-    QUnit.test("removing tag by backspace should not load data from DS", (assert) => {
+    QUnit.test("removing tag by backspace should not load data from DS", function(assert) {
         const data = ["one", "two", "three"];
         let loadedCount = 0;
 
@@ -2882,7 +2882,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal(loadedCount, 1, "data source did not load data again");
     });
 
-    QUnit.test("search after selection first item", (assert) => {
+    QUnit.test("search after selection first item", function(assert) {
         const items = [{ text: "item1" }, { text: "item2" }];
         const $tagBox = $("#tagBox").dxTagBox({
             items,
@@ -2905,7 +2905,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($input.val(), "It", "input value is correct");
     });
 
-    QUnit.test("input should not be cleared after the 'value' option change", assert => {
+    QUnit.test("input should not be cleared after the 'value' option change", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["one", "two"],
             searchEnabled: true,
@@ -2921,7 +2921,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($input.val(), searchValue, "input is clear");
     });
 
-    QUnit.test("input should be cleared after list item is clicked", assert => {
+    QUnit.test("input should be cleared after list item is clicked", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["one", "two"],
             searchEnabled: true,
@@ -2937,7 +2937,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($input.val(), "", "input is clear");
     });
 
-    QUnit.test("input should not be cleared after list item is clicked when checkboxes are visible", assert => {
+    QUnit.test("input should not be cleared after list item is clicked when checkboxes are visible", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["one", "two"],
             searchEnabled: true,
@@ -2954,7 +2954,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($input.val(), "one", "input was not cleared");
     });
 
-    QUnit.test("input should not be cleared after tag is removed", assert => {
+    QUnit.test("input should not be cleared after tag is removed", function(assert) {
         const items = [1, 2, 3];
 
         const $element = $("#tagBox").dxTagBox({
@@ -2972,7 +2972,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($input.val(), searchValue, "search value is not cleared");
     });
 
-    QUnit.testInActiveWindow("input should be cleared after widget focus out", assert => {
+    QUnit.testInActiveWindow("input should be cleared after widget focus out", function(assert) {
         const items = [1, 2, 3];
         const $element = $("#tagBox").dxTagBox({
             items,
@@ -2990,7 +2990,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($input.val(), "", "search value is cleared");
     });
 
-    QUnit.test("search was work if acceptCustomValue is set to true", assert => {
+    QUnit.test("search was work if acceptCustomValue is set to true", function(assert) {
         const $element = $("#tagBox").dxTagBox({
             dataSource: ["item 1", "element 1", "item 2"],
             searchEnabled: true,
@@ -3007,7 +3007,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal(listItems.length, 2, "search was performed");
     });
 
-    QUnit.test("tag should be added after enter press key if popup was not opened early", assert => {
+    QUnit.test("tag should be added after enter press key if popup was not opened early", function(assert) {
         const $element = $("#tagBox").dxTagBox({
             dataSource: ["q", "er", "fsd", "fd"],
             searchEnabled: true,
@@ -3029,7 +3029,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($element.find(".dx-tag").length, 1, "tag is added");
     });
 
-    QUnit.test("popup should be repaint after change height of input", assert => {
+    QUnit.test("popup should be repaint after change height of input", function(assert) {
         const $element = $("#tagBox").dxTagBox({
             dataSource: ["Antigua and Barbuda", "Albania", "American Samoa"],
             value: ["Antigua and Barbuda", "Albania"],
@@ -3052,7 +3052,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.ok(handlerStub.called, "repaint was fired");
     });
 
-    QUnit.test("the input size should change if autocompletion is Enabled (T378411)", (assert) => {
+    QUnit.test("the input size should change if autocompletion is Enabled (T378411)", function(assert) {
         const items = ["Antigua and Barbuda", "Albania"];
         const $element = $("#tagBox").dxTagBox({
             dataSource: items,
@@ -3069,7 +3069,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.ok($input.width() > inputWidth, "input size is changed for substitution");
     });
 
-    QUnit.test("filter should be reset after the search value clearing (T385456)", assert => {
+    QUnit.test("filter should be reset after the search value clearing (T385456)", function(assert) {
         const items = ["111", "222", "333"];
 
         const $element = $("#tagBox").dxTagBox({
@@ -3090,7 +3090,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($listItems.length, items.length, "list items count is correct");
     });
 
-    QUnit.test("filtering operation should pass 'customQueryParams' to the data source (T683047)", (assert) => {
+    QUnit.test("filtering operation should pass 'customQueryParams' to the data source (T683047)", function(assert) {
         const done = assert.async();
 
         ajaxMock.setup({
@@ -3111,7 +3111,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         });
     });
 
-    QUnit.test("filtering operation should pass 'expand' parameter to the dataSource", (assert) => {
+    QUnit.test("filtering operation should pass 'expand' parameter to the dataSource", function(assert) {
         const done = assert.async();
 
         ajaxMock.setup({
@@ -3135,7 +3135,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         });
     });
 
-    QUnit.testInActiveWindow("input should be focused after click on field (searchEnabled is true or acceptCustomValue is true)", (assert) => {
+    QUnit.testInActiveWindow("input should be focused after click on field (searchEnabled is true or acceptCustomValue is true)", function(assert) {
         const items = ["111", "222", "333"];
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -3154,7 +3154,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.ok($input.is(":focus"), "input was focused");
     });
 
-    QUnit.test("Select all' checkBox is checked when filtered items are selected only", assert => {
+    QUnit.test("Select all' checkBox is checked when filtered items are selected only", function(assert) {
         const items = ["111", "222", "333"];
 
         const $element = $("#tagBox").dxTagBox({
@@ -3175,7 +3175,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal(instance.option("selectedItems").length, 1, "selected items count");
     });
 
-    QUnit.test("filter should not be cleared when no focusout and no item selection happened", assert => {
+    QUnit.test("filter should not be cleared when no focusout and no item selection happened", function(assert) {
         const items = ["111", "222", "333"];
 
         const $element = $("#tagBox").dxTagBox({
@@ -3199,7 +3199,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.equal($.trim($(".dx-item").first().text()), "111", "value of first item");
     });
 
-    QUnit.test("TagBox with selection controls shouldn't clear search after click on item", (assert) => {
+    QUnit.test("TagBox with selection controls shouldn't clear search after click on item", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["test1", "custom", "test2"],
             searchEnabled: true,
@@ -3226,7 +3226,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
         assert.deepEqual(instance.option("value"), ["test1", "test2"], "Correct value");
     });
 
-    QUnit.test("load tags data should not raise an error after widget has been disposed", (assert) => {
+    QUnit.test("load tags data should not raise an error after widget has been disposed", function(assert) {
         assert.expect(1);
 
         const $container = $("#tagBox").dxTagBox({
@@ -3277,7 +3277,7 @@ QUnit.module("searchEnabled", moduleSetup, () => {
 });
 
 QUnit.module("popup position and size", moduleSetup, () => {
-    QUnit.testInActiveWindow("popup height should be depended from its content height", assert => {
+    QUnit.testInActiveWindow("popup height should be depended from its content height", function(assert) {
         const $element = $("#tagBox").dxTagBox({
             dataSource: ["Antigua and Barbuda", "Albania", "American Samoa"],
             acceptCustomValue: true,
@@ -3300,7 +3300,7 @@ QUnit.module("popup position and size", moduleSetup, () => {
         assert.notEqual(height, currentHeight);
     });
 
-    QUnit.test("popup changes its position when field height changed", assert => {
+    QUnit.test("popup changes its position when field height changed", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["item1", "item2", "item3", "item4", "item5", "item6"],
             showSelectionControls: true,
@@ -3322,7 +3322,7 @@ QUnit.module("popup position and size", moduleSetup, () => {
         assert.roughEqual(popupContent.offset().top, popupContentTop - initialHeight + $tagBox.height(), 1, "selectAll moved");
     });
 
-    QUnit.test("refresh popup size after dataSource loaded", (assert) => {
+    QUnit.test("refresh popup size after dataSource loaded", function(assert) {
         const d = $.Deferred();
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -3345,7 +3345,7 @@ QUnit.module("popup position and size", moduleSetup, () => {
         assert.ok($popup.height() > popupHeight, "popup enlarged after loading");
     });
 
-    QUnit.test("Second search should be work, when first search are running", (assert) => {
+    QUnit.test("Second search should be work, when first search are running", function(assert) {
         const items = [
             { name: 'Zambia', code: 'ZM' },
             { name: 'Zimbabwe', code: 'ZW' }
@@ -3384,7 +3384,7 @@ QUnit.module("popup position and size", moduleSetup, () => {
         assert.equal($(".dx-list-item").length, 1, "search was completed");
     });
 
-    QUnit.test("load selected item data via custom store", (assert) => {
+    QUnit.test("load selected item data via custom store", function(assert) {
         let testPassed = true;
         try {
             const $tagBox = $("#tagBox").dxTagBox({
@@ -3410,7 +3410,7 @@ QUnit.module("popup position and size", moduleSetup, () => {
 });
 
 QUnit.module("the 'acceptCustomValue' option", moduleSetup, () => {
-    QUnit.test("acceptCustomValue", (assert) => {
+    QUnit.test("acceptCustomValue", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["item1", "item2"],
             acceptCustomValue: true,
@@ -3435,7 +3435,7 @@ QUnit.module("the 'acceptCustomValue' option", moduleSetup, () => {
         assert.equal($.trim($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text()), "item1test", "all tags rendered");
     });
 
-    QUnit.test("acceptCustomValue should not add empty tag", assert => {
+    QUnit.test("acceptCustomValue should not add empty tag", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             acceptCustomValue: true
         });
@@ -3447,7 +3447,7 @@ QUnit.module("the 'acceptCustomValue' option", moduleSetup, () => {
         assert.deepEqual($tagBox.dxTagBox("option", "value"), [], "empty value was not added");
     });
 
-    QUnit.test("adding the custom tag should clear input value (T385448)", assert => {
+    QUnit.test("adding the custom tag should clear input value (T385448)", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             acceptCustomValue: true
         });
@@ -3461,7 +3461,7 @@ QUnit.module("the 'acceptCustomValue' option", moduleSetup, () => {
         assert.equal($input.val(), "", "the input is empty");
     });
 
-    QUnit.test("adding the custom tag shouldn't lead to duplicating of ordinary tags", (assert) => {
+    QUnit.test("adding the custom tag shouldn't lead to duplicating of ordinary tags", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             acceptCustomValue: true,
             items: [1, 2, 3]
@@ -3482,7 +3482,7 @@ QUnit.module("the 'acceptCustomValue' option", moduleSetup, () => {
 });
 
 QUnit.module("the 'selectedItems' option", moduleSetup, () => {
-    QUnit.test("The 'selectedItems' option value is correct on init if the 'value' option is specified", assert => {
+    QUnit.test("The 'selectedItems' option value is correct on init if the 'value' option is specified", function(assert) {
         const items = [1, 2, 3];
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -3493,7 +3493,7 @@ QUnit.module("the 'selectedItems' option", moduleSetup, () => {
         assert.deepEqual(tagBox.option("selectedItems"), [items[1]], "the 'selectedItems' option value is correct");
     });
 
-    QUnit.test("The 'selectedItems' option changes after the 'value' option", assert => {
+    QUnit.test("The 'selectedItems' option changes after the 'value' option", function(assert) {
         const items = [1, 2, 3];
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -3504,7 +3504,7 @@ QUnit.module("the 'selectedItems' option", moduleSetup, () => {
         assert.deepEqual(tagBox.option("selectedItems"), items, "the 'selectedItems' option value is changed");
     });
 
-    QUnit.test("selected items should be correct if the list item is selected", assert => {
+    QUnit.test("selected items should be correct if the list item is selected", function(assert) {
         const items = [1, 2, 3];
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -3519,7 +3519,7 @@ QUnit.module("the 'selectedItems' option", moduleSetup, () => {
         assert.deepEqual(tagBox.option("selectedItems"), [items[0], items[1]], "the 'selectedItems' option value is correct");
     });
 
-    QUnit.test("selected items should be correct if the list item is unselected", assert => {
+    QUnit.test("selected items should be correct if the list item is unselected", function(assert) {
         const items = [1, 2, 3];
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -3534,7 +3534,7 @@ QUnit.module("the 'selectedItems' option", moduleSetup, () => {
         assert.deepEqual(tagBox.option("selectedItems"), [items[1], items[2]], "the 'selectedItems' option value is correct");
     });
 
-    QUnit.test("all items are selected correctly when the last item is deselected from an editor", (assert) => {
+    QUnit.test("all items are selected correctly when the last item is deselected from an editor", function(assert) {
         let selectedItems;
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -3572,7 +3572,7 @@ QUnit.module("the 'selectedItems' option", moduleSetup, () => {
 });
 
 QUnit.module("the 'onSelectionChanged' option", moduleSetup, () => {
-    QUnit.test("the 'onSelectionChanged' action should contain correct 'addedItems' argument", assert => {
+    QUnit.test("the 'onSelectionChanged' action should contain correct 'addedItems' argument", function(assert) {
         const items = [1, 2, 3];
         const spy = sinon.spy();
 
@@ -3594,7 +3594,7 @@ QUnit.module("the 'onSelectionChanged' option", moduleSetup, () => {
         assert.deepEqual(spy.args[3][0].addedItems, [], "no items in the 'addedItems' argument after item is unselected");
     });
 
-    QUnit.test("the 'onSelectionChanged' action should contain correct 'removedItems' argument", assert => {
+    QUnit.test("the 'onSelectionChanged' action should contain correct 'removedItems' argument", function(assert) {
         const items = [1, 2, 3];
         const spy = sinon.spy();
 
@@ -3638,7 +3638,7 @@ QUnit.module("the 'onSelectionChanged' option", moduleSetup, () => {
         });
     };
 
-    QUnit.test("the 'onSelectionChanged' action should contain correct 'addedItems' when a remote store is used", assert => {
+    QUnit.test("the 'onSelectionChanged' action should contain correct 'addedItems' when a remote store is used", function(assert) {
         const data = [
             {
                 "id": 1,
@@ -3675,7 +3675,7 @@ QUnit.module("the 'onSelectionChanged' option", moduleSetup, () => {
         assert.equal(spy.args[1][0].removedItems.length, 0, "the 'removedItems' argument");
     });
 
-    QUnit.test("the 'onSelectionChanged' action should contain correct 'removedItems' when a remote store is used", assert => {
+    QUnit.test("the 'onSelectionChanged' action should contain correct 'removedItems' when a remote store is used", function(assert) {
         const data = [
             {
                 "id": 1,
@@ -3710,7 +3710,7 @@ QUnit.module("the 'onSelectionChanged' option", moduleSetup, () => {
 });
 
 QUnit.module("the 'fieldTemplate' option", moduleSetup, () => {
-    QUnit.test("the 'fieldTemplate' function should be called only once on init and value change", assert => {
+    QUnit.test("the 'fieldTemplate' function should be called only once on init and value change", function(assert) {
         let callCount = 0;
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -3729,7 +3729,7 @@ QUnit.module("the 'fieldTemplate' option", moduleSetup, () => {
         assert.equal(callCount, 1, "the 'fieldTemplate' was called once on value change");
     });
 
-    QUnit.test("the 'fieldTemplate' has correct arguments", assert => {
+    QUnit.test("the 'fieldTemplate' has correct arguments", function(assert) {
         const args = [];
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -3751,7 +3751,7 @@ QUnit.module("the 'fieldTemplate' option", moduleSetup, () => {
         assert.deepEqual(args[2], [2], "arguments are correct after removing values");
     });
 
-    QUnit.testInActiveWindow("field should not be updated on focus changing", assert => {
+    QUnit.testInActiveWindow("field should not be updated on focus changing", function(assert) {
         const fieldTemplate = () => {
             return $("<div>").dxTextBox();
         };
@@ -3771,7 +3771,7 @@ QUnit.module("the 'fieldTemplate' option", moduleSetup, () => {
         assert.equal(fieldTemplateSpy.callCount, 0, "fieldTemplate render was not called");
     });
 
-    QUnit.test("tagbox should get template classes after fieldTemplate option change", assert => {
+    QUnit.test("tagbox should get template classes after fieldTemplate option change", function(assert) {
         const fieldTemplate = () => {
             return $("<div>").dxTextBox();
         };
@@ -3787,7 +3787,7 @@ QUnit.module("the 'fieldTemplate' option", moduleSetup, () => {
         assert.ok($tagBox.hasClass(TAGBOX_CUSTOM_FIELD_TEMPLATE_CLASS), "default template class wasn't applied");
     });
 
-    QUnit.test("value should be cleared after deselect all items if fieldTemplate and searchEnabled is used", assert => {
+    QUnit.test("value should be cleared after deselect all items if fieldTemplate and searchEnabled is used", function(assert) {
         const $field = $("<div>");
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -3817,7 +3817,7 @@ QUnit.module("the 'fieldTemplate' option", moduleSetup, () => {
 });
 
 QUnit.module("applyValueMode = 'useButtons'", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
 
@@ -3844,13 +3844,13 @@ QUnit.module("applyValueMode = 'useButtons'", {
             this._init(options);
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         this.clock.restore();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("popup should not be hidden after list item click", (assert) => {
+    QUnit.test("popup should not be hidden after list item click", function(assert) {
         const $listItems = this.$listItems;
 
         $($listItems.eq(0)).trigger("dxclick");
@@ -3862,7 +3862,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [], "value is not changed after the second item is clicked");
     });
 
-    QUnit.test("tags should not be rendered on list item click", (assert) => {
+    QUnit.test("tags should not be rendered on list item click", function(assert) {
         const $listItems = this.$listItems;
 
         $($listItems.eq(0)).trigger("dxclick");
@@ -3872,7 +3872,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.equal(this.$element.find(".dx-tag").length, 0, "tag is not rendered after the second list item is clicked");
     });
 
-    QUnit.test("value should be applied after the 'done' button click", (assert) => {
+    QUnit.test("value should be applied after the 'done' button click", function(assert) {
         const items = this.instance.option("items");
         const $listItems = this.$listItems;
 
@@ -3885,7 +3885,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [items[0], items[1]], "value is changed to selected list items");
     });
 
-    QUnit.test("value should not be changed after the 'cancel' button click", (assert) => {
+    QUnit.test("value should not be changed after the 'cancel' button click", function(assert) {
         const $listItems = this.$listItems;
 
         $($listItems.eq(0)).trigger("dxclick");
@@ -3897,7 +3897,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [], "value is changed to selected list items");
     });
 
-    QUnit.test("value should not be changed after the popup is closed", (assert) => {
+    QUnit.test("value should not be changed after the popup is closed", function(assert) {
         const $listItems = this.$listItems;
         const initialValue = this.instance.option("value");
 
@@ -3908,7 +3908,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), initialValue, "value is not changed");
     });
 
-    QUnit.test("selected list items should be reset after the 'cancel' button is clicked", (assert) => {
+    QUnit.test("selected list items should be reset after the 'cancel' button is clicked", function(assert) {
         const $listItems = this.$listItems;
 
         $($listItems.eq(0)).trigger("dxclick");
@@ -3918,7 +3918,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.getListInstance().option("selectedItems"), [], "selected items are reset");
     });
 
-    QUnit.test("selected list items should be reset after the popup is closed", (assert) => {
+    QUnit.test("selected list items should be reset after the popup is closed", function(assert) {
         const $listItems = this.$listItems;
 
         $($listItems.eq(0)).trigger("dxclick");
@@ -3928,7 +3928,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.getListInstance().option("selectedItems"), [], "selected items are reset");
     });
 
-    QUnit.test("list items selection should not be reset after next page loading", (assert) => {
+    QUnit.test("list items selection should not be reset after next page loading", function(assert) {
         const dataSource = new DataSource({
             store: new CustomStore({
                 load(loadOptions) {
@@ -3966,12 +3966,12 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.equal(list.option("selectedItems").length, selectedItemsCount, "selection is not reset");
     });
 
-    QUnit.test("the 'selectedItems' should not be updated after list item click", (assert) => {
+    QUnit.test("the 'selectedItems' should not be updated after list item click", function(assert) {
         $(this.$listItems.eq(0)).trigger("dxclick");
         assert.deepEqual(this.instance.option("selectedItems"), [], "selected items are not changed");
     });
 
-    QUnit.test("'onValueChanged' should not be fired after clicking on list item (T378374)", (assert) => {
+    QUnit.test("'onValueChanged' should not be fired after clicking on list item (T378374)", function(assert) {
         const valueChangedSpy = sinon.spy();
         this.reinit({
             applyValueMode: "useButtons",
@@ -3985,7 +3985,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.equal(valueChangedSpy.callCount, 0, "the 'onValueChanged' was not fired after checking an item");
     });
 
-    QUnit.test("'onValueChanged' should not be fired after clicking on list item when value is not empty (T378374)", (assert) => {
+    QUnit.test("'onValueChanged' should not be fired after clicking on list item when value is not empty (T378374)", function(assert) {
         const valueChangedSpy = sinon.spy();
         this.reinit({
             applyValueMode: "useButtons",
@@ -4000,7 +4000,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.equal(valueChangedSpy.callCount, 0, "the 'onValueChanged' was not fired after checking an item");
     });
 
-    QUnit.test("the list selection should be updated after value is changed while editor is opened", (assert) => {
+    QUnit.test("the list selection should be updated after value is changed while editor is opened", function(assert) {
         const items = this.instance.option("items");
         const list = this.getListInstance();
 
@@ -4011,7 +4011,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.equal(this.getListInstance().option("selectedItems").length, 1, "list selection is updated after removing item");
     });
 
-    QUnit.testInActiveWindow("the value should be applied after search (T402855)", (assert) => {
+    QUnit.testInActiveWindow("the value should be applied after search (T402855)", function(assert) {
         this.reinit({
             applyValueMode: "useButtons",
             items: ["aa", "ab", "bb", "ac", "bc"],
@@ -4034,7 +4034,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), ["ac", "bc"], "value is applied correctly");
     });
 
-    QUnit.test("the search should be cleared after pressing the 'OK' button", (assert) => {
+    QUnit.test("the search should be cleared after pressing the 'OK' button", function(assert) {
         this.reinit({
             applyValueMode: "useButtons",
             items: ["aa", "ab", "bb", "ac", "bc"],
@@ -4056,7 +4056,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.notOk(this.instance._dataSource.searchValue(), "The search value is cleared");
     });
 
-    QUnit.test("value should keep initial tag order", (assert) => {
+    QUnit.test("value should keep initial tag order", function(assert) {
         const items = this.instance.option("items");
         const $listItems = this.$listItems;
 
@@ -4071,7 +4071,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [items[1], items[0]], "tags order is correct");
     });
 
-    QUnit.test("value should keep initial tag order with object items", (assert) => {
+    QUnit.test("value should keep initial tag order with object items", function(assert) {
         this.reinit({
             items: [{ id: 1, name: "Alex" }, { id: 2, name: "John" }, { id: 3, name: "Max" }],
             valueExpr: "id",
@@ -4093,7 +4093,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [items[1].id, items[0].id], "tags order is correct");
     });
 
-    QUnit.test("value should keep initial tag order with object items and 'this' valueExpr", (assert) => {
+    QUnit.test("value should keep initial tag order with object items and 'this' valueExpr", function(assert) {
         this.reinit({
             items: [{ id: 1, name: "Alex" }, { id: 2, name: "John" }, { id: 3, name: "Max" }],
             valueExpr: "this",
@@ -4115,7 +4115,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [items[1], items[0]], "tags order is correct");
     });
 
-    QUnit.test("Value should keep initial order if tags aren't changed", (assert) => {
+    QUnit.test("Value should keep initial order if tags aren't changed", function(assert) {
         const items = this.instance.option("items");
         const $listItems = this.$listItems;
 
@@ -4129,7 +4129,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [items[0], items[1]], "tags order is correct");
     });
 
-    QUnit.test("Value should correctly update if items count isn't changed", (assert) => {
+    QUnit.test("Value should correctly update if items count isn't changed", function(assert) {
         const items = this.instance.option("items");
         const $listItems = this.$listItems;
 
@@ -4145,7 +4145,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [items[2], items[0]], "tags order is correct");
     });
 
-    QUnit.test("Object value should keep initial order if tags aren't changed", (assert) => {
+    QUnit.test("Object value should keep initial order if tags aren't changed", function(assert) {
         this.reinit({
             items: [{ id: 1, name: "Alex" }, { id: 2, name: "John" }, { id: 3, name: "Max" }],
             valueExpr: "id",
@@ -4166,7 +4166,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [items[0].id, items[1].id], "tags order is correct");
     });
 
-    QUnit.test("Value should correctly update if valueExpr is 'this' and value is object", (assert) => {
+    QUnit.test("Value should correctly update if valueExpr is 'this' and value is object", function(assert) {
         this.reinit({
             items: [{ id: 1, name: "Alex" }, { id: 2, name: "John" }, { id: 3, name: "Max" }],
             valueExpr: "this",
@@ -4189,7 +4189,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
         assert.deepEqual(this.instance.option("value"), [items[0], items[1]], "tags order is correct");
     });
 
-    QUnit.testInActiveWindow("tags are rendered correctly when minSearchLength is used", (assert) => {
+    QUnit.testInActiveWindow("tags are rendered correctly when minSearchLength is used", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: [
                 {
@@ -4235,7 +4235,7 @@ QUnit.module("applyValueMode = 'useButtons'", {
 });
 
 QUnit.module("the 'onSelectAllValueChanged' option", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.items = [1, 2, 3];
 
         this._init = (options) => {
@@ -4261,11 +4261,11 @@ QUnit.module("the 'onSelectAllValueChanged' option", {
             items: this.items
         });
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
     }
 }, () => {
-    QUnit.test("the 'onSelectAllValueChanged' option behavior", (assert) => {
+    QUnit.test("the 'onSelectAllValueChanged' option behavior", function(assert) {
         const $selectAllCheckbox = this.instance._list.$element().find(".dx-list-select-all-checkbox");
 
         $($selectAllCheckbox).trigger("dxclick");
@@ -4275,13 +4275,13 @@ QUnit.module("the 'onSelectAllValueChanged' option", {
         assert.ok(this.spy.args[this.spy.args.length - 1][0].value === false, "all items are unselected");
     });
 
-    QUnit.test("the 'onSelectAllValueChanged' action is fired only one time if all items are selected", (assert) => {
+    QUnit.test("the 'onSelectAllValueChanged' action is fired only one time if all items are selected", function(assert) {
         const $list = this.instance._list.$element();
         $($list.find(".dx-list-select-all-checkbox")).trigger("dxclick");
         assert.equal(this.spy.callCount, 1, "count is correct");
     });
 
-    QUnit.test("the 'onSelectAllValueChanged' action is fired only one time if all items are unselected", (assert) => {
+    QUnit.test("the 'onSelectAllValueChanged' action is fired only one time if all items are unselected", function(assert) {
         this.reinit({
             items: this.items,
             value: this.items.slice()
@@ -4292,13 +4292,13 @@ QUnit.module("the 'onSelectAllValueChanged' option", {
         assert.equal(this.spy.callCount, 1, "count is correct");
     });
 
-    QUnit.test("the 'onSelectAllValueChanged' action is fired only one time if one item is selected", (assert) => {
+    QUnit.test("the 'onSelectAllValueChanged' action is fired only one time if one item is selected", function(assert) {
         const $list = this.instance._list.$element();
         $($list.find(".dx-list-item").eq(0)).trigger("dxclick");
         assert.equal(this.spy.callCount, 1, "count is correct");
     });
 
-    QUnit.test("the 'onSelectAllValueChanged' action is fired only one time if one item is unselected", (assert) => {
+    QUnit.test("the 'onSelectAllValueChanged' action is fired only one time if one item is unselected", function(assert) {
         this.reinit({
             items: this.items,
             value: this.items.splice()
@@ -4311,7 +4311,7 @@ QUnit.module("the 'onSelectAllValueChanged' option", {
 });
 
 QUnit.module("single line mode", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.items = ["Africa", "Antarctica", "Asia", "Australia/Oceania", "Europe", "North America", "South America"];
@@ -4329,12 +4329,12 @@ QUnit.module("single line mode", {
             });
         this.instance = this.$element.dxTagBox("instance");
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("single line class presence should depend the 'multiline' option", (assert) => {
+    QUnit.test("single line class presence should depend the 'multiline' option", function(assert) {
         this.instance.option("multiline", true);
         assert.notOk(this.$element.hasClass(TAGBOX_SINGLE_LINE_CLASS), "there is no single line class on widget");
 
@@ -4342,7 +4342,7 @@ QUnit.module("single line mode", {
         assert.ok(this.$element.hasClass(TAGBOX_SINGLE_LINE_CLASS), "the single line class is added");
     });
 
-    QUnit.test("tags container should be scrolled to the end on value change", (assert) => {
+    QUnit.test("tags container should be scrolled to the end on value change", function(assert) {
         const $container = this.$element.find("." + TAGBOX_TAG_CONTAINER_CLASS);
 
         this.instance.option("value", [this.items[0]]);
@@ -4352,7 +4352,7 @@ QUnit.module("single line mode", {
         assert.equal($container.scrollLeft(), $container.get(0).scrollWidth - $container.outerWidth(), "tags container is scrolled to the end");
     });
 
-    QUnit.test("tags should be scrolled by mouse wheel (T386939)", (assert) => {
+    QUnit.test("tags should be scrolled by mouse wheel (T386939)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "desktop specific test");
             return;
@@ -4388,7 +4388,7 @@ QUnit.module("single line mode", {
         assert.equal($tagContainer.scrollLeft(), 2 * delta * TAGBOX_MOUSE_WHEEL_DELTA_MULTIPLIER, "tag container position is correct after the second scroll");
     });
 
-    QUnit.test("stopPropagation and preventDefault should be called for the mouse wheel event (T386939)", (assert) => {
+    QUnit.test("stopPropagation and preventDefault should be called for the mouse wheel event (T386939)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "desktop specific test");
             return;
@@ -4407,7 +4407,7 @@ QUnit.module("single line mode", {
         assert.ok(event.isPropagationStopped(), "propagation is stopped");
     });
 
-    QUnit.test("it is should be possible to scroll tag container natively on mobile device", assert => {
+    QUnit.test("it is should be possible to scroll tag container natively on mobile device", function(assert) {
         const currentDevice = devices.real();
         let $tagBox;
 
@@ -4431,7 +4431,7 @@ QUnit.module("single line mode", {
         }
     });
 
-    QUnit.testInActiveWindow("tag container should be scrolled to the start after rendering and focusout (T390041)", (assert) => {
+    QUnit.testInActiveWindow("tag container should be scrolled to the start after rendering and focusout (T390041)", function(assert) {
         const $container = this.$element.find("." + TAGBOX_TAG_CONTAINER_CLASS);
         const $input = this.$element.find(`.${TEXTBOX_CLASS}`);
 
@@ -4444,14 +4444,14 @@ QUnit.module("single line mode", {
         assert.equal($container.scrollLeft(), 0, "scroll position is correct on focus out");
     });
 
-    QUnit.test("tags container should be scrolled to the end on focusin (T390041)", (assert) => {
+    QUnit.test("tags container should be scrolled to the end on focusin (T390041)", function(assert) {
         const $container = this.$element.find("." + TAGBOX_TAG_CONTAINER_CLASS);
 
         this.instance.focus();
         assert.equal($container.scrollLeft(), $container.get(0).scrollWidth - $container.outerWidth(), "tags container is scrolled to the end");
     });
 
-    QUnit.test("list should save it's scroll position after value changed", (assert) => {
+    QUnit.test("list should save it's scroll position after value changed", function(assert) {
         this.instance.option({
             opened: true,
             showSelectionControls: true
@@ -4470,7 +4470,7 @@ QUnit.module("single line mode", {
         assert.equal(scrollView.scrollTop(), 2, "list should not be scrolled to the top after value changed");
     });
 
-    QUnit.testInActiveWindow("tag container should be scrolled to the start after rendering and focusout in the RTL mode (T390041)", (assert) => {
+    QUnit.testInActiveWindow("tag container should be scrolled to the start after rendering and focusout in the RTL mode (T390041)", function(assert) {
         this.instance.option("rtlEnabled", true);
 
         const $container = this.$element.find("." + TAGBOX_TAG_CONTAINER_CLASS);
@@ -4488,7 +4488,7 @@ QUnit.module("single line mode", {
         assert.equal($container.scrollLeft(), expectedScrollPosition, "scroll position is correct on focus out");
     });
 
-    QUnit.test("tags container should be scrolled to the end on focusin in the RTL mode (T390041)", (assert) => {
+    QUnit.test("tags container should be scrolled to the end on focusin in the RTL mode (T390041)", function(assert) {
         this.instance.option("rtlEnabled", true);
 
         const $container = this.$element.find("." + TAGBOX_TAG_CONTAINER_CLASS);
@@ -4502,7 +4502,7 @@ QUnit.module("single line mode", {
         assert.equal($container.scrollLeft(), expectedScrollPosition, "tags container is scrolled to the end");
     });
 
-    QUnit.test("tags container should be scrolled on mobile devices", (assert) => {
+    QUnit.test("tags container should be scrolled on mobile devices", function(assert) {
         const $container = this.$element.find("." + TAGBOX_TAG_CONTAINER_CLASS);
 
         if(devices.real().deviceType === "desktop") {
@@ -4512,7 +4512,7 @@ QUnit.module("single line mode", {
         }
     });
 
-    QUnit.test("focusOut should be prevented when tagContainer clicked - T454876", (assert) => {
+    QUnit.test("focusOut should be prevented when tagContainer clicked - T454876", function(assert) {
         assert.expect(1);
 
         const $inputWrapper = this.$element.find(".dx-dropdowneditor-input-wrapper");
@@ -4528,7 +4528,7 @@ QUnit.module("single line mode", {
 });
 
 QUnit.module("keyboard navigation through tags in single line mode", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.items = ["Africa", "Antarctica", "Asia", "Australia/Oceania", "Europe", "North America", "South America"];
@@ -4567,12 +4567,12 @@ QUnit.module("keyboard navigation through tags in single line mode", {
 
         this._init();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.$element.remove();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("the focused tag should be visible during keyboard navigation to the left", (assert) => {
+    QUnit.test("the focused tag should be visible during keyboard navigation to the left", function(assert) {
         this.keyboard
             .focus()
             .press("left")
@@ -4588,7 +4588,7 @@ QUnit.module("keyboard navigation through tags in single line mode", {
         assert.roughEqual(this.getFocusedTag().position().left, 0, 1, "focused tag is visible");
     });
 
-    QUnit.test("the focused tag should be visible during keyboard navigation to the right", (assert) => {
+    QUnit.test("the focused tag should be visible during keyboard navigation to the right", function(assert) {
         const containerWidth = this.$element.find("." + TAGBOX_TAG_CONTAINER_CLASS).outerWidth();
 
         this.keyboard.focus();
@@ -4613,7 +4613,7 @@ QUnit.module("keyboard navigation through tags in single line mode", {
         assert.roughEqual($focusedTag.position().left + $focusedTag.width(), containerWidth, 1, "focused tag is visible");
     });
 
-    QUnit.test("tags container should be scrolled to the end after the last tag loses focus during navigation to the right", (assert) => {
+    QUnit.test("tags container should be scrolled to the end after the last tag loses focus during navigation to the right", function(assert) {
         this.reinit({
             items: this.items,
             value: this.items,
@@ -4635,7 +4635,7 @@ QUnit.module("keyboard navigation through tags in single line mode", {
         assert.equal($container.scrollLeft(), $container.get(0).scrollWidth - $container.outerWidth(), "tags container is scrolled to the end");
     });
 
-    QUnit.test("tags container should be scrolled to the start on value change in the RTL mode", (assert) => {
+    QUnit.test("tags container should be scrolled to the start on value change in the RTL mode", function(assert) {
         this.reinit({
             items: this.items,
             value: this.items,
@@ -4658,7 +4658,7 @@ QUnit.module("keyboard navigation through tags in single line mode", {
         assert.equal($container.scrollLeft(), expectedScrollPosition, "tags container is scrolled to the start");
     });
 
-    QUnit.test("the focused tag should be visible during keyboard navigation to the right in the RTL mode", (assert) => {
+    QUnit.test("the focused tag should be visible during keyboard navigation to the right in the RTL mode", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test is not relevant for mobile devices");
             return;
@@ -4692,7 +4692,7 @@ QUnit.module("keyboard navigation through tags in single line mode", {
         assert.roughEqual($focusedTag.position().left + $focusedTag.width(), containerWidth, 1, "focused tag is visible");
     });
 
-    QUnit.test("the focused tag should be visible during keyboard navigation to the left in the RTL mode", (assert) => {
+    QUnit.test("the focused tag should be visible during keyboard navigation to the left in the RTL mode", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test is not relevant for mobile devices");
             return;
@@ -4726,7 +4726,7 @@ QUnit.module("keyboard navigation through tags in single line mode", {
         assert.roughEqual(this.getFocusedTag().position().left, 0, 1, "focused tag is not hidden at left");
     });
 
-    QUnit.test("tags container should be scrolled to the start after the last tag loses focus during navigation to the left in the RTL mode", (assert) => {
+    QUnit.test("tags container should be scrolled to the start after the last tag loses focus during navigation to the left in the RTL mode", function(assert) {
         this.reinit({
             items: this.items,
             value: this.items,
@@ -4755,7 +4755,7 @@ QUnit.module("keyboard navigation through tags in single line mode", {
 });
 
 QUnit.module("dataSource integration", moduleSetup, () => {
-    QUnit.test("item should be chosen synchronously if item is already loaded", (assert) => {
+    QUnit.test("item should be chosen synchronously if item is already loaded", function(assert) {
         assert.expect(0);
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -4771,7 +4771,7 @@ QUnit.module("dataSource integration", moduleSetup, () => {
         $tagBox.dxTagBox("option", "value", [1]);
     });
 
-    QUnit.test("first page should be displayed after search and tag select", assert => {
+    QUnit.test("first page should be displayed after search and tag select", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: {
                 store: new CustomStore({
@@ -4810,7 +4810,7 @@ QUnit.module("dataSource integration", moduleSetup, () => {
         assert.equal($.trim($(".dx-item").first().text()), "0", "first item loaded");
     });
 
-    QUnit.test("'byKey' should not be called on initialization (T533200)", assert => {
+    QUnit.test("'byKey' should not be called on initialization (T533200)", function(assert) {
         const byKeySpy = sinon.spy(key => {
             return key;
         });
@@ -4828,7 +4828,7 @@ QUnit.module("dataSource integration", moduleSetup, () => {
         assert.equal(byKeySpy.callCount, 0);
     });
 
-    QUnit.test("tagBox should not load data from the DataSource when showDataBeforeSearch is disabled", (assert) => {
+    QUnit.test("tagBox should not load data from the DataSource when showDataBeforeSearch is disabled", function(assert) {
         const load = sinon.stub().returns([{ text: "Item 1" }]);
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -4850,7 +4850,7 @@ QUnit.module("dataSource integration", moduleSetup, () => {
         assert.ok(load.called, "load has been called after the search only");
     });
 
-    QUnit.test("map function should correctly applies to the widget datasource with the default value", (assert) => {
+    QUnit.test("map function should correctly applies to the widget datasource with the default value", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             dataSource: new DataSource({
                 store: [
@@ -4871,7 +4871,7 @@ QUnit.module("dataSource integration", moduleSetup, () => {
         assert.strictEqual(tagText, "Test1 changed", "Tag text contains an updated data");
     });
 
-    QUnit.test("Tagbox should not try to update size if input is empty(T818690)", (assert) => {
+    QUnit.test("Tagbox should not try to update size if input is empty(T818690)", function(assert) {
         const instance = $("#tagBox").dxTagBox({
             multiline: false,
             searchEnabled: true,
@@ -4900,7 +4900,7 @@ QUnit.module("dataSource integration", moduleSetup, () => {
         assert.ok(true, "TagBox rendered");
     });
 
-    QUnit.test("TagBox should correctly handle disposing on data loading", (assert) => {
+    QUnit.test("TagBox should correctly handle disposing on data loading", function(assert) {
         assert.expect(1);
 
         try {
@@ -4936,7 +4936,7 @@ QUnit.module("dataSource integration", moduleSetup, () => {
 });
 
 QUnit.module("performance", () => {
-    QUnit.test("selectionHandler should call twice on popup opening", assert => {
+    QUnit.test("selectionHandler should call twice on popup opening", function(assert) {
         const items = [1, 2, 3, 4, 5];
         const tagBox = $("#tagBox").dxTagBox({
             items,
@@ -4951,7 +4951,7 @@ QUnit.module("performance", () => {
         assert.ok(selectionChangeHandlerSpy.callCount <= 2, "selection change handler called less than 2 (ListContentReady and SelectAll)");
     });
 
-    QUnit.test("loadOptions.filter should be a filter expression when key is specified", assert => {
+    QUnit.test("loadOptions.filter should be a filter expression when key is specified", function(assert) {
         const load = sinon.stub().returns([{ id: 1, text: "item 1" }, { id: 2, text: "item 2" }]);
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -4974,7 +4974,7 @@ QUnit.module("performance", () => {
         assert.deepEqual(filter, [["!", ["id", 1]]], "filter should be correct");
     });
 
-    QUnit.test("loadOptions.filter should be a function when valueExpr is function", assert => {
+    QUnit.test("loadOptions.filter should be a function when valueExpr is function", function(assert) {
         const load = sinon.stub().returns([{ id: 1, text: "item 1" }, { id: 2, text: "item 2" }]);
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -4998,7 +4998,7 @@ QUnit.module("performance", () => {
         assert.ok($.isFunction(filter), "filter is function");
     });
 
-    QUnit.test("loadOptions.filter should be correct when user filter is also used", assert => {
+    QUnit.test("loadOptions.filter should be correct when user filter is also used", function(assert) {
         const load = sinon.stub().returns([{ id: 1, text: "item 1" }, { id: 2, text: "item 2" }]);
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -5029,7 +5029,7 @@ QUnit.module("performance", () => {
         assert.deepEqual(filter, [["!", ["id", 1]], ["!", ["id", 2]], ["id", ">", 0]], "filter is correct");
     });
 
-    QUnit.test("loadOptions.filter should be correct after some items selecting/deselecting", assert => {
+    QUnit.test("loadOptions.filter should be correct after some items selecting/deselecting", function(assert) {
         const load = sinon.stub().returns([{ id: 1, text: "item 1" }, { id: 2, text: "item 2" }]);
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -5055,7 +5055,7 @@ QUnit.module("performance", () => {
         assert.deepEqual(filter, null, "filter is correct");
     });
 
-    QUnit.test("Select All should use cache", assert => {
+    QUnit.test("Select All should use cache", function(assert) {
         const items = [];
         let keyGetterCounter = 0;
 
@@ -5099,7 +5099,7 @@ QUnit.module("performance", () => {
         assert.equal(isValueEqualsSpy.callCount, 0, "_isValueEquals is not called");
     });
 
-    QUnit.test("load filter should be undefined when tagBox has a lot of initial values", assert => {
+    QUnit.test("load filter should be undefined when tagBox has a lot of initial values", function(assert) {
         const load = sinon.stub();
 
         $("#tagBox").dxTagBox({
@@ -5114,7 +5114,7 @@ QUnit.module("performance", () => {
         assert.strictEqual(load.getCall(0).args[0].filter, undefined);
     });
 
-    QUnit.test("load filter should be array when tagBox has not a lot of initial values", assert => {
+    QUnit.test("load filter should be array when tagBox has not a lot of initial values", function(assert) {
         const load = sinon.stub();
 
         $("#tagBox").dxTagBox({
@@ -5129,7 +5129,7 @@ QUnit.module("performance", () => {
         assert.deepEqual(load.getCall(0).args[0].filter, [["id", "=", 0], "or", ["id", "=", 1]]);
     });
 
-    QUnit.test("initial items value should be loaded when filter is not implemented in load method", assert => {
+    QUnit.test("initial items value should be loaded when filter is not implemented in load method", function(assert) {
         const load = sinon.stub().returns([{ id: 1, text: "item 1" }, { id: 2, text: "item 2" }, {
             id: 3,
             text: "item 3"
@@ -5147,7 +5147,7 @@ QUnit.module("performance", () => {
         assert.equal($tagBox.find("." + TAGBOX_TAG_CLASS).text(), "item 2item 3");
     });
 
-    QUnit.test("initial items value should be loaded and selected when valueExpr = this and dataSource.key is used (T662546)", assert => {
+    QUnit.test("initial items value should be loaded and selected when valueExpr = this and dataSource.key is used (T662546)", function(assert) {
         const load = sinon.stub().returns([{ id: 1, text: "item 1" }, { id: 2, text: "item 2" }, {
             id: 3,
             text: "item 3"
@@ -5170,7 +5170,7 @@ QUnit.module("performance", () => {
         assert.deepEqual(list.option("selectedItems"), [{ id: 2, text: "item 2" }]);
     });
 
-    QUnit.test("initial items value should be loaded and selected when valueExpr = this and dataSource.key and deferred datasource is used", assert => {
+    QUnit.test("initial items value should be loaded and selected when valueExpr = this and dataSource.key and deferred datasource is used", function(assert) {
         const clock = sinon.useFakeTimers();
 
         const $tagBox = $("#tagBox").dxTagBox({
@@ -5204,7 +5204,7 @@ QUnit.module("performance", () => {
         assert.equal($tagBox.find("." + TAGBOX_TAG_CLASS).text(), "item 1");
     });
 
-    QUnit.test("useSubmitBehavior option", assert => {
+    QUnit.test("useSubmitBehavior option", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: [1, 2],
             useSubmitBehavior: false,
@@ -5226,7 +5226,7 @@ QUnit.module("performance", () => {
         assert.equal($tagBox.find("select").length, 0, "submit element was removed");
     });
 
-    QUnit.test("Unnecessary a load calls do not happen of custom store when item is selected", assert => {
+    QUnit.test("Unnecessary a load calls do not happen of custom store when item is selected", function(assert) {
         let loadCallCounter = 0;
 
         const store = new CustomStore({
@@ -5257,16 +5257,16 @@ QUnit.module("performance", () => {
 });
 
 QUnit.module("regression", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         fx.off = false;
     }
 }, () => {
-    QUnit.test("Selection refreshing process should wait for the items data will be loaded from the data source (T673636)", assert => {
+    QUnit.test("Selection refreshing process should wait for the items data will be loaded from the data source (T673636)", function(assert) {
         const clock = sinon.useFakeTimers();
 
         const tagBox = $("#tagBox").dxTagBox({
@@ -5290,7 +5290,7 @@ QUnit.module("regression", {
         clock.restore();
     });
 
-    QUnit.test("should render function item template that returns default template's name (T726777)", (assert) => {
+    QUnit.test("should render function item template that returns default template's name (T726777)", function(assert) {
         const tagBox = $("#tagBox").dxTagBox({
             items: [{ text: "item1" }, { text: "item2" }],
             itemTemplate: () => "item",
@@ -5308,7 +5308,7 @@ QUnit.module("regression", {
         checkItemsRender();
     });
 
-    QUnit.test("tagBox should not fail when asynchronous data source is used (T381326)", (assert) => {
+    QUnit.test("tagBox should not fail when asynchronous data source is used (T381326)", function(assert) {
         const data = [1, 2, 3, 4, 5];
         const timeToWait = 500;
 
@@ -5339,7 +5339,7 @@ QUnit.module("regression", {
         assert.expect(0);
     });
 
-    QUnit.test("tagBox should not fail when asynchronous data source is used in the single line mode (T381326)", (assert) => {
+    QUnit.test("tagBox should not fail when asynchronous data source is used in the single line mode (T381326)", function(assert) {
         const data = [1, 2, 3, 4, 5];
         const timeToWait = 500;
 
@@ -5371,7 +5371,7 @@ QUnit.module("regression", {
         assert.expect(0);
     });
 
-    QUnit.test("tagBox should not render duplicated tags after searching", (assert) => {
+    QUnit.test("tagBox should not render duplicated tags after searching", function(assert) {
         const data = [{ "id": 1, "Name": "Item14" }, { "id": 2, "Name": "Item21" }, {
             "id": 3,
             "Name": "Item31"
@@ -5424,7 +5424,7 @@ QUnit.module("regression", {
         assert.equal($.trim($tagContainer.text()), "Item14Item41", "selected values are rendered correctly");
     });
 
-    QUnit.test("T403756 - dxTagBox treats removing a dxTagBox item for the first time as removing the item", (assert) => {
+    QUnit.test("T403756 - dxTagBox treats removing a dxTagBox item for the first time as removing the item", function(assert) {
         const items = [
             { id: 1, name: "Item 1" },
             { id: 2, name: "Item 2" },
@@ -5477,7 +5477,7 @@ QUnit.module("regression", {
         assert.equal(tagBox.option("selectedItems").length, 1, "selectedItems was changed correctly");
     });
 
-    QUnit.testInActiveWindow("Searching should work correctly in grouped tagBox (T516798)", (assert) => {
+    QUnit.testInActiveWindow("Searching should work correctly in grouped tagBox (T516798)", function(assert) {
         if(devices.real().deviceType !== "desktop") {
             assert.ok(true, "test does not actual for mobile devices");
             return;
@@ -5519,7 +5519,7 @@ QUnit.module("regression", {
         assert.equal($.trim($tagContainer.text()), "Item1Item3", "selected values are rendered");
     });
 
-    QUnit.test("selection should work with pregrouped data without paging and with preloaded datasource", (assert) => {
+    QUnit.test("selection should work with pregrouped data without paging and with preloaded datasource", function(assert) {
         const ds = new DataSource({
             store: [
                 { key: "Category 1", items: [{ id: 11, name: "Item 11" }, { id: 12, name: "Item 12" }] },
@@ -5539,7 +5539,7 @@ QUnit.module("regression", {
         assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text(), "Item 21", "Tag was selected");
     });
 
-    QUnit.test("selection should work with pregrouped data without paging", (assert) => {
+    QUnit.test("selection should work with pregrouped data without paging", function(assert) {
         const loadMock = sinon.stub().returns([
             { key: "Category 1", items: [{ id: 11, name: "Item 11" }, { id: 12, name: "Item 12" }] },
             { key: "Category 2", items: [{ id: 21, name: "Item 21" }, { id: 22, name: "Item 22" }] }
@@ -5560,7 +5560,7 @@ QUnit.module("regression", {
         assert.strictEqual($tagBox.find("." + TAGBOX_TAG_CONTAINER_CLASS).text(), "Item 21", "Tag was selected");
     });
 
-    QUnit.testInActiveWindow("focusout event should remove focus class from the widget", assert => {
+    QUnit.testInActiveWindow("focusout event should remove focus class from the widget", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({});
         const $input = $tagBox.find(`.${TEXTBOX_CLASS}`);
 
@@ -5571,7 +5571,7 @@ QUnit.module("regression", {
         assert.notOk($tagBox.hasClass(FOCUSED_CLASS), "focused class was removed");
     });
 
-    QUnit.test("search filter should be cleared on close", (assert) => {
+    QUnit.test("search filter should be cleared on close", function(assert) {
         const $tagBox = $("#tagBox").dxTagBox({
             items: ["111", "222", "333"],
             searchTimeout: 0,
@@ -5595,7 +5595,7 @@ QUnit.module("regression", {
         assert.equal($(instance.content()).find("." + LIST_ITEM_CLASS).length, 3, "filter was cleared");
     });
 
-    QUnit.test("Items is not selected when values is set on the onSelectAllValueChanged event", assert => {
+    QUnit.test("Items is not selected when values is set on the onSelectAllValueChanged event", function(assert) {
         const dataSource = ["Item 1", "item 2", "item 3", "item 4"];
 
         $("#tagBox").dxTagBox({
@@ -5621,7 +5621,7 @@ QUnit.module("regression", {
         assert.equal(selectedItems.length, 4, "selected items");
     });
 
-    QUnit.test("Read only TagBox should be able to render the multitag", assert => {
+    QUnit.test("Read only TagBox should be able to render the multitag", function(assert) {
         assert.expect(1);
 
         try {
@@ -5639,7 +5639,7 @@ QUnit.module("regression", {
         assert.ok(true, "Widget rendered");
     });
 
-    QUnit.test("Disabled TagBox should be able to render the multitag", assert => {
+    QUnit.test("Disabled TagBox should be able to render the multitag", function(assert) {
         assert.expect(1);
 
         try {

--- a/testing/tests/DevExpress.ui.widgets.editors/textArea.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textArea.tests.js
@@ -36,7 +36,7 @@ const SCROLLABLE_CONTAINER_CLASS = "dx-scrollable-container";
 
 QUnit.module("rendering");
 
-QUnit.test("onContentReady fired after the widget is fully ready", assert => {
+QUnit.test("onContentReady fired after the widget is fully ready", function(assert) {
     assert.expect(1);
 
     $("#textarea").dxTextArea({
@@ -46,7 +46,7 @@ QUnit.test("onContentReady fired after the widget is fully ready", assert => {
     });
 });
 
-QUnit.test("scrolling with dxpointer events", assert => {
+QUnit.test("scrolling with dxpointer events", function(assert) {
     assert.expect(4);
 
     const longValue = "qwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTYqwertyQWERTY";
@@ -72,7 +72,7 @@ QUnit.test("scrolling with dxpointer events", assert => {
     $(document).off(".dxtestns");
 });
 
-QUnit.test("scrolling with dxpointer events, empty TextArea", assert => {
+QUnit.test("scrolling with dxpointer events, empty TextArea", function(assert) {
     const $element = $("#textarea").dxTextArea({ height: 100, width: 100 });
     const $input = $element.dxTextArea("instance")._input();
 
@@ -86,7 +86,7 @@ QUnit.test("scrolling with dxpointer events, empty TextArea", assert => {
 
 QUnit.module("options changing");
 
-QUnit.test("value", assert => {
+QUnit.test("value", function(assert) {
     assert.expect(2);
 
     const $element = $("#textarea").dxTextArea({});
@@ -100,7 +100,7 @@ QUnit.test("value", assert => {
     assert.equal($input.val(), "321");
 });
 
-QUnit.test("disabled", assert => {
+QUnit.test("disabled", function(assert) {
     assert.expect(2);
 
     const $element = $("#textarea").dxTextArea({});
@@ -114,7 +114,7 @@ QUnit.test("disabled", assert => {
     assert.equal($input.prop("disabled"), false);
 });
 
-QUnit.test("placeholder", assert => {
+QUnit.test("placeholder", function(assert) {
     assert.expect(2);
 
     const $element = $("#textarea").dxTextArea({});
@@ -127,7 +127,7 @@ QUnit.test("placeholder", assert => {
     assert.equal($element.find(`.${INPUT_CLASS}`).prop("placeholder") || $element.find(`.${PLACEHOLDER_CLASS}`).attr("data-dx_placeholder"), "John Jr. Doe");
 });
 
-QUnit.test("inputAttr", assert => {
+QUnit.test("inputAttr", function(assert) {
     const $textArea = $("#textarea").dxTextArea({
         inputAttr: { id: "testId" }
     });
@@ -141,7 +141,7 @@ QUnit.test("inputAttr", assert => {
     assert.equal($input.attr("id"), "newTestId", "Attr ID was changed");
 });
 
-QUnit.test("the 'inputAttr' option should preserve widget specific classes", assert => {
+QUnit.test("the 'inputAttr' option should preserve widget specific classes", function(assert) {
     const $textArea = $("#textarea").dxTextArea({
         inputAttr: { class: "some-class" }
     });
@@ -149,7 +149,7 @@ QUnit.test("the 'inputAttr' option should preserve widget specific classes", ass
     assert.equal($textArea.find(`.${INPUT_CLASS}`).length, 1, "widget specific class is preserved");
 });
 
-QUnit.test("the 'inputAttr' option should affect only custom classes on change", assert => {
+QUnit.test("the 'inputAttr' option should affect only custom classes on change", function(assert) {
     const firstClassName = "first";
     const secondClassName = "second";
     const $textArea = $("#textarea").dxTextArea();
@@ -167,7 +167,7 @@ QUnit.test("the 'inputAttr' option should affect only custom classes on change",
     assert.notOk($input.hasClass(firstClassName), "first custom class is removed");
 });
 
-QUnit.test("readOnly", assert => {
+QUnit.test("readOnly", function(assert) {
     assert.expect(2);
 
     const $element = $("#textarea").dxTextArea({});
@@ -181,7 +181,7 @@ QUnit.test("readOnly", assert => {
     assert.equal($input.prop("readOnly"), false);
 });
 
-QUnit.test("B234546 dxTextArea - It is impossible to change the height via code", assert => {
+QUnit.test("B234546 dxTextArea - It is impossible to change the height via code", function(assert) {
     assert.expect(1);
 
     const $element = $("#textarea").dxTextArea({});
@@ -192,13 +192,13 @@ QUnit.test("B234546 dxTextArea - It is impossible to change the height via code"
     assert.equal($element.height(), height, "Widget height should change too");
 });
 
-QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", assert => {
+QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
     $("#textarea").dxTextArea({
         onValueChanged() { assert.ok(true); }
     }).dxTextArea("instance").option("value", true);
 });
 
-QUnit.test("B254647 dxTextArea - widget overlaps another widgets", assert => {
+QUnit.test("B254647 dxTextArea - widget overlaps another widgets", function(assert) {
     const $element = $("#textarea").dxTextArea({});
     const instance = $element.dxTextArea("instance");
     const height = 500;
@@ -209,13 +209,13 @@ QUnit.test("B254647 dxTextArea - widget overlaps another widgets", assert => {
 
 QUnit.module("widget sizing render");
 
-QUnit.test("default", assert => {
+QUnit.test("default", function(assert) {
     const $element = $("#widget").dxTextArea();
 
     assert.ok($element.outerWidth() > 0, "outer width of the element must be more than zero");
 });
 
-QUnit.test("root with custom width", assert => {
+QUnit.test("root with custom width", function(assert) {
     const $element = $("#widthRootStyle").dxTextArea();
     const instance = $element.dxTextArea("instance");
 
@@ -223,7 +223,7 @@ QUnit.test("root with custom width", assert => {
     assert.strictEqual($element.outerWidth(), 300, "outer width of the element must be equal to custom width");
 });
 
-QUnit.test("change width", assert => {
+QUnit.test("change width", function(assert) {
     const $element = $("#widget").dxTextArea();
     const instance = $element.dxTextArea("instance");
     const customWidth = 400;
@@ -233,7 +233,7 @@ QUnit.test("change width", assert => {
     assert.strictEqual($element.outerWidth(), customWidth, "outer width of the element must be equal to custom width");
 });
 
-QUnit.test("widget renders correctly when minHeight and maxHeight is specified in pixels", assert => {
+QUnit.test("widget renders correctly when minHeight and maxHeight is specified in pixels", function(assert) {
     const minHeight = 100;
     const $element = $("#widget").dxTextArea({
         minHeight: minHeight + "px",
@@ -249,7 +249,7 @@ QUnit.test("widget renders correctly when minHeight and maxHeight is specified i
 
 QUnit.module("the 'autoResizeEnabled' option");
 
-QUnit.test("widget is resized on init", assert => {
+QUnit.test("widget is resized on init", function(assert) {
     const $element = $("#textarea").dxTextArea({
         autoResizeEnabled: true
     });
@@ -262,7 +262,7 @@ QUnit.test("widget is resized on init", assert => {
     assert.equal(inputHeight, $input[0].scrollHeight, "widget height is correct");
 });
 
-QUnit.test("widget is resized on input", assert => {
+QUnit.test("widget is resized on input", function(assert) {
     const $element = $("#textarea").dxTextArea({
         autoResizeEnabled: true
     });
@@ -279,7 +279,7 @@ QUnit.test("widget is resized on input", assert => {
     assert.equal(inputHeight, $input[0].scrollHeight, "widget height is correct");
 });
 
-QUnit.test("widget is resized on value change", assert => {
+QUnit.test("widget is resized on value change", function(assert) {
     const $element = $("#textarea").dxTextArea({
         autoResizeEnabled: true
     });
@@ -295,7 +295,7 @@ QUnit.test("widget is resized on value change", assert => {
     assert.equal(inputHeight, $input[0].scrollHeight, "widget height is correct");
 });
 
-QUnit.test("widget is resized on paste", assert => {
+QUnit.test("widget is resized on paste", function(assert) {
     const $element = $("#textarea").dxTextArea({
         autoResizeEnabled: true
     });
@@ -313,7 +313,7 @@ QUnit.test("widget is resized on paste", assert => {
 });
 
 [true, false].forEach((autoResizeEnabled) => {
-    QUnit.test(`auto resize class depends on the "autoResizeEnabled" value, "autoResizeEnabled" is ${autoResizeEnabled}`, (assert) => {
+    QUnit.test(`auto resize class depends on the "autoResizeEnabled" value, "autoResizeEnabled" is ${autoResizeEnabled}`, function(assert) {
         const $element = $("#textarea").dxTextArea({
             autoResizeEnabled,
             value: "1"
@@ -325,7 +325,7 @@ QUnit.test("widget is resized on paste", assert => {
     });
 });
 
-QUnit.test("widget has correct height with auto resize mode and the 'maxHeight' option", assert => {
+QUnit.test("widget has correct height with auto resize mode and the 'maxHeight' option", function(assert) {
     const boundaryHeight = 50;
 
     const $element = $("#textarea").dxTextArea({
@@ -346,7 +346,7 @@ QUnit.test("widget has correct height with auto resize mode and the 'maxHeight' 
     assert.equal(inputHeight, boundaryHeight - heightDifference, "widget height is correct");
 });
 
-QUnit.test("widget with auto resize should have a scrollbar if content is higher than the max height", assert => {
+QUnit.test("widget with auto resize should have a scrollbar if content is higher than the max height", function(assert) {
     const boundaryHeight = 50;
 
     const $element = $("#textarea");
@@ -365,7 +365,7 @@ QUnit.test("widget with auto resize should have a scrollbar if content is higher
     assert.ok($input.hasClass(AUTO_RESIZE_CLASS), "textarea with auto resize hasn't a scrollbar in case the content fit into container");
 });
 
-QUnit.test("widget with auto resize should not have a scrollbar after max-height changed to the higher value", assert => {
+QUnit.test("widget with auto resize should not have a scrollbar after max-height changed to the higher value", function(assert) {
     const $element = $("#textarea");
     const instance = $element.dxTextArea({
         autoResizeEnabled: true,
@@ -379,7 +379,7 @@ QUnit.test("widget with auto resize should not have a scrollbar after max-height
     assert.ok($input.hasClass(AUTO_RESIZE_CLASS), "textarea with auto resize hasn't a scrollbar in case the content fit into container");
 });
 
-QUnit.test("widget has correct height with auto resize mode and the 'minHeight' option", assert => {
+QUnit.test("widget has correct height with auto resize mode and the 'minHeight' option", function(assert) {
     const boundaryHeight = 50;
 
     const $element = $("#textarea").dxTextArea({
@@ -400,7 +400,7 @@ QUnit.test("widget has correct height with auto resize mode and the 'minHeight' 
     assert.equal(inputHeight, boundaryHeight - heightDifference, "input height is correct");
 });
 
-QUnit.test("widget should adopt its size on shown (T403238)", assert => {
+QUnit.test("widget should adopt its size on shown (T403238)", function(assert) {
     const $element = $("#textarea")
         .hide()
         .dxTextArea({
@@ -418,7 +418,7 @@ QUnit.test("widget should adopt its size on shown (T403238)", assert => {
     assert.ok($element.height() > initialHeight, "widget is resized");
 });
 
-QUnit.test("widget should adopt its size on 'visible' option change (T403238)", assert => {
+QUnit.test("widget should adopt its size on 'visible' option change (T403238)", function(assert) {
     const $element = $("#textarea")
         .dxTextArea({
             width: 70,
@@ -438,7 +438,7 @@ QUnit.test("widget should adopt its size on 'visible' option change (T403238)", 
     assert.ok($element.height() > initialHeight, "widget is resized");
 });
 
-QUnit.test("vertical scroll bar is hidden in auto resize mode", assert => {
+QUnit.test("vertical scroll bar is hidden in auto resize mode", function(assert) {
     const $element = $("#textarea").dxTextArea({
         autoResizeEnabled: true,
     });
@@ -458,7 +458,7 @@ QUnit.test("vertical scroll bar is hidden in auto resize mode", assert => {
 });
 
 
-QUnit.test("widget can not scroll container to the top on change content height (T755402)", assert => {
+QUnit.test("widget can not scroll container to the top on change content height (T755402)", function(assert) {
     const container = $("#container").css({
         "overflow": "scroll",
         "height": "60px"
@@ -543,7 +543,7 @@ QUnit.module("TextArea in simulated scrollable", () => {
                 }
             }
 
-            QUnit.test(`mousewheel: textArea (scrollPosition - MIN) - wheel -> up -> down - scrollable direction: ${direction}`, (assert) => {
+            QUnit.test(`mousewheel: textArea (scrollPosition - MIN) - wheel -> up -> down - scrollable direction: ${direction}`, function(assert) {
                 const helper = new TextAreaInScrollableTestHelper(direction);
                 const $container = helper.getScrollableContainer();
 
@@ -558,7 +558,7 @@ QUnit.module("TextArea in simulated scrollable", () => {
                 helper.checkAsserts(assert, 80);
             });
 
-            QUnit.test(`mousewheel: textArea (scrollPosition - MAX) - wheel -> down -> up - scrollable direction: ${direction}`, (assert) => {
+            QUnit.test(`mousewheel: textArea (scrollPosition - MAX) - wheel -> down -> up - scrollable direction: ${direction}`, function(assert) {
                 const helper = new TextAreaInScrollableTestHelper(direction);
                 const $container = helper.getScrollableContainer();
 
@@ -574,7 +574,7 @@ QUnit.module("TextArea in simulated scrollable", () => {
                 helper.checkAsserts(assert, 70);
             });
 
-            QUnit.test(`mousewheel: textArea (scrollPosition - MIDDLE) - wheel -> down -> up - scrollable direction: ${direction}`, (assert) => {
+            QUnit.test(`mousewheel: textArea (scrollPosition - MIDDLE) - wheel -> down -> up - scrollable direction: ${direction}`, function(assert) {
                 const helper = new TextAreaInScrollableTestHelper(direction);
                 const $container = helper.getScrollableContainer();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -26,14 +26,14 @@ const EVENTS = [
 ];
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.element = $("#texteditor").dxTextEditor({});
         this.input = this.element.find("." + INPUT_CLASS);
         this.instance = this.element.dxTextEditor("instance");
         this.keyboard = keyboardMock(this.input);
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 };
@@ -50,7 +50,7 @@ const prepareEvent = (eventName) => {
 };
 
 QUnit.module("general", {}, () => {
-    QUnit.test("markup init", (assert) => {
+    QUnit.test("markup init", function(assert) {
         const element = $("#texteditor").dxTextEditor();
 
         assert.ok(element.hasClass(TEXTEDITOR_CLASS));
@@ -60,7 +60,7 @@ QUnit.module("general", {}, () => {
         assert.equal(element.find("." + CONTAINER_CLASS).length, 1);
     });
 
-    QUnit.test("init with options", (assert) => {
+    QUnit.test("init with options", function(assert) {
         const element = $("#texteditor").dxTextEditor({
             value: "custom",
             placeholder: "enter value",
@@ -76,7 +76,7 @@ QUnit.module("general", {}, () => {
         assert.equal(input.prop("tabindex"), 3);
     });
 
-    QUnit.test("init with focusStateEnabled = false", (assert) => {
+    QUnit.test("init with focusStateEnabled = false", function(assert) {
         const element = $("#texteditor").dxTextEditor({
             focusStateEnabled: false,
             tabIndex: 3
@@ -87,7 +87,7 @@ QUnit.module("general", {}, () => {
         assert.equal(input.prop("tabindex"), -1);
     });
 
-    QUnit.test("repaint() should not drop any elements without any widget option changing", (assert) => {
+    QUnit.test("repaint() should not drop any elements without any widget option changing", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             showClearButton: true,
             mode: "search"
@@ -99,7 +99,7 @@ QUnit.module("general", {}, () => {
         assert.equal($textEditor.find("*").length, $contentElements.length);
     });
 
-    QUnit.test("value === 0 should be rendered on init", (assert) => {
+    QUnit.test("value === 0 should be rendered on init", function(assert) {
         const $element = $("#texteditor").dxTextEditor({
             value: 0
         });
@@ -108,7 +108,7 @@ QUnit.module("general", {}, () => {
         assert.equal(input.val(), "0", "value rendered correctly");
     });
 
-    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", (assert) => {
+    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         const handler = sinon.stub();
 
         const textEditor = $("#texteditor").dxTextEditor({
@@ -120,7 +120,7 @@ QUnit.module("general", {}, () => {
         assert.ok(handler.calledOnce, "Handler should be called once");
     });
 
-    QUnit.test("tabIndex option change", (assert) => {
+    QUnit.test("tabIndex option change", function(assert) {
         const $element = $("#texteditor").dxTextEditor({
             tabIndex: 1
         });
@@ -133,7 +133,7 @@ QUnit.module("general", {}, () => {
         assert.equal(input.prop("tabindex"), 4);
     });
 
-    QUnit.test("Marking with 'focus' CSS class", (assert) => {
+    QUnit.test("Marking with 'focus' CSS class", function(assert) {
         const $element = $("#texteditor").dxTextEditor();
         const instance = $element.dxTextEditor("instance");
 
@@ -144,7 +144,7 @@ QUnit.module("general", {}, () => {
         assert.ok(!$element.hasClass(STATE_FOCUSED_CLASS), "Loose 'focus' CSS class when input loose focus");
     });
 
-    QUnit.test("Marking with 'empty input' CSS class", (assert) => {
+    QUnit.test("Marking with 'empty input' CSS class", function(assert) {
         const $element = $("#texteditor").dxTextEditor();
         const $input = $("#texteditor input");
         const keyboard = keyboardMock($input);
@@ -157,7 +157,7 @@ QUnit.module("general", {}, () => {
         assert.ok($element.hasClass(EMPTY_INPUT_CLASS), "Has 'empty input' CSS class when input is empty");
     });
 
-    QUnit.test("render placeholder", (assert) => {
+    QUnit.test("render placeholder", function(assert) {
         const element = $("#texteditor").dxTextEditor({
             placeholder: "enter value"
         });
@@ -185,7 +185,7 @@ QUnit.module("general", {}, () => {
         assert.ok(element.hasClass("dx-texteditor-empty"));
     });
 
-    QUnit.test("render placeholder if value was set", (assert) => {
+    QUnit.test("render placeholder if value was set", function(assert) {
         const element = $("#texteditor").dxTextEditor({
             value: 'test'
         });
@@ -195,7 +195,7 @@ QUnit.module("general", {}, () => {
         assert.equal($placeholder.hasClass('dx-state-invisible'), true, "placeholder is invisible");
     });
 
-    QUnit.testInActiveWindow("placeholder pointerup event (T181734)", (assert) => {
+    QUnit.testInActiveWindow("placeholder pointerup event (T181734)", function(assert) {
         const $element = $("#texteditor").dxTextEditor({
             placeholder: "enter value"
         });
@@ -207,7 +207,7 @@ QUnit.module("general", {}, () => {
         assert.ok($input.is(":focus"), "input get focus on pointerup (needed for win8 native app)");
     });
 
-    QUnit.testInActiveWindow("input is focused after click on the 'clear' button", (assert) => {
+    QUnit.testInActiveWindow("input is focused after click on the 'clear' button", function(assert) {
         const $element = $("#texteditor").dxTextEditor({
             showClearButton: true,
             value: "Text"
@@ -233,7 +233,7 @@ QUnit.module("general", {}, () => {
         assert.ok($input.is(":focus"), "input is still focused");
     });
 
-    QUnit.test("clearButton is rendered correctly", (assert) => {
+    QUnit.test("clearButton is rendered correctly", function(assert) {
         // NOTE: native clear button is missing for real IE9 (T202090)
 
         const $textEditor = $("#texteditor").dxTextEditor({
@@ -246,7 +246,7 @@ QUnit.module("general", {}, () => {
         assert.equal($clearButton.length, 1, "clearButton was rendered");
     });
 
-    QUnit.test("dxTextEditor reset value after click on clearButton", (assert) => {
+    QUnit.test("dxTextEditor reset value after click on clearButton", function(assert) {
         const device = devices.real();
         if(device.platform === "android" && device.version[0] <= 2) {
             assert.ok(true, "this device do not support 'focus' event correctly");
@@ -268,7 +268,7 @@ QUnit.module("general", {}, () => {
         assert.equal($textEditor.dxTextEditor("option", "value"), "", "value reset");
     });
 
-    QUnit.test("dxTextEditor should save focus after buttons option changed", (assert) => {
+    QUnit.test("dxTextEditor should save focus after buttons option changed", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({ value: "text" });
         const textEditor = $textEditor.dxTextEditor("instance");
 
@@ -279,7 +279,7 @@ QUnit.module("general", {}, () => {
         assert.ok($textEditor.hasClass("dx-state-focused"), "input is still focused");
     });
 
-    QUnit.testInActiveWindow("dxTextEditor should save focus after inner buttons were clicked", (assert) => {
+    QUnit.testInActiveWindow("dxTextEditor should save focus after inner buttons were clicked", function(assert) {
         const focusStub = sinon.stub();
         const blurStub = sinon.stub();
         const clickStub = sinon.stub();
@@ -311,7 +311,7 @@ QUnit.module("general", {}, () => {
         assert.strictEqual(clickStub.callCount, 1, "action button is clicked");
     });
 
-    QUnit.testInActiveWindow("dxTextEditor should save focus after inner buttons were focused", (assert) => {
+    QUnit.testInActiveWindow("dxTextEditor should save focus after inner buttons were focused", function(assert) {
         const focusStub = sinon.stub();
         const blurStub = sinon.stub();
 
@@ -339,7 +339,7 @@ QUnit.module("general", {}, () => {
         assert.strictEqual(blurStub.callCount, 0, "FocusOut event has not been triggered");
     });
 
-    QUnit.test("T220209 - the 'displayValueFormatter' option", (assert) => {
+    QUnit.test("T220209 - the 'displayValueFormatter' option", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             value: "First",
             displayValueFormatter(value) {
@@ -351,7 +351,7 @@ QUnit.module("general", {}, () => {
         assert.equal($textEditor.find(".dx-texteditor-input").val(), "First format", "input value is correct");
     });
 
-    QUnit.test("T220209 - the 'displayValueFormatter' option when value is changed using keyboard", (assert) => {
+    QUnit.test("T220209 - the 'displayValueFormatter' option when value is changed using keyboard", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             value: "First",
             displayValueFormatter(value) {
@@ -371,7 +371,7 @@ QUnit.module("general", {}, () => {
         assert.equal($textEditor.find(".dx-texteditor-input").val(), "First format2 format", "input value is correct");
     });
 
-    QUnit.test("default displayValueFormatter of null should return an empty string", (assert) => {
+    QUnit.test("default displayValueFormatter of null should return an empty string", function(assert) {
         const textEditor = $("#texteditor").dxTextEditor({}).dxTextEditor("instance");
         const displayValueFormatter = textEditor.option("displayValueFormatter");
 
@@ -382,7 +382,7 @@ QUnit.module("general", {}, () => {
         assert.strictEqual(displayValueFormatter(""), "", "empty value formatted correctly");
     });
 
-    QUnit.test("dxTextEditor with height option should have min-height auto style on input", (assert) => {
+    QUnit.test("dxTextEditor with height option should have min-height auto style on input", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             height: 50,
             value: "First"
@@ -393,7 +393,7 @@ QUnit.module("general", {}, () => {
         assert.equal($input.get(0).style.minHeight, "0px", "min-height inline style is defined");
     });
 
-    QUnit.test("dxTextEditor with wrong stylingMode option should set the class according to default option value", (assert) => {
+    QUnit.test("dxTextEditor with wrong stylingMode option should set the class according to default option value", function(assert) {
         let $textEditor = $("#texteditor").dxTextEditor({
             stylingMode: "someWrongOptionValue"
         });
@@ -401,7 +401,7 @@ QUnit.module("general", {}, () => {
         assert.ok($textEditor.hasClass("dx-editor-outlined"));
     });
 
-    QUnit.test("dxTextEditor with wrong stylingMode option should set the class according to default option value (platform specific)", (assert) => {
+    QUnit.test("dxTextEditor with wrong stylingMode option should set the class according to default option value (platform specific)", function(assert) {
         const realIsMaterial = themes.isMaterial;
         themes.isMaterial = () => {
             return true;
@@ -418,7 +418,7 @@ QUnit.module("general", {}, () => {
 });
 
 QUnit.module("text option", moduleConfig, () => {
-    QUnit.test("Typing in input should affext 'text' option, but not 'value'", (assert) => {
+    QUnit.test("Typing in input should affext 'text' option, but not 'value'", function(assert) {
         const textEditor = $("#texteditor").dxTextEditor({
             value: "original"
         }).dxTextEditor("instance");
@@ -429,7 +429,7 @@ QUnit.module("text option", moduleConfig, () => {
         assert.equal(textEditor.option("text"), "original123", "text should reflect user input");
     });
 
-    QUnit.test("'Text' option should not be 'undefined'", (assert) => {
+    QUnit.test("'Text' option should not be 'undefined'", function(assert) {
         const textEditor = $("#texteditor").dxTextEditor({
             value: "original"
         }).dxTextEditor("instance");
@@ -443,7 +443,7 @@ QUnit.module("text option", moduleConfig, () => {
 });
 
 QUnit.module("the 'name' option", {}, () => {
-    QUnit.test("widget input should get the 'name' attribute with a correct value", (assert) => {
+    QUnit.test("widget input should get the 'name' attribute with a correct value", function(assert) {
         const expectedName = "some_name";
 
         const $element = $("#texteditor").dxTextEditor({
@@ -457,7 +457,7 @@ QUnit.module("the 'name' option", {}, () => {
 });
 
 QUnit.module("options changing", moduleConfig, () => {
-    QUnit.test("value", (assert) => {
+    QUnit.test("value", function(assert) {
         this.instance.option("value", "123");
         assert.equal(this.input.val(), "123");
 
@@ -465,7 +465,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal(this.input.val(), "321");
     });
 
-    QUnit.test("the 'inputAttr' option", (assert) => {
+    QUnit.test("the 'inputAttr' option", function(assert) {
         let $div1;
         let $div2;
 
@@ -491,7 +491,7 @@ QUnit.module("options changing", moduleConfig, () => {
         }
     });
 
-    QUnit.test("name option should not conflict with inputAttr.name option", (assert) => {
+    QUnit.test("name option should not conflict with inputAttr.name option", function(assert) {
         this.instance.option("inputAttr", { name: "some_name" });
 
         assert.equal(this.input.attr("name"), "some_name", "inputAttr should be applied");
@@ -512,7 +512,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.notOk(this.input.get(0).hasAttribute("name"), "name attribute has been removed");
     });
 
-    QUnit.test("the 'inputAttr' option should preserve widget specific classes", (assert) => {
+    QUnit.test("the 'inputAttr' option should preserve widget specific classes", function(assert) {
         const $element = $("<div>").appendTo("body");
 
         try {
@@ -523,7 +523,7 @@ QUnit.module("options changing", moduleConfig, () => {
         }
     });
 
-    QUnit.test("the 'inputAttr' option should affect only custom classes on change", (assert) => {
+    QUnit.test("the 'inputAttr' option should affect only custom classes on change", function(assert) {
         const firstClassName = "first";
         const secondClassName = "second";
 
@@ -539,7 +539,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.notOk($input.hasClass(firstClassName), "first custom class is removed");
     });
 
-    QUnit.test("autocomplete is disabled by default", (assert) => {
+    QUnit.test("autocomplete is disabled by default", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({});
 
         assert.equal($textEditor.find("input").attr("autocomplete"), "off", "autocomplete prop is disabled by default");
@@ -549,7 +549,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal($textEditor.find("input").attr("autocomplete"), "on", "autocomplete attr overwritten");
     });
 
-    QUnit.test("valueChangeEvent", (assert) => {
+    QUnit.test("valueChangeEvent", function(assert) {
         this.instance.option("valueChangeEvent", "blur");
 
         this.keyboard.type("123");
@@ -568,7 +568,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal(this.instance.option("value"), "321");
     });
 
-    QUnit.test("onValueChanged callback", (assert) => {
+    QUnit.test("onValueChanged callback", function(assert) {
         let called = 0;
 
         this.instance.option("onValueChanged", () => {
@@ -586,7 +586,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal(called, 4);
     });
 
-    QUnit.test("onValueChanged callback shouldn't have event if value was changed programmatically", (assert) => {
+    QUnit.test("onValueChanged callback shouldn't have event if value was changed programmatically", function(assert) {
         const textEditor = $("#texteditor").dxTextEditor({
             valueChangeEvent: 'keyup change',
         }).dxTextEditor("instance");
@@ -602,7 +602,7 @@ QUnit.module("options changing", moduleConfig, () => {
         textEditor.option("value", "value is set programmatically");
     });
 
-    QUnit.test("disabled", (assert) => {
+    QUnit.test("disabled", function(assert) {
         this.instance.option("disabled", true);
         assert.ok(this.input.prop("disabled"));
 
@@ -610,7 +610,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.ok(!this.input.prop("disabled"));
     });
 
-    QUnit.test("focusStateEnabled", (assert) => {
+    QUnit.test("focusStateEnabled", function(assert) {
         this.instance.option("focusStateEnabled", false);
         assert.equal(this.input.prop("tabIndex"), -1);
 
@@ -618,7 +618,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.ok(!this.input.prop("tabIndex"));
     });
 
-    QUnit.test("spellcheck", (assert) => {
+    QUnit.test("spellcheck", function(assert) {
         this.instance.option("spellcheck", true);
         assert.ok(this.input.prop("spellcheck"));
 
@@ -626,7 +626,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.ok(!this.input.prop("spellcheck"));
     });
 
-    QUnit.test("placeholder", (assert) => {
+    QUnit.test("placeholder", function(assert) {
         this.instance.option("placeholder", "John Doe");
         assert.equal(this.element.find("." + PLACEHOLDER_CLASS).attr("data-dx_placeholder"), "John Doe");
 
@@ -634,7 +634,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal(this.element.find("." + PLACEHOLDER_CLASS).attr("data-dx_placeholder"), "John Jr. Doe");
     });
 
-    QUnit.test("readOnly", (assert) => {
+    QUnit.test("readOnly", function(assert) {
         this.instance.option("readOnly", true);
         assert.ok(this.input.prop("readOnly"));
 
@@ -642,7 +642,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal(this.input.prop("readOnly"), false);
     });
 
-    QUnit.test("event handler callbacks", (assert) => {
+    QUnit.test("event handler callbacks", function(assert) {
         const input = this.input;
         let called = 0;
         const options = {};
@@ -671,7 +671,7 @@ QUnit.module("options changing", moduleConfig, () => {
         });
     });
 
-    QUnit.test("events should be fired in readOnly state", (assert) => {
+    QUnit.test("events should be fired in readOnly state", function(assert) {
         const input = this.input;
         let called;
         const options = { readOnly: true };
@@ -698,7 +698,7 @@ QUnit.module("options changing", moduleConfig, () => {
         });
     });
 
-    QUnit.test("editor should have actual value in the event handler when this event included into valueChangeEvent", (assert) => {
+    QUnit.test("editor should have actual value in the event handler when this event included into valueChangeEvent", function(assert) {
         const $textBox = this.element;
         const textBox = $textBox.dxTextEditor("instance");
         const input = this.input;
@@ -726,7 +726,7 @@ QUnit.module("options changing", moduleConfig, () => {
         });
     });
 
-    QUnit.test("Click on 'clear' button", (assert) => {
+    QUnit.test("Click on 'clear' button", function(assert) {
         const $element = $("#texteditor").dxTextEditor({
             showClearButton: true,
             value: "foo"
@@ -753,7 +753,7 @@ QUnit.module("options changing", moduleConfig, () => {
         clock.restore();
     });
 
-    QUnit.test("'Clear' button visibility depends on value", (assert) => {
+    QUnit.test("'Clear' button visibility depends on value", function(assert) {
         const $element = $("#texteditor").dxTextEditor({ showClearButton: true, value: "foo" });
         const instance = $element.dxTextEditor("instance");
         const $clearButton = $element.find(CLEAR_BUTTON_SELECTOR).eq(0);
@@ -767,7 +767,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.ok($clearButton.is(":visible"), "TextEditor has clear button again");
     });
 
-    QUnit.test("clear button should disappear when text changed without value change", (assert) => {
+    QUnit.test("clear button should disappear when text changed without value change", function(assert) {
         const $element = $("#texteditor").dxTextEditor({ showClearButton: true, value: "" });
         const instance = $element.dxTextEditor("instance");
         const $input = $element.find("." + INPUT_CLASS);
@@ -783,7 +783,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.notOk($clearButton.is(":visible"), "clear button was hidden");
     });
 
-    QUnit.test("click on clear button should not reset active focus (T241583)", (assert) => {
+    QUnit.test("click on clear button should not reset active focus (T241583)", function(assert) {
         const $element = $("#texteditor").dxTextEditor({ showClearButton: true, value: "foo" });
         const $clearButton = $element.find(CLEAR_BUTTON_SELECTOR).eq(0);
 
@@ -795,7 +795,7 @@ QUnit.module("options changing", moduleConfig, () => {
         }).trigger(dxPointerDown);
     });
 
-    QUnit.test("click on clear button should raise input event (T521817)", (assert) => {
+    QUnit.test("click on clear button should raise input event (T521817)", function(assert) {
         let callCount = 0;
 
         const $element = $("#texteditor").dxTextEditor({
@@ -814,7 +814,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal(callCount, 1, "onInput was called once");
     });
 
-    QUnit.test("tap on clear button should reset value (T310102)", (assert) => {
+    QUnit.test("tap on clear button should reset value (T310102)", function(assert) {
         const $element = $("#texteditor").dxTextEditor({ showClearButton: true, value: "foo" });
         const $clearButton = $element.find(CLEAR_BUTTON_SELECTOR).eq(0);
 
@@ -825,7 +825,7 @@ QUnit.module("options changing", moduleConfig, () => {
         }).trigger(dxPointerDown);
     });
 
-    QUnit.test("tap on clear button should not raise onValueChange event (T812448)", (assert) => {
+    QUnit.test("tap on clear button should not raise onValueChange event (T812448)", function(assert) {
         const valueChangeStub = sinon.stub();
 
         const $element = $("#texteditor").dxTextEditor({
@@ -848,7 +848,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.ok(valueChangeStub.calledOnce, "onValueChanged was called once");
     });
 
-    QUnit.test("texteditor is clear when option 'value' changed to null", (assert) => {
+    QUnit.test("texteditor is clear when option 'value' changed to null", function(assert) {
         const instance = $("#texteditor").dxTextEditor({
             value: "test"
         }).dxTextEditor("instance");
@@ -857,7 +857,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal($("." + EMPTY_INPUT_CLASS).length, 1, "texteditor is empty");
     });
 
-    QUnit.testInActiveWindow("focusIn and focusOut fired after enable disable state", (assert) => {
+    QUnit.testInActiveWindow("focusIn and focusOut fired after enable disable state", function(assert) {
         let focusInCount = 0;
         let focusOutCount = 0;
         const $textEditor = $("#texteditor").dxTextEditor({
@@ -880,7 +880,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.equal(focusOutCount, 1, "focusout fired once");
     });
 
-    QUnit.testInActiveWindow("Remove .dx-state-focused class after disabled of the element", (assert) => {
+    QUnit.testInActiveWindow("Remove .dx-state-focused class after disabled of the element", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor();
 
         $textEditor
@@ -895,7 +895,7 @@ QUnit.module("options changing", moduleConfig, () => {
         assert.ok(!$textEditor.hasClass("dx-state-focused"), "dx-state-focused was removed");
     });
 
-    QUnit.test("texteditor get 'stylingMode' option from global config", (assert) => {
+    QUnit.test("texteditor get 'stylingMode' option from global config", function(assert) {
         config({ editorStylingMode: "underlined" });
         const container = $("<div>");
         const instance = container.dxTextEditor().dxTextEditor("instance");
@@ -906,7 +906,7 @@ QUnit.module("options changing", moduleConfig, () => {
         config({ editorStylingMode: null });
     });
 
-    QUnit.test("texteditor 'stylingMode' option: runtime change", (assert) => {
+    QUnit.test("texteditor 'stylingMode' option: runtime change", function(assert) {
         this.element = $("#texteditor");
         assert.equal(this.element.hasClass("dx-editor-outlined"), true, "initial value is right");
 
@@ -917,7 +917,7 @@ QUnit.module("options changing", moduleConfig, () => {
 });
 
 QUnit.module("api", moduleConfig, () => {
-    QUnit.test("focus method", (assert) => {
+    QUnit.test("focus method", function(assert) {
         const input = this.input.get(0);
         const focusSpy = sinon.spy(eventsEngine, "trigger").withArgs(sinon.match($element => {
             return ($element.get && $element.get(0) || $element) === input;
@@ -927,7 +927,7 @@ QUnit.module("api", moduleConfig, () => {
         assert.ok(focusSpy.called);
     });
 
-    QUnit.test("blur method", (assert) => {
+    QUnit.test("blur method", function(assert) {
         const done = assert.async();
         this.instance.focus();
 
@@ -942,7 +942,7 @@ QUnit.module("api", moduleConfig, () => {
         this.instance.blur();
     });
 
-    QUnit.test("onValueChanged fired only when value is changed", (assert) => {
+    QUnit.test("onValueChanged fired only when value is changed", function(assert) {
         const textBox = this.instance;
         const $input = this.input;
 
@@ -959,7 +959,7 @@ QUnit.module("api", moduleConfig, () => {
         assert.equal(valueChangeCounter, 0, "onValueChanged not fired");
     });
 
-    QUnit.test("reset()", (assert) => {
+    QUnit.test("reset()", function(assert) {
         const textBox = this.instance;
         // act
         textBox.reset();
@@ -967,7 +967,7 @@ QUnit.module("api", moduleConfig, () => {
         assert.strictEqual(textBox.option("value"), "", "Value should be reset");
     });
 
-    QUnit.test("onFocusOut and other events fired after value was changed", (assert) => {
+    QUnit.test("onFocusOut and other events fired after value was changed", function(assert) {
         const textEditor = this.instance;
         const keyboard = this.keyboard;
         let valueOnFocusOut = "";
@@ -992,7 +992,7 @@ QUnit.module("api", moduleConfig, () => {
         assert.equal(valueOnValueChange, typedString, "valueChangeEvent fired after value was changed");
     });
 
-    QUnit.test("enterKey event", (assert) => {
+    QUnit.test("enterKey event", function(assert) {
         const enterKeyEvent = sinon.stub();
 
         const textBox = this.instance;
@@ -1004,7 +1004,7 @@ QUnit.module("api", moduleConfig, () => {
         assert.equal(enterKeyEvent.called, true, "enterKey was fired");
     });
 
-    QUnit.test("events work when relevant actions is not set", (assert) => {
+    QUnit.test("events work when relevant actions is not set", function(assert) {
         assert.expect(12);
         const textBox = this.instance;
         const keyboard = this.keyboard;
@@ -1033,7 +1033,7 @@ QUnit.module("api", moduleConfig, () => {
         keyboard.type("x");
     });
 
-    QUnit.test("events supports chains", (assert) => {
+    QUnit.test("events supports chains", function(assert) {
         assert.expect(3);
         const textBox = this.instance;
         const keyboard = this.keyboard;
@@ -1049,7 +1049,7 @@ QUnit.module("api", moduleConfig, () => {
         keyboard.type("x");
     });
 
-    QUnit.test("event should be fired once when there are multiple subscriptions", (assert) => {
+    QUnit.test("event should be fired once when there are multiple subscriptions", function(assert) {
         const textBox = this.instance;
         const keyboard = this.keyboard;
         const keyDownSpy = sinon.spy();
@@ -1069,7 +1069,7 @@ QUnit.module("api", moduleConfig, () => {
 });
 
 QUnit.module("regressions", moduleConfig, () => {
-    QUnit.test("event handlers are not set", (assert) => {
+    QUnit.test("event handlers are not set", function(assert) {
         assert.expect(0);
 
         const EVENTS = [
@@ -1087,7 +1087,7 @@ QUnit.module("regressions", moduleConfig, () => {
         });
     });
 
-    QUnit.test("B233344 dxNumberbox/dxTextbox/dxDatebox - Incorrect changing of 'disabled' option", (assert) => {
+    QUnit.test("B233344 dxNumberbox/dxTextbox/dxDatebox - Incorrect changing of 'disabled' option", function(assert) {
         this.instance.option("disabled", true);
         assert.ok(this.element.hasClass(DISABLED_CLASS));
 
@@ -1101,7 +1101,7 @@ QUnit.module("regressions", moduleConfig, () => {
         assert.ok(!this.element.hasClass(DISABLED_CLASS));
     });
 
-    QUnit.test("B233277 dxNumberbox/dxTextbox - cursor jump over the right digit, impossible to remove all digits after the cursor moving", (assert) => {
+    QUnit.test("B233277 dxNumberbox/dxTextbox - cursor jump over the right digit, impossible to remove all digits after the cursor moving", function(assert) {
         this.instance.option("valueChangeEvent", "keyup");
         keyboardMock(this.element.find("." + INPUT_CLASS))
             .type("123")
@@ -1111,7 +1111,7 @@ QUnit.module("regressions", moduleConfig, () => {
         assert.equal(this.instance.option("value"), "123");
     });
 
-    QUnit.test("Text editor should propagate keyboard events to the document", (assert) => {
+    QUnit.test("Text editor should propagate keyboard events to the document", function(assert) {
         const keydownHandler = sinon.spy();
         eventsEngine.on(document, "keydown", keydownHandler);
 
@@ -1124,7 +1124,7 @@ QUnit.module("regressions", moduleConfig, () => {
         assert.equal(keydownHandler.callCount, 4, "keydown was handled 4 times");
     });
 
-    QUnit.test("Enter key event raising (B238135)", (assert) => {
+    QUnit.test("Enter key event raising (B238135)", function(assert) {
         const handler = sinon.stub();
 
         $("#texteditor").dxTextEditor({
@@ -1137,7 +1137,7 @@ QUnit.module("regressions", moduleConfig, () => {
         assert.ok(handler.getCall(0).args[0].event, "event args have Event prop");
     });
 
-    QUnit.test("Enter key event changing handler (B238135)", (assert) => {
+    QUnit.test("Enter key event changing handler (B238135)", function(assert) {
         const instance = $("#texteditor").dxTextEditor({}).dxTextEditor("instance");
         let once = true;
 
@@ -1159,7 +1159,7 @@ QUnit.module("regressions", moduleConfig, () => {
         $("#texteditor input").trigger(keyUpEvent);
     });
 
-    QUnit.test("Enter key action is not fired is widget is disposed", (assert) => {
+    QUnit.test("Enter key action is not fired is widget is disposed", function(assert) {
         const enterKeyStub = sinon.stub();
         const keyUpStub = sinon.stub();
         const keyDownStub = sinon.stub();
@@ -1189,7 +1189,7 @@ QUnit.module("regressions", moduleConfig, () => {
         }
     });
 
-    QUnit.test("Placeholder text should be hidden when value is set (T124525)", (assert) => {
+    QUnit.test("Placeholder text should be hidden when value is set (T124525)", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             placeholder: "test",
             value: "val"

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/markup.tests.js
@@ -13,7 +13,7 @@ const TEXTEDITOR_INPUT_CONTAINER_CLASS = "dx-texteditor-input-container";
 const { test, module } = QUnit;
 
 module("Basic markup", () => {
-    test("basic init", (assert) => {
+    test("basic init", function(assert) {
         const element = $("#texteditor").dxTextEditor();
         assert.ok(element.hasClass(TEXTEDITOR_CLASS));
         assert.equal(element.children().length, 1);
@@ -22,7 +22,7 @@ module("Basic markup", () => {
         assert.equal(element.find(`.${CONTAINER_CLASS}`).length, 1);
     });
 
-    test("init with placeholder in the input container", (assert) => {
+    test("init with placeholder in the input container", function(assert) {
         const element = $("#texteditor").dxTextEditor({
             placeholder: "enter value"
         });
@@ -35,7 +35,7 @@ module("Basic markup", () => {
         assert.notOk(placeholder.hasClass(STATE_INVISIBLE_CLASS), "placeholder is visible when editor hasn't a value");
     });
 
-    test("init with options", (assert) => {
+    test("init with options", function(assert) {
         const element = $("#texteditor").dxTextEditor({
             value: "custom",
             placeholder: "enter value",
@@ -53,7 +53,7 @@ module("Basic markup", () => {
         assert.equal(input.prop("tabindex"), 3);
     });
 
-    test("init with focusStateEnabled = false", (assert) => {
+    test("init with focusStateEnabled = false", function(assert) {
         const element = $("#texteditor").dxTextEditor({
             focusStateEnabled: false,
             tabIndex: 3
@@ -64,7 +64,7 @@ module("Basic markup", () => {
         assert.equal(input.prop("tabindex"), -1);
     });
 
-    test("value === 0 should be rendered on init", (assert) => {
+    test("value === 0 should be rendered on init", function(assert) {
         const $element = $("#texteditor").dxTextEditor({
             value: 0
         });
@@ -73,7 +73,7 @@ module("Basic markup", () => {
         assert.equal(input.val(), "0", "value rendered correctly");
     });
 
-    test("T220209 - the 'displayValueFormatter' option", (assert) => {
+    test("T220209 - the 'displayValueFormatter' option", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             value: "First",
             displayValueFormatter: function(value) {
@@ -85,7 +85,7 @@ module("Basic markup", () => {
         assert.equal($textEditor.find(`.${INPUT_CLASS}`).val(), "First format", "input value is correct");
     });
 
-    test("renderValue should return a promise that resolves after render input value", (assert) => {
+    test("renderValue should return a promise that resolves after render input value", function(assert) {
         assert.expect(1);
 
         const done = assert.async();
@@ -110,7 +110,7 @@ module("Basic markup", () => {
 });
 
 module("the 'name' option", () => {
-    test("widget input should get the 'name' attribute with a correct value", (assert) => {
+    test("widget input should get the 'name' attribute with a correct value", function(assert) {
         const expectedName = "some_name",
             $element = $("#texteditor").dxTextEditor({
                 name: expectedName

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -6,7 +6,7 @@ import caretWorkaround from "./caretWorkaround.js";
 import "ui/text_box/ui.text_editor";
 
 const testMaskRule = (title, config) => {
-    QUnit.test(title, (assert) => {
+    QUnit.test(title, function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: config.mask,
             maskRules: config.maskRules || {},
@@ -25,7 +25,7 @@ const testMaskRule = (title, config) => {
 };
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
         this.focusAndTick = ($input, delay) => {
             $input.focus();
@@ -33,13 +33,13 @@ const moduleConfig = {
         };
     },
 
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 };
 
 QUnit.module("rendering", {}, () => {
-    QUnit.test("render", (assert) => {
+    QUnit.test("render", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             maskRules: {
                 "X": ""
@@ -54,7 +54,7 @@ QUnit.module("rendering", {}, () => {
         assert.ok($textEditor.hasClass("dx-texteditor-masked"), "textEditor masked");
     });
 
-    QUnit.test("render mask with fixed chars", (assert) => {
+    QUnit.test("render mask with fixed chars", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(X)",
             maskRules: {
@@ -68,7 +68,7 @@ QUnit.module("rendering", {}, () => {
 });
 
 QUnit.module("typing", moduleConfig, () => {
-    QUnit.test("accept only allowed chars", (assert) => {
+    QUnit.test("accept only allowed chars", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X",
             maskRules: {
@@ -88,7 +88,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal($input.val(), "x");
     });
 
-    QUnit.test("prevent typing at the end", (assert) => {
+    QUnit.test("prevent typing at the end", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X",
             maskRules: {
@@ -105,7 +105,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal($input.val(), "x");
     });
 
-    QUnit.test("two chars with different maskRules", (assert) => {
+    QUnit.test("two chars with different maskRules", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XY",
             maskRules: {
@@ -123,7 +123,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal($input.val(), "xy");
     });
 
-    QUnit.test("two chars with different maskRules surrounded by fixed chars", (assert) => {
+    QUnit.test("two chars with different maskRules surrounded by fixed chars", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XY)",
             maskRules: {
@@ -143,7 +143,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal($input.val(), "(xy)", "mask rendered correctly");
     });
 
-    QUnit.test("using same maskRules in the mask", (assert) => {
+    QUnit.test("using same maskRules in the mask", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: {
@@ -160,7 +160,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal($input.val(), "x_", "first char is typed");
     });
 
-    QUnit.test("typing when caret position in the middle of the text", (assert) => {
+    QUnit.test("typing when caret position in the middle of the text", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: {
@@ -176,7 +176,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal($input.val(), "_x", "second char is typed");
     });
 
-    QUnit.test("cursor should be set after fixed mask letters during typing", (assert) => {
+    QUnit.test("cursor should be set after fixed mask letters during typing", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X--X",
             maskRules: {
@@ -193,7 +193,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 3, "cursor set after fixed mask letters");
     });
 
-    QUnit.test("cursor should be set after fixed mask letter during typing at first position", (assert) => {
+    QUnit.test("cursor should be set after fixed mask letter during typing at first position", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(X",
             maskRules: {
@@ -208,7 +208,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 2, "cursor set after first fixed mask letter");
     });
 
-    QUnit.test("cursor should be set after last typed char", (assert) => {
+    QUnit.test("cursor should be set after last typed char", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: {
@@ -231,7 +231,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal($input.val(), "yx", "value is correct");
     });
 
-    QUnit.test("cursor should stay at current position when typed char is not allowed", (assert) => {
+    QUnit.test("cursor should stay at current position when typed char is not allowed", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: {
@@ -247,7 +247,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 1, "caret position is not changed");
     });
 
-    QUnit.test("cursor should stay at current position when typed char is not allowed and value is not empty", (assert) => {
+    QUnit.test("cursor should stay at current position when typed char is not allowed and value is not empty", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: {
@@ -264,7 +264,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 0, "caret position is not changed");
     });
 
-    QUnit.test("cursor should have correct position when type stub", (assert) => {
+    QUnit.test("cursor should have correct position when type stub", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "x-X",
             maskRules: {
@@ -282,7 +282,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.deepEqual(keyboard.caret(), { start: 1, end: 1 }, "cursor in correct position");
     });
 
-    QUnit.test("caret position is correct after typing stub and non-stub char", (assert) => {
+    QUnit.test("caret position is correct after typing stub and non-stub char", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "1(X",
             maskRules: {
@@ -302,7 +302,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 3, "caret in correct position");
     });
 
-    QUnit.test("caret position should be correct after typing", (assert) => {
+    QUnit.test("caret position should be correct after typing", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: " (X",
             maskRules: {
@@ -319,7 +319,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 3, "caret in correct position");
     });
 
-    QUnit.test("arrow keys should not be prevented", (assert) => {
+    QUnit.test("arrow keys should not be prevented", function(assert) {
         const controlKeys = [
             "Tab",
             "End",
@@ -354,7 +354,7 @@ QUnit.module("typing", moduleConfig, () => {
         });
     });
 
-    QUnit.test("keypress with meta key should not be prevented", (assert) => {
+    QUnit.test("keypress with meta key should not be prevented", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: " "
         });
@@ -370,7 +370,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal(isKeyPressPrevented, false, "keypress with meta is not prevented");
     });
 
-    QUnit.test("press enter when caret position in the middle of the text", (assert) => {
+    QUnit.test("press enter when caret position in the middle of the text", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: {
@@ -386,7 +386,7 @@ QUnit.module("typing", moduleConfig, () => {
         assert.equal($input.val(), "_x", "second char is still there");
     });
 
-    QUnit.test("TextEditor with mask option should firing the 'onChange' event", (assert) => {
+    QUnit.test("TextEditor with mask option should firing the 'onChange' event", function(assert) {
         const handler = sinon.stub();
         const clock = sinon.useFakeTimers();
 
@@ -421,7 +421,7 @@ QUnit.module("typing", moduleConfig, () => {
 });
 
 QUnit.module("backspace key", moduleConfig, () => {
-    QUnit.test("backspace should remove last char and move caret backward", (assert) => {
+    QUnit.test("backspace should remove last char and move caret backward", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X",
             maskRules: {
@@ -439,7 +439,7 @@ QUnit.module("backspace key", moduleConfig, () => {
         assert.equal($input.val(), "_", "char was removed");
     });
 
-    QUnit.test("backspace should remove last char considering fixed letter", (assert) => {
+    QUnit.test("backspace should remove last char considering fixed letter", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X-X",
             maskRules: {
@@ -462,7 +462,7 @@ QUnit.module("backspace key", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 0, "caret moved to start position");
     });
 
-    QUnit.test("backspace should move caret after fixed letters", (assert) => {
+    QUnit.test("backspace should move caret after fixed letters", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X-X",
             maskRules: {
@@ -481,7 +481,7 @@ QUnit.module("backspace key", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 2, "cursor moved after fixed letters");
     });
 
-    QUnit.test("backspace at start of input should not change caret position", (assert) => {
+    QUnit.test("backspace at start of input should not change caret position", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(X",
             maskRules: {
@@ -496,7 +496,7 @@ QUnit.module("backspace key", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 0, "cursor at start position");
     });
 
-    QUnit.test("backspace should remove chars correctly considering fixed letters", (assert) => {
+    QUnit.test("backspace should remove chars correctly considering fixed letters", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X-XX",
             maskRules: {
@@ -525,7 +525,7 @@ QUnit.module("backspace key", moduleConfig, () => {
         assert.equal($input.val(), "_-_x", "chars removed correctly");
     });
 
-    QUnit.test("input event with the 'deleteContentBackward' input type should remove char", (assert) => {
+    QUnit.test("input event with the 'deleteContentBackward' input type should remove char", function(assert) {
         const BACKSPACE_INPUT_TYPE = "deleteContentBackward";
 
         const $textEditor = $("#texteditor").dxTextEditor({
@@ -552,7 +552,7 @@ QUnit.module("backspace key", moduleConfig, () => {
 });
 
 QUnit.module("delete key", {}, () => {
-    QUnit.test("char should be deleted after pressing on delete key", (assert) => {
+    QUnit.test("char should be deleted after pressing on delete key", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X",
             maskRules: {
@@ -571,7 +571,7 @@ QUnit.module("delete key", {}, () => {
         assert.equal($input.val(), "_", "letter deleted");
     });
 
-    QUnit.test("delete should remove only selected valuable chars (T242341)", (assert) => {
+    QUnit.test("delete should remove only selected valuable chars (T242341)", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X- X",
             maskRules: {
@@ -593,7 +593,7 @@ QUnit.module("delete key", {}, () => {
 });
 
 QUnit.module("selection", moduleConfig, () => {
-    QUnit.test("all selected chars should be deleted on key press", (assert) => {
+    QUnit.test("all selected chars should be deleted on key press", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: {
@@ -616,7 +616,7 @@ QUnit.module("selection", moduleConfig, () => {
         assert.equal($input.val(), "x_", "printed only one char");
     });
 
-    QUnit.test("all selected chars should be deleted on backspace", (assert) => {
+    QUnit.test("all selected chars should be deleted on backspace", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XXX",
             maskRules: {
@@ -646,7 +646,7 @@ QUnit.module("selection", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 1, "caret position set to start");
     });
 
-    QUnit.test("all selected chars should be deleted on del key", (assert) => {
+    QUnit.test("all selected chars should be deleted on del key", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XXX",
             maskRules: {
@@ -671,7 +671,7 @@ QUnit.module("selection", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 1, "caret position set to start");
     });
 
-    QUnit.test("it should correctly handle selected range changing when input is missed", (assert) => {
+    QUnit.test("it should correctly handle selected range changing when input is missed", function(assert) {
         assert.expect(1);
 
         $("#texteditor").dxTextEditor({
@@ -691,7 +691,7 @@ QUnit.module("selection", moduleConfig, () => {
 });
 
 QUnit.module("showMaskMode", moduleConfig, () => {
-    QUnit.test("show mask always", (assert) => {
+    QUnit.test("show mask always", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             showMaskMode: "always",
@@ -709,7 +709,7 @@ QUnit.module("showMaskMode", moduleConfig, () => {
         assert.equal(textEditor.option("text"), "__", "editor is not empty");
     });
 
-    QUnit.testInActiveWindow("show mask on focus only", (assert) => {
+    QUnit.testInActiveWindow("show mask on focus only", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             showMaskMode: "onFocus",
@@ -739,7 +739,7 @@ QUnit.module("showMaskMode", moduleConfig, () => {
         assert.equal($input.val(), "", "input is empty");
     });
 
-    QUnit.testInActiveWindow("show mask on focus only with useMaskedValue and stub symbols", (assert) => {
+    QUnit.testInActiveWindow("show mask on focus only with useMaskedValue and stub symbols", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "0-0",
             useMaskedValue: true,
@@ -764,7 +764,7 @@ QUnit.module("showMaskMode", moduleConfig, () => {
         assert.equal($input.val(), "", "input is empty");
     });
 
-    QUnit.testInActiveWindow("change mask visibility", (assert) => {
+    QUnit.testInActiveWindow("change mask visibility", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             showMaskMode: "always",
@@ -787,7 +787,7 @@ QUnit.module("showMaskMode", moduleConfig, () => {
 });
 
 QUnit.module("focusing", moduleConfig, () => {
-    QUnit.testInActiveWindow("cursor should be set after fixed mask letters", (assert) => {
+    QUnit.testInActiveWindow("cursor should be set after fixed mask letters", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XX)",
             maskRules: {
@@ -805,7 +805,7 @@ QUnit.module("focusing", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 1, "caret position set before first rule");
     });
 
-    QUnit.testInActiveWindow("selection should consider fixed mask letters", (assert) => {
+    QUnit.testInActiveWindow("selection should consider fixed mask letters", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: ")X))",
             maskRules: {
@@ -824,7 +824,7 @@ QUnit.module("focusing", moduleConfig, () => {
         assert.equal(keyboard.caret().end, 1, "caret position set before last fixed mask letter");
     });
 
-    QUnit.testInActiveWindow("Editor with mask isn't focused after render", (assert) => {
+    QUnit.testInActiveWindow("Editor with mask isn't focused after render", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XX)",
             focusStateEnabled: true
@@ -833,7 +833,7 @@ QUnit.module("focusing", moduleConfig, () => {
         assert.notOk($textEditor.hasClass("dx-state-focused"), "editor isn't focused");
     });
 
-    QUnit.testInActiveWindow("caret should be in start position on first editor focusing", (assert) => {
+    QUnit.testInActiveWindow("caret should be in start position on first editor focusing", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "00",
             focusStateEnabled: true
@@ -849,7 +849,7 @@ QUnit.module("focusing", moduleConfig, () => {
         assert.equal(keyboard.caret().end, 0, "caret is at the start");
     });
 
-    QUnit.testInActiveWindow("caret should be at the last symbol when input is incomplete", (assert) => {
+    QUnit.testInActiveWindow("caret should be at the last symbol when input is incomplete", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "00",
             focusStateEnabled: true
@@ -872,7 +872,7 @@ QUnit.module("focusing", moduleConfig, () => {
 });
 
 QUnit.module("value", moduleConfig, () => {
-    QUnit.test("extra backspace when clear value set by option should be ignored", (assert) => {
+    QUnit.test("extra backspace when clear value set by option should be ignored", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "phone",
             mask: "999-999-9999"
@@ -894,7 +894,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($textEditor.option("value"), "", "cleared correctly");
     });
 
-    QUnit.test("extra char that do not fit in the field should be ignored", (assert) => {
+    QUnit.test("extra char that do not fit in the field should be ignored", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "phone",
             mask: "999-999-9999"
@@ -917,7 +917,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($textEditor.option("value"), "9998887222", "extra symbols are ignored");
     });
 
-    QUnit.test("inappropriate to mask char should be recognized as a space", (assert) => {
+    QUnit.test("inappropriate to mask char should be recognized as a space", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "phone",
             mask: "999-999-9999"
@@ -940,7 +940,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($textEditor.option("value"), "999   7777", "extra symbols are ignored");
     });
 
-    QUnit.test("value considers mask", (assert) => {
+    QUnit.test("value considers mask", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(X)",
             valueChangeEvent: "keyup",
@@ -960,7 +960,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($textEditor.dxTextEditor("option", "text"), "(x)", "text option contains fixed letters");
     });
 
-    QUnit.test("value should be set considering stub chars", (assert) => {
+    QUnit.test("value should be set considering stub chars", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "1(XXX)",
             maskRules: {
@@ -974,7 +974,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($input.val(), "1(123)", "value is set correctly");
     });
 
-    QUnit.test("stub char in value should be processed as value", (assert) => {
+    QUnit.test("stub char in value should be processed as value", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X1X",
             maskRules: { "X": /\d/ },
@@ -986,7 +986,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($input.val(), "111", "value is set");
     });
 
-    QUnit.test("set value via option", (assert) => {
+    QUnit.test("set value via option", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(X)",
             maskRules: {
@@ -1007,7 +1007,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($input.val(), "(_)", "value set considering mask");
     });
 
-    QUnit.test("set value via option", (assert) => {
+    QUnit.test("set value via option", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XX)X",
             maskRules: {
@@ -1021,7 +1021,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($input.val(), "(xy)z", "initial value");
     });
 
-    QUnit.test("option change should be fired during typing", (assert) => {
+    QUnit.test("option change should be fired during typing", function(assert) {
         let changeEventArgs = {};
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X",
@@ -1047,7 +1047,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal(changeEventArgs.previousValue, "", "previous value is empty");
     });
 
-    QUnit.test("valueChangeEvent=change should fire change on blur", (assert) => {
+    QUnit.test("valueChangeEvent=change should fire change on blur", function(assert) {
         let valueChangedFired = 0;
 
         const $textEditor = $("#texteditor").dxTextEditor({
@@ -1074,7 +1074,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal(valueChangedFired, 1, "change fired once on blur");
     });
 
-    QUnit.test("valueChangeEvent=change should fire change on blur after removing", (assert) => {
+    QUnit.test("valueChangeEvent=change should fire change on blur after removing", function(assert) {
         const valueChangedHandler = sinon.spy();
 
         const $textEditor = $("#texteditor").dxTextEditor({
@@ -1101,7 +1101,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal(valueChangedHandler.callCount, 1, "change fired once on blur");
     });
 
-    QUnit.test("valueChangeEvent=change should fire change on beforedeactivate (ie raises blur in wrong time)", (assert) => {
+    QUnit.test("valueChangeEvent=change should fire change on beforedeactivate (ie raises blur in wrong time)", function(assert) {
         let valueChangedFired = 0;
 
         const $textEditor = $("#texteditor").dxTextEditor({
@@ -1127,7 +1127,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal(valueChangedFired, 1, "change fired once on beforedeactivate");
     });
 
-    QUnit.test("valueChangeEvent=change should fire change on pressing enter key", (assert) => {
+    QUnit.test("valueChangeEvent=change should fire change on pressing enter key", function(assert) {
         let valueChangedFired = 0;
 
         const $textEditor = $("#texteditor").dxTextEditor({
@@ -1153,7 +1153,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal(valueChangedFired, 1, "change fired once on pressing enter key");
     });
 
-    QUnit.test("T278701 - the error should not be thrown if value is null and mask is set", (assert) => {
+    QUnit.test("T278701 - the error should not be thrown if value is null and mask is set", function(assert) {
         try {
             $("#texteditor").dxTextEditor({
                 value: null,
@@ -1165,7 +1165,7 @@ QUnit.module("value", moduleConfig, () => {
         }
     });
 
-    QUnit.test("text should be set not considering stub chars", (assert) => {
+    QUnit.test("text should be set not considering stub chars", function(assert) {
         const maskText = "x-x";
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X-XX",
@@ -1183,7 +1183,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($textEditor.dxTextEditor("option", "value"), maskText, "value is unclear");
     });
 
-    QUnit.test("text should be set and maskChar replaced by space", (assert) => {
+    QUnit.test("text should be set and maskChar replaced by space", function(assert) {
         const maskText = " -x";
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X-XX",
@@ -1200,7 +1200,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($textEditor.dxTextEditor("option", "value"), " -x", "text was set");
     });
 
-    QUnit.test("mask should be rendered if value is undefined", (assert) => {
+    QUnit.test("mask should be rendered if value is undefined", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "\\X",
             value: undefined
@@ -1210,7 +1210,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($input.val(), "X", "special symbols is rendered");
     });
 
-    QUnit.test("mask stub should be cleared after set mask option to empty string", (assert) => {
+    QUnit.test("mask stub should be cleared after set mask option to empty string", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "00",
             value: ""
@@ -1222,7 +1222,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal($input.val(), "", "value is empty");
     });
 
-    QUnit.test("mask validation should be cleared after set mask option to empty string", (assert) => {
+    QUnit.test("mask validation should be cleared after set mask option to empty string", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "00",
             value: ""
@@ -1236,7 +1236,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal(textEditor.option("isValid"), true, "isValid is true");
     });
 
-    QUnit.test("validationRequest event should fire after set mask option to empty string", (assert) => {
+    QUnit.test("validationRequest event should fire after set mask option to empty string", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "00",
             value: ""
@@ -1255,7 +1255,7 @@ QUnit.module("value", moduleConfig, () => {
         assert.equal(params.editor, textEditor, "textEditor was passed");
     });
 
-    QUnit.test("mask should not be crushed after set in mask option empty value in code", (assert) => {
+    QUnit.test("mask should not be crushed after set in mask option empty value in code", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "00",
             value: ""
@@ -1278,7 +1278,7 @@ QUnit.module("value", moduleConfig, () => {
 });
 
 QUnit.module("clear button", () => {
-    QUnit.test("mask should be displayed instead of empty string after clear button click", (assert) => {
+    QUnit.test("mask should be displayed instead of empty string after clear button click", function(assert) {
         const clock = sinon.useFakeTimers();
 
         try {
@@ -1306,7 +1306,7 @@ QUnit.module("clear button", () => {
         }
     });
 
-    QUnit.test("clear button click should not lead to error when value is empty", (assert) => {
+    QUnit.test("clear button click should not lead to error when value is empty", function(assert) {
         const clock = sinon.useFakeTimers();
 
         try {
@@ -1329,7 +1329,7 @@ QUnit.module("clear button", () => {
 });
 
 QUnit.module("paste", moduleConfig, () => {
-    QUnit.test("paste on empty editor", (assert) => {
+    QUnit.test("paste on empty editor", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XX)",
             maskRules: {
@@ -1345,7 +1345,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.equal($input.val(), "(xx)", "paste event handled correctly");
     });
 
-    QUnit.test("paste in the middle", (assert) => {
+    QUnit.test("paste in the middle", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XX)",
             maskRules: {
@@ -1362,7 +1362,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.equal($input.val(), "(xx)", "paste at middle handled correctly");
     });
 
-    QUnit.test("paste in the middle of input without value", (assert) => {
+    QUnit.test("paste in the middle of input without value", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XX)",
             maskRules: {
@@ -1378,7 +1378,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.equal($input.val(), "(_x)", "paste at middle handled correctly");
     });
 
-    QUnit.test("paste replaces selection", (assert) => {
+    QUnit.test("paste replaces selection", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XXX)XXX-XX-XX",
             maskRules: {
@@ -1395,7 +1395,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.equal($input.val(), "(123)999-78-90", "paste replaced selection");
     });
 
-    QUnit.test("paste handles stubs and valid chars correctly", (assert) => {
+    QUnit.test("paste handles stubs and valid chars correctly", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "1(XXX",
             maskRules: {
@@ -1411,7 +1411,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.equal($input.val(), "1(178", "paste handled correctly");
     });
 
-    QUnit.test("paste handles stub correctly", (assert) => {
+    QUnit.test("paste handles stub correctly", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "+1(XXX)XXX-XX-XX",
             maskRules: {
@@ -1428,7 +1428,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.equal($input.val(), "+1(999)888-77-66", "paste handled correctly");
     });
 
-    QUnit.test("paste move cursor after inserted text", (assert) => {
+    QUnit.test("paste move cursor after inserted text", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XXX",
             maskRules: {
@@ -1449,7 +1449,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.deepEqual(keyboard.caret(), { start: 2, end: 2 }, "caret has correct position");
     });
 
-    QUnit.test("paste move cursor after accepted chars", (assert) => {
+    QUnit.test("paste move cursor after accepted chars", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XXX",
             maskRules: {
@@ -1465,7 +1465,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.deepEqual(keyboard.caret(), { start: 2, end: 2 }, "caret has correct position");
     });
 
-    QUnit.test("paste considers stub maskRules", (assert) => {
+    QUnit.test("paste considers stub maskRules", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(X)",
             maskRules: {
@@ -1482,7 +1482,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 2, "caret has correct position");
     });
 
-    QUnit.test("paste should not replace following chars", (assert) => {
+    QUnit.test("paste should not replace following chars", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: { "X": /\d/ },
@@ -1498,7 +1498,7 @@ QUnit.module("paste", moduleConfig, () => {
         assert.equal(keyboard.caret().start, 1, "caret in correctly position");
     });
 
-    QUnit.test("paste event should be fired in the FireFox when ctrl+V pressed", (assert) => {
+    QUnit.test("paste event should be fired in the FireFox when ctrl+V pressed", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XX",
             maskRules: { "X": /[v0]/ },
@@ -1526,7 +1526,7 @@ QUnit.module("paste", moduleConfig, () => {
 });
 
 QUnit.module("drag text", moduleConfig, () => {
-    QUnit.test("mask should support drag", (assert) => {
+    QUnit.test("mask should support drag", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XX)",
             maskRules: {
@@ -1544,7 +1544,7 @@ QUnit.module("drag text", moduleConfig, () => {
         assert.equal($input.val(), "(x_)", "mask is correct");
     });
 
-    QUnit.test("mask should support drag with spaces", (assert) => {
+    QUnit.test("mask should support drag with spaces", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XXXX)",
             maskRules: {
@@ -1564,7 +1564,7 @@ QUnit.module("drag text", moduleConfig, () => {
 });
 
 QUnit.module("cut", () => {
-    QUnit.test("cut handled correctly", (assert) => {
+    QUnit.test("cut handled correctly", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "XXX",
             maskRules: {
@@ -1613,7 +1613,7 @@ QUnit.module("custom mask maskRules", moduleConfig, () => {
         }, text: "z0y$ ", result: "zy"
     });
 
-    QUnit.test("build-in rules should not be influenced by custom rules", (assert) => {
+    QUnit.test("build-in rules should not be influenced by custom rules", function(assert) {
         $("<div>").appendTo("#qunit-fixture").dxTextEditor({
             mask: "0",
             maskRules: {
@@ -1629,7 +1629,7 @@ QUnit.module("custom mask maskRules", moduleConfig, () => {
         assert.equal($textEditor.find(".dx-texteditor-input").val(), "1", "'0' rule preserved");
     });
 
-    QUnit.test("custom function get fullText and current index", (assert) => {
+    QUnit.test("custom function get fullText and current index", function(assert) {
         $("#texteditor").dxTextEditor({
             mask: "-x",
             maskRules: {
@@ -1644,7 +1644,7 @@ QUnit.module("custom mask maskRules", moduleConfig, () => {
         });
     });
 
-    QUnit.test("fullText updated, if pasted text is accepted", (assert) => {
+    QUnit.test("fullText updated, if pasted text is accepted", function(assert) {
         // Fix blinking on blur in MS Edge (https://trello.com/c/HyC0Shoz)
         assert.expect(1);
         let firstTimeCall = true;
@@ -1670,7 +1670,7 @@ QUnit.module("custom mask maskRules", moduleConfig, () => {
         keyboard.caret(0).paste("xy");
     });
 
-    QUnit.test("validate method has fullText and index args", (assert) => {
+    QUnit.test("validate method has fullText and index args", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "xy",
             maskRules: {
@@ -1686,7 +1686,7 @@ QUnit.module("custom mask maskRules", moduleConfig, () => {
         assert.ok(!$textEditor.dxTextEditor("option", "isValid"), "editor is not valid");
     });
 
-    QUnit.test("text argument has maskChar instead of spaces", (assert) => {
+    QUnit.test("text argument has maskChar instead of spaces", function(assert) {
         $("#texteditor").dxTextEditor({
             mask: "xy",
             maskRules: {
@@ -1701,7 +1701,7 @@ QUnit.module("custom mask maskRules", moduleConfig, () => {
 });
 
 QUnit.module("escape built-in rules", {}, () => {
-    QUnit.test("built-in rules should be escaped with '\\'", (assert) => {
+    QUnit.test("built-in rules should be escaped with '\\'", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: '\\ll',
             value: 'a'
@@ -1712,7 +1712,7 @@ QUnit.module("escape built-in rules", {}, () => {
 });
 
 QUnit.module("validation", {}, () => {
-    QUnit.test("validation for 9", (assert) => {
+    QUnit.test("validation for 9", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "09",
             value: "1"
@@ -1726,7 +1726,7 @@ QUnit.module("validation", {}, () => {
         assert.equal(textEditor.option("isValid"), false, "valid value");
     });
 
-    QUnit.test("mask validation message", (assert) => {
+    QUnit.test("mask validation message", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "90",
             maskInvalidMessage: "test",
@@ -1743,7 +1743,7 @@ QUnit.module("validation", {}, () => {
         assert.equal($(".dx-invalid-message").eq(0).text(), "test", "validation message");
     });
 
-    QUnit.test("mask should be validated before valueChangeEvent is fired", (assert) => {
+    QUnit.test("mask should be validated before valueChangeEvent is fired", function(assert) {
         let maskIsValidOnValueChange;
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "90",
@@ -1763,7 +1763,7 @@ QUnit.module("validation", {}, () => {
         assert.strictEqual(maskIsValidOnValueChange, false, "input is validated before valueChangeEvent was fired");
     });
 
-    QUnit.test("reset should not request validation", (assert) => {
+    QUnit.test("reset should not request validation", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(X)",
             maskRules: {
@@ -1777,7 +1777,7 @@ QUnit.module("validation", {}, () => {
         assert.ok(!$textEditor.hasClass("dx-invalid"), "value is not validated");
     });
 
-    QUnit.test("validation after value changed", (assert) => {
+    QUnit.test("validation after value changed", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "0"
         });
@@ -1800,7 +1800,7 @@ QUnit.module("validation", {}, () => {
 });
 
 QUnit.module("T9", moduleConfig, () => {
-    QUnit.test("mask works when keypress is not fired", (assert) => {
+    QUnit.test("mask works when keypress is not fired", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(X)",
             maskRules: {
@@ -1826,7 +1826,7 @@ QUnit.module("T9", moduleConfig, () => {
         assert.equal($input.val(), "(x)", "mask works correctly");
     });
 
-    QUnit.test("mask works when keypress fired after input", (assert) => {
+    QUnit.test("mask works when keypress fired after input", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "(XX)",
             maskRules: {
@@ -1855,7 +1855,7 @@ QUnit.module("T9", moduleConfig, () => {
         assert.equal($input.val(), "(x_)", "mask works correctly");
     });
 
-    QUnit.testInActiveWindow("Last char remove correctly when keypress fired after backspace", (assert) => {
+    QUnit.testInActiveWindow("Last char remove correctly when keypress fired after backspace", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X-X",
             maskRules: {
@@ -1885,7 +1885,7 @@ QUnit.module("T9", moduleConfig, () => {
 });
 
 QUnit.module("states", {}, () => {
-    QUnit.test("mask should not be changed when readonly mode is enabled", (assert) => {
+    QUnit.test("mask should not be changed when readonly mode is enabled", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "X",
             maskRules: {
@@ -1905,7 +1905,7 @@ QUnit.module("states", {}, () => {
 });
 
 QUnit.module("Hidden input", {}, () => {
-    QUnit.test("Render a hidden input to keep a user's input if mask is defined", (assert) => {
+    QUnit.test("Render a hidden input to keep a user's input if mask is defined", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "number",
             mask: "(X)"
@@ -1919,7 +1919,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($hiddenInput.attr("name"), "number", "hidden input has a right name");
     });
 
-    QUnit.test("Do not render a hidden input if mask is undefined", (assert) => {
+    QUnit.test("Do not render a hidden input if mask is undefined", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "number"
         });
@@ -1928,7 +1928,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($hiddenInput.length, 0, "there isn't a hidden input");
     });
 
-    QUnit.test("Render a hidden input when mask option is set via api", (assert) => {
+    QUnit.test("Render a hidden input when mask option is set via api", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "number"
         });
@@ -1943,7 +1943,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($hiddenInput.attr("name"), "number", "hidden input has a right name");
     });
 
-    QUnit.test("Remove a hidden input if mask is changed to undefined", (assert) => {
+    QUnit.test("Remove a hidden input if mask is changed to undefined", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "number",
             mask: "00-00-00"
@@ -1958,7 +1958,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($visibleInput.attr("name"), "number", "Visible input name is restored");
     });
 
-    QUnit.test("Replace hidden input if mask is changed to another value", (assert) => {
+    QUnit.test("Replace hidden input if mask is changed to another value", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "number",
             mask: "00-00-00"
@@ -1971,7 +1971,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($hiddenInput.length, 1, "Hidden value is replaced");
     });
 
-    QUnit.test("A hidden input should have a correct value if useMaskedValue is true", (assert) => {
+    QUnit.test("A hidden input should have a correct value if useMaskedValue is true", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "00-00-00",
             useMaskedValue: true,
@@ -1983,7 +1983,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($hiddenInput.val(), "45-23-10", "value of hidden input");
     });
 
-    QUnit.test("A hidden input should have a correct value if useMaskedValue is false", (assert) => {
+    QUnit.test("A hidden input should have a correct value if useMaskedValue is false", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "00-00-00",
             value: "342312"
@@ -1994,7 +1994,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($hiddenInput.val(), "342312", "value of hidden input");
     });
 
-    QUnit.test("A hidden input has empty value without mask if useMasked Value is true", (assert) => {
+    QUnit.test("A hidden input has empty value without mask if useMasked Value is true", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "+1 (000) 0000000",
             useMaskedValue: true
@@ -2004,7 +2004,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($hiddenInput.val(), "", "value of hidden input is empty");
     });
 
-    QUnit.test("A hidden input has empty value without mask if useMasked Value is false", (assert) => {
+    QUnit.test("A hidden input has empty value without mask if useMasked Value is false", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             mask: "+1 (000) 0000000"
         });
@@ -2013,7 +2013,7 @@ QUnit.module("Hidden input", {}, () => {
         assert.equal($hiddenInput.val(), "", "value of hidden input is empty");
     });
 
-    QUnit.test("Name attr of hidden input is changed when name option of editor is changed", (assert) => {
+    QUnit.test("Name attr of hidden input is changed when name option of editor is changed", function(assert) {
         const $textEditor = $("#texteditor").dxTextEditor({
             name: "Test name",
             mask: "+1 (000) 0000000"
@@ -2027,7 +2027,7 @@ QUnit.module("Hidden input", {}, () => {
 });
 
 QUnit.module("Strategies", () => {
-    QUnit.test("default strategy should be used for all devices, except android 5+", (assert) => {
+    QUnit.test("default strategy should be used for all devices, except android 5+", function(assert) {
         const instance = $("#texteditor").dxTextEditor({
             mask: "0"
         }).dxTextEditor("instance");
@@ -2039,7 +2039,7 @@ QUnit.module("Strategies", () => {
         assert.strictEqual(instance._maskStrategy.NAME, expectedMaskStrategy, "strategy name is correct");
     });
 
-    QUnit.test("default strategy should be used for devices with android less than v5", (assert) => {
+    QUnit.test("default strategy should be used for devices with android less than v5", function(assert) {
         const currentDevice = devices.real();
 
         devices.real({

--- a/testing/tests/DevExpress.ui.widgets.editors/textbox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textbox.tests.js
@@ -25,7 +25,7 @@ const SEARCHBOX_CLASS = "dx-searchbox";
 const SEARCH_ICON_CLASS = "dx-icon-search";
 
 QUnit.module("common", {}, () => {
-    QUnit.test("onContentReady fired after the widget is fully ready", assert => {
+    QUnit.test("onContentReady fired after the widget is fully ready", function(assert) {
         assert.expect(1);
 
         $("#textbox").dxTextBox({
@@ -35,7 +35,7 @@ QUnit.module("common", {}, () => {
         });
     });
 
-    QUnit.test("changing mode to 'search' should render search icon", assert => {
+    QUnit.test("changing mode to 'search' should render search icon", function(assert) {
         const element = $("#textbox").dxTextBox();
         const textBox = element.dxTextBox("instance");
 
@@ -45,7 +45,7 @@ QUnit.module("common", {}, () => {
         assert.equal(element.find("." + SEARCH_ICON_CLASS).length, 1);
     });
 
-    QUnit.test("'maxLength' option on android 2.3 and 4.1", assert => {
+    QUnit.test("'maxLength' option on android 2.3 and 4.1", function(assert) {
         const originalDevices = devices.real();
         devices.real({
             platform: "android",
@@ -73,7 +73,7 @@ QUnit.module("common", {}, () => {
         }
     });
 
-    QUnit.test("'maxLength' option on IE", assert => {
+    QUnit.test("'maxLength' option on IE", function(assert) {
         const originalIE = browser.msie;
 
         try {
@@ -94,7 +94,7 @@ QUnit.module("common", {}, () => {
         }
     });
 
-    QUnit.test("call focus() method", assert => {
+    QUnit.test("call focus() method", function(assert) {
         executeAsyncMock.setup();
         try {
             let inFocus;
@@ -116,7 +116,7 @@ QUnit.module("common", {}, () => {
         }
     });
 
-    QUnit.test("T218573 - clearButton should be hidden if mode is 'search' and the 'showClearButton' option is false", assert => {
+    QUnit.test("T218573 - clearButton should be hidden if mode is 'search' and the 'showClearButton' option is false", function(assert) {
         const $element = $("#textbox").dxTextBox({
             showClearButton: false,
             mode: "search",
@@ -129,7 +129,7 @@ QUnit.module("common", {}, () => {
         assert.equal($(".dx-clear-button-area").length, 0, "clear button is not rendered");
     });
 
-    QUnit.test("clear button should save valueChangeEvent", assert => {
+    QUnit.test("clear button should save valueChangeEvent", function(assert) {
         const valueChangedHandler = sinon.spy();
 
         const $element = $("#textbox").dxTextBox({
@@ -145,7 +145,7 @@ QUnit.module("common", {}, () => {
         assert.equal(valueChangedHandler.getCall(0).args[0].event.type, "dxclick", "event is correct");
     });
 
-    QUnit.test("T810808 - should be possible to type characters in IE in TextBox with maxLength and mask", assert => {
+    QUnit.test("T810808 - should be possible to type characters in IE in TextBox with maxLength and mask", function(assert) {
         const originalIE = browser.msie;
 
         try {
@@ -162,7 +162,7 @@ QUnit.module("common", {}, () => {
         }
     });
 
-    QUnit.test("TextBox shouldn't lose last characters on change event in IE", assert => {
+    QUnit.test("TextBox shouldn't lose last characters on change event in IE", function(assert) {
         const originalIE = browser.msie;
 
         try {
@@ -190,20 +190,20 @@ QUnit.module("common", {}, () => {
 });
 
 QUnit.module("options changing", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.element = $("#textbox").dxTextBox({});
         this.input = this.element.find("." + INPUT_CLASS);
         this.instance = this.element.dxTextBox("instance");
     }
 }, () => {
-    QUnit.test("mode", (assert) => {
+    QUnit.test("mode", function(assert) {
         assert.expect(1);
 
         this.instance.option("mode", "search");
         assert.equal(this.element.find("." + INPUT_CLASS).attr("type"), "text");
     });
 
-    QUnit.test("value", (assert) => {
+    QUnit.test("value", function(assert) {
         assert.expect(2);
 
         this.instance.option("value", "123");
@@ -213,7 +213,7 @@ QUnit.module("options changing", {
         assert.equal(this.input.val(), "321");
     });
 
-    QUnit.test("disabled", (assert) => {
+    QUnit.test("disabled", function(assert) {
         assert.expect(2);
 
         this.instance.option("disabled", true);
@@ -223,7 +223,7 @@ QUnit.module("options changing", {
         assert.ok(!this.input.prop("disabled"));
     });
 
-    QUnit.test("placeholder", (assert) => {
+    QUnit.test("placeholder", function(assert) {
         assert.expect(2);
 
         this.instance.option("placeholder", "John Doe");
@@ -233,7 +233,7 @@ QUnit.module("options changing", {
         assert.equal(this.element.find("." + INPUT_CLASS).prop("placeholder") || this.element.find("." + PLACEHOLDER_CLASS).attr("data-dx_placeholder"), "John Jr. Doe");
     });
 
-    QUnit.test("'maxLength' option", (assert) => {
+    QUnit.test("'maxLength' option", function(assert) {
         const originalDevices = devices.real();
         const originalIE = browser.msie;
         devices.real({
@@ -257,7 +257,7 @@ QUnit.module("options changing", {
         }
     });
 
-    QUnit.test("'maxLength' on android 2.3 and 4.1 ", (assert) => {
+    QUnit.test("'maxLength' on android 2.3 and 4.1 ", function(assert) {
         const originalDevices = devices.real();
         devices.real({
             platform: "android",
@@ -290,7 +290,7 @@ QUnit.module("options changing", {
         }
     });
 
-    QUnit.test("'maxLength' should be ignored if mask is specified", (assert) => {
+    QUnit.test("'maxLength' should be ignored if mask is specified", function(assert) {
         const originalDevices = devices.real();
         const originalIE = browser.msie;
         devices.real({
@@ -312,7 +312,7 @@ QUnit.module("options changing", {
         }
     });
 
-    QUnit.test("readOnly", (assert) => {
+    QUnit.test("readOnly", function(assert) {
         assert.expect(2);
 
         this.instance.option("readOnly", true);
@@ -322,14 +322,14 @@ QUnit.module("options changing", {
         assert.equal(this.input.prop("readOnly"), false);
     });
 
-    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", (assert) => {
+    QUnit.test("Changing the 'value' option must invoke the 'onValueChanged' action", function(assert) {
         this.instance.option("onValueChanged", () => {
             assert.ok(true);
         });
         this.instance.option("value", true);
     });
 
-    QUnit.test("options 'height' and 'width'", (assert) => {
+    QUnit.test("options 'height' and 'width'", function(assert) {
         let h = 500;
         let w = 400;
         this.instance.option({
@@ -358,13 +358,13 @@ QUnit.module("options changing", {
 });
 
 QUnit.module("widget sizing render", {}, () => {
-    QUnit.test("default", assert => {
+    QUnit.test("default", function(assert) {
         const $element = $("#textbox").dxTextBox();
 
         assert.ok($element.outerWidth() > 0, "outer width of the element must be more than zero");
     });
 
-    QUnit.test("constructor", assert => {
+    QUnit.test("constructor", function(assert) {
         const $element = $("#textbox").dxTextBox({ width: 400 });
         const instance = $element.dxTextBox("instance");
 
@@ -372,7 +372,7 @@ QUnit.module("widget sizing render", {}, () => {
         assert.strictEqual($element.outerWidth(), 400, "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("root with custom width", assert => {
+    QUnit.test("root with custom width", function(assert) {
         const $element = $("#widthRootStyle").dxTextBox();
         const instance = $element.dxTextBox("instance");
 
@@ -380,7 +380,7 @@ QUnit.module("widget sizing render", {}, () => {
         assert.strictEqual($element.outerWidth(), 300, "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("change width", assert => {
+    QUnit.test("change width", function(assert) {
         const $element = $("#textbox").dxTextBox();
         const instance = $element.dxTextBox("instance");
         const customWidth = 400;

--- a/testing/tests/DevExpress.ui.widgets.editors/validationGroup.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationGroup.markup.tests.js
@@ -51,11 +51,11 @@ testStart(() => {
 
 
 testModule("General", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.fixture = new Fixture();
     }
 }, () => {
-    test("dxValidationGroup can be created", (assert) => {
+    test("dxValidationGroup can be created", function(assert) {
         const $container = $("#dxValidationGroup");
         // act
         const group = this.fixture.createGroup($container);
@@ -64,7 +64,7 @@ testModule("General", {
         assert.ok($container.hasClass("dx-validationgroup"), "Specific class should be added");
     });
 
-    test("dxValidationGroup should not remove container content", (assert) => {
+    test("dxValidationGroup should not remove container content", function(assert) {
         const $container = $("#dxValidationGroup");
         $("<img/>").appendTo($container);
 
@@ -74,7 +74,7 @@ testModule("General", {
         assert.equal($container.find("img").length, 1, "Image inside of container should remain untouched");
     });
 
-    test("dxValidator can be validated as part of dxValidationGroup", (assert) => {
+    test("dxValidator can be validated as part of dxValidationGroup", function(assert) {
         const $container = $("#dxValidationGroup");
         const group = this.fixture.createGroup($container);
         const validator = this.fixture.createValidatorInGroup();
@@ -87,7 +87,7 @@ testModule("General", {
     });
 
 
-    test("dxValidator should be registered as part of dxValidationGroup - when dxValidationGroup was created after dxValidator", (assert) => {
+    test("dxValidator should be registered as part of dxValidationGroup - when dxValidationGroup was created after dxValidator", function(assert) {
         const $container = $("#dxValidationGroup");
 
         this.fixture.createValidationGroupContainer($container);
@@ -104,7 +104,7 @@ testModule("General", {
         assert.ok(validator.validate.calledOnce, "Validator should be validated as part of group");
     });
 
-    test("dxValidationGroup can be disposed, container should be cleared (T199232)", (assert) => {
+    test("dxValidationGroup can be disposed, container should be cleared (T199232)", function(assert) {
         const $container = $("#dxValidationGroup");
         this.fixture.createGroup($container);
         // act
@@ -114,7 +114,7 @@ testModule("General", {
     });
 
 
-    test("dxValidator can be reset as part of dxValidationGroup", (assert) => {
+    test("dxValidator can be reset as part of dxValidationGroup", function(assert) {
         const $container = $("#dxValidationGroup");
         const group = this.fixture.createGroup($container);
         const validator = this.fixture.createValidatorInGroup();
@@ -128,14 +128,14 @@ testModule("General", {
 });
 
 testModule("API", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.fixture = new Fixture();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.fixture.teardown();
     }
 }, () => {
-    test("group.validate", (assert) => {
+    test("group.validate", function(assert) {
         const $container = $("#dxValidationGroup");
         const group = this.fixture.createGroup($container);
 
@@ -150,7 +150,7 @@ testModule("API", {
         assert.equal(ValidationEngine.validateGroup.getCall(0).args[0], group, "correct group key should be passed");
     });
 
-    test("empty validation group should return valid 'validationResult' object", (assert) => {
+    test("empty validation group should return valid 'validationResult' object", function(assert) {
         const $container = $("#dxValidationGroup");
         const group = this.fixture.createGroup($container);
         const { isValid, brokenRules, validators } = group.validate();


### PR DESCRIPTION
Clarification:
---

> QUnit test and module callbacks can share state by modifying properties of `this` within those callbacks.
> 
> This only works when using function expressions, which allow for dynamic binding of `this` by the QUnit library. Arrow function expressions will not work in this case, because arrow functions will always bind to whatever the value of `this` was in the enclosing scope (in QUnit tests, usually the global object). This means that developers who use arrow function expressions as test or module callbacks will not be able to share state and may encounter other problems.

See https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md

Examples:
---

![image](https://user-images.githubusercontent.com/1420883/69529618-af08aa80-0f81-11ea-83b5-923eacd10628.png)

![image](https://user-images.githubusercontent.com/1420883/69529778-f5f6a000-0f81-11ea-8cac-10c531e987fa.png)

etc.