### PR TITLE
Scheduler: Fix globals in tests

### DIFF
--- a/testing/tests/DevExpress.serverSide/scheduler.tests.js
+++ b/testing/tests/DevExpress.serverSide/scheduler.tests.js
@@ -13,7 +13,7 @@ QUnit.testStart(() => {
 
 QUnit.module("View switcher server markup");
 
-QUnit.test("View switcher tabs should be expanded on server", (assert) => {
+QUnit.test("View switcher tabs should be expanded on server", function(assert) {
     var scheduler = $("#scheduler").dxScheduler().dxScheduler("instance");
     var $switcher = scheduler.$element().find(".dx-tabs.dx-scheduler-view-switcher");
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointmentPopup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointmentPopup.tests.js
@@ -54,7 +54,7 @@ QUnit.module("Appointment popup form", moduleConfig, () => {
         return createWrapper($.extend(defaultOption, options));
     };
 
-    QUnit.test("onAppointmentFormOpening event should handle e.cancel value", assert => {
+    QUnit.test("onAppointmentFormOpening event should handle e.cancel value", function(assert) {
         const data = [{
             text: "Website Re-Design Plan",
             startDate: new Date(2017, 4, 22, 9, 30),
@@ -92,7 +92,7 @@ QUnit.module("Appointment popup form", moduleConfig, () => {
         });
     });
 
-    QUnit.test("Appointment popup should work properly", assert => {
+    QUnit.test("Appointment popup should work properly", function(assert) {
         const NEW_EXPECTED_SUBJECT = "NEW SUBJECT";
         const scheduler = createScheduler();
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.markup.tests.js
@@ -13,7 +13,7 @@ QUnit.testStart(() => {
 });
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
 
         this.instance = $("#scheduler").dxScheduler().dxScheduler("instance");
@@ -37,23 +37,23 @@ const moduleConfig = {
             }
         ];
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         fx.off = false;
     }
 };
 
 QUnit.module("Scheduler markup", moduleConfig, () => {
-    QUnit.test("Scheduler should be initialized", (assert) => {
+    QUnit.test("Scheduler should be initialized", function(assert) {
         assert.ok(this.instance instanceof dxScheduler, "Scheduler was initialized");
     });
 
-    QUnit.test("Scheduler should have a right css classes", (assert) => {
+    QUnit.test("Scheduler should have a right css classes", function(assert) {
         assert.ok(this.instance.$element().hasClass("dx-scheduler"), "Scheduler has 'dx-scheduler' css class");
         assert.ok(this.instance.$element().hasClass("dx-widget"), "Scheduler has 'dx-widget' css class");
     });
 
-    QUnit.test("Scheduler should not fail when dataSource is set", (assert) => {
+    QUnit.test("Scheduler should not fail when dataSource is set", function(assert) {
         const data = new DataSource.DataSource({
             store: this.tasks
         });
@@ -69,7 +69,7 @@ QUnit.module("Scheduler markup", moduleConfig, () => {
         assert.ok(instance._appointmentModel._dataSource instanceof DataSource.DataSource, "Task model has data source instance");
     });
 
-    QUnit.test("Scheduler should not fail when dataSource is set, timelineView", (assert) => {
+    QUnit.test("Scheduler should not fail when dataSource is set, timelineView", function(assert) {
         const data = new DataSource.DataSource({
             store: this.tasks
         });
@@ -85,7 +85,7 @@ QUnit.module("Scheduler markup", moduleConfig, () => {
         assert.ok(instance._appointmentModel._dataSource instanceof DataSource.DataSource, "Task model has data source instance");
     });
 
-    QUnit.test("Scheduler should not fail when dataSource is set, timelineWeek", (assert) => {
+    QUnit.test("Scheduler should not fail when dataSource is set, timelineWeek", function(assert) {
         const data = new DataSource.DataSource({
             store: this.tasks
         });
@@ -101,7 +101,7 @@ QUnit.module("Scheduler markup", moduleConfig, () => {
         assert.ok(instance._appointmentModel._dataSource instanceof DataSource.DataSource, "Task model has data source instance");
     });
 
-    QUnit.test("Scheduler should not fail when dataSource is set, agenda", (assert) => {
+    QUnit.test("Scheduler should not fail when dataSource is set, agenda", function(assert) {
         const data = new DataSource.DataSource({
             store: this.tasks
         });
@@ -117,7 +117,7 @@ QUnit.module("Scheduler markup", moduleConfig, () => {
         assert.ok(instance._appointmentModel._dataSource instanceof DataSource.DataSource, "Task model has data source instance");
     });
 
-    QUnit.test("Header & work space currentDate should not contain information about hours, minutes, seconds", (assert) => {
+    QUnit.test("Header & work space currentDate should not contain information about hours, minutes, seconds", function(assert) {
         var currentDate = this.instance.option("currentDate"),
             header = this.instance.getHeader(),
             workSpace = this.instance.getWorkSpace(),
@@ -141,17 +141,17 @@ QUnit.module("Scheduler markup", moduleConfig, () => {
 });
 
 QUnit.module("Scheduler with config", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler").dxScheduler(options).dxScheduler("instance");
         };
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("Scheduler should have specific viewName setting of the view", (assert) => {
+    QUnit.test("Scheduler should have specific viewName setting of the view", function(assert) {
         this.createInstance({
             views: [{
                 type: "day",
@@ -168,7 +168,7 @@ QUnit.module("Scheduler with config", {
         assert.equal($header.find(".dx-tab").eq(1).text(), "Week");
     });
 
-    QUnit.test("Workspace shouldn't have specific class if maxAppointmentsPerCell=null", (assert) => {
+    QUnit.test("Workspace shouldn't have specific class if maxAppointmentsPerCell=null", function(assert) {
         this.createInstance({
             currentView: "Week",
             maxAppointmentsPerCell: null,
@@ -182,7 +182,7 @@ QUnit.module("Scheduler with config", {
         assert.notOk($workSpace.hasClass("dx-scheduler-work-space-overlapping"), "workspace hasn't class");
     });
 
-    QUnit.test("Scheduler should not fail when crossScrollingEnabled is set", (assert) => {
+    QUnit.test("Scheduler should not fail when crossScrollingEnabled is set", function(assert) {
         this.createInstance();
 
         assert.strictEqual(this.instance.getWorkSpace().option("crossScrollingEnabled"), false, "option is OK");
@@ -191,7 +191,7 @@ QUnit.module("Scheduler with config", {
         assert.strictEqual(this.instance.getWorkSpace().option("crossScrollingEnabled"), true, "option is OK");
     });
 
-    QUnit.test("Scheduler should not fail when crossScrollingEnabled is set, agenda view", (assert) => {
+    QUnit.test("Scheduler should not fail when crossScrollingEnabled is set, agenda view", function(assert) {
         this.createInstance({
             crossScrollingEnabled: true,
             currentView: "agenda"

--- a/testing/tests/DevExpress.ui.widgets.scheduler/dragAndDropAppointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/dragAndDropAppointments.tests.js
@@ -217,9 +217,9 @@ module("Drag and drop appointments", moduleConfig, () => {
                 .up();
         };
 
-        test("in common views", assert => testViews(commonViews, assert));
-        test("in time line views", assert => testViews(timeLineViews, assert));
-        test("in group views", assert => testViews(groupViews, assert));
+        test("in common views", function(assert) { testViews(commonViews, assert); });
+        test("in time line views", function(assert) { testViews(timeLineViews, assert); });
+        test("in group views", function(assert) { testViews(groupViews, assert); });
     });
 
     module("Appointment should move a same distance as mouse", () => {
@@ -304,9 +304,9 @@ module("Drag and drop appointments", moduleConfig, () => {
             });
         };
 
-        test("in common views", assert => testViews(commonViews, assert));
-        test("in time line views", assert => testViews(timeLineViews, assert));
-        test("in group views", assert => testViews(groupViews, assert));
+        test("in common views", function(assert) { testViews(commonViews, assert); });
+        test("in time line views", function(assert) { testViews(timeLineViews, assert); });
+        test("in group views", function(assert) { testViews(groupViews, assert); });
     });
 
     test("DropDownAppointment shouldn't be draggable if editing.allowDragging is false", function(assert) {
@@ -528,7 +528,7 @@ module("Drag and drop appointments", moduleConfig, () => {
                 }, options));
         };
 
-        test("Event calls on appointment drag", assert => {
+        test("Event calls on appointment drag", function(assert) {
             const appointmentDragging = {
                 onDragStart: sinon.spy(),
                 onDragEnd: sinon.spy(),
@@ -563,7 +563,7 @@ module("Drag and drop appointments", moduleConfig, () => {
             assert.strictEqual(appointmentDragging.onRemove.callCount, 0, "onRemove is not called");
         });
 
-        test("Cancel onDragStart event", assert => {
+        test("Cancel onDragStart event", function(assert) {
             const appointmentDragging = {
                 onDragStart: sinon.spy(e => {
                     e.cancel = true;
@@ -594,7 +594,7 @@ module("Drag and drop appointments", moduleConfig, () => {
             assert.strictEqual(appointmentDragging.onDragEnd.callCount, 0, "onDragEnd is not called");
         });
 
-        test("Cancel onDragEnd event", assert => {
+        test("Cancel onDragEnd event", function(assert) {
             const appointmentDragging = {
                 onDragEnd: e => {
                     e.cancel = true;
@@ -622,7 +622,7 @@ module("Drag and drop appointments", moduleConfig, () => {
             assert.deepEqual(dataSource[0].startDate, new Date(2018, 4, 21, 9, 30), "startDate is not changed");
         });
 
-        test("Move appointment from Draggable", assert => {
+        test("Move appointment from Draggable", function(assert) {
             const group = "testGroup";
 
             const appointmentDragging = {
@@ -663,7 +663,7 @@ module("Drag and drop appointments", moduleConfig, () => {
             assert.deepEqual(draggableData, { text: "App from Draggable" }, "draggable data is not changed");
         });
 
-        test("Move appointment to Draggable", assert => {
+        test("Move appointment to Draggable", function(assert) {
             const group = "testGroup";
 
             const appointmentDragging = {
@@ -695,7 +695,7 @@ module("Drag and drop appointments", moduleConfig, () => {
             assert.strictEqual(appointmentDragging.onRemove.getCall(0).args[0].itemData.text, "App 1", "onRemove itemData parameter");
         });
 
-        test("Move appointment to Draggable from tooltip", assert => {
+        test("Move appointment to Draggable from tooltip", function(assert) {
             const group = "testGroup";
 
             const appointmentDragging = {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.RTL.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.RTL.tests.js
@@ -23,7 +23,7 @@ const moduleConfig = {
 
 module("RTL", moduleConfig, () => {
     if(isDesktopEnvironment()) {
-        test("Appointment should have correct position with multiple resources if rtlEnabled is true (T803275)", assert => {
+        test("Appointment should have correct position with multiple resources if rtlEnabled is true (T803275)", function(assert) {
             const views = ["month", "week", "day"];
 
             const expectedValues = {
@@ -116,7 +116,7 @@ module("RTL", moduleConfig, () => {
             });
         };
 
-        test("Day view", assert => {
+        test("Day view", function(assert) {
             const scheduler = createScheduler("day");
 
             const cell = scheduler.workSpace.getCell(8);
@@ -125,7 +125,7 @@ module("RTL", moduleConfig, () => {
             assert.equal(appointment.position().left + appointment.outerWidth(), cell.position().left + cell.outerWidth(), "task position is correct");
         });
 
-        test("Week view", assert => {
+        test("Week view", function(assert) {
             const scheduler = createScheduler("week");
 
             const cell = scheduler.workSpace.getCell(1);
@@ -134,7 +134,7 @@ module("RTL", moduleConfig, () => {
             assert.equal(Math.round(appointment.position().left + appointment.outerWidth()), Math.round(cell.position().left + cell.outerWidth()), "task position is correct");
         });
 
-        test("Month view", assert => {
+        test("Month view", function(assert) {
             const scheduler = createScheduler("month");
 
             const cell = scheduler.workSpace.getCell(1);

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentCollector.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentCollector.tests.js
@@ -25,7 +25,7 @@ const ADAPTIVE_COLLECTOR_RIGHT_OFFSET = 5;
 const COMPACT_THEME_ADAPTIVE_COLLECTOR_RIGHT_OFFSET = 1;
 
 QUnit.module("Integration: Appointments Collector Base Tests", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.editing = true;
@@ -57,24 +57,24 @@ QUnit.module("Integration: Appointments Collector Base Tests", {
             }));
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.test("Appointment collector should be rendered with right class", (assert) => {
+    QUnit.test("Appointment collector should be rendered with right class", function(assert) {
         const $collector = this.renderAppointmentsCollectorContainer();
         assert.ok($collector.hasClass("dx-scheduler-appointment-collector"), "Container is rendered");
         assert.ok($collector.dxButton("instance"), "Container is button");
     });
 
-    QUnit.test("Appointment collector should be painted", (assert) => {
+    QUnit.test("Appointment collector should be painted", function(assert) {
         this.color = "#0000ff";
         const $collector = this.renderAppointmentsCollectorContainer();
 
         assert.equal(new Color($collector.css("backgroundColor")).toHex(), this.color, "Color is OK");
     });
 
-    QUnit.test("Appointment collector should not be painted if items have different colors", (assert) => {
+    QUnit.test("Appointment collector should not be painted if items have different colors", function(assert) {
         this.color = "#0000ff";
         const $collector = this.renderAppointmentsCollectorContainer({
             data: [
@@ -87,7 +87,7 @@ QUnit.module("Integration: Appointments Collector Base Tests", {
         assert.notEqual(new Color($collector.css("backgroundColor")).toHex(), this.color, "Color is OK");
     });
 
-    QUnit.test("Appointment collector should have a correct markup", (assert) => {
+    QUnit.test("Appointment collector should have a correct markup", function(assert) {
         const $button = this.renderAppointmentsCollectorContainer();
         const $collectorContent = $button.find(".dx-scheduler-appointment-collector-content");
 
@@ -97,7 +97,7 @@ QUnit.module("Integration: Appointments Collector Base Tests", {
 });
 
 QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
         this.tasks = [
@@ -113,7 +113,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
             return new Color($task.css(checkedProperty)).toHex();
         };
 
-        this.checkItemDataInDropDownTemplate = (assert, dataSource, currentDate) => {
+        this.checkItemDataInDropDownTemplate = function(assert, dataSource, currentDate) {
             this.createInstance({
                 dataSource: dataSource,
                 height: 600,
@@ -127,7 +127,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
             });
             this.scheduler.appointments.compact.click();
         };
-        this.createInstance = (options) => {
+        this.createInstance = function(options) {
             this.instance = $("#scheduler").dxScheduler($.extend({
                 dataSource: this.tasks,
                 views: ["month", "week"],
@@ -135,18 +135,18 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
                 currentView: "month",
                 height: 1000,
                 currentDate: new Date(2019, 2, 4),
-                onContentReady: () => {
-                    this.scheduler = new SchedulerTestWrapper(this.instance);
-                }
+                onContentReady: function(e) {
+                    this.scheduler = new SchedulerTestWrapper(e.component);
+                }.bind(this)
             }, options)).dxScheduler("instance");
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("Appointment collector should have correct coordinates on month view", (assert) => {
+    QUnit.test("Appointment collector should have correct coordinates on month view", function(assert) {
         this.createInstance();
 
         assert.equal(this.scheduler.appointments.compact.getButtonCount(), 0, "Collector wasn't rendered");
@@ -166,7 +166,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.roughEqual(collectorCoordinates.top, expectedCoordinates.top, 1.001, "Top coordinate is OK");
     });
 
-    QUnit.test("Appointment collector should have correct size in material theme", (assert) => {
+    QUnit.test("Appointment collector should have correct size in material theme", function(assert) {
         const origIsMaterial = themes.isMaterial;
 
         try {
@@ -189,7 +189,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         }
     });
 
-    QUnit.test("DropDown appointment button should have correct coordinates on weekView, not in allDay panel", (assert) => {
+    QUnit.test("DropDown appointment button should have correct coordinates on weekView, not in allDay panel", function(assert) {
         const WEEK_VIEW_BUTTON_OFFSET = 5;
 
         this.createInstance({
@@ -216,7 +216,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.roughEqual(collectorCoordinates.top, expectedCoordinates.top, 1.001, "Top coordinate is OK");
     });
 
-    QUnit.test("Appointment collector should have correct size when intervalCount is set", (assert) => {
+    QUnit.test("Appointment collector should have correct size when intervalCount is set", function(assert) {
         this.createInstance({
             views: [{ type: "month", intervalCount: 2 }],
             width: 850,
@@ -244,7 +244,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.roughEqual(this.scheduler.appointments.compact.getButtonHeight(), 20, 1, "Collector height is ok");
     });
 
-    QUnit.test("Appointment collector count should be ok when there are multiday appointments", (assert) => {
+    QUnit.test("Appointment collector count should be ok when there are multiday appointments", function(assert) {
         this.createInstance({
             views: ['month'],
             currentView: 'month',
@@ -265,7 +265,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.equal(this.scheduler.appointments.compact.getButtonCount(), 3, "Collectors count is ok");
     });
 
-    QUnit.test("Many dropDown appts with one multi day task should be grouped correctly", (assert) => {
+    QUnit.test("Many dropDown appts with one multi day task should be grouped correctly", function(assert) {
         this.createInstance({
             views: ['month'],
             currentView: 'month',
@@ -293,7 +293,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.equal(this.scheduler.tooltip.getItemCount(), 8, "There are 8 collapsed appts");
     });
 
-    QUnit.test("Many collapsed appts should be grouped correctly with one multi day task which started before collector (T525443)", (assert) => {
+    QUnit.test("Many collapsed appts should be grouped correctly with one multi day task which started before collector (T525443)", function(assert) {
         this.createInstance({
             views: ['month'],
             currentView: 'month',
@@ -327,7 +327,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.equal(this.scheduler.tooltip.getItemCount(), 13, "There are 13 drop down appts");
     });
 
-    QUnit.test("Appointment collector should have correct coordinates: rtl mode", (assert) =>{
+    QUnit.test("Appointment collector should have correct coordinates: rtl mode", function(assert) {
         this.createInstance({
             currentDate: new Date(2019, 2, 4),
             views: ["month"],
@@ -347,7 +347,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.roughEqual(collectorCoordinates.top, expectedCoordinates.top, 1.001, "Top coordinate is OK");
     });
 
-    QUnit.test("Collapsed appointment should raise the onAppointmentClick event", (assert) => {
+    QUnit.test("Collapsed appointment should raise the onAppointmentClick event", function(assert) {
         let tooltipItemElement = null;
         const spy = sinon.spy();
         const appointments = [
@@ -396,7 +396,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         }
     });
 
-    QUnit.test("Collapse appointment should process the onAppointmentClick event correctly if e.cancel = true", (assert) => {
+    QUnit.test("Collapse appointment should process the onAppointmentClick event correctly if e.cancel = true", function(assert) {
         const spy = sinon.spy();
         this.createInstance({
             currentDate: new Date(2015, 2, 4),
@@ -435,7 +435,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         }
     });
 
-    QUnit.test("Appointment collector should be painted depend on resource color", (assert) => {
+    QUnit.test("Appointment collector should be painted depend on resource color", function(assert) {
         const colors = [
             "#ff0000",
             "#ff0000",
@@ -482,7 +482,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         });
     });
 
-    QUnit.test("Appointment collector should be painted depend on resource color when resourses store is asynchronous", (assert) => {
+    QUnit.test("Appointment collector should be painted depend on resource color when resourses store is asynchronous", function(assert) {
         const colors = [
             "#ff0000",
             "#ff0000",
@@ -541,7 +541,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         });
     });
 
-    QUnit.test("Collapsed appointments should not be duplicated when items option change (T503748)", (assert) => {
+    QUnit.test("Collapsed appointments should not be duplicated when items option change (T503748)", function(assert) {
         this.createInstance({
             views: ['month'],
             currentView: 'month',
@@ -568,7 +568,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.equal(this.scheduler.tooltip.getItemCount(), 2, "There are 3 drop down appts");
     });
 
-    QUnit.test("Collapsed appointment should be rendered correctly with expressions on custom template", (assert) => {
+    QUnit.test("Collapsed appointment should be rendered correctly with expressions on custom template", function(assert) {
         const startDate = new Date(2015, 1, 4, 1);
         const endDate = new Date(2015, 1, 4, 2);
         const appointments = [{
@@ -606,7 +606,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
     });
 
 
-    QUnit.test("Appointment collector should be rendered correctly when appointmentCollectorTemplate is used", (assert) => {
+    QUnit.test("Appointment collector should be rendered correctly when appointmentCollectorTemplate is used", function(assert) {
         const startDate = new Date(2015, 1, 4, 1);
         const endDate = new Date(2015, 1, 4, 2);
         const appointments = [{
@@ -644,7 +644,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.equal($collector.find(".button-title").text(), "Appointment count is 2", "Template is applied correctly");
     });
 
-    QUnit.test("dxScheduler should render dropDownAppointment appointment template with render function that returns dom node", (assert) => {
+    QUnit.test("dxScheduler should render dropDownAppointment appointment template with render function that returns dom node", function(assert) {
         const startDate = new Date(2015, 1, 4, 1);
         const endDate = new Date(2015, 1, 4, 2);
         const appointments = [{
@@ -692,7 +692,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.equal(this.scheduler.tooltip.getItemElement().text(), "text", "Text is correct on init");
     });
 
-    QUnit.test("Appointment collector should have correct width on timeline view", (assert) => {
+    QUnit.test("Appointment collector should have correct width on timeline view", function(assert) {
         this.createInstance({
             currentDate: new Date(2015, 2, 4),
             views: [{ type: "timelineDay", name: "timelineDay" }],
@@ -716,7 +716,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         assert.roughEqual(collectorWidth, cellWidth - 4, 1.5, "DropDown button has correct width");
     });
 
-    QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source", (assert) => {
+    QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source", function(assert) {
         const dataSource = [{
             startDate: new Date(2015, 4, 24, 9),
             endDate: new Date(2015, 4, 24, 11),
@@ -736,7 +736,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
         this.checkItemDataInDropDownTemplate(assert, dataSource, new Date(2015, 4, 24));
     });
 
-    QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source for recurrence rule", (assert) => {
+    QUnit.test("The itemData argument of the drop down appointment template is should be instance of the data source for recurrence rule", function(assert) {
         const dataSource = [{
             startDate: new Date(2015, 4, 24, 9),
             endDate: new Date(2015, 4, 24, 11),
@@ -762,7 +762,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = false", {
 });
 
 QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
         this.clock = sinon.useFakeTimers();
         this.tasks = [
@@ -786,12 +786,12 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         };
         this.scheduler = new SchedulerTestWrapper(this.instance);
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("There are no ordinary appointments on adaptive month view", (assert) => {
+    QUnit.test("There are no ordinary appointments on adaptive month view", function(assert) {
         this.createInstance();
 
         assert.equal(this.scheduler.appointments.compact.getButtonCount(), 1, "Collector is rendered");
@@ -803,7 +803,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.equal(this.scheduler.appointments.getAppointmentCount(), 0, "Appointments are not rendered");
     });
 
-    QUnit.test("There are no ordinary appointments on adaptive week view allDay panel", (assert) => {
+    QUnit.test("There are no ordinary appointments on adaptive week view allDay panel", function(assert) {
         this.createInstance();
 
         this.instance.option("dataSource", [{ startDate: new Date(2019, 2, 4), text: "a", endDate: new Date(2019, 2, 4, 0, 30), allDay: true }]);
@@ -813,7 +813,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.equal(this.scheduler.appointments.getAppointmentCount(), 0, "Appointments are not rendered");
     });
 
-    QUnit.test("Adaptive collector should have correct coordinates", (assert) => {
+    QUnit.test("Adaptive collector should have correct coordinates", function(assert) {
         this.createInstance();
 
         let $collector = this.scheduler.appointments.compact.getButton(0);
@@ -825,7 +825,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.roughEqual(buttonCoordinates.top, expectedCoordinates.top + this.scheduler.workSpace.getCellHeight() - ADAPTIVE_COLLECTOR_BOTTOM_OFFSET, 1.001, "Top coordinate is OK");
     });
 
-    QUnit.test("Adaptive collector should have correct sizes", (assert) => {
+    QUnit.test("Adaptive collector should have correct sizes", function(assert) {
         this.createInstance();
 
         let $collector = this.scheduler.appointments.compact.getButton(0);
@@ -834,7 +834,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.roughEqual($collector.outerHeight(), ADAPTIVE_COLLECTOR_DEFAULT_SIZE, 1.001, "Height is OK");
     });
 
-    QUnit.test("Adaptive collector should have correct size in material theme", (assert) => {
+    QUnit.test("Adaptive collector should have correct size in material theme", function(assert) {
         const origIsMaterial = themes.isMaterial;
         themes.isMaterial = () => true;
 
@@ -847,7 +847,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         themes.isMaterial = origIsMaterial;
     });
 
-    QUnit.test("Adaptive collector should have correct coordinates on allDay panel", (assert) => {
+    QUnit.test("Adaptive collector should have correct coordinates on allDay panel", function(assert) {
         this.createInstance();
 
         this.instance.option("dataSource", [{ startDate: new Date(2019, 2, 4), text: "a", endDate: new Date(2019, 2, 4, 0, 30), allDay: true }]);
@@ -862,7 +862,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.roughEqual(buttonCoordinates.top, (this.scheduler.workSpace.getAllDayCellHeight() - ADAPTIVE_COLLECTOR_DEFAULT_SIZE) / 2, 1.001, "Top coordinate is OK");
     });
 
-    QUnit.test("Adaptive collector should have correct sizes on allDayPanel", (assert) => {
+    QUnit.test("Adaptive collector should have correct sizes on allDayPanel", function(assert) {
         this.createInstance();
 
         this.instance.option("dataSource", [{ startDate: new Date(2019, 2, 4), text: "a", endDate: new Date(2019, 2, 4, 0, 30), allDay: true }]);
@@ -874,7 +874,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.roughEqual($collector.outerHeight(), ADAPTIVE_COLLECTOR_DEFAULT_SIZE, 1.001, "Height is OK");
     });
 
-    QUnit.test("Ordinary appointment count depends on scheduler width on week view", (assert) => {
+    QUnit.test("Ordinary appointment count depends on scheduler width on week view", function(assert) {
         this.createInstance();
 
         this.instance.option("dataSource", [{ startDate: new Date(2019, 2, 4), text: "a", endDate: new Date(2019, 2, 4, 0, 30) }, { startDate: new Date(2019, 2, 4), text: "b", endDate: new Date(2019, 2, 4, 0, 30) }]);
@@ -894,7 +894,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.equal(this.scheduler.appointments.getAppointmentCount(), 2, "Appointments are rendered");
     });
 
-    QUnit.test("Ordinary appointments should have correct sizes on week view", (assert) => {
+    QUnit.test("Ordinary appointments should have correct sizes on week view", function(assert) {
         this.createInstance();
 
         this.instance.option("dataSource", [{ startDate: new Date(2019, 2, 4), text: "a", endDate: new Date(2019, 2, 4, 0, 30) }, { startDate: new Date(2019, 2, 4), text: "b", endDate: new Date(2019, 2, 4, 0, 30) }]);
@@ -917,7 +917,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.roughEqual($secondAppointment.outerHeight(), 50, 1.001, "Height is OK");
     });
 
-    QUnit.test("Adaptive collector should have correct coordinates on week view", (assert) => {
+    QUnit.test("Adaptive collector should have correct coordinates on week view", function(assert) {
         this.createInstance();
 
         this.instance.option("dataSource", [{ startDate: new Date(2019, 2, 4), text: "a", endDate: new Date(2019, 2, 4, 0, 30) }, { startDate: new Date(2019, 2, 4), text: "b", endDate: new Date(2019, 2, 4, 0, 30) }]);
@@ -932,7 +932,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         assert.roughEqual(collectorCoordinates.top, expectedCoordinates.top, 1.001, "Top coordinate is OK");
     });
 
-    QUnit.test("Adaptive collector should have correct coordinates coordinates on week view in compact theme", (assert) => {
+    QUnit.test("Adaptive collector should have correct coordinates coordinates on week view in compact theme", function(assert) {
         try {
             this.themeMock = sinon.stub(themes, "current").returns("generic.light.compact");
             this.createInstance();
@@ -950,7 +950,7 @@ QUnit.module("Integration: Appointments Collector, adaptivityEnabled = true", {
         }
     });
 
-    QUnit.test("Adaptive collector should have correct sizes on week view", (assert) => {
+    QUnit.test("Adaptive collector should have correct sizes on week view", function(assert) {
         this.createInstance();
 
         this.instance.option("dataSource", [{ startDate: new Date(2019, 2, 4), text: "a", endDate: new Date(2019, 2, 4, 0, 30) }, { startDate: new Date(2019, 2, 4), text: "b", endDate: new Date(2019, 2, 4, 0, 30) }]);

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
@@ -1178,7 +1178,7 @@ QUnit.module("New common tooltip for compact and cell appointments", moduleConfi
         module("Keyboard navigation in tooltip", () => {
             const ITEM_FOCUSED_STATE_CLASS_NAME = "dx-state-focused";
 
-            test("List should be navigate by keyboard", assert => {
+            test("List should be navigate by keyboard", function(assert) {
                 const scheduler = createScheduler();
 
                 const checkFocusedState = index => scheduler.tooltip.getItemElement(index).hasClass(ITEM_FOCUSED_STATE_CLASS_NAME);
@@ -1204,7 +1204,7 @@ QUnit.module("New common tooltip for compact and cell appointments", moduleConfi
                 assert.ok(checkFocusedState(1), "After press key down, second list item should focused");
             });
 
-            test("focusStateEnabled property should disable or enable navigate in list", assert => {
+            test("focusStateEnabled property should disable or enable navigate in list", function(assert) {
                 const scheduler = createScheduler();
 
                 scheduler.appointments.click();
@@ -1313,7 +1313,7 @@ QUnit.module("New common tooltip for compact and cell appointments", moduleConfi
         assert.roughEqual(getItemElement().outerHeight(), getOverlayContentElement().outerHeight(), 10, "Tooltip height should equals then list height");
     });
 
-    test("Component should draw correctly, if component append to container in appointmentTooltipTemplate", assert => {
+    test("Component should draw correctly, if component append to container in appointmentTooltipTemplate", function(assert) {
         const data = [
             {
                 text: "Website Re-Design Plan",

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.crossScrollingEnabled.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.crossScrollingEnabled.tests.js
@@ -27,7 +27,7 @@ const config = {
 module("crossScrollingEnabled = true", config, () => {
     const isMobile = devices.current().deviceType !== "desktop";
 
-    test("Appointments should be rendered on the same line after navigating to the next month(T804721)", assert => {
+    test("Appointments should be rendered on the same line after navigating to the next month(T804721)", function(assert) {
         const expectedTop = 26;
         const views = ["timelineMonth", "timelineWeek"];
 
@@ -73,7 +73,7 @@ module("crossScrollingEnabled = true", config, () => {
         });
     });
 
-    test("Appointment should have correct position while vertical dragging", assert => {
+    test("Appointment should have correct position while vertical dragging", function(assert) {
         const scheduler = createWrapper({
             currentDate: new Date(2015, 6, 10),
             editing: true,
@@ -116,7 +116,7 @@ module("crossScrollingEnabled = true", config, () => {
         pointer.up();
     });
 
-    test("Appointments should be repainted if the 'crossScrollingEnabled' is changed", assert => {
+    test("Appointments should be repainted if the 'crossScrollingEnabled' is changed", function(assert) {
         const scheduler = createWrapper({
             currentDate: new Date(2015, 6, 10),
             dataSource: [{
@@ -136,7 +136,7 @@ module("crossScrollingEnabled = true", config, () => {
     });
 
     if(!isMobile) {
-        test("Month appointment inside grouped view should have a right resizable area after horizontal scroll end", assert => {
+        test("Month appointment inside grouped view should have a right resizable area after horizontal scroll end", function(assert) {
             const scheduler = createWrapper({
                 currentDate: new Date(2015, 6, 10),
                 views: ["month"],
@@ -177,7 +177,7 @@ module("crossScrollingEnabled = true", config, () => {
             assert.equal($appointment.dxResizable("instance").option("area").right, initialResizableAreaRight - scrollOffset);
         });
 
-        test("Appointment should have correct position while horizontal dragging", assert => {
+        test("Appointment should have correct position while horizontal dragging", function(assert) {
             const dragDistance = 150;
 
             const scheduler = createWrapper({
@@ -202,7 +202,7 @@ module("crossScrollingEnabled = true", config, () => {
             pointer.up();
         });
 
-        test("Appointment should have correct position while horizontal dragging, crossScrollingEnabled = true (T732885)", assert => {
+        test("Appointment should have correct position while horizontal dragging, crossScrollingEnabled = true (T732885)", function(assert) {
             const scheduler = createWrapper({
                 height: 500,
                 editing: true,
@@ -230,7 +230,7 @@ module("crossScrollingEnabled = true", config, () => {
             pointer.up();
         });
 
-        test("Appointment should have correct position while horizontal dragging in scrolled date table", assert => {
+        test("Appointment should have correct position while horizontal dragging in scrolled date table", function(assert) {
             const scheduler = createWrapper({
                 height: 500,
                 width: 800,

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointments.tests.js
@@ -3837,21 +3837,21 @@ QUnit.module("Appointments", () => {
     }];
 
     QUnit.module("appointmentTemplate", () => {
-        QUnit.test("model.targetedAppointmentData argument should have current appointment data", assert => {
+        QUnit.test("model.targetedAppointmentData argument should have current appointment data", function(assert) {
             const scheduler = createScheduler(commonData);
             scheduler.option({ appointmentTemplate: createTestForCommonData(assert) });
 
             assert.ok(eventCallCount === 5, "appointmentTemplate should be raised");
         });
 
-        QUnit.test("model.targetedAppointmentData argument should have current appointment data in case recurrence", assert => {
+        QUnit.test("model.targetedAppointmentData argument should have current appointment data in case recurrence", function(assert) {
             const scheduler = createScheduler(recurrenceData);
             scheduler.option({ appointmentTemplate: createTestForRecurrenceData(assert, scheduler) });
 
             assert.ok(eventCallCount === 5, "appointmentTemplate should be raised");
         });
 
-        QUnit.test("model.targetedAppointmentData argument should have current appointment data in case recurrence and custom data properties", assert => {
+        QUnit.test("model.targetedAppointmentData argument should have current appointment data in case recurrence and custom data properties", function(assert) {
             const scheduler = createScheduler(recurrenceDataWithCustomNames, {
                 textExpr: "textCustom",
                 startDateExpr: "startDateCustom",
@@ -3864,7 +3864,7 @@ QUnit.module("Appointments", () => {
     });
 
     QUnit.module("appointmentTooltipTemplate", () => {
-        QUnit.test("model.targetedAppointmentData argument should have current appointment data", assert => {
+        QUnit.test("model.targetedAppointmentData argument should have current appointment data", function(assert) {
             const scheduler = createScheduler(commonData);
             scheduler.option({ appointmentTooltipTemplate: createTestForCommonData(assert, true) });
 
@@ -3875,7 +3875,7 @@ QUnit.module("Appointments", () => {
             assert.ok(eventCallCount === 5, "appointmentTemplate should be raised");
         });
 
-        QUnit.test("model.targetedAppointmentData argument should have current appointment data in case recurrence", assert => {
+        QUnit.test("model.targetedAppointmentData argument should have current appointment data in case recurrence", function(assert) {
             const scheduler = createScheduler(recurrenceData);
             scheduler.option({ appointmentTooltipTemplate: createTestForRecurrenceData(assert, scheduler) });
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.common.tests.js
@@ -18,7 +18,7 @@ const moduleConfig = {
 
 module("Views:startDate property", moduleConfig, () => {
     module("Month", () => {
-        test("if set startDate shouldn't throw exception(T828646)", assert => {
+        test("if set startDate shouldn't throw exception(T828646)", function(assert) {
             const data = [{
                 text: "Google AdWords Strategy",
                 startDate: new Date(2019, 10, 1, 9, 0, 0),

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.resources.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.resources.tests.js
@@ -29,7 +29,7 @@ const moduleConfig = {
 };
 
 QUnit.module("Integration: Resources", moduleConfig, () => {
-    QUnit.test("Grouping by value = 0 in case nested groups shouldn't ignore(T821935)", assert => {
+    QUnit.test("Grouping by value = 0 in case nested groups shouldn't ignore(T821935)", function(assert) {
         const views = ["timelineDay", "day"];
         const expectedValues = [
             {
@@ -122,7 +122,7 @@ QUnit.module("Integration: Resources", moduleConfig, () => {
         });
     });
 
-    QUnit.test("Resource editors should have valid value after show appointment form", assert => {
+    QUnit.test("Resource editors should have valid value after show appointment form", function(assert) {
         const dataSource = [{
             text: "Task 1",
             ownerId: 1,
@@ -606,7 +606,7 @@ if(devices.real().deviceType === "desktop") {
         const SCHEDULER_HORIZONTAL_SCROLLBAR = ".dx-scheduler-date-table-scrollable .dx-scrollbar-horizontal";
         const SCHEDULER_SCROLLBAR_CONTAINER = ".dx-scheduler-work-space-both-scrollbar";
 
-        QUnit.test("Scheduler with multiple resources and fixed height container has visible horizontal scrollbar (T716993)", assert => {
+        QUnit.test("Scheduler with multiple resources and fixed height container has visible horizontal scrollbar (T716993)", function(assert) {
             const getData = function(count) {
                 let result = [];
                 for(let i = 0; i < count; i++) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.timeline.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.timeline.tests.js
@@ -34,7 +34,7 @@ QUnit.module("Integration: Timeline", {
     }
 });
 
-QUnit.test("Special classes should be applied in grouped timeline", assert => {
+QUnit.test("Special classes should be applied in grouped timeline", function(assert) {
     let $style = $("<style>").text('#scheduler .dx-scheduler-cell-sizes-vertical {height: 100px } ');
 
     try {
@@ -66,7 +66,7 @@ QUnit.test("Special classes should be applied in grouped timeline", assert => {
     }
 });
 
-QUnit.test("Scheduler should have a right timeline work space", assert => {
+QUnit.test("Scheduler should have a right timeline work space", function(assert) {
     let scheduler = createInstance({
         views: ["timelineDay", "timelineWeek", "timelineWorkWeek", "timelineMonth"],
         currentView: "timelineDay"
@@ -84,7 +84,7 @@ QUnit.test("Scheduler should have a right timeline work space", assert => {
     assert.ok(scheduler.workSpace.getWorkSpace().dxSchedulerTimelineMonth("instance"), "Work space is timelineMonth after change option ");
 });
 
-QUnit.test("Scheduler should not update scroll position if appointment is visible, timeline day view ", assert => {
+QUnit.test("Scheduler should not update scroll position if appointment is visible, timeline day view ", function(assert) {
     let scheduler = createInstance({
         currentDate: new Date(2015, 1, 9),
         dataSource: new DataSource({
@@ -106,7 +106,7 @@ QUnit.test("Scheduler should not update scroll position if appointment is visibl
     }
 });
 
-QUnit.test("Scheduler should not update scroll position if appointment is visible, timeline week view ", assert => {
+QUnit.test("Scheduler should not update scroll position if appointment is visible, timeline week view ", function(assert) {
     let scheduler = createInstance({
         firstDayOfWeek: 1,
         currentDate: new Date(2015, 2, 2),
@@ -134,7 +134,7 @@ QUnit.test("Scheduler should not update scroll position if appointment is visibl
     }
 });
 
-QUnit.test("Scheduler should update scroll position if appointment is not visible, timeline week view ", assert => {
+QUnit.test("Scheduler should update scroll position if appointment is not visible, timeline week view ", function(assert) {
     let scheduler = createInstance({
         firstDayOfWeek: 1,
         currentDate: new Date(2015, 2, 2),
@@ -162,7 +162,7 @@ QUnit.test("Scheduler should update scroll position if appointment is not visibl
     }
 });
 
-QUnit.test("getEndViewDate should return correct value on timelineMonth view DST date (T720694)", assert => {
+QUnit.test("getEndViewDate should return correct value on timelineMonth view DST date (T720694)", function(assert) {
     let scheduler = createInstance({
         currentDate: new Date(2019, 2, 5),
         views: ["timelineMonth"],
@@ -175,7 +175,7 @@ QUnit.test("getEndViewDate should return correct value on timelineMonth view DST
     assert.deepEqual(workSpace.getEndViewDate(), new Date(2019, 2, 31, 23, 59), "End view date is OK");
 });
 
-QUnit.test("Scheduler should not update scroll position if appointment is visible, timeline month view ", assert => {
+QUnit.test("Scheduler should not update scroll position if appointment is visible, timeline month view ", function(assert) {
     let scheduler = createInstance({
         firstDayOfWeek: 1,
         currentDate: new Date(2015, 2, 2),
@@ -203,7 +203,7 @@ QUnit.test("Scheduler should not update scroll position if appointment is visibl
     }
 });
 
-QUnit.test("Scheduler should update scroll position if appointment is not visible, timeline month view ", assert => {
+QUnit.test("Scheduler should update scroll position if appointment is not visible, timeline month view ", function(assert) {
     let scheduler = createInstance({
         firstDayOfWeek: 1,
         currentDate: new Date(2015, 2, 2),
@@ -231,7 +231,7 @@ QUnit.test("Scheduler should update scroll position if appointment is not visibl
     }
 });
 
-QUnit.test("Appointments should have a right order on timeline month(lots of appts)", assert => {
+QUnit.test("Appointments should have a right order on timeline month(lots of appts)", function(assert) {
     let scheduler = createInstance({
         currentDate: new Date(2016, 1, 2),
         maxAppointmentsPerCell: null,
@@ -298,7 +298,7 @@ QUnit.test("Appointments should have a right order on timeline month(lots of app
     assert.roughEqual(translator.locate(scheduler.appointments.getAppointment(3)).top, 300, 2.001, "Appointment position is OK");
 });
 
-QUnit.test("Appointments should have a right order on timeline month", assert => {
+QUnit.test("Appointments should have a right order on timeline month", function(assert) {
     let scheduler = createInstance({
         currentDate: new Date(2016, 1, 2),
         dataSource: new DataSource([
@@ -324,7 +324,7 @@ QUnit.test("Appointments should have a right order on timeline month", assert =>
     assert.equal($appointments.eq(1).data("dxItemData").text, "a", "Appointment data is OK");
 });
 
-QUnit.test("Scheduler timeline dateTable should have right height after changing size if crossScrollingEnabled = true (T644407)", assert => {
+QUnit.test("Scheduler timeline dateTable should have right height after changing size if crossScrollingEnabled = true (T644407)", function(assert) {
     const resourcesData = [
         { text: "One", id: 2 },
         { text: "Two", id: 3 },
@@ -357,7 +357,7 @@ QUnit.test("Scheduler timeline dateTable should have right height after changing
     assert.equal(scheduler.workSpace.getCell(0).height(), cellHeight, "Cells has correct height");
 });
 
-QUnit.test("Scheduler timeline groupTable should have right height if widget has auto-height", assert => {
+QUnit.test("Scheduler timeline groupTable should have right height if widget has auto-height", function(assert) {
     const resourcesData = [
         { text: "One", id: 2 },
         { text: "Two", id: 3 },

--- a/testing/tests/DevExpress.ui.widgets.scheduler/navigator.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/navigator.markup.tests.js
@@ -13,7 +13,7 @@ QUnit.testStart(() => {
 });
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         devices.current({ platform: "generic" });
         this.instance = $("#navigator").dxSchedulerNavigator().dxSchedulerNavigator("instance");
         this.instance.notifyObserver = noop.noop;
@@ -21,17 +21,17 @@ const moduleConfig = {
 };
 
 QUnit.module("Navigator markup", moduleConfig, () => {
-    QUnit.test("Scheduler navigator should be initialized", (assert) => {
+    QUnit.test("Scheduler navigator should be initialized", function(assert) {
         assert.ok(this.instance instanceof SchedulerNavigator, "dxSchedulerNavigator was initialized");
     });
 
-    QUnit.test("Scheduler navigator should have a right css class", (assert) => {
+    QUnit.test("Scheduler navigator should have a right css class", function(assert) {
         var $element = this.instance.$element();
 
         assert.ok($element.hasClass("dx-scheduler-navigator"), "dxSchedulerNavigator has 'dx-scheduler-navigator' css class");
     });
 
-    QUnit.test("Scheduler navigator should contain the 'next' button", (assert) => {
+    QUnit.test("Scheduler navigator should contain the 'next' button", function(assert) {
         var $element = this.instance.$element();
 
         var $button = $element.find(".dx-scheduler-navigator-next");
@@ -41,7 +41,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal($button.attr("aria-label"), "Next period", "Navigator 'next' button has right label");
     });
 
-    QUnit.test("Scheduler navigator should contain the 'previous' button", (assert) => {
+    QUnit.test("Scheduler navigator should contain the 'previous' button", function(assert) {
         var $element = this.instance.$element();
 
         var $button = $element.find(".dx-scheduler-navigator-previous");
@@ -51,7 +51,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal($button.attr("aria-label"), "Previous period", "Navigator 'previous' button has right label");
     });
 
-    QUnit.test("Scheduler navigator should contain the 'caption' button", (assert) => {
+    QUnit.test("Scheduler navigator should contain the 'caption' button", function(assert) {
         var $element = this.instance.$element();
 
         var $button = $element.find(".dx-scheduler-navigator-caption");
@@ -60,7 +60,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.ok($button.hasClass("dx-button"), "Navigator 'caption' is dxButton");
     });
 
-    QUnit.test("Caption should be OK with default options", (assert) => {
+    QUnit.test("Caption should be OK with default options", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(),
@@ -69,7 +69,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Caption is OK");
     });
 
-    QUnit.test("customizeDateNavigatorText shoulde be applied correctly", (assert) => {
+    QUnit.test("customizeDateNavigatorText shoulde be applied correctly", function(assert) {
         var $element = this.instance.$element(),
             date = new Date(2018, 11, 14, 9, 20),
             caption = [dateLocalization.format(date, "day"), dateLocalization.format(date, "monthAndYear")].join(" ");
@@ -88,7 +88,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
     });
 
 
-    QUnit.test("Caption should be OK when step and date are changed", (assert) => {
+    QUnit.test("Caption should be OK when step and date are changed", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2015, 0, 24),
@@ -124,7 +124,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Step is agenda: Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for workWeek view & firstDayOfWeek = 0", (assert) => {
+    QUnit.test("Caption should be OK for workWeek view & firstDayOfWeek = 0", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2015, 0, 24);
@@ -138,7 +138,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Step is workWeek: Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for Day with intervalCount", (assert) => {
+    QUnit.test("Caption should be OK for Day with intervalCount", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2015, 4, 25),
@@ -150,7 +150,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for workWeek view with intervalCount", (assert) => {
+    QUnit.test("Caption should be OK for workWeek view with intervalCount", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2015, 4, 25),
@@ -164,7 +164,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for week view with intervalCount", (assert) => {
+    QUnit.test("Caption should be OK for week view with intervalCount", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2015, 4, 25),
@@ -178,7 +178,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for Month with intervalCount", (assert) => {
+    QUnit.test("Caption should be OK for Month with intervalCount", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2017, 4, 25),
@@ -191,7 +191,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for Month with intervalCount for different years", (assert) => {
+    QUnit.test("Caption should be OK for Month with intervalCount for different years", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2017, 10, 25),
@@ -204,7 +204,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for workWeek view, if date = Sunday", (assert) => {
+    QUnit.test("Caption should be OK for workWeek view, if date = Sunday", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2016, 0, 10);
@@ -218,7 +218,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Step is workWeek: Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for workWeek view, if date = Sunday and firstDayOfWeek != 0", (assert) => {
+    QUnit.test("Caption should be OK for workWeek view, if date = Sunday and firstDayOfWeek != 0", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2016, 0, 10);
@@ -232,7 +232,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Step is workWeek: Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for workWeek view, if date = Saturday & firstDayOfWeek = 6", (assert) => {
+    QUnit.test("Caption should be OK for workWeek view, if date = Saturday & firstDayOfWeek = 6", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2016, 0, 9);
@@ -246,7 +246,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Step is workWeek: Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for workWeek view, if date = Sunday & firstDayOfWeek = 6", (assert) => {
+    QUnit.test("Caption should be OK for workWeek view, if date = Sunday & firstDayOfWeek = 6", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2016, 0, 10);
@@ -260,7 +260,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), caption, "Step is workWeek: Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for week view, if date = Sunday & firstDayOfWeek = 1", (assert) => {
+    QUnit.test("Caption should be OK for week view, if date = Sunday & firstDayOfWeek = 1", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2015, 2, 1);
@@ -272,7 +272,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), "23 Feb-1 Mar 2015", "Step is week: Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for agenda view, different months", (assert) => {
+    QUnit.test("Caption should be OK for agenda view, different months", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance"),
             date = new Date(2015, 2, 29);
@@ -283,7 +283,7 @@ QUnit.module("Navigator markup", moduleConfig, () => {
         assert.equal(button.option("text"), "29 Mar-4 Apr 2015", "Step is week: Caption is OK");
     });
 
-    QUnit.test("Caption should be OK for workWeek view and depends on displayedDate", (assert) => {
+    QUnit.test("Caption should be OK for workWeek view and depends on displayedDate", function(assert) {
         var $element = this.instance.$element(),
             button = $element.find(".dx-scheduler-navigator-caption").dxButton("instance");
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/timeline.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/timeline.markup.tests.js
@@ -47,7 +47,7 @@ const stubInvokeMethod = (instance) => {
 };
 
 const moduleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimeline().dxSchedulerTimeline("instance");
             stubInvokeMethod(this.instance, options);
@@ -58,15 +58,15 @@ const moduleConfig = {
 };
 
 QUnit.module("Timeline markup", moduleConfig, () => {
-    QUnit.test("Scheduler timeline should be initialized", (assert) => {
+    QUnit.test("Scheduler timeline should be initialized", function(assert) {
         assert.ok(this.instance instanceof SchedulerTimeline, "dxSchedulerTimeLine was initialized");
     });
 
-    QUnit.test("Scheduler timeline should have right groupedStrategy by default", (assert) => {
+    QUnit.test("Scheduler timeline should have right groupedStrategy by default", function(assert) {
         assert.ok(this.instance._groupedStrategy instanceof SchedulerWorkSpaceVerticalStrategy, "Grouped strategy is right");
     });
 
-    QUnit.test("Two scrollable elements should be rendered", (assert) => {
+    QUnit.test("Two scrollable elements should be rendered", function(assert) {
         let $dateTableScrollable = this.instance.$element().find(".dx-scheduler-date-table-scrollable"),
             $headerScrollable = this.instance.$element().find(".dx-scheduler-header-scrollable");
 
@@ -78,27 +78,27 @@ QUnit.module("Timeline markup", moduleConfig, () => {
         assert.ok($headerScrollable.dxScrollable("instance"), "Header scrollable is instance of dxScrollable");
     });
 
-    QUnit.test("Both scrollable elements should be rendered if crossScrollingEnabled=true", (assert) => {
+    QUnit.test("Both scrollable elements should be rendered if crossScrollingEnabled=true", function(assert) {
         this.instance.option("crossScrollingEnabled", true);
         assert.ok(this.instance.$element().hasClass("dx-scheduler-work-space-both-scrollbar"), "CSS class is OK");
         this.instance.option("crossScrollingEnabled", false);
         assert.notOk(this.instance.$element().hasClass("dx-scheduler-work-space-both-scrollbar"), "CSS class is OK");
     });
 
-    QUnit.test("Date table scrollable should have right config", (assert) => {
+    QUnit.test("Date table scrollable should have right config", function(assert) {
         let dateTableScrollable = this.instance.$element().find(".dx-scheduler-date-table-scrollable").dxScrollable("instance");
 
         assert.equal(dateTableScrollable.option("direction"), "horizontal", "Direction is OK");
     });
 
-    QUnit.test("Date table scrollable should have right config for crossScrolling", (assert) => {
+    QUnit.test("Date table scrollable should have right config for crossScrolling", function(assert) {
         this.instance.option("crossScrollingEnabled", true);
         let dateTableScrollable = this.instance.$element().find(".dx-scheduler-date-table-scrollable").dxScrollable("instance");
 
         assert.equal(dateTableScrollable.option("direction"), "both", "Direction is OK");
     });
 
-    QUnit.test("Sidebar should contain group table in grouped mode", (assert) => {
+    QUnit.test("Sidebar should contain group table in grouped mode", function(assert) {
         let $element = this.instance.$element();
 
         this.instance.option("groups", [{ name: "one", items: [{ id: 1, text: "a" }, { id: 2, text: "b" }] }]);
@@ -107,7 +107,7 @@ QUnit.module("Timeline markup", moduleConfig, () => {
         assert.equal($groupTable.length, 1, "Group table is rendered");
     });
 
-    QUnit.test("Header panel should not contain group rows in grouped mode", (assert) => {
+    QUnit.test("Header panel should not contain group rows in grouped mode", function(assert) {
         let $element = this.instance.$element();
 
         this.instance.option("groups", [{ name: "one", items: [{ id: 1, text: "a" }, { id: 2, text: "b" }] }]);
@@ -116,7 +116,7 @@ QUnit.module("Timeline markup", moduleConfig, () => {
         assert.strictEqual($groupRows.length, 0, "Header panel does not contain any group row");
     });
 
-    QUnit.test("Group table should contain right rows and cells count", (assert) => {
+    QUnit.test("Group table should contain right rows and cells count", function(assert) {
         let $element = this.instance.$element();
 
         this.instance.option("groups", [
@@ -134,7 +134,7 @@ QUnit.module("Timeline markup", moduleConfig, () => {
         assert.equal($secondColumnCells.length, 4, "Cell count is OK");
     });
 
-    QUnit.test("Timeline should have the right 'dx-group-column-count' attr depend on group count", (assert) => {
+    QUnit.test("Timeline should have the right 'dx-group-column-count' attr depend on group count", function(assert) {
         let $element = this.instance.$element();
 
         this.instance.option("groups", [
@@ -152,7 +152,7 @@ QUnit.module("Timeline markup", moduleConfig, () => {
 });
 
 let timelineDayModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineDay().dxSchedulerTimelineDay("instance");
             stubInvokeMethod(this.instance, options);
@@ -163,24 +163,24 @@ let timelineDayModuleConfig = {
 };
 
 QUnit.module("TimelineDay markup", timelineDayModuleConfig, () => {
-    QUnit.test("Scheduler timelineDay should be initialized", (assert) => {
+    QUnit.test("Scheduler timelineDay should be initialized", function(assert) {
         assert.ok(this.instance instanceof SchedulerTimelineDay, "dxSchedulerTimeLineDay was initialized");
     });
 
-    QUnit.test("Scheduler timeline day should have a right css class", (assert) => {
+    QUnit.test("Scheduler timeline day should have a right css class", function(assert) {
         let $element = this.instance.$element();
         assert.ok($element.hasClass("dx-scheduler-timeline"), "dxSchedulerTimelineDay has 'dx-scheduler-timeline' css class");
         assert.ok($element.hasClass("dx-scheduler-timeline-day"), "dxSchedulerTimelineDay has 'dx-scheduler-timeline' css class");
     });
 
-    QUnit.test("Scheduler timeline day view should have right cell & row count", (assert) => {
+    QUnit.test("Scheduler timeline day view should have right cell & row count", function(assert) {
         let $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-date-table-row").length, 1, "Date table has 1 rows");
         assert.equal($element.find(".dx-scheduler-date-table-cell").length, 48, "Date table has 48 cells");
     });
 
-    QUnit.test("Scheduler timeline day should have rigth first view date", (assert) => {
+    QUnit.test("Scheduler timeline day should have rigth first view date", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21),
             firstDayOfWeek: 1,
@@ -190,7 +190,7 @@ QUnit.module("TimelineDay markup", timelineDayModuleConfig, () => {
         assert.deepEqual(this.instance.getStartViewDate(), new Date(2015, 9, 21, 4), "First view date is OK");
     });
 
-    QUnit.test("Each cell of scheduler timeline day should contain rigth jQuery dxCellData", (assert) => {
+    QUnit.test("Each cell of scheduler timeline day should contain rigth jQuery dxCellData", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21),
             firstDayOfWeek: 1,
@@ -219,7 +219,7 @@ QUnit.module("TimelineDay markup", timelineDayModuleConfig, () => {
         }, "data of 10th cell is rigth");
     });
 
-    QUnit.test("Each cell of grouped scheduler timeline day should contain rigth jQuery dxCellData", (assert) => {
+    QUnit.test("Each cell of grouped scheduler timeline day should contain rigth jQuery dxCellData", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21),
             firstDayOfWeek: 1,
@@ -264,14 +264,14 @@ QUnit.module("TimelineDay markup", timelineDayModuleConfig, () => {
         }, "data of 10th cell is rigth");
     });
 
-    QUnit.test("Header panel should have right quantity of cells", (assert) => {
+    QUnit.test("Header panel should have right quantity of cells", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21, 0, 0)
         });
         checkHeaderCells(this.instance.$element(), assert);
     });
 
-    QUnit.test("Date table should have right quantity of cells", (assert) => {
+    QUnit.test("Date table should have right quantity of cells", function(assert) {
         var $element = this.instance.$element();
 
         this.instance.option("groups", [{ name: "one", items: [{ id: 1, text: "a" }, { id: 2, text: "b" }] }]);
@@ -282,7 +282,7 @@ QUnit.module("TimelineDay markup", timelineDayModuleConfig, () => {
         assert.equal($rows.eq(1).find(".dx-scheduler-date-table-cell").length, 48, "The second group row has 48 cells");
     });
 
-    QUnit.test("Scheduler timeline day should correctly process startDayHour=0", (assert) => {
+    QUnit.test("Scheduler timeline day should correctly process startDayHour=0", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 5, 30),
             startDayHour: 10
@@ -293,7 +293,7 @@ QUnit.module("TimelineDay markup", timelineDayModuleConfig, () => {
         assert.deepEqual(this.instance.getStartViewDate(), new Date(2015, 5, 30, 0), "First view date is correct");
     });
 
-    QUnit.test("Cell count should depend on start/end day hour & hoursInterval", (assert) => {
+    QUnit.test("Cell count should depend on start/end day hour & hoursInterval", function(assert) {
         let $element = this.instance.$element();
 
         this.instance.option({
@@ -308,7 +308,7 @@ QUnit.module("TimelineDay markup", timelineDayModuleConfig, () => {
 });
 
 timelineDayModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineDay({
                 currentDate: new Date(2015, 9, 16)
@@ -321,7 +321,7 @@ timelineDayModuleConfig = {
 };
 
 QUnit.module("TimelineDay with intervalCount markup", timelineDayModuleConfig, () => {
-    QUnit.test("TimelineDay has right intervalCount of cells with view option intervalCount", (assert) => {
+    QUnit.test("TimelineDay has right intervalCount of cells with view option intervalCount", function(assert) {
         this.instance.option("intervalCount", 2);
 
         var cells = this.instance.$element().find(".dx-scheduler-date-table-cell");
@@ -333,7 +333,7 @@ QUnit.module("TimelineDay with intervalCount markup", timelineDayModuleConfig, (
         assert.equal(cells.length, this.instance._getCellCountInDay() * 4, "view has right cell count");
     });
 
-    QUnit.test("TimelineDay Day view cells have right cellData with view option intervalCount=2", (assert) => {
+    QUnit.test("TimelineDay Day view cells have right cellData with view option intervalCount=2", function(assert) {
         this.instance.option("intervalCount", 2);
         this.instance.option("currentDate", new Date(2017, 5, 29));
 
@@ -347,7 +347,7 @@ QUnit.module("TimelineDay with intervalCount markup", timelineDayModuleConfig, (
         assert.deepEqual(secondCellData.endDate, new Date(2017, 5, 31, 0), "cell has right endtDate");
     });
 
-    QUnit.test("Get date range", (assert) => {
+    QUnit.test("Get date range", function(assert) {
         this.instance.option("currentDate", new Date(2015, 2, 16));
         this.instance.option("intervalCount", 2);
 
@@ -357,7 +357,7 @@ QUnit.module("TimelineDay with intervalCount markup", timelineDayModuleConfig, (
         assert.deepEqual(this.instance.getDateRange(), [new Date(2015, 2, 16, 0, 0), new Date(2015, 2, 19, 23, 59)], "Range is OK");
     });
 
-    QUnit.test("Scheduler timeline day header cells should have right class", (assert) => {
+    QUnit.test("Scheduler timeline day header cells should have right class", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 29),
             intervalCount: 2
@@ -368,7 +368,7 @@ QUnit.module("TimelineDay with intervalCount markup", timelineDayModuleConfig, (
         assert.equal($firstRow.find(".dx-scheduler-header-panel-week-cell").length, 2, "First row cells count and class is ok");
     });
 
-    QUnit.test("Scheduler timeline day should contain two rows in header panel, if intervalCount is set", (assert) => {
+    QUnit.test("Scheduler timeline day should contain two rows in header panel, if intervalCount is set", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 29),
             firstDayOfWeek: 1,
@@ -396,7 +396,7 @@ QUnit.module("TimelineDay with intervalCount markup", timelineDayModuleConfig, (
 });
 
 timelineDayModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineDay({
                 groupOrientation: "horizontal"
@@ -411,23 +411,23 @@ timelineDayModuleConfig = {
 };
 
 QUnit.module("TimelineDay with horizontal grouping markup", timelineDayModuleConfig, () => {
-    QUnit.test("Scheduler timeline day should have right groupedStrategy, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Scheduler timeline day should have right groupedStrategy, groupOrientation = horizontal", function(assert) {
         assert.ok(this.instance._groupedStrategy instanceof SchedulerWorkSpaceHorizontalStrategy, "Grouped strategy is right");
     });
 
-    QUnit.test("Scheduler timeline day should have a right css class, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Scheduler timeline day should have a right css class, groupOrientation = horizontal", function(assert) {
         let $element = this.instance.$element();
         assert.ok($element.hasClass("dx-scheduler-work-space-horizontal-grouped"), "dxSchedulerTimelineDay has 'dx-scheduler-work-space-horizontal-grouped' css class");
     });
 
-    QUnit.test("Scheduler timeline day view should have right cell & row count, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Scheduler timeline day view should have right cell & row count, groupOrientation = horizontal", function(assert) {
         let $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-date-table-row").length, 1, "Date table has 1 rows");
         assert.equal($element.find(".dx-scheduler-date-table-cell").length, 96, "Date table has 96 cells");
     });
 
-    QUnit.test("Each cell of scheduler timeline day should contain rigth jQuery dxCellData, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Each cell of scheduler timeline day should contain rigth jQuery dxCellData, groupOrientation = horizontal", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21),
             firstDayOfWeek: 1,
@@ -457,14 +457,14 @@ QUnit.module("TimelineDay with horizontal grouping markup", timelineDayModuleCon
         }, "data of 5th cell is rigth");
     });
 
-    QUnit.test("Header panel should have right quantity of cells, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Header panel should have right quantity of cells, groupOrientation = horizontal", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21, 0, 0)
         });
         checkHeaderCells(this.instance.$element(), assert, 0.5, 2);
     });
 
-    QUnit.test("Date table should have right quantity of cells, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Date table should have right quantity of cells, groupOrientation = horizontal", function(assert) {
         var $element = this.instance.$element();
 
         let $rows = $element.find(".dx-scheduler-date-table-row");
@@ -473,7 +473,7 @@ QUnit.module("TimelineDay with horizontal grouping markup", timelineDayModuleCon
         assert.equal($rows.eq(0).find(".dx-scheduler-date-table-cell").length, 48 * 2, "The first group row has 96 cells");
     });
 
-    QUnit.test("Header panel should contain group rows in grouped mode, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Header panel should contain group rows in grouped mode, groupOrientation = horizontal", function(assert) {
         let $element = this.instance.$element();
 
         let $groupRows = $element.find(".dx-scheduler-header-panel .dx-scheduler-group-row");
@@ -481,7 +481,7 @@ QUnit.module("TimelineDay with horizontal grouping markup", timelineDayModuleCon
         assert.strictEqual($groupRows.length, 1, "Header panel does not contain any group row");
     });
 
-    QUnit.test("Group table should contain right rows and cells count, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Group table should contain right rows and cells count, groupOrientation = horizontal", function(assert) {
         let $element = this.instance.$element();
 
         let $groupRows = $element.find(".dx-scheduler-group-row"),
@@ -491,7 +491,7 @@ QUnit.module("TimelineDay with horizontal grouping markup", timelineDayModuleCon
         assert.equal($firstRowCells.length, 2, "Cell count is OK");
     });
 
-    QUnit.test("Last group cell should have right class", (assert) => {
+    QUnit.test("Last group cell should have right class", function(assert) {
         let $element = this.instance.$element();
 
         assert.ok($element.find(".dx-scheduler-date-table-cell").eq(47).hasClass("dx-scheduler-last-group-cell"), 'cell has correct class');
@@ -499,7 +499,7 @@ QUnit.module("TimelineDay with horizontal grouping markup", timelineDayModuleCon
 });
 
 let timelineWeekModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineWeek().dxSchedulerTimelineWeek("instance");
             stubInvokeMethod(this.instance, options);
@@ -514,17 +514,17 @@ let formatWeekdayAndDay = function(date) {
 };
 
 QUnit.module("TimelineWeek markup", timelineWeekModuleConfig, () => {
-    QUnit.test("Scheduler timeline week should be initialized", (assert) => {
+    QUnit.test("Scheduler timeline week should be initialized", function(assert) {
         assert.ok(this.instance instanceof SchedulerTimelineWeek, "dxSchedulerTimeLineWeek was initialized");
     });
 
-    QUnit.test("Scheduler timeline week should have a right css class", (assert) => {
+    QUnit.test("Scheduler timeline week should have a right css class", function(assert) {
         let $element = this.instance.$element();
         assert.ok($element.hasClass("dx-scheduler-timeline"), "dxSchedulerTimelineWeek has 'dx-scheduler-timeline' css class");
         assert.ok($element.hasClass("dx-scheduler-timeline-week"), "dxSchedulerTimelineWeek has 'dx-scheduler-timeline' css class");
     });
 
-    QUnit.test("Scheduler timeline week view should have right cell & row count", (assert) => {
+    QUnit.test("Scheduler timeline week view should have right cell & row count", function(assert) {
         let $element = this.instance.$element();
 
 
@@ -532,7 +532,7 @@ QUnit.module("TimelineWeek markup", timelineWeekModuleConfig, () => {
         assert.equal($element.find(".dx-scheduler-date-table-cell").length, 336, "Date table has 336 cells");
     });
 
-    QUnit.test("Scheduler timeline week view should have right cell & row count is startDayHour and endDayHour are defined", (assert) => {
+    QUnit.test("Scheduler timeline week view should have right cell & row count is startDayHour and endDayHour are defined", function(assert) {
         this.instance.option({
             startDayHour: 9,
             endDayHour: 10,
@@ -552,7 +552,7 @@ QUnit.module("TimelineWeek markup", timelineWeekModuleConfig, () => {
         assert.equal($lastRow.find(".dx-scheduler-header-panel-cell").eq(2).text(), dateLocalization.format(new Date(2015, 9, 29, 9), "shorttime"));
     });
 
-    QUnit.test("Scheduler timeline week header cells should have right class", (assert) => {
+    QUnit.test("Scheduler timeline week header cells should have right class", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 29)
         });
@@ -562,7 +562,7 @@ QUnit.module("TimelineWeek markup", timelineWeekModuleConfig, () => {
         assert.equal($firstRow.find(".dx-scheduler-header-panel-week-cell").length, 7, "First row cells count and class is ok");
     });
 
-    QUnit.test("Scheduler timeline week should have rigth first view date", (assert) => {
+    QUnit.test("Scheduler timeline week should have rigth first view date", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21),
             firstDayOfWeek: 1,
@@ -572,7 +572,7 @@ QUnit.module("TimelineWeek markup", timelineWeekModuleConfig, () => {
         assert.deepEqual(this.instance.getStartViewDate(), new Date(2015, 9, 19, 4), "First view date is OK");
     });
 
-    QUnit.test("Scheduler timeline week should contain two rows in header panel", (assert) => {
+    QUnit.test("Scheduler timeline week should contain two rows in header panel", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 29),
             firstDayOfWeek: 1,
@@ -593,7 +593,7 @@ QUnit.module("TimelineWeek markup", timelineWeekModuleConfig, () => {
         }
     });
 
-    QUnit.test("Cell count should depend on start/end day hour & hoursInterval", (assert) => {
+    QUnit.test("Cell count should depend on start/end day hour & hoursInterval", function(assert) {
         let $element = this.instance.$element();
 
         this.instance.option({
@@ -609,7 +609,7 @@ QUnit.module("TimelineWeek markup", timelineWeekModuleConfig, () => {
 });
 
 timelineWeekModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineWeek(options).dxSchedulerTimelineWeek("instance");
             stubInvokeMethod(this.instance, options);
@@ -622,7 +622,7 @@ timelineWeekModuleConfig = {
 };
 
 QUnit.module("TimelineWeek with intervalCount markup", timelineWeekModuleConfig, () => {
-    QUnit.test("TimelineWeek has right count of cells with view option intervalCount", (assert) => {
+    QUnit.test("TimelineWeek has right count of cells with view option intervalCount", function(assert) {
         this.instance.option("intervalCount", 2);
 
         let cells = this.instance.$element().find(".dx-scheduler-date-table-cell");
@@ -634,7 +634,7 @@ QUnit.module("TimelineWeek with intervalCount markup", timelineWeekModuleConfig,
         assert.equal(cells.length, this.instance._getCellCountInDay() * 7 * 4, "view has right cell count");
     });
 
-    QUnit.test("TimelineWeek view cells have right cellData with view option intervalCount=2", (assert) => {
+    QUnit.test("TimelineWeek view cells have right cellData with view option intervalCount=2", function(assert) {
         this.instance.option("intervalCount", 2);
         this.instance.option("currentDate", new Date(2017, 5, 29));
 
@@ -648,7 +648,7 @@ QUnit.module("TimelineWeek with intervalCount markup", timelineWeekModuleConfig,
         assert.deepEqual(secondCellData.endDate, new Date(2017, 6, 9, 0), "cell has right endtDate");
     });
 
-    QUnit.test("Get date range", (assert) => {
+    QUnit.test("Get date range", function(assert) {
         this.instance.option("currentDate", new Date(2017, 5, 26));
         this.instance.option("intervalCount", 2);
         this.instance.option("firstDayOfWeek", 1);
@@ -659,7 +659,7 @@ QUnit.module("TimelineWeek with intervalCount markup", timelineWeekModuleConfig,
         assert.deepEqual(this.instance.getDateRange(), [new Date(2017, 5, 26, 0, 0), new Date(2017, 6, 23, 23, 59)], "Range is OK");
     });
 
-    QUnit.test("TimelineWeek view should contain right header if intervalCount=3", (assert) => {
+    QUnit.test("TimelineWeek view should contain right header if intervalCount=3", function(assert) {
         this.instance.option("currentDate", new Date(2017, 5, 26));
         this.instance.option("intervalCount", 3);
 
@@ -671,7 +671,7 @@ QUnit.module("TimelineWeek with intervalCount markup", timelineWeekModuleConfig,
 });
 
 timelineWeekModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineWeek({
                 groupOrientation: "horizontal"
@@ -686,14 +686,14 @@ timelineWeekModuleConfig = {
 };
 
 QUnit.module("TimelineWeek with horizontal grouping markup", timelineWeekModuleConfig, () => {
-    QUnit.test("Scheduler timeline day view should have right cell & row count, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Scheduler timeline day view should have right cell & row count, groupOrientation = horizontal", function(assert) {
         let $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-date-table-row").length, 1, "Date table has 1 rows");
         assert.equal($element.find(".dx-scheduler-date-table-cell").length, 336 * 2, "Date table has 672 cells");
     });
 
-    QUnit.test("Each cell of scheduler timeline week should contain rigth jQuery dxCellData, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Each cell of scheduler timeline week should contain rigth jQuery dxCellData, groupOrientation = horizontal", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21),
             firstDayOfWeek: 1,
@@ -723,7 +723,7 @@ QUnit.module("TimelineWeek with horizontal grouping markup", timelineWeekModuleC
         }, "data of 25th cell is rigth");
     });
 
-    QUnit.test("Header panel should contain group rows in grouped mode, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Header panel should contain group rows in grouped mode, groupOrientation = horizontal", function(assert) {
         let $element = this.instance.$element();
 
         let $groupRows = $element.find(".dx-scheduler-header-panel .dx-scheduler-group-row");
@@ -731,7 +731,7 @@ QUnit.module("TimelineWeek with horizontal grouping markup", timelineWeekModuleC
         assert.strictEqual($groupRows.length, 1, "Header panel does not contain any group row");
     });
 
-    QUnit.test("Group table should contain right rows and cells count, groupOrientation = horizontal", (assert) => {
+    QUnit.test("Group table should contain right rows and cells count, groupOrientation = horizontal", function(assert) {
         let $element = this.instance.$element();
 
         let $groupRows = $element.find(".dx-scheduler-group-row"),
@@ -743,7 +743,7 @@ QUnit.module("TimelineWeek with horizontal grouping markup", timelineWeekModuleC
 });
 
 let timelineWorkWeekModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineWorkWeek().dxSchedulerTimelineWorkWeek("instance");
             stubInvokeMethod(this.instance, options);
@@ -754,23 +754,23 @@ let timelineWorkWeekModuleConfig = {
 };
 
 QUnit.module("TimelineWorkWeek markup", timelineWorkWeekModuleConfig, () => {
-    QUnit.test("Scheduler timeline work week should be initialized", (assert) => {
+    QUnit.test("Scheduler timeline work week should be initialized", function(assert) {
         assert.ok(this.instance instanceof SchedulerTimelineWorkWeek, "dxSchedulerTimeLineWorkWeek was initialized");
     });
 
-    QUnit.test("Scheduler timeline work week should have a right css class", (assert) => {
+    QUnit.test("Scheduler timeline work week should have a right css class", function(assert) {
         let $element = this.instance.$element();
         assert.ok($element.hasClass("dx-scheduler-timeline"), "dxSchedulerTimelineWorkWeek has 'dx-scheduler-timeline' css class");
         assert.ok($element.hasClass("dx-scheduler-timeline-work-week"), "dxSchedulerTimelineWorkWeek has 'dx-scheduler-timeline-work-week' css class");
     });
 
-    QUnit.test("Scheduler timeline work week view should have right cell & row count", (assert) => {
+    QUnit.test("Scheduler timeline work week view should have right cell & row count", function(assert) {
         let $element = this.instance.$element();
         assert.equal($element.find(".dx-scheduler-date-table-row").length, 1, "Date table has 1 rows");
         assert.equal($element.find(".dx-scheduler-date-table-cell").length, 240, "Date table has 240 cells");
     });
 
-    QUnit.test("Scheduler timeline work week should have rigth first view date", (assert) => {
+    QUnit.test("Scheduler timeline work week should have rigth first view date", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21),
             firstDayOfWeek: 1,
@@ -780,7 +780,7 @@ QUnit.module("TimelineWorkWeek markup", timelineWorkWeekModuleConfig, () => {
         assert.deepEqual(this.instance.getStartViewDate(), new Date(2015, 9, 19, 4), "First view date is OK");
     });
 
-    QUnit.test("Scheduler timeline workweek should contain two rows in header panel", (assert) => {
+    QUnit.test("Scheduler timeline workweek should contain two rows in header panel", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 29),
             firstDayOfWeek: 1,
@@ -801,7 +801,7 @@ QUnit.module("TimelineWorkWeek markup", timelineWorkWeekModuleConfig, () => {
         }
     });
 
-    QUnit.test("Scheduler timeline workweek view should be correct, if currentDate is Monday, but firstDayOfWeek = 0", (assert) => {
+    QUnit.test("Scheduler timeline workweek view should be correct, if currentDate is Monday, but firstDayOfWeek = 0", function(assert) {
         let $element = this.instance.$element();
 
         this.instance.option("firstDayOfWeek", 0);
@@ -816,7 +816,7 @@ QUnit.module("TimelineWorkWeek markup", timelineWorkWeekModuleConfig, () => {
 });
 
 timelineWorkWeekModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineWorkWeek(options).dxSchedulerTimelineWorkWeek("instance");
             stubInvokeMethod(this.instance, options);
@@ -829,7 +829,7 @@ timelineWorkWeekModuleConfig = {
 };
 
 QUnit.module("TimelineWorkWeek with intervalCount markup", timelineWorkWeekModuleConfig, () => {
-    QUnit.test("TimelineWorkWeek has right count of cells with view option intervalCount", (assert) => {
+    QUnit.test("TimelineWorkWeek has right count of cells with view option intervalCount", function(assert) {
         this.instance.option("intervalCount", 2);
 
         let cells = this.instance.$element().find(".dx-scheduler-date-table-cell");
@@ -841,7 +841,7 @@ QUnit.module("TimelineWorkWeek with intervalCount markup", timelineWorkWeekModul
         assert.equal(cells.length, this.instance._getCellCountInDay() * 5 * 4, "view has right cell count");
     });
 
-    QUnit.test("TimelineWorkWeek view cells have right cellData with view option intervalCount=2", (assert) => {
+    QUnit.test("TimelineWorkWeek view cells have right cellData with view option intervalCount=2", function(assert) {
         this.instance.option("intervalCount", 2);
         this.instance.option("currentDate", new Date(2017, 5, 29));
 
@@ -855,7 +855,7 @@ QUnit.module("TimelineWorkWeek with intervalCount markup", timelineWorkWeekModul
         assert.deepEqual(secondCellData.endDate, new Date(2017, 6, 8, 0), "cell has right endtDate");
     });
 
-    QUnit.test("Get date range", (assert) => {
+    QUnit.test("Get date range", function(assert) {
         this.instance.option("currentDate", new Date(2017, 5, 26));
         this.instance.option("intervalCount", 2);
         this.instance.option("firstDayOfWeek", 1);
@@ -866,7 +866,7 @@ QUnit.module("TimelineWorkWeek with intervalCount markup", timelineWorkWeekModul
         assert.deepEqual(this.instance.getDateRange(), [new Date(2017, 5, 26, 0, 0), new Date(2017, 6, 21, 23, 59)], "Range is OK");
     });
 
-    QUnit.test("TimelineWorkWeek view should contain right header if intervalCount=3", (assert) => {
+    QUnit.test("TimelineWorkWeek view should contain right header if intervalCount=3", function(assert) {
         this.instance.option("currentDate", new Date(2017, 5, 26));
         this.instance.option("intervalCount", 3);
 
@@ -882,7 +882,7 @@ QUnit.module("TimelineWorkWeek with intervalCount markup", timelineWorkWeekModul
 });
 
 let timelineMonthModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineMonth(options).dxSchedulerTimelineMonth("instance");
             stubInvokeMethod(this.instance, options);
@@ -895,24 +895,24 @@ let timelineMonthModuleConfig = {
 };
 
 QUnit.module("TimelineMonth markup", timelineMonthModuleConfig, () => {
-    QUnit.test("Scheduler timeline month should be initialized", (assert) => {
+    QUnit.test("Scheduler timeline month should be initialized", function(assert) {
         assert.ok(this.instance instanceof SchedulerTimelineMonth, "dxSchedulerTimeLineMonth was initialized");
     });
 
-    QUnit.test("Scheduler timeline month should have a right css class", (assert) => {
+    QUnit.test("Scheduler timeline month should have a right css class", function(assert) {
         let $element = this.instance.$element();
         assert.ok($element.hasClass("dx-scheduler-timeline"), "dxSchedulerTimelineMonth has 'dx-scheduler-timeline' css class");
         assert.ok($element.hasClass("dx-scheduler-timeline-month"), "dxSchedulerTimelineMonth has 'dx-scheduler-timeline' css class");
     });
 
-    QUnit.test("Scheduler timeline month view should have right cell & row count", (assert) => {
+    QUnit.test("Scheduler timeline month view should have right cell & row count", function(assert) {
         let $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-date-table-row").length, 1, "Date table has 1 rows");
         assert.equal($element.find(".dx-scheduler-date-table-cell").length, 31, "Date table has 240 cells");
     });
 
-    QUnit.test("Scheduler timeline month header panel should have right quantity of cells", (assert) => {
+    QUnit.test("Scheduler timeline month header panel should have right quantity of cells", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 8, 21)
         });
@@ -925,7 +925,7 @@ QUnit.module("TimelineMonth markup", timelineMonthModuleConfig, () => {
         });
     });
 
-    QUnit.test("Scheduler timeline month should have rigth first view date", (assert) => {
+    QUnit.test("Scheduler timeline month should have rigth first view date", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 9, 21),
             firstDayOfWeek: 1,
@@ -941,7 +941,7 @@ QUnit.module("TimelineMonth markup", timelineMonthModuleConfig, () => {
         assert.deepEqual(this.instance.getStartViewDate(), new Date(2015, 9, 1, 0), "First view date is OK after startDayHour option changed");
     });
 
-    QUnit.test("Each cell of scheduler timeline month should contain rigth jQuery dxCellData", (assert) => {
+    QUnit.test("Each cell of scheduler timeline month should contain rigth jQuery dxCellData", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 3, 1),
             startDayHour: 1,
@@ -960,7 +960,7 @@ QUnit.module("TimelineMonth markup", timelineMonthModuleConfig, () => {
         });
     });
 
-    QUnit.test("Cells should have right date", (assert) => {
+    QUnit.test("Cells should have right date", function(assert) {
         this.instance.option({
             currentDate: new Date(2016, 3, 21),
             firstDayOfWeek: 1,
@@ -975,7 +975,7 @@ QUnit.module("TimelineMonth markup", timelineMonthModuleConfig, () => {
 });
 
 timelineMonthModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineMonth(options).dxSchedulerTimelineMonth("instance");
             stubInvokeMethod(this.instance, options);
@@ -988,7 +988,7 @@ timelineMonthModuleConfig = {
 };
 
 QUnit.module("TimelineMonth with intervalCount", timelineMonthModuleConfig, () => {
-    QUnit.test("TimelineMonth has right count of cells with view option intervalCount", (assert) => {
+    QUnit.test("TimelineMonth has right count of cells with view option intervalCount", function(assert) {
         this.instance.option("intervalCount", 2);
 
         let cells = this.instance.$element().find(".dx-scheduler-date-table-cell");
@@ -1000,7 +1000,7 @@ QUnit.module("TimelineMonth with intervalCount", timelineMonthModuleConfig, () =
         assert.equal(cells.length, 123, "view has right cell count");
     });
 
-    QUnit.test("TimelineMonth view cells have right cellData with view option intervalCount=2", (assert) => {
+    QUnit.test("TimelineMonth view cells have right cellData with view option intervalCount=2", function(assert) {
         this.instance.option("intervalCount", 2);
         this.instance.option("currentDate", new Date(2017, 5, 29));
 
@@ -1014,7 +1014,7 @@ QUnit.module("TimelineMonth with intervalCount", timelineMonthModuleConfig, () =
         assert.deepEqual(secondCellData.endDate, new Date(2017, 7, 1, 0), "cell has right endtDate");
     });
 
-    QUnit.test("Get date range", (assert) => {
+    QUnit.test("Get date range", function(assert) {
         this.instance.option("currentDate", new Date(2017, 5, 26));
         this.instance.option("intervalCount", 2);
         this.instance.option("firstDayOfWeek", 1);
@@ -1027,7 +1027,7 @@ QUnit.module("TimelineMonth with intervalCount", timelineMonthModuleConfig, () =
 });
 
 timelineMonthModuleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#scheduler-timeline").dxSchedulerTimelineMonth({
                 groupOrientation: "horizontal",
@@ -1043,14 +1043,14 @@ timelineMonthModuleConfig = {
 };
 
 QUnit.module("TimelineMonth with horizontal scrolling markup", timelineMonthModuleConfig, () => {
-    QUnit.test("Scheduler timeline month view should have right cell & row count", (assert) => {
+    QUnit.test("Scheduler timeline month view should have right cell & row count", function(assert) {
         let $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-date-table-row").length, 1, "Date table has 1 rows");
         assert.equal($element.find(".dx-scheduler-date-table-cell").length, 60, "Date table has 60 cells");
     });
 
-    QUnit.test("Scheduler timeline month header panel should have right quantity of cells", (assert) => {
+    QUnit.test("Scheduler timeline month header panel should have right quantity of cells", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 8, 21)
         });
@@ -1064,7 +1064,7 @@ QUnit.module("TimelineMonth with horizontal scrolling markup", timelineMonthModu
         });
     });
 
-    QUnit.test("Each cell of scheduler timeline month should contain rigth jQuery dxCellData", (assert) => {
+    QUnit.test("Each cell of scheduler timeline month should contain rigth jQuery dxCellData", function(assert) {
         this.instance.option({
             currentDate: new Date(2015, 3, 1),
             startDayHour: 1,
@@ -1089,7 +1089,7 @@ QUnit.module("TimelineMonth with horizontal scrolling markup", timelineMonthModu
         });
     });
 
-    QUnit.test("Cells should have right date", (assert) => {
+    QUnit.test("Cells should have right date", function(assert) {
         this.instance.option({
             currentDate: new Date(2016, 3, 21),
             firstDayOfWeek: 1,

--- a/testing/tests/DevExpress.ui.widgets.scheduler/workSpace.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/workSpace.markup.tests.js
@@ -95,26 +95,26 @@ const checkRowsAndCells = function($element, assert, interval, start, end, group
 };
 
 const moduleConfig = {
-    beforeEach: () =>{
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space").dxSchedulerWorkSpace().dxSchedulerWorkSpace("instance");
     }
 };
 
 QUnit.module("Workspace markup", moduleConfig, () => {
-    QUnit.test("Scheduler workspace should be initialized", (assert) => {
+    QUnit.test("Scheduler workspace should be initialized", function(assert) {
         assert.ok(this.instance instanceof SchedulerWorkSpace, "dxSchedulerWorkSpace was initialized");
     });
 
-    QUnit.test("Scheduler workspace day should have right groupedStrategy by default", (assert) => {
+    QUnit.test("Scheduler workspace day should have right groupedStrategy by default", function(assert) {
         assert.ok(this.instance._groupedStrategy instanceof SchedulerWorkSpaceHorizontalStrategy, "Grouped strategy is right");
     });
 
-    QUnit.test("Scheduler workspace should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace should have a right css class", function(assert) {
         const $element = this.instance.$element();
         assert.ok($element.hasClass(WORKSPACE_CLASS), "dxSchedulerWorkSpace has 'dx-scheduler-workspace' css class");
     });
 
-    QUnit.test("Scheduler workspace with intervalCount should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace with intervalCount should have a right css class", function(assert) {
         this.instance.option("intervalCount", 3);
         let $element = this.instance.$element();
         assert.ok($element.hasClass(WORKSPACE_WITH_COUNT_CLASS), "dxSchedulerWorkSpace has right css class");
@@ -124,7 +124,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.notOk($element.hasClass(WORKSPACE_WITH_COUNT_CLASS), "dxSchedulerWorkSpace has 'dx-scheduler-workspace' css class");
     });
 
-    QUnit.test("Scheduler workspace with groupByDate should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace with groupByDate should have a right css class", function(assert) {
         this.instance.option("groupOrientation", "vertical");
 
         let $element = this.instance.$element();
@@ -144,7 +144,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.ok($element.hasClass(WORKSPACE_WITH_GROUP_BY_DATE_CLASS), "dxSchedulerWorkSpace right css class");
     });
 
-    QUnit.test("Scheduler workspace should contain time panel, header panel, allday panel and content", (assert) => {
+    QUnit.test("Scheduler workspace should contain time panel, header panel, allday panel and content", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.find(toSelector(HEADER_PANEL_CLASS)).length, 1, "Workspace contains the time panel");
@@ -153,13 +153,13 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.equal($element.find(toSelector(DATE_TABLE_CLASS)).length, 1, "Workspace contains date table");
     });
 
-    QUnit.test("All day title should be rendered in workspace directly", (assert) => {
+    QUnit.test("All day title should be rendered in workspace directly", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.children(toSelector(ALL_DAY_TITLE_CLASS)).length, 1, "All-day-title is OK");
     });
 
-    QUnit.test("All day title has a special CSS class, if showAllDayPanel = false", (assert) => {
+    QUnit.test("All day title has a special CSS class, if showAllDayPanel = false", function(assert) {
         this.instance.option("showAllDayPanel", false);
 
         const $element = this.instance.$element(),
@@ -172,7 +172,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.notOk($allDayTitle.hasClass("dx-scheduler-all-day-title-hidden"), "CSS class is OK");
     });
 
-    QUnit.test("Workspace should have specific css class, if showAllDayPanel = true ", (assert) => {
+    QUnit.test("Workspace should have specific css class, if showAllDayPanel = true ", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         const $element = this.instance.$element();
@@ -182,7 +182,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.notOk($element.hasClass("dx-scheduler-work-space-all-day"), "dxSchedulerWorkSpace hasn't 'dx-scheduler-work-space-all-day' css class");
     });
 
-    QUnit.test("Workspace should have specific css class, if hoursInterval = 0.5 ", (assert) => {
+    QUnit.test("Workspace should have specific css class, if hoursInterval = 0.5 ", function(assert) {
         this.instance.option("hoursInterval", 0.5);
 
         const $element = this.instance.$element();
@@ -192,7 +192,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.notOk($element.hasClass("dx-scheduler-work-space-odd-cells"), "dxSchedulerWorkSpace hasn't 'dx-scheduler-work-space-odd-cells' css class");
     });
 
-    QUnit.test("All day panel has specific class when allDayExpanded = true", (assert) => {
+    QUnit.test("All day panel has specific class when allDayExpanded = true", function(assert) {
         this.instance.option("showAllDayPanel", true);
         this.instance.option("allDayExpanded", true);
 
@@ -205,7 +205,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.ok($element.hasClass("dx-scheduler-work-space-all-day-collapsed"), "dxSchedulerWorkSpace has 'dx-scheduler-work-space-all-day-collapsed' css class");
     });
 
-    QUnit.test("Workspace should not has specific class when showAllDayPanel = false", (assert) => {
+    QUnit.test("Workspace should not has specific class when showAllDayPanel = false", function(assert) {
         this.instance.option("showAllDayPanel", false);
         this.instance.option("allDayExpanded", false);
 
@@ -218,14 +218,14 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.ok($element.hasClass("dx-scheduler-work-space-all-day-collapsed"), "dxSchedulerWorkSpace has 'dx-scheduler-work-space-all-day-collapsed' css class");
     });
 
-    QUnit.test("Scheduler workspace parts should be wrapped by scrollable", (assert) => {
+    QUnit.test("Scheduler workspace parts should be wrapped by scrollable", function(assert) {
         const $element = this.instance.$element();
 
         assert.ok($element.find(".dx-scheduler-time-panel").parent().hasClass("dx-scrollable-content"), "Scrollable contains the time panel");
         assert.ok($element.find(".dx-scheduler-date-table").parent().hasClass("dx-scrollable-content"), "Scrollable contains date table");
     });
 
-    QUnit.test("Time panel cells and rows should have special css classes", (assert) => {
+    QUnit.test("Time panel cells and rows should have special css classes", function(assert) {
         const $element = this.instance.$element(),
             $row = $element.find(".dx-scheduler-time-panel tr").first(),
             $cell = $row.find("td").first();
@@ -235,7 +235,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.ok($cell.hasClass(VERTICAL_SIZES_CLASS), "Css class of cell is correct");
     });
 
-    QUnit.test("All day panel row should have special css class", (assert) => {
+    QUnit.test("All day panel row should have special css class", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         const $element = this.instance.$element(),
@@ -244,19 +244,19 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.ok($row.hasClass("dx-scheduler-all-day-table-row"), "Css class of row is correct");
     });
 
-    QUnit.test("All-day-appointments container should be rendered directly in workspace", (assert) => {
+    QUnit.test("All-day-appointments container should be rendered directly in workspace", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.children(".dx-scheduler-all-day-appointments").length, 1, "Container is rendered correctly");
     });
 
-    QUnit.test("Fixed appointments container should be rendered directly in workspace", (assert) => {
+    QUnit.test("Fixed appointments container should be rendered directly in workspace", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.children(".dx-scheduler-fixed-appointments").length, 1, "Container is rendered correctly");
     });
 
-    QUnit.test("Work space should have 'grouped' class & group row count attr if there are some groups", (assert) => {
+    QUnit.test("Work space should have 'grouped' class & group row count attr if there are some groups", function(assert) {
         assert.ok(!this.instance.$element().hasClass("dx-scheduler-work-space-grouped"), "'grouped' class is not applied");
 
         this.instance.option("groups", [{
@@ -272,7 +272,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.notOk(this.instance.$element().attr("dx-group-row-count"), "'dx-group-row-count' isn't applied");
     });
 
-    QUnit.test("Work space should not have 'grouped' class & group row count attr if groups exist but empty(T381796)", (assert) => {
+    QUnit.test("Work space should not have 'grouped' class & group row count attr if groups exist but empty(T381796)", function(assert) {
         assert.ok(!this.instance.$element().hasClass("dx-scheduler-work-space-grouped"), "'grouped' class is not applied");
 
         this.instance.option("groups", [{
@@ -284,7 +284,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.notOk(this.instance.$element().attr("dx-group-row-count"), "'dx-group-row-count' isn't applied");
     });
 
-    QUnit.test("Group header should be rendered if there are some groups", (assert) => {
+    QUnit.test("Group header should be rendered if there are some groups", function(assert) {
 
         assert.equal(this.instance.$element().find(".dx-scheduler-group-header").length, 0, "Groups are not rendered");
 
@@ -324,7 +324,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.equal(secondRowCells.eq(5).text(), "e", "Cell has a right text");
     });
 
-    QUnit.test("Group header should be rendered if there is a single group", (assert) => {
+    QUnit.test("Group header should be rendered if there is a single group", function(assert) {
         this.instance.option("groups", [{ name: "one", items: [{ id: 1, text: "a" }] }]);
 
         const headers = this.instance.$element().find(".dx-scheduler-group-header");
@@ -333,7 +333,7 @@ QUnit.module("Workspace markup", moduleConfig, () => {
         assert.equal(headers.eq(0).text(), "a", "Group header text is right");
     });
 
-    QUnit.test("Group header should contain group header content", (assert) => {
+    QUnit.test("Group header should contain group header content", function(assert) {
         this.instance.option("groups", [{ name: "one", items: [{ id: 1, text: "a" }] }]);
 
         const header = this.instance.$element().find(".dx-scheduler-group-header"),
@@ -345,20 +345,20 @@ QUnit.module("Workspace markup", moduleConfig, () => {
 
 
 const dayModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space").dxSchedulerWorkSpaceDay().dxSchedulerWorkSpaceDay("instance");
         stubInvokeMethod(this.instance);
     }
 };
 
 QUnit.module("Workspace Day markup", dayModuleConfig, () => {
-    QUnit.test("Scheduler workspace day should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace day should have a right css class", function(assert) {
         const $element = this.instance.$element();
 
         assert.ok($element.hasClass("dx-scheduler-work-space-day"), "dxSchedulerWorkSpaceDay has 'dx-scheduler-workspace-day' css class");
     });
 
-    QUnit.test("Date table cells should have a special css classes", (assert) => {
+    QUnit.test("Date table cells should have a special css classes", function(assert) {
         const $element = this.instance.$element(),
             classes = $element.find(".dx-scheduler-date-table td").attr("class").split(" ");
 
@@ -367,7 +367,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.ok($.inArray(VERTICAL_SIZES_CLASS, classes) > -1, "Cell has a css class");
     });
 
-    QUnit.test("Scheduler all day panel should contain one row", (assert) => {
+    QUnit.test("Scheduler all day panel should contain one row", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         const $allDayPanel = this.instance.$element().find(".dx-scheduler-all-day-panel");
@@ -376,7 +376,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.equal($allDayPanel.find("tbody tr>td").length, 1, "All day panel contains 1 cell");
     });
 
-    QUnit.test("Scheduler workspace date-table rows and cells should have correct css-class", (assert) => {
+    QUnit.test("Scheduler workspace date-table rows and cells should have correct css-class", function(assert) {
         const $element = this.instance.$element(),
             $dateTable = $element.find(".dx-scheduler-date-table"),
             $row = $dateTable.find("tr").first(),
@@ -386,7 +386,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.ok($cell.hasClass("dx-scheduler-date-table-cell"), "Cell class is correct");
     });
 
-    QUnit.test("Scheduler workspace day view", (assert) => {
+    QUnit.test("Scheduler workspace day view", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -403,7 +403,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.equal(cellCounter, 48, "Each row has a single cell");
     });
 
-    QUnit.test("Scheduler workspace day grouped view", (assert) => {
+    QUnit.test("Scheduler workspace day grouped view", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -421,7 +421,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.equal(cellCounter, 48, "Each row has a two cells");
     });
 
-    QUnit.test("Grouped cells should have a right group field in dxCellData", (assert) => {
+    QUnit.test("Grouped cells should have a right group field in dxCellData", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("groups", [{ name: "one", items: [{ id: 1, text: "a" }, { id: 2, text: "b" }] }]);
@@ -432,13 +432,13 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.deepEqual($element.find(".dx-scheduler-date-table tbody tr>td").eq(1).data("dxCellData").groups, { one: 2 }, "Cell group is OK");
     });
 
-    QUnit.test("Scheduler workspace day view should not contain a single header", (assert) => {
+    QUnit.test("Scheduler workspace day view should not contain a single header", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-header-row th").length, 0, "Date table has not header cell");
     });
 
-    QUnit.test("Scheduler workspace day grouped view should contain a few headers", (assert) => {
+    QUnit.test("Scheduler workspace day grouped view should contain a few headers", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("groups", [
@@ -457,11 +457,11 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.strictEqual($element.find(".dx-scheduler-group-row").eq(1).find("th").attr("colspan"), undefined, "Group header has a right 'colspan'");
     });
 
-    QUnit.test("Time panel should have 24 rows and 24 cells", (assert) => {
+    QUnit.test("Time panel should have 24 rows and 24 cells", function(assert) {
         checkRowsAndCells(this.instance.$element(), assert);
     });
 
-    QUnit.test("Time panel should have 22 rows and 22 cells for hoursInterval = 1 & startDayHour = 2", (assert) => {
+    QUnit.test("Time panel should have 22 rows and 22 cells for hoursInterval = 1 & startDayHour = 2", function(assert) {
         this.instance.option({
             hoursInterval: 1,
             startDayHour: 2
@@ -470,7 +470,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         checkRowsAndCells(this.instance.$element(), assert, 1, 2);
     });
 
-    QUnit.test("Time panel should have right cell text when hoursInterval is fractional", (assert) => {
+    QUnit.test("Time panel should have right cell text when hoursInterval is fractional", function(assert) {
         this.instance.option({
             hoursInterval: 2.1666666666666665,
             endDayHour: 5
@@ -479,7 +479,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         checkRowsAndCells(this.instance.$element(), assert, 2.1666666666666665, 0, 5);
     });
 
-    QUnit.test("Cell count should depend on start/end day hour & hoursInterval", (assert) => {
+    QUnit.test("Cell count should depend on start/end day hour & hoursInterval", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option({
@@ -492,7 +492,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.equal($element.find(".dx-scheduler-date-table-cell").length, 5, "Cell count is OK");
     });
 
-    QUnit.test("WorkSpace Day view has right count of cells with view option intervalCount=2", (assert) => {
+    QUnit.test("WorkSpace Day view has right count of cells with view option intervalCount=2", function(assert) {
         this.instance.option("intervalCount", 2);
 
         let cells = this.instance.$element().find(".dx-scheduler-date-table-cell");
@@ -504,7 +504,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         assert.equal(cells.length, this.instance._getCellCountInDay() * 4, "view has right cell count");
     });
 
-    QUnit.test("WorkSpace Day view cells should have right class when intervalCount and groups", (assert) => {
+    QUnit.test("WorkSpace Day view cells should have right class when intervalCount and groups", function(assert) {
         this.instance.option("intervalCount", 3);
 
         this.instance.option("groups", [{ name: "a", items: [{ id: 1, text: "a.1" }, { id: 2, text: "a.2" }] }]);
@@ -534,7 +534,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
         });
     });
 
-    QUnit.test("WorkSpace Day view cells should have right class when intervalCount and groups, groupByDate = true", (assert) => {
+    QUnit.test("WorkSpace Day view cells should have right class when intervalCount and groups, groupByDate = true", function(assert) {
         this.instance.option("intervalCount", 3);
         this.instance.option("groupByDate", true);
 
@@ -567,7 +567,7 @@ QUnit.module("Workspace Day markup", dayModuleConfig, () => {
 });
 
 const dayWithGroupingModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space-grouped").dxSchedulerWorkSpaceDay({
             groupOrientation: "vertical",
             showCurrentTimeIndicator: false,
@@ -582,17 +582,17 @@ const dayWithGroupingModuleConfig = {
 };
 
 QUnit.module("Workspace Day markup with vertical grouping", dayWithGroupingModuleConfig, () => {
-    QUnit.test("Scheduler workspace day should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace day should have a right css class", function(assert) {
         const $element = this.instance.$element();
 
         assert.ok($element.hasClass("dx-scheduler-work-space-vertical-grouped"), "Workspace has 'dx-scheduler-work-space-vertical-grouped' css class");
     });
 
-    QUnit.test("Scheduler workspace day should have right groupedStrategy, groupOrientation = vertical", (assert) => {
+    QUnit.test("Scheduler workspace day should have right groupedStrategy, groupOrientation = vertical", function(assert) {
         assert.ok(this.instance._groupedStrategy instanceof SchedulerWorkSpaceVerticalStrategy, "Grouped strategy is right");
     });
 
-    QUnit.test("Scheduler all day rows should be built into dateTable", (assert) => {
+    QUnit.test("Scheduler all day rows should be built into dateTable", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         const $allDayRows = this.instance.$element().find(toSelector(ALL_DAY_ROW_CLASS));
@@ -600,7 +600,7 @@ QUnit.module("Workspace Day markup with vertical grouping", dayWithGroupingModul
         assert.equal($allDayRows.length, 2, "DateTable contains 2 allDay rows");
     });
 
-    QUnit.test("Scheduler all day titles should be built into timePanel", (assert) => {
+    QUnit.test("Scheduler all day titles should be built into timePanel", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         const $timePanel = this.instance.$element().find(toSelector(TIME_PANEL_CLASS));
@@ -609,29 +609,29 @@ QUnit.module("Workspace Day markup with vertical grouping", dayWithGroupingModul
         assert.equal($allDayTitles.length, 2, "TimePanel contains 2 allDay titles");
     });
 
-    QUnit.test("Date table should have right group header", (assert) => {
+    QUnit.test("Date table should have right group header", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.find("." + VERTICAL_GROUP_TABLE_CLASS).length, 1, "Group header is rendered");
     });
 
-    QUnit.test("Date table should have right group header cells count", (assert) => {
+    QUnit.test("Date table should have right group header cells count", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-group-header").length, 2, "Group header cells count is ok");
     });
 
-    QUnit.test("Scheduler workspace Day should have a right rows count", (assert) => {
+    QUnit.test("Scheduler workspace Day should have a right rows count", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-date-table tbody tr").length, 48, "Workspace has 48 rows");
     });
 
-    QUnit.test("Time panel should have right rows count and cell text, even cells count", (assert) => {
+    QUnit.test("Time panel should have right rows count and cell text, even cells count", function(assert) {
         checkRowsAndCells(this.instance.$element(), assert, 0.5, 8, 20, 2);
     });
 
-    QUnit.test("Time panel should have right rows count and cell text, odd cells count", (assert) => {
+    QUnit.test("Time panel should have right rows count and cell text, odd cells count", function(assert) {
         this.instance.option({
             startDayHour: 9,
             endDayHour: 16,
@@ -641,7 +641,7 @@ QUnit.module("Workspace Day markup with vertical grouping", dayWithGroupingModul
         checkRowsAndCells(this.instance.$element(), assert, 1, 9, 16, 2);
     });
 
-    QUnit.test("Time panel should have 48 rows and 48 cells", (assert) => {
+    QUnit.test("Time panel should have 48 rows and 48 cells", function(assert) {
         const $element = this.instance.$element();
 
         let cellCount = $element.find(".dx-scheduler-date-table tbody tr").length;
@@ -650,7 +650,7 @@ QUnit.module("Workspace Day markup with vertical grouping", dayWithGroupingModul
         assert.equal($element.find(".dx-scheduler-time-panel-cell").length, cellCount, "Time panel has a right count of cells");
     });
 
-    QUnit.test("Grouped cells should have a right group field in dxCellData", (assert) => {
+    QUnit.test("Grouped cells should have a right group field in dxCellData", function(assert) {
         const $element = this.instance.$element();
 
         assert.deepEqual($element.find(".dx-scheduler-date-table tbody tr>td").eq(0).data("dxCellData").groups, {
@@ -659,7 +659,7 @@ QUnit.module("Workspace Day markup with vertical grouping", dayWithGroupingModul
         assert.deepEqual($element.find(".dx-scheduler-date-table tbody tr>td").eq(25).data("dxCellData").groups, { a: 2 }, "Cell group is OK");
     });
 
-    QUnit.test("Grouped allDay cells should have a right group field in dxCellData", (assert) => {
+    QUnit.test("Grouped allDay cells should have a right group field in dxCellData", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         let $allDayCells = this.instance.$element().find(toSelector(ALL_DAY_TABLE_CELL_CLASS));
@@ -668,7 +668,7 @@ QUnit.module("Workspace Day markup with vertical grouping", dayWithGroupingModul
         assert.deepEqual($allDayCells.eq(1).data("dxCellData").groups, { a: 2 }, "Cell group is OK");
     });
 
-    QUnit.test("WorkSpace Day view cells should have right class when groups", (assert) => {
+    QUnit.test("WorkSpace Day view cells should have right class when groups", function(assert) {
         var rowCountInGroup = 24;
 
         this.instance.$element().find(".dx-scheduler-date-table-cell").each(function(index) {
@@ -696,7 +696,7 @@ QUnit.module("Workspace Day markup with vertical grouping", dayWithGroupingModul
 });
 
 const weekModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space").dxSchedulerWorkSpaceWeek({
             showCurrentTimeIndicator: false
         }).dxSchedulerWorkSpaceWeek("instance");
@@ -705,13 +705,13 @@ const weekModuleConfig = {
 };
 
 QUnit.module("Workspace Week markup", weekModuleConfig, () => {
-    QUnit.test("Scheduler workspace week should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace week should have a right css class", function(assert) {
         const $element = this.instance.$element();
 
         assert.ok($element.hasClass("dx-scheduler-work-space-week"), "dxSchedulerWorkSpaceWeek has 'dx-scheduler-workspace-week' css class");
     });
 
-    QUnit.test("Header cells should have a special css classes", (assert) => {
+    QUnit.test("Header cells should have a special css classes", function(assert) {
         const $element = this.instance.$element(),
             classes = $element.find(".dx-scheduler-header-panel th").attr("class").split(" ");
 
@@ -720,7 +720,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         assert.notOk($.inArray(VERTICAL_SIZES_CLASS, classes) > -1, "Cell hasn't a css class");
     });
 
-    QUnit.test("Scheduler all day panel should contain one row & 7 cells", (assert) => {
+    QUnit.test("Scheduler all day panel should contain one row & 7 cells", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         const $allDayPanel = this.instance.$element().find(".dx-scheduler-all-day-panel");
@@ -729,7 +729,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         assert.equal($allDayPanel.find("tbody tr>td").length, 7, "All day panel contains 7 cell");
     });
 
-    QUnit.test("Scheduler workspace week view", (assert) => {
+    QUnit.test("Scheduler workspace week view", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -745,12 +745,12 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         assert.equal(cellCounter, 48, "Each row has a seven cells");
     });
 
-    QUnit.test("Time panel should have 24 rows and 24 cells", (assert) => {
+    QUnit.test("Time panel should have 24 rows and 24 cells", function(assert) {
         this.instance.option("currentDate", new Date(1970, 0));
         checkRowsAndCells(this.instance.$element(), assert);
     });
 
-    QUnit.test("Scheduler workspace week grouped view", (assert) => {
+    QUnit.test("Scheduler workspace week grouped view", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -768,7 +768,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         assert.equal(cellCounter, 48, "Each row has a fourteen cells");
     });
 
-    QUnit.test("Scheduler workspace week view should contain a 7 headers", (assert) => {
+    QUnit.test("Scheduler workspace week view should contain a 7 headers", function(assert) {
         const $element = this.instance.$element();
 
         const weekStartDate = new Date().getDate() - new Date().getDay();
@@ -791,7 +791,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         });
     });
 
-    QUnit.test("Scheduler workspace grouped week view should contain a few headers", (assert) => {
+    QUnit.test("Scheduler workspace grouped week view should contain a few headers", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("groups", [
@@ -813,7 +813,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         assert.equal($element.find(".dx-scheduler-group-row").eq(1).find("th").attr("colspan"), "7", "Group header has a right 'colspan'");
     });
 
-    QUnit.test("Group header should be rendered if there are some groups, groupByDate = true", (assert) => {
+    QUnit.test("Group header should be rendered if there are some groups, groupByDate = true", function(assert) {
 
         assert.equal(this.instance.$element().find(".dx-scheduler-group-header").length, 0, "Groups are not rendered");
 
@@ -855,7 +855,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         assert.equal(secondRowCells.eq(5).text(), "e", "Cell has a right text");
     });
 
-    QUnit.test("Group row should be rendered before header row", (assert) => {
+    QUnit.test("Group row should be rendered before header row", function(assert) {
         this.instance.option("groups", [
             {
                 name: "one",
@@ -869,7 +869,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         assert.deepEqual($groupRow.next().get(0), $headerRow.get(0), "Group row rendered correctly");
     });
 
-    QUnit.test("WorkSpace Week view has right count of cells with view option intervalCount", (assert) => {
+    QUnit.test("WorkSpace Week view has right count of cells with view option intervalCount", function(assert) {
         this.instance.option("intervalCount", 2);
 
         let cells = this.instance.$element().find(".dx-scheduler-date-table-cell");
@@ -881,7 +881,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
         assert.equal(cells.length, this.instance._getCellCountInDay() * 7 * 4, "view has right cell count");
     });
 
-    QUnit.test("WorkSpace Week view cells should have right class when intervalCount and groups", (assert) => {
+    QUnit.test("WorkSpace Week view cells should have right class when intervalCount and groups", function(assert) {
         this.instance.option("intervalCount", 3);
 
         this.instance.option("groups", [{ name: "a", items: [{ id: 1, text: "a.1" }, { id: 2, text: "a.2" }] }]);
@@ -913,7 +913,7 @@ QUnit.module("Workspace Week markup", weekModuleConfig, () => {
 });
 
 const weekWithGroupingModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space-grouped").dxSchedulerWorkSpaceWeek({
             groupOrientation: "vertical",
             startDayHour: 8,
@@ -927,30 +927,30 @@ const weekWithGroupingModuleConfig = {
 };
 
 QUnit.module("Workspace Week markup with vertical grouping", weekWithGroupingModuleConfig, () => {
-    QUnit.test("Scheduler workspace day should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace day should have a right css class", function(assert) {
         const $element = this.instance.$element();
 
         assert.ok($element.hasClass("dx-scheduler-work-space-vertical-grouped"), "Workspace has 'dx-scheduler-work-space-vertical-grouped' css class");
     });
 
-    QUnit.test("Scheduler workspace Week should have a right rows count", (assert) => {
+    QUnit.test("Scheduler workspace Week should have a right rows count", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-date-table tbody tr").length, 48, "Workspace has 48 rows");
     });
 
-    QUnit.test("Scheduler all day rows should be built into dateTable", (assert) => {
+    QUnit.test("Scheduler all day rows should be built into dateTable", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         const $allDayRows = this.instance.$element().find(toSelector(ALL_DAY_ROW_CLASS));
 
         assert.equal($allDayRows.length, 2, "DateTable contains 2 allDay rows");
     });
-    QUnit.test("Time panel should have right rows count and cell text", (assert) => {
+    QUnit.test("Time panel should have right rows count and cell text", function(assert) {
         checkRowsAndCells(this.instance.$element(), assert, 0.5, 8, 20, 2);
     });
 
-    QUnit.test("Grouped cells should have a right group field in dxCellData", (assert) => {
+    QUnit.test("Grouped cells should have a right group field in dxCellData", function(assert) {
         let $element = this.instance.$element(),
             $cells = $element.find(".dx-scheduler-date-table tbody tr>td"),
             cellCount = $cells.length;
@@ -963,20 +963,20 @@ QUnit.module("Workspace Week markup with vertical grouping", weekWithGroupingMod
 });
 
 const workWeekModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space").dxSchedulerWorkSpaceWorkWeek().dxSchedulerWorkSpaceWorkWeek("instance");
         stubInvokeMethod(this.instance);
     }
 };
 
 QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
-    QUnit.test("Scheduler workspace work week should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace work week should have a right css class", function(assert) {
         const $element = this.instance.$element();
 
         assert.ok($element.hasClass("dx-scheduler-work-space-work-week"), "dxSchedulerWorkSpaceWorkWeek has 'dx-scheduler-workspace-work-week' css class");
     });
 
-    QUnit.test("Scheduler all day panel should contain one row & 5 cells", (assert) => {
+    QUnit.test("Scheduler all day panel should contain one row & 5 cells", function(assert) {
         this.instance.option("showAllDayPanel", true);
 
         const $allDayPanel = this.instance.$element().find(".dx-scheduler-all-day-panel");
@@ -985,7 +985,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         assert.equal($allDayPanel.find("tbody tr>td").length, 5, "All day panel contains 5 cell");
     });
 
-    QUnit.test("Scheduler workspace work week view", (assert) => {
+    QUnit.test("Scheduler workspace work week view", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -1001,7 +1001,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         assert.equal(cellCounter, 48, "Each row has a five cells");
     });
 
-    QUnit.test("Scheduler workspace work week grouped view", (assert) => {
+    QUnit.test("Scheduler workspace work week grouped view", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -1019,7 +1019,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         assert.equal(cellCounter, 48, "Each row has a ten cells");
     });
 
-    QUnit.test("Scheduler workspace work week view should contain a 5 headers", (assert) => {
+    QUnit.test("Scheduler workspace work week view should contain a 5 headers", function(assert) {
         const currentDate = new Date(),
             $element = this.instance.$element(),
             weekStartDate = new Date(currentDate).getDate() - (new Date(currentDate).getDay() - 1),
@@ -1034,7 +1034,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         });
     });
 
-    QUnit.test("Scheduler workspace work week grouped view should contain a few headers", (assert) => {
+    QUnit.test("Scheduler workspace work week grouped view should contain a few headers", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("groups", [
@@ -1055,7 +1055,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         assert.equal($element.find(".dx-scheduler-group-row").eq(1).find("th").attr("colspan"), "5", "Group header has a right 'colspan'");
     });
 
-    QUnit.test("Scheduler workspace work week view should be correct with any first day of week", (assert) => {
+    QUnit.test("Scheduler workspace work week view should be correct with any first day of week", function(assert) {
         const instance = $("#scheduler-work-space").dxSchedulerWorkSpaceWorkWeek({
             firstDayOfWeek: 2,
             currentDate: new Date(2015, 1, 4)
@@ -1070,7 +1070,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         assert.equal($headerCells.last().text().toLowerCase(), dateLocalization.getDayNames("abbreviated")[1].toLowerCase() + " 9", "last header has a right text");
     });
 
-    QUnit.test("Scheduler workspace work week view should be correct, if currentDate is Sunday", (assert) => {
+    QUnit.test("Scheduler workspace work week view should be correct, if currentDate is Sunday", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("firstDayOfWeek", 0);
@@ -1083,7 +1083,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         assert.equal($headerCells.last().text().toLowerCase(), dateLocalization.getDayNames("abbreviated")[5].toLowerCase() + " 15", "last header has a right text");
     });
 
-    QUnit.test("Scheduler workspace work week view should be correct with any first day of week, if currentDate is Sunday", (assert) => {
+    QUnit.test("Scheduler workspace work week view should be correct with any first day of week, if currentDate is Sunday", function(assert) {
         const instance = $("#scheduler-work-space").dxSchedulerWorkSpaceWorkWeek({
             currentDate: new Date(2016, 0, 10),
             firstDayOfWeek: 3
@@ -1098,11 +1098,11 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         assert.equal($headerCells.last().text().toLowerCase(), dateLocalization.getDayNames("abbreviated")[2].toLowerCase() + " 12", "last header has a right text");
     });
 
-    QUnit.test("Time panel should have 24 rows and 24 cells", (assert) => {
+    QUnit.test("Time panel should have 24 rows and 24 cells", function(assert) {
         checkRowsAndCells(this.instance.$element(), assert);
     });
 
-    QUnit.test("WorkSpace WorkWeek view has right count of cells with view option intervalCount", (assert) => {
+    QUnit.test("WorkSpace WorkWeek view has right count of cells with view option intervalCount", function(assert) {
         this.instance.option("intervalCount", 2);
 
         let cells = this.instance.$element().find(".dx-scheduler-date-table-cell");
@@ -1114,7 +1114,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         assert.equal(cells.length, this.instance._getCellCountInDay() * 5 * 4, "view has right cell count");
     });
 
-    QUnit.test("Workspace work week view should contain 15 headers if intervalCount=3", (assert) => {
+    QUnit.test("Workspace work week view should contain 15 headers if intervalCount=3", function(assert) {
         this.instance.option({
             intervalCount: 3,
             firstDayOfWeek: 1,
@@ -1147,7 +1147,7 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
         }
     });
 
-    QUnit.test("Grouped Workspace work week view should contain right count of headers with view option intervalCount", (assert) => {
+    QUnit.test("Grouped Workspace work week view should contain right count of headers with view option intervalCount", function(assert) {
         this.instance.option({
             intervalCount: 2,
             firstDayOfWeek: 1,
@@ -1189,26 +1189,26 @@ QUnit.module("Workspace Work Week markup", workWeekModuleConfig, () => {
 });
 
 const monthModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space").dxSchedulerWorkSpaceMonth().dxSchedulerWorkSpaceMonth("instance");
         stubInvokeMethod(this.instance);
     }
 };
 
 QUnit.module("Workspace Month markup", monthModuleConfig, () => {
-    QUnit.test("Scheduler workspace month should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace month should have a right css class", function(assert) {
         const $element = this.instance.$element();
 
         assert.ok($element.hasClass("dx-scheduler-work-space-month"), "dxSchedulerWorkSpaceMonth has 'dx-scheduler-workspace-month' css class");
     });
 
-    QUnit.test("Scheduler workspace month scrollable content should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace month scrollable content should have a right css class", function(assert) {
         const $scrollableContent = this.instance.getScrollable().$content();
 
         assert.ok($scrollableContent.hasClass("dx-scheduler-scrollable-fixed-content"), "Scrollable content has 'dx-scheduler-scrollable-fixed-content' css class");
     });
 
-    QUnit.test("Scheduler workspace month scrollable content should not have a right css class, if intervalCount is set", (assert) => {
+    QUnit.test("Scheduler workspace month scrollable content should not have a right css class, if intervalCount is set", function(assert) {
         this.instance.option("intervalCount", 2);
 
         const $scrollableContent = this.instance.getScrollable().$content();
@@ -1216,19 +1216,19 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.notOk($scrollableContent.hasClass("dx-scheduler-scrollable-fixed-content"), "Scrollable content hasn't 'dx-scheduler-scrollable-fixed-content' css class");
     });
 
-    QUnit.test("Scheduler all day panel should not contain rows & cells", (assert) => {
+    QUnit.test("Scheduler all day panel should not contain rows & cells", function(assert) {
         const $allDayPanel = this.instance.$element().find(".dx-scheduler-all-day-panel");
 
         assert.equal($allDayPanel.find("tbody tr").length, 0, "All day panel does not contain rows");
     });
 
-    QUnit.test("Scheduler time panel should not contain rows & cells", (assert) => {
+    QUnit.test("Scheduler time panel should not contain rows & cells", function(assert) {
         const $timePanel = this.instance.$element().find(".dx-scheduler-time-panel");
 
         assert.equal($timePanel.find("tbody tr").length, 0, "Time panel does not contain rows");
     });
 
-    QUnit.test("Scheduler workspace month view", (assert) => {
+    QUnit.test("Scheduler workspace month view", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -1244,7 +1244,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal(cellCounter, 6, "Each row has a seven cells");
     });
 
-    QUnit.test("Scheduler workspace month grouped view", (assert) => {
+    QUnit.test("Scheduler workspace month grouped view", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -1266,7 +1266,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal($element.find(".dx-scheduler-date-table tbody tr>td").eq(7).text(), "23", "Text is OK");
     });
 
-    QUnit.test("Scheduler workspace month view should contain a 7 headers", (assert) => {
+    QUnit.test("Scheduler workspace month view should contain a 7 headers", function(assert) {
         const $element = this.instance.$element();
 
         const $headerCells = $element.find(".dx-scheduler-header-row th");
@@ -1278,7 +1278,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         });
     });
 
-    QUnit.test("Scheduler workspace month grouped view should contain a few headers", (assert) => {
+    QUnit.test("Scheduler workspace month grouped view should contain a few headers", function(assert) {
         const $element = this.instance.$element();
         this.instance.option("groups", [
             {
@@ -1298,7 +1298,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal($element.find(".dx-scheduler-group-row").eq(1).find("th").attr("colspan"), 7, "Group header has a right 'colspan'");
     });
 
-    QUnit.test("Scheduler workspace month view should have a right date in each cell", (assert) => {
+    QUnit.test("Scheduler workspace month view should have a right date in each cell", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("currentDate", new Date(2015, 2, 1));
@@ -1313,7 +1313,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         });
     });
 
-    QUnit.test("Scheduler workspace month view should have a right date in each cell, groupByDate = true", (assert) => {
+    QUnit.test("Scheduler workspace month view should have a right date in each cell, groupByDate = true", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("groupByDate", true);
@@ -1337,7 +1337,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         });
     });
 
-    QUnit.test("Scheduler workspace month view should have a date with current-date class", (assert) => {
+    QUnit.test("Scheduler workspace month view should have a date with current-date class", function(assert) {
         const $element = this.instance.$element();
 
         const currentDate = new Date(),
@@ -1348,7 +1348,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal(parseInt($cell.text(), 10), currentDate.getDate().toString(), "Cell text is correct");
     });
 
-    QUnit.test("Scheduler workspace month view should have a dates with other-month class", (assert) => {
+    QUnit.test("Scheduler workspace month view should have a dates with other-month class", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("currentDate", new Date(2015, 2, 1));
@@ -1357,7 +1357,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal($cells.length, 11, "Other-month cells count is correct");
     });
 
-    QUnit.test("Scheduler workspace month view should have a dates with other-month class, if startDate is set", (assert) => {
+    QUnit.test("Scheduler workspace month view should have a dates with other-month class, if startDate is set", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("currentDate", new Date(2015, 2, 1));
@@ -1367,7 +1367,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal($cells.length, 11, "Other-month cells count is correct");
     });
 
-    QUnit.test("Scheduler workspace month view should have a dates with other-month class, if startDate & intervalCount is set", (assert) => {
+    QUnit.test("Scheduler workspace month view should have a dates with other-month class, if startDate & intervalCount is set", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("currentDate", new Date(2015, 2, 1));
@@ -1378,7 +1378,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal($cells.length, 6, "Other-month cells count is correct");
     });
 
-    QUnit.test("Scheduler workspace should have a right first day of week", (assert) => {
+    QUnit.test("Scheduler workspace should have a right first day of week", function(assert) {
         const $element = this.instance.$element();
 
         const days = dateLocalization.getDayNames("abbreviated");
@@ -1393,7 +1393,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal(firstCellHeader.toLowerCase(), days[this.instance.option("firstDayOfWeek")].toLowerCase(), "Workspace has a right first day of week when option was changed");
     });
 
-    QUnit.test("WorkSpace Month view has right count of rows with view option intervalCount", (assert) => {
+    QUnit.test("WorkSpace Month view has right count of rows with view option intervalCount", function(assert) {
         this.instance.option("intervalCount", 2);
 
         let rows = this.instance.$element().find(".dx-scheduler-date-table-row");
@@ -1405,14 +1405,14 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
         assert.equal(rows.length, 18, "view has right rows count");
     });
 
-    QUnit.test("WorkSpace Month view has right count of cells with view option intervalCount", (assert) => {
+    QUnit.test("WorkSpace Month view has right count of cells with view option intervalCount", function(assert) {
         this.instance.option("intervalCount", 2);
 
         const rows = this.instance.$element().find(".dx-scheduler-date-table-cell");
         assert.equal(rows.length, 7 * 10, "view has right cells count");
     });
 
-    QUnit.test("WorkSpace Month view with option intervalCount has cells with special firstDayOfMonth class", (assert) => {
+    QUnit.test("WorkSpace Month view with option intervalCount has cells with special firstDayOfMonth class", function(assert) {
         this.instance.option({
             intervalCount: 2,
             currentDate: new Date(2017, 5, 25)
@@ -1428,7 +1428,7 @@ QUnit.module("Workspace Month markup", monthModuleConfig, () => {
 });
 
 const monthWithGroupingModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space-grouped").dxSchedulerWorkSpaceMonth({
             groupOrientation: "vertical",
             startDayHour: 8,
@@ -1442,13 +1442,13 @@ const monthWithGroupingModuleConfig = {
 };
 
 QUnit.module("Workspace Month markup with vertical grouping", monthWithGroupingModuleConfig, () => {
-    QUnit.test("Scheduler workspace day should have a right css class", (assert) => {
+    QUnit.test("Scheduler workspace day should have a right css class", function(assert) {
         const $element = this.instance.$element();
 
         assert.ok($element.hasClass("dx-scheduler-work-space-vertical-grouped"), "Workspace has 'dx-scheduler-work-space-vertical-grouped' css class");
     });
 
-    QUnit.test("Workspace Month markup should contain three scrollable elements", (assert) => {
+    QUnit.test("Workspace Month markup should contain three scrollable elements", function(assert) {
         var $dateTableScrollable = this.instance.$element().find(".dx-scheduler-date-table-scrollable"),
             $sidebarScrollable = this.instance.$element().find(".dx-scheduler-sidebar-scrollable"),
             $headerScrollable = this.instance.$element().find(".dx-scheduler-header-scrollable");
@@ -1463,7 +1463,7 @@ QUnit.module("Workspace Month markup with vertical grouping", monthWithGroupingM
         assert.ok($headerScrollable.data("dxScrollable"), "Header scrollable is instance of dxScrollable");
     });
 
-    QUnit.test("Date table scrollable should have right config with vertical grouping", (assert) => {
+    QUnit.test("Date table scrollable should have right config with vertical grouping", function(assert) {
         var dateTableScrollable = this.instance.$element().find(".dx-scheduler-date-table-scrollable").dxScrollable("instance"),
             device = devices.current(),
             expectedShowScrollbarOption = "onHover";
@@ -1478,19 +1478,19 @@ QUnit.module("Workspace Month markup with vertical grouping", monthWithGroupingM
         assert.strictEqual(dateTableScrollable.option("updateManually"), true, "updateManually is OK");
     });
 
-    QUnit.test("Scheduler workspace month scrollable content should not have fixed-content class with vertical grouping", (assert) => {
+    QUnit.test("Scheduler workspace month scrollable content should not have fixed-content class with vertical grouping", function(assert) {
         const $scrollableContent = this.instance.getScrollable().$content();
 
         assert.notOk($scrollableContent.hasClass("dx-scheduler-scrollable-fixed-content"), "Scrollable content hasn't 'dx-scheduler-scrollable-fixed-content' css class");
     });
 
-    QUnit.test("Sidebar scrollable should contain group table", (assert) => {
+    QUnit.test("Sidebar scrollable should contain group table", function(assert) {
         var $sidebarScrollable = this.instance.$element().find(".dx-scheduler-sidebar-scrollable");
 
         assert.equal($sidebarScrollable.find(".dx-scheduler-group-header").length, 2, "Group header cells count is ok");
     });
 
-    QUnit.test("Scheduler workspace month should have correct rows and cells count", (assert) => {
+    QUnit.test("Scheduler workspace month should have correct rows and cells count", function(assert) {
         const $element = this.instance.$element();
         let cellCounter = 0;
 
@@ -1506,7 +1506,7 @@ QUnit.module("Workspace Month markup with vertical grouping", monthWithGroupingM
         assert.equal(cellCounter, 12, "Each row has a 7 cells");
     });
 
-    QUnit.test("Grouped cells should have a right group field in dxCellData", (assert) => {
+    QUnit.test("Grouped cells should have a right group field in dxCellData", function(assert) {
         let $element = this.instance.$element(),
             $cells = $element.find(".dx-scheduler-date-table tbody tr>td"),
             cellCount = $cells.length;
@@ -1517,7 +1517,7 @@ QUnit.module("Workspace Month markup with vertical grouping", monthWithGroupingM
         assert.deepEqual($cells.eq(cellCount / 2).data("dxCellData").groups, { a: 2 }, "Cell group is OK");
     });
 
-    QUnit.test("Scheduler workspace month view should have a dates with other-month class", (assert) => {
+    QUnit.test("Scheduler workspace month view should have a dates with other-month class", function(assert) {
         const $element = this.instance.$element();
 
         this.instance.option("currentDate", new Date(2015, 2, 1));
@@ -1526,7 +1526,7 @@ QUnit.module("Workspace Month markup with vertical grouping", monthWithGroupingM
         assert.equal($cells.length, 22, "Other-month cells count is correct");
     });
 
-    QUnit.test("Scheduler workspace month view should have a dates text", (assert) => {
+    QUnit.test("Scheduler workspace month view should have a dates text", function(assert) {
         const $element = this.instance.$element(),
             viewStart = new Date(2018, 1, 25);
 
@@ -1545,13 +1545,13 @@ QUnit.module("Workspace Month markup with vertical grouping", monthWithGroupingM
         });
     });
 
-    QUnit.test("Date table should have right group header", (assert) => {
+    QUnit.test("Date table should have right group header", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.find("." + VERTICAL_GROUP_TABLE_CLASS).length, 1, "Group header is rendered");
     });
 
-    QUnit.test("Date table should have right group header cells count", (assert) => {
+    QUnit.test("Date table should have right group header cells count", function(assert) {
         const $element = this.instance.$element();
 
         assert.equal($element.find(".dx-scheduler-group-header").length, 2, "Group header cells count is ok");
@@ -1559,7 +1559,7 @@ QUnit.module("Workspace Month markup with vertical grouping", monthWithGroupingM
 });
 
 const scrollingModuleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.instance = $("#scheduler-work-space").dxSchedulerWorkSpaceWeek({
             crossScrollingEnabled: true,
             width: 100
@@ -1568,13 +1568,13 @@ const scrollingModuleConfig = {
 };
 
 QUnit.module("Workspace with crossScrollingEnabled markup", scrollingModuleConfig, () => {
-    QUnit.test("Workspace should have correct class", (assert) => {
+    QUnit.test("Workspace should have correct class", function(assert) {
         assert.ok(this.instance.$element().hasClass("dx-scheduler-work-space-both-scrollbar"), "CSS class is OK");
         this.instance.option("crossScrollingEnabled", false);
         assert.notOk(this.instance.$element().hasClass("dx-scheduler-work-space-both-scrollbar"), "CSS class is OK");
     });
 
-    QUnit.test("Three scrollable elements should be rendered", (assert) => {
+    QUnit.test("Three scrollable elements should be rendered", function(assert) {
         var $dateTableScrollable = this.instance.$element().find(".dx-scheduler-date-table-scrollable"),
             $timePanelScrollable = this.instance.$element().find(".dx-scheduler-sidebar-scrollable"),
             $headerScrollable = this.instance.$element().find(".dx-scheduler-header-scrollable");
@@ -1589,14 +1589,14 @@ QUnit.module("Workspace with crossScrollingEnabled markup", scrollingModuleConfi
         assert.ok($headerScrollable.data("dxScrollable"), "Header scrollable is instance of dxScrollable");
     });
 
-    QUnit.test("Time panel scrollable should contain time panel", (assert) => {
+    QUnit.test("Time panel scrollable should contain time panel", function(assert) {
         var timePanelScrollable = this.instance.$element().find(".dx-scheduler-sidebar-scrollable").dxScrollable("instance"),
             scrollableContent = timePanelScrollable.$content();
 
         assert.equal(scrollableContent.find(".dx-scheduler-time-panel").length, 1, "Time panel exists");
     });
 
-    QUnit.test("Header scrollable should have right config", (assert) => {
+    QUnit.test("Header scrollable should have right config", function(assert) {
         var headerScrollable = this.instance.$element().find(".dx-scheduler-header-scrollable").dxScrollable("instance");
 
         assert.equal(headerScrollable.option("direction"), "horizontal", "Direction is OK");
@@ -1605,7 +1605,7 @@ QUnit.module("Workspace with crossScrollingEnabled markup", scrollingModuleConfi
         assert.strictEqual(headerScrollable.option("updateManually"), true, "updateManually is OK");
     });
 
-    QUnit.test("Time panel scrollable should have right config", (assert) => {
+    QUnit.test("Time panel scrollable should have right config", function(assert) {
         var timePanelScrollable = this.instance.$element().find(".dx-scheduler-sidebar-scrollable").dxScrollable("instance");
 
         assert.equal(timePanelScrollable.option("direction"), "vertical", "Direction is OK");


### PR DESCRIPTION
Clarification:
---

> QUnit test and module callbacks can share state by modifying properties of `this` within those callbacks.
> 
> This only works when using function expressions, which allow for dynamic binding of `this` by the QUnit library. Arrow function expressions will not work in this case, because arrow functions will always bind to whatever the value of `this` was in the enclosing scope (in QUnit tests, usually the global object). This means that developers who use arrow function expressions as test or module callbacks will not be able to share state and may encounter other problems.

See https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md

Examples:
---
![image](https://user-images.githubusercontent.com/1420883/69533858-afa53f00-0f89-11ea-8c2b-f330d00fbb30.png)

![image](https://user-images.githubusercontent.com/1420883/69533919-d5324880-0f89-11ea-88cb-86e33cad8d6f.png)

etc.