### PR TITLE
Core: Fix globals in tests

### DIFF
--- a/testing/tests/DevExpress.core/class.tests.js
+++ b/testing/tests/DevExpress.core/class.tests.js
@@ -353,7 +353,7 @@ QUnit.test("static methods should be inherited", function(assert) {
 QUnit.module("API");
 
 
-QUnit.test("subclassOf method for es6 inheritors", assert => {
+QUnit.test("subclassOf method for es6 inheritors", function(assert) {
     const Base = Class.inherit({});
 
     class ES6Inheritor extends Base {}

--- a/testing/tests/DevExpress.core/component.tests.js
+++ b/testing/tests/DevExpress.core/component.tests.js
@@ -126,7 +126,7 @@ const TestComponent = Component.inherit({
 });
 
 QUnit.module("default", {}, () => {
-    QUnit.test("options api - 'option' method", (assert) => {
+    QUnit.test("options api - 'option' method", function(assert) {
         const instance = new TestComponent({ opt2: "custom" });
 
         instance.option({
@@ -138,7 +138,7 @@ QUnit.module("default", {}, () => {
         assert.equal(instance.option("opt2"), "mass2");
     });
 
-    QUnit.test("setOptionSilently method", (assert) => {
+    QUnit.test("setOptionSilently method", function(assert) {
         const instance = new TestComponent({
             opt2: "custom"
         });
@@ -150,7 +150,7 @@ QUnit.module("default", {}, () => {
         assert.strictEqual(log.length, 0, "optionChanged method has not been called");
     });
 
-    QUnit.test("options api - 'onOptionChanged' action", (assert) => {
+    QUnit.test("options api - 'onOptionChanged' action", function(assert) {
         const actionChangeLog = [];
         const eventChangeLog = [];
 
@@ -192,7 +192,7 @@ QUnit.module("default", {}, () => {
         assert.deepEqual(eventChangeLog, expectedLog);
     });
 
-    QUnit.test("options api - 'onOptionChanged' changing", (assert) => {
+    QUnit.test("options api - 'onOptionChanged' changing", function(assert) {
         let called = null;
 
         const instance = new TestComponent({
@@ -211,13 +211,13 @@ QUnit.module("default", {}, () => {
         assert.equal(called, "new handler");
     });
 
-    QUnit.test("component should initialize PostponedOperations", (assert) => {
+    QUnit.test("component should initialize PostponedOperations", function(assert) {
         const instance = new TestComponent({ a: 1 });
 
         assert.ok(instance.postponedOperations instanceof PostponedOperations, "Componend initialize PostponedOperations");
     });
 
-    QUnit.test("postponed operations should be called on endUpdate", (assert) => {
+    QUnit.test("postponed operations should be called on endUpdate", function(assert) {
         const instance = new TestComponent({ a: 1 });
         const callPostponed = sinon.stub(instance.postponedOperations, "callPostponedOperations");
 
@@ -225,7 +225,7 @@ QUnit.module("default", {}, () => {
         assert.ok(callPostponed.calledOnce, "Postponed operations are called");
     });
 
-    QUnit.test("postponed operations should be called correctly without promises", (assert) => {
+    QUnit.test("postponed operations should be called correctly without promises", function(assert) {
         const instance = new TestComponent({ a: 1 });
 
         const postponedOperation = () => {
@@ -242,7 +242,7 @@ QUnit.module("default", {}, () => {
         assert.ok(true, "Postponed operations are called correctly");
     });
 
-    QUnit.test("component lifecycle, changing a couple of options", (assert) => {
+    QUnit.test("component lifecycle, changing a couple of options", function(assert) {
         const instance = new TestComponent({ a: 1 });
         // Method is injected here (not in the TestComponent prototype) in order to not overwhelm prototype because of one test
         instance._optionChanging = function() {
@@ -287,7 +287,7 @@ QUnit.module("default", {}, () => {
         assert.deepEqual(optionChangedArgs[1].arguments[0].name, "c");
     });
 
-    QUnit.test("mass option change", (assert) => {
+    QUnit.test("mass option change", function(assert) {
         const instance = new TestComponent({
             opt1: "firstCall",
             opt2: "firstCall"
@@ -303,7 +303,7 @@ QUnit.module("default", {}, () => {
         assert.equal(instance.option("opt3"), "secondCall");
     });
 
-    QUnit.test("mass option getting", (assert) => {
+    QUnit.test("mass option getting", function(assert) {
         const instance = new TestComponent({
             opt1: "firstCall",
             opt2: "firstCall"
@@ -315,7 +315,7 @@ QUnit.module("default", {}, () => {
         assert.ok(options["opt2"]);
     });
 
-    QUnit.test("complex options", (assert) => {
+    QUnit.test("complex options", function(assert) {
         let component1 = Component.inherit({
             NAME: "component1",
 
@@ -355,7 +355,7 @@ QUnit.module("default", {}, () => {
 
     });
 
-    QUnit.test("option value equality comparison", (assert) => {
+    QUnit.test("option value equality comparison", function(assert) {
         let triggered;
 
         const instance = new (Component.inherit({ NAME: "temp" }))({
@@ -400,7 +400,7 @@ QUnit.module("default", {}, () => {
         }, true);
     });
 
-    QUnit.test("option getter by path gets value", (assert) => {
+    QUnit.test("option getter by path gets value", function(assert) {
         const instance = new TestComponent({
             prop: {
                 name: "John",
@@ -411,7 +411,7 @@ QUnit.module("default", {}, () => {
         assert.equal(instance.option("prop.items.1"), 2);
     });
 
-    QUnit.test("option setter by path sets value ", (assert) => {
+    QUnit.test("option setter by path sets value ", function(assert) {
         const instance = new TestComponent({
             prop: {
                 name: "John",
@@ -426,7 +426,7 @@ QUnit.module("default", {}, () => {
         assert.equal(instance.option("prop.items.2"), 10);
     });
 
-    QUnit.test("option setter by path triggers option changed callback", (assert) => {
+    QUnit.test("option setter by path triggers option changed callback", function(assert) {
         const instance = new TestComponent({
             opt3: {
                 subOpt: "value"
@@ -439,7 +439,7 @@ QUnit.module("default", {}, () => {
         assert.equal(instance._getTraceLogByMethod("_optionChanged").length, 1);
     });
 
-    QUnit.test("option by value", (assert) => {
+    QUnit.test("option by value", function(assert) {
         const value = {
             a: 3,
             b: 4
@@ -454,7 +454,7 @@ QUnit.module("default", {}, () => {
         assert.notStrictEqual(instance.option("byValue"), value, "option set by value");
     });
 
-    QUnit.test("option by reference", (assert) => {
+    QUnit.test("option by reference", function(assert) {
         const value = { a: 3, b: 4 };
 
         const instance = new TestComponent({
@@ -467,13 +467,13 @@ QUnit.module("default", {}, () => {
         assert.strictEqual(instance.option("byReference"), value, "option set by reference");
     });
 
-    QUnit.test("'option' method with undefined value", (assert) => {
+    QUnit.test("'option' method with undefined value", function(assert) {
         const instance = new TestComponent({ optionWithUndefinedValue: undefined });
 
         assert.strictEqual(instance.option("optionWithUndefinedValue"), undefined);
     });
 
-    QUnit.test("set and get option silently", (assert) => {
+    QUnit.test("set and get option silently", function(assert) {
         const instance = new TestComponent();
         let warningCount = 0;
         const _logDeprecatedWarningMock = option => {
@@ -490,7 +490,7 @@ QUnit.module("default", {}, () => {
         assert.equal(warningCount, 0);
     });
 
-    QUnit.test("reading & writing a deprecated option must invoke the _logDeprecatedWarning method and pass the option name as a parameter", (assert) => {
+    QUnit.test("reading & writing a deprecated option must invoke the _logDeprecatedWarning method and pass the option name as a parameter", function(assert) {
         const instance = new TestComponent();
         const deprecatedOption = "deprecatedOption";
         const _logDeprecatedWarningMock = option => {
@@ -504,7 +504,7 @@ QUnit.module("default", {}, () => {
         instance.option({ fakeOption: true, deprecatedOption: true });
     });
 
-    QUnit.test("writing a deprecated option must invoke optionChanged for deprecated option", (assert) => {
+    QUnit.test("writing a deprecated option must invoke optionChanged for deprecated option", function(assert) {
         const actionChangeLog = [];
 
         const instance = new TestComponent({
@@ -539,7 +539,7 @@ QUnit.module("default", {}, () => {
         assert.deepEqual(instance.option("deprecatedOptionAliasWithSugarSyntax"), "new test");
     });
 
-    QUnit.test("reading all options should not invoke the _logDeprecatedWarning method", (assert) => {
+    QUnit.test("reading all options should not invoke the _logDeprecatedWarning method", function(assert) {
         const instance = new TestComponent();
         let warningCount = 0;
         const _logDeprecatedWarningMock = option => {
@@ -551,7 +551,7 @@ QUnit.module("default", {}, () => {
         assert.strictEqual(warningCount, 0);
     });
 
-    QUnit.test("component should _suppressDeprecatedWarnings while initializing _defaultOptions in the constructor and _resumeDeprecatedWarnings afterwards", (assert) => {
+    QUnit.test("component should _suppressDeprecatedWarnings while initializing _defaultOptions in the constructor and _resumeDeprecatedWarnings afterwards", function(assert) {
         const instance = new TestComponent();
         const deprecatedOption = "deprecatedOption";
         let warningCount = 0;
@@ -566,7 +566,7 @@ QUnit.module("default", {}, () => {
         assert.strictEqual(warningCount, 1);
     });
 
-    QUnit.test("deprecated options api syntactic sugar for options having aliases", (assert) => {
+    QUnit.test("deprecated options api syntactic sugar for options having aliases", function(assert) {
         const originalLog = errors.log;
         const log = [];
 
@@ -597,7 +597,7 @@ QUnit.module("default", {}, () => {
     });
 
     // T116550
-    QUnit.test("deprecated options api syntactic sugar for second level options having aliases", (assert) => {
+    QUnit.test("deprecated options api syntactic sugar for second level options having aliases", function(assert) {
         const originalLog = errors.log;
         const log = [];
 
@@ -631,7 +631,7 @@ QUnit.module("default", {}, () => {
         }
     });
 
-    QUnit.test("changing a nested options triggers only top level name option change handler", (assert) => {
+    QUnit.test("changing a nested options triggers only top level name option change handler", function(assert) {
         const instance = new TestComponent({
             firstLevel: {
                 secondLevel: [0, 1, 2]
@@ -694,7 +694,7 @@ QUnit.module("default", {}, () => {
         ];
     };
 
-    QUnit.test("T320061 - the third level of nesting option deprecated message on initialize", (assert) => {
+    QUnit.test("T320061 - the third level of nesting option deprecated message on initialize", function(assert) {
         const originalLog = errors.log;
         const log = [];
 
@@ -734,7 +734,7 @@ QUnit.module("default", {}, () => {
         }
     });
 
-    QUnit.test("T320061 - third level of nesting option deprecated message on option change using object", (assert) => {
+    QUnit.test("T320061 - third level of nesting option deprecated message on option change using object", function(assert) {
         const originalLog = errors.log;
         const log = [];
 
@@ -773,7 +773,7 @@ QUnit.module("default", {}, () => {
         }
     });
 
-    QUnit.test("dispose optionManager", (assert) => {
+    QUnit.test("dispose optionManager", function(assert) {
         const component = new TestComponent();
         const callbacks = ["_deprecatedCallbacks"];
         const optionManagerCallbacks = ["_changedCallbacks", "_changingCallbacks"];
@@ -796,7 +796,7 @@ QUnit.module("default", {}, () => {
         });
     });
 
-    QUnit.test("T320061 - third level of nesting option deprecated message on option change using string", (assert) => {
+    QUnit.test("T320061 - third level of nesting option deprecated message on option change using string", function(assert) {
         const originalLog = errors.log;
         const log = [];
 
@@ -829,7 +829,7 @@ QUnit.module("default", {}, () => {
         }
     });
 
-    QUnit.test("'onDisposing' action and event should be fired on component disposing", (assert) => {
+    QUnit.test("'onDisposing' action and event should be fired on component disposing", function(assert) {
         let actionArgs = null;
         let eventArgs = null;
 
@@ -856,7 +856,7 @@ QUnit.module("default", {}, () => {
         });
     });
 
-    QUnit.test("'onDisposing' changing", (assert) => {
+    QUnit.test("'onDisposing' changing", function(assert) {
         let called = null;
 
         const component = new TestComponent({
@@ -874,7 +874,7 @@ QUnit.module("default", {}, () => {
         assert.equal(called, "new handler");
     });
 
-    QUnit.test("'onInitialized' action should be fired on component initialized", (assert) => {
+    QUnit.test("'onInitialized' action should be fired on component initialized", function(assert) {
         let actionArgs = null;
 
         const component = new TestComponent({
@@ -889,7 +889,7 @@ QUnit.module("default", {}, () => {
         });
     });
 
-    QUnit.test("'onInitialized' action should accept option changing (T313907)", (assert) => {
+    QUnit.test("'onInitialized' action should accept option changing (T313907)", function(assert) {
         let optionChangedCounter = 0;
 
         new TestComponent({
@@ -904,13 +904,13 @@ QUnit.module("default", {}, () => {
         assert.equal(optionChangedCounter, 0, "if option change will fired, partial re-render lead to error");
     });
 
-    QUnit.test("'hasActionSubscription' should be false if component doesn't have subscribe", (assert) => {
+    QUnit.test("'hasActionSubscription' should be false if component doesn't have subscribe", function(assert) {
         const component = new TestComponent();
 
         assert.notOk(component.hasActionSubscription("onInitialized"), "component doesn't have onInitialized subscribe");
     });
 
-    QUnit.test("'hasActionSubscription' should be true if component has subscribe via option", (assert) => {
+    QUnit.test("'hasActionSubscription' should be true if component has subscribe via option", function(assert) {
         const component = new TestComponent({
             onInitialized() {
             }
@@ -919,7 +919,7 @@ QUnit.module("default", {}, () => {
         assert.ok(component.hasActionSubscription("onInitialized"), "component has onInitialized subscribe");
     });
 
-    QUnit.test("'hasActionSubscription' should be true if component has subscribe via event", (assert) => {
+    QUnit.test("'hasActionSubscription' should be true if component has subscribe via event", function(assert) {
         const component = new TestComponent();
 
         component.on("initialized", () => {
@@ -928,7 +928,7 @@ QUnit.module("default", {}, () => {
         assert.ok(component.hasActionSubscription("onInitialized"), "component has onInitialized subscribe");
     });
 
-    QUnit.test("changing value to NaN does not call optionChanged twice", (assert) => {
+    QUnit.test("changing value to NaN does not call optionChanged twice", function(assert) {
         let called = 0;
 
         const instance = new TestComponent({
@@ -944,7 +944,7 @@ QUnit.module("default", {}, () => {
         assert.equal(called, 1, "NaN handled once");
     });
 
-    QUnit.test("DOM Element comparing by reference", (assert) => {
+    QUnit.test("DOM Element comparing by reference", function(assert) {
         let called = 0;
         const element = document.createElement("div");
 
@@ -963,7 +963,7 @@ QUnit.module("default", {}, () => {
         assert.equal(called, 1, "DOM Element compared by reference");
     });
 
-    QUnit.test("_optionChanging is called before inner _options object is changed", (assert) => {
+    QUnit.test("_optionChanging is called before inner _options object is changed", function(assert) {
         const instance = new TestComponent({
             option1: 1
         });
@@ -977,7 +977,7 @@ QUnit.module("default", {}, () => {
         instance.option("option1", 2);
     });
 
-    QUnit.test("T359818 - option changed should be called when deprecated option is changed", (assert) => {
+    QUnit.test("T359818 - option changed should be called when deprecated option is changed", function(assert) {
         const instance = new TestComponent();
         const value = 5;
 
@@ -993,7 +993,7 @@ QUnit.module("default", {}, () => {
         assert.equal(logRecord[1].arguments[0].value, value, "the 'optionChanged' method option value is correct");
     });
 
-    QUnit.test("T359818 - option changed should be called when the second level deprecated option is changed", (assert) => {
+    QUnit.test("T359818 - option changed should be called when the second level deprecated option is changed", function(assert) {
         const instance = new TestComponent();
         const value = 5;
 
@@ -1009,7 +1009,7 @@ QUnit.module("default", {}, () => {
         assert.equal(logRecord[1].arguments[0].value, value, "the 'optionChanged' method option value is correct");
     });
 
-    QUnit.test("T359818 - option changed should be called when deprecated option is changed", (assert) => {
+    QUnit.test("T359818 - option changed should be called when deprecated option is changed", function(assert) {
         const instance = new TestComponent();
         const value = 5;
 
@@ -1025,7 +1025,7 @@ QUnit.module("default", {}, () => {
         assert.equal(logRecord[1].arguments[0].value, value, "the 'optionChanged' method option value is correct");
     });
 
-    QUnit.test("T359818 - option changed should be called when the second level deprecated option is changed", (assert) => {
+    QUnit.test("T359818 - option changed should be called when the second level deprecated option is changed", function(assert) {
         const instance = new TestComponent();
         const value = 5;
 
@@ -1041,7 +1041,7 @@ QUnit.module("default", {}, () => {
         assert.equal(logRecord[1].arguments[0].value, value, "the 'optionChanged' method option value is correct");
     });
 
-    QUnit.test("T359818 - deprecated option changed should be called when alias option is changed", (assert) => {
+    QUnit.test("T359818 - deprecated option changed should be called when alias option is changed", function(assert) {
         const instance = new TestComponent();
         const value = 5;
 
@@ -1057,13 +1057,13 @@ QUnit.module("default", {}, () => {
         assert.equal(logRecord[1].arguments[0].value, value, "the 'optionChanged' method option value is correct");
     });
 
-    QUnit.test("the isOptionDeprecated method", (assert) => {
+    QUnit.test("the isOptionDeprecated method", function(assert) {
         const instance = new TestComponent();
         assert.ok(instance.isOptionDeprecated("deprecated"), "it is correct for deprecated option");
         assert.ok(!instance.isOptionDeprecated("opt1"), "it is correct for an ordinary option");
     });
 
-    QUnit.test("the _getOptionValue method sets the context for function option (T577942)", (assert) => {
+    QUnit.test("the _getOptionValue method sets the context for function option (T577942)", function(assert) {
         const instance = new TestComponent();
         const context = { contextField: 1 };
 
@@ -1073,7 +1073,7 @@ QUnit.module("default", {}, () => {
 });
 
 QUnit.module("defaultOptions", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.originalDevice = devices.current();
         this.createClass = defaultOptionsRules => {
             return Component.inherit({
@@ -1083,11 +1083,11 @@ QUnit.module("defaultOptions", {
             });
         };
     },
-    afterEach: () => {
+    afterEach: function() {
         devices.current(this.originalDevice);
     }
 }, () => {
-    QUnit.test("set default option for specific component", (assert) => {
+    QUnit.test("set default option for specific component", function(assert) {
         const TestComponent = this.createClass([{
             options: {
                 test: "value"
@@ -1097,7 +1097,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new TestComponent().option("test"), "value", "test option is configured");
     });
 
-    QUnit.test("set default options for specific device platform", (assert) => {
+    QUnit.test("set default options for specific device platform", function(assert) {
         const TestComponent = this.createClass([{
             device: { platform: "ios" },
             options: {
@@ -1112,7 +1112,7 @@ QUnit.module("defaultOptions", {
         assert.notEqual(new TestComponent().option("test"), "value", "test option is not configured for android");
     });
 
-    QUnit.test("set default options for specific device type", (assert) => {
+    QUnit.test("set default options for specific device type", function(assert) {
         const TestComponent = this.createClass([{
             device: { deviceType: "phone" },
             options: {
@@ -1127,7 +1127,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new TestComponent().option("test"), "value", "test option is configured for phone");
     });
 
-    QUnit.test("set default options for device filter flags", (assert) => {
+    QUnit.test("set default options for device filter flags", function(assert) {
         const TestComponent = this.createClass([{
             device: { ios: true, phone: true },
             options: {
@@ -1142,7 +1142,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new TestComponent().option("test"), "value", "test option is configured for iPhone");
     });
 
-    QUnit.test("set default options for several devices at once", (assert) => {
+    QUnit.test("set default options for several devices at once", function(assert) {
         const TestComponent = this.createClass([{
             device: [
                 { platform: "android" },
@@ -1160,7 +1160,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new TestComponent().option("test"), "value", "test option is configured for ios");
     });
 
-    QUnit.test("set default options for filtering device with custom function", (assert) => {
+    QUnit.test("set default options for filtering device with custom function", function(assert) {
         const TestComponent = this.createClass([{
             device(device) {
                 return device.platform !== "android";
@@ -1177,7 +1177,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new TestComponent().option("test"), "value", "test option is configured for ios");
     });
 
-    QUnit.test("options configuration inheritance", (assert) => {
+    QUnit.test("options configuration inheritance", function(assert) {
         const TestComponent = this.createClass([{
             options: {
                 test: "value"
@@ -1188,7 +1188,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new ChildComponent().option("test"), "value", "test option is configured for child component");
     });
 
-    QUnit.test("default options of child overrides default options of parent", (assert) => {
+    QUnit.test("default options of child overrides default options of parent", function(assert) {
         const TestComponent = this.createClass([{
             options: {
                 test: "parent"
@@ -1207,7 +1207,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new ChildComponent().option("test"), "child", "test option configured with child component defaults");
     });
 
-    QUnit.test("rules priority", (assert) => {
+    QUnit.test("rules priority", function(assert) {
         const TestComponent = this.createClass([{
             options: {
                 test: "parent"
@@ -1231,7 +1231,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new ChildComponent().option("test"), "byRule", "test option configured with child component defaults");
     });
 
-    QUnit.test("initial option test", (assert) => {
+    QUnit.test("initial option test", function(assert) {
         const TestComponent = Component.inherit({
             _getDefaultOptions() {
                 return {
@@ -1262,7 +1262,7 @@ QUnit.module("defaultOptions", {
         assert.equal(new ChildComponent().initialOption("anotherTest"), "byRule", "test initial option configured with child component defaults rules");
     });
 
-    QUnit.test("Checking current option value with initial option value (option value as function)", (assert) => {
+    QUnit.test("Checking current option value with initial option value (option value as function)", function(assert) {
         const TestComponent = Component.inherit({
             _getDefaultOptions() {
                 return {
@@ -1281,7 +1281,7 @@ QUnit.module("defaultOptions", {
         })._isInitialOptionValue("test"), "current value not equal initial value");
     });
 
-    QUnit.test("Checking current option value with initial option value (option value as object)", (assert) => {
+    QUnit.test("Checking current option value with initial option value (option value as object)", function(assert) {
         const TestComponent = Component.inherit({
             _getDefaultOptions() {
                 return {
@@ -1301,7 +1301,7 @@ QUnit.module("defaultOptions", {
         })._isInitialOptionValue("test"), "current value not equal initial value");
     });
 
-    QUnit.test("'defaultOptionRules' option", (assert) => {
+    QUnit.test("'defaultOptionRules' option", function(assert) {
         const TestComponent = Component.inherit({
             _defaultOptionsRules() {
                 return this.callBase().slice(0).concat([{
@@ -1327,7 +1327,7 @@ QUnit.module("defaultOptions", {
         assert.equal(options.c, 3);
     });
 
-    QUnit.test("reset option", (assert) => {
+    QUnit.test("reset option", function(assert) {
         const instance = new TestComponent();
 
         instance.option({
@@ -1365,7 +1365,7 @@ QUnit.module("defaultOptions", {
         assert.equal(instance.option("opt6[0].subOpt"), "default");
     });
 
-    QUnit.test("reset option with empty option name", (assert) => {
+    QUnit.test("reset option with empty option name", function(assert) {
         const instance = new TestComponent();
         let error = false;
 
@@ -1378,7 +1378,7 @@ QUnit.module("defaultOptions", {
         }
     });
 
-    QUnit.test("reset option after setting initialOption", (assert) => {
+    QUnit.test("reset option after setting initialOption", function(assert) {
         const instance = new TestComponent();
 
         instance.resetOption("opt5.subOpt2");
@@ -1402,11 +1402,11 @@ QUnit.module("defaultOptions", {
 });
 
 QUnit.module("event API", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.component = new Component();
     }
 }, () => {
-    QUnit.test("on", (assert) => {
+    QUnit.test("on", function(assert) {
         let triggered = false;
 
         this.component.on("event", () => {
@@ -1417,7 +1417,7 @@ QUnit.module("event API", {
         assert.ok(triggered);
     });
 
-    QUnit.test("hasEvent", (assert) => {
+    QUnit.test("hasEvent", function(assert) {
         assert.ok(!this.component._eventsStrategy.hasEvent("event"));
         this.component.on("event", noop);
         assert.ok(this.component._eventsStrategy.hasEvent("event"));
@@ -1425,7 +1425,7 @@ QUnit.module("event API", {
         assert.ok(!this.component._eventsStrategy.hasEvent("event"));
     });
 
-    QUnit.test("fire context and args", (assert) => {
+    QUnit.test("fire context and args", function(assert) {
         assert.expect(2);
 
         const component = this.component;
@@ -1436,7 +1436,7 @@ QUnit.module("event API", {
         component._eventsStrategy.fireEvent("event", ["OK"]);
     });
 
-    QUnit.test("off", (assert) => {
+    QUnit.test("off", function(assert) {
         const component = this.component;
 
         let count = 0;
@@ -1459,7 +1459,7 @@ QUnit.module("event API", {
         assert.equal(count, 2);
     });
 
-    QUnit.test("on with hash", (assert) => {
+    QUnit.test("on with hash", function(assert) {
         const component = this.component;
         let count = 0;
         const h1 = () => {
@@ -1481,13 +1481,13 @@ QUnit.module("event API", {
         assert.equal(count, 3);
     });
 
-    QUnit.test("methods are chainable", (assert) => {
+    QUnit.test("methods are chainable", function(assert) {
         assert.strictEqual(this.component.on(), this.component);
         assert.strictEqual(this.component.off(), this.component);
         assert.strictEqual(this.component._eventsStrategy.fireEvent(), this.component);
     });
 
-    QUnit.test("event callbacks should be disposed on component disposing", (assert) => {
+    QUnit.test("event callbacks should be disposed on component disposing", function(assert) {
         assert.expect(0);
 
         this.component.on("event", () => {
@@ -1499,7 +1499,7 @@ QUnit.module("event API", {
 });
 
 QUnit.module("action API", {}, () => {
-    QUnit.test("_createAction function makes wrong arguments if called w/o config", (assert) => {
+    QUnit.test("_createAction function makes wrong arguments if called w/o config", function(assert) {
         const instance = new TestComponent();
 
         instance._createAction(e => {
@@ -1508,7 +1508,7 @@ QUnit.module("action API", {}, () => {
         })();
     });
 
-    QUnit.test("_createActionByOption should call _suppressDeprecatedWarnings before reading the action option value and then call _resumeDeprecatedWarnings", (assert) => {
+    QUnit.test("_createActionByOption should call _suppressDeprecatedWarnings before reading the action option value and then call _resumeDeprecatedWarnings", function(assert) {
         const instance = new TestComponent();
         const deprecatedOption = "deprecatedOption";
         let warningCount = 0;
@@ -1523,7 +1523,7 @@ QUnit.module("action API", {}, () => {
         assert.strictEqual(warningCount, 1);
     });
 
-    QUnit.test("action executing should fire event handlers with same arguments and context", (assert) => {
+    QUnit.test("action executing should fire event handlers with same arguments and context", function(assert) {
         let actionArguments = null;
         let actionContext = null;
         let eventArguments = null;
@@ -1550,7 +1550,7 @@ QUnit.module("action API", {}, () => {
         assert.strictEqual(eventContext, actionContext);
     });
 
-    QUnit.test("action executing should fire event handlers when not exists option and exists subscriptions", (assert) => {
+    QUnit.test("action executing should fire event handlers when not exists option and exists subscriptions", function(assert) {
         let eventArguments = null;
         let eventContext = null;
 
@@ -1571,7 +1571,7 @@ QUnit.module("action API", {}, () => {
         assert.strictEqual(eventContext, instance, "event context");
     });
 
-    QUnit.test("_createActionByOption should run 'beforeExecute' before the action handler when event was subscribed with 'on' method", (assert) => {
+    QUnit.test("_createActionByOption should run 'beforeExecute' before the action handler when event was subscribed with 'on' method", function(assert) {
         let value = "";
 
         const instance = new TestComponent();
@@ -1591,7 +1591,7 @@ QUnit.module("action API", {}, () => {
         assert.equal(value, "value from 'onTestEvent'", "action value was not overwritten by the 'beforeExecute' method");
     });
 
-    QUnit.test("_createActionByOption should not override user 'afterExecute' option", (assert) => {
+    QUnit.test("_createActionByOption should not override user 'afterExecute' option", function(assert) {
         assert.expect(1);
 
         const instance = new TestComponent({
@@ -1607,7 +1607,7 @@ QUnit.module("action API", {}, () => {
         executeAction({});
     });
 
-    QUnit.test("action should be wrapped only once (T611040)", (assert) => {
+    QUnit.test("action should be wrapped only once (T611040)", function(assert) {
         const originFlag = config().wrapActionsBeforeExecute;
         config({ wrapActionsBeforeExecute: true });
 

--- a/testing/tests/DevExpress.core/domComponent.tests.js
+++ b/testing/tests/DevExpress.core/domComponent.tests.js
@@ -23,7 +23,7 @@ QUnit.testStart(() => {
 const RTL_CLASS = "dx-rtl";
 
 QUnit.module("default", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.TestComponentWithTemplate = DomComponentWithTemplate.inherit({
             _initTemplates() {
                 this.callBase();
@@ -156,17 +156,17 @@ QUnit.module("default", {
         registerComponent("TestComponentWithTemplate", nameSpace, this.TestComponentWithTemplate);
     },
 
-    afterEach: () => {
+    afterEach: function() {
         delete $.fn.TestComponent;
     }
 }, () => {
-    QUnit.test("component has registered", (assert) => {
+    QUnit.test("component has registered", function(assert) {
         assert.strictEqual(nameSpace.TestComponent, this.TestComponent);
         assert.ok("TestComponent" in $());
         assert.equal(publicComponentUtils.name(this.TestComponent), "TestComponent");
     });
 
-    QUnit.test("obtaining instance from element", (assert) => {
+    QUnit.test("obtaining instance from element", function(assert) {
         const element = $("#component").TestComponent();
         if(!QUnit.urlParams["nojquery"]) {
             assert.ok(element.TestComponent("instance") instanceof this.TestComponent);
@@ -174,14 +174,14 @@ QUnit.module("default", {
         assert.ok(element.TestComponent("instance") instanceof this.TestComponent);
     });
 
-    QUnit.test("method call api", (assert) => {
+    QUnit.test("method call api", function(assert) {
         const element = $("#component").TestComponent();
         assert.equal(element.TestComponent("func", "abc"), "abc");
         assert.strictEqual(element.TestComponent("action"), undefined);
         assert.ok(element.TestComponent("instance").instanceChain() instanceof this.TestComponent);
     });
 
-    QUnit.test("method call made on not initialized widget throws informative exception", (assert) => {
+    QUnit.test("method call made on not initialized widget throws informative exception", function(assert) {
         let message;
         try {
             $("<div></div>").TestComponent("func");
@@ -191,7 +191,7 @@ QUnit.module("default", {
         assert.ok(message.indexOf("TestComponent") > -1);
     });
 
-    QUnit.test("options api", (assert) => {
+    QUnit.test("options api", function(assert) {
         const element = $("#component").TestComponent({ opt2: "custom" });
         const instance = element.TestComponent("instance");
 
@@ -213,7 +213,7 @@ QUnit.module("default", {
         assert.equal(instance.option("opt2"), "mass2");
     });
 
-    QUnit.test("component lifecycle, changing a couple of options", (assert) => {
+    QUnit.test("component lifecycle, changing a couple of options", function(assert) {
         const TestComponent = this.TestComponent.inherit({
             _optionChanged(args) {
                 this.callBase(args);
@@ -266,7 +266,7 @@ QUnit.module("default", {
         assert.deepEqual(optionChangedArgs[1].arguments[0].name, "c");
     });
 
-    QUnit.test("mass option change", (assert) => {
+    QUnit.test("mass option change", function(assert) {
         const element = $("#component").TestComponent({
             opt1: "firstCall",
             opt2: "firstCall"
@@ -286,7 +286,7 @@ QUnit.module("default", {
         assert.equal(instance.option("opt3"), "secondCall");
     });
 
-    QUnit.test("mass option change call 'refresh' once", (assert) => {
+    QUnit.test("mass option change call 'refresh' once", function(assert) {
         const TestComponent = this.TestComponent.inherit({
             _optionChanged(args) {
                 this.callBase(args);
@@ -313,7 +313,7 @@ QUnit.module("default", {
         assert.equal(instance._getTraceLogByMethod("_refresh").length, 1);
     });
 
-    QUnit.test("mass option getting", (assert) => {
+    QUnit.test("mass option getting", function(assert) {
         const element = $("#component").TestComponent({});
         const instance = element.TestComponent("instance");
         const options = instance.option();
@@ -323,7 +323,7 @@ QUnit.module("default", {
         assert.ok(options["opt2"]);
     });
 
-    QUnit.test("'option' method invoking directly and by jQuery plugin syntax should works consistently with undefined value", (assert) => {
+    QUnit.test("'option' method invoking directly and by jQuery plugin syntax should works consistently with undefined value", function(assert) {
         const $element = $("#component");
         const instance = new this.TestComponent($element, { optionWithUndefinedValue: undefined });
 
@@ -331,7 +331,7 @@ QUnit.module("default", {
         assert.strictEqual($element.TestComponent("option", "optionWithUndefinedValue"), undefined);
     });
 
-    QUnit.test("mass method invoking should call method for each component (setter case)", (assert) => {
+    QUnit.test("mass method invoking should call method for each component (setter case)", function(assert) {
         const $firstElement = $("#component");
         const $secondElement = $("#anotherComponent");
         const $elements = $($firstElement).add($secondElement);
@@ -352,7 +352,7 @@ QUnit.module("default", {
         assert.ok(secondInstance._setterReturningThisCalled);
     });
 
-    QUnit.test("mass method invoking should return first instance method result", (assert) => {
+    QUnit.test("mass method invoking should return first instance method result", function(assert) {
         const $firstElement = $("#component");
         const $secondElement = $("#anotherComponent");
         const $elements = $($firstElement).add($secondElement);
@@ -372,7 +372,7 @@ QUnit.module("default", {
         assert.strictEqual(firstInstance, result);
     });
 
-    QUnit.test("jQuery instances should be compared by DOM elements set (not by reference)", (assert) => {
+    QUnit.test("jQuery instances should be compared by DOM elements set (not by reference)", function(assert) {
         const $element = $("<div>");
 
         const instance = $("#component").TestComponent({
@@ -383,27 +383,27 @@ QUnit.module("default", {
         assert.ok(!instance._optionChangedCalled);
     });
 
-    QUnit.test("component should not be refreshed after unknown option changing (B251443)", (assert) => {
+    QUnit.test("component should not be refreshed after unknown option changing (B251443)", function(assert) {
         const instance = new this.TestComponent("#component");
         instance.option("unknown option", 1);
         assert.equal(instance._getTraceLogByMethod("_refresh"), 0);
     });
 
-    QUnit.test("no infinite loop during refresh()", (assert) => {
+    QUnit.test("no infinite loop during refresh()", function(assert) {
         assert.expect(0);
 
         const instance = new this.TestComponent("#component");
         instance.option("option2", 2);
     });
 
-    QUnit.test("option 'disabled' is false on init", (assert) => {
+    QUnit.test("option 'disabled' is false on init", function(assert) {
         const $element = $("#component").TestComponent();
         const instance = $element.TestComponent("instance");
 
         assert.strictEqual(instance.option("disabled"), false);
     });
 
-    QUnit.test("'disabled' option is passed to createComponent", (assert) => {
+    QUnit.test("'disabled' option is passed to createComponent", function(assert) {
         const $firstElement = $("#component");
         const $secondElement = $("#anotherComponent");
 
@@ -419,7 +419,7 @@ QUnit.module("default", {
         assert.ok(secondInstance.option("disabled"), "disabled state is correct");
     });
 
-    QUnit.test("T283132 - the 'disabled' option of inner component is changed if the 'disabled' option of outer component is changed", (assert) => {
+    QUnit.test("T283132 - the 'disabled' option of inner component is changed if the 'disabled' option of outer component is changed", function(assert) {
         const $firstElement = $("#component");
         const $secondElement = $("#anotherComponent");
 
@@ -436,7 +436,7 @@ QUnit.module("default", {
         assert.ok(!secondInstance.option("disabled"), "disabled state is correct");
     });
 
-    QUnit.test("'rtlEnabled' option is passed to createComponent", (assert) => {
+    QUnit.test("'rtlEnabled' option is passed to createComponent", function(assert) {
         const $firstElement = $("#component");
         const $secondElement = $("#anotherComponent");
 
@@ -452,7 +452,7 @@ QUnit.module("default", {
         assert.ok(secondInstance.option("rtlEnabled"), true);
     });
 
-    QUnit.test("'templatesRenderAsynchronously' option is passed to createComponent", (assert) => {
+    QUnit.test("'templatesRenderAsynchronously' option is passed to createComponent", function(assert) {
         const $firstElement = $("#component");
         const $secondElement = $("#anotherComponent");
 
@@ -468,7 +468,7 @@ QUnit.module("default", {
         assert.ok(secondInstance.option("templatesRenderAsynchronously"), true);
     });
 
-    QUnit.test("custom template should not be taken from integrationOptions when it is skipped", (assert) => {
+    QUnit.test("custom template should not be taken from integrationOptions when it is skipped", function(assert) {
         const instance = new DomComponentWithTemplate("#component", {
             template: "customTemplate",
             integrationOptions: {
@@ -494,7 +494,7 @@ QUnit.module("default", {
         assert.strictEqual(template.render(), "Created custom template", "name2 is found in integration options. Use it");
     });
 
-    QUnit.test("default template should not be taken from integrationOptions when it is skipped", (assert) => {
+    QUnit.test("default template should not be taken from integrationOptions when it is skipped", function(assert) {
         const instance = new this.TestComponentWithTemplate("#component", {
             integrationOptions: {
                 skipTemplates: ["content"],
@@ -512,7 +512,7 @@ QUnit.module("default", {
         assert.strictEqual(template.render(), "Default content markup", "name1 is not found in integrationOptions. Use the default");
     });
 
-    QUnit.test("option 'rtl'", (assert) => {
+    QUnit.test("option 'rtl'", function(assert) {
         const $element = $("#component").TestComponent();
         const instance = $element.TestComponent("instance");
 
@@ -522,7 +522,7 @@ QUnit.module("default", {
         assert.ok($element.hasClass(RTL_CLASS));
     });
 
-    QUnit.test("init option 'rtl' is true", (assert) => {
+    QUnit.test("init option 'rtl' is true", function(assert) {
         const $element = $("#component").TestComponent({ rtlEnabled: true });
         const instance = $element.TestComponent("instance");
 
@@ -532,7 +532,7 @@ QUnit.module("default", {
         assert.ok(!$element.hasClass(RTL_CLASS));
     });
 
-    QUnit.test("dispose on remove from DOM", (assert) => {
+    QUnit.test("dispose on remove from DOM", function(assert) {
         const element = $("#component").TestComponent();
         const instance = element.TestComponent("instance");
         let disposed = false;
@@ -547,7 +547,7 @@ QUnit.module("default", {
         assert.ok(disposed);
     });
 
-    QUnit.test("customizing default option rules", (assert) => {
+    QUnit.test("customizing default option rules", function(assert) {
         const TestComponent = DOMComponent.inherit({
             _defaultOptionsRules() {
                 return this.callBase().slice(0).concat([{
@@ -575,7 +575,7 @@ QUnit.module("default", {
         assert.notEqual(new TestComponent($("<div/>")).option("test"), "value", "test option is not customized for android");
     });
 
-    QUnit.test("customizing default option rules applies only on the target component class", (assert) => {
+    QUnit.test("customizing default option rules applies only on the target component class", function(assert) {
         const TestComponent1 = DOMComponent.inherit({
             _getDefaultOptions() {
                 return $.extend(this.callBase(), {
@@ -621,7 +621,7 @@ QUnit.module("default", {
         assert.equal(new TestComponent1($("<div/>")).option("anotherOption"), "Another option value", "Multiple calls should not clean previous rules");
     });
 
-    QUnit.test("DevExpress.rtlEnabled proxied to DOMComponent", (assert) => {
+    QUnit.test("DevExpress.rtlEnabled proxied to DOMComponent", function(assert) {
         assert.equal(coreConfig().rtlEnabled, false, "DevExpress.rtlEnabled equals false by default");
         assert.equal(new DOMComponent($("<div/>")).option("rtlEnabled"), false, "false by default");
 
@@ -631,7 +631,7 @@ QUnit.module("default", {
         coreConfig({ rtlEnabled: false });
     });
 
-    QUnit.test("_visibilityChanged is called on dxhiding and dxshown events and special css class is attached", (assert) => {
+    QUnit.test("_visibilityChanged is called on dxhiding and dxshown events and special css class is attached", function(assert) {
         let hidingFired = 0;
         let shownFired = 0;
 
@@ -661,7 +661,7 @@ QUnit.module("default", {
         assert.equal(shownFired, 1, "shown was fired");
     });
 
-    QUnit.test("visibility change subscriptions should not clash", (assert) => {
+    QUnit.test("visibility change subscriptions should not clash", function(assert) {
         let hidingFired = 0;
         let shownFired = 0;
 
@@ -690,7 +690,7 @@ QUnit.module("default", {
         assert.equal(shownFired, 2, "shown fired for both components");
     });
 
-    QUnit.test("visibility change handling works optimally (initially visible)", (assert) => {
+    QUnit.test("visibility change handling works optimally (initially visible)", function(assert) {
         let hidingFired = 0;
         let shownFired = 0;
 
@@ -719,7 +719,7 @@ QUnit.module("default", {
         assert.equal(hidingFired, 1, "hiding is not fired for the second time");
     });
 
-    QUnit.test("visibility change handling works optimally (initially hidden)", (assert) => {
+    QUnit.test("visibility change handling works optimally (initially hidden)", function(assert) {
         let hidingFired = 0;
         let shownFired = 0;
 
@@ -748,7 +748,7 @@ QUnit.module("default", {
         assert.equal(shownFired, 1, "shown is not fired for the second time");
     });
 
-    QUnit.test("visibility change handling works with hidden parent", (assert) => {
+    QUnit.test("visibility change handling works with hidden parent", function(assert) {
         let hidingFired = 0;
         let shownFired = 0;
 
@@ -777,7 +777,7 @@ QUnit.module("default", {
         assert.equal(shownFired, 1, "shown is fired since parent is shown");
     });
 
-    QUnit.test("_dimensionChanged is called when window resize fired", (assert) => {
+    QUnit.test("_dimensionChanged is called when window resize fired", function(assert) {
         let dimensionChanged = 0;
 
         const TestComponent = this.TestComponent.inherit({
@@ -798,7 +798,7 @@ QUnit.module("default", {
         assert.equal(dimensionChanged, 1, "resize fired");
     });
 
-    QUnit.test("_dimensionChanged is called when dxresize event fired", (assert) => {
+    QUnit.test("_dimensionChanged is called when dxresize event fired", function(assert) {
         let dimensionChanged = 0;
 
         const TestComponent = this.TestComponent.inherit({
@@ -821,7 +821,7 @@ QUnit.module("default", {
         assert.equal(dimensionChanged, 1, "dimension changed fired");
     });
 
-    QUnit.test("'option' method should work correctly with $.Event instance (T105184)", (assert) => {
+    QUnit.test("'option' method should work correctly with $.Event instance (T105184)", function(assert) {
         const component = $("#component").TestComponent({
             position: {
                 of: window,
@@ -842,7 +842,7 @@ QUnit.module("default", {
         assert.ok(component.option("position.of") instanceof $.Event);
     });
 
-    QUnit.test("element method should return correct component element", (assert) => {
+    QUnit.test("element method should return correct component element", function(assert) {
         const $element = $("#component").TestComponent();
         const instance = $element.TestComponent("instance");
 
@@ -850,7 +850,7 @@ QUnit.module("default", {
     });
 
     $.each(["onInitialized", "onOptionChanged", "onDisposing"], (_, action) => {
-        QUnit.test("'" + action + "' action should be fired even in disabled & readOnly", (assert) => {
+        QUnit.test("'" + action + "' action should be fired even in disabled & readOnly", function(assert) {
             const config = {
                 value: true
             };
@@ -870,7 +870,7 @@ QUnit.module("default", {
         });
     });
 
-    QUnit.test("the 'elementAttr' option should set attributes to widget element according to the object passed", (assert) => {
+    QUnit.test("the 'elementAttr' option should set attributes to widget element according to the object passed", function(assert) {
         const $element = $("#component").TestComponent({
             elementAttr: {
                 attr1: "widget 01"
@@ -880,7 +880,7 @@ QUnit.module("default", {
         assert.equal($element.attr("attr1"), "widget 01", "the second attribute is set correctly");
     });
 
-    QUnit.test("changing elementAttr option should not rerender the component", (assert) => {
+    QUnit.test("changing elementAttr option should not rerender the component", function(assert) {
         const $element = $("#component").TestComponent({ elementAttr: { attr1: "widget 01" } });
         const instance = $element.TestComponent("instance");
         const render = sinon.spy(instance, "_render");
@@ -891,7 +891,7 @@ QUnit.module("default", {
         assert.equal($element.attr("attr1"), "widget 02", "attribute is correct");
     });
 
-    QUnit.test("changing class via 'elementAttr' option should preserve component specific classes", (assert) => {
+    QUnit.test("changing class via 'elementAttr' option should preserve component specific classes", function(assert) {
         const SomeComponent = DOMComponent.inherit({
             _render() {
                 this.$element().addClass("dx-some-class1");
@@ -914,7 +914,7 @@ QUnit.module("default", {
         assert.ok($element.hasClass(specialClass), "the new class is also present");
     });
 
-    QUnit.test("Dispose: component can be recreated after dispose", (assert) => {
+    QUnit.test("Dispose: component can be recreated after dispose", function(assert) {
         let element = $("#component").TestComponent();
         let instance = element.TestComponent("instance");
 
@@ -936,7 +936,7 @@ QUnit.module("default", {
         assert.ok(element.TestComponent("instance") instanceof this.TestComponent);
     });
 
-    QUnit.test("Dispose: content of container is cleaned", (assert) => {
+    QUnit.test("Dispose: content of container is cleaned", function(assert) {
         const SomeComponent = DOMComponent.inherit({
             _render() {
                 const p = document.createElement("p");
@@ -958,7 +958,7 @@ QUnit.module("default", {
         assert.equal(element[0].childElementCount, 0);
     });
 
-    QUnit.test("Dispose: dx classes are removed", (assert) => {
+    QUnit.test("Dispose: dx classes are removed", function(assert) {
         const element = $("#component").TestComponent();
         const instance = element.TestComponent("instance");
 
@@ -978,7 +978,7 @@ QUnit.module("default", {
         assert.ok(element.hasClass("some-class-3"));
     });
 
-    QUnit.test("Dispose: attributes deleted", (assert) => {
+    QUnit.test("Dispose: attributes deleted", function(assert) {
         const element = $("#component").TestComponent();
         const instance = element.TestComponent("instance");
 
@@ -1028,7 +1028,7 @@ QUnit.module("default", {
         assert.equal(element.attr("tabindex"), undefined);
     });
 
-    QUnit.test("Dispose: events are cleaned, dxremove is fired", (assert) => {
+    QUnit.test("Dispose: events are cleaned, dxremove is fired", function(assert) {
 
         let disposeRun = false;
         let clickRun = false;
@@ -1059,7 +1059,7 @@ QUnit.module("default", {
         assert.notOk(clickRun);
     });
 
-    QUnit.test("get element", (assert) => {
+    QUnit.test("get element", function(assert) {
         const element = $("#component").TestComponent();
         const instance = dataUtils.data(element[0], "TestComponent");
 
@@ -1070,7 +1070,7 @@ QUnit.module("default", {
         }
     });
 
-    QUnit.test("getInstance method", (assert) => {
+    QUnit.test("getInstance method", function(assert) {
         const $element = $("#component");
         const instance = new this.TestComponent($element);
         const AnotherComponent = DOMComponent.inherit();
@@ -1082,7 +1082,7 @@ QUnit.module("default", {
         assert.strictEqual(AnotherComponent.getInstance($element.get(0)), undefined);
     });
 
-    QUnit.test("reset dimensions", (assert) => {
+    QUnit.test("reset dimensions", function(assert) {
         const $element = $("#component").TestComponent({ width: 200, height: 100 });
         const element = $element.get(0);
         const instance = $element.TestComponent("instance");
@@ -1096,7 +1096,7 @@ QUnit.module("default", {
         assert.equal(element.style.height, "", "height is correct");
     });
 
-    QUnit.test("reset dimensions with custom default value", (assert) => {
+    QUnit.test("reset dimensions with custom default value", function(assert) {
         const TestComponentCustomDefault = DOMComponent.inherit({
             _getDefaultOptions() {
                 return $.extend(

--- a/testing/tests/DevExpress.core/utils.common.tests.js
+++ b/testing/tests/DevExpress.core/utils.common.tests.js
@@ -17,15 +17,15 @@ import config from "core/config";
 const { module, test } = QUnit;
 
 module("runtime utils", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
     },
 
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    test("executeAsync", (assert) => {
+    test("executeAsync", function(assert) {
         assert.expect(1);
 
         let called = false;
@@ -39,7 +39,7 @@ module("runtime utils", {
         this.clock.tick(60);
     });
 
-    test("executeAsync with deferred response", (assert) => {
+    test("executeAsync with deferred response", function(assert) {
         assert.expect(1);
 
         let called = false;
@@ -61,7 +61,7 @@ module("runtime utils", {
         clock.tick(60);
     });
 
-    test("executeAsync with context parameter", (assert) => {
+    test("executeAsync with context parameter", function(assert) {
         assert.expect(2);
 
         const context = {
@@ -78,7 +78,7 @@ module("runtime utils", {
         this.clock.tick(60);
     });
 
-    test("executeAsync with timeout", (assert) => {
+    test("executeAsync with timeout", function(assert) {
         let called = false;
 
         executeAsync(() => {
@@ -101,7 +101,7 @@ module("runtime utils", {
 
 
 module("findBestMatches", () => {
-    test("basic", (assert) => {
+    test("basic", function(assert) {
         const items = [
             {
                 a: 1,
@@ -151,7 +151,7 @@ module("findBestMatches", () => {
         assert.equal(filteredItems.length, 2);
     });
 
-    test("only filter fields should be considered for calculating a specificity", (assert) => {
+    test("only filter fields should be considered for calculating a specificity", function(assert) {
         const items = [{
             a: 1,
             b: 2
@@ -169,7 +169,7 @@ module("findBestMatches", () => {
         assert.equal(filteredItems.length, 2);
     });
 
-    test("filtering items by array fields", (assert) => {
+    test("filtering items by array fields", function(assert) {
         const items = [
             {
                 a: 1
@@ -225,14 +225,14 @@ module("findBestMatches", () => {
 
 
 module("defer render/update", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
     }
 }, () => {
-    test("deferRender execute immediately without deferUpdate", (assert) => {
+    test("deferRender execute immediately without deferUpdate", function(assert) {
         const logs = [];
 
         // act
@@ -253,7 +253,7 @@ module("defer render/update", {
         assert.equal(logs[2], "after inner render", "after inner render");
     });
 
-    test("deferUpdate execute immediately without deferRender", (assert) => {
+    test("deferUpdate execute immediately without deferRender", function(assert) {
         const logs = [];
 
         // act
@@ -274,7 +274,7 @@ module("defer render/update", {
         assert.equal(logs[2], "after inner update", "after inner update");
     });
 
-    test("deferRender execute delayed in deferUpdate", (assert) => {
+    test("deferRender execute delayed in deferUpdate", function(assert) {
         const logs = [];
 
         // act
@@ -301,7 +301,7 @@ module("defer render/update", {
         assert.equal(logs[4], "update deferred done", "update deferred done");
     });
 
-    test("deferUpdate execute delayed in deferRender", (assert) => {
+    test("deferUpdate execute delayed in deferRender", function(assert) {
         const logs = [];
 
         // act
@@ -328,7 +328,7 @@ module("defer render/update", {
         assert.equal(logs[4], "render deferred done", "render deferred done");
     });
 
-    test("several deferUpdate in one deferRender", (assert) => {
+    test("several deferUpdate in one deferRender", function(assert) {
         const logs = [];
 
         // act
@@ -362,7 +362,7 @@ module("defer render/update", {
         assert.equal(logs[5], "render completed");
     });
 
-    test("Return deferred in deferRender and using deferUpdater", (assert) => {
+    test("Return deferred in deferRender and using deferUpdater", function(assert) {
         const logs = [];
 
         // act
@@ -394,7 +394,7 @@ module("defer render/update", {
         assert.equal(logs[2], "render completed");
     });
 
-    test("Return deferred in deferUpdate and using deferRenderer", (assert) => {
+    test("Return deferred in deferUpdate and using deferRenderer", function(assert) {
         const logs = [];
 
         // act
@@ -429,7 +429,7 @@ module("defer render/update", {
 
 
 module("applyServerDecimalSeparator", () => {
-    test("formats the value passed according to the DevExpress.config", (assert) => {
+    test("formats the value passed according to the DevExpress.config", function(assert) {
         const originalConfig = config();
         try {
             config({ serverDecimalSeparator: "|" });
@@ -442,7 +442,7 @@ module("applyServerDecimalSeparator", () => {
 
 
 module("grep", () => {
-    test("basic", (assert) => {
+    test("basic", function(assert) {
         const array = [6, 3, 8, 2, 5];
         const object = {};
         const filterNumbers = (number) => {
@@ -465,7 +465,7 @@ module("grep", () => {
 
 
 module("equalByValue", () => {
-    test("The `equalByValue` should compare GUIDs by values", (assert) => {
+    test("The `equalByValue` should compare GUIDs by values", function(assert) {
         const guid1 = new Guid('1111');
         const guid2 = new Guid('1111');
 
@@ -504,7 +504,7 @@ module("getKeyHash", () => {
     }];
 
     TEST_VALUES.forEach(({ value, result }) => {
-        test(`getKeyHash from the ${typeof value} value`, (assert) => {
+        test(`getKeyHash from the ${typeof value} value`, function(assert) {
             assert.strictEqual(getKeyHash(value), result, "Correct hash");
         });
     });

--- a/testing/tests/DevExpress.core/utils.data.tests.js
+++ b/testing/tests/DevExpress.core/utils.data.tests.js
@@ -37,7 +37,7 @@ var mockVariableWrapper = {
 const { test } = QUnit;
 
 QUnit.module("getter", () => {
-    test("it works", (assert) => {
+    test("it works", function(assert) {
         const obj = {
             a: "a",
             b: () => { return "b()"; },
@@ -62,7 +62,7 @@ QUnit.module("getter", () => {
         assert.equal(GETTER("c.a.a")(obj), "c.a.a");
     });
 
-    test("defaultValue", (assert) => {
+    test("defaultValue", function(assert) {
         const obj = {
             zero: 0,
             emptyString: "",
@@ -91,7 +91,7 @@ QUnit.module("getter", () => {
         assert.equal(GETTER("missing")(new Child, { defaultValue: DEFAULT_VALUE }), DEFAULT_VALUE);
     });
 
-    test("complex getter", (assert) => {
+    test("complex getter", function(assert) {
         const original = {
             a: {
                 a1: "a1",
@@ -113,7 +113,7 @@ QUnit.module("getter", () => {
         assert.deepEqual(GETTER([])(original), undefined);
     });
 
-    test("functionsAsIs option", (assert) => {
+    test("functionsAsIs option", function(assert) {
         const obj = {
             b: () => {
                 return "value";
@@ -127,7 +127,7 @@ QUnit.module("getter", () => {
         assert.deepEqual(GETTER("b", "b2")(obj, { functionsAsIs: true }), { b: obj.b, b2: obj.b2 });
     });
 
-    test("square brackets in expr", (assert) => {
+    test("square brackets in expr", function(assert) {
         const obj = {
             prop: {
                 items: ["first", "second", "third"]
@@ -138,7 +138,7 @@ QUnit.module("getter", () => {
         assert.equal(GETTER("prop[items][1]")(obj), "second");
     });
 
-    test("empty results are the same", (assert) => {
+    test("empty results are the same", function(assert) {
         const monoGetter = GETTER("field1");
         const polyGetter = GETTER("field1", "field2");
 
@@ -149,7 +149,7 @@ QUnit.module("getter", () => {
         assert.strictEqual(emptyResultOfPolyGetter, undefined);
     });
 
-    test("Issue #8552", (assert) => {
+    test("Issue #8552", function(assert) {
         // https://github.com/DevExpress/DevExtreme/issues/8552
         var getter = GETTER([ "B.Id", "B.Key" ]);
         var obj = { B: { Id: "Id", Key: "Key" } };
@@ -159,14 +159,14 @@ QUnit.module("getter", () => {
 
 
 QUnit.module("getter with wrapped variables", {
-    beforeEach: () => {
+    beforeEach: function() {
         variableWrapper.inject(mockVariableWrapper);
     },
-    afterEach: () => {
+    afterEach: function() {
         variableWrapper.resetInjection();
     }
 }, () => {
-    test("wrap support", (assert) => {
+    test("wrap support", function(assert) {
         const mockWrapper = variableWrapper.wrap,
             obj = mockWrapper({
                 prop: mockWrapper({
@@ -178,7 +178,7 @@ QUnit.module("getter with wrapped variables", {
         assert.equal(getter(obj, { functionsAsIs: true }), 3);
     });
 
-    test("not unwrapped when unwrapObservables = false", (assert) => {
+    test("not unwrapped when unwrapObservables = false", function(assert) {
         const mockWrapper = variableWrapper.wrap,
             obj = {
                 prop: {
@@ -193,7 +193,7 @@ QUnit.module("getter with wrapped variables", {
 
 
 QUnit.module("setter", () => {
-    test("single-level prop", (assert) => {
+    test("single-level prop", function(assert) {
         let obj = {
             name: "Alex"
         };
@@ -205,14 +205,14 @@ QUnit.module("setter", () => {
         assert.equal(obj.age, 18);
     });
 
-    test("single-level func", (assert) => {
+    test("single-level func", function(assert) {
         let date = new Date(2012, 7, 31);
 
         SETTER("setMonth")(date, 0);
         assert.equal(date.getMonth(), 0);
     });
 
-    test("complex values are replaced (default mode)", (assert) => {
+    test("complex values are replaced (default mode)", function(assert) {
         let obj = {
             person: {
                 firstName: "John"
@@ -230,7 +230,7 @@ QUnit.module("setter", () => {
         });
     });
 
-    test("complex values are merged (merge option)", (assert) => {
+    test("complex values are merged (merge option)", function(assert) {
         let obj = {
             person: {
                 name: {
@@ -261,7 +261,7 @@ QUnit.module("setter", () => {
         });
     });
 
-    test("multi-level expression", (assert) => {
+    test("multi-level expression", function(assert) {
         let obj = {
             person: {
                 firstName: "John"
@@ -273,7 +273,7 @@ QUnit.module("setter", () => {
 
     });
 
-    test("multi-level expression with functions", (assert) => {
+    test("multi-level expression with functions", function(assert) {
         let person = {
             _firstName: "John",
             setFirstName: function(value) {
@@ -292,7 +292,7 @@ QUnit.module("setter", () => {
         assert.equal(obj._person._firstName, "Alex");
     });
 
-    test("attempt to assign scalar to self", (assert) => {
+    test("attempt to assign scalar to self", function(assert) {
         assert.throws(() => {
             SETTER()("personName", "Alex");
         });
@@ -301,13 +301,13 @@ QUnit.module("setter", () => {
         });
     });
 
-    test("able to assign to self with merge", (assert) => {
+    test("able to assign to self with merge", function(assert) {
         let target = { a: 1 };
         SETTER("this")(target, { b: 2 }, { merge: true });
         assert.deepEqual(target, { a: 1, b: 2 });
     });
 
-    test("setting a function (should use functionsAsIs)", (assert) => {
+    test("setting a function (should use functionsAsIs)", function(assert) {
         const func1 = () => { },
             func2 = () => { };
 
@@ -322,7 +322,7 @@ QUnit.module("setter", () => {
         assert.strictEqual(obj.g, func1, { functionsAsIs: true });
     });
 
-    test("square brackets in expr", (assert) => {
+    test("square brackets in expr", function(assert) {
         let obj = {
             prop: {
                 items: ["first", "second", "third"]
@@ -336,7 +336,7 @@ QUnit.module("setter", () => {
         assert.equal(obj.prop.items[0], "zero");
     });
 
-    test("merging sub-object to non-existent property", (assert) => {
+    test("merging sub-object to non-existent property", function(assert) {
         let obj = {
         };
 
@@ -346,7 +346,7 @@ QUnit.module("setter", () => {
         });
     });
 
-    test("prevent jQuery deep array extending (B239679)", (assert) => {
+    test("prevent jQuery deep array extending (B239679)", function(assert) {
         let obj = {
             sub: {
                 array: [1, 2, 3]
@@ -359,7 +359,7 @@ QUnit.module("setter", () => {
         assert.deepEqual(obj.sub.array, [9]);
     });
 
-    test("complex values are merged only when it is plain object", (assert) => {
+    test("complex values are merged only when it is plain object", function(assert) {
         const SomeClass = function(firstName, lastName) {
             this.firstName = firstName;
             this.lastName = lastName;
@@ -387,7 +387,7 @@ QUnit.module("setter", () => {
         assert.equal(obj1.sub.person.lastName, undefined);
     });
 
-    test("plain objects are cloned if previous value is null (T521407)", (assert) => {
+    test("plain objects are cloned if previous value is null (T521407)", function(assert) {
         let obj = {
             dataSource: null
         };
@@ -415,21 +415,21 @@ QUnit.module("setter", () => {
         assert.equal(dataSource1.store, "Store 1");
     });
 
-    test("non existing multi-level prop (w/ merge = false)", (assert) => {
+    test("non existing multi-level prop (w/ merge = false)", function(assert) {
         let obj = {};
 
         SETTER("prop.subProp1.subProp2")(obj, "Nested value", { merge: false });
         assert.equal(obj.prop.subProp1.subProp2, "Nested value");
     });
 
-    test("non existing multi-level prop (w/ merge = true)", (assert) => {
+    test("non existing multi-level prop (w/ merge = true)", function(assert) {
         let obj = {};
 
         SETTER("prop.subProp1.subProp2")(obj, "Nested value", { merge: true });
         assert.equal(obj.prop.subProp1.subProp2, "Nested value");
     });
 
-    test("multi-level prop instead of primitives", (assert) => {
+    test("multi-level prop instead of primitives", function(assert) {
         const primitives = [ false, 0, "", true, 1, "someValue" ];
 
         primitives.forEach((primitive) => {
@@ -444,7 +444,7 @@ QUnit.module("setter", () => {
         });
     });
 
-    test("multi-level prop instead of function", (assert) => {
+    test("multi-level prop instead of function", function(assert) {
         let called = 0;
 
         let obj = {
@@ -462,7 +462,7 @@ QUnit.module("setter", () => {
         assert.equal(called, 0);
     });
 
-    test("not existing multi-level prop assignment", (assert) => {
+    test("not existing multi-level prop assignment", function(assert) {
         assert.expect(1);
 
         let obj = {
@@ -481,14 +481,14 @@ QUnit.module("setter", () => {
 
 
 QUnit.module("setter with wrapped variables", {
-    beforeEach: () => {
+    beforeEach: function() {
         variableWrapper.inject(mockVariableWrapper);
     },
-    afterEach: () => {
+    afterEach: function() {
         variableWrapper.resetInjection();
     }
 }, () => {
-    test("wrap support", (assert) => {
+    test("wrap support", function(assert) {
         const mockWrapper = variableWrapper.wrap;
         let obj = mockWrapper({
             prop: mockWrapper({
@@ -502,7 +502,7 @@ QUnit.module("setter with wrapped variables", {
         assert.equal(obj().prop().subProp(), 5);
     });
 
-    test("not unwrapped when unwrapObservables = false", (assert) => {
+    test("not unwrapped when unwrapObservables = false", function(assert) {
         const mockWrapper = variableWrapper.wrap;
         let obj = {
             prop: {
@@ -516,7 +516,7 @@ QUnit.module("setter with wrapped variables", {
         assert.equal(obj.prop.subProp, 5);
     });
 
-    test("wrap with merge and functions unwrapping", (assert) => {
+    test("wrap with merge and functions unwrapping", function(assert) {
         const mockWrapper = variableWrapper.wrap;
         let obj = {
             prop: mockWrapper({ a: 1 })
@@ -528,7 +528,7 @@ QUnit.module("setter with wrapped variables", {
         assert.deepEqual(obj.prop(), { a: 1, b: 2 });
     });
 
-    test("multi-level prop into the wrapped value", (assert) => {
+    test("multi-level prop into the wrapped value", function(assert) {
         const mockWrapper = variableWrapper.wrap;
         let obj = mockWrapper({
             prop: mockWrapper(undefined)
@@ -539,7 +539,7 @@ QUnit.module("setter with wrapped variables", {
         assert.equal(obj().prop().subProp, "New value");
     });
 
-    test("multi-level prop instead of wrapped value without unwrapping", (assert) => {
+    test("multi-level prop instead of wrapped value without unwrapping", function(assert) {
         assert.expect(0);
         variableWrapper.inject({
             unwrap: function() {

--- a/testing/tests/DevExpress.core/utils.extend.tests.js
+++ b/testing/tests/DevExpress.core/utils.extend.tests.js
@@ -1,6 +1,6 @@
 import { extend } from "core/utils/extend";
 
-QUnit.test("extend does not pollute object prototype", (assert) => {
+QUnit.test("extend does not pollute object prototype", function(assert) {
     extend(true, { }, JSON.parse(`{ "__proto__": { "pollution": true }}`));
     assert.ok(!("pollution" in { }), "object prototype is not polluted");
 });

--- a/testing/tests/DevExpress.core/utils.icon.tests.js
+++ b/testing/tests/DevExpress.core/utils.icon.tests.js
@@ -6,7 +6,7 @@ const ICON_CLASS = "dx-icon";
 const SVG_ICON_CLASS = "dx-svg-icon";
 
 testModule("icon utils", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.sourceArray = [{ // 1
             source: "data:image/png;base64,qwertyuiopasdfghjklzxcvbmnQWERTYUIOPLKJHGFDSAZXCVBNM/+0987654321",
             result: "image"
@@ -95,7 +95,7 @@ testModule("icon utils", {
         }];
     }
 }, () => {
-    test("getImageSourceType", (assert) => {
+    test("getImageSourceType", function(assert) {
         assert.expect(19);
 
         this.sourceArray.forEach(({ source, result }) => {
@@ -103,7 +103,7 @@ testModule("icon utils", {
         });
     });
 
-    test("getImageContainer", (assert) => {
+    test("getImageContainer", function(assert) {
         this.sourceArray.forEach(({ source, result }) => {
             var $iconElement = getImageContainer(source);
             switch(result) {


### PR DESCRIPTION
Clarification:
---

> QUnit test and module callbacks can share state by modifying properties of `this` within those callbacks.
> 
> This only works when using function expressions, which allow for dynamic binding of `this` by the QUnit library. Arrow function expressions will not work in this case, because arrow functions will always bind to whatever the value of `this` was in the enclosing scope (in QUnit tests, usually the global object). This means that developers who use arrow function expressions as test or module callbacks will not be able to share state and may encounter other problems.

See https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md

Examples:
---
![image](https://user-images.githubusercontent.com/1420883/69541793-12eb9d00-0f9b-11ea-9dbc-9a88170201c9.png)

![image](https://user-images.githubusercontent.com/1420883/69541942-6d84f900-0f9b-11ea-95ee-1246c671bfa6.png)

![image](https://user-images.githubusercontent.com/1420883/69542052-a8872c80-0f9b-11ea-9b56-584ca9f10c26.png)

etc.