### PR TITLE
Form: Fix globals in tests

### DIFF
--- a/testing/tests/DevExpress.knockout/form.tests.js
+++ b/testing/tests/DevExpress.knockout/form.tests.js
@@ -590,7 +590,7 @@ QUnit.test("The formData is empty object when formData has 'undefined' value", f
     assert.deepEqual(viewModel.formData(), { });
 });
 
-QUnit.test("Check name argument of the simple item template when name is defined", assert => {
+QUnit.test("Check name argument of the simple item template when name is defined", function(assert) {
     // arrange
     const viewModel = {
         items: [{ name: "TestName", template: "simpleTemplate2" }]
@@ -603,7 +603,7 @@ QUnit.test("Check name argument of the simple item template when name is defined
     assert.strictEqual($("#name").text(), "TestName", "the name argument of template");
 });
 
-QUnit.test("Check name argument of the simple item template when name and dataField are defined", assert => {
+QUnit.test("Check name argument of the simple item template when name and dataField are defined", function(assert) {
     // arrange
     const viewModel = {
         items: [{ name: "TestName", dataField: "TestDataField", template: "simpleTemplate2" }]
@@ -616,7 +616,7 @@ QUnit.test("Check name argument of the simple item template when name and dataFi
     assert.strictEqual($("#name").text(), "TestName", "the name argument of template");
 });
 
-QUnit.test("Check name argument of the simple item template when name is undefined", assert => {
+QUnit.test("Check name argument of the simple item template when name is undefined", function(assert) {
     // arrange
     const viewModel = {
         items: [{ template: "simpleTemplate2" }]
@@ -629,7 +629,7 @@ QUnit.test("Check name argument of the simple item template when name is undefin
     assert.strictEqual($("#name").text(), "", "the name argument of template");
 });
 
-QUnit.test("Check name argument of the simple item template when name is undefined and dataField is defined", assert => {
+QUnit.test("Check name argument of the simple item template when name is undefined and dataField is defined", function(assert) {
     // arrange
     const viewModel = {
         items: [{ dataField: "TestDataField", template: "simpleTemplate2" }]

--- a/testing/tests/DevExpress.ui.widgets.form/form.API.option_formData.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.API.option_formData.tests.js
@@ -180,7 +180,7 @@ QUnit.test("Set { formData: {dataField1: a}, items: [dxTextArea] }, change edito
     assert.equal(form.getEditor("custom1").option("value"), "val1");
 });
 
-QUnit.test("Set { formData: {dataField1: a, dataField2: b}, items: [dataField1, dataField2], call option(formData, {dataField3: c}", assert => {
+QUnit.test("Set { formData: {dataField1: a, dataField2: b}, items: [dataField1, dataField2], call option(formData, {dataField3: c}", function(assert) {
     const onFieldDataChangedStub = sinon.stub();
     const form = $("#form").dxForm({
         formData: {
@@ -203,7 +203,7 @@ QUnit.test("Set { formData: {dataField1: a, dataField2: b}, items: [dataField1, 
     assert.equal(calls[0].args[0].value, "c", "value argument of the onFieldDataChanged event");
 });
 
-QUnit.test("Set { formData: {dataField1: a, dataField2: b}, items: [dataField1, dataField2], call option(formData, {dataField3: c}, change editor value", assert => {
+QUnit.test("Set { formData: {dataField1: a, dataField2: b}, items: [dataField1, dataField2], call option(formData, {dataField3: c}, change editor value", function(assert) {
     const onFieldDataChangedStub = sinon.stub();
     const form = $("#form").dxForm({
         formData: {
@@ -229,7 +229,7 @@ QUnit.test("Set { formData: {dataField1: a, dataField2: b}, items: [dataField1, 
     assert.equal(calls[1].args[0].value, "d", "second call - value argument of the onFieldDataChanged event");
 });
 
-QUnit.test("Set { formData: {dataField3: c}, items: [dataField1, dataField2], call option(formData, {dataField1: a, dataField2: b})", assert => {
+QUnit.test("Set { formData: {dataField3: c}, items: [dataField1, dataField2], call option(formData, {dataField1: a, dataField2: b})", function(assert) {
     const onFieldDataChangedStub = sinon.stub();
     const form = $("#form").dxForm({
         formData: {
@@ -257,7 +257,7 @@ QUnit.test("Set { formData: {dataField3: c}, items: [dataField1, dataField2], ca
     assert.equal(calls[1].args[0].value, "b", "second call - value argument of the onFieldDataChanged event");
 });
 
-QUnit.test("Reset editor's value when set formData: {dataField1: a}", assert => {
+QUnit.test("Reset editor's value when set formData: {dataField1: a}", function(assert) {
     const formData = {
         dxTextBox: "a",
         dxDateBox: new Date(),

--- a/testing/tests/DevExpress.ui.widgets.form/form.API.option_items_cssClass.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.API.option_items_cssClass.tests.js
@@ -24,7 +24,7 @@ QUnit.testStart(function() {
             return $("#form").dxForm({ items: items }).dxForm("instance");
         };
 
-        QUnit.testInActiveWindow("SimpleItem(undefined -> null)", assert => {
+        QUnit.testInActiveWindow("SimpleItem(undefined -> null)", function(assert) {
             const form = createForm();
 
             $("#form").find(".dx-texteditor-input").focus();
@@ -41,7 +41,7 @@ QUnit.testStart(function() {
             assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
         });
 
-        QUnit.testInActiveWindow("SimpleItem(undefined -> class1)", assert => {
+        QUnit.testInActiveWindow("SimpleItem(undefined -> class1)", function(assert) {
             const form = createForm();
 
             $("#form").find(".dx-texteditor-input").focus();
@@ -59,7 +59,7 @@ QUnit.testStart(function() {
             assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
         });
 
-        QUnit.testInActiveWindow("SimpleItem(null -> undefined)", assert => {
+        QUnit.testInActiveWindow("SimpleItem(null -> undefined)", function(assert) {
             const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
@@ -81,7 +81,7 @@ QUnit.testStart(function() {
             assert.ok($("#form").find(".dx-texteditor-input").is(":focus"), "final focus");
         });
 
-        QUnit.testInActiveWindow("SimpleItem(null -> class1)", assert => {
+        QUnit.testInActiveWindow("SimpleItem(null -> class1)", function(assert) {
             const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
@@ -104,7 +104,7 @@ QUnit.testStart(function() {
             assert.strictEqual($("#form").find(".class1").length, 1, "$(#form).find(class1).length");
         });
 
-        QUnit.testInActiveWindow("SimpleItem(class1 -> undefined)", assert => {
+        QUnit.testInActiveWindow("SimpleItem(class1 -> undefined)", function(assert) {
             const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
@@ -128,7 +128,7 @@ QUnit.testStart(function() {
             assert.strictEqual($("#form").find(".class1").length, 0, "$(#form).find(class1).length");
         });
 
-        QUnit.testInActiveWindow("SimpleItem(class1 -> null)", assert => {
+        QUnit.testInActiveWindow("SimpleItem(class1 -> null)", function(assert) {
             const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
@@ -152,7 +152,7 @@ QUnit.testStart(function() {
             assert.strictEqual($("#form").find(".class1").length, 0, "$(#form).find(class1).length");
         });
 
-        QUnit.testInActiveWindow("SimpleItem(class1 -> class2)", assert => {
+        QUnit.testInActiveWindow("SimpleItem(class1 -> class2)", function(assert) {
             const form = createForm([{
                 itemType: "simple",
                 editorType: "dxTextBox",
@@ -184,7 +184,7 @@ QUnit.testStart(function() {
             assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
         });
 
-        QUnit.testInActiveWindow("SimpleItem(class1 -> class2) in form with 2 items", assert => {
+        QUnit.testInActiveWindow("SimpleItem(class1 -> class2) in form with 2 items", function(assert) {
             const form = createForm([
                 {
                     itemType: "simple",
@@ -222,7 +222,7 @@ QUnit.testStart(function() {
             assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
         });
 
-        QUnit.test("SimpleItem(undefined -> class1) when item is hidden via api", assert => {
+        QUnit.test("SimpleItem(undefined -> class1) when item is hidden via api", function(assert) {
             const form = createForm([
                 {
                     itemType: "simple",
@@ -244,7 +244,7 @@ QUnit.testStart(function() {
             assert.strictEqual($("#form").find(".class2").length, 0, "$(#form).find(class2).length");
         });
 
-        QUnit.testInActiveWindow("ButtonItem(class1 -> class2)", assert => {
+        QUnit.testInActiveWindow("ButtonItem(class1 -> class2)", function(assert) {
             if(devices.real().deviceType !== "desktop") {
                 assert.ok(true, "desktop specific test");
                 return;
@@ -272,7 +272,7 @@ QUnit.testStart(function() {
             assert.strictEqual($("#form").find(".class2").length, 1, "$(#form).find(class2).length");
         });
 
-        QUnit.testInActiveWindow("ButtonItem(class1 -> class2) in form with 2 items", assert => {
+        QUnit.testInActiveWindow("ButtonItem(class1 -> class2) in form with 2 items", function(assert) {
             if(devices.real().deviceType !== "desktop") {
                 assert.ok(true, "desktop specific test");
                 return;

--- a/testing/tests/DevExpress.ui.widgets.form/form.API.update_items_dynamically.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.API.update_items_dynamically.tests.js
@@ -154,8 +154,8 @@ testStart(function() {
     $("#qunit-fixture").html(markup);
 });
 
-module("Group item. Use the option method", () => {
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change visible of dataField2)`, () => {
+module("Group item. Use the option method", function() {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -184,7 +184,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkItemElement(".test-item", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change editorOptions of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change editorOptions of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -209,7 +209,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkFormsReRender("editorOptions: { }");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change items of group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change items of group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -243,7 +243,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change visible of first group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change visible of first group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -280,7 +280,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkItemElement(".test-item", true, "simple item element");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of first group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of first group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -328,7 +328,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change visible of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -360,7 +360,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkItemElement(".test-item", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change editorOptions of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change editorOptions of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -388,7 +388,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkFormsReRender("editorOptions: { }");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of last group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of last group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -424,7 +424,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change visible of dataField2 and dataField3)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change visible of dataField2 and dataField3)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -472,7 +472,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkItemElement(".test-item3", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change items in the both groups)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change items in the both groups)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -514,7 +514,7 @@ module("Group item. Use the option method", () => {
         testWrapper.checkSimpleItem("dataField22", "", "Data Field 22");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change options of dataField2 and dataField3)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change options of dataField2 and dataField3)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -560,8 +560,8 @@ module("Group item. Use the option method", () => {
     });
 });
 
-module("Tabbed item. Use the option method", () => {
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change visible of dataField2)`, () => {
+module("Tabbed item. Use the option method", function() {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -592,7 +592,7 @@ module("Tabbed item. Use the option method", () => {
         testWrapper.checkItemElement(".test-item", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change items of tab)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change items of tab)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -628,7 +628,7 @@ module("Tabbed item. Use the option method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change editorOptions of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change editorOptions of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -655,7 +655,7 @@ module("Tabbed item. Use the option method", () => {
         testWrapper.checkFormsReRender("editorOptions: { }");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change visible of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -690,7 +690,7 @@ module("Tabbed item. Use the option method", () => {
         testWrapper.checkItemElement(".test-item", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change items of group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change items of group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -730,7 +730,7 @@ module("Tabbed item. Use the option method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change editorOptions of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change editorOptions of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -761,7 +761,7 @@ module("Tabbed item. Use the option method", () => {
         testWrapper.checkFormsReRender("editorOptions: { }");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items: [{itemType: 'tabbed', tabs:[{items: ['dataField2']}]}] }, change visible of tabbed item)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items: [{itemType: 'tabbed', tabs:[{items: ['dataField2']}]}] }, change visible of tabbed item)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -797,8 +797,8 @@ module("Tabbed item. Use the option method", () => {
     });
 });
 
-module("Group item. Use the itemOption method", () => {
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change visible of dataField2)`, () => {
+module("Group item. Use the itemOption method", function() {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -827,7 +827,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkItemElement(".test-item", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change options of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change options of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -855,7 +855,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkHelpText(".test-item", "Test help text");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change editorOptions of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change editorOptions of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -880,7 +880,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkFormsReRender("editorOptions: { }");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change items of group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change items of group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -915,7 +915,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change items of group, change visible of dataField12)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}] }, change items of group, change visible of dataField12)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -947,7 +947,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkItemElement(".test-item12", false, "item element of the dataField12");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change visible of first group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change visible of first group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -984,7 +984,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkItemElement(".test-item", true, "simple item element");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of first group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of first group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1033,7 +1033,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change visible of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1065,7 +1065,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkItemElement(".test-item", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of second group, change visible of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of second group, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1101,7 +1101,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkItemElement(".test-item11", false, "item element of the dataField11");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change editorOptions of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change editorOptions of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1129,7 +1129,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkFormsReRender("editorOptions: { }");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of last group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:[{itemType: 'group', items: ['dataField2']}]}] }, change items of last group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1166,7 +1166,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change visible of dataField2 and dataField3)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change visible of dataField2 and dataField3)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1214,7 +1214,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkItemElement(".test-item3", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change items in the both groups)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change items in the both groups)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1258,7 +1258,7 @@ module("Group item. Use the itemOption method", () => {
         testWrapper.checkSimpleItem("dataField22", "", "Data Field 22");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change options of dataField2 and dataField3)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items:['dataField2']}, {itemType: 'group', items:['dataField3']}] }, change options of dataField2 and dataField3)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1305,8 +1305,8 @@ module("Group item. Use the itemOption method", () => {
     });
 });
 
-module("Tabbed item. Use the itemOption method", () => {
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change visible of dataField2)`, () => {
+module("Tabbed item. Use the itemOption method", function() {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1338,7 +1338,7 @@ module("Tabbed item. Use the itemOption method", () => {
         testWrapper.checkItemElement(".test-item", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {temType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change items of tab)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {temType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change items of tab)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1375,7 +1375,7 @@ module("Tabbed item. Use the itemOption method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change editorOptions of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: 'dataField2'}]}] }, change editorOptions of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1403,7 +1403,7 @@ module("Tabbed item. Use the itemOption method", () => {
         testWrapper.checkFormsReRender("editorOptions: { }");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change visible of dataField2)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change visible of dataField2)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1439,7 +1439,7 @@ module("Tabbed item. Use the itemOption method", () => {
         testWrapper.checkItemElement(".test-item", true);
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change items of group)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change items of group)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1480,7 +1480,7 @@ module("Tabbed item. Use the itemOption method", () => {
         testWrapper.checkSimpleItem("dataField3", "", "Data Field 3");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change editorOptions of dataField2")`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'tabbed', tabs:[{items: [{itemType: 'group', items:['dataField2']}]}]}] }, change editorOptions of dataField2")`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1512,7 +1512,7 @@ module("Tabbed item. Use the itemOption method", () => {
         testWrapper.checkFormsReRender("editorOptions: { }");
     });
 
-    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items: [{itemType: 'tabbed', tabs:[{items: ['dataField2']}]}] }, change visible of tabbed item)`, () => {
+    test(`Set { formData: {'DataField1', 'DataField2'}, items: ['dataField1', {itemType: 'group', items: [{itemType: 'tabbed', tabs:[{items: ['dataField2']}]}] }, change visible of tabbed item)`, function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1",
@@ -1550,7 +1550,7 @@ module("Tabbed item. Use the itemOption method", () => {
 });
 
 module("Align labels", () => {
-    test("Change visible of the simple item in the group when col count is 1", () => {
+    test("Change visible of the simple item in the group when col count is 1", function() {
         const testWrapper = new FormTestWrapper({
             items: [{
                 itemType: "group",
@@ -1568,7 +1568,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInGroup({ columnIndex: 0, etalonLabelText: "Last Name" });
     });
 
-    test("Change items of the second group item when col count is 1", () => {
+    test("Change items of the second group item when col count is 1", function() {
         const testWrapper = new FormTestWrapper({
             items: [{
                 itemType: "group",
@@ -1586,7 +1586,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInGroup({ columnIndex: 0, etalonLabelText: "Description" });
     });
 
-    test("Change visible of the nested group item inside a group when col count is 1", () => {
+    test("Change visible of the nested group item inside a group when col count is 1", function() {
         const testWrapper = new FormTestWrapper({
             items: [{
                 itemType: "group",
@@ -1607,7 +1607,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInGroup({ columnIndex: 0, etalonLabelText: "Last Name" });
     });
 
-    test("Change visible of the simple item in the group when col count is 2", () => {
+    test("Change visible of the simple item in the group when col count is 2", function() {
         const testWrapper = new FormTestWrapper({
             colCount: 2,
             screenByWidth: () => "lg",
@@ -1635,7 +1635,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInGroup({ columnIndex: 1, etalonLabelText: "Test City" });
     });
 
-    test("Change items of the groups when groups has col count is 2", () => {
+    test("Change items of the groups when groups has col count is 2", function() {
         const testWrapper = new FormTestWrapper({
             screenByWidth: () => "lg",
             items: [{
@@ -1670,7 +1670,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInGroup({ columnIndex: 0, groupColumnIndex: 1, etalonLabelText: "Description" });
     });
 
-    test("Change visible of the simple item and set colspan = 2 in the group with colCount = 2", () => {
+    test("Change visible of the simple item and set colspan = 2 in the group with colCount = 2", function() {
         const testWrapper = new FormTestWrapper({
             screenByWidth: () => "lg",
             items: [{
@@ -1688,7 +1688,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInGroup({ columnIndex: 0, groupColumnIndex: 1, etalonLabelText: "City" });
     });
 
-    test("Change visible of the simple item in the tab when col count is 2", () => {
+    test("Change visible of the simple item in the tab when col count is 2", function() {
         const testWrapper = new FormTestWrapper({
             screenByWidth: () => "lg",
             items: [{
@@ -1710,7 +1710,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInTab({ tabColumnIndex: 1, etalonLabelText: "Home Address" });
     });
 
-    test("Change visible of the simple item in the tab when col count is 1", () => {
+    test("Change visible of the simple item in the tab when col count is 1", function() {
         const testWrapper = new FormTestWrapper({
             screenByWidth: () => "lg",
             items: [{
@@ -1730,7 +1730,7 @@ module("Align labels", () => {
 
     });
 
-    test("Change items of the simple item in the tab when col count is 2", () => {
+    test("Change items of the simple item in the tab when col count is 2", function() {
         const testWrapper = new FormTestWrapper({
             screenByWidth: () => "lg",
             items: [{
@@ -1752,7 +1752,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInTab({ tabColumnIndex: 1, etalonLabelText: "Home Address" });
     });
 
-    test("Change visible of the simple items of groups in the tab when col count of the groups is 2", () => {
+    test("Change visible of the simple items of groups in the tab when col count of the groups is 2", function() {
         const testWrapper = new FormTestWrapper({
             screenByWidth: () => "lg",
             items: [{
@@ -1791,7 +1791,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInGroup({ columnIndex: 0, groupColumnIndex: 1, etalonLabelText: "Home Address" });
     });
 
-    test("Labels of common layout align independently from labels of the tabbed item when parent col count is 1", () => {
+    test("Labels of common layout align independently from labels of the tabbed item when parent col count is 1", function() {
         const testWrapper = new FormTestWrapper({
             screenByWidth: () => "lg",
             items: [{
@@ -1830,7 +1830,7 @@ module("Align labels", () => {
         testWrapper.checkLabelsWidthInGroup({ columnIndex: 0, groupColumnIndex: 1, etalonLabelText: "Home Address" });
     });
 
-    test("Labels of common layout align independently from labels of the tabbed item when parent col count is 2", () => {
+    test("Labels of common layout align independently from labels of the tabbed item when parent col count is 2", function() {
         const testWrapper = new FormTestWrapper({
             screenByWidth: () => "lg",
             colCount: 2,
@@ -1874,7 +1874,7 @@ module("Align labels", () => {
 });
 
 module("Validation", () => {
-    test("Rendering new item with validation rules", () => {
+    test("Rendering new item with validation rules", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"
@@ -1893,7 +1893,7 @@ module("Validation", () => {
         testWrapper.checkValidationResult({ isValid: false, brokenRulesCount: 1, validatorsCount: 1 });
     });
 
-    test("Rendering new simple item instead of a simple item with validation rules", () => {
+    test("Rendering new simple item instead of a simple item with validation rules", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"
@@ -1914,7 +1914,7 @@ module("Validation", () => {
         testWrapper.checkValidationResult({ isValid: true, brokenRulesCount: 0, validatorsCount: 0 });
     });
 
-    test("Rendering new items with validation rules", () => {
+    test("Rendering new items with validation rules", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"
@@ -1936,7 +1936,7 @@ module("Validation", () => {
         testWrapper.checkValidationResult({ isValid: false, brokenRulesCount: 2, validatorsCount: 2 });
     });
 
-    test("Rendering new items with validation rules instead of items without validation rules in the group and check the validation summary", () => {
+    test("Rendering new items with validation rules instead of items without validation rules in the group and check the validation summary", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"
@@ -1960,7 +1960,7 @@ module("Validation", () => {
         testWrapper.checkValidationSummaryContent(["dataField2 is required", "dataField3 is required"]);
     });
 
-    test("Rendering new simple item without validation rules instead of items with validation rules in the group and check the validation summary", () => {
+    test("Rendering new simple item without validation rules instead of items with validation rules in the group and check the validation summary", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"
@@ -1988,7 +1988,7 @@ module("Validation", () => {
         testWrapper.checkValidationSummaryContent([]);
     });
 
-    test("Add new validator of simple item after validating form with the validation summary", () => {
+    test("Add new validator of simple item after validating form with the validation summary", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"
@@ -2019,7 +2019,7 @@ module("Validation", () => {
         testWrapper.checkValidationSummaryContent(["dataField2 is required", "dataField3 is required"]);
     });
 
-    test("Change the isRequired option of the simple item", () => {
+    test("Change the isRequired option of the simple item", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"
@@ -2041,7 +2041,7 @@ module("Validation", () => {
         testWrapper.checkValidationResult({ isValid: true, brokenRulesCount: 0, validatorsCount: 0 });
     });
 
-    test("Change the visible option of the simple item", () => {
+    test("Change the visible option of the simple item", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"
@@ -2064,7 +2064,7 @@ module("Validation", () => {
         testWrapper.checkValidationResult({ isValid: false, brokenRulesCount: 1, validatorsCount: 1 });
     });
 
-    test("Change the visible option of the simple item with validationSummary", () => {
+    test("Change the visible option of the simple item with validationSummary", function() {
         const testWrapper = new FormTestWrapper({
             formData: {
                 dataField1: "DataField1"

--- a/testing/tests/DevExpress.ui.widgets.form/form.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.markup.tests.js
@@ -33,7 +33,7 @@ QUnit.testStart(() => {
 });
 
 QUnit.module("Form", () => {
-    test("Invalidate after option changed", (assert) => {
+    test("Invalidate after option changed", function(assert) {
         // arrange
         let testingOptions = ["formData", "items", "colCount", "onFieldDataChanged", "labelLocation",
                 "alignItemLabels", "showColonAfterLabel", "customizeItem", "minColWidth", "alignItemLabelsInAllGroups", "onEditorEnterKey", "scrollingEnabled", "formID"],
@@ -64,7 +64,7 @@ QUnit.module("Form", () => {
         assert.equal(invalidateStub.callCount, testingOptions.length);
     });
 
-    test("Invalidate is not called when formData is changed and items option is defined", (assert) => {
+    test("Invalidate is not called when formData is changed and items option is defined", function(assert) {
         // arrange
         let form = $("#form").dxForm({
                 items: [
@@ -84,7 +84,7 @@ QUnit.module("Form", () => {
         assert.equal(invalidateStub.callCount, 0);
     });
 
-    test("Default render", (assert) => {
+    test("Default render", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
             items: [
@@ -101,7 +101,7 @@ QUnit.module("Form", () => {
         assert.equal($formContainer.find("." + internals.FORM_LAYOUT_MANAGER_CLASS).length, 1, "Layout manager is rendered");
     });
 
-    test("Check the default focus target", (assert) => {
+    test("Check the default focus target", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
             items: [
@@ -118,7 +118,7 @@ QUnit.module("Form", () => {
         assert.equal($formContainer.dxForm("instance")._focusTarget().closest(".dx-widget").html(), $input.closest(".dx-widget").html(), "Correct focus target");
     });
 
-    test("Check root layout width on option change", (assert) => {
+    test("Check root layout width on option change", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 items: [
@@ -137,7 +137,7 @@ QUnit.module("Form", () => {
         assert.equal(rootLayoutManager.option("width"), 100, "Correct width");
     });
 
-    test("Form isn't refresh on dimension changed if colCount is auto", (assert) => {
+    test("Form isn't refresh on dimension changed if colCount is auto", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 colCount: "auto",
@@ -157,7 +157,7 @@ QUnit.module("Form", () => {
         assert.equal(refreshStub.callCount, 0, "don't refresh on resize if colCount is auto");
     });
 
-    test("Form doesn't refresh on dimension changed if colCount is not auto", (assert) => {
+    test("Form doesn't refresh on dimension changed if colCount is not auto", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 items: [
@@ -177,7 +177,7 @@ QUnit.module("Form", () => {
         assert.equal(refreshStub.callCount, 0, "do not refresh on resize if colCount isn't auto");
     });
 
-    test("Render read only form", (assert) => {
+    test("Render read only form", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
             readOnly: true,
@@ -193,7 +193,7 @@ QUnit.module("Form", () => {
         assert.ok($formContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor").hasClass("dx-state-readonly"), "editor is read only");
     });
 
-    test("Render form with colspan", (assert) => {
+    test("Render form with colspan", function(assert) {
         // arrange, act
         let $testContainer = $("#form");
 
@@ -220,7 +220,7 @@ QUnit.module("Form", () => {
         assert.equal($fieldItems.length, 5, "4 simple items + 1 group item");
     });
 
-    test("'readOnly' is changed in inner components on optionChanged", (assert) => {
+    test("'readOnly' is changed in inner components on optionChanged", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
             items: [
@@ -239,7 +239,7 @@ QUnit.module("Form", () => {
         assert.ok($formContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor").hasClass("dx-state-readonly"), "editor is read only");
     });
 
-    test("'disable' is changed in inner components on optionChanged", (assert) => {
+    test("'disable' is changed in inner components on optionChanged", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
             items: [
@@ -259,7 +259,7 @@ QUnit.module("Form", () => {
         assert.notOk($formContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor").hasClass("dx-state-disabled"), "editor isn't disabled");
     });
 
-    test("Customize item event", (assert) => {
+    test("Customize item event", function(assert) {
         // arrange, act
         let testObject = {
                 ID: 1,
@@ -303,7 +303,7 @@ QUnit.module("Form", () => {
 
     });
 
-    test("Check that data fully changes after object replace", (assert) => {
+    test("Check that data fully changes after object replace", function(assert) {
         // arrange
         let $testContainer = $("#form");
 
@@ -319,7 +319,7 @@ QUnit.module("Form", () => {
 
     });
 
-    test("Check data at render with items", (assert) => {
+    test("Check data at render with items", function(assert) {
         // arrange, act
         let $testContainer = $("#form");
 
@@ -333,7 +333,7 @@ QUnit.module("Form", () => {
         assert.deepEqual($testContainer.find(".dx-layout-manager").dxLayoutManager("instance").option("layoutData"), { FamousPirate: "John Morgan" }, "Correct formData");
     });
 
-    test("Check data at render with items and change widget's value", (assert) => {
+    test("Check data at render with items and change widget's value", function(assert) {
         // arrange
         let $testContainer = $("#form");
 
@@ -349,7 +349,7 @@ QUnit.module("Form", () => {
         assert.deepEqual($testContainer.dxForm("instance").option("formData"), { FamousPirate: "John Morgan", FamousDetective: "Sherlock Holmes" }, "Correct formData");
     });
 
-    test("Change of editor's value changing 'formData' option", (assert) => {
+    test("Change of editor's value changing 'formData' option", function(assert) {
         // arrange
         let $testContainer = $("#form");
 
@@ -364,7 +364,7 @@ QUnit.module("Form", () => {
         assert.deepEqual($testContainer.dxForm("instance").option("formData"), { FamousPirate: "Cpt. Jack Sparrow" }, "Correct formData");
     });
 
-    test("Update of editor's value when formOption is changed and items is defined", (assert) => {
+    test("Update of editor's value when formOption is changed and items is defined", function(assert) {
         // arrange
         let $testContainer = $("#form"),
             form,
@@ -394,7 +394,7 @@ QUnit.module("Form", () => {
         assert.ok(!form._rootLayoutManager._invalidate.called, "_invalidate of layout manger is not called");
     });
 
-    test("Check the work of onFieldDataChanged", (assert) => {
+    test("Check the work of onFieldDataChanged", function(assert) {
         // arrange
         let $testContainer = $("#form"),
             testObject,
@@ -425,7 +425,7 @@ QUnit.module("Form", () => {
         assert.equal(callCount, 3, "onFieldDataChanged called 3 times");
     });
 
-    test("Check the work of onFieldDataChanged with complex dataField", (assert) => {
+    test("Check the work of onFieldDataChanged with complex dataField", function(assert) {
         // arrange
         let $testContainer = $("#form"),
             testObject,
@@ -463,7 +463,7 @@ QUnit.module("Form", () => {
         assert.equal(callCount, 2, "onFieldDataChanged called 2 times");
     });
 
-    test("Check the work of onFieldDataChanged when whole object is changed", (assert) => {
+    test("Check the work of onFieldDataChanged when whole object is changed", function(assert) {
         // arrange
         let $testContainer = $("#form"),
             testObjects = [];
@@ -487,7 +487,7 @@ QUnit.module("Form", () => {
         assert.deepEqual(testObjects[1], { dataField: "famousDetective", value: "Sherlock Holmes" }, "Correct data");
     });
 
-    test("Check the work of onFieldDataChanged when whole object is changed and items are defined", (assert) => {
+    test("Check the work of onFieldDataChanged when whole object is changed and items are defined", function(assert) {
         // arrange
         let $testContainer = $("#form"),
             testObjects = [];
@@ -508,7 +508,7 @@ QUnit.module("Form", () => {
         assert.equal(testObjects.length, 2, "onFieldDataChanged fired 2 times");
     });
 
-    test("Check the onFieldDataChanged resets old subscriptions", (assert) => {
+    test("Check the onFieldDataChanged resets old subscriptions", function(assert) {
         // arrange
         let $testContainer = $("#form"),
             testObjects = [];
@@ -541,7 +541,7 @@ QUnit.module("Form", () => {
         assert.equal(testObjects.length, 4, "onFieldDataChanged fired 4 times");
     });
 
-    test("alignItemLabels option for not grouping", (assert) => {
+    test("alignItemLabels option for not grouping", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 formData: { name: "Test", lastName: "surname" }
@@ -552,7 +552,7 @@ QUnit.module("Form", () => {
         assert.equal($layoutManager.option("alignItemLabels"), true);
     });
 
-    test("Render scrollable", (assert) => {
+    test("Render scrollable", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
             height: 200,
@@ -577,7 +577,7 @@ QUnit.module("Form", () => {
         assert.equal($formContainer.find(".dx-scrollable-content > ." + internals.FORM_LAYOUT_MANAGER_CLASS).length, 1, "scrollable content");
     });
 
-    test("Show validation summary", (assert) => {
+    test("Show validation summary", function(assert) {
         // arrange
         let $formContainer = $("#form").dxForm({
                 showValidationSummary: true,
@@ -602,7 +602,7 @@ QUnit.module("Form", () => {
         assert.equal($summaryContents.eq(0).text(), "Required", "summary item");
     });
 
-    test("Show validation summary via option method", (assert) => {
+    test("Show validation summary via option method", function(assert) {
         // arrange
         let $formContainer = $("#form").dxForm({
             showValidationSummary: false,
@@ -621,7 +621,7 @@ QUnit.module("Form", () => {
         assert.equal($formContainer.find(`.${VALIDATION_SUMMARY_CLASS}`).length, 1);
     });
 
-    test("Hide validation summary via option method", (assert) => {
+    test("Hide validation summary via option method", function(assert) {
         // arrange
         let $formContainer = $("#form").dxForm({
             showValidationSummary: true,
@@ -640,7 +640,7 @@ QUnit.module("Form", () => {
         assert.equal($formContainer.find("form .dx-validationsummary").length, 0);
     });
 
-    test("The dxForm is not rendered correctly when colCount is zero", (assert) => {
+    test("The dxForm is not rendered correctly when colCount is zero", function(assert) {
         // arrange, act
         let form = $("#form").dxForm({
             formData: { name: "Batman" },
@@ -660,7 +660,7 @@ QUnit.module("Form", () => {
         assert.equal(form.$element().find("." + internals.FORM_FIELD_ITEM_COL_CLASS + "0").length, 1);
     });
 
-    test("Render form item with specific class", (assert) => {
+    test("Render form item with specific class", function(assert) {
         // arrange, act
         let $testContainer = $("#form").dxForm({
             items: [
@@ -706,7 +706,7 @@ QUnit.module("Form", () => {
         assert.equal($testContainer.find("." + internals.FIELD_ITEM_CLASS + " .custom-empty-class").length, 1, "custom class for empty");
     });
 
-    test("Validation boundary for editors when scrolling is enabled_T306331", (assert) => {
+    test("Validation boundary for editors when scrolling is enabled_T306331", function(assert) {
         // arrange
         let form = $("#form").dxForm({
             scrollingEnabled: true,
@@ -732,7 +732,7 @@ QUnit.module("Form", () => {
         assert.equal($editors.eq(1).dxTextBox("option", "validationBoundary"), form.$element());
     });
 
-    test("Validation boundary for editors when scrolling is disabled_T306331", (assert) => {
+    test("Validation boundary for editors when scrolling is disabled_T306331", function(assert) {
         // arrange
         let form = $("#form").dxForm({
             scrollingEnabled: false,
@@ -758,7 +758,7 @@ QUnit.module("Form", () => {
         assert.equal($editors.eq(1).dxTextBox("option", "validationBoundary"), undefined);
     });
 
-    test("button item should have a Form's validation group by default", (assert) => {
+    test("button item should have a Form's validation group by default", function(assert) {
         // arrange, act
         let $testContainer = $("#form"),
             form = $testContainer.dxForm({
@@ -779,7 +779,7 @@ QUnit.module("Form", () => {
         assert.equal(secondButtonValidationGroup, "test", "Custom validation group");
     });
 
-    test("button item should catch a custom validation group from Form", (assert) => {
+    test("button item should catch a custom validation group from Form", function(assert) {
         // arrange, act
         let $testContainer = $("#form");
 
@@ -796,7 +796,7 @@ QUnit.module("Form", () => {
         assert.equal(buttonValidationGroup, "test", "Button validationGroup is OK");
     });
 
-    test("Check name argument of the simple item template when name is defined", (assert) => {
+    test("Check name argument of the simple item template when name is defined", function(assert) {
         const templateStub = sinon.stub();
         $("#form").dxForm({
             items: [{
@@ -808,7 +808,7 @@ QUnit.module("Form", () => {
         assert.equal(templateStub.getCall(0).args[0].name, "TestName", "name argument");
     });
 
-    test("Check name argument of the simple item template when name and dataField are defined", (assert) => {
+    test("Check name argument of the simple item template when name and dataField are defined", function(assert) {
         const templateStub = sinon.stub();
         $("#form").dxForm({
             items: [{
@@ -821,7 +821,7 @@ QUnit.module("Form", () => {
         assert.equal(templateStub.getCall(0).args[0].name, "TestName", "name argument");
     });
 
-    test("Check name argument of the simple item template when name is undefined", (assert) => {
+    test("Check name argument of the simple item template when name is undefined", function(assert) {
         const templateStub = sinon.stub();
         $("#form").dxForm({
             items: [{
@@ -832,7 +832,7 @@ QUnit.module("Form", () => {
         assert.equal(templateStub.getCall(0).args[0].name, undefined, "name argument");
     });
 
-    test("Check name argument of the simple item template when name is undefined and dataField is defined", (assert) => {
+    test("Check name argument of the simple item template when name is undefined and dataField is defined", function(assert) {
         const templateStub = sinon.stub();
         $("#form").dxForm({
             items: [{
@@ -853,7 +853,7 @@ QUnit.module("Validation group", () => {
             .dxForm(options).dxForm("instance");
     };
 
-    test("Set { items: [{dataField: name, isRequired: true}] }", (assert) => {
+    test("Set { items: [{dataField: name, isRequired: true}] }", function(assert) {
         const $formContainer = $("#form").dxForm({
             items: [{ dataField: "name", isRequired: true }]
         });
@@ -866,7 +866,7 @@ QUnit.module("Validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig(form), "form's validation group in the validation engine");
     });
 
-    test("Set { items: [{dataField: name, isRequired: true}], showValidationSummary: true }", (assert) => {
+    test("Set { items: [{dataField: name, isRequired: true}], showValidationSummary: true }", function(assert) {
         const $formContainer = $("#form").dxForm({
             showValidationSummary: true,
             items: [{ dataField: "name", isRequired: true }]
@@ -879,7 +879,7 @@ QUnit.module("Validation group", () => {
         assert.equal(validationSummary.option("validationGroup"), form, "validation group of the validation summary");
     });
 
-    test("Set { items: [{dataField: name, isRequired: true}], validationGroup: Test }", (assert) => {
+    test("Set { items: [{dataField: name, isRequired: true}], validationGroup: Test }", function(assert) {
         const $formContainer = $("#form").dxForm({
             items: [{ dataField: "name", isRequired: true }],
             validationGroup: "Test"
@@ -892,7 +892,7 @@ QUnit.module("Validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig("Test"), "form's validation group in the validation engine");
     });
 
-    test("Set { items: [{dataField: name, isRequired: true}], validationGroup: Test, showValidationSummary: true }", (assert) => {
+    test("Set { items: [{dataField: name, isRequired: true}], validationGroup: Test, showValidationSummary: true }", function(assert) {
         const $formContainer = $("#form").dxForm({
             validationGroup: "Test",
             showValidationSummary: true,
@@ -905,7 +905,7 @@ QUnit.module("Validation group", () => {
         assert.equal(validationSummary.option("validationGroup"), "Test", "validation group of the validation summary");
     });
 
-    test("Set { items: [{dataField: name}] }", (assert) => {
+    test("Set { items: [{dataField: name}] }", function(assert) {
         const $formContainer = $("#form").dxForm({
             items: [{ dataField: "name" }]
         });
@@ -916,7 +916,7 @@ QUnit.module("Validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig(form), "form's validation group in the validation engine");
     });
 
-    test("Set { items: [{dataField: name}], showValidationSummary: true }", (assert) => {
+    test("Set { items: [{dataField: name}], showValidationSummary: true }", function(assert) {
         const $formContainer = $("#form").dxForm({
             items: [{ dataField: "name" }],
             showValidationSummary: true
@@ -929,7 +929,7 @@ QUnit.module("Validation group", () => {
         assert.equal(validationSummary.option("validationGroup"), form, "validation group of the validation summary");
     });
 
-    test("Set { items: [{dataField: name}], validationGroup: Test }", (assert) => {
+    test("Set { items: [{dataField: name}], validationGroup: Test }", function(assert) {
         const $formContainer = $("#form").dxForm({
             items: [{ dataField: "name" }],
             validationGroup: "Test"
@@ -940,7 +940,7 @@ QUnit.module("Validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig("Test"), "form's validation group in the validation engine");
     });
 
-    test("Set { items: [{dataField: name}], validationGroup: Test, showValidationSummary: true }", (assert) => {
+    test("Set { items: [{dataField: name}], validationGroup: Test, showValidationSummary: true }", function(assert) {
         const $formContainer = $("#form").dxForm({
             items: [{ dataField: "name" }],
             validationGroup: "Test",
@@ -953,7 +953,7 @@ QUnit.module("Validation group", () => {
         assert.equal(validationSummary.option("validationGroup"), "Test", "validation group of the validation summary");
     });
 
-    test("Create two forms, Set { items: [{dataField: name1}], Set { items: [{dataField: name2}]", (assert) => {
+    test("Create two forms, Set { items: [{dataField: name1}], Set { items: [{dataField: name2}]", function(assert) {
         const form1 = $("#form").dxForm({
             items: [{ dataField: "name1" }]
         }).dxForm("instance");
@@ -966,7 +966,7 @@ QUnit.module("Validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig(form2), "form2 validation group in the validation engine");
     });
 
-    test("Set { items: [{dataField: name}] }, re-create form with same options", (assert) => {
+    test("Set { items: [{dataField: name}] }, re-create form with same options", function(assert) {
         const options = {
             items: [{ dataField: "name" }]
         };
@@ -978,7 +978,7 @@ QUnit.module("Validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig(form2), "the new validation group of the Form is contained in the validation engine");
     });
 
-    test("Set { items: [{dataField: name}], validationGroup: Test1 }, re-create form with { items: [{dataField: name}], validationGroup: Test2 }", (assert) => {
+    test("Set { items: [{dataField: name}], validationGroup: Test1 }, re-create form with { items: [{dataField: name}], validationGroup: Test2 }", function(assert) {
         createFormInsideContainer({
             items: [{ dataField: "name" }],
             validationGroup: "Test1"
@@ -995,7 +995,7 @@ QUnit.module("Validation group", () => {
 });
 
 QUnit.module("Grouping", () => {
-    test("Render groups", (assert) => {
+    test("Render groups", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 formData: {
@@ -1066,7 +1066,7 @@ QUnit.module("Grouping", () => {
         assert.equal($labelTexts.eq(1).text(), "Address street:", "group3 label text 2");
     });
 
-    test("ColCount for groups", (assert) => {
+    test("ColCount for groups", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 formData: {
@@ -1123,7 +1123,7 @@ QUnit.module("Grouping", () => {
         assert.equal($layoutManagers.eq(2).dxLayoutManager("instance").option("colCount"), 2, "colCount from 3 layout manager");
     });
 
-    test("Caption of group", (assert) => {
+    test("Caption of group", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 formData: {
@@ -1151,7 +1151,7 @@ QUnit.module("Grouping", () => {
         assert.equal($captions.eq(0).text(), "Personal");
     });
 
-    test("helpText element didn't render for group item", (assert) => {
+    test("helpText element didn't render for group item", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 formData: {
@@ -1175,7 +1175,7 @@ QUnit.module("Grouping", () => {
         assert.equal($helpTextElement.length, 0, "There is no helpText element");
     });
 
-    test("Group template", (assert) => {
+    test("Group template", function(assert) {
         // arrange, act
         let $formContainer = $("#form").dxForm({
                 formData: {
@@ -1216,7 +1216,7 @@ QUnit.module("Grouping", () => {
         assert.equal($groups.eq(1).find(".template-biography").text(), "bla-bla-bla", "Template's content has correct data");
     });
 
-    test("Template has correct component instance", (assert) => {
+    test("Template has correct component instance", function(assert) {
         // arrange, act
         let templateOwnerComponent;
 
@@ -1235,7 +1235,7 @@ QUnit.module("Grouping", () => {
         assert.equal(templateOwnerComponent, "dxForm", "Template's data.component is 'dxForm'");
     });
 
-    test("Recursive grouping", (assert) => {
+    test("Recursive grouping", function(assert) {
         // arrange, act
         let form = $("#form").dxForm({
                 formData: {
@@ -1327,7 +1327,7 @@ QUnit.module("Grouping", () => {
         template.remove();
     });
 
-    test("Hide nested group item", (assert) => {
+    test("Hide nested group item", function(assert) {
         // arrange
         let $formContainer = $("#form").dxForm({
                 formData: {
@@ -1370,7 +1370,7 @@ QUnit.module("Grouping", () => {
     });
 
     [undefined, null, []].forEach(groupItems => {
-        test(`The empty group should not be rendered items when an items option has ${formatTestValue(groupItems)} value`, (assert) => {
+        test(`The empty group should not be rendered items when an items option has ${formatTestValue(groupItems)} value`, function(assert) {
             const form = $("#form").dxForm({
                 formData: {
                     field: "Test"
@@ -1390,19 +1390,19 @@ QUnit.module("Grouping", () => {
 });
 
 QUnit.module("Tabs", {
-    beforeEach: () => {
+    beforeEach: function() {
         let that = this;
         that.clock = sinon.useFakeTimers();
 
         responsiveBoxScreenMock.setup.call(this, 1200);
     },
 
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         responsiveBoxScreenMock.teardown.call(this);
     }
 }, () => {
-    test("Render tabs", (assert) => {
+    test("Render tabs", function(assert) {
         // arrange, act
         let testContainer = $("#form");
 
@@ -1453,7 +1453,7 @@ QUnit.module("Tabs", {
         assert.notEqual(testContainer.find(".dx-multiview-item ." + internals.FORM_LAYOUT_MANAGER_CLASS).length, 0, "layout manager inside multiview item");
     });
 
-    test("Render tabs with groups", (assert) => {
+    test("Render tabs with groups", function(assert) {
         // arrange, act
         let clock = sinon.useFakeTimers();
         let testContainer = $("#form");
@@ -1516,7 +1516,7 @@ QUnit.module("Tabs", {
         clock.restore();
     });
 
-    test("tabElement argument of tabTemplate option is correct", (assert) => {
+    test("tabElement argument of tabTemplate option is correct", function(assert) {
         let testContainer = $("#form");
         testContainer.dxForm({
             formData: {
@@ -1538,7 +1538,7 @@ QUnit.module("Tabs", {
     });
 
     [undefined, null, []].forEach(tabbedItems => {
-        test(`The empty tab should not be rendered items when an items option has ${formatTestValue(tabbedItems)} value`, (assert) => {
+        test(`The empty tab should not be rendered items when an items option has ${formatTestValue(tabbedItems)} value`, function(assert) {
             const form = $("#form").dxForm({
                 formData: {
                     field: "Test"

--- a/testing/tests/DevExpress.ui.widgets.form/form.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.tests.js
@@ -1376,7 +1376,7 @@ QUnit.test("Labels are not aligned when labelLocation is top with the groups", f
     assert.notEqual($labelTexts.eq(0).width(), $labelTexts.eq(1).width(), "group 2");
 });
 
-QUnit.test("required mark aligned", (assert) => {
+QUnit.test("required mark aligned", function(assert) {
     let $testContainer = $("#form").dxForm({
         requiredMark: "!",
         items: [{
@@ -1395,7 +1395,7 @@ QUnit.test("required mark aligned", (assert) => {
     assert.ok($requiredLabel.position().left < $requiredMark.position().left, "required mark should be after of the text");
 });
 
-QUnit.test("optional mark aligned", (assert) => {
+QUnit.test("optional mark aligned", function(assert) {
     let $testContainer = $("#form").dxForm({
         optionalMark: "optMark",
         showOptionalMark: true,
@@ -2501,7 +2501,7 @@ const formatTestValue = value => Array.isArray(value) ? "[]" : value;
             }
         }
 
-        QUnit.test("Change the badge option", () => {
+        QUnit.test("Change the badge option", function() {
             const testWrapper = new FormTestWrapper(useItemOption);
             testWrapper.setTabOption(0, "badge", "TestBadge1");
             testWrapper.checkFormsReRender();
@@ -2512,7 +2512,7 @@ const formatTestValue = value => Array.isArray(value) ? "[]" : value;
             testWrapper.checkTabBadge(1, "TestBadge2");
         });
 
-        QUnit.test("Change the disabled option", () => {
+        QUnit.test("Change the disabled option", function() {
             const testWrapper = new FormTestWrapper(useItemOption);
             testWrapper.setTabOption(0, "disabled", true);
             testWrapper.checkFormsReRender();
@@ -2531,7 +2531,7 @@ const formatTestValue = value => Array.isArray(value) ? "[]" : value;
             testWrapper.checkTabDisabled(1, false);
         });
 
-        QUnit.test("Change the icon option", () => {
+        QUnit.test("Change the icon option", function() {
             const testWrapper = new FormTestWrapper(useItemOption);
 
             testWrapper.setTabOption(0, "icon", "plus");
@@ -2543,7 +2543,7 @@ const formatTestValue = value => Array.isArray(value) ? "[]" : value;
             testWrapper.checkTabIcon(1, "trash");
         });
 
-        QUnit.test("Change the template option", () => {
+        QUnit.test("Change the template option", function() {
             const testWrapper = new FormTestWrapper(useItemOption);
 
             const template1 = "<div class='custom-template-1'></div>";
@@ -2558,7 +2558,7 @@ const formatTestValue = value => Array.isArray(value) ? "[]" : value;
             testWrapper.checkTabContentTemplate(1, $(template2));
         });
 
-        QUnit.test("Change the tab template option", () => {
+        QUnit.test("Change the tab template option", function() {
             const testWrapper = new FormTestWrapper(useItemOption);
 
             const template1 = "<div class='custom-tab-template-1'></div>";
@@ -2573,7 +2573,7 @@ const formatTestValue = value => Array.isArray(value) ? "[]" : value;
             testWrapper.checkTabTemplate(1, $(template2));
         });
 
-        QUnit.test("Change the title option", () => {
+        QUnit.test("Change the title option", function() {
             const testWrapper = new FormTestWrapper(useItemOption);
             testWrapper.setTabOption(0, "title", "TestTitle1");
             testWrapper.checkFormsReRender();
@@ -2584,7 +2584,7 @@ const formatTestValue = value => Array.isArray(value) ? "[]" : value;
             testWrapper.checkTabTitle(1, "TestTitle2");
         });
 
-        QUnit.test("Title is set correctly when it is changed on the onInitialized event", () => {
+        QUnit.test("Title is set correctly when it is changed on the onInitialized event", function() {
             const testWrapper = new FormTestWrapper(useItemOption, ({ component }) => {
                 if(useItemOption) {
                     component.itemOption("tabbedItem.title0", "title", "New Title");
@@ -2598,7 +2598,7 @@ const formatTestValue = value => Array.isArray(value) ? "[]" : value;
         });
 
         ["badge", "icon", "template", "tabTemplate", "title"].forEach(optionName => {
-            QUnit.test(`Change the ${optionName} of a tab when tabbed item is hidden via api`, () => {
+            QUnit.test(`Change the ${optionName} of a tab when tabbed item is hidden via api`, function() {
                 const testWrapper = new FormTestWrapper(useItemOption);
 
                 testWrapper.setTabbedItemOption("visible", false);
@@ -3050,7 +3050,7 @@ QUnit.test("Form redraw layout when colCount is 'auto' and an calculated colCoun
 
 QUnit.module("Form when rtlEnabled is true");
 
-QUnit.test("required mark aligned when rtlEnabled option is set to true", (assert) => {
+QUnit.test("required mark aligned when rtlEnabled option is set to true", function(assert) {
     let $testContainer = $("#form").dxForm({
         requiredMark: "!",
         rtlEnabled: true,
@@ -3070,7 +3070,7 @@ QUnit.test("required mark aligned when rtlEnabled option is set to true", (asser
     assert.ok($requiredLabel.position().left > $requiredMark.position().left, "required mark should be before of the text");
 });
 
-QUnit.test("optional mark aligned when rtlEnabled option is set to true", (assert) => {
+QUnit.test("optional mark aligned when rtlEnabled option is set to true", function(assert) {
     let $testContainer = $("#form").dxForm({
         optionalMark: "optMark",
         showOptionalMark: true,

--- a/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
@@ -90,7 +90,7 @@ function getID(form, dataField) {
     return "dx_" + form.option("formID") + "_" + dataField;
 }
 
-QUnit.test("The validation result is invalid when item has validation rules", assert => {
+QUnit.test("The validation result is invalid when item has validation rules", function(assert) {
     const form = $("#form").dxForm({
         formData: {
             name: ""
@@ -110,7 +110,7 @@ QUnit.test("The validation result is invalid when item has validation rules", as
     assert.equal(form.$element().find(invalidSelector + " [id=" + getID(form, "name") + "]").length, 1, "invalid name editor");
 });
 
-QUnit.test("The validation result is valid when item has validation rules", assert => {
+QUnit.test("The validation result is valid when item has validation rules", function(assert) {
     const form = $("#form").dxForm({
         formData: {
             name: "Test"
@@ -129,7 +129,7 @@ QUnit.test("The validation result is valid when item has validation rules", asse
     assert.equal(form.$element().find(invalidSelector).length, 0, "invalid editors count");
 });
 
-QUnit.test("Validate with template wrapper", assert => {
+QUnit.test("Validate with template wrapper", function(assert) {
     // arrange
     const validationSpy = sinon.spy();
     const form = $("#form").dxForm({
@@ -158,7 +158,7 @@ QUnit.test("Validate with template wrapper", assert => {
     assert.equal(validationSpy.callCount, 1, "invalid editors count");
 });
 
-QUnit.test("CustomRule.validationCallback accepts formItem", assert => {
+QUnit.test("CustomRule.validationCallback accepts formItem", function(assert) {
     // arrange
     const validationSpy = sinon.spy(),
         form = $("#form").dxForm({
@@ -190,7 +190,7 @@ QUnit.test("CustomRule.validationCallback accepts formItem", assert => {
     assert.ok(params.formItem.validationRules, "formItem.validationRule !== null");
 });
 
-QUnit.test("AsyncRule.validationCallback accepts formItem", assert => {
+QUnit.test("AsyncRule.validationCallback accepts formItem", function(assert) {
     // arrange
     const validationSpy = sinon.spy(function() { return new Deferred().resolve().promise(); }),
         form = $("#form").dxForm({
@@ -222,7 +222,7 @@ QUnit.test("AsyncRule.validationCallback accepts formItem", assert => {
     assert.ok(params.formItem.validationRules, "formItem.validationRule !== null");
 });
 
-QUnit.test("Validate with a custom validation group", assert => {
+QUnit.test("Validate with a custom validation group", function(assert) {
     // arrange
     const form = $("#form").dxForm({
         validationGroup: "Custom validation group",
@@ -248,7 +248,7 @@ QUnit.test("Validate with a custom validation group", assert => {
     assert.equal(form.$element().find(invalidSelector + " [id=" + getID(form, "firstName") + "]").length, 1, "invalid firstName editor");
 });
 
-QUnit.test("Reset validation summary items when using a custom validation group", assert => {
+QUnit.test("Reset validation summary items when using a custom validation group", function(assert) {
     // arrange
     const form = $("#form").dxForm({
         validationGroup: "Custom validation group",
@@ -278,7 +278,7 @@ QUnit.test("Reset validation summary items when using a custom validation group"
     assert.equal($validationSummaryItems.length, 0, "There is no validation summary items");
 });
 
-QUnit.test("Validate form when several forms are rendered", assert => {
+QUnit.test("Validate form when several forms are rendered", function(assert) {
     // arrange
     const form1 = $("#form").dxForm({
         formData: {
@@ -320,7 +320,7 @@ QUnit.test("Validate form when several forms are rendered", assert => {
     assert.equal(form2.$element().find(invalidSelector + " [id=" + getID(form2, "firstName2") + "]").length, 0, "invalid firstName editor");
 });
 
-QUnit.test("Validate via 'isRequired' item option", assert => {
+QUnit.test("Validate via 'isRequired' item option", function(assert) {
     // arrange
     const form = $("#form").dxForm({
         formData: {
@@ -350,7 +350,7 @@ QUnit.test("Validate via 'isRequired' item option", assert => {
     assert.equal(form.$element().find(".dx-invalid-message").last().text(), "First Name is required", "Message contains the name of validated field by default if label isn't defined");
 });
 
-QUnit.test("Validate via validationRules when rules and 'isRequired' item option are both defined", assert => {
+QUnit.test("Validate via validationRules when rules and 'isRequired' item option are both defined", function(assert) {
     // arrange
     const form = $("#form").dxForm({
         formData: {
@@ -373,7 +373,7 @@ QUnit.test("Validate via validationRules when rules and 'isRequired' item option
     assert.equal(form.$element().find(invalidSelector + " [id=" + getID(form, "lastName") + "]").length, 1, "invalid lastName editor");
 });
 
-QUnit.test("validate -> resetValues old test", assert => {
+QUnit.test("validate -> resetValues old test", function(assert) {
     // arrange
     const form = $("#form").dxForm({
         formData: {
@@ -452,7 +452,7 @@ QUnit.test("validate -> resetValues when there are invalid validation rules", fu
     form.dispose();
 });
 
-QUnit.test("Changing an validationRules options of an any item does not invalidate whole form (T673188)", assert => {
+QUnit.test("Changing an validationRules options of an any item does not invalidate whole form (T673188)", function(assert) {
     // arrange
     const form = $("#form").dxForm({
         formData: {
@@ -474,7 +474,7 @@ QUnit.test("Changing an validationRules options of an any item does not invalida
     assert.strictEqual(renderComponentSpy.callCount, 0, "renderComponentSpy.callCount");
 });
 
-QUnit.test("Validate the form without validation rules for an any simple items", (assert) => {
+QUnit.test("Validate the form without validation rules for an any simple items", function(assert) {
     const errorStub = sinon.stub();
     logger.error = errorStub;
 
@@ -492,7 +492,7 @@ QUnit.test("Validate the form without validation rules for an any simple items",
     assert.equal(errorStub.getCalls().length, 0, "errors are not written to the console");
 });
 
-QUnit.test("Change validation rules when simple item is hidden via api", (assert) => {
+QUnit.test("Change validation rules when simple item is hidden via api", function(assert) {
     const form = $("#form").dxForm({
         items: [{
             itemType: "simple",
@@ -507,7 +507,7 @@ QUnit.test("Change validation rules when simple item is hidden via api", (assert
     assert.deepEqual(form.itemOption("item1").validationRules, [{ type: "required" }], "validation rules");
 });
 
-QUnit.testInActiveWindow("Change RangeRule.max", assert => {
+QUnit.testInActiveWindow("Change RangeRule.max", function(assert) {
     const runChangeRuleRageMaxTest = (options) => {
         [true, false].forEach(useItemOption => {
             runChangeValidationRuleTest({
@@ -534,7 +534,7 @@ QUnit.testInActiveWindow("Change RangeRule.max", assert => {
     runChangeRuleRageMaxTest({ fieldValue: 10, initialMax: 1, targetMax: 11, validationResult: true });
 });
 
-QUnit.testInActiveWindow("Add RangeRule to item.validationRules", assert => {
+QUnit.testInActiveWindow("Add RangeRule to item.validationRules", function(assert) {
     const runSetRangeRuleTest = (options) => {
         runChangeValidationRuleTest(extend(
             {
@@ -554,7 +554,7 @@ QUnit.testInActiveWindow("Add RangeRule to item.validationRules", assert => {
     });
 });
 
-QUnit.testInActiveWindow("Remove RangeRule from item.validationRules", assert => {
+QUnit.testInActiveWindow("Remove RangeRule from item.validationRules", function(assert) {
     const runRemoveRangedRuleTest = (options) => {
         runChangeValidationRuleTest(extend(
             {
@@ -575,7 +575,7 @@ QUnit.testInActiveWindow("Remove RangeRule from item.validationRules", assert =>
     });
 });
 
-QUnit.testInActiveWindow("Add RequiredRule to item.validationRules", assert => {
+QUnit.testInActiveWindow("Add RequiredRule to item.validationRules", function(assert) {
     [undefined, null, []].forEach(validationRules => {
         [true, false].forEach(useItemOption => {
             runChangeValidationRuleTest({
@@ -591,7 +591,7 @@ QUnit.testInActiveWindow("Add RequiredRule to item.validationRules", assert => {
     });
 });
 
-QUnit.testInActiveWindow("Remove RequiredRule from item.validationRules", assert => {
+QUnit.testInActiveWindow("Remove RequiredRule from item.validationRules", function(assert) {
     [undefined, null, []].forEach(newValidationRules => {
         [true, false].forEach(useItemOption => {
             runChangeValidationRuleTest({
@@ -607,7 +607,7 @@ QUnit.testInActiveWindow("Remove RequiredRule from item.validationRules", assert
     });
 });
 
-QUnit.testInActiveWindow("Change item.isRequired", assert => {
+QUnit.testInActiveWindow("Change item.isRequired", function(assert) {
     [true, false].forEach(isRequired => {
         [true, false].forEach(useItemOption => {
             runChangeValidationRuleTest({
@@ -643,7 +643,7 @@ QUnit.module("validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig("Test"), "the new validation group of the Form is contained in the validation engine");
     });
 
-    QUnit.test("Set { items: [name], showValidationSummary: true }, call option(validationGroup, Test)", (assert) => {
+    QUnit.test("Set { items: [name], showValidationSummary: true }, call option(validationGroup, Test)", function(assert) {
         const $formContainer = $("#form").dxForm({
             showValidationSummary: true,
             items: ["name"]
@@ -671,7 +671,7 @@ QUnit.module("validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig("Test2"), "the new validation group of the Form is contained in the validation engine");
     });
 
-    QUnit.test("Set { items: [name], validationGroup: Test1, showValidationSummary: true }, call option(validationGroup, Test2)", (assert) => {
+    QUnit.test("Set { items: [name], validationGroup: Test1, showValidationSummary: true }, call option(validationGroup, Test2)", function(assert) {
         const $formContainer = $("#form").dxForm({
             showValidationSummary: true,
             validationGroup: "Test1",
@@ -708,7 +708,7 @@ QUnit.module("validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig("Test"), "the new validation group of the Form is contained in the validation engine");
     });
 
-    QUnit.test("Set { items: [{dataField: name, isRequired: true}], showValidationSummary: true }, call option(validationGroup, Test)", (assert) => {
+    QUnit.test("Set { items: [{dataField: name, isRequired: true}], showValidationSummary: true }, call option(validationGroup, Test)", function(assert) {
         const $formContainer = $("#form").dxForm({
             showValidationSummary: true,
             items: [{ dataField: "name", isRequired: true }]
@@ -745,7 +745,7 @@ QUnit.module("validation group", () => {
         assert.ok(ValidationEngine.getGroupConfig("Test2"), "the new validation group of the Form is contained in the validation engine");
     });
 
-    QUnit.test("Set { items: [{dataField: name, isRequired: true}], validationGroup: Test1, showValidationSummary: true }, call option(validationGroup, Test2)", (assert) => {
+    QUnit.test("Set { items: [{dataField: name, isRequired: true}], validationGroup: Test1, showValidationSummary: true }, call option(validationGroup, Test2)", function(assert) {
         const $formContainer = $("#form").dxForm({
             showValidationSummary: true,
             validationGroup: "Test1",

--- a/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
@@ -69,7 +69,7 @@ const createTestObject = () => ({
 });
 
 QUnit.module("Layout manager", () => {
-    test("Default render", (assert) => {
+    test("Default render", function(assert) {
         const contentReadyStub = sinon.stub();
         const $testContainer = $("#container").dxLayoutManager({
             items: [{
@@ -93,7 +93,7 @@ QUnit.module("Layout manager", () => {
         assert.equal(contentReadyStub.callCount, windowUtils.hasWindow() ? 1 : 0, "contentReady event");
     });
 
-    test("Default render with editorOptions.inputAttr", (assert) => {
+    test("Default render with editorOptions.inputAttr", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
             layoutData: {
@@ -114,7 +114,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($testContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor-input").attr("alt"), "test", "attr merge successfully");
     });
 
-    test("Default render with template", (assert) => {
+    test("Default render with template", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 layoutData: {
@@ -155,7 +155,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($items.length, 2, "field items is rendered");
     });
 
-    test("Default render with marks", (assert) => {
+    test("Default render with marks", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -187,7 +187,7 @@ QUnit.module("Layout manager", () => {
         assert.ok(!$optionalItem.find("." + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).length, "field item hasn't optional mark");
     });
 
-    test("Show optional marks", (assert) => {
+    test("Show optional marks", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -208,7 +208,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($optionalItem.find("." + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).length, "field item hasn optional mark");
     });
 
-    test("Render custom marks", (assert) => {
+    test("Render custom marks", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 showOptionalMark: true,
@@ -233,7 +233,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($.trim($optionalItem.find("." + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).text()), "-", "custom optional mark");
     });
 
-    test("Change marks", (assert) => {
+    test("Change marks", function(assert) {
         // arrange
         let $testContainer = $("#container").dxLayoutManager({
                 showOptionalMark: true,
@@ -261,7 +261,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($.trim($optionalItem.find("." + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).text()), "-", "custom optional mark");
     });
 
-    test("Change marks visibility", (assert) => {
+    test("Change marks visibility", function(assert) {
         // arrange
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -288,7 +288,7 @@ QUnit.module("Layout manager", () => {
         assert.ok(!$optionalItem.find("." + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).length, "Item has optional mark");
     });
 
-    test("Render read only layoutManager", (assert) => {
+    test("Render read only layoutManager", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
             readOnly: true,
@@ -302,7 +302,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($testContainer.find("." + internals.FIELD_ITEM_CLASS + " .dx-texteditor").hasClass(READONLY_STATE_CLASS), "editor is read only");
     });
 
-    test("Render label by default", (assert) => {
+    test("Render label by default", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 form: {
@@ -326,7 +326,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($label.parent().hasClass(internals.LABEL_HORIZONTAL_ALIGNMENT_CLASS), "field item contains label has horizontal align class");
     });
 
-    test("Baseline align of label for large editors is applied when browser is supported flex", (assert) => {
+    test("Baseline align of label for large editors is applied when browser is supported flex", function(assert) {
         const largeEditors = ["dxTextArea", "dxRadioGroup", "dxCalendar", "dxHtmlEditor"];
         const customItems = ["item", "itemWithHelpText"];
         const items = [...customItems, ...largeEditors].map(item => ({
@@ -347,7 +347,7 @@ QUnit.module("Layout manager", () => {
         });
     });
 
-    test("Baseline align of label for large editors is not applied when label location is top", (assert) => {
+    test("Baseline align of label for large editors is not applied when label location is top", function(assert) {
         const largeEditors = ["dxTextArea", "dxRadioGroup", "dxCalendar", "dxHtmlEditor"];
         const customItems = ["item", "itemWithHelpText"];
         const $testContainer = $("#container").dxLayoutManager({
@@ -366,7 +366,7 @@ QUnit.module("Layout manager", () => {
         });
     });
 
-    test("Render label for item without name or dateField", (assert) => {
+    test("Render label for item without name or dateField", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 form: {
@@ -387,7 +387,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.attr("for"), $input.attr("input"), "input ID equal to label's 'for' attribute");
     });
 
-    test("Render label with position top render before widget", (assert) => {
+    test("Render label with position top render before widget", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -405,7 +405,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($fieldItemChildren.first().is("label"), "Label is the first child");
     });
 
-    test("Render label with position bottom render after widget", (assert) => {
+    test("Render label with position bottom render after widget", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -423,7 +423,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($fieldItemChildren.last().is("label"), "Label is the last child");
     });
 
-    test("Render label with position top and alignment left", (assert) => {
+    test("Render label with position top and alignment left", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -442,7 +442,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.css("textAlign"), "left", "Label has text-align left");
     });
 
-    test("Render label with position top and alignment center", (assert) => {
+    test("Render label with position top and alignment center", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -461,7 +461,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.css("textAlign"), "center", "Label has text-align center");
     });
 
-    test("Render label with position top and alignment right", (assert) => {
+    test("Render label with position top and alignment right", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -480,7 +480,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.css("textAlign"), "right", "Label has text-align right");
     });
 
-    test("Render label with horizontal alignment (left) ", (assert) => {
+    test("Render label with horizontal alignment (left) ", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -497,7 +497,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($fieldItem.hasClass(internals.LABEL_HORIZONTAL_ALIGNMENT_CLASS), "Field item contains label that has horizontal align");
     });
 
-    test("Render label with default position and alignment left", (assert) => {
+    test("Render label with default position and alignment left", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -514,7 +514,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.css("textAlign"), "left", "Label has text-align left");
     });
 
-    test("Render label with default position and alignment center", (assert) => {
+    test("Render label with default position and alignment center", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -531,7 +531,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.css("textAlign"), "center", "Label has text-align center");
     });
 
-    test("Render label with showColonAfterLabel", (assert) => {
+    test("Render label with showColonAfterLabel", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 showColonAfterLabel: true,
@@ -546,7 +546,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.text(), "Name:", "text of label");
     });
 
-    test("Label is not rendered when name is defined", (assert) => {
+    test("Label is not rendered when name is defined", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
             items: [{
@@ -559,7 +559,7 @@ QUnit.module("Layout manager", () => {
         assert.ok(!$testContainer.find("." + internals.FIELD_ITEM_LABEL_CLASS).length);
     });
 
-    test("If item is not visible we will not render them", (assert) => {
+    test("If item is not visible we will not render them", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -579,7 +579,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($fieldItems.last().find("." + internals.FIELD_ITEM_LABEL_CLASS).text(), "Phone", "Correct second item rendered");
     });
 
-    test("Item should be removed from DOM if it's visibility changed", (assert) => {
+    test("Item should be removed from DOM if it's visibility changed", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -604,7 +604,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($fieldItems.last().find("." + internals.FIELD_ITEM_LABEL_CLASS).text(), "Phone", "Correct second item rendered");
     });
 
-    test("Render items as array of strings", (assert) => {
+    test("Render items as array of strings", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: ["FirstName", "LastName"]
@@ -617,7 +617,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($fieldItems.last().find("." + internals.FIELD_ITEM_LABEL_CLASS).text(), "Last Name", "Correct second item rendered");
     });
 
-    test("Render mixed set of items(2 as strings, 1 as object)", (assert) => {
+    test("Render mixed set of items(2 as strings, 1 as object)", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: ["FirstName", {
@@ -633,7 +633,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($fieldItems.last().find("." + internals.FIELD_ITEM_LABEL_CLASS).text(), "Last Name", "Correct third item rendered");
     });
 
-    test("If label is not visible we will not render them", (assert) => {
+    test("If label is not visible we will not render them", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -651,7 +651,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($fieldItems.find("." + internals.FIELD_ITEM_CONTENT_CLASS).length, 1, "We have widget in field");
     });
 
-    test("Render label with horizontal alignment (right) ", (assert) => {
+    test("Render label with horizontal alignment (right) ", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -669,7 +669,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($fieldItem.hasClass(internals.LABEL_HORIZONTAL_ALIGNMENT_CLASS), "Field item contains label that has horizontal align");
     });
 
-    test("Default render with label", (assert) => {
+    test("Default render with label", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 showColonAfterLabel: true,
@@ -688,7 +688,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.text(), "New label:", "text of label");
     });
 
-    test("Colon symbol is not added to label when showColon is disabled for label", (assert) => {
+    test("Colon symbol is not added to label when showColon is disabled for label", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 showColonAfterLabel: true,
@@ -707,7 +707,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.text(), "New label", "text of label");
     });
 
-    test("Render editor with id attribute", (assert) => {
+    test("Render editor with id attribute", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 form: {
@@ -730,7 +730,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($input.attr("id"), "dx_FormID_name", "id attr of input");
     });
 
-    test("Render editor by default is data is unknown", (assert) => {
+    test("Render editor by default is data is unknown", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
             layoutData: {
@@ -744,7 +744,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($editor.hasClass("dx-textbox"), "It is dxTextBox by default");
     });
 
-    test("Generate several items in layout", (assert) => {
+    test("Generate several items in layout", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -779,7 +779,7 @@ QUnit.module("Layout manager", () => {
         }
     });
 
-    test("Generate items from layoutData", (assert) => {
+    test("Generate items from layoutData", function(assert) {
         // arrange, act
         let layoutManager = $("#container").dxLayoutManager({
             layoutData: {
@@ -818,7 +818,7 @@ QUnit.module("Layout manager", () => {
         }]);
     });
 
-    test("Generate items from layoutData with unacceptable data", (assert) => {
+    test("Generate items from layoutData with unacceptable data", function(assert) {
         // arrange, act
         let layoutManager = $("#container").dxLayoutManager({
             layoutData: {
@@ -837,7 +837,7 @@ QUnit.module("Layout manager", () => {
         }]);
     });
 
-    test("Generate items from layoutData and items", (assert) => {
+    test("Generate items from layoutData and items", function(assert) {
         // arrange, act
         let layoutManager = $("#container").dxLayoutManager({
             layoutData: {
@@ -881,7 +881,7 @@ QUnit.module("Layout manager", () => {
         );
     });
 
-    test("Check data when generate items from layoutData and items with initial value", (assert) => {
+    test("Check data when generate items from layoutData and items with initial value", function(assert) {
         // arrange, act
         let layoutManager = $("#container").dxLayoutManager({
             layoutData: {
@@ -915,7 +915,7 @@ QUnit.module("Layout manager", () => {
         );
     });
 
-    test("Rerender items after change 'items' option", (assert) => {
+    test("Rerender items after change 'items' option", function(assert) {
         // arrange
         let $testContainer = $("#container").dxLayoutManager({
                 items: [{
@@ -951,7 +951,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($fieldItems.eq(1).find(".dx-datebox").length, "Second item is dxDateBox");
     });
 
-    test("Generate items after change 'layoutData' option", (assert) => {
+    test("Generate items after change 'layoutData' option", function(assert) {
         // arrange
         let layoutManager = $("#container").dxLayoutManager({
             layoutData: {
@@ -991,7 +991,7 @@ QUnit.module("Layout manager", () => {
         }]);
     });
 
-    test("Set values from layoutData", (assert) => {
+    test("Set values from layoutData", function(assert) {
         // arrange, act
         let $editors,
             $testContainer = $("#container");
@@ -1014,7 +1014,7 @@ QUnit.module("Layout manager", () => {
         assert.deepEqual($editors.eq(3).dxDateBox("instance").option("value"), new Date("10/10/2010"), "4 editor");
     });
 
-    test("Value from layoutData shouldn't pass to the editor in case when the 'dataField' options isn't specified", (assert) => {
+    test("Value from layoutData shouldn't pass to the editor in case when the 'dataField' options isn't specified", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -1034,7 +1034,7 @@ QUnit.module("Layout manager", () => {
         assert.equal(editor.option("value"), null, "Editor hasn't a value");
     });
 
-    test("layoutData isn't updating on editor value change if the 'dataField' option isn't specified", (assert) => {
+    test("layoutData isn't updating on editor value change if the 'dataField' option isn't specified", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -1057,7 +1057,7 @@ QUnit.module("Layout manager", () => {
         }, "layoutData keeps the same data");
     });
 
-    test("Set value via editor options", (assert) => {
+    test("Set value via editor options", function(assert) {
         // arrange, act
         let $editors,
             $testContainer = $("#container");
@@ -1084,7 +1084,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($editors.eq(2).dxNumberBox("instance").option("value"), 34);
     });
 
-    test("Change item.visible on customizeItem works correct", (assert) => {
+    test("Change item.visible on customizeItem works correct", function(assert) {
         // arrange, act
         let $editors,
             $testContainer = $("#container");
@@ -1108,7 +1108,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($testContainer.find("." + internals.FIELD_ITEM_LABEL_CLASS).text(), "Age", "Correct field rendered");
     });
 
-    test("CustomizeItem work well after option change", (assert) => {
+    test("CustomizeItem work well after option change", function(assert) {
         // arrange, act
         let $editors,
             $testContainer = $("#container");
@@ -1138,7 +1138,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($editors.eq(2).dxNumberBox("instance").option("value"), 34);
     });
 
-    test("Get value from editor", (assert) => {
+    test("Get value from editor", function(assert) {
         // arrange
         let $editors,
             layoutManager,
@@ -1176,7 +1176,7 @@ QUnit.module("Layout manager", () => {
         });
     });
 
-    test("Editors with object value correctly work with values from data", (assert) => {
+    test("Editors with object value correctly work with values from data", function(assert) {
         // arrange, act
         let layoutManager,
             $testContainer = $("#container"),
@@ -1211,7 +1211,7 @@ QUnit.module("Layout manager", () => {
         assert.equal(lookupCurrentItemText, "test2", "lookup has correct current item");
     });
 
-    test("A layoutData object change at changing widget from items option", (assert) => {
+    test("A layoutData object change at changing widget from items option", function(assert) {
         // arrange
         let layoutManager,
             $testContainer = $("#container");
@@ -1242,7 +1242,7 @@ QUnit.module("Layout manager", () => {
         }, "Custom field data updated");
     });
 
-    test("A layoutData is not changed when dataField is undefined_T310737", (assert) => {
+    test("A layoutData is not changed when dataField is undefined_T310737", function(assert) {
         // arrange
         let layoutManager,
             $testContainer = $("#container");
@@ -1276,7 +1276,7 @@ QUnit.module("Layout manager", () => {
         assert.equal(textBoxes[2].option("value"), "test3", "editor 3");
     });
 
-    test("Set 'disabled' option to layoutManager and check internal element state", (assert) => {
+    test("Set 'disabled' option to layoutManager and check internal element state", function(assert) {
         // arrange
         let $editors,
             $testContainer = $("#container");
@@ -1301,7 +1301,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($editors.eq(3).dxDateBox("instance").option("disabled"), true);
     });
 
-    test("Label creates when item has no name but has 'label.text' option", (assert) => {
+    test("Label creates when item has no name but has 'label.text' option", function(assert) {
         // arrange, act
         let $testContainer = $("#container"),
             $label;
@@ -1322,7 +1322,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($label.text(), "NewLabel", "Correct label's text");
     });
 
-    test("Render field items from fieldData and items", (assert) => {
+    test("Render field items from fieldData and items", function(assert) {
         // arrange, act
         let $testContainer = $("#container"),
             layoutManager;
@@ -1341,7 +1341,7 @@ QUnit.module("Layout manager", () => {
         assert.ok($testContainer.find(".dx-button").length, "Form has button");
     });
 
-    test("Render field items from fieldData and items when fieldData is a complex object", (assert) => {
+    test("Render field items from fieldData and items when fieldData is a complex object", function(assert) {
         // arrange, act
         let $testContainer = $("#container"),
             complexObject = {
@@ -1383,7 +1383,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($inputs.eq(1).val(), "George", "Second input value");
     });
 
-    test("Render field items from fieldData and items when fieldData is a complex object and custom label text", (assert) => {
+    test("Render field items from fieldData and items when fieldData is a complex object and custom label text", function(assert) {
         // arrange, act
         let $testContainer = $("#container"),
             complexObject = {
@@ -1430,7 +1430,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($inputs.eq(1).val(), "George", "Second input value");
     });
 
-    test("Render help text", (assert) => {
+    test("Render help text", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -1459,7 +1459,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($fieldItems.eq(1).find("." + internals.FIELD_ITEM_HELP_TEXT_CLASS).length, 0, "Second field item has't help text element");
     });
 
-    test("Change the order of items", (assert) => {
+    test("Change the order of items", function(assert) {
         // arrange, act
         let $testContainer = $("#container"),
             data = {
@@ -1500,7 +1500,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($inputs.eq(2).val(), "40", "First input value");
     });
 
-    test("Change the order of items with items without visibleIndex", (assert) => {
+    test("Change the order of items with items without visibleIndex", function(assert) {
         // arrange, act
         let $testContainer = $("#container"),
             data = {
@@ -1545,7 +1545,7 @@ QUnit.module("Layout manager", () => {
         assert.equal($inputs.eq(3).val(), "male", "Second input value");
     });
 
-    test("Update editor with nested dataField when layoutData changed", (assert) => {
+    test("Update editor with nested dataField when layoutData changed", function(assert) {
         // arrange
         let $testContainer = $("#container"),
             layoutManager;
@@ -1570,7 +1570,7 @@ QUnit.module("Layout manager", () => {
         assert.equal(layoutManager.getEditor("personalInfo.firstName").option("value"), "Jane", "Editor is up to date");
     });
 
-    test("Render empty item", (assert) => {
+    test("Render empty item", function(assert) {
         // arrange, act
         let $testContainer = $("#container").dxLayoutManager({
             formData: {
@@ -1652,7 +1652,7 @@ QUnit.module("Layout manager", () => {
 });
 
 QUnit.module("Render multiple columns", () => {
-    test("Render layoutManager with 2 columns", (assert) => {
+    test("Render layoutManager with 2 columns", function(assert) {
         // arrange, act
         let layoutManager = $("#container").dxLayoutManager({
                 layoutData: createTestObject(),
@@ -1710,7 +1710,7 @@ QUnit.module("Render multiple columns", () => {
         }, "col 0 row 5");
     });
 
-    test("Render layout items in order", (assert) => {
+    test("Render layout items in order", function(assert) {
         // arrange, act
         $("#container").dxLayoutManager({
             layoutData: {
@@ -1741,7 +1741,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal($editors.eq(4).val(), "test id", "4 input");
     });
 
-    test("Check that layoutManager create correct rows count", (assert) => {
+    test("Check that layoutManager create correct rows count", function(assert) {
         // arrange, act
         let layoutManager = $("#container").dxLayoutManager({
             layoutData: createTestObject(),
@@ -1753,7 +1753,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal(layoutManager._getRowsCount(), 6, "11 items / 2 columns = 6 rows");
     });
 
-    test("Check rows and cols in responsiveBox", (assert) => {
+    test("Check rows and cols in responsiveBox", function(assert) {
         // arrange, act
         $("#container").dxLayoutManager({
             layoutData: createTestObject(),
@@ -1768,7 +1768,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal(responsiveBox.option("rows").length, 6, "rows count");
     });
 
-    test("Prepare items for col span", (assert) => {
+    test("Prepare items for col span", function(assert) {
         // arrange, act
         let layoutManager = $("#container").dxLayoutManager({
                 layoutData: createTestObject(),
@@ -1891,7 +1891,7 @@ QUnit.module("Render multiple columns", () => {
         }, "15 item");
     });
 
-    test("Generate layout items for col span", (assert) => {
+    test("Generate layout items for col span", function(assert) {
         // arrange, act
         $("#container").dxLayoutManager({
             layoutData: createTestObject(),
@@ -1932,7 +1932,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal(items[10].location.colspan, undefined, "StateID has no colSpan");
     });
 
-    test("Prepare items for col span when labelLocation is 'top' (T307223)", (assert) => {
+    test("Prepare items for col span when labelLocation is 'top' (T307223)", function(assert) {
         // arrange, act
         let layoutManager = $("#container").dxLayoutManager({
                 layoutData: createTestObject(),
@@ -2056,7 +2056,7 @@ QUnit.module("Render multiple columns", () => {
         }, "15 item");
     });
 
-    test("Generate rows ratio for col span", (assert) => {
+    test("Generate rows ratio for col span", function(assert) {
         // arrange, act
         $("#container").dxLayoutManager({
             layoutData: createTestObject(),
@@ -2086,7 +2086,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal(rows.length, 4);
     });
 
-    test("Change of editor's value changing 'layoutData' option", (assert) => {
+    test("Change of editor's value changing 'layoutData' option", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2105,7 +2105,7 @@ QUnit.module("Render multiple columns", () => {
         }, "Correct layoutData");
     });
 
-    test("Change of editor's value changing 'items.editorOptions.value' option", (assert) => {
+    test("Change of editor's value changing 'items.editorOptions.value' option", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2128,7 +2128,7 @@ QUnit.module("Render multiple columns", () => {
         }, "Correct layoutData");
     });
 
-    test("Render when 'colCount' is 'auto' and have 1 item", (assert) => {
+    test("Render when 'colCount' is 'auto' and have 1 item", function(assert) {
         // arrange
         let $testContainer = $("#container").width(450);
 
@@ -2148,7 +2148,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal(colCount, 1, "We have only 1 column, because have only one item");
     });
 
-    test("Correct colCount when width is less that minColWidth and colCount is auto", (assert) => {
+    test("Correct colCount when width is less that minColWidth and colCount is auto", function(assert) {
         // arrange
         let $testContainer = $("#container").width(450);
 
@@ -2169,7 +2169,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal(colCount, 1, "Correct colCount");
     });
 
-    test("Render when 'colCount' is 'auto' and have 3 items", (assert) => {
+    test("Render when 'colCount' is 'auto' and have 3 items", function(assert) {
         // arrange
         let $testContainer = $("#container").width(450);
 
@@ -2192,7 +2192,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal(colCount, expectedColCount, "We have only 2 columns");
     });
 
-    test("Change minColWidth when colCount is auto", (assert) => {
+    test("Change minColWidth when colCount is auto", function(assert) {
         // arrange
         let $testContainer = $("#container").width(450);
 
@@ -2222,7 +2222,7 @@ QUnit.module("Render multiple columns", () => {
         invalidateStub.restore();
     });
 
-    test("Clear item watchers after disposing", (assert) => {
+    test("Clear item watchers after disposing", function(assert) {
         // arrange
         let $testContainer = $("#container").width(450);
 
@@ -2244,7 +2244,7 @@ QUnit.module("Render multiple columns", () => {
         cleanWatcherStub.restore();
     });
 
-    test("Render validate", (assert) => {
+    test("Render validate", function(assert) {
         // arrange, act
         let $container = $("#container");
 
@@ -2280,7 +2280,7 @@ QUnit.module("Render multiple columns", () => {
         assert.equal($container.find(".dx-validator [id='dx_FormID_FirstName']").length, 1, "validator for lastName");
     });
 
-    test("Validation rules and required marks render", (assert) => {
+    test("Validation rules and required marks render", function(assert) {
         // arrange, act
         let $container = $("#container");
 
@@ -2327,7 +2327,7 @@ QUnit.module("Render multiple columns", () => {
 });
 
 QUnit.module("Templates", () => {
-    test("Render template", (assert) => {
+    test("Render template", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2364,7 +2364,7 @@ QUnit.module("Templates", () => {
         assert.equal(textArea.option("value"), layoutManager.option("layoutData.test"), "Widget's value equal to bound datafield");
     });
 
-    test("Check arguments of the template", (assert) => {
+    test("Check arguments of the template", function(assert) {
         const templateStub = sinon.stub();
         const layoutManager = $("#container").dxLayoutManager({
             items: [{
@@ -2388,7 +2388,7 @@ QUnit.module("Templates", () => {
         assert.equal(args.component, layoutManager, "component argument");
     });
 
-    test("Check template bound to data", (assert) => {
+    test("Check template bound to data", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2426,7 +2426,7 @@ QUnit.module("Templates", () => {
 });
 
 QUnit.module("Public methods", () => {
-    test("UpdateData, simple case", (assert) => {
+    test("UpdateData, simple case", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2446,7 +2446,7 @@ QUnit.module("Public methods", () => {
         assert.equal(layoutManager.option("layoutData.test2"), "qwerty", "Correct data");
     });
 
-    test("UpdateData, update with object", (assert) => {
+    test("UpdateData, update with object", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2472,7 +2472,7 @@ QUnit.module("Public methods", () => {
         }, "Correct data");
     });
 
-    test("Get editor instance", (assert) => {
+    test("Get editor instance", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2501,7 +2501,7 @@ QUnit.module("Public methods", () => {
 });
 
 QUnit.module("Accessibility", () => {
-    test("Check required state", (assert) => {
+    test("Check required state", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2520,7 +2520,7 @@ QUnit.module("Accessibility", () => {
         assert.equal($fieldItems.last().find("input").attr("aria-required"), "true", "Second item is required");
     });
 
-    test("Check help text", (assert) => {
+    test("Check help text", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2540,7 +2540,7 @@ QUnit.module("Accessibility", () => {
         assert.equal(itemDescribedBy, helpTextID, "Help text id and input's describedby attributes are equal");
     });
 
-    test("Check aria-labelledby attribute for ariaTarget and id attr for label (T813296)", (assert) => {
+    test("Check aria-labelledby attribute for ariaTarget and id attr for label (T813296)", function(assert) {
         const items = supportedEditors.map((editorType, index) => ({ dataField: `test${index}`, editorType: editorType }));
         const layoutManager = $("#container").dxLayoutManager({ items }).dxLayoutManager("instance");
         const editorClassesRequiringIdForLabel = ["dx-radiogroup", "dx-checkbox", "dx-lookup", "dx-slider", "dx-rangeslider", "dx-switch", "dx-htmleditor"]; // TODO: support "dx-calendar"
@@ -2566,14 +2566,14 @@ QUnit.module("Accessibility", () => {
 });
 
 QUnit.module("Layout manager responsibility", {
-    beforeEach: () => {
+    beforeEach: function() {
         responsiveBoxScreenMock.setup.call(this);
     },
-    afterEach: () => {
+    afterEach: function() {
         responsiveBoxScreenMock.teardown.call(this);
     }
 }, () => {
-    test("Middle screen size", (assert) => {
+    test("Middle screen size", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -2591,7 +2591,7 @@ QUnit.module("Layout manager responsibility", {
         assert.ok(!$testContainer.hasClass(internals.LAYOUT_MANAGER_ONE_COLUMN), "Layout manager hasn't one column mode");
     });
 
-    test("Small screen size", (assert) => {
+    test("Small screen size", function(assert) {
         // arrange
         let $testContainer = $("#container");
 
@@ -2614,7 +2614,7 @@ QUnit.module("Layout manager responsibility", {
 });
 
 QUnit.module("Button item", () => {
-    test("Base rendering", (assert) => {
+    test("Base rendering", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -2637,7 +2637,7 @@ QUnit.module("Button item", () => {
         assert.equal(secondButtonText, "Test", "Button gets the correct config");
     });
 
-    test("cssClass", (assert) => {
+    test("cssClass", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -2654,7 +2654,7 @@ QUnit.module("Button item", () => {
         assert.ok($buttonItem.hasClass("privateClass"), "Item has a custom class");
     });
 
-    test("column class", (assert) => {
+    test("column class", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -2676,7 +2676,7 @@ QUnit.module("Button item", () => {
         assert.ok($buttonItems.last().hasClass("dx-last-col"), "Correct column index");
     });
 
-    test("Check deprecated alignment option", (assert) => {
+    test("Check deprecated alignment option", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
         let logStub = sinon.stub(errors, "log");
@@ -2709,7 +2709,7 @@ QUnit.module("Button item", () => {
         logStub.restore();
     });
 
-    test("Horizontal alignment", (assert) => {
+    test("Horizontal alignment", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -2733,7 +2733,7 @@ QUnit.module("Button item", () => {
         assert.equal($buttonItems.last().css("textAlign"), "center", "Center alignment accepted");
     });
 
-    test("Vertical alignment", (assert) => {
+    test("Vertical alignment", function(assert) {
         // arrange, act
         let $testContainer = $("#container");
 
@@ -2770,7 +2770,7 @@ QUnit.module("Supported editors", () => {
     const getEditorClassName = editorName => `dx-${editorName.substr(2, editorName.length - 1).toLowerCase()}`;
     const checkSupportedEditors = callBack => supportedEditors.forEach(supportedEditor => callBack(supportedEditor, getEditorClassName(supportedEditor)));
 
-    test("Render supported editors with default options", (assert) => {
+    test("Render supported editors with default options", function(assert) {
         const layoutManager = createFormWithSupportedEditors();
 
         checkSupportedEditors((supportedEditor, className) => {
@@ -2780,7 +2780,7 @@ QUnit.module("Supported editors", () => {
         });
     });
 
-    test("Editor type for items where this option is not defined", (assert) => {
+    test("Editor type for items where this option is not defined", function(assert) {
         const consoleErrorStub = sinon.stub(consoleUtils.logger, "error");
         const layoutManager = $("#container").dxLayoutManager({
             layoutData: {
@@ -2804,7 +2804,7 @@ QUnit.module("Supported editors", () => {
         consoleErrorStub.restore();
     });
 
-    test("Render RangeSlider", (assert) => {
+    test("Render RangeSlider", function(assert) {
         const layoutManager = $("#container").dxLayoutManager({
             layoutData: {
                 range: [1, 5]
@@ -2824,7 +2824,7 @@ QUnit.module("Supported editors", () => {
         assert.deepEqual(layoutManager.option("layoutData.noRange"), [2, 6], "data updated");
     });
 
-    test("Form with dxRadioGroup that items are defined via 'dataSource' option renders without error", (assert) => {
+    test("Form with dxRadioGroup that items are defined via 'dataSource' option renders without error", function(assert) {
         const $testContainer = $("#container");
         let errorMessage;
         let _error = consoleUtils.logger.log;
@@ -2850,7 +2850,7 @@ QUnit.module("Supported editors", () => {
         }
     });
 
-    test("Set value to the dxSelectBox editor from data option", (assert) => {
+    test("Set value to the dxSelectBox editor from data option", function(assert) {
         const $testContainer = $("#container");
         $testContainer.dxLayoutManager({
             layoutData: {
@@ -2878,7 +2878,7 @@ QUnit.module("Supported editors", () => {
         assert.deepEqual(selectBox.option("value"), "SuperLCD 70");
     });
 
-    test("Set default value to the dxSelectBox editor when dataField is not contained in a formData", (assert) => {
+    test("Set default value to the dxSelectBox editor when dataField is not contained in a formData", function(assert) {
         const $testContainer = $("#container");
 
         $testContainer.dxLayoutManager({
@@ -2908,7 +2908,7 @@ QUnit.module("Supported editors", () => {
         assert.deepEqual(selectBox.option("value"), null);
     });
 
-    test("Update value in dxSelectBox editor when data option is changed", (assert) => {
+    test("Update value in dxSelectBox editor when data option is changed", function(assert) {
         const $testContainer = $("#container");
         const layoutManager = $testContainer.dxLayoutManager({
             layoutData: {
@@ -2940,7 +2940,7 @@ QUnit.module("Supported editors", () => {
         assert.ok(!layoutManager._isFieldValueChanged);
     });
 
-    test("Set value to the dxTagBox editor from data option", (assert) => {
+    test("Set value to the dxTagBox editor from data option", function(assert) {
         const $testContainer = $("#container");
 
         $testContainer.dxLayoutManager({
@@ -2970,7 +2970,7 @@ QUnit.module("Supported editors", () => {
         assert.deepEqual(tagBox.option("value"), ["HD Video Player", "SuperLCD 70"]);
     });
 
-    test("Set default value to the dxTagBox editor when dataField is not contained in a formData", (assert) => {
+    test("Set default value to the dxTagBox editor when dataField is not contained in a formData", function(assert) {
         const $testContainer = $("#container");
 
         $testContainer.dxLayoutManager({
@@ -3001,7 +3001,7 @@ QUnit.module("Supported editors", () => {
         assert.deepEqual(tagBox.option("value"), []);
     });
 
-    test("Update value in dxTagBox editor when data option is changed", (assert) => {
+    test("Update value in dxTagBox editor when data option is changed", function(assert) {
         const $testContainer = $("#container");
         const layoutManager = $testContainer.dxLayoutManager({
             layoutData: {
@@ -3033,7 +3033,7 @@ QUnit.module("Supported editors", () => {
         assert.ok(!layoutManager._isFieldValueChanged);
     });
 
-    test("Update data option of layout manager when value is changed in the dxSelectBox editor", (assert) => {
+    test("Update data option of layout manager when value is changed in the dxSelectBox editor", function(assert) {
         // arrange
         let $testContainer = $("#container"),
             selectBox,
@@ -3070,7 +3070,7 @@ QUnit.module("Supported editors", () => {
         assert.ok(!layoutManager._isValueChangedCalled);
     });
 
-    test("Update data option of layout manager when value is changed in the dxTagBox editor", (assert) => {
+    test("Update data option of layout manager when value is changed in the dxTagBox editor", function(assert) {
         // arrange
         let $testContainer = $("#container"),
             tagBox,
@@ -3107,7 +3107,7 @@ QUnit.module("Supported editors", () => {
         assert.ok(!layoutManager._isValueChangedCalled);
     });
 
-    test("Check that inner widgets change readOnly option at layoutManager optionChange", (assert) => {
+    test("Check that inner widgets change readOnly option at layoutManager optionChange", function(assert) {
         const layoutManager = createFormWithSupportedEditors();
         const $testContainer = layoutManager.$element();
 
@@ -3122,7 +3122,7 @@ QUnit.module("Supported editors", () => {
         });
     });
 
-    test("Check readOnly state for editor when readOnly is enabled in the editorOptions", (assert) => {
+    test("Check readOnly state for editor when readOnly is enabled in the editorOptions", function(assert) {
         const layoutManager = createFormWithSupportedEditors({ readOnly: true });
         const $testContainer = layoutManager.$element();
 
@@ -3131,7 +3131,7 @@ QUnit.module("Supported editors", () => {
         });
     });
 
-    test("Editor's read only state should not be reset on the dxForm 'readOnly' option changing", (assert) => {
+    test("Editor's read only state should not be reset on the dxForm 'readOnly' option changing", function(assert) {
         const layoutManager = createFormWithSupportedEditors({ readOnly: true });
         const $testContainer = layoutManager.$element();
 
@@ -3143,7 +3143,7 @@ QUnit.module("Supported editors", () => {
         });
     });
 
-    test("Check the Html Editor with a value and toolbar items", (assert) => {
+    test("Check the Html Editor with a value and toolbar items", function(assert) {
         const expectedText = "This <b>text</b> for testing the <i>Html Editor</i>";
         const layoutManager = $("#container").dxLayoutManager({
             layoutData: {
@@ -3168,7 +3168,7 @@ QUnit.module("Supported editors", () => {
         }
     });
 
-    test("Check updating the layoutData when the value of the HtmlEditor is changed", (assert) => {
+    test("Check updating the layoutData when the value of the HtmlEditor is changed", function(assert) {
         const layoutManager = $("#container").dxLayoutManager({
             layoutData: {
                 description: "This <b>text</b> for testing the <i>Html Editor</i>"

--- a/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.tests.js
@@ -316,7 +316,7 @@ QUnit.test("onEditorEnterKey", function(assert) {
     assert.equal(testArgs.dataField, "name", "dataField");
 });
 
-QUnit.test("Should save layoutData properties by reference (T706177)", (assert) => {
+QUnit.test("Should save layoutData properties by reference (T706177)", function(assert) {
     const done = assert.async();
 
     const items = [


### PR DESCRIPTION
Clarification:
---

> QUnit test and module callbacks can share state by modifying properties of `this` within those callbacks.
> 
> This only works when using function expressions, which allow for dynamic binding of `this` by the QUnit library. Arrow function expressions will not work in this case, because arrow functions will always bind to whatever the value of `this` was in the enclosing scope (in QUnit tests, usually the global object). This means that developers who use arrow function expressions as test or module callbacks will not be able to share state and may encounter other problems.

See https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md

Examples:
---
![image](https://user-images.githubusercontent.com/1420883/69534324-994bb300-0f8a-11ea-9ddc-1fb597126850.png)

![image](https://user-images.githubusercontent.com/1420883/69534389-c1d3ad00-0f8a-11ea-8b56-c37084a0b60b.png)

