### PR TITLE
Navigation & Layout widgets: Fix globals in tests

### DIFF
--- a/testing/tests/DevExpress.serverSide/tabs.tests.js
+++ b/testing/tests/DevExpress.serverSide/tabs.tests.js
@@ -13,7 +13,7 @@ QUnit.testStart(() => {
     $("#qunit-fixture").html(markup);
 });
 
-QUnit.test("tabs should have overflow-hidden class on server", (assert) => {
+QUnit.test("tabs should have overflow-hidden class on server", function(assert) {
     const $tabsElement = $("#tabs").dxTabs({
         items: ["1", "2", "3"]
     });

--- a/testing/tests/DevExpress.ui.widgets/accordion.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.markup.tests.js
@@ -362,7 +362,7 @@ QUnit.test("template should be rendered correctly with title with html", functio
     { title: new Date(2019, 10, 13), expected: String(new Date(2019, 10, 13)) },
     { title: { value: "title" }, expected: "" }
 ].forEach((value) => {
-    QUnit.test(`DefaultTemplate: title template property - ${value.title}`, (assert) => {
+    QUnit.test(`DefaultTemplate: title template property - ${value.title}`, function(assert) {
         const $element = $("<div>").appendTo("#qunit-fixture");
 
         const widget = new Accordion($element, { items: [ { title: value.title }] });
@@ -372,7 +372,7 @@ QUnit.test("template should be rendered correctly with title with html", functio
         assert.strictEqual($itemElements.eq(0).find(`.${ACCORDION_ITEM_TITLE_CLASS}`).text(), value.expected, "item.title");
     });
 
-    QUnit.test(`DefaultTemplate: items["${value.title}"] as primitive`, (assert) => {
+    QUnit.test(`DefaultTemplate: items["${value.title}"] as primitive`, function(assert) {
         const $element = $("<div>").appendTo("#qunit-fixture");
 
         const widget = new Accordion($element, { items: [ value.title ] });

--- a/testing/tests/DevExpress.ui.widgets/box.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/box.markup.tests.js
@@ -38,7 +38,7 @@ const BOX_CLASS = "dx-box",
     BOX_ITEM_CLASS = "dx-box-item";
 
 QUnit.module("render", () => {
-    QUnit.test("render", (assert) => {
+    QUnit.test("render", function(assert) {
         const $box = $("#box").dxBox({
             items: [1, 2]
         });
@@ -52,7 +52,7 @@ QUnit.module("render", () => {
         assert.equal($items.eq(1).text(), "2", "second item rendered");
     });
 
-    QUnit.test("render the box item content with flexBasis equal zero pixel", (assert) => {
+    QUnit.test("render the box item content with flexBasis equal zero pixel", function(assert) {
         const $box = $("#box").dxBox({
             items: [1],
             _layoutStrategy: "flex"
@@ -61,7 +61,7 @@ QUnit.module("render", () => {
         assert.equal($box.find("." + BOX_ITEM_CLASS + "-content").css("flexBasis"), "0px");
     });
 
-    QUnit.test("strategy class", (assert) => {
+    QUnit.test("strategy class", function(assert) {
         const $box = $("#box").dxBox({
             _layoutStrategy: "test"
         });
@@ -71,7 +71,7 @@ QUnit.module("render", () => {
 });
 
 QUnit.module("layouting", () => {
-    QUnit.test("render box in dxBox", (assert) => {
+    QUnit.test("render box in dxBox", function(assert) {
         const $box = $("#box").dxBox({
             items: [{ box: { direction: "row" } }]
         });
@@ -82,7 +82,7 @@ QUnit.module("layouting", () => {
         assert.ok(innerBox instanceof Box, "box was created inside box");
     });
 
-    QUnit.test("box pass _layoutStrategy to children box", (assert) => {
+    QUnit.test("box pass _layoutStrategy to children box", function(assert) {
         const $box = $("#box").dxBox({
             _layoutStrategy: 'test',
             items: [{ box: {} }]
@@ -93,7 +93,7 @@ QUnit.module("layouting", () => {
         assert.equal(innerBox.option("_layoutStrategy"), "test", "_layoutStrategy was passed to children box");
     });
 
-    QUnit.test("box must have a correct flex direction on items rendering (T604581)", (assert) => {
+    QUnit.test("box must have a correct flex direction on items rendering (T604581)", function(assert) {
         new Box($("#box"), {
             direction: "col",
             items: [{ baseSize: 100 }],
@@ -109,7 +109,7 @@ QUnit.module("layouting", () => {
 });
 
 QUnit.module("template rendering", () => {
-    QUnit.test("innerBox with template", (assert) => {
+    QUnit.test("innerBox with template", function(assert) {
         const $box = $("#boxWithInnerBox").dxBox({
             items: [
                 {
@@ -123,7 +123,7 @@ QUnit.module("template rendering", () => {
         assert.equal($.trim($box.text()), "test", "inner box rendered with template");
     });
 
-    QUnit.test("innerBox with item renderer", (assert) => {
+    QUnit.test("innerBox with item renderer", function(assert) {
         const $box = $("#box").dxBox({
             items: [
                 {
@@ -138,7 +138,7 @@ QUnit.module("template rendering", () => {
         assert.equal($.trim($box.text()), "test1test2", "inner box rendered");
     });
 
-    QUnit.test("innerBox with nested box item", (assert) => {
+    QUnit.test("innerBox with nested box item", function(assert) {
         const $box = $("#nestedBox").dxBox({});
 
         assert.equal($.trim($box.text()), "Box1", "inner box rendered");
@@ -146,7 +146,7 @@ QUnit.module("template rendering", () => {
 });
 
 QUnit.module("rendering box item", () => {
-    QUnit.test("callstack should not grow when nesting is growing", (assert) => {
+    QUnit.test("callstack should not grow when nesting is growing", function(assert) {
         const originalBox = Box;
         let deep = 0;
 
@@ -180,7 +180,7 @@ QUnit.module("rendering box item", () => {
         }
     });
 
-    QUnit.test("onItemStateChanged action should fire after item visibility changed", (assert) => {
+    QUnit.test("onItemStateChanged action should fire after item visibility changed", function(assert) {
         const items = [{ text: "Item 1" }],
             itemStateChangedHandler = sinon.spy(),
             $box = $("#box").dxBox({ items: items, onItemStateChanged: itemStateChangedHandler }),

--- a/testing/tests/DevExpress.ui.widgets/box.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/box.tests.js
@@ -48,7 +48,7 @@ const createBox = (...parameters) => {
 const getBoxInstance = $element => $($element).dxBox("instance");
 
 module("Scrollable integration", () => {
-    test("Scrollable placed in dxBox stretch correctly", assert => {
+    test("Scrollable placed in dxBox stretch correctly", function(assert) {
         const $box = createBox("#boxWithScrollable", {
             height: 100,
             direction: "col"
@@ -61,7 +61,7 @@ module("Scrollable integration", () => {
 });
 
 module("layouting", () => {
-    test("direction column", assert => {
+    test("direction column", function(assert) {
         const size = 100;
         const $box = createBox({
             direction: "col",
@@ -104,7 +104,7 @@ module("layouting", () => {
         assert.deepEqual(secondItemLayout, secondItemExpectedLayout, "second item positioned correctly");
     });
 
-    test("direction row", assert => {
+    test("direction row", function(assert) {
         const size = 100;
         const $box = createBox({
             direction: "row",
@@ -151,7 +151,7 @@ module("layouting", () => {
         assert.equal($firstItemContent.width(), size / 2, "item content width is less or equal to item width");
     });
 
-    test("align for column direction", assert => {
+    test("align for column direction", function(assert) {
         const baseSize = 40;
         const boxSize = baseSize * 5;
         const $box = createBox({
@@ -191,7 +191,7 @@ module("layouting", () => {
         assert.equal(relativeOffset($secondItem).top, (boxSize / 2) + (boxSize / 2 - baseSize) / 2, "second item positioned correctly for align: space-around");
     });
 
-    test("align for row direction", assert => {
+    test("align for row direction", function(assert) {
         const baseSize = 40;
         const boxSize = baseSize * 5;
         const $box = createBox({
@@ -228,7 +228,7 @@ module("layouting", () => {
         assert.equal(relativeOffset($secondItem).left, (boxSize / 2) + (boxSize / 2 - baseSize) / 2, "second item positioned correctly for align: space-around");
     });
 
-    test("crossAlign for column direction", assert => {
+    test("crossAlign for column direction", function(assert) {
         const size = 50;
         const boxSize = 2 * size;
         const $box = createBox({
@@ -257,7 +257,7 @@ module("layouting", () => {
         assert.equal($item.width(), boxSize, "element is stretched over container");
     });
 
-    test("crossAlign for row direction", assert => {
+    test("crossAlign for row direction", function(assert) {
         const size = 50;
         const boxSize = 2 * size;
         const $box = createBox({
@@ -286,7 +286,7 @@ module("layouting", () => {
         assert.equal($item.height(), boxSize, "element is stretched over container");
     });
 
-    test("percent baseSize", assert => {
+    test("percent baseSize", function(assert) {
         const firstItemDimension = { baseSize: "60%" };
         const secondItemDimension = { baseSize: "40%" };
 
@@ -305,7 +305,7 @@ module("layouting", () => {
         assert.equal($secondItem.width(), 0.4 * boxSize, "second item has correct size");
     });
 
-    test("items with auto baseSize should have size of content", assert => {
+    test("items with auto baseSize should have size of content", function(assert) {
         const firstItemDimension = { ratio: 0, baseSize: "auto" };
         const secondItemDimension = { ratio: 0, baseSize: "auto" };
 
@@ -328,7 +328,7 @@ module("layouting", () => {
         assert.equal($secondItem.width(), 50, "second item has correct size");
     });
 
-    test("items should have baseSize 0 by default", assert => {
+    test("items should have baseSize 0 by default", function(assert) {
         const firstItemDimension = { ratio: 1 };
         const secondItemDimension = { ratio: 1 };
         const boxSize = 300;
@@ -352,7 +352,7 @@ module("layouting", () => {
         assert.equal($firstItem.width(), $secondItem.width(), "items has same width");
     });
 
-    test("baseSize and ratio option", assert => {
+    test("baseSize and ratio option", function(assert) {
         const firstItemDimension = { ratio: 1, baseSize: 100 };
         const secondItemDimension = { ratio: 3, baseSize: 20 };
         const boxSize = 300;
@@ -374,7 +374,7 @@ module("layouting", () => {
         assert.equal($secondItem.width(), secondItemDimension.baseSize + secondItemDimension.ratio * partSpace, "second item has correct size");
     });
 
-    test("default shrink option", assert => {
+    test("default shrink option", function(assert) {
         const firstItemDimension = { ratio: 1, baseSize: 160 };
         const secondItemDimension = { ratio: 3, baseSize: 40 };
         const thirdItemDimension = { ratio: 3 };
@@ -399,7 +399,7 @@ module("layouting", () => {
         assert.equal($thirdItem.width(), 0, "third item has correct size");
     });
 
-    test("minSize & maxSize", assert => {
+    test("minSize & maxSize", function(assert) {
         const boxSize = 100;
         const minSize = 80;
         const maxSize = 5;
@@ -431,7 +431,7 @@ module("layouting", () => {
         assert.equal($thirdItem.css("minHeight"), "0px", "min-height is 0 by default");
     });
 
-    test("rendering after visibility changing", assert => {
+    test("rendering after visibility changing", function(assert) {
         const clock = sinon.useFakeTimers();
         try {
             const $box = createBox({
@@ -458,7 +458,7 @@ module("layouting", () => {
         }
     });
 
-    test("shrink", assert => {
+    test("shrink", function(assert) {
         const boxSize = 100;
         const itemBaseSize = 100;
         const shrinkRatio1 = 1;
@@ -475,7 +475,7 @@ module("layouting", () => {
         assert.equal($items.eq(1).height(), itemBaseSize - (itemBaseSize * 2 - boxSize) / (shrinkRatio1 + shrinkRatio2) * shrinkRatio2);
     });
 
-    test("shrink may be set to 0", assert => {
+    test("shrink may be set to 0", function(assert) {
         const boxSize = 100;
         const firstItemSize = 75;
         const secondItemSize = 100;
@@ -495,7 +495,7 @@ module("layouting", () => {
 });
 
 module("fallback strategy", () => {
-    test("total baseSize should be used when size is zero", assert => {
+    test("total baseSize should be used when size is zero", function(assert) {
         const baseSize1 = 100;
         const baseSize2 = 200;
 
@@ -509,7 +509,7 @@ module("fallback strategy", () => {
         assert.equal($box.height(), baseSize1 + baseSize2, "box height calculated based on total baseSize");
     });
 
-    test("baseSize in % in invisible area", assert => {
+    test("baseSize in % in invisible area", function(assert) {
         const $box = $("#box").hide().dxBox({
             height: 100,
             _layoutStrategy: "fallback",
@@ -525,7 +525,7 @@ module("fallback strategy", () => {
         assert.equal(round($items.eq(0).outerHeight()), round($box.outerHeight() * 0.5), "second item has correct width");
     });
 
-    test("items size should be changed after dxupdate event inside fieldset", assert => {
+    test("items size should be changed after dxupdate event inside fieldset", function(assert) {
         const $box = $("#box");
         const $wrapper = $box.wrap("<fieldset>").parent();
         $wrapper.width(400);
@@ -547,7 +547,7 @@ module("fallback strategy", () => {
 });
 
 module("layouting in RTL (fallback strategy)", () => {
-    test("align for row direction", assert => {
+    test("align for row direction", function(assert) {
         const baseSize = 40;
         const boxSize = baseSize * 5;
         const $box = createBox({
@@ -588,7 +588,7 @@ module("layouting in RTL (fallback strategy)", () => {
         assert.equal(relativeOffset($secondItem).left, (boxSize / 2 - baseSize) / 2, "second item positioned correctly for align: space-around");
     });
 
-    test("crossAlign for column direction", assert => {
+    test("crossAlign for column direction", function(assert) {
         const size = 50;
         const boxSize = 2 * size;
         const $box = createBox({

--- a/testing/tests/DevExpress.ui.widgets/buttonGroup.selection.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/buttonGroup.selection.tests.js
@@ -98,7 +98,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                 config = `, onInitial=${onInitialOption}, selectionMode=${selectionMode}`;
 
                 [null, undefined, []].forEach((selectedOptionValue) => {
-                    QUnit.test(`${selectedOption}: ${selectedOptionValue}` + config, () => {
+                    QUnit.test(`${selectedOption}: ${selectedOptionValue}` + config, function() {
                         let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                         if(selectedOption === "selectedItems") {
@@ -115,7 +115,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     });
                 });
 
-                QUnit.test(`${selectedOption}: ['notExist']` + config, () => {
+                QUnit.test(`${selectedOption}: ['notExist']` + config, function() {
                     try {
                         let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
                         if(selectedOption === "selectedItems") {
@@ -129,7 +129,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     }
                 });
 
-                QUnit.test(`${selectedOption}: ['btn1']` + config, () => {
+                QUnit.test(`${selectedOption}: ['btn1']` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -147,7 +147,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     helper.checkSelectedItems([items[0].id]);
                 });
 
-                QUnit.test(`${selectedOption}: ['btn2']` + config, () => {
+                QUnit.test(`${selectedOption}: ['btn2']` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -165,7 +165,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     helper.checkSelectedItems([items[1].id]);
                 });
 
-                QUnit.test(`${selectedOption}: ['btn1', 'btn2']` + config, (assert) => {
+                QUnit.test(`${selectedOption}: ['btn1', 'btn2']` + config, function(assert) {
                     if(selectionMode === "single") {
                         assert.ok("skip");
                         return;
@@ -188,7 +188,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     helper.checkSelectedItems([items[0].id, items[1].id]);
                 });
 
-                QUnit.test(`${selectedOption}: [], click(btn1)` + config, () => {
+                QUnit.test(`${selectedOption}: [], click(btn1)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -207,7 +207,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     helper.checkSelectedItems([items[0].id]);
                 });
 
-                QUnit.test(`${selectedOption}: [], click(btn2)` + config, () => {
+                QUnit.test(`${selectedOption}: [], click(btn2)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -226,7 +226,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     helper.checkSelectedItems([items[1].id]);
                 });
 
-                QUnit.test(`${selectedOption}: [], click(btn1, btn2)` + config, () => {
+                QUnit.test(`${selectedOption}: [], click(btn1, btn2)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -256,7 +256,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     }
                 });
 
-                QUnit.test(`${selectedOption}: [], click(btn1, btn1)` + config, () => {
+                QUnit.test(`${selectedOption}: [], click(btn1, btn1)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -285,7 +285,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     }
                 });
 
-                QUnit.test(`${selectedOption}: [{ "text": "btn2" }], click(btn1)` + config, () => {
+                QUnit.test(`${selectedOption}: [{ "text": "btn2" }], click(btn1)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -313,7 +313,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     }
                 });
 
-                QUnit.test(`${selectedOption}: [{ "text": "btn2" }], click(btn2)` + config, () => {
+                QUnit.test(`${selectedOption}: [{ "text": "btn2" }], click(btn2)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -341,7 +341,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     }
                 });
 
-                QUnit.test(`${selectedOption}: [{ "text": "btn2" }], click(btn1, btn2)` + config, () => {
+                QUnit.test(`${selectedOption}: [{ "text": "btn2" }], click(btn1, btn2)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -371,7 +371,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     }
                 });
 
-                QUnit.test(`${selectedOption}: ['btn1', 'btn2'], click(btn1)` + config, (assert) => {
+                QUnit.test(`${selectedOption}: ['btn1', 'btn2'], click(btn1)` + config, function(assert) {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -394,7 +394,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     }
                 });
 
-                QUnit.test(`${selectedOption}: ['btn1', 'btn2'], click(bnt2)` + config, () => {
+                QUnit.test(`${selectedOption}: ['btn1', 'btn2'], click(bnt2)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -420,7 +420,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                     }
                 });
 
-                QUnit.test(`${selectedOption}: ['btn1', 'btn2'], click(bnt2, btn1)` + config, () => {
+                QUnit.test(`${selectedOption}: ['btn1', 'btn2'], click(bnt2, btn1)` + config, function() {
                     let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
 
                     if(selectedOption === "selectedItems") {
@@ -449,7 +449,7 @@ QUnit.module(`Selection for items: ${JSON.stringify(items)}, `, () => {
                 });
             });
 
-            QUnit.test("KeyExpr: custom, set items: [], selectedItems[], click(btn1) -> click(btn3)" + config, () => {
+            QUnit.test("KeyExpr: custom, set items: [], selectedItems[], click(btn1) -> click(btn3)" + config, function() {
                 let helper = new ButtonGroupSelectionTestHelper(onInitialOption, selectionMode);
                 helper.createButtonGroup({
                     items: [

--- a/testing/tests/DevExpress.ui.widgets/buttonGroup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/buttonGroup.tests.js
@@ -178,7 +178,7 @@ QUnit.module("option changed", {
         assert.strictEqual($buttonGroup.find(`.${BUTTON_CONTENT_CLASS}`).text(), "item.template", "template is correct");
     });
 
-    QUnit.test("it should be possible to set full set of options for each button", assert => {
+    QUnit.test("it should be possible to set full set of options for each button", function(assert) {
         const $element = $("#widget").dxButtonGroup({
             items: [{ text: "button 1", width: 24, elementAttr: { class: "test" }, customOption: "Test option" }]
         });
@@ -190,7 +190,7 @@ QUnit.module("option changed", {
         assert.strictEqual(button.option("customOption"), "Test option", "all options should be passed to the button");
     });
 
-    QUnit.test("default options should not be redefined", assert => {
+    QUnit.test("default options should not be redefined", function(assert) {
         const $element = $("#widget").dxButtonGroup({
             items: [{ text: "Test", focusStateEnabled: true }]
         });
@@ -200,7 +200,7 @@ QUnit.module("option changed", {
         assert.strictEqual(button.option("focusStateEnabled"), false, "focusStateEnabled has not been redefined");
     });
 
-    QUnit.test("onClick can be redefined", assert => {
+    QUnit.test("onClick can be redefined", function(assert) {
         const handler = sinon.spy();
         const $element = $("#widget").dxButtonGroup({
             items: [{ text: "Test", onClick: handler }]
@@ -292,7 +292,7 @@ QUnit.module("Events", () => {
                 ["click", "touch", "space", "enter"].forEach((eventName) => {
                     let config = ` ${eventName}, onItemClick is initial option=${isItemClickInInitialOption}, disabled: ${isDisabled} ${isItemDisabled ? `, item.disabled=${isItemDisabled}` : ``}`;
 
-                    QUnit.test("Check onItemClick for" + config, (assert) => {
+                    QUnit.test("Check onItemClick for" + config, function(assert) {
                         let helper = new ButtonGroupEventsTestHelper(eventName, isItemClickInInitialOption, isDisabled, isItemDisabled);
                         helper.createButtonGroup();
                         helper.performAction();

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.async.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.async.tests.js
@@ -14,7 +14,7 @@ QUnit.testStart(() => {
 
 QUnit.module("Context menu", () => {
     // T755681
-    QUnit.test("Context menu should shown in the same position after repaint()", (assert) => {
+    QUnit.test("Context menu should shown in the same position after repaint()", function(assert) {
         assert.expect(5);
 
         const menuTargetSelector = "#menuTarget";
@@ -44,7 +44,7 @@ QUnit.module("Context menu", () => {
         });
     });
 
-    QUnit.test("Add item on positioning", (assert) => {
+    QUnit.test("Add item on positioning", function(assert) {
         const menuTargetSelector = "#menuTarget";
         const instance = new ContextMenu($("#simpleMenu"), {
             items: [{ text: "item 1" }],

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
@@ -34,7 +34,7 @@ const DX_MENU_ITEM_POPOUT_CLASS = "dx-menu-item-popout";
 const DX_SUBMENU_CLASS = "dx-submenu";
 const DX_HAS_SUBMENU_CLASS = "dx-menu-item-has-submenu";
 
-const isDeviceDesktop = assert => {
+const isDeviceDesktop = function(assert) {
     if(devices.real().deviceType !== "desktop") {
         assert.ok(true, "skip this test on mobile devices");
         return false;
@@ -43,7 +43,7 @@ const isDeviceDesktop = assert => {
 };
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
 
         this.items = [
@@ -58,21 +58,21 @@ const moduleConfig = {
         this.clock = sinon.useFakeTimers();
     },
 
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
         this.clock.restore();
     }
 };
 
 QUnit.module("Rendering", moduleConfig, () => {
-    QUnit.test("all items in root level should be wrapped in submenu", (assert) => {
+    QUnit.test("all items in root level should be wrapped in submenu", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: "item1" }], visible: true });
         const $itemsContainer = instance.itemsContainer();
 
         assert.ok($itemsContainer.children().hasClass(DX_SUBMENU_CLASS), "items are wrapped in submenu");
     });
 
-    QUnit.test("lazy rendering: not render overlay on init", (assert) => {
+    QUnit.test("lazy rendering: not render overlay on init", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: "item1" }] });
         let $itemsContainer = instance.itemsContainer();
 
@@ -83,7 +83,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.ok($itemsContainer.length, "overlay is defined");
     });
 
-    QUnit.test("item click should not prevent document click handler", (assert) => {
+    QUnit.test("item click should not prevent document click handler", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "a" }]
         });
@@ -99,7 +99,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         $(document).off("click");
     });
 
-    QUnit.test("context menu items with submenu should have 'has-submenu' class", (assert) => {
+    QUnit.test("context menu items with submenu should have 'has-submenu' class", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item1", items: [{ text: "item11" }] }],
             visible: true
@@ -115,7 +115,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.notOk($items.eq(1).hasClass(DX_HAS_SUBMENU_CLASS), "item without children has not special class");
     });
 
-    QUnit.test("context menu items with submenu should have item popout", (assert) => {
+    QUnit.test("context menu items with submenu should have item popout", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item1", items: [{ text: "item11" }] }],
             visible: true
@@ -127,7 +127,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.equal($items.eq(0).find("." + DX_MENU_ITEM_POPOUT_CLASS).length, 1, "popout is on the first item");
     });
 
-    QUnit.test("item container should have special class for phone devices", (assert) => {
+    QUnit.test("item container should have special class for phone devices", function(assert) {
         const device = devices.current();
 
         devices.current({ deviceType: "phone" });
@@ -140,7 +140,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         }
     });
 
-    QUnit.test("context menu should create only root level at first", (assert) => {
+    QUnit.test("context menu should create only root level at first", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11" }] }],
             visible: true
@@ -151,14 +151,14 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.equal(submenus.length, 1, "only root level rendered");
     });
 
-    QUnit.test("root level should not be rendered without items", (assert) => {
+    QUnit.test("root level should not be rendered without items", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [], visible: true });
         const submenus = instance.itemsContainer().find("." + DX_SUBMENU_CLASS);
 
         assert.equal(submenus.length, 0, "there is no submenus in menu");
     });
 
-    QUnit.test("submenus should not be rendered without items", (assert) => {
+    QUnit.test("submenus should not be rendered without items", function(assert) {
         const instance = new ContextMenu(this.$element, {
             visible: true,
             items: [{ text: "item1", items: [] }]
@@ -176,7 +176,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.notOk($rootItem.hasClass(DX_HAS_SUBMENU_CLASS), "root item has no 'has-submenu' class");
     });
 
-    QUnit.test("onSubmenuCreated should be fired after submenu was rendered", (assert) => {
+    QUnit.test("onSubmenuCreated should be fired after submenu was rendered", function(assert) {
         const onSubmenuCreated = sinon.spy();
 
         const instance = new ContextMenu(this.$element, {
@@ -200,7 +200,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.equal(onSubmenuCreated.callCount, 1, "handler should not be called after the second showing");
     });
 
-    QUnit.test("contextMenu should not create a new overlay after refresh", (assert) => {
+    QUnit.test("contextMenu should not create a new overlay after refresh", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: 1 }, { text: 2 }] });
 
         instance.option("items", [{ text: 3 }, { text: 4 }]);
@@ -208,7 +208,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.equal($(".dx-overlay").length, 1, "only one overlay should exists");
     });
 
-    QUnit.test("submenus in the same level should have same horizontal offset", (assert) => {
+    QUnit.test("submenus in the same level should have same horizontal offset", function(assert) {
         const instance = new ContextMenu(this.$element, {
             target: "#menuTarget",
             items: [
@@ -233,7 +233,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.equal(offsets[0], offsets[1], "offsets are equal");
     });
 
-    QUnit.test("event handlers should be bound for detached target", (assert) => {
+    QUnit.test("event handlers should be bound for detached target", function(assert) {
         const $target = $("#menuTarget");
         const $parent = $target.parent();
 
@@ -246,7 +246,7 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.ok(contextMenu.option("visible"), "context menu is shown after detached target been attached");
     });
 
-    QUnit.test("not create keyboardProcessor on rendering", (assert) => {
+    QUnit.test("not create keyboardProcessor on rendering", function(assert) {
         const instance = new ContextMenu(this.$element, {});
 
         assert.notOk(instance._keyboardProcessor, "keyboard processor is undefined");
@@ -254,7 +254,7 @@ QUnit.module("Rendering", moduleConfig, () => {
 });
 
 QUnit.module("Showing and hiding context menu", moduleConfig, () => {
-    QUnit.test("visible option should toggle menu's visibility", (assert) => {
+    QUnit.test("visible option should toggle menu's visibility", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: 1, items: [{ text: 11 }] }], visible: true });
         const $itemsContainer = instance.itemsContainer();
 
@@ -267,28 +267,28 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         assert.ok($itemsContainer.is(":visible"), "menu is visible");
     });
 
-    QUnit.test("context menu should not leak overlays", (assert) => {
+    QUnit.test("context menu should not leak overlays", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
 
         instance.option("items", [{ text: 1 }]);
         assert.equal($(".dx-overlay").length, 1, "overlays cleaned correctly");
     });
 
-    QUnit.test("show method should toggle menu's visibility", (assert) => {
+    QUnit.test("show method should toggle menu's visibility", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: false });
 
         instance.show();
         assert.ok(instance.option("visible"), "option visible was changed to true");
     });
 
-    QUnit.test("hide method should toggle menu's visibility", (assert) => {
+    QUnit.test("hide method should toggle menu's visibility", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
 
         instance.hide();
         assert.notOk(instance.option("visible"), "option visible was changed to false");
     });
 
-    QUnit.test("expanded class should be removed from submenus after hiding menu with hide method", (assert) => {
+    QUnit.test("expanded class should be removed from submenus after hiding menu with hide method", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true
@@ -311,7 +311,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         });
     });
 
-    QUnit.test("expanded class should be removed from submenus after hiding menu with visible option", (assert) => {
+    QUnit.test("expanded class should be removed from submenus after hiding menu with visible option", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true
@@ -334,7 +334,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         });
     });
 
-    QUnit.test("expanded class should be removed from submenus after hiding menu with outside click", (assert) => {
+    QUnit.test("expanded class should be removed from submenus after hiding menu with outside click", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true
@@ -357,7 +357,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         });
     });
 
-    QUnit.test("context menu should not be shown if target is disabled", (assert) => {
+    QUnit.test("context menu should not be shown if target is disabled", function(assert) {
         try {
             let eventCounter = 0;
             const incrementCounter = () => {
@@ -383,7 +383,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         }
     });
 
-    QUnit.test("context menu should not be shown if it is disabled", (assert) => {
+    QUnit.test("context menu should not be shown if it is disabled", function(assert) {
         try {
             let eventCounter = 0;
             const incrementCounter = () => {
@@ -410,7 +410,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         }
     });
 
-    QUnit.test("context menu should be shown after submenuDirection option change", (assert) => {
+    QUnit.test("context menu should be shown after submenuDirection option change", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
         let $itemsContainer;
 
@@ -424,21 +424,21 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         assert.ok($itemsContainer.is(":visible"), "menu is rendered again");
     });
 
-    QUnit.test("context menu's overlay should have flipfit position as native context menu", (assert) => {
+    QUnit.test("context menu's overlay should have flipfit position as native context menu", function(assert) {
         new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
 
         const overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
         assert.equal(overlay.option("position").collision, "flipfit", "position is correct");
     });
 
-    QUnit.test("overlay should have innerOverlay option", (assert) => {
+    QUnit.test("overlay should have innerOverlay option", function(assert) {
         new ContextMenu(this.$element, { items: [{ text: "item 1" }], visible: true });
 
         const overlay = this.$element.find(".dx-overlay").dxOverlay("instance");
         assert.ok(overlay.option("innerOverlay"));
     });
 
-    QUnit.test("Document should be default target", (assert) => {
+    QUnit.test("Document should be default target", function(assert) {
         const showingHandler = sinon.stub();
 
         new ContextMenu(this.$element, {
@@ -454,7 +454,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
     });
 
     // T459373
-    QUnit.test("Show context menu when position and target is defined", (assert) => {
+    QUnit.test("Show context menu when position and target is defined", function(assert) {
         let overlay;
 
         const instance = new ContextMenu(this.$element, {
@@ -475,7 +475,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
     });
 
-    QUnit.test("Show context menu when position.of is defined", (assert) => {
+    QUnit.test("Show context menu when position.of is defined", function(assert) {
         let overlay;
 
         const instance = new ContextMenu(this.$element, {
@@ -495,7 +495,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         assert.deepEqual(overlay.option("position.of").get(0), $("#menuShower").get(0), "position is correct");
     });
 
-    QUnit.test("Show context menu when position is undefined", (assert) => {
+    QUnit.test("Show context menu when position is undefined", function(assert) {
         let overlay;
 
         const instance = new ContextMenu(this.$element, {
@@ -511,7 +511,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         assert.ok(overlay.option("position.of") instanceof $.Event, "position is correct");
     });
 
-    QUnit.test("Show context menu via api when position is defined", (assert) => {
+    QUnit.test("Show context menu via api when position is defined", function(assert) {
         let overlay;
 
         const instance = new ContextMenu(this.$element, {
@@ -532,7 +532,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
     });
 
-    QUnit.test("Show context menu via api when position is undefined", (assert) => {
+    QUnit.test("Show context menu via api when position is undefined", function(assert) {
         let overlay;
 
         const instance = new ContextMenu(this.$element, {
@@ -548,7 +548,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
         assert.deepEqual(overlay.option("position.of").get(0), $("#menuTarget").get(0), "position is correct");
     });
 
-    QUnit.test("show/hide methods should return Deferred", (assert) => {
+    QUnit.test("show/hide methods should return Deferred", function(assert) {
         const instance = new ContextMenu(this.$element, {
             target: $("#menuTarget"),
             items: [{ text: "item 1" }],
@@ -566,7 +566,7 @@ QUnit.module("Showing and hiding context menu", moduleConfig, () => {
 });
 
 QUnit.module("Showing and hiding submenus", moduleConfig, () => {
-    QUnit.test("submenu should be shown after click on root item", (assert) => {
+    QUnit.test("submenu should be shown after click on root item", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item1", items: [{ text: "item11" }] }],
             visible: true
@@ -584,7 +584,7 @@ QUnit.module("Showing and hiding submenus", moduleConfig, () => {
         assert.ok($rootItem.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was added");
     });
 
-    QUnit.test("all submenus should hide after click on item from different branch", (assert) => {
+    QUnit.test("all submenus should hide after click on item from different branch", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11" }] }, { text: "item 2" }],
             visible: true
@@ -602,7 +602,7 @@ QUnit.module("Showing and hiding submenus", moduleConfig, () => {
         assert.notOk($items.eq(0).hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was removed from first item");
     });
 
-    QUnit.test("submenu should not hide after click on parent submenu", (assert) => {
+    QUnit.test("submenu should not hide after click on parent submenu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true
@@ -622,7 +622,7 @@ QUnit.module("Showing and hiding submenus", moduleConfig, () => {
         assert.ok($items.eq(1).hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was not removed");
     });
 
-    QUnit.test("submenu should not hide after second click on root item", (assert) => {
+    QUnit.test("submenu should not hide after second click on root item", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item1", items: [{ text: "item11" }] }],
             visible: true
@@ -641,7 +641,7 @@ QUnit.module("Showing and hiding submenus", moduleConfig, () => {
         assert.ok($rootItem.hasClass(DX_MENU_ITEM_EXPANDED_CLASS), "expanded class was not removed");
     });
 
-    QUnit.test("context menu should not blink after second hover on root item", (assert) => {
+    QUnit.test("context menu should not blink after second hover on root item", function(assert) {
         if(!isDeviceDesktop(assert)) {
             return;
         }
@@ -673,7 +673,7 @@ QUnit.module("Showing and hiding submenus", moduleConfig, () => {
         }
     });
 
-    QUnit.test("custom slide animation should work for submenus", (assert) => {
+    QUnit.test("custom slide animation should work for submenus", function(assert) {
         const instance = new ContextMenu(this.$element, {
             visible: true,
             animation: {
@@ -707,7 +707,7 @@ QUnit.module("Showing and hiding submenus", moduleConfig, () => {
 });
 
 QUnit.module("Visibility callbacks", moduleConfig, () => {
-    QUnit.test("onHiding and onHidden options with outside click", (assert) => {
+    QUnit.test("onHiding and onHidden options with outside click", function(assert) {
         const events = [];
 
         new ContextMenu(this.$element, {
@@ -725,7 +725,7 @@ QUnit.module("Visibility callbacks", moduleConfig, () => {
         assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
     });
 
-    QUnit.test("onHiding and onHidden options with hide method", (assert) => {
+    QUnit.test("onHiding and onHidden options with hide method", function(assert) {
         const events = [];
 
         const instance = new ContextMenu(this.$element, {
@@ -743,7 +743,7 @@ QUnit.module("Visibility callbacks", moduleConfig, () => {
         assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
     });
 
-    QUnit.test("onHiding and onHidden options with visible option", (assert) => {
+    QUnit.test("onHiding and onHidden options with visible option", function(assert) {
         const events = [];
 
         const instance = new ContextMenu(this.$element, {
@@ -761,7 +761,7 @@ QUnit.module("Visibility callbacks", moduleConfig, () => {
         assert.deepEqual(events, ["onHiding", "onHidden"], "events triggered and trigger order is correct");
     });
 
-    QUnit.test("visibility callbacks should not fire for submenus", (assert) => {
+    QUnit.test("visibility callbacks should not fire for submenus", function(assert) {
         let events = [];
 
         const instance = new ContextMenu(this.$element, {
@@ -791,7 +791,7 @@ QUnit.module("Visibility callbacks", moduleConfig, () => {
         assert.deepEqual(events, [], "events was not triggered");
     });
 
-    QUnit.test("onShowing and onShown options with show method", (assert) => {
+    QUnit.test("onShowing and onShown options with show method", function(assert) {
         const events = [];
 
         const instance = new ContextMenu(this.$element, {
@@ -809,7 +809,7 @@ QUnit.module("Visibility callbacks", moduleConfig, () => {
         assert.deepEqual(events, ["onShowing", "onShown"], "events triggered and trigger order is correct");
     });
 
-    QUnit.test("onShowing and onShown options should fire when visible is initially true", (assert) => {
+    QUnit.test("onShowing and onShown options should fire when visible is initially true", function(assert) {
         const events = [];
 
         new ContextMenu(this.$element, {
@@ -826,7 +826,7 @@ QUnit.module("Visibility callbacks", moduleConfig, () => {
         assert.deepEqual(events, ["onShowing", "onShown"], "events triggered and trigger order is correct");
     });
 
-    QUnit.test("onShowing and onShown options with visible option", (assert) => {
+    QUnit.test("onShowing and onShown options with visible option", function(assert) {
         const events = [];
 
         const instance = new ContextMenu(this.$element, {
@@ -846,7 +846,7 @@ QUnit.module("Visibility callbacks", moduleConfig, () => {
 });
 
 QUnit.module("Options", moduleConfig, () => {
-    QUnit.test("onItemClick option", (assert) => {
+    QUnit.test("onItemClick option", function(assert) {
         assert.expect(1);
 
         const instance = new ContextMenu(this.$element, {
@@ -862,7 +862,7 @@ QUnit.module("Options", moduleConfig, () => {
         $($items.eq(0)).trigger("dxclick");
     });
 
-    QUnit.test("itemsExpr option", (assert) => {
+    QUnit.test("itemsExpr option", function(assert) {
         const instance = new ContextMenu(this.$element, {
             visible: true,
             items: [{ text: "itemA", subItems: [{ text: "itemB" }] }],
@@ -878,7 +878,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal($items.length, 2, "second level is rendered");
     });
 
-    QUnit.test("target option as string", (assert) => {
+    QUnit.test("target option as string", function(assert) {
         const instance = new ContextMenu(this.$element, {
             visible: false,
             items: [{ text: "itemA" }],
@@ -890,7 +890,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(instance.option("visible"), "menu was shown");
     });
 
-    QUnit.test("target option as jQuery", (assert) => {
+    QUnit.test("target option as jQuery", function(assert) {
         const instance = new ContextMenu(this.$element, {
             visible: false,
             items: [{ text: "itemA" }],
@@ -902,7 +902,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(instance.option("visible"), "menu was shown");
     });
 
-    QUnit.test("target option as DOM element", (assert) => {
+    QUnit.test("target option as DOM element", function(assert) {
         const instance = new ContextMenu(this.$element, {
             visible: false,
             items: [{ text: "itemA" }],
@@ -914,7 +914,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(instance.option("visible"), "menu was shown");
     });
 
-    QUnit.test("target option changing should change the target", (assert) => {
+    QUnit.test("target option changing should change the target", function(assert) {
         const instance = new ContextMenu(this.$element, {
             visible: false,
             items: [{ text: "itemA" }],
@@ -930,7 +930,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(instance.option("visible"), "menu was shown");
     });
 
-    QUnit.test("showSubmenuMode hover without delay", (assert) => {
+    QUnit.test("showSubmenuMode hover without delay", function(assert) {
         if(!isDeviceDesktop(assert)) {
             return;
         }
@@ -953,7 +953,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal($items.length, 2, "second item was rendered");
     });
 
-    QUnit.test("showSubmenuMode hover with custom delay", (assert) => {
+    QUnit.test("showSubmenuMode hover with custom delay", function(assert) {
         if(!isDeviceDesktop(assert)) {
             return;
         }
@@ -976,7 +976,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal($items.length, 2, "second item was rendered");
     });
 
-    QUnit.test("submenu should not be shown if hover was ended before show delay time exceeded", (assert) => {
+    QUnit.test("submenu should not be shown if hover was ended before show delay time exceeded", function(assert) {
         if(!isDeviceDesktop(assert)) {
             return;
         }
@@ -1001,7 +1001,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal($items.length, 1, "second item was not rendered");
     });
 
-    QUnit.test("showSubmenuMode click with custom delay", (assert) => {
+    QUnit.test("showSubmenuMode click with custom delay", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             visible: true,
@@ -1019,7 +1019,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal($items.length, 2, "delay should be ignored");
     });
 
-    QUnit.test("showSubmenuMode click during hover delay", (assert) => {
+    QUnit.test("showSubmenuMode click during hover delay", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             visible: true,
@@ -1039,7 +1039,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal($items.length, 2, "delay should be ignored");
     });
 
-    QUnit.test("context menu should not crash when items changing during onShowing event", (assert) => {
+    QUnit.test("context menu should not crash when items changing during onShowing event", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }, { text: 2 }],
             onShowing() {
@@ -1051,7 +1051,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(1, "context menu did not crash");
     });
 
-    QUnit.test("context menu should not show if showing is prevented during onPositioning action", (assert) => {
+    QUnit.test("context menu should not show if showing is prevented during onPositioning action", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1064,7 +1064,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.notOk(instance.option("visible"));
     });
 
-    QUnit.test("context menu should not show if showing is prevented during onShowing action", (assert) => {
+    QUnit.test("context menu should not show if showing is prevented during onShowing action", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1077,7 +1077,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.notOk(instance.option("visible"));
     });
 
-    QUnit.test("default browser menu should not be prevented if context menu showing is prevented", (assert) => {
+    QUnit.test("default browser menu should not be prevented if context menu showing is prevented", function(assert) {
         new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1092,7 +1092,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.notOk(e.isDefaultPrevented(), "default behavior should not be prevented");
     });
 
-    QUnit.test("default browser menu should not be prevented if context menu positioning is prevented", (assert) => {
+    QUnit.test("default browser menu should not be prevented if context menu positioning is prevented", function(assert) {
         new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1107,7 +1107,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.notOk(e.isDefaultPrevented(), "default behavior should not be prevented");
     });
 
-    QUnit.test("show event should not be handled by other menus targeted on the parent div", (assert) => {
+    QUnit.test("show event should not be handled by other menus targeted on the parent div", function(assert) {
         new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget"
@@ -1119,7 +1119,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(e.isPropagationStopped(), "propagation was stopped");
     });
 
-    QUnit.test("disabling for nested item should work correctly", (assert) => {
+    QUnit.test("disabling for nested item should work correctly", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1, items: [{ text: 11 }] }],
             target: "#menuTarget",
@@ -1136,7 +1136,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok($items.eq(1).hasClass("dx-state-disabled"), "item was disabled");
     });
 
-    QUnit.test("onItemContextMenu option when context menu initially hidden", (assert) => {
+    QUnit.test("onItemContextMenu option when context menu initially hidden", function(assert) {
         let fired = 0;
         let args = {};
 
@@ -1165,7 +1165,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal(args.itemData.text, "1", "item data is correct");
     });
 
-    QUnit.test("Separator should not be shown if last rendered item was in other level", (assert) => {
+    QUnit.test("Separator should not be shown if last rendered item was in other level", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 {
@@ -1191,7 +1191,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.equal(instance.itemsContainer().find(".dx-menu-separator").length, 0, "separator should not be rendered");
     });
 
-    QUnit.test("showEvent can prevent showing", (assert) => {
+    QUnit.test("showEvent can prevent showing", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1203,7 +1203,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(!instance.option("visible"), "default behaviour was prevented");
     });
 
-    QUnit.test("showEvent set as string", (assert) => {
+    QUnit.test("showEvent set as string", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1214,7 +1214,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(instance.option("visible"), "context menu was shown");
     });
 
-    QUnit.test("showEvent set as string with several events", (assert) => {
+    QUnit.test("showEvent set as string with several events", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1231,7 +1231,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(instance.option("visible"), "context menu was shown");
     });
 
-    QUnit.test("showEvent set as object", (assert) => {
+    QUnit.test("showEvent set as object", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1247,7 +1247,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(instance.option("visible"), "context menu was shown");
     });
 
-    QUnit.test("showEvent set only as delay", (assert) => {
+    QUnit.test("showEvent set only as delay", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
             target: "#menuTarget",
@@ -1262,7 +1262,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.ok(instance.option("visible"), "context menu was shown");
     });
 
-    QUnit.test("items change should clear focused item", (assert) => {
+    QUnit.test("items change should clear focused item", function(assert) {
         const items1 = [{ text: "item 1" }, { text: "item 2" }];
         const items2 = [{ text: "item 3" }, { text: "item 4" }];
         const instance = new ContextMenu(this.$element, { items: items1, focusStateEnabled: true, visible: true });
@@ -1275,7 +1275,7 @@ QUnit.module("Options", moduleConfig, () => {
         assert.strictEqual(instance.option("focusedElement"), null, "focused element is cleaned");
     });
 
-    QUnit.test("items changed should not break keyboard navigation", (assert) => {
+    QUnit.test("items changed should not break keyboard navigation", function(assert) {
         if(!isDeviceDesktop(assert)) {
             return;
         }
@@ -1292,14 +1292,14 @@ QUnit.module("Options", moduleConfig, () => {
 });
 
 QUnit.module("Public api", moduleConfig, () => {
-    QUnit.test("itemsContainer method should return overlay content", (assert) => {
+    QUnit.test("itemsContainer method should return overlay content", function(assert) {
         const instance = new ContextMenu(this.$element, { items: [{ text: 1 }], visible: true });
 
         assert.ok(instance.itemsContainer().hasClass("dx-overlay-content"));
         assert.ok(instance.itemsContainer().hasClass(DX_CONTEXT_MENU_CLASS));
     });
 
-    QUnit.test("Overlay's position should be correct when the target option is changed", (assert) => {
+    QUnit.test("Overlay's position should be correct when the target option is changed", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: 1 }],
         });
@@ -1323,7 +1323,7 @@ QUnit.module("Public api", moduleConfig, () => {
 });
 
 QUnit.module("Behavior", moduleConfig, () => {
-    QUnit.test("it should be possible to update items on item click", (assert) => {
+    QUnit.test("it should be possible to update items on item click", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "a" }],
             onItemClick(e) {
@@ -1345,7 +1345,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.equal($items.eq(0).text(), "b", "items was changed");
     });
 
-    QUnit.test("context menu should hide after click on item without children", (assert) => {
+    QUnit.test("context menu should hide after click on item without children", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "a" }],
             visible: true
@@ -1357,7 +1357,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.notOk(instance.option("visible"), "menu was hidden");
     });
 
-    QUnit.test("submenu shouldn't be hidden after click on item with children (T640708)", (assert) => {
+    QUnit.test("submenu shouldn't be hidden after click on item with children (T640708)", function(assert) {
         const contextMenuItems = [
             {
                 text: 'item',
@@ -1387,7 +1387,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.equal(getVisibleSubmenuCount(instance), 3, "All submenus is visible");
     });
 
-    QUnit.test("context menu should not hide after click when item.closeMenuOnClick is false", (assert) => {
+    QUnit.test("context menu should not hide after click when item.closeMenuOnClick is false", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "a", closeMenuOnClick: false }],
             visible: true
@@ -1399,7 +1399,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.ok(instance.option("visible"), "menu is visible");
     });
 
-    QUnit.test("context menu should hide after outside click", (assert) => {
+    QUnit.test("context menu should hide after outside click", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true
@@ -1410,7 +1410,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.notOk(instance.option("visible"), "menu was hidden");
     });
 
-    QUnit.test("context menu should not hide after outsideclick when event is canceled", (assert) => {
+    QUnit.test("context menu should not hide after outsideclick when event is canceled", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", items: [{ text: "item 111" }] }] }],
             visible: true,
@@ -1424,7 +1424,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.ok(instance.option("visible"), "menu is visible");
     });
 
-    QUnit.test("context menu should not block outside click for other overlays on outside click", (assert) => {
+    QUnit.test("context menu should not block outside click for other overlays on outside click", function(assert) {
         const otherOverlay = $("<div>").appendTo("#qunit-fixture").dxOverlay({
             closeOnOutsideClick: true,
             visible: true
@@ -1438,7 +1438,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.notOk(contextMenu.option("visible"), "context menu was hidden");
     });
 
-    QUnit.test("context menu should prevent default behavior if it shows", (assert) => {
+    QUnit.test("context menu should prevent default behavior if it shows", function(assert) {
         new ContextMenu(this.$element, {
             items: [{ text: "item 1" }],
             target: "#menuTarget",
@@ -1451,7 +1451,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.ok(contextMenuEvent.isDefaultPrevented(), "default prevented");
     });
 
-    QUnit.test("onItemClick should fire for submenus", (assert) => {
+    QUnit.test("onItemClick should fire for submenus", function(assert) {
         const itemClickArgs = [];
         const items = [{
             text: "item 1",
@@ -1477,7 +1477,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.deepEqual(itemClickArgs, [items[0], items[0].items[0]], "onItemClick fired with correct arguments");
     });
 
-    QUnit.test("First item should not get focus after menu shown", (assert) => {
+    QUnit.test("First item should not get focus after menu shown", function(assert) {
         let focusedElementChangeCount = 0;
 
         const instance = new ContextMenu(this.$element, {
@@ -1499,7 +1499,7 @@ QUnit.module("Behavior", moduleConfig, () => {
         assert.equal(instance.itemsContainer().find("." + DX_STATE_FOCUSED_CLASS).length, 0, "there are no focused elements in ui");
     });
 
-    QUnit.test("incomplete show animation should be stopped when new submenu item starts to show", (assert) => {
+    QUnit.test("incomplete show animation should be stopped when new submenu item starts to show", function(assert) {
         const origFxStop = fx.stop;
         let stopCalls = 0;
 
@@ -1534,7 +1534,7 @@ QUnit.module("Behavior", moduleConfig, () => {
 });
 
 QUnit.module("Selection", moduleConfig, () => {
-    QUnit.test("select item via item.selected property", (assert) => {
+    QUnit.test("select item via item.selected property", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11", selected: true, items: [{ text: "item 111" }] }] }],
             visible: true
@@ -1548,7 +1548,7 @@ QUnit.module("Selection", moduleConfig, () => {
         assert.equal($itemContainer.find("." + DX_MENU_ITEM_SELECTED_CLASS).length, 1, "one selected items");
     });
 
-    QUnit.test("select item via selectedItem option", (assert) => {
+    QUnit.test("select item via selectedItem option", function(assert) {
         const items = [{ text: "item 1", selected: true, items: [{ text: "item 11", items: [{ text: "item 111" }] }] }];
 
         const instance = new ContextMenu(this.$element, {
@@ -1567,7 +1567,7 @@ QUnit.module("Selection", moduleConfig, () => {
         assert.ok(items[0].items[0].selected, "nested item selected");
     });
 
-    QUnit.test("changing selection via selectedItem option", (assert) => {
+    QUnit.test("changing selection via selectedItem option", function(assert) {
         const items = [{ text: "item 1", selected: true, items: [{ text: "item 11", items: [{ text: "item 111" }] }] }];
 
         const instance = new ContextMenu(this.$element, {
@@ -1589,7 +1589,7 @@ QUnit.module("Selection", moduleConfig, () => {
 
 var helper;
 QUnit.module("Aria accessibility", {
-    beforeEach: () => {
+    beforeEach: function() {
         helper = new ariaAccessibilityTestHelper({
             createWidget: ($element, options) => new ContextMenu($element,
                 $.extend({
@@ -1597,11 +1597,11 @@ QUnit.module("Aria accessibility", {
                 }, options))
         });
     },
-    afterEach: () => {
+    afterEach: function() {
         helper.$widget.remove();
     }
 }, () => {
-    QUnit.test(`Items: [] -> show() -> hide()`, () => {
+    QUnit.test(`Items: [] -> show() -> hide()`, function() {
         helper.createWidget({ items: [] });
         helper.checkAttributes(helper.$widget, { }, "widget");
         helper.checkItemsAttributes([], { });
@@ -1616,7 +1616,7 @@ QUnit.module("Aria accessibility", {
         helper.checkItemsAttributes([], { });
     });
 
-    QUnit.test(`Items: [1, 2, 3] -> show() -> hide()`, () => {
+    QUnit.test(`Items: [1, 2, 3] -> show() -> hide()`, function() {
         helper.createWidget({ items: [1, 2, 3] });
         helper.checkAttributes(helper.$widget, { }, "widget");
         helper.checkItemsAttributes([], { });
@@ -1631,7 +1631,7 @@ QUnit.module("Aria accessibility", {
         helper.checkItemsAttributes([], { role: "menuitem", tabindex: "-1" });
     });
 
-    QUnit.test(`Items: [1, 2, 3] -> set focusedElement: item[0] -> clean focusedElement`, () => {
+    QUnit.test(`Items: [1, 2, 3] -> set focusedElement: item[0] -> clean focusedElement`, function() {
         helper.createWidget({ items: [1, 2, 3] });
         helper.checkAttributes(helper.$widget, { }, "widget");
         helper.checkItemsAttributes([], { });
@@ -1648,7 +1648,7 @@ QUnit.module("Aria accessibility", {
         helper.checkItemsAttributes([], { role: "menuitem", tabindex: "-1" });
     });
 
-    QUnit.test(`Items: [{items[{}, {}], {}] -> set focusedElement by keyboard on inner level`, () => {
+    QUnit.test(`Items: [{items[{}, {}], {}] -> set focusedElement by keyboard on inner level`, function() {
         helper.createWidget({
             focusStateEnabled: true,
             items: [{ text: "Item1_1", items: [{ text: "Item2_1" }, { text: "Item2_2" }] }, { text: "item1_2" }]
@@ -1676,7 +1676,7 @@ QUnit.module("Aria accessibility", {
 });
 
 QUnit.module("Keyboard navigation", moduleConfig, () => {
-    QUnit.test("onItemClick should fire when enter pressed", (assert) => {
+    QUnit.test("onItemClick should fire when enter pressed", function(assert) {
         let itemClicked = 0;
 
         const instance = new ContextMenu(this.$element, {
@@ -1696,7 +1696,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(itemClicked, 1, "press enter on item call item click action");
     });
 
-    QUnit.test("hide menu when space pressed", (assert) => {
+    QUnit.test("hide menu when space pressed", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }, { text: "item 2" }],
             focusStateEnabled: true
@@ -1712,7 +1712,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.notOk(instance.option("visible"));
     });
 
-    QUnit.test("select item when space pressed", (assert) => {
+    QUnit.test("select item when space pressed", function(assert) {
         const items = [{ text: "item 1" }, { text: "item 2" }];
 
         const instance = new ContextMenu(this.$element, {
@@ -1733,7 +1733,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.ok(items[1].selected, "item has selected property");
     });
 
-    QUnit.test("when selectionMode is none, not select item when space pressed", (assert) => {
+    QUnit.test("when selectionMode is none, not select item when space pressed", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }, { text: "item 2" }],
             selectByClick: true,
@@ -1751,7 +1751,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(instance.option("selectedItem"), null, "no item is selected");
     });
 
-    QUnit.test("select item when space pressed on inner level", (assert) => {
+    QUnit.test("select item when space pressed on inner level", function(assert) {
         const items = [{ text: "item 1" }, { text: "item 2", items: [{ text: "item 21" }, { text: "item 22" }] }];
 
         const instance = new ContextMenu(this.$element, {
@@ -1773,7 +1773,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(instance.option("selectedItem").text, "item 22", "correct item is selected");
     });
 
-    QUnit.test("onSelectionChanged handle fire when space pressed", (assert) => {
+    QUnit.test("onSelectionChanged handle fire when space pressed", function(assert) {
         let itemSelected = 0;
 
         const instance = new ContextMenu(this.$element, {
@@ -1795,7 +1795,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(itemSelected, 1, "press space on item call item select");
     });
 
-    QUnit.test("when selectionMode is none, onSelectionChanged handle not fire when space pressed", (assert) => {
+    QUnit.test("when selectionMode is none, onSelectionChanged handle not fire when space pressed", function(assert) {
         let itemSelected = 0;
 
         const instance = new ContextMenu(this.$element, {
@@ -1817,7 +1817,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(itemSelected, 0, "press space on item call item select");
     });
 
-    QUnit.test("hide context menu when esc pressed", (assert) => {
+    QUnit.test("hide context menu when esc pressed", function(assert) {
         const instance = new ContextMenu(this.$element, { focusStateEnabled: true });
 
         instance.show();
@@ -1828,7 +1828,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.ok(!instance.option("visible"), "context menu is hidden");
     });
 
-    QUnit.test("when press right arrow key we only show submenu if exist", (assert) => {
+    QUnit.test("when press right arrow key we only show submenu if exist", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }, { text: "item 2", items: [{ text: "item 21" }] }],
             focusStateEnabled: true
@@ -1856,7 +1856,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(getVisibleSubmenuCount(instance), 2, "we still see two submenus");
     });
 
-    QUnit.test("don't open submenu on right key press when item is disabled", (assert) => {
+    QUnit.test("don't open submenu on right key press when item is disabled", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }, { text: "item 2", disabled: true, items: [{ text: "item 21" }] }],
             focusStateEnabled: true
@@ -1872,7 +1872,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(instance.itemsContainer().find("." + DX_MENU_ITEM_CLASS).length, 2, "submenu was not rendered");
     });
 
-    QUnit.test("end key work only in current submenu", (assert) => {
+    QUnit.test("end key work only in current submenu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "item 1" },
@@ -1894,7 +1894,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal($(instance.option("focusedElement")).text(), "item 23", "focus on last item of current submenu");
     });
 
-    QUnit.test("home key work only in current submenu", (assert) => {
+    QUnit.test("home key work only in current submenu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "item 1" },
@@ -1916,7 +1916,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal($(instance.option("focusedElement")).text(), "item 21", "focus on first item of current submenu");
     });
 
-    QUnit.test("down key work only in current submenu", (assert) => {
+    QUnit.test("down key work only in current submenu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "item 1" },
@@ -1940,7 +1940,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal($(instance.option("focusedElement")).text(), "item 22", "focus on first item of current submenu");
     });
 
-    QUnit.test("up key work only in current submenu", (assert) => {
+    QUnit.test("up key work only in current submenu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "item 1" },
@@ -1964,7 +1964,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal($(instance.option("focusedElement")).text(), "item 23", "focus on first item of current submenu");
     });
 
-    QUnit.test("left arrow key should not close context menu", (assert) => {
+    QUnit.test("left arrow key should not close context menu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }],
             focusStateEnabled: true
@@ -1979,7 +1979,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(getVisibleSubmenuCount(instance), 1, "submenu should not open");
     });
 
-    QUnit.test("left arrow key should hide only previous submenu", (assert) => {
+    QUnit.test("left arrow key should hide only previous submenu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "item 1" },
@@ -2003,7 +2003,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(getFocusedItemText(instance), "item 2", "focus on second item of root submenu");
     });
 
-    QUnit.test("rtl: when press left arrow key we only show submenu if exist", (assert) => {
+    QUnit.test("rtl: when press left arrow key we only show submenu if exist", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1" }, { text: "item 2", items: [{ text: "item 21" }] }],
             rtlEnabled: true,
@@ -2027,7 +2027,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(getVisibleSubmenuCount(instance), 2, "we still see two submenus");
     });
 
-    QUnit.test("rtl: right arrow key should not close context menu", (assert) => {
+    QUnit.test("rtl: right arrow key should not close context menu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "item 1", items: [{ text: "item 11" }] }],
             rtlEnabled: true,
@@ -2043,7 +2043,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(getVisibleSubmenuCount(instance), 1, "submenu should not open");
     });
 
-    QUnit.test("rtl: right arrow key should hide only previous submenu", (assert) => {
+    QUnit.test("rtl: right arrow key should hide only previous submenu", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "item 1" },
@@ -2068,7 +2068,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal(getFocusedItemText(instance), "item 2", "focus on second item of root submenu");
     });
 
-    QUnit.test("Moving focus should starts from the hovered item", (assert) => {
+    QUnit.test("Moving focus should starts from the hovered item", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "Item 1" },
@@ -2095,7 +2095,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.equal($itemsContainer.find("." + DX_STATE_FOCUSED_CLASS).text(), "Item 3", "last item was focused");
     });
 
-    QUnit.test("Moving focus should starts from the hovered item in nested level", (assert) => {
+    QUnit.test("Moving focus should starts from the hovered item in nested level", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 {
@@ -2132,7 +2132,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.ok($items.eq(3).hasClass(DX_STATE_FOCUSED_CLASS), "Item 13 is focused");
     });
 
-    QUnit.test("Disabled item should be skipped when keyboard navigation", (assert) => {
+    QUnit.test("Disabled item should be skipped when keyboard navigation", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "Item 1", disabled: true },
@@ -2152,7 +2152,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.ok($items.eq(1).hasClass(DX_STATE_FOCUSED_CLASS), "disabled item was skipped");
     });
 
-    QUnit.test("Focus should follow the nested hovered item if item in the parent level is focused", (assert) => {
+    QUnit.test("Focus should follow the nested hovered item if item in the parent level is focused", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [
                 { text: "Item 1" },
@@ -2182,7 +2182,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
     });
 
     // T806502
-    QUnit.test("Keyboard should be work when submenu shown in second time", (assert) => {
+    QUnit.test("Keyboard should be work when submenu shown in second time", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "Item 1" }, { text: "Item 2", items: [{ text: "Item 2_1" }, { text: "Item 2_2" }] }],
             focusStateEnabled: true
@@ -2217,7 +2217,7 @@ QUnit.module("Keyboard navigation", moduleConfig, () => {
         assert.strictEqual(getVisibleSubmenuCount(instance), 1, "submenu.count");
     });
 
-    QUnit.test("FocusedElement should be cleaned when context menu was hidden", (assert) => {
+    QUnit.test("FocusedElement should be cleaned when context menu was hidden", function(assert) {
         const instance = new ContextMenu(this.$element, {
             items: [{ text: "Item 1" }, { text: "Item 2" }, { text: "Item 3" } ],
             focusStateEnabled: true

--- a/testing/tests/DevExpress.ui.widgets/drawer.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/drawer.markup.tests.js
@@ -37,7 +37,7 @@ QUnit.testStart(() => {
 
 QUnit.module("rendering");
 
-QUnit.test("render drawer", assert => {
+QUnit.test("render drawer", function(assert) {
     const $element = $("#drawer").dxDrawer({});
 
     assert.ok($element.hasClass(DRAWER_CLASS), "drawer rendered");
@@ -46,19 +46,19 @@ QUnit.test("render drawer", assert => {
     assert.equal($element.find("." + DRAWER_CONTENT_CLASS).length, 1, "drawer has content");
 });
 
-QUnit.test("drawer should have correct mode class by default", assert => {
+QUnit.test("drawer should have correct mode class by default", function(assert) {
     const $element = $("#drawer").dxDrawer();
 
     assert.ok($element.hasClass(DRAWER_CLASS + "-shrink"), "drawer class is correct");
 });
 
-QUnit.test("drawer should have correct revealMode class by default", assert => {
+QUnit.test("drawer should have correct revealMode class by default", function(assert) {
     const $element = $("#drawer").dxDrawer();
 
     assert.ok($element.hasClass(DRAWER_CLASS + "-slide"), "drawer class is correct");
 });
 
-QUnit.test("render drawer content", assert => {
+QUnit.test("render drawer content", function(assert) {
     const $element = $("#drawer").dxDrawer({});
     const $content = $element.find("." + DRAWER_CONTENT_CLASS);
 
@@ -66,7 +66,7 @@ QUnit.test("render drawer content", assert => {
 });
 
 
-QUnit.test("opened class should be applied correctly", assert => {
+QUnit.test("opened class should be applied correctly", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true
     });
@@ -80,7 +80,7 @@ QUnit.test("opened class should be applied correctly", assert => {
     assert.notOk($element.hasClass(OPENED_STATE_CLASS), "drawer hasn't opened class");
 });
 
-QUnit.test("custom template for panel should be rendered correctly", assert => {
+QUnit.test("custom template for panel should be rendered correctly", function(assert) {
     const $element = $("#contentTemplate").dxDrawer({
         template: "customPanel"
     });
@@ -90,7 +90,7 @@ QUnit.test("custom template for panel should be rendered correctly", assert => {
     assert.equal($panel.text().trim(), "Test panel Template", "panel content text is correct");
 });
 
-QUnit.test("templates should be dom nodes without jQuery", assert => {
+QUnit.test("templates should be dom nodes without jQuery", function(assert) {
     assert.expect(2);
     $("#contentTemplate").dxDrawer({
         template(element) {
@@ -102,7 +102,7 @@ QUnit.test("templates should be dom nodes without jQuery", assert => {
     });
 });
 
-QUnit.test("custom content template for content should be rendered correctly", assert => {
+QUnit.test("custom content template for content should be rendered correctly", function(assert) {
     const $element = $("#contentTemplate").dxDrawer({
         contentTemplate: "customContent"
     });
@@ -112,7 +112,7 @@ QUnit.test("custom content template for content should be rendered correctly", a
     assert.equal($content.text().trim(), "Test Content Template", "content text is correct");
 });
 
-QUnit.test("render panel positions", assert => {
+QUnit.test("render panel positions", function(assert) {
     const $element = $("#contentTemplate").dxDrawer({
         position: "right",
         openedStateMode: "shrink",
@@ -130,7 +130,7 @@ QUnit.test("render panel positions", assert => {
     assert.ok($element.hasClass(DRAWER_CLASS + "-top"), "top panel position class added");
 });
 
-QUnit.test("shader should be rendered by default if panel is visible", assert => {
+QUnit.test("shader should be rendered by default if panel is visible", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true
     });
@@ -138,7 +138,7 @@ QUnit.test("shader should be rendered by default if panel is visible", assert =>
     assert.equal($element.find("." + DRAWER_SHADER_CLASS).length, 1, "drawer has shader");
 });
 
-QUnit.test("shader should not be rendered if shading = false", assert => {
+QUnit.test("shader should not be rendered if shading = false", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         shading: false
@@ -149,7 +149,7 @@ QUnit.test("shader should not be rendered if shading = false", assert => {
 
 QUnit.module("push mode");
 
-QUnit.test("drawer should have correct class depending on mode", assert => {
+QUnit.test("drawer should have correct class depending on mode", function(assert) {
     const $element = $("#drawer").dxDrawer({
         openedStateMode: "push"
     });
@@ -159,7 +159,7 @@ QUnit.test("drawer should have correct class depending on mode", assert => {
 
 QUnit.module("overlap mode");
 
-QUnit.test("drawer should have correct class depending on mode", assert => {
+QUnit.test("drawer should have correct class depending on mode", function(assert) {
     const $element = $("#drawer").dxDrawer({
         openedStateMode: "overlap"
     });
@@ -167,7 +167,7 @@ QUnit.test("drawer should have correct class depending on mode", assert => {
     assert.ok($element.hasClass(DRAWER_CLASS + "-overlap"), "drawer class is correct");
 });
 
-QUnit.test("drawer panel should be overlay in overlap mode", assert => {
+QUnit.test("drawer panel should be overlay in overlap mode", function(assert) {
     const drawer = $("#drawer").dxDrawer({
         openedStateMode: "overlap"
     }).dxDrawer("instance");

--- a/testing/tests/DevExpress.ui.widgets/drawer.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/drawer.tests.js
@@ -91,7 +91,7 @@ QUnit.testStart(() => {
 
 QUnit.module("Drawer behavior");
 
-QUnit.test("defaults", assert => {
+QUnit.test("defaults", function(assert) {
     const $element = $("#drawer").dxDrawer({});
     const instance = $element.dxDrawer("instance");
 
@@ -105,14 +105,14 @@ QUnit.test("defaults", assert => {
     assert.equal(instance.option("animationDuration"), 400, "animationDuration is OK");
 });
 
-QUnit.test("drawer should preserve content", assert => {
+QUnit.test("drawer should preserve content", function(assert) {
     const $content = $("#drawer #content"),
         $element = $("#drawer").dxDrawer();
 
     assert.equal($content[0], $element.find("#content")[0]);
 });
 
-QUnit.test("drawer shouldn't lose its content after repaint (T731771)", assert => {
+QUnit.test("drawer shouldn't lose its content after repaint (T731771)", function(assert) {
     let $button = $("#button").dxButton();
 
     const $element = $("#drawerWithContent").dxDrawer();
@@ -127,7 +127,7 @@ QUnit.test("drawer shouldn't lose its content after repaint (T731771)", assert =
     assert.ok(buttonInstance instanceof Button, "button into drawer content wasn't clean after repaint");
 });
 
-QUnit.test("drawer tabIndex should be removed after _clean", assert => {
+QUnit.test("drawer tabIndex should be removed after _clean", function(assert) {
     const $element = $("#drawer").dxDrawer();
     const instance = $element.dxDrawer("instance");
 
@@ -136,7 +136,7 @@ QUnit.test("drawer tabIndex should be removed after _clean", assert => {
     assert.equal($element.attr("tabIndex"), undefined, "tabIndex was removed");
 });
 
-QUnit.test("subscribe on toggle function should fired at the end of animation", assert => {
+QUnit.test("subscribe on toggle function should fired at the end of animation", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: false
     });
@@ -154,7 +154,7 @@ QUnit.test("subscribe on toggle function should fired at the end of animation", 
     assert.equal(count, 0, "callback not fired at animation start");
 });
 
-QUnit.test("dxresize event should be fired for content at the end of animation", assert => {
+QUnit.test("dxresize event should be fired for content at the end of animation", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: false
     });
@@ -178,7 +178,7 @@ QUnit.test("dxresize event should be fired for content at the end of animation",
     }
 });
 
-QUnit.test("dxresize event should be fired if there is no any animation", assert => {
+QUnit.test("dxresize event should be fired if there is no any animation", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: false,
         position: "right"
@@ -201,7 +201,7 @@ QUnit.test("dxresize event should be fired if there is no any animation", assert
     }
 });
 
-QUnit.test("incomplete animation should be stopped after toggling visibility", assert => {
+QUnit.test("incomplete animation should be stopped after toggling visibility", function(assert) {
     let origFxStop = fx.stop,
         panelStopCalls = 0,
         contentStopCalls = 0,
@@ -252,7 +252,7 @@ QUnit.test("incomplete animation should be stopped after toggling visibility", a
     }
 });
 
-QUnit.test("incomplete animation should be stopped after closing on outside click", assert => {
+QUnit.test("incomplete animation should be stopped after closing on outside click", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         openedStateMode: "overlap",
@@ -303,7 +303,7 @@ QUnit.test("incomplete animation should be stopped after closing on outside clic
     }
 });
 
-QUnit.test("incomplete animation should be stopped after changing modes", assert => {
+QUnit.test("incomplete animation should be stopped after changing modes", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         openedStateMode: "push",
@@ -350,7 +350,7 @@ QUnit.test("incomplete animation should be stopped after changing modes", assert
     }
 });
 
-QUnit.test("drawer shouldn't fail after changing openedStateMode", assert => {
+QUnit.test("drawer shouldn't fail after changing openedStateMode", function(assert) {
     const $element = $("#drawer").dxDrawer({
         openedStateMode: "push"
     });
@@ -362,7 +362,7 @@ QUnit.test("drawer shouldn't fail after changing openedStateMode", assert => {
     assert.ok(true, "Drawer works correctly");
 });
 
-QUnit.test("target option", assert => {
+QUnit.test("target option", function(assert) {
     const $element = $("#drawer").dxDrawer({
         openedStateMode: "overlap"
     });
@@ -374,7 +374,7 @@ QUnit.test("target option", assert => {
     assert.ok($(instance._overlay.option("position").of).hasClass("dx-drawer-content"), "target is ok");
 });
 
-QUnit.test("content() function", assert => {
+QUnit.test("content() function", function(assert) {
     const $element = $("#drawer").dxDrawer({});
     const instance = $element.dxDrawer("instance");
     const $panel = $element.find("." + DRAWER_PANEL_CONTENT_CLASS).eq(0);
@@ -382,7 +382,7 @@ QUnit.test("content() function", assert => {
     assert.equal($panel.get(0), $(instance.content()).get(0), "content function return correct DOMNode");
 });
 
-QUnit.test("viewContent() function", assert => {
+QUnit.test("viewContent() function", function(assert) {
     const $element = $("#drawer").dxDrawer({});
     const instance = $element.dxDrawer("instance");
     const $content = $element.find("." + DRAWER_CONTENT_CLASS).eq(0);
@@ -390,7 +390,7 @@ QUnit.test("viewContent() function", assert => {
     assert.equal($content.get(0), $(instance.viewContent()).get(0), "content function return correct DOMNode");
 });
 
-QUnit.test("show() and hide() methods", assert => {
+QUnit.test("show() and hide() methods", function(assert) {
     const $element = $("#drawer").dxDrawer({});
     const instance = $element.dxDrawer("instance");
 
@@ -401,7 +401,7 @@ QUnit.test("show() and hide() methods", assert => {
     assert.equal(instance.option("opened"), false, "panel was hidden");
 });
 
-QUnit.test("toggle() method", assert => {
+QUnit.test("toggle() method", function(assert) {
     const $element = $("#drawer").dxDrawer({});
     const instance = $element.dxDrawer("instance");
     const opened = instance.option("opened");
@@ -413,7 +413,7 @@ QUnit.test("toggle() method", assert => {
     assert.equal(instance.option("opened"), opened, "panel was hidden");
 });
 
-QUnit.test("wrapper content should be reversed if position = 'bottom' or 'right'", assert => {
+QUnit.test("wrapper content should be reversed if position = 'bottom' or 'right'", function(assert) {
     const $element = $("#drawer").dxDrawer({
         openedStateMode: "shrink"
     });
@@ -434,7 +434,7 @@ QUnit.test("wrapper content should be reversed if position = 'bottom' or 'right'
     assert.ok($content.eq(1).hasClass("dx-drawer-content"));
 });
 
-QUnit.test("wrapper content should be reversed if position = 'right' and openedStateMode is changed", assert => {
+QUnit.test("wrapper content should be reversed if position = 'right' and openedStateMode is changed", function(assert) {
     const $element = $("#drawer").dxDrawer({
         openedStateMode: "push",
         position: "right"
@@ -456,7 +456,7 @@ QUnit.test("wrapper content should be reversed if position = 'right' and openedS
     assert.ok($content.eq(1).hasClass("dx-drawer-content"));
 });
 
-QUnit.test("drawer panel should be repositioned correctly after dimension changed,left position", assert => {
+QUnit.test("drawer panel should be repositioned correctly after dimension changed,left position", function(assert) {
     fx.off = true;
 
     const $element = $("#drawer").dxDrawer({
@@ -480,7 +480,7 @@ QUnit.test("drawer panel should be repositioned correctly after dimension change
     fx.off = false;
 });
 
-QUnit.test("drawer panel should be repositioned correctly after dimension changed,top position", assert => {
+QUnit.test("drawer panel should be repositioned correctly after dimension changed,top position", function(assert) {
     fx.off = true;
 
     const $element = $("#drawer").dxDrawer({
@@ -505,7 +505,7 @@ QUnit.test("drawer panel should be repositioned correctly after dimension change
     fx.off = false;
 });
 
-QUnit.test("drawer panel should have correct size after dimension changed,top position", assert => {
+QUnit.test("drawer panel should have correct size after dimension changed,top position", function(assert) {
     fx.off = true;
 
     const $element = $("#drawer").dxDrawer({
@@ -532,7 +532,7 @@ QUnit.test("drawer panel should have correct size after dimension changed,top po
     fx.off = false;
 });
 
-QUnit.test("drawer panel should be repositioned correctly after dimension changed, right position", assert => {
+QUnit.test("drawer panel should be repositioned correctly after dimension changed, right position", function(assert) {
     fx.off = true;
 
     const $element = $("#drawer").dxDrawer({
@@ -558,7 +558,7 @@ QUnit.test("drawer panel should be repositioned correctly after dimension change
     fx.off = false;
 });
 
-QUnit.test("drawer panel should be repositioned after dimension changed, right position", assert => {
+QUnit.test("drawer panel should be repositioned after dimension changed, right position", function(assert) {
     fx.off = true;
 
     const $element = $("#drawer").dxDrawer({
@@ -583,7 +583,7 @@ QUnit.test("drawer panel should be repositioned after dimension changed, right p
     fx.off = false;
 });
 
-QUnit.test("content container should have correct position if panel isn't visible", assert => {
+QUnit.test("content container should have correct position if panel isn't visible", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: false
     });
@@ -594,7 +594,7 @@ QUnit.test("content container should have correct position if panel isn't visibl
     assert.equal(position($content), 0, "container rendered at correct position");
 });
 
-QUnit.test("content container should have correct position if panel is visible", assert => {
+QUnit.test("content container should have correct position if panel is visible", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true
     });
@@ -606,7 +606,7 @@ QUnit.test("content container should have correct position if panel is visible",
     assert.equal(position($content), $panel.width(), "container rendered at correct position");
 });
 
-QUnit.test("content container should have correct position after resize", assert => {
+QUnit.test("content container should have correct position after resize", function(assert) {
     const $element = $("#drawer2").dxDrawer({
         width: "100%",
         opened: true
@@ -622,7 +622,7 @@ QUnit.test("content container should have correct position after resize", assert
     assert.equal(position($content), $(instance.content()).width(), "container rendered at correct position");
 });
 
-QUnit.test("content container should have correct position if it is rendered in invisible container", assert => {
+QUnit.test("content container should have correct position if it is rendered in invisible container", function(assert) {
     const $container = $("#drawerContainer");
     const $element = $("#drawer2");
 
@@ -642,7 +642,7 @@ QUnit.test("content container should have correct position if it is rendered in 
     assert.equal(position($content), 50, "container rendered at correct position");
 });
 
-QUnit.test("drawer panel should have correct width when panel content is wrapped by div with borders (T702576)", assert => {
+QUnit.test("drawer panel should have correct width when panel content is wrapped by div with borders (T702576)", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         template: function($content) {
@@ -661,7 +661,7 @@ QUnit.test("drawer panel should have correct width when panel content is wrapped
     assert.equal($panelContent.outerWidth(), 200, "panel content has correct outerWidth");
 });
 
-QUnit.test("drawer panel should have correct width when async template is used", assert => {
+QUnit.test("drawer panel should have correct width when async template is used", function(assert) {
     var clock = sinon.useFakeTimers();
 
     $("#drawer").dxDrawer({
@@ -690,7 +690,7 @@ QUnit.test("drawer panel should have correct width when async template is used",
     clock.restore();
 });
 
-QUnit.test("drawer panel should have correct width when async template is used, overlap mode", assert => {
+QUnit.test("drawer panel should have correct width when async template is used, overlap mode", function(assert) {
     var clock = sinon.useFakeTimers();
 
     $("#drawer").dxDrawer({
@@ -719,7 +719,7 @@ QUnit.test("drawer panel should have correct width when async template is used, 
     clock.restore();
 });
 
-QUnit.test("drawer panel should have correct z-index when async template is used, overlap mode", assert => {
+QUnit.test("drawer panel should have correct z-index when async template is used, overlap mode", function(assert) {
     var clock = sinon.useFakeTimers();
 
     $("#drawer").dxDrawer({
@@ -748,7 +748,7 @@ QUnit.test("drawer panel should have correct z-index when async template is used
     clock.restore();
 });
 
-QUnit.test("drawer panel should have correct margin when async template is used", assert => {
+QUnit.test("drawer panel should have correct margin when async template is used", function(assert) {
     var clock = sinon.useFakeTimers();
 
     $("#drawer").dxDrawer({
@@ -778,7 +778,7 @@ QUnit.test("drawer panel should have correct margin when async template is used"
     clock.restore();
 });
 
-QUnit.test("getting real panel position in accordance with rtlEnabled and position options", assert => {
+QUnit.test("getting real panel position in accordance with rtlEnabled and position options", function(assert) {
     const $element = $("#drawer").dxDrawer({
         position: "after"
     });
@@ -808,7 +808,7 @@ QUnit.module("Animation", {
     }
 });
 
-QUnit.test("animationEnabled option test", assert => {
+QUnit.test("animationEnabled option test", function(assert) {
     fx.off = false;
 
     const origFX = fx.animate;
@@ -861,7 +861,7 @@ QUnit.test("animationDuration option test", function(assert) {
 
 QUnit.module("Shader");
 
-QUnit.test("shader should be visible if drawer is opened and shading = true", assert => {
+QUnit.test("shader should be visible if drawer is opened and shading = true", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         shading: true
@@ -872,7 +872,7 @@ QUnit.test("shader should be visible if drawer is opened and shading = true", as
     assert.ok($shader.is(":visible"), "shader is visible");
 });
 
-QUnit.test("shader should not be visible if drawer is closed", assert => {
+QUnit.test("shader should not be visible if drawer is closed", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: false,
         shading: true
@@ -884,7 +884,7 @@ QUnit.test("shader should not be visible if drawer is closed", assert => {
     assert.equal($shader.css("visibility"), "hidden", "shader is hidden");
 });
 
-QUnit.test("shader should have correct visibility after toggling state", assert => {
+QUnit.test("shader should have correct visibility after toggling state", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         shading: true,
@@ -899,7 +899,7 @@ QUnit.test("shader should have correct visibility after toggling state", assert 
     assert.equal($shader.css("visibility"), "hidden", "shader is hidden");
 });
 
-QUnit.test("shader should have correct opacity after toggling state", assert => {
+QUnit.test("shader should have correct opacity after toggling state", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         shading: true,
@@ -913,7 +913,7 @@ QUnit.test("shader should have correct opacity after toggling state", assert => 
     assert.equal($shader.css("opacity"), 0, "shader has right opacity");
 });
 
-QUnit.test("shading option", assert => {
+QUnit.test("shading option", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         shading: true
@@ -927,7 +927,7 @@ QUnit.test("shading option", assert => {
     assert.ok($shader.is(":hidden"), "shader is hidden");
 });
 
-QUnit.test("click on shader should not close drawer", assert => {
+QUnit.test("click on shader should not close drawer", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         shading: true
@@ -940,7 +940,7 @@ QUnit.test("click on shader should not close drawer", assert => {
     assert.ok(instance.option("opened"), "drawer is opened");
 });
 
-QUnit.test("shader should be visible during animation", assert => {
+QUnit.test("shader should be visible during animation", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: false,
         shading: true
@@ -953,7 +953,7 @@ QUnit.test("shader should be visible during animation", assert => {
     assert.ok($shader.is(":visible"), "shader is visible during animation");
 });
 
-QUnit.test("shader should have correct position", assert => {
+QUnit.test("shader should have correct position", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         shading: true
@@ -966,7 +966,7 @@ QUnit.test("shader should have correct position", assert => {
     assert.equal($shader.offset().left, $content.offset().left, "shader has correct position");
 });
 
-QUnit.test("shader should have correct position after widget resize", assert => {
+QUnit.test("shader should have correct position after widget resize", function(assert) {
     const $element = $("#drawer2").dxDrawer({
         width: "100%",
         opened: true,
@@ -984,7 +984,7 @@ QUnit.test("shader should have correct position after widget resize", assert => 
     assert.equal($shader.offset().left, $content.offset().left, "shader has correct position");
 });
 
-QUnit.test("shader should have correct zIndex in overlap mode", assert => {
+QUnit.test("shader should have correct zIndex in overlap mode", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         openedStateMode: "overlap",
@@ -998,7 +998,7 @@ QUnit.test("shader should have correct zIndex in overlap mode", assert => {
 
 QUnit.module("Rtl");
 
-QUnit.test("content should have correct position if panel is visible in rtl mode", assert => {
+QUnit.test("content should have correct position if panel is visible in rtl mode", function(assert) {
     const $element = $("#drawer").dxDrawer({
         opened: true,
         openedStateMode: "push",
@@ -1012,7 +1012,7 @@ QUnit.test("content should have correct position if panel is visible in rtl mode
     assert.equal(position($content), $panel.width(), "container rendered at correct position");
 });
 
-QUnit.test("drawer panel overlay should have right position config", assert => {
+QUnit.test("drawer panel overlay should have right position config", function(assert) {
     let drawer = $("#drawer").dxDrawer({
             openedStateMode: "overlap",
             rtlEnabled: true
@@ -1029,7 +1029,7 @@ QUnit.test("drawer panel overlay should have right position config", assert => {
     assert.equal(overlay.option("position").at, "top right");
 });
 
-QUnit.test("minSize and maxSize should be rendered correctly in overlap mode rtl, slide", assert => {
+QUnit.test("minSize and maxSize should be rendered correctly in overlap mode rtl, slide", function(assert) {
     fx.off = true;
     let drawer = $("#drawer").dxDrawer({
         openedStateMode: "overlap",
@@ -1059,7 +1059,7 @@ QUnit.test("minSize and maxSize should be rendered correctly in overlap mode rtl
     fx.off = false;
 });
 
-QUnit.test("wrapper content should be reversed if position = 'right' and openedStateMode is changed, rtl", assert => {
+QUnit.test("wrapper content should be reversed if position = 'right' and openedStateMode is changed, rtl", function(assert) {
     const $element = $("#drawer").dxDrawer({
         openedStateMode: "push",
         rtlEnabled: true,
@@ -1085,7 +1085,7 @@ QUnit.test("wrapper content should be reversed if position = 'right' and openedS
 
 QUnit.module("CloseOnOutsideClick");
 
-QUnit.test("drawer should be hidden after click on content", (assert) => {
+QUnit.test("drawer should be hidden after click on content", function(assert) {
     var drawer = $("#drawer").dxDrawer({
             closeOnOutsideClick: false,
             opened: true,
@@ -1105,7 +1105,7 @@ QUnit.test("drawer should be hidden after click on content", (assert) => {
     assert.ok($shader.is(":hidden"), "shader is hidden");
 });
 
-QUnit.test("closeOnOutsideClick as function should be processed correctly", (assert) => {
+QUnit.test("closeOnOutsideClick as function should be processed correctly", function(assert) {
     var drawer = $("#drawer").dxDrawer({
             closeOnOutsideClick: () => {
                 return false;
@@ -1127,7 +1127,7 @@ QUnit.test("closeOnOutsideClick as function should be processed correctly", (ass
 
 
 QUnit.module("Push mode", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#drawer").dxDrawer($.extend(options, {
                 openedStateMode: "push",
@@ -1143,11 +1143,11 @@ QUnit.module("Push mode", {
 
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.test("minSize and maxSize should be rendered correctly in push mode", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in push mode", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 400,
@@ -1163,7 +1163,7 @@ QUnit.module("Push mode", {
         assert.equal($content.position().left, 50, "content has correct left when minSize and maxSize are set");
     });
 
-    QUnit.test("drawer should be rendered correctly in push mode, right panel position", assert => {
+    QUnit.test("drawer should be rendered correctly in push mode, right panel position", function(assert) {
         this.createInstance({
             position: "right",
             opened: true
@@ -1180,7 +1180,7 @@ QUnit.module("Push mode", {
         fx.off = false;
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in push mode, right panel position", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in push mode, right panel position", function(assert) {
         this.createInstance({
             position: "right",
             minSize: 50,
@@ -1199,7 +1199,7 @@ QUnit.module("Push mode", {
         fx.off = false;
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in push mode, top panel position", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in push mode, top panel position", function(assert) {
         this.createInstance({
             position: "top",
             minSize: 50,
@@ -1218,7 +1218,7 @@ QUnit.module("Push mode", {
         fx.off = false;
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in push mode, bottom panel position", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in push mode, bottom panel position", function(assert) {
         this.createInstance({
             position: "bottom",
             minSize: 50,
@@ -1239,7 +1239,7 @@ QUnit.module("Push mode", {
 });
 
 QUnit.module("Shrink mode", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#drawer").dxDrawer($.extend(options, {
                 openedStateMode: "shrink",
@@ -1257,11 +1257,11 @@ QUnit.module("Shrink mode", {
 
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, expand", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, expand", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 100,
@@ -1284,7 +1284,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.width(), 100, "panel has correct width when minSize is set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, slide", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, slide", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 200,
@@ -1309,7 +1309,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.width(), 300, "panel has correct width when minSize is set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, right panel position expand", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, right panel position expand", function(assert) {
         this.createInstance({
             position: "right",
             minSize: 50,
@@ -1333,7 +1333,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.width(), 100, "panel has correct width when minSize is set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, right panel position slide", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, right panel position slide", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 200,
@@ -1359,7 +1359,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.width(), 300, "panel has correct width when minSize is set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, top panel position expand", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, top panel position expand", function(assert) {
         this.createInstance({
             position: "top",
             minSize: 50,
@@ -1383,7 +1383,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.height(), 100, "panel has correct height");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, top panel position slide", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, top panel position slide", function(assert) {
         this.createInstance({
             position: "top",
             minSize: 50,
@@ -1409,7 +1409,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.css("marginTop"), "-100px", "panel content has correct marginTop");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, bottom panel position expand", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, bottom panel position expand", function(assert) {
         this.createInstance({
             position: "bottom",
             minSize: 50,
@@ -1433,7 +1433,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.height(), 100, "panel has correct height");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, bottom panel position slide", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in shrink mode, bottom panel position slide", function(assert) {
         this.createInstance({
             position: "bottom",
             minSize: 50,
@@ -1459,7 +1459,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.css("marginBottom"), "-100px", "panel content has correct marginBottom");
     });
 
-    QUnit.test("panel should have correct width in shrink mode after drawer resizing, expand", assert => {
+    QUnit.test("panel should have correct width in shrink mode after drawer resizing, expand", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 100,
@@ -1475,7 +1475,7 @@ QUnit.module("Shrink mode", {
         assert.equal($panel.width(), 50, "panel has correct width when minSize is set");
     });
 
-    QUnit.test("panel should have correct height in shrink mode after drawer resizing, expand", assert => {
+    QUnit.test("panel should have correct height in shrink mode after drawer resizing, expand", function(assert) {
         this.createInstance({
             position: "top",
             minSize: 50,
@@ -1496,7 +1496,7 @@ QUnit.module("Shrink mode", {
 });
 
 QUnit.module("Overlap mode", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#drawer").dxDrawer($.extend({
                 openedStateMode: "overlap",
@@ -1508,11 +1508,11 @@ QUnit.module("Overlap mode", {
 
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.test("drawer panel should be overlay in overlap mode", assert => {
+    QUnit.test("drawer panel should be overlay in overlap mode", function(assert) {
         this.createInstance({});
 
         assert.ok(this.instance.getOverlay() instanceof Overlay, "Drawer has overlay");
@@ -1522,7 +1522,7 @@ QUnit.module("Overlap mode", {
     [true, false].forEach((shading) => {
         [true, false].forEach((isOpened) => {
             [0, 100, null, undefined].forEach((minSize) => {
-                QUnit.test(`overlay configuration: opened- ${isOpened}, shading- ${shading}, minSize-${minSize}`, assert => {
+                QUnit.test(`overlay configuration: opened- ${isOpened}, shading- ${shading}, minSize-${minSize}`, function(assert) {
                     this.createInstance({
                         shading: shading,
                         opened: isOpened,
@@ -1561,7 +1561,7 @@ QUnit.module("Overlap mode", {
         });
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, expand", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, expand", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 300,
@@ -1588,7 +1588,7 @@ QUnit.module("Overlap mode", {
         assert.equal($overlayContent.width(), 300, "panel content has correct width when minSize and max size are set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, slide", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, slide", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 300,
@@ -1612,7 +1612,7 @@ QUnit.module("Overlap mode", {
         assert.equal($overlayContent.width(), 300, "panel has correct width when minSize and max size are set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, right panel position expand", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, right panel position expand", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 300,
@@ -1640,7 +1640,7 @@ QUnit.module("Overlap mode", {
         assert.equal($overlayContent.width(), 300, "panel content has correct width when minSize and max size are set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, right panel position slide", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, right panel position slide", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 300,
@@ -1665,7 +1665,7 @@ QUnit.module("Overlap mode", {
         assert.equal($overlayContent.width(), 300, "panel has correct width when minSize is set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, top panel position expand", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, top panel position expand", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 300,
@@ -1688,7 +1688,7 @@ QUnit.module("Overlap mode", {
         assert.equal($content.css("paddingTop"), "50px", "content has correct padding when minSize and max size are set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, top panel position slide", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, top panel position slide", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 300,
@@ -1709,7 +1709,7 @@ QUnit.module("Overlap mode", {
         assert.equal($panel.position().top, 100, "panel has correct top when minSize is set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, bottom panel position expand", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, bottom panel position expand", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 300,
@@ -1734,7 +1734,7 @@ QUnit.module("Overlap mode", {
         assert.equal($content.css("paddingBottom"), "50px", "content has correct padding when minSize and max size are set");
     });
 
-    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, bottom panel position slide", assert => {
+    QUnit.test("minSize and maxSize should be rendered correctly in overlap mode, bottom panel position slide", function(assert) {
         this.createInstance({
             minSize: 50,
             maxSize: 300,
@@ -1755,7 +1755,7 @@ QUnit.module("Overlap mode", {
         assert.equal($panel.position().top, -100, "panel has correct top when minSize is set");
     });
 
-    QUnit.test("nested drawers. Inner drawer should have right overflow", assert => {
+    QUnit.test("nested drawers. Inner drawer should have right overflow", function(assert) {
         $("#outerDrawer").dxDrawer({
             opened: true,
             height: 400,
@@ -1774,7 +1774,7 @@ QUnit.module("Overlap mode", {
 });
 
 QUnit.module("Modes changing", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.createInstance = function(options) {
             this.instance = $("#drawer").dxDrawer($.extend(options, {
                 template: function($content) {
@@ -1789,11 +1789,11 @@ QUnit.module("Modes changing", {
 
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 }, () => {
-    QUnit.test("panel should be rendered correctly after openedStateMode changing", assert => {
+    QUnit.test("panel should be rendered correctly after openedStateMode changing", function(assert) {
         this.createInstance({
             maxSize: 300,
             opened: false,
@@ -1811,7 +1811,7 @@ QUnit.module("Modes changing", {
         assert.equal($panel.width(), 300, "panel has correct size");
     });
 
-    QUnit.test("panel should be rendered correctly after openedStateMode changing, right panel position, slide", assert => {
+    QUnit.test("panel should be rendered correctly after openedStateMode changing, right panel position, slide", function(assert) {
         this.createInstance({
             maxSize: 300,
             opened: true,
@@ -1827,7 +1827,7 @@ QUnit.module("Modes changing", {
         assert.equal($panel.position().left, 700, "panel has correct left");
     });
 
-    QUnit.test("panel should be rendered correctly after openedStateMode changing, right panel position, expand", assert => {
+    QUnit.test("panel should be rendered correctly after openedStateMode changing, right panel position, expand", function(assert) {
         this.createInstance({
             maxSize: 300,
             opened: true,
@@ -1842,7 +1842,7 @@ QUnit.module("Modes changing", {
         assert.equal($panel.css("marginRight"), "0px", "panel has correct right");
     });
 
-    QUnit.test("panel should be rendered correctly after openedStateMode changing, vertical direction", assert => {
+    QUnit.test("panel should be rendered correctly after openedStateMode changing, vertical direction", function(assert) {
         this.createInstance({
             maxSize: 300,
             opened: false,
@@ -1860,7 +1860,7 @@ QUnit.module("Modes changing", {
         assert.equal($panel.height(), 300, "panel has correct size");
     });
 
-    QUnit.test("panel and content should be rendered correctly after revealMode changing, horizontal direction", assert => {
+    QUnit.test("panel and content should be rendered correctly after revealMode changing, horizontal direction", function(assert) {
         this.createInstance({
             minSize: 50,
             opened: true,
@@ -1889,7 +1889,7 @@ QUnit.module("Modes changing", {
         assert.equal($panelContent.position().left, 0, "panel content has correct position");
     });
 
-    QUnit.test("panel and content should be rendered correctly after revealMode changing, vertical direction", assert => {
+    QUnit.test("panel and content should be rendered correctly after revealMode changing, vertical direction", function(assert) {
         this.createInstance({
             minSize: 50,
             opened: true,
@@ -1919,7 +1919,7 @@ QUnit.module("Modes changing", {
         assert.equal($panelContent.position().top, 0, "panel content has correct position");
     });
 
-    QUnit.test("drawer panel should be rendered correctly in overlap mode after mode changing, expand", assert => {
+    QUnit.test("drawer panel should be rendered correctly in overlap mode after mode changing, expand", function(assert) {
         this.createInstance({
             opened: false,
             revealMode: "expand",
@@ -1936,7 +1936,7 @@ QUnit.module("Modes changing", {
         assert.equal($overlayContent.width(), 300, "overlay content should have correct width after option changing");
     });
 
-    QUnit.test("drawer panel and content should be rendered correctly in overlap mode after mode changing, slide", assert => {
+    QUnit.test("drawer panel and content should be rendered correctly in overlap mode after mode changing, slide", function(assert) {
         this.createInstance({
             opened: true,
             revealMode: "slide",
@@ -1953,7 +1953,7 @@ QUnit.module("Modes changing", {
         assert.equal($content.css("transform"), "none", "content has right css transform");
     });
 
-    QUnit.test("drawer should have only one panel after mode changing", assert => {
+    QUnit.test("drawer should have only one panel after mode changing", function(assert) {
         this.createInstance({
             opened: true,
             revealMode: "expand",

--- a/testing/tests/DevExpress.ui.widgets/menu.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menu.markup.tests.js
@@ -31,15 +31,15 @@ const createMenu = (options) => {
 const toSelector = cssClass => "." + cssClass;
 
 QUnit.module("Menu rendering", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 });
 
-QUnit.test("Render items with custom model", (assert) => {
+QUnit.test("Render items with custom model", function(assert) {
     let menu = createMenu({
             items: [{
                 name: "item 1",
@@ -60,13 +60,13 @@ QUnit.test("Render items with custom model", (assert) => {
     assert.ok($item1.find(toSelector(DX_MENU_ITEM_POPOUT_CLASS)).length, "popout was rendered");
 });
 
-QUnit.test("Check default css class", (assert) => {
+QUnit.test("Check default css class", function(assert) {
     let menu = createMenu({});
 
     assert.ok($(menu.element).hasClass(DX_MENU_CLASS));
 });
 
-QUnit.test("Do not render menu with empty items", (assert) => {
+QUnit.test("Do not render menu with empty items", function(assert) {
     let menu = createMenu({ items: [] }),
         root = $(menu.element).find(toSelector(DX_MENU_HORIZONTAL));
 
@@ -75,17 +75,17 @@ QUnit.test("Do not render menu with empty items", (assert) => {
 });
 
 QUnit.module("Menu - selection", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.clock = sinon.useFakeTimers();
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         this.clock.restore();
         fx.off = false;
     }
 });
 
-QUnit.test("Create root childfree item selected", (assert) => {
+QUnit.test("Create root childfree item selected", function(assert) {
     let menu = createMenu({
             items: [{ text: "root", selected: true }],
             selectionMode: "single"
@@ -96,15 +96,15 @@ QUnit.test("Create root childfree item selected", (assert) => {
 
 
 QUnit.module("Menu with templates", {
-    beforeEach: () => {
+    beforeEach: function() {
         fx.off = true;
     },
-    afterEach: () => {
+    afterEach: function() {
         fx.off = false;
     }
 });
 
-QUnit.test("Create items with template", (assert) => {
+QUnit.test("Create items with template", function(assert) {
     let $template = $("<div>").text("test"),
         options = {
             showFirstSubmenuMode: "onClick",
@@ -130,7 +130,7 @@ QUnit.test("Create items with template", (assert) => {
 
 var helper;
 QUnit.module("Aria accessibility", {
-    beforeEach: () => {
+    beforeEach: function() {
         helper = new ariaAccessibilityTestHelper({
             createWidget: ($element, options) => new Menu($element,
                 $.extend({
@@ -138,17 +138,17 @@ QUnit.module("Aria accessibility", {
                 }, options))
         });
     },
-    afterEach: () => {
+    afterEach: function() {
         helper.$widget.remove();
     }
 }, () => {
-    QUnit.test(`Items: []`, () => {
+    QUnit.test(`Items: []`, function() {
         helper.createWidget({ items: [] });
         helper.checkAttributes(helper.$widget, { role: "menubar", tabindex: "0" }, "widget");
         helper.checkItemsAttributes([], { role: "menuitem", tabindex: "-1" });
     });
 
-    QUnit.test(`Items: [{items[{}, {}], {}] -> set focusedElement: items[0]`, () => {
+    QUnit.test(`Items: [{items[{}, {}], {}] -> set focusedElement: items[0]`, function() {
         helper.createWidget({
             items: [{ text: "Item1_1", items: [{ text: "Item2_1" }, { text: "Item2_2" }] }, { text: "item1_2" }]
         });

--- a/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
@@ -891,7 +891,7 @@ QUnit.test('Raise onItemClick on root item click', function(assert) {
 
 var helper;
 QUnit.module("Aria accessibility", {
-    beforeEach: () => {
+    beforeEach: function() {
         helper = new ariaAccessibilityTestHelper({
             createWidget: ($element, options) => new TestComponent($element,
                 $.extend({
@@ -899,17 +899,17 @@ QUnit.module("Aria accessibility", {
                 }, options))
         });
     },
-    afterEach: () => {
+    afterEach: function() {
         helper.$widget.remove();
     }
 }, () => {
-    QUnit.test(`Items: [1]`, () => {
+    QUnit.test(`Items: [1]`, function() {
         helper.createWidget({ items: [1] });
         helper.checkAttributes(helper.$widget, { tabindex: "0" }, "widget");
         helper.checkItemsAttributes([], { role: "menuitem", tabindex: "-1" });
     });
 
-    QUnit.test(`Items: [{items[{}, {}], {}] -> set focusedElement: items[0]`, () => {
+    QUnit.test(`Items: [{items[{}, {}], {}] -> set focusedElement: items[0]`, function() {
         helper.createWidget({
             items: [{ text: "Item1_1", items: [{ text: "Item2_1" }, { text: "Item2_2" }] }, { text: "item1_2" }]
         });

--- a/testing/tests/DevExpress.ui.widgets/multiView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/multiView.tests.js
@@ -975,7 +975,7 @@ QUnit.test("inactive item should have aria-hidden attribute", function(assert) {
 });
 
 QUnit.module("swipeable disabled state", () => {
-    QUnit.test("{items: [], swipeEnabled: false}", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: false}", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: false
@@ -987,7 +987,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), false, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [], swipeEnabled: false} -> items: [1, 2]", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: false} -> items: [1, 2]", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: false
@@ -1001,7 +1001,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), false, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [], swipeEnabled: false} -> items: [1, 2], swipeEnabled: true", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: false} -> items: [1, 2], swipeEnabled: true", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: false
@@ -1016,7 +1016,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [], swipeEnabled: false} -> swipeEnabled: true", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: false} -> swipeEnabled: true", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: false
@@ -1030,7 +1030,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [], swipeEnabled: true}", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: true}", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: true
@@ -1042,7 +1042,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [], swipeEnabled: true} -> items: [1, 2]", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: true} -> items: [1, 2]", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: true
@@ -1056,7 +1056,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [], swipeEnabled: true} -> items: [1, 2], swipeEnabled: false", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: true} -> items: [1, 2], swipeEnabled: false", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: true
@@ -1071,7 +1071,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), false, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [], swipeEnabled: true} -> swipeEnabled: false", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: true} -> swipeEnabled: false", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: true
@@ -1085,7 +1085,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), false, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [], swipeEnabled: true} -> swipeEnabled: false, items: [1, 2]", (assert) => {
+    QUnit.test("{items: [], swipeEnabled: true} -> swipeEnabled: false, items: [1, 2]", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [],
             swipeEnabled: true
@@ -1100,7 +1100,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), false, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1], swipeEnabled: false}", (assert) => {
+    QUnit.test("{items: [1], swipeEnabled: false}", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1],
             swipeEnabled: false
@@ -1112,7 +1112,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), false, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1], swipeEnabled: true}", (assert) => {
+    QUnit.test("{items: [1], swipeEnabled: true}", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1],
             swipeEnabled: true
@@ -1124,7 +1124,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: false}", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: false}", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: false
@@ -1136,7 +1136,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), false, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: false} -> items: [], swipeEnabled: true", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: false} -> items: [], swipeEnabled: true", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: false
@@ -1151,7 +1151,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: false} -> swipeEnabled: true", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: false} -> swipeEnabled: true", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: false
@@ -1165,7 +1165,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: true}", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: true}", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: true
@@ -1177,7 +1177,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: true} -> items: []", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: true} -> items: []", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: true
@@ -1191,7 +1191,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: true} -> items: [1]", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: true} -> items: [1]", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: true
@@ -1205,7 +1205,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: true} -> items: [1,2,3]", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: true} -> items: [1,2,3]", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: true
@@ -1219,7 +1219,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), true, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: true} -> swipeEnabled: false", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: true} -> swipeEnabled: false", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: true
@@ -1233,7 +1233,7 @@ QUnit.module("swipeable disabled state", () => {
         assert.equal(multiView.option("swipeEnabled"), false, "MultiView.swipeEnabled");
     });
 
-    QUnit.test("{items: [1, 2], swipeEnabled: true} -> swipeEnabled: false, items: [1,2,3]", (assert) => {
+    QUnit.test("{items: [1, 2], swipeEnabled: true} -> swipeEnabled: false, items: [1,2,3]", function(assert) {
         const $multiView = $("#multiView").dxMultiView({
             items: [1, 2],
             swipeEnabled: true

--- a/testing/tests/DevExpress.ui.widgets/responsiveBox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/responsiveBox.markup.tests.js
@@ -26,16 +26,16 @@ const BOX_CLASS = "dx-box",
 
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         responsiveBoxScreenMock.setup.call(this);
     },
-    afterEach: () => {
+    afterEach: function() {
         responsiveBoxScreenMock.teardown.call(this);
     }
 };
 
 QUnit.module("render", moduleConfig, () => {
-    QUnit.test("render", (assert) => {
+    QUnit.test("render", function(assert) {
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             items: [{ text: 1 }, { text: 2 }]
         });
@@ -45,7 +45,7 @@ QUnit.module("render", moduleConfig, () => {
         assert.equal($items.length, 2, "items rendered when rows and columns are not defined (using single column layout)");
     });
 
-    QUnit.test("empty widget shouldn't raise exception on resize (T259132)", (assert) => {
+    QUnit.test("empty widget shouldn't raise exception on resize (T259132)", function(assert) {
         assert.expect(0);
 
         $("#responsiveBox").dxResponsiveBox({});
@@ -54,7 +54,7 @@ QUnit.module("render", moduleConfig, () => {
 });
 
 QUnit.module("layouting", moduleConfig, () => {
-    QUnit.test("grid without items", (assert) => {
+    QUnit.test("grid without items", function(assert) {
         let rows = [{ ratio: 1, baseSize: 100 }, { ratio: 2, baseSize: 200 }];
         let cols = [{ ratio: 2, baseSize: 200 }, { ratio: 1, baseSize: 100 }];
         let height = 600;
@@ -83,7 +83,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.equal(columnBoxSecond.option("items").length, 2);
     });
 
-    QUnit.test("grid with items", (assert) => {
+    QUnit.test("grid with items", function(assert) {
         let rows = [{ ratio: 1, baseSize: 100 }, { ratio: 2, baseSize: 200 }];
         let cols = [{ ratio: 2, baseSize: 200 }, { ratio: 1, baseSize: 100 }];
         let height = 600;
@@ -108,7 +108,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.equal($rootBox.text(), "item11item12item21item22", "items rendered correctly");
     });
 
-    QUnit.test("grid with factors", (assert) => {
+    QUnit.test("grid with factors", function(assert) {
         // screen:   xs      sm           md          lg
         //  width: <768    768-<992    992-<1200    >1200
 
@@ -167,7 +167,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.equal($responsiveBox.text(), lgExpectedText);
     });
 
-    QUnit.test("colspan", (assert) => {
+    QUnit.test("colspan", function(assert) {
         let cols = [{ ratio: 1, baseSize: 100 }, { ratio: 2, baseSize: 200 }, { ratio: 1, baseSize: 200 }];
         let size = 900;
 
@@ -184,7 +184,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.equal($boxItems.length, 2, "two items were rendered");
     });
 
-    QUnit.test("rowspan", (assert) => {
+    QUnit.test("rowspan", function(assert) {
         let rows = [{ ratio: 1, baseSize: 100 }, { ratio: 2, baseSize: 200 }, { ratio: 1, baseSize: 200 }];
         let size = 900;
 
@@ -200,7 +200,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.equal($boxItems.length, 2, "two items were rendered");
     });
 
-    QUnit.test("repaint should not detach items", (assert) => {
+    QUnit.test("repaint should not detach items", function(assert) {
         assert.expect(0);
 
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
@@ -225,7 +225,7 @@ QUnit.module("layouting", moduleConfig, () => {
         }
     });
 
-    QUnit.test("recalculation on size changing", (assert) => {
+    QUnit.test("recalculation on size changing", function(assert) {
         // screen:   xs      sm           md          lg
         //  width: <768    768-<992    992-<1200    >1200
         let $responsiveBox = $("#responsiveBox");
@@ -248,7 +248,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.equal($.trim($responsiveBox.text()), "md", "md item apply");
     });
 
-    QUnit.test("singleColumnScreen render items in one column", (assert) => {
+    QUnit.test("singleColumnScreen render items in one column", function(assert) {
         this.updateScreenSize(500);
 
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
@@ -286,7 +286,7 @@ QUnit.module("layouting", moduleConfig, () => {
         checkLayoutByScreen(800, "1234");
     });
 
-    QUnit.test("too complex layout", (assert) => {
+    QUnit.test("too complex layout", function(assert) {
         assert.throws(() => {
             let size = 900;
 
@@ -318,7 +318,7 @@ QUnit.module("layouting", moduleConfig, () => {
         "raised error E1025");
     });
 
-    QUnit.test("dxUpdate trigger async after render and dimension changed", (assert) => {
+    QUnit.test("dxUpdate trigger async after render and dimension changed", function(assert) {
         let clock = sinon.useFakeTimers();
         try {
             // screen:   xs      sm           md          lg
@@ -360,7 +360,7 @@ QUnit.module("layouting", moduleConfig, () => {
         }
     });
 
-    QUnit.test("Box should has a class appropriate a screen resolution", (assert) => {
+    QUnit.test("Box should has a class appropriate a screen resolution", function(assert) {
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             width: "auto",
             height: "auto"
@@ -391,7 +391,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.ok(!$responsiveBox.hasClass(SCREEN_SIZE_CLASS_PREFIX + "md"));
     });
 
-    QUnit.test("Set the shrink option of row to box", (assert) => {
+    QUnit.test("Set the shrink option of row to box", function(assert) {
         const $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             _layoutStrategy: "flex",
             rows: [{
@@ -412,7 +412,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.equal($items.eq(1).css("flex-shrink"), 1, "flex-shrink style for second row");
     });
 
-    QUnit.test("Set the shrink option of column to box", (assert) => {
+    QUnit.test("Set the shrink option of column to box", function(assert) {
         const $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             _layoutStrategy: "flex",
             rows: [{ ratio: 1 }],
@@ -428,7 +428,7 @@ QUnit.module("layouting", moduleConfig, () => {
         assert.equal($items.eq(2).css("flex-shrink"), 0, "flex-shrink style for second column");
     });
 
-    QUnit.test("Set the shrink option of row to box when the singleColumnMode is applied", (assert) => {
+    QUnit.test("Set the shrink option of row to box when the singleColumnMode is applied", function(assert) {
         this.updateScreenSize(500);
 
         const $responsiveBox = $("#responsiveBox").dxResponsiveBox({
@@ -456,7 +456,7 @@ QUnit.module("layouting", moduleConfig, () => {
 
 
 QUnit.module("behavior", () => {
-    QUnit.test("update does not rerender items", (assert) => {
+    QUnit.test("update does not rerender items", function(assert) {
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             rows: [{}],
             cols: [{}],
@@ -471,7 +471,7 @@ QUnit.module("behavior", () => {
 });
 
 QUnit.module("templates", () => {
-    QUnit.test("custom item templates", (assert) => {
+    QUnit.test("custom item templates", function(assert) {
         let $responsiveBox = $("#responsiveBoxWithTemplate").dxResponsiveBox({
             rows: [{}],
             cols: [{}]
@@ -479,7 +479,7 @@ QUnit.module("templates", () => {
         assert.equal($.trim($responsiveBox.text()), "test", "item template rendered");
     });
 
-    QUnit.test("custom item renderer", (assert) => {
+    QUnit.test("custom item renderer", function(assert) {
         let templateContext,
             $responsiveBox = $("#responsiveBox").dxResponsiveBox({
                 rows: [{}],
@@ -497,7 +497,7 @@ QUnit.module("templates", () => {
 });
 
 QUnit.module("template rendering", moduleConfig, () => {
-    QUnit.test("template rendered when it set after creation", (assert) => {
+    QUnit.test("template rendered when it set after creation", function(assert) {
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             rows: [{}],
             cols: [{}],
@@ -513,7 +513,7 @@ QUnit.module("template rendering", moduleConfig, () => {
         assert.equal($.trim($responsiveBox.text()), "after rendering", "item template was rendered");
     });
 
-    QUnit.test("widget rendered correctly after rows option was changed", (assert) => {
+    QUnit.test("widget rendered correctly after rows option was changed", function(assert) {
         // screen:   xs      sm           md          lg
         //  width: <768    768-<992    992-<1200    >1200
 
@@ -539,7 +539,7 @@ QUnit.module("template rendering", moduleConfig, () => {
 });
 
 QUnit.module("collision", moduleConfig, () => {
-    QUnit.test("item located at the same cell of another item", (assert) => {
+    QUnit.test("item located at the same cell of another item", function(assert) {
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             rows: [{}, {}],
             cols: [{}, {}],
@@ -554,7 +554,7 @@ QUnit.module("collision", moduleConfig, () => {
         assert.equal($.trim($responsiveBox.text()), "02", "the former item rendered");
     });
 
-    QUnit.test("item located at spanning cell", (assert) => {
+    QUnit.test("item located at spanning cell", function(assert) {
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             rows: [{}],
             cols: [{}, {}],
@@ -567,7 +567,7 @@ QUnit.module("collision", moduleConfig, () => {
         assert.equal($.trim($responsiveBox.text()), "0", "the former item rendered");
     });
 
-    QUnit.test("item spanning located at spanning of another item", (assert) => {
+    QUnit.test("item spanning located at spanning of another item", function(assert) {
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             rows: [{}, {}],
             cols: [{}, {}],
@@ -580,7 +580,7 @@ QUnit.module("collision", moduleConfig, () => {
         assert.equal($.trim($responsiveBox.text()), "0", "the former item rendered");
     });
 
-    QUnit.test("item spanning out of bounds", (assert) => {
+    QUnit.test("item spanning out of bounds", function(assert) {
         let $responsiveBox = $("#responsiveBox").dxResponsiveBox({
             rows: [{}, {}],
             cols: [{}],

--- a/testing/tests/DevExpress.ui.widgets/scrollView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollView.tests.js
@@ -2173,7 +2173,7 @@ QUnit.test("refreshStrategy for android set by real device", function(assert) {
 
 
 module("pullDown, reachBottom events", moduleConfig, () => {
-    test("topPocket visibility depends on pullDown event", (assert) => {
+    test("topPocket visibility depends on pullDown event", function(assert) {
         const $scrollView = $("#scrollView").dxScrollView({ useNative: false });
         const $topPocket = $scrollView.find("." + SCROLLVIEW_PULLDOWN_CLASS);
 
@@ -2182,7 +2182,7 @@ module("pullDown, reachBottom events", moduleConfig, () => {
         assert.ok($topPocket.is(":visible"), "topPocket is visible");
     });
 
-    test("pullDown event should be fired after refresh method call", (assert) => {
+    test("pullDown event should be fired after refresh method call", function(assert) {
         assert.expect(1);
 
         const $scrollView = $("#scrollView").dxScrollView({ useNative: false });
@@ -2195,7 +2195,7 @@ module("pullDown, reachBottom events", moduleConfig, () => {
         instance.refresh();
     });
 
-    test("bottomPocket element depends on reachBottom event", (assert) => {
+    test("bottomPocket element depends on reachBottom event", function(assert) {
         const $scrollView = $("#scrollView").dxScrollView({ useNative: false });
 
         $scrollView.dxScrollView("instance").on("reachBottom", noop);
@@ -2205,7 +2205,7 @@ module("pullDown, reachBottom events", moduleConfig, () => {
         assert.ok($reachBottom.is(":visible"), "reach bottom is visible");
     });
 
-    test("scrollview events support chains", (assert) => {
+    test("scrollview events support chains", function(assert) {
         const $scrollView = $("#scrollView").dxScrollView({ useNative: false });
 
         $scrollView.dxScrollView("instance").on("reachBottom", noop).on("pullDown", noop);
@@ -2213,7 +2213,7 @@ module("pullDown, reachBottom events", moduleConfig, () => {
         assert.ok(true, "chains is supported");
     });
 
-    test("scrollview events support chains", (assert) => {
+    test("scrollview events support chains", function(assert) {
         const $scrollView = $("#scrollView").dxScrollView({ useNative: false });
 
         $scrollView.dxScrollView("instance").on("reachBottom", noop).on("pullDown", noop);
@@ -2222,7 +2222,7 @@ module("pullDown, reachBottom events", moduleConfig, () => {
     });
 
     ["config", "onInitialized"].forEach(assignMethod => {
-        test(`Check pullDown event handler - ` + assignMethod, (assert) => {
+        test(`Check pullDown event handler - ` + assignMethod, function(assert) {
             let config = {};
             let pullDownHandler = sinon.stub();
 
@@ -2249,7 +2249,7 @@ module("pullDown, reachBottom events", moduleConfig, () => {
             assert.strictEqual(pullDownHandler.callCount, 1, "pullDownHandler.callCount");
         });
 
-        test(`Check reachBottom event handler - ` + assignMethod, (assert) => {
+        test(`Check reachBottom event handler - ` + assignMethod, function(assert) {
             let config = {};
             let reachBottomHandler = sinon.stub();
 

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.api.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.api.tests.js
@@ -694,7 +694,7 @@ class ScrollableTestHelper {
 [0, 10].forEach((pushBackValue) => {
     [true, false].forEach((useNative) => {
         QUnit.module(`Scroll arguments, native: ${useNative}, pushBackValue: ${pushBackValue}`, moduleConfig, () => {
-            QUnit.test(`Direction: 'vertical', rtl: false, scrollPosition: { top: 0 } -> { top: 1 } -> { top: center } -> { top: max-1 } -> { top: max }`, () => {
+            QUnit.test(`Direction: 'vertical', rtl: false, scrollPosition: { top: 0 } -> { top: 1 } -> { top: center } -> { top: max-1 } -> { top: max }`, function() {
                 const helper = new ScrollableTestHelper({ direction: "vertical", useNative: useNative, rtlEnabled: false, pushBackValue: pushBackValue });
                 const maxOffset = helper.getMaxScrollOffset();
 
@@ -722,7 +722,7 @@ class ScrollableTestHelper {
                 helper.checkScrollEvent({ reachedTop: false, reachedBottom: true, reachedLeft: undefined, reachedRight: undefined });
             });
 
-            QUnit.test(`Direction: 'horizontal', rtl: false, scrollPosition: { left: 0 } -> { left: 1 } -> { left: center } -> { left: max-1 } -> { left: max }`, () => {
+            QUnit.test(`Direction: 'horizontal', rtl: false, scrollPosition: { left: 0 } -> { left: 1 } -> { left: center } -> { left: max-1 } -> { left: max }`, function() {
                 const helper = new ScrollableTestHelper({ direction: "horizontal", useNative: useNative, rtlEnabled: false, pushBackValue: pushBackValue });
                 const maxOffset = helper.getMaxScrollOffset();
 
@@ -750,7 +750,7 @@ class ScrollableTestHelper {
                 helper.checkScrollEvent({ reachedTop: undefined, reachedBottom: undefined, reachedLeft: false, reachedRight: true });
             });
 
-            QUnit.test(`Direction: 'both', rtl: false, scrollPosition: { top: 0, left: 0 } -> { top:1, left: 1 } -> { top: center, left: center } -> { top: max-1, left: max-1 } -> { top: max, left: max }`, () => {
+            QUnit.test(`Direction: 'both', rtl: false, scrollPosition: { top: 0, left: 0 } -> { top:1, left: 1 } -> { top: center, left: center } -> { top: max-1, left: max-1 } -> { top: max, left: max }`, function() {
                 const helper = new ScrollableTestHelper({ direction: "both", useNative: useNative, rtlEnabled: false, pushBackValue: pushBackValue });
                 const maxOffset = helper.getMaxScrollOffset();
 
@@ -778,7 +778,7 @@ class ScrollableTestHelper {
                 helper.checkScrollEvent({ reachedTop: false, reachedBottom: true, reachedLeft: false, reachedRight: true });
             });
 
-            QUnit.test(`Direction: 'vertical', rtl: true, scrollPosition: { top: 0 } -> { top: 1 } -> { top: center } -> { top: max-1 } -> { top: max }`, () => {
+            QUnit.test(`Direction: 'vertical', rtl: true, scrollPosition: { top: 0 } -> { top: 1 } -> { top: center } -> { top: max-1 } -> { top: max }`, function() {
                 const helper = new ScrollableTestHelper({ direction: "vertical", useNative: useNative, rtlEnabled: true, pushBackValue: pushBackValue });
                 const maxOffset = helper.getMaxScrollOffset();
 
@@ -806,7 +806,7 @@ class ScrollableTestHelper {
                 helper.checkScrollEvent({ reachedTop: false, reachedBottom: true, reachedLeft: undefined, reachedRight: undefined });
             });
 
-            QUnit.test(`Direction: 'horizontal', rtl: true, scrollPosition: { left: max } -> { left: max-1 } -> { left: center } -> { left: 1 } -> { left: 0 }`, () => {
+            QUnit.test(`Direction: 'horizontal', rtl: true, scrollPosition: { left: max } -> { left: max-1 } -> { left: center } -> { left: 1 } -> { left: 0 }`, function() {
                 const helper = new ScrollableTestHelper({ direction: "horizontal", useNative: useNative, rtlEnabled: true, pushBackValue: pushBackValue });
                 const maxOffset = helper.getMaxScrollOffset();
 
@@ -834,7 +834,7 @@ class ScrollableTestHelper {
                 helper.checkScrollEvent({ reachedTop: undefined, reachedBottom: undefined, reachedLeft: true, reachedRight: false });
             });
 
-            QUnit.test(`Direction: 'both', rtl: true, scrollPosition: { top: 0, left: max } -> { top:1, left: max-1 } -> { top: center, left: center } -> { top: max-1, left: 1 } -> { top: max, left: 0 }`, () => {
+            QUnit.test(`Direction: 'both', rtl: true, scrollPosition: { top: 0, left: max } -> { top:1, left: max-1 } -> { top: center, left: center } -> { top: max-1, left: 1 } -> { top: max, left: 0 }`, function() {
                 const helper = new ScrollableTestHelper({ direction: "both", useNative: useNative, rtlEnabled: true, pushBackValue: pushBackValue });
                 const maxOffset = helper.getMaxScrollOffset();
 

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.keyboard.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.keyboard.tests.js
@@ -275,7 +275,7 @@ QUnit.testInActiveWindow("arrows was not handled when focus on input element", f
             QUnit.assert.deepEqual(scrollLocation, expectedLocation, "scroll location");
         }
 
-        QUnit.testInActiveWindow(`Update vertical scroll location on tab: useNative - ${useNativeMode}`, (assert) => {
+        QUnit.testInActiveWindow(`Update vertical scroll location on tab: useNative - ${useNativeMode}`, function(assert) {
             if(devices.real().deviceType !== "desktop") {
                 assert.ok(true, "mobile device does not support tabindex on div element");
                 return;

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.main.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.main.tests.js
@@ -304,7 +304,7 @@ QUnit.test("reset unused position after change direction (both)", function(asser
 
 QUnit.module("Hoverable interaction",
     {
-        beforeEach: () => {
+        beforeEach: function() {
             var markup = '\
             <div id="scrollable" style="height: 50px; width: 50px;">\
                 <div class="content1" style="height: 100px; width: 100px;"></div>\
@@ -318,7 +318,7 @@ QUnit.module("Hoverable interaction",
             [false, true].forEach((onInitialize) => {
                 ["vertical", "horizontal"].forEach((direction) => {
                     ["onScroll", "onHover", "always", "never"].forEach((showScrollbarMode) => {
-                        QUnit.test(`ScrollBar hoverable - disabled: ${disabled}, showScrollbar: ${showScrollbarMode}, direction: ${direction}, onInitialize: ${onInitialize}`, (assert) => {
+                        QUnit.test(`ScrollBar hoverable - disabled: ${disabled}, showScrollbar: ${showScrollbarMode}, direction: ${direction}, onInitialize: ${onInitialize}`, function(assert) {
                             const $scrollable = $("#scrollable").dxScrollable({
                                 useNative: false,
                                 useSimulatedScrollbar: true,
@@ -809,7 +809,7 @@ QUnit.testInActiveWindow("scrollable should not reset active element outside (B2
 });
 
 QUnit.module("visibility events integration", {
-    beforeEach: () => {
+    beforeEach: function() {
         var markup = '\
         <div id="scrollable" style="height: 50px; width: 50px;">\
             <div class="content1" style="height: 100px; width: 100px;"></div>\

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.mouseWheel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.mouseWheel.tests.js
@@ -418,7 +418,7 @@ if(devices.current().deviceType === "desktop") {
             }
         }
 
-        QUnit.test(`validate() mouse wheel (top, left) - direction:${direction}`, (assert) => {
+        QUnit.test(`validate() mouse wheel (top, left) - direction:${direction}`, function(assert) {
             let helper = new ValidateMouseWheelEventTestHelper(direction);
             let event = helper.getEvent();
 
@@ -429,7 +429,7 @@ if(devices.current().deviceType === "desktop") {
             assert.strictEqual(!!helper.strategy.validate(event), true, "validate result when event.delta = -1");
         });
 
-        QUnit.test(`validate() mousewheel (bottom, right)- direction:${direction}`, (assert) => {
+        QUnit.test(`validate() mousewheel (bottom, right)- direction:${direction}`, function(assert) {
             let helper = new ValidateMouseWheelEventTestHelper(direction);
             let event = helper.getEvent();
             let $container = helper.getScrollableContainer();
@@ -444,7 +444,7 @@ if(devices.current().deviceType === "desktop") {
             assert.strictEqual(!!helper.strategy.validate(event), false, "validate result when event.delta = -1");
         });
 
-        QUnit.test(`validate() mousewheel (center, center)- direction:${direction}`, (assert) => {
+        QUnit.test(`validate() mousewheel (center, center)- direction:${direction}`, function(assert) {
             let helper = new ValidateMouseWheelEventTestHelper(direction);
             let event = helper.getEvent();
             let $container = helper.getScrollableContainer();

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.rtl.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.rtl.tests.js
@@ -102,7 +102,7 @@ QUnit.test("init option 'rtl' is true", function(assert) {
     assert.ok(!$element.hasClass(RTL_CLASS));
 });
 
-QUnit.test("rtlEnabled scrolls to very right position when a width was changing via API", assert => {
+QUnit.test("rtlEnabled scrolls to very right position when a width was changing via API", function(assert) {
     const $scrollable = $("#scrollable")
         .dxScrollable({
             direction: "horizontal",

--- a/testing/tests/DevExpress.ui.widgets/tabPanel.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabPanel.markup.tests.js
@@ -32,22 +32,22 @@ const nestedElementsCount = function($element, cssClass) {
 };
 
 QUnit.module("TabPanel markup", () => {
-    QUnit.test("tabPanel should have correct class", (assert) => {
+    QUnit.test("tabPanel should have correct class", function(assert) {
         const $tabPanel = $("#tabPanel").dxTabPanel();
         assert.ok($tabPanel.hasClass(TABPANEL_CLASS), "widget class added");
     });
 
-    QUnit.test("rendering tabs widget test", (assert) => {
+    QUnit.test("rendering tabs widget test", function(assert) {
         const $tabPanel = $("#tabPanel").dxTabPanel();
         assert.ok($tabPanel.find("." + TABS_CLASS), "tabs widget added");
     });
 
-    QUnit.test("rendering multiview widget test", (assert) => {
+    QUnit.test("rendering multiview widget test", function(assert) {
         const $tabPanel = $("#tabPanel").dxTabPanel();
         assert.ok($tabPanel.hasClass(MULTIVIEW_CLASS), "multiview widget added");
     });
 
-    QUnit.test("count of nested widget elements test", (assert) => {
+    QUnit.test("count of nested widget elements test", function(assert) {
         assert.expect(1);
 
         const items = [{ text: "user", icon: "user", title: "Personal Data", firstName: "John", lastName: "Smith" },
@@ -65,7 +65,7 @@ QUnit.module("TabPanel markup", () => {
 });
 
 QUnit.module("TabPanel items", () => {
-    QUnit.test("items option test - changing a single item at runtime", (assert) => {
+    QUnit.test("items option test - changing a single item at runtime", function(assert) {
         const items = [
             { text: "Greg", title: "Name" }
         ];
@@ -82,7 +82,7 @@ QUnit.module("TabPanel items", () => {
             "test", "option <items> of nested tabs widget successfully changed - tabs were rerendered");
     });
 
-    QUnit.test("itemTitleTemplate rendering test", (assert) => {
+    QUnit.test("itemTitleTemplate rendering test", function(assert) {
         assert.expect(2);
 
         const items = [{ text: "user", icon: "user", title: "Personal Data", firstName: "John", lastName: "Smith" },
@@ -106,7 +106,7 @@ QUnit.module("TabPanel items", () => {
             "option <itemTitleTemplate> of nested tabs widget successfully changed");
     });
 
-    QUnit.test("disabled item should be rendered correctly", (assert) => {
+    QUnit.test("disabled item should be rendered correctly", function(assert) {
         const items = [
             { text: "Greg", title: "Name" },
             { text: "Albert", title: "Name" }
@@ -136,7 +136,7 @@ QUnit.module("TabPanel items", () => {
         { title: new Date(2019, 10, 13), expected: String(new Date(2019, 10, 13)) },
         { title: { value: "title" }, expected: "" }
     ].forEach((value) => {
-        QUnit.test(`DefaultTemplate: title template property - ${value.title}`, (assert) => {
+        QUnit.test(`DefaultTemplate: title template property - ${value.title}`, function(assert) {
             const $element = $("<div>").appendTo("#qunit-fixture");
 
             new TabPanel($element, { items: [ { title: value.title }] });
@@ -146,7 +146,7 @@ QUnit.module("TabPanel items", () => {
             assert.strictEqual($itemElements.eq(0).find(".dx-tab-text").text(), value.expected, "item.title");
         });
 
-        QUnit.test(`DefaultTemplate: items["${value.title}"] as primitive`, (assert) => {
+        QUnit.test(`DefaultTemplate: items["${value.title}"] as primitive`, function(assert) {
             const $element = $("<div>").appendTo("#qunit-fixture");
 
             new TabPanel($element, { items: [ value.title ] });
@@ -159,12 +159,12 @@ QUnit.module("TabPanel items", () => {
 });
 
 QUnit.module("aria accessibility", () => {
-    QUnit.test("aria role", (assert) => {
+    QUnit.test("aria role", function(assert) {
         const $element = $("#tabPanel").dxTabPanel();
         assert.equal($element.attr("role"), "tabpanel");
     });
 
-    QUnit.test("tabpanel should NOT have aria-activedescendant", (assert) => {
+    QUnit.test("tabpanel should NOT have aria-activedescendant", function(assert) {
         const $element = $("#tabPanel").dxTabPanel({ items: [1, 2] }),
             instance = $element.dxTabPanel("instance");
 

--- a/testing/tests/DevExpress.ui.widgets/tabPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabPanel.tests.js
@@ -46,7 +46,7 @@ QUnit.module("rendering", {
     }
 });
 
-QUnit.test("container should consider tabs height", (assert) => {
+QUnit.test("container should consider tabs height", function(assert) {
     const $tabPanel = $("#tabPanel").dxTabPanel({
         items: [{ text: "test" }]
     });
@@ -57,7 +57,7 @@ QUnit.test("container should consider tabs height", (assert) => {
     assert.roughEqual(parseFloat($container.css("margin-top")), -$tabs.outerHeight(), 0.5, "margin correct");
 });
 
-QUnit.test("container should consider tabs height for async datasource", (assert) => {
+QUnit.test("container should consider tabs height for async datasource", function(assert) {
     const clock = sinon.useFakeTimers();
     const $tabPanel = $("#tabPanel").dxTabPanel({
         dataSource: {
@@ -80,7 +80,7 @@ QUnit.test("container should consider tabs height for async datasource", (assert
     assert.roughEqual(parseFloat($container.css("margin-top")), -$tabs.outerHeight(), 0.5, "margin correct");
 });
 
-QUnit.test("container should consider tabs height for async templates", (assert) => {
+QUnit.test("container should consider tabs height for async templates", function(assert) {
     const clock = sinon.useFakeTimers();
     const $tabPanel = $("#tabPanel").hide().dxTabPanel({
         items: [{ text: "test" }],
@@ -96,7 +96,7 @@ QUnit.test("container should consider tabs height for async templates", (assert)
     assert.roughEqual(parseFloat($container.css("margin-top")), -$tabs.outerHeight(), 0.5, "margin correct");
 });
 
-QUnit.test("container should consider tabs height when it rendered in hiding area", (assert) => {
+QUnit.test("container should consider tabs height when it rendered in hiding area", function(assert) {
     const $tabPanel = $("<div>").dxTabPanel({
         items: [{ text: "test" }]
     });
@@ -111,7 +111,7 @@ QUnit.test("container should consider tabs height when it rendered in hiding are
 });
 
 // T803640
-QUnit.test("content should be rendered if create widget inside deferUpdate (React)", (assert) => {
+QUnit.test("content should be rendered if create widget inside deferUpdate (React)", function(assert) {
     var $tabPanel;
 
     deferUpdate(function() {
@@ -325,7 +325,7 @@ QUnit.test("'onItemHold' and 'onTitleHold' options test", function(assert) {
     this.tabWidgetMouse.up();
 });
 
-QUnit.test("click on tab should be handled correctly when the 'deferRendering' option is true", (assert) => {
+QUnit.test("click on tab should be handled correctly when the 'deferRendering' option is true", function(assert) {
     const items = [
         { text: "Greg", title: "Name" },
         { text: "31", title: "Age" },
@@ -450,7 +450,7 @@ QUnit.module("focus policy", {
     }
 });
 
-QUnit.test("focusing empty tab should not cause infinite loop", (assert) => {
+QUnit.test("focusing empty tab should not cause infinite loop", function(assert) {
     assert.expect(0);
 
     const tabPanel = new TabPanel($("<div>").appendTo("#qunit-fixture"), {
@@ -459,7 +459,7 @@ QUnit.test("focusing empty tab should not cause infinite loop", (assert) => {
     tabPanel.focus();
 });
 
-QUnit.test("click on dxTabPanel should not scroll page to the tabs", (assert) => {
+QUnit.test("click on dxTabPanel should not scroll page to the tabs", function(assert) {
     const $tabPanel = $("<div>").appendTo("#qunit-fixture");
 
     const tabPanel = new TabPanel($tabPanel, {
@@ -550,7 +550,7 @@ if(devices.current().deviceType === "desktop") {
 
 QUnit.module("aria accessibility");
 
-QUnit.test("active tab should have aria-controls attribute pointing to active multiview item", (assert) => {
+QUnit.test("active tab should have aria-controls attribute pointing to active multiview item", function(assert) {
     const $element = $("#tabPanel").dxTabPanel({
         focusStateEnabled: true,
         items: [1, 2],
@@ -575,7 +575,7 @@ QUnit.test("active tab should have aria-controls attribute pointing to active mu
 
 QUnit.module("dataSource integration");
 
-QUnit.test("dataSource loading should be fired once", (assert) => {
+QUnit.test("dataSource loading should be fired once", function(assert) {
     const deferred = $.Deferred();
     let dataSourceLoadCalled = 0;
 

--- a/testing/tests/DevExpress.ui.widgets/tabPanel.width.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabPanel.width.tests.js
@@ -95,42 +95,42 @@ class TabPanelWidthTestHelper {
 ["resizeBrowser", "container", "option"].forEach((setWidthApproach) => {
     const config = `, change ${setWidthApproach}.width`;
 
-    QUnit.test(`Tabpanel with fixed tabs, resize to show navigation button tabs${config}`, (assert) => {
+    QUnit.test(`Tabpanel with fixed tabs, resize to show navigation button tabs${config}`, function(assert) {
         let helper = new TabPanelWidthTestHelper(assert, setWidthApproach);
         helper.createTabPanel({ width: 400, expectNavButtons: 0 });
         helper.setWidth(100);
         helper.checkTabPanel({ width: 100, expectNavButtons: 2 });
     });
 
-    QUnit.test(`Tabpanel with navigation button tabs, resize to fixed tabs ${config}`, (assert) => {
+    QUnit.test(`Tabpanel with navigation button tabs, resize to fixed tabs ${config}`, function(assert) {
         let helper = new TabPanelWidthTestHelper(assert, setWidthApproach);
         helper.createTabPanel({ width: 100, expectNavButtons: 2 });
         helper.setWidth(400);
         helper.checkTabPanel({ width: 400, expectNavButtons: 0 });
     });
 
-    QUnit.test(`Tabpanel with navigation button tabs, resize to stretched tabs ${config}`, (assert) => {
+    QUnit.test(`Tabpanel with navigation button tabs, resize to stretched tabs ${config}`, function(assert) {
         let helper = new TabPanelWidthTestHelper(assert, setWidthApproach);
         helper.createTabPanel({ width: 100, expectNavButtons: 2 });
         helper.setWidth(150);
         helper.checkTabPanel({ width: 150, expectNavButtons: 0 });
     });
 
-    QUnit.test(`Tabpanel with fixed tabs, resize to stretched tabs ${config}`, (assert) => {
+    QUnit.test(`Tabpanel with fixed tabs, resize to stretched tabs ${config}`, function(assert) {
         let helper = new TabPanelWidthTestHelper(assert, setWidthApproach);
         helper.createTabPanel({ width: 400, expectNavButtons: 0 });
         helper.setWidth(150);
         helper.checkTabPanel({ width: 150, expectNavButtons: 0 });
     });
 
-    QUnit.test(`Tabpanel with stretched tabs, resize to fixed tabs ${config}`, (assert) => {
+    QUnit.test(`Tabpanel with stretched tabs, resize to fixed tabs ${config}`, function(assert) {
         let helper = new TabPanelWidthTestHelper(assert, setWidthApproach);
         helper.createTabPanel({ width: 150, expectNavButtons: 0 });
         helper.setWidth(400);
         helper.checkTabPanel({ width: 400, expectNavButtons: 0 });
     });
 
-    QUnit.test(`Tabpanel with stretched tabs, resize to navigation buttons tabs ${config}`, (assert) => {
+    QUnit.test(`Tabpanel with stretched tabs, resize to navigation buttons tabs ${config}`, function(assert) {
         let helper = new TabPanelWidthTestHelper(assert, setWidthApproach);
         helper.createTabPanel({ width: 150, expectNavButtons: 0 });
         helper.setWidth(100);

--- a/testing/tests/DevExpress.ui.widgets/tabs.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabs.markup.tests.js
@@ -17,7 +17,7 @@ const TABS_CLASS = "dx-tabs",
 const toSelector = cssClass => "." + cssClass;
 
 QUnit.module("Tabs markup", () => {
-    QUnit.test("tabs should have correct class", (assert) => {
+    QUnit.test("tabs should have correct class", function(assert) {
         const $tabsElement = $("#tabs").dxTabs({
             items: ["1", "2", "3"]
         });
@@ -25,7 +25,7 @@ QUnit.module("Tabs markup", () => {
         assert.ok($tabsElement.hasClass(TABS_CLASS), "tabs has correct class");
     });
 
-    QUnit.test("tabs should have wrapper with correct class", (assert) => {
+    QUnit.test("tabs should have wrapper with correct class", function(assert) {
         const $tabsElement = $("#tabs").dxTabs({
             items: ["1", "2", "3"]
         });
@@ -33,7 +33,7 @@ QUnit.module("Tabs markup", () => {
         assert.ok($tabsElement.find(toSelector(TABS_WRAPPER_CLASS)).length, "tabs has wrapper");
     });
 
-    QUnit.test("items rendering", (assert) => {
+    QUnit.test("items rendering", function(assert) {
         const tabsElement = $("#tabs").dxTabs({
             items: [
                 { text: "0", icon: "custom" },
@@ -58,7 +58,7 @@ QUnit.module("Tabs markup", () => {
 });
 
 QUnit.module("Badges", () => {
-    QUnit.test("item badge render", (assert) => {
+    QUnit.test("item badge render", function(assert) {
         const $element = $("#widget").dxTabs({
             items: [
                 { text: "user", badge: 1 },
@@ -73,7 +73,7 @@ QUnit.module("Badges", () => {
 });
 
 QUnit.module("Widget sizing render", () => {
-    QUnit.test("constructor", (assert) => {
+    QUnit.test("constructor", function(assert) {
         const $element = $("#widget").dxTabs({
                 items: [
                     { text: "user" },
@@ -89,7 +89,7 @@ QUnit.module("Widget sizing render", () => {
         assert.strictEqual($element[0].style.width, 400 + "px", "outer width of the element must be equal to custom width");
     });
 
-    QUnit.test("root with custom width", (assert) => {
+    QUnit.test("root with custom width", function(assert) {
         const $element = $("#widthRootStyle").dxTabs({
                 items: [
                     { text: "user" },
@@ -108,7 +108,7 @@ QUnit.module("Widget sizing render", () => {
 
 var helper;
 QUnit.module("Aria accessibility", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.items = [{ text: "Item_1" }, { text: "Item_2" }, { text: "Item_3" }];
         helper = new ariaAccessibilityTestHelper({
             createWidget: ($element, options) => new Tabs($element, $.extend({
@@ -116,25 +116,25 @@ QUnit.module("Aria accessibility", {
             }, options))
         });
     },
-    afterEach: () => {
+    afterEach: function() {
         helper.$widget.remove();
     }
 }, () => {
-    QUnit.test(`3 items`, () => {
+    QUnit.test(`3 items`, function() {
         helper.createWidget({ items: this.items });
 
         helper.checkAttributes(helper.$widget, { role: "tablist", tabindex: "0" }, "widget");
         helper.checkItemsAttributes([], { attributes: ["aria-selected"], role: "tab" });
     });
 
-    QUnit.test(`3 items, selectedIndex: 1`, () => {
+    QUnit.test(`3 items, selectedIndex: 1`, function() {
         helper.createWidget({ items: this.items, selectedIndex: 1 });
 
         helper.checkAttributes(helper.$widget, { role: "tablist", tabindex: "0" }, "widget");
         helper.checkItemsAttributes([1], { attributes: ["aria-selected"], role: "tab" });
     });
 
-    QUnit.test(`3 items, selectedIndex: 1, set focusedElement: items[1] -> clean focusedElement`, () => {
+    QUnit.test(`3 items, selectedIndex: 1, set focusedElement: items[1] -> clean focusedElement`, function() {
         helper.createWidget({ items: this.items, selectedIndex: 1 });
 
         helper.widget.option("focusedElement", helper.getItems().eq(1));
@@ -150,7 +150,7 @@ QUnit.module("Aria accessibility", {
 const TABS_ITEM_TEXT_CLASS = "dx-tab-text";
 
 const moduleConfig = {
-    beforeEach: () => {
+    beforeEach: function() {
         this.prepareItemTest = (data) => {
             const tabs = new Tabs($("<div>"), {
                 items: [data]
@@ -162,31 +162,31 @@ const moduleConfig = {
 };
 
 QUnit.module("Default template", moduleConfig, () => {
-    QUnit.test("template should be rendered correctly with text", (assert) => {
+    QUnit.test("template should be rendered correctly with text", function(assert) {
         const $content = this.prepareItemTest("custom");
 
         assert.equal($content.text(), "custom");
     });
 
-    QUnit.test("template should be rendered correctly with boolean", (assert) => {
+    QUnit.test("template should be rendered correctly with boolean", function(assert) {
         const $content = this.prepareItemTest(true);
 
         assert.equal($.trim($content.text()), "true");
     });
 
-    QUnit.test("template should be rendered correctly with number", (assert) => {
+    QUnit.test("template should be rendered correctly with number", function(assert) {
         const $content = this.prepareItemTest(1);
 
         assert.equal($.trim($content.text()), "1");
     });
 
-    QUnit.test("template should be rendered correctly with text", (assert) => {
+    QUnit.test("template should be rendered correctly with text", function(assert) {
         const $content = this.prepareItemTest({ text: "custom" });
 
         assert.equal($.trim($content.text()), "custom");
     });
 
-    QUnit.test("template should be rendered correctly with html", (assert) => {
+    QUnit.test("template should be rendered correctly with html", function(assert) {
         const $content = this.prepareItemTest({ html: "<span>test</span>" });
 
         const $span = $content.is("span") ? $content : $content.children();
@@ -194,13 +194,13 @@ QUnit.module("Default template", moduleConfig, () => {
         assert.equal($span.text(), "test");
     });
 
-    QUnit.test("template should be rendered correctly with htmlstring", (assert) => {
+    QUnit.test("template should be rendered correctly with htmlstring", function(assert) {
         const $content = this.prepareItemTest("<span>test</span>");
 
         assert.equal($content.text(), "<span>test</span>");
     });
 
-    QUnit.test("template should be rendered correctly with html & text", (assert) => {
+    QUnit.test("template should be rendered correctly with html & text", function(assert) {
         const $content = this.prepareItemTest({ text: "text", html: "<span>test</span>" });
 
         const $span = $content.is("span") ? $content : $content.children();
@@ -209,37 +209,37 @@ QUnit.module("Default template", moduleConfig, () => {
         assert.equal($content.text(), "test");
     });
 
-    QUnit.test("template should be rendered correctly with tab text wrapper for data with text field", (assert) => {
+    QUnit.test("template should be rendered correctly with tab text wrapper for data with text field", function(assert) {
         const $content = this.prepareItemTest({ text: "test" });
 
         assert.equal($content.filter("." + TABS_ITEM_TEXT_CLASS).text(), "test");
     });
 
-    QUnit.test("template should be rendered correctly with tab text wrapper for string data", (assert) => {
+    QUnit.test("template should be rendered correctly with tab text wrapper for string data", function(assert) {
         const $content = this.prepareItemTest("test");
 
         assert.equal($content.filter("." + TABS_ITEM_TEXT_CLASS).text(), "test");
     });
 
-    QUnit.test("template should be rendered correctly with tab text wrapper for string data", (assert) => {
+    QUnit.test("template should be rendered correctly with tab text wrapper for string data", function(assert) {
         const $content = this.prepareItemTest("test");
 
         assert.equal($content.filter("." + TABS_ITEM_TEXT_CLASS).text(), "test");
     });
 
-    QUnit.test("template should be rendered correctly with icon", (assert) => {
+    QUnit.test("template should be rendered correctly with icon", function(assert) {
         const $content = this.prepareItemTest({ icon: "test" });
 
         assert.equal($content.filter(".dx-icon-test").length, 1);
     });
 
-    QUnit.test("template should be rendered correctly with icon path", (assert) => {
+    QUnit.test("template should be rendered correctly with icon path", function(assert) {
         const $content = this.prepareItemTest({ icon: "test.jpg" });
 
         assert.equal($content.filter(".dx-icon").attr("src"), "test.jpg");
     });
 
-    QUnit.test("template should be rendered correctly with external icon", (assert) => {
+    QUnit.test("template should be rendered correctly with external icon", function(assert) {
         const $content = this.prepareItemTest({ icon: "fa fa-icon" });
 
         assert.equal($content.filter(".fa.fa-icon").length, 1);

--- a/testing/tests/DevExpress.ui.widgets/tabs.width.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabs.width.tests.js
@@ -166,7 +166,7 @@ class TabsWidthTestHelper {
     });
 });
 
-QUnit.test("Does not render navbuttons: dx-tabs{ max-width: 413px; } .dx-tab{ width: 100px; }", (assert) => {
+QUnit.test("Does not render navbuttons: dx-tabs{ max-width: 413px; } .dx-tab{ width: 100px; }", function(assert) {
     var styles = '<style>.dx-tabs{ max-width: 413px; } .dx-tab{ width: 100px; }</style>';
 
     $("#qunit-fixture").html(styles);
@@ -194,7 +194,7 @@ QUnit.test("Does not render navbuttons: dx-tabs{ max-width: 413px; } .dx-tab{ wi
     $("#qunit-fixture").html("");
 });
 
-QUnit.test("Render navbuttons: dx-tabs{ max-width: 380px; } .dx-tab{ width: 100px; }", (assert) => {
+QUnit.test("Render navbuttons: dx-tabs{ max-width: 380px; } .dx-tab{ width: 100px; }", function(assert) {
     var styles = '<style>.dx-tabs{ max-width: 380px; } .dx-tab{ width: 100px; }</style>';
 
     $("#qunit-fixture").html(styles);

--- a/testing/tests/DevExpress.ui.widgets/toolbar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.markup.tests.js
@@ -234,7 +234,7 @@ QUnit.module("render", {
         assert.equal(this.element.find("#toolbar2 #2").length, 1, "#toolbar2 #2");
     });
 
-    test("Clear timer for the animation in the Material theme", (assert) => {
+    test("Clear timer for the animation in the Material theme", function(assert) {
         this.origIsMaterial = themes.isMaterial;
         themes.isMaterial = function() { return true; };
         this.element.dxToolbar({});

--- a/testing/tests/DevExpress.ui.widgets/toolbar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.markup.tests.js
@@ -36,11 +36,11 @@ const prepareItemTest = function(itemData) {
 };
 
 QUnit.module("render", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.element = $("#toolbar");
     }
 }, () => {
-    test("containers", (assert) => {
+    test("containers", function(assert) {
         this.element.dxToolbar({});
 
         let beforeContainer = this.element.find("." + TOOLBAR_BEFORE_CONTAINER_CLASS);
@@ -53,7 +53,7 @@ QUnit.module("render", {
         assert.equal(centerContainer.length, 1);
     });
 
-    test("render dropDownMenu", (assert) => {
+    test("render dropDownMenu", function(assert) {
         this.element.dxToolbar({
             items: [
                 { location: "after", locateInMenu: "always", widget: "button", options: { text: "After Button" } }
@@ -66,7 +66,7 @@ QUnit.module("render", {
         assert.ok($toolbarMenuContainer.children().hasClass(DROP_DOWN_MENU_CLASS), "DropDownMenu rendered");
     });
 
-    test("items - widgets", (assert) => {
+    test("items - widgets", function(assert) {
         this.element.dxToolbar({
             items: [
                 { location: "before", widget: "button", options: { text: "Before Button" } },
@@ -88,7 +88,7 @@ QUnit.module("render", {
 
     });
 
-    test("items - label", (assert) => {
+    test("items - label", function(assert) {
         this.element.dxToolbar({
             items: [
                 { location: "center", text: "Label" }
@@ -102,7 +102,7 @@ QUnit.module("render", {
         assert.ok(label.hasClass(TOOLBAR_LABEL_CLASS));
     });
 
-    test("items - custom html", (assert) => {
+    test("items - custom html", function(assert) {
         this.element.dxToolbar({
             items: [
                 { location: "center", html: "<b>Label</b>" }
@@ -115,7 +115,7 @@ QUnit.module("render", {
         assert.ok(this.element.find("." + TOOLBAR_ITEM_CLASS).hasClass(TOOLBAR_LABEL_CLASS));
     });
 
-    test("items - location", (assert) => {
+    test("items - location", function(assert) {
         let element = this.element.dxToolbar({
             items: [
                 { location: "before", text: "before" },
@@ -129,7 +129,7 @@ QUnit.module("render", {
         });
     });
 
-    test("items - location", (assert) => {
+    test("items - location", function(assert) {
         let element = this.element.dxToolbar({
             items: [
                 { location: "before", text: "before" },
@@ -143,7 +143,7 @@ QUnit.module("render", {
         });
     });
 
-    test("add a custom CSS class to item", (assert) => {
+    test("add a custom CSS class to item", function(assert) {
         this.element.dxToolbar({
             items: [
                 { location: "before", cssClass: "test-before" },
@@ -162,7 +162,7 @@ QUnit.module("render", {
         });
     });
 
-    test("items with nested toolbar config 1", (assert) => {
+    test("items with nested toolbar config 1", function(assert) {
         this.element.dxToolbar({
             items: [
                 {
@@ -183,7 +183,7 @@ QUnit.module("render", {
         assert.equal(this.element.find("#toolbar2 #2").length, 1, "#toolbar2 #2");
     });
 
-    test("items with nested toolbar config 2", (assert) => {
+    test("items with nested toolbar config 2", function(assert) {
         this.element.dxToolbar({
             items: [
                 { html: '<div id="1">1</div>' },
@@ -204,7 +204,7 @@ QUnit.module("render", {
         assert.equal(this.element.find("#toolbar2 #2").length, 1, "#toolbar2 #2");
     });
 
-    test("items with nested toolbar config 3", (assert) => {
+    test("items with nested toolbar config 3", function(assert) {
         this.element.dxToolbar({
             items: [
                 {
@@ -266,11 +266,11 @@ QUnit.test("elementAttr should be rendered on button items", function(assert) {
 });
 
 QUnit.module("option change handlers", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.element = $("#toolbar");
     }
 }, () => {
-    test("items", (assert) => {
+    test("items", function(assert) {
         let instance = this.element.dxToolbar({ items: [{ location: "center", text: "0" }] }).dxToolbar("instance");
 
         instance.option("items", [{ location: "center", text: "1" }]);
@@ -279,12 +279,12 @@ QUnit.module("option change handlers", {
 });
 
 QUnit.module("regressions", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.element = $("#toolbar").dxToolbar({});
         this.instance = this.element.dxToolbar("instance");
     }
 }, () => {
-    test("B231277", (assert) => {
+    test("B231277", function(assert) {
         this.instance.option("items", [{ location: "center" }]);
         assert.equal($.trim(this.element.text()), "");
 
@@ -297,7 +297,7 @@ QUnit.module("regressions", {
 });
 
 QUnit.module("aria accessibility", () => {
-    test("aria role", (assert) => {
+    test("aria role", function(assert) {
         let $element = $("#toolbar").dxToolbar();
 
         assert.equal($element.attr("role"), "toolbar", "role is correct");
@@ -305,7 +305,7 @@ QUnit.module("aria accessibility", () => {
 });
 
 QUnit.module("item groups", {
-    beforeEach: () => {
+    beforeEach: function() {
         this.$element = $("#toolbar");
         this.groups = [
             {
@@ -332,7 +332,7 @@ QUnit.module("item groups", {
         ];
     }
 }, () => {
-    test("toolbar should show item groups", (assert) => {
+    test("toolbar should show item groups", function(assert) {
         let $element = this.$element.dxToolbar({
                 items: this.groups,
                 grouped: true,
@@ -344,7 +344,7 @@ QUnit.module("item groups", {
         assert.equal($groups.eq(1).find("." + TOOLBAR_ITEM_CLASS).length, 3, "second group contains 3 items");
     });
 
-    test("toolbar groups should be placed inside toolbar blocks", (assert) => {
+    test("toolbar groups should be placed inside toolbar blocks", function(assert) {
         let $element = this.$element.dxToolbar({
                 items: this.groups,
                 grouped: true
@@ -360,31 +360,31 @@ QUnit.module("item groups", {
 });
 
 QUnit.module("default template", () => {
-    test("template should be rendered correctly with text", (assert) => {
+    test("template should be rendered correctly with text", function(assert) {
         let $content = prepareItemTest("custom");
 
         assert.equal($content.text(), "custom");
     });
 
-    test("template should be rendered correctly with boolean", (assert) => {
+    test("template should be rendered correctly with boolean", function(assert) {
         let $content = prepareItemTest(true);
 
         assert.equal($.trim($content.text()), "true");
     });
 
-    test("template should be rendered correctly with number", (assert) => {
+    test("template should be rendered correctly with number", function(assert) {
         let $content = prepareItemTest(1);
 
         assert.equal($.trim($content.text()), "1");
     });
 
-    test("template should be rendered correctly with text", (assert) => {
+    test("template should be rendered correctly with text", function(assert) {
         let $content = prepareItemTest({ text: "custom" });
 
         assert.equal($.trim($content.text()), "custom");
     });
 
-    test("template should be rendered correctly with html", (assert) => {
+    test("template should be rendered correctly with html", function(assert) {
         let $content = prepareItemTest({ html: "<span>test</span>" });
 
         let $span = $content.is("span") ? $content : $content.children();
@@ -392,13 +392,13 @@ QUnit.module("default template", () => {
         assert.equal($span.text(), "test");
     });
 
-    test("template should be rendered correctly with htmlstring", (assert) => {
+    test("template should be rendered correctly with htmlstring", function(assert) {
         let $content = prepareItemTest("<span>test</span>");
 
         assert.equal($content.text(), "<span>test</span>");
     });
 
-    test("template should be rendered correctly with html & text", (assert) => {
+    test("template should be rendered correctly with html & text", function(assert) {
         let $content = prepareItemTest({ text: "text", html: "<span>test</span>" });
 
         let $span = $content.is("span") ? $content : $content.children();
@@ -407,21 +407,21 @@ QUnit.module("default template", () => {
         assert.equal($content.text(), "test");
     });
 
-    test("template should be rendered correctly with button without options", (assert) => {
+    test("template should be rendered correctly with button without options", function(assert) {
         let $content = prepareItemTest({ widget: "button" });
 
         let button = $content.filter(".dx-button");
         assert.equal(button.length, 1);
     });
 
-    test("template should be rendered correctly with dxbutton without options", (assert) => {
+    test("template should be rendered correctly with dxbutton without options", function(assert) {
         let $content = prepareItemTest({ widget: "dxButton" });
 
         let button = $content.filter(".dx-button");
         assert.equal(button.length, 1);
     });
 
-    test("template should be rendered correctly with button", (assert) => {
+    test("template should be rendered correctly with button", function(assert) {
         let $content = prepareItemTest({ widget: "button", options: { text: "test" } });
 
         let button = $content.filter(".dx-button");
@@ -429,7 +429,7 @@ QUnit.module("default template", () => {
         assert.equal($.trim(button.text()), "test");
     });
 
-    test("template should be rendered correctly with dxtabs", (assert) => {
+    test("template should be rendered correctly with dxtabs", function(assert) {
         let $content = prepareItemTest({ widget: "dxTabs", options: { items: [{ text: "test" }] } });
 
         let tabs = $content.filter(".dx-tabs");
@@ -439,7 +439,7 @@ QUnit.module("default template", () => {
         assert.equal($.trim(tabs.text()), "test");
     });
 
-    test("template should be rendered correctly with tabs", (assert) => {
+    test("template should be rendered correctly with tabs", function(assert) {
         let $content = prepareItemTest({ widget: "tabs", options: { items: [{ text: "test" }] } });
 
         let tabs = $content.filter(".dx-tabs");
@@ -449,7 +449,7 @@ QUnit.module("default template", () => {
         assert.equal($.trim(tabs.text()), "test");
     });
 
-    test("template should be rendered correctly with dropDownMenu", (assert) => {
+    test("template should be rendered correctly with dropDownMenu", function(assert) {
         let $content = prepareItemTest({ widget: "dropDownMenu", options: { items: [{ text: "test" }] } });
 
         let dropDown = $content.filter(".dx-dropdownmenu");

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -1250,7 +1250,7 @@ QUnit.test("add a custom CSS to item of menu", function(assert) {
     assert.equal($("." + TOOLBAR_MENU_SECTION_CLASS + " ." + LIST_ITEM_CLASS + ".test").length, 1, "item with the custom CSS");
 });
 
-QUnit.test("dropDown should use default container", (assert) => {
+QUnit.test("dropDown should use default container", function(assert) {
     const $element = $("#widget").dxToolbar({
         items: [
             {
@@ -1266,7 +1266,7 @@ QUnit.test("dropDown should use default container", (assert) => {
     assert.strictEqual($element.find(`.${DROP_DOWN_MENU_POPUP_WRAPPER_CLASS}`).length, 0, "Toolbar's container isn't contains a dropDown list");
 });
 
-QUnit.test("init Toolbar with new menuContainer", (assert) => {
+QUnit.test("init Toolbar with new menuContainer", function(assert) {
     const $element = $("#widget");
 
     $element.dxToolbar({
@@ -1285,7 +1285,7 @@ QUnit.test("init Toolbar with new menuContainer", (assert) => {
     assert.strictEqual($element.find(`.${DROP_DOWN_MENU_POPUP_WRAPPER_CLASS}`).length, 1, "Toolbar's container contains a dropDown list");
 });
 
-QUnit.test("change Toolbar menuContainer", (assert) => {
+QUnit.test("change Toolbar menuContainer", function(assert) {
     const $element = $("#widget");
 
     const instance = $element.dxToolbar({

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/accessibility.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/accessibility.js
@@ -8,7 +8,7 @@ const { module, test } = QUnit;
 var helper;
 [true, false].forEach((searchEnabled) => {
     module(`Aria accessibility, searchEnabled: ${searchEnabled}`, {
-        beforeEach: () => {
+        beforeEach: function() {
             this.items = [{ id: 1, text: "Item_1", expanded: true, items: [{ id: 3, text: "Item_1_1" }, { id: 4, text: "Item_1_2" }] }, { id: 2, text: "Item_2", expanded: false }];
             helper = new ariaAccessibilityTestHelper({
                 createWidget: ($element, options) => new TreeView($element,
@@ -21,12 +21,12 @@ var helper;
             });
             this.clock = sinon.useFakeTimers();
         },
-        afterEach: () => {
+        afterEach: function() {
             this.clock.restore();
             helper.$widget.remove();
         }
     }, () => {
-        test(`Selected: [], selectionMode: "single"`, () => {
+        test(`Selected: [], selectionMode: "single"`, function() {
             helper.createWidget({ items: this.items, selectionMode: "single" });
 
             if(searchEnabled) {
@@ -40,7 +40,7 @@ var helper;
             helper.checkItemsAttributes([], { });
         });
 
-        test(`Selected: [], change searchEnabled after initialize"`, () => {
+        test(`Selected: [], change searchEnabled after initialize"`, function() {
             helper.createWidget({ items: this.items, selectionMode: "single" });
             helper.widget.option("searchEnabled", !searchEnabled);
 
@@ -55,7 +55,7 @@ var helper;
             helper.checkItemsAttributes([], { });
         });
 
-        test(`Selected: ["Item_1"], selectionMode: "single"`, () => {
+        test(`Selected: ["Item_1"], selectionMode: "single"`, function() {
             this.items[0].selected = true;
 
             helper.createWidget({ items: this.items, selectionMode: "single" });
@@ -65,7 +65,7 @@ var helper;
             helper.checkItemsAttributes([0], { });
         });
 
-        test(`Selected: ["Item_1_1"], selectionMode: "single", Item_1.expanded: true, collapseItem(["Item_1"]) -> expand(["Item_1"])`, () => {
+        test(`Selected: ["Item_1_1"], selectionMode: "single", Item_1.expanded: true, collapseItem(["Item_1"]) -> expand(["Item_1"])`, function() {
             this.items[0].items[0].selected = true;
 
             helper.createWidget({ items: this.items, selectionMode: "single" });
@@ -84,7 +84,7 @@ var helper;
             helper.checkItemsAttributes([1], { });
         });
 
-        test(`Selected: ["Item_1"], selectionMode: "single", Item_1.expanded: false, expand(["Item_1"]) -> collapseItem(["Item_1"])`, () => {
+        test(`Selected: ["Item_1"], selectionMode: "single", Item_1.expanded: false, expand(["Item_1"]) -> collapseItem(["Item_1"])`, function() {
             this.items[0].selected = true;
             this.items[0].expanded = false;
 
@@ -104,7 +104,7 @@ var helper;
             helper.checkItemsAttributes([0], { });
         });
 
-        test(`Selected: ["Item_1_1"], selectionMode: "single", collapseItem(["Item_1"]) -> expand(["Item_1"])`, () => {
+        test(`Selected: ["Item_1_1"], selectionMode: "single", collapseItem(["Item_1"]) -> expand(["Item_1"])`, function() {
             this.items[0].items[0].selected = true;
 
             helper.createWidget({ items: this.items, selectionMode: "single" });
@@ -123,7 +123,7 @@ var helper;
             helper.checkItemsAttributes([1], { });
         });
 
-        test(`Selected: [], selectionMode: "single", selectItem(["Item_1"])`, () => {
+        test(`Selected: [], selectionMode: "single", selectItem(["Item_1"])`, function() {
             helper.createWidget({ items: this.items, selectionMode: "single" });
             helper.widget.selectItem(1);
 
@@ -132,7 +132,7 @@ var helper;
             helper.checkItemsAttributes([0], { });
         });
 
-        test(`Selected: [], selectionMode: "single", click checkbox ["Item_1"] -> ["Item_1_1"]`, () => {
+        test(`Selected: [], selectionMode: "single", click checkbox ["Item_1"] -> ["Item_1_1"]`, function() {
             helper.createWidget({ items: this.items, selectionMode: "single" });
 
             eventsEngine.trigger(helper.getItems().eq(0).prev(), "dxclick");
@@ -148,7 +148,7 @@ var helper;
             helper.checkItemsAttributes([1], { focusedNodeIndex: 1, });
         });
 
-        test(`Selected: [], selectionMode: "multiple", selectNodesRecursive: true, click checkbox ["Item_1"] -> ["Item_1_1"]`, () => {
+        test(`Selected: [], selectionMode: "multiple", selectNodesRecursive: true, click checkbox ["Item_1"] -> ["Item_1_1"]`, function() {
             helper.createWidget({ items: this.items, selectionMode: "multiple", selectNodesRecursive: true });
 
             eventsEngine.trigger(helper.getItems().eq(0).prev(), "dxclick");
@@ -164,7 +164,7 @@ var helper;
             helper.checkItemsAttributes([0, 2], { focusedNodeIndex: 1, selectionMode: "multiple" });
         });
 
-        test(`Selected: ["Item_1", "Item_1_1"], selectionMode: "multiple", selectNodesRecursive: false, unselectItem(["Item_1"]) -> selectItem(["Item_1_2"])`, () => {
+        test(`Selected: ["Item_1", "Item_1_1"], selectionMode: "multiple", selectNodesRecursive: false, unselectItem(["Item_1"]) -> selectItem(["Item_1_2"])`, function() {
             this.items[0].items[0].selected = true;
             this.items[0].selected = true;
 
@@ -181,7 +181,7 @@ var helper;
             helper.checkItemsAttributes([1, 2], { selectionMode: "multiple" });
         });
 
-        test(`Selected: [], selectionMode: "single" -> focusin -> focusout`, () => {
+        test(`Selected: [], selectionMode: "single" -> focusin -> focusout`, function() {
             helper.createWidget({ items: this.items, selectionMode: "single" });
 
             if(searchEnabled) {
@@ -200,7 +200,7 @@ var helper;
             helper.checkItemsAttributes([], { focusedNodeIndex: 0 });
         });
 
-        test(`Selected: [], selectionMode: "single" -> set focusedElement -> clean focusedElement`, () => {
+        test(`Selected: [], selectionMode: "single" -> set focusedElement -> clean focusedElement`, function() {
             helper.createWidget({ items: this.items, selectionMode: "single" });
 
             helper.widget.option("focusedElement", helper.getItems().eq(2).closest(".dx-treeview-node"));

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/expandedItems.js
@@ -31,7 +31,7 @@ module("Expanded items", {
         this.clock.restore();
     }
 }, () => {
-    test("Some item has'expanded' field", assert => {
+    test("Some item has'expanded' field", function(assert) {
         const data = $.extend(true, [], DATA[5]);
         data[0].items[1].expanded = true;
         const $treeView = initTree({
@@ -41,7 +41,7 @@ module("Expanded items", {
         assert.equal($treeView.find("." + internals.OPENED_NODE_CONTAINER_CLASS).length, 3);
     });
 
-    test("expansion by itemData", assert => {
+    test("expansion by itemData", function(assert) {
         const data = [
             { id: 1, text: "Item 1", expanded: false, items: [{ id: 11, text: "Item 11" }] }, { id: 12, text: "Item 12" }
         ];
@@ -54,7 +54,7 @@ module("Expanded items", {
         assert.notOk(data[0].expanded, "item is not expanded");
     });
 
-    test("onItemExpanded callback", assert => {
+    test("onItemExpanded callback", function(assert) {
         const data = $.extend(true, [], DATA[5]),
             itemExpandedHandler = sinon.spy(noop),
             $treeView = initTree({
@@ -80,7 +80,7 @@ module("Expanded items", {
         });
     });
 
-    test("hidden items should be rendered when deferRendering is false", assert => {
+    test("hidden items should be rendered when deferRendering is false", function(assert) {
         const $treeView = initTree({
             items: [{ text: "Item 1", items: [{ text: "Item 11", items: [{ text: "Item 111" }] }] }],
             deferRendering: false
@@ -89,7 +89,7 @@ module("Expanded items", {
         assert.equal($treeView.find(".dx-treeview-node").length, 3, "all items have been rendered");
     });
 
-    test("onContentReady rises after first expand", assert => {
+    test("onContentReady rises after first expand", function(assert) {
         const data = $.extend(true, [], DATA[5]);
         const onContentReadyHandler = sinon.spy(noop);
         const $treeView = initTree({
@@ -109,7 +109,7 @@ module("Expanded items", {
         assert.equal(onContentReadyHandler.callCount, 2);
     });
 
-    test("onItemExpanded callback after click should have correct arguments", assert => {
+    test("onItemExpanded callback after click should have correct arguments", function(assert) {
         assert.expect(4);
 
         const data = $.extend(true, [], DATA[5]);
@@ -132,7 +132,7 @@ module("Expanded items", {
         });
     });
 
-    test("onItemCollapsed callback", assert => {
+    test("onItemCollapsed callback", function(assert) {
         const data = $.extend(true, [], DATA[5]);
         data[0].expanded = true;
         const itemCollapsedHandler = sinon.spy(noop);
@@ -157,7 +157,7 @@ module("Expanded items", {
         });
     });
 
-    test("onItemCollapsed callback after click should have correct arguments", assert => {
+    test("onItemCollapsed callback after click should have correct arguments", function(assert) {
         assert.expect(4);
 
         const data = $.extend(true, [], DATA[5]);
@@ -182,7 +182,7 @@ module("Expanded items", {
         });
     });
 
-    test("disabled item should not expand on click", assert => {
+    test("disabled item should not expand on click", function(assert) {
         const data = $.extend(true, [], DATA[5]);
         data[0].disabled = true;
         const $treeView = initTree({
@@ -197,7 +197,7 @@ module("Expanded items", {
         assert.ok(!treeView.option("items")[0].expanded, "disabled item was not expanded");
     });
 
-    test("expanded disabled item should not collapse on click", assert => {
+    test("expanded disabled item should not collapse on click", function(assert) {
         const data = $.extend(true, [], DATA[5]);
         data[0].expanded = true;
         data[0].disabled = true;
@@ -213,7 +213,7 @@ module("Expanded items", {
         assert.ok(treeView.option("items")[0].expanded, "disabled item was not expanded");
     });
 
-    test("expanded item shouldn't collapse after setting .disable for it", assert => {
+    test("expanded item shouldn't collapse after setting .disable for it", function(assert) {
         const data = $.extend(true, [], DATA[5]);
         data[0].expanded = true;
 
@@ -245,7 +245,7 @@ module("Expanded items", {
         assert.ok($toggleExpandIcon.hasClass("dx-treeview-toggle-item-visibility-opened"));
     });
 
-    test("itemExpanded should be fired when expanding item", assert => {
+    test("itemExpanded should be fired when expanding item", function(assert) {
         const data = $.extend(true, [], DATA[5]);
 
         const $treeView = initTree({
@@ -259,7 +259,7 @@ module("Expanded items", {
         $toggleExpandIcon.trigger("dxclick");
     });
 
-    test("itemCollapsed should be fired when collapsing item by click", assert => {
+    test("itemCollapsed should be fired when collapsing item by click", function(assert) {
         const data = $.extend(true, [], DATA[5]);
         data[0].items[1].expanded = true;
         const $treeView = initTree({
@@ -274,7 +274,7 @@ module("Expanded items", {
         $item.trigger("dxclick");
     });
 
-    test("item should expand by click when expansion by click enabled", assert => {
+    test("item should expand by click when expansion by click enabled", function(assert) {
         const items = [{ text: "Item 1", items: [{ text: "Item 11" }] }];
         const $treeView = initTree({
             items: items,
@@ -286,7 +286,7 @@ module("Expanded items", {
         assert.ok(items[0].expanded, "item is expanded");
     });
 
-    test("item should collapse by click when expansion by click enabled", assert => {
+    test("item should collapse by click when expansion by click enabled", function(assert) {
         const items = [{ text: "Item 1", items: [{ text: "Item 11" }] }];
         const $treeView = initTree({
             items: items,
@@ -299,7 +299,7 @@ module("Expanded items", {
         assert.notOk(items[0].expanded, "item is collapsed");
     });
 
-    test("item should not expand by click when expansion by click disabling", assert => {
+    test("item should not expand by click when expansion by click disabling", function(assert) {
         const items = [{ text: "Item 1", items: [{ text: "Item 11" }] }];
         const $treeView = initTree({
             items: items,
@@ -314,7 +314,7 @@ module("Expanded items", {
         assert.notOk(items[0].expanded, "item is collapsed");
     });
 
-    test("collapseAll method should collapse all expanded items", assert => {
+    test("collapseAll method should collapse all expanded items", function(assert) {
         const items = [{ text: "Item 1", expanded: true, items: [{ text: "Item 11" }] }];
         const $treeView = initTree({
             items: items
@@ -326,7 +326,7 @@ module("Expanded items", {
         assert.notOk(items[0].expanded, "item is collapsed");
     });
 
-    test("onItemExpanded should not fire if item is leaf", assert => {
+    test("onItemExpanded should not fire if item is leaf", function(assert) {
         const items = [{ text: "Item 1" }];
         let itemExpanded = 0;
         const $treeView = initTree({
@@ -341,7 +341,7 @@ module("Expanded items", {
         assert.equal(itemExpanded, 0, "event was not fired");
     });
 
-    test("not expand parent items in non-recursive case", assert => {
+    test("not expand parent items in non-recursive case", function(assert) {
         const items = [{ text: "1", id: 1, items: [{ text: "11", id: 11, items: [{ text: "111", id: 111 }] }] }];
         const $treeView = initTree({
             items: items,
@@ -364,7 +364,7 @@ module("Expanded items", {
         assert.equal($items.length, 3, "root item was expanded");
     });
 
-    test("expand parent items in recursive case", assert => {
+    test("expand parent items in recursive case", function(assert) {
         const items = [{ text: "1", id: 1, items: [{ text: "11", id: 11, items: [{ text: "111", id: 111 }] }] }];
         const $treeView = initTree({
             items: items
@@ -381,7 +381,7 @@ module("Expanded items", {
         assert.ok(nodes[0].children[0].expanded, "child node is expanded");
     });
 
-    test("Expand parent items in markup after expand of rendered nested child (T671960)", assert => {
+    test("Expand parent items in markup after expand of rendered nested child (T671960)", function(assert) {
         const items = [{
             text: "1",
             id: 1,
@@ -408,7 +408,7 @@ module("Expanded items", {
         assert.ok(nodeElements.eq(2).hasClass(TREEVIEW_NODE_CONTAINER_OPENED_CLASS), "item 111");
     });
 
-    test("expand childless item in recursive case", assert => {
+    test("expand childless item in recursive case", function(assert) {
         const items = [{ text: "1", id: 1, items: [{ text: "11", id: 11 }] }];
         const $treeView = initTree({
             items: items
@@ -425,7 +425,7 @@ module("Expanded items", {
         assert.ok(nodes[0].children[0].expanded, "child node is expanded");
     });
 
-    test("Expand all method", assert => {
+    test("Expand all method", function(assert) {
         const items = [{
             text: "1",
             id: 1,
@@ -451,7 +451,7 @@ module("Expanded items", {
         assert.ok(nodes[0].items[0].items[0].expanded, "item 111");
     });
 
-    test("Collapse all method", assert => {
+    test("Collapse all method", function(assert) {
         const items = [{
             text: "1",
             id: 1,

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/selection.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/selection.js
@@ -8,7 +8,7 @@ let { module, test } = QUnit;
 const createInstance = (options) => new TreeViewTestWrapper(options);
 
 module("selection common", () => {
-    test("selection should work without checkboxes on init", () => {
+    test("selection should work without checkboxes on init", function() {
         const items = [{ text: "item 1", selected: true }, { text: "item 2" }];
         const treeView = createInstance({
             items: items,
@@ -18,7 +18,7 @@ module("selection common", () => {
         treeView.checkSelected([0], items);
     });
 
-    test("selection methods should work with item keys", () => {
+    test("selection methods should work with item keys", function() {
         const items = [{ text: "item 1", selected: true }, { text: "item 2" }];
         const treeView = createInstance({
             items: items
@@ -31,7 +31,7 @@ module("selection common", () => {
         treeView.checkSelected([1], items);
     });
 
-    test("selection methods should work with itemElements", () => {
+    test("selection methods should work with itemElements", function() {
         const items = [{ text: "item 1", selected: true }, { text: "item 2" }];
         const treeView = createInstance({
             items: items
@@ -44,7 +44,7 @@ module("selection common", () => {
         treeView.checkSelected([1], items);
     });
 
-    test("selection methods should work with dom itemElements", (assert) => {
+    test("selection methods should work with dom itemElements", function(assert) {
         const items = [{ text: "item 1", selected: true }, { text: "item 2" }];
         const treeView = createInstance({
             items: items
@@ -57,7 +57,7 @@ module("selection common", () => {
         treeView.checkSelected([1], items);
     });
 
-    test("selectionChanged should fire only when selection was changed", (assert) => {
+    test("selectionChanged should fire only when selection was changed", function(assert) {
         let selectionChangedHandler = sinon.spy();
         const items = [{ text: "item 1", selected: true }, { text: "item 2", items: [{ text: "item 21" }] }];
         const treeView = createInstance({
@@ -74,7 +74,7 @@ module("selection common", () => {
         assert.equal(selectionChangedHandler.callCount, 2, "selectionChanged should call twice");
     });
 
-    test("onItemSelectionChanged should have correct arguments", (assert) => {
+    test("onItemSelectionChanged should have correct arguments", function(assert) {
         let itemSelectionChangedHandler = sinon.spy();
         const treeView = createInstance({
             items: [{ text: "Item 1", id: 2 }],
@@ -91,7 +91,7 @@ module("selection common", () => {
         assert.ok(treeView.hasItemClass($(itemSelectionChangedHandler.getCall(0).args[0].itemElement)), "itemElement is correct");
     });
 
-    test("itemSelected should fire when select", (assert) => {
+    test("itemSelected should fire when select", function(assert) {
         let itemSelectionChangedHandler = sinon.spy();
 
         const items = [{ text: "item 1", selected: true }, { text: "item 2" }];
@@ -106,7 +106,7 @@ module("selection common", () => {
         assert.equal(itemSelectionChangedHandler.callCount, 1, "event was fired");
     });
 
-    test("itemSelected should not fire when selection was not changed", (assert) => {
+    test("itemSelected should not fire when selection was not changed", function(assert) {
         let itemSelectionChangedHandler = sinon.spy();
 
         const items = [{ text: "item 1", selected: true }, { text: "item 2" }];
@@ -121,7 +121,7 @@ module("selection common", () => {
         assert.equal(itemSelectionChangedHandler.callCount, 0, "event was not fired");
     });
 
-    test("disabled item should be selectable via api", (assert) => {
+    test("disabled item should be selectable via api", function(assert) {
         const items = [{ text: "item 1", disabled: true }, { text: "item 2", disabled: true, selected: true }];
         const treeView = createInstance({
             items: items,
@@ -135,7 +135,7 @@ module("selection common", () => {
         treeView.checkSelected([1], items);
     });
 
-    test("all nodes should have selected class if they have selected property", (assert) => {
+    test("all nodes should have selected class if they have selected property", function(assert) {
         const items = [{ text: "item 1", selected: true, expanded: true, items: [{ text: "item 11", selected: true }] }, { text: "item 2", selected: true }];
         const treeView = createInstance({
             items: items,
@@ -146,7 +146,7 @@ module("selection common", () => {
         assert.equal(treeView.getSelectedNodes().length, 3, "all nodes should have selected class");
     });
 
-    test("should not fire an error when try to select unspecified item", (assert) => {
+    test("should not fire an error when try to select unspecified item", function(assert) {
         const items = [{ text: "item 1", selected: true, expanded: true, items: [{ text: "item 11", selected: true }] }, { text: "item 2", selected: true }];
         const treeView = createInstance({ items: items });
 
@@ -159,7 +159,7 @@ module("selection common", () => {
         }
     });
 
-    test("should not fire an error when item contains 'nodeType' field", (assert) => {
+    test("should not fire an error when item contains 'nodeType' field", function(assert) {
         const treeView = createInstance({ items: [{ id: 1, nodeType: "test" }] });
 
         try {
@@ -173,7 +173,7 @@ module("selection common", () => {
 });
 
 module("Selection mode", () => {
-    test("Selected: [node 1], single -> multiple, click(node 2)", (assert) => {
+    test("Selected: [node 1], single -> multiple, click(node 2)", function(assert) {
         const items = [{ text: "item 1", selected: true }, { text: "item 2" }];
         const treeView = createInstance({
             items: items,
@@ -190,7 +190,7 @@ module("Selection mode", () => {
         treeView.checkSelected([0, 1], items);
     });
 
-    test("Selected: [], multiple -> single, click(node 2)", (assert) => {
+    test("Selected: [], multiple -> single, click(node 2)", function(assert) {
         const items = [{ text: "item 1" }, { text: "item 2" }];
         const treeView = createInstance({
             items: items,
@@ -209,7 +209,7 @@ module("Selection mode", () => {
         treeView.checkSelected([1], items);
     });
 
-    test("Selected: [node 2], single -> multiple, click(node 1), selectNodesRecursive: false", (assert) => {
+    test("Selected: [node 2], single -> multiple, click(node 1), selectNodesRecursive: false", function(assert) {
         const items = [{ id: 1, text: "item 1", expanded: true, items: [{ id: 11, text: "Item 11", selected: true }, { id: 12, text: "Item 12" }] }];
         const treeView = createInstance({
             items: items,
@@ -227,7 +227,7 @@ module("Selection mode", () => {
         treeView.checkSelected([0, 1], items);
     });
 
-    test("Selected: [node 2], single -> multiple, click(node 1), selectNodesRecursive: true", (assert) => {
+    test("Selected: [node 2], single -> multiple, click(node 1), selectNodesRecursive: true", function(assert) {
         const items = [{ id: 1, text: "item 1", expanded: true, items: [{ id: 11, text: "Item 11", selected: true }, { id: 12, text: "Item 12" }] }];
         const treeView = createInstance({
             items: items,
@@ -245,7 +245,7 @@ module("Selection mode", () => {
         treeView.checkSelected([0, 1, 2], items);
     });
 
-    test("Selected nodes: [node 2, node 3], multiple -> single, selectNodesRecursive: false", (assert) => {
+    test("Selected nodes: [node 2, node 3], multiple -> single, selectNodesRecursive: false", function(assert) {
         const items = [{ id: 1, text: "item 1", expanded: true, items: [{ id: 11, text: "Item 11", selected: true }, { id: 12, text: "Item 12", selected: true }] }];
         const treeView = createInstance({
             items: items,
@@ -262,7 +262,7 @@ module("Selection mode", () => {
         treeView.checkSelected([2], items);
     });
 
-    test("Selected nodes: [node 1, node 2, node 3], multiple -> single, selectNodesRecursive: true", (assert) => {
+    test("Selected nodes: [node 1, node 2, node 3], multiple -> single, selectNodesRecursive: true", function(assert) {
         const items = [{ id: 1, text: "item 1", expanded: true, items: [{ id: 11, text: "Item 11", selected: true }, { id: 12, text: "Item 12", selected: true }] }];
         const treeView = createInstance({
             items: items,
@@ -281,14 +281,14 @@ module("Selection mode", () => {
 });
 
 module("selection single", () => {
-    test("only one node should be selected on init", (assert) => {
+    test("only one node should be selected on init", function(assert) {
         const items = [{ text: "item 1", selected: true }, { text: "item 2", selected: true }];
         const treeView = createInstance({ items: items, selectionMode: "single" });
 
         treeView.checkSelected([1], items);
     });
 
-    test("only one node should be selected on selection change", (assert) => {
+    test("only one node should be selected on selection change", function(assert) {
         const items = [{ text: "item 1", selected: true }, { text: "item 2" }];
         const treeView = createInstance({ items: items, selectionMode: "single" });
 
@@ -297,7 +297,7 @@ module("selection single", () => {
         treeView.checkSelected([1], items);
     });
 
-    test("last item should not be deselected when selectionRequired is used with checkboxes", (assert) => {
+    test("last item should not be deselected when selectionRequired is used with checkboxes", function(assert) {
         const items = [{ id: 1, text: "item 1", selected: true }];
         const treeView = createInstance({
             items: items,
@@ -315,7 +315,7 @@ module("selection single", () => {
         assert.ok($checkBox.dxCheckBox("instance").option("value"), "node's checkbox is still checked");
     });
 
-    test("last item should not be deselected when selectionRequired is used without checkboxes", (assert) => {
+    test("last item should not be deselected when selectionRequired is used without checkboxes", function(assert) {
         const items = [{ id: 1, text: "item 1", selected: true }];
         const treeView = createInstance({
             items: items,
@@ -333,7 +333,7 @@ module("selection single", () => {
         assert.deepEqual(treeView.instance.getSelectedNodesKeys(), [1], "node was not removed from selected nodes array");
     });
 
-    test("last item should not be deselected when selectionRequired is used with api", (assert) => {
+    test("last item should not be deselected when selectionRequired is used with api", function(assert) {
         const items = [{ id: 1, text: "item 1", selected: true }];
         const treeView = createInstance({
             items: items,
@@ -348,7 +348,7 @@ module("selection single", () => {
         assert.deepEqual(treeView.instance.getSelectedNodesKeys(), [1], "node was not removed from selected nodes array");
     });
 
-    test("last item should not be deselected when selectionRequired is used with multiple selection", (assert) => {
+    test("last item should not be deselected when selectionRequired is used with multiple selection", function(assert) {
         const items = [{ id: 1, text: "item 1", selected: true }, { id: 2, text: "item 2", selected: true }];
         const treeView = createInstance({
             items: items,
@@ -367,7 +367,7 @@ module("selection single", () => {
         assert.deepEqual(treeView.instance.getSelectedNodesKeys(), [2], "node was not removed from selected nodes array");
     });
 
-    test("last item should not be deselected when selectionRequired is used with recursive selection", (assert) => {
+    test("last item should not be deselected when selectionRequired is used with recursive selection", function(assert) {
         const items = [{ id: 1, text: "item 1", selected: true, expanded: true, items: [{ id: 11, text: "Item 11" }] }];
         const treeView = createInstance({
             items: items,
@@ -382,7 +382,7 @@ module("selection single", () => {
         assert.deepEqual(treeView.instance.getSelectedNodesKeys(), [1, 11], "all nodes are still in the selected array");
     });
 
-    test("last item should not be deselected when selectionRequired is used with select all", (assert) => {
+    test("last item should not be deselected when selectionRequired is used with select all", function(assert) {
         const items = [{ id: 1, text: "item 1", selected: true, expanded: true, items: [{ id: 11, text: "Item 11" }] }, { id: 2, text: "Item 2", selected: true }];
         const treeView = createInstance({
             items: items,
@@ -397,7 +397,7 @@ module("selection single", () => {
         assert.deepEqual(treeView.instance.getSelectedNodesKeys(), [2], "last noder is still in the selected array");
     });
 
-    test("selectByClick option should select item  by single click", (assert) => {
+    test("selectByClick option should select item  by single click", function(assert) {
         const items = [{ text: "item 1" }, { text: "item 2" }];
         const treeView = createInstance({
             items: items,
@@ -411,7 +411,7 @@ module("selection single", () => {
         treeView.checkSelected([0], items);
     });
 
-    test("selectByClick option should unselect item  by second click", (assert) => {
+    test("selectByClick option should unselect item  by second click", function(assert) {
         const items = [{ text: "item 1" }, { text: "item 2" }];
         const treeView = createInstance({
             items: items,
@@ -425,7 +425,7 @@ module("selection single", () => {
         treeView.checkSelected([], items);
     });
 
-    test("selection can be prevented on itemClick", (assert) => {
+    test("selection can be prevented on itemClick", function(assert) {
         const items = [{ text: "item 1" }, { text: "item 2" }];
         const treeView = createInstance({
             items: items,
@@ -440,7 +440,7 @@ module("selection single", () => {
         treeView.checkSelected([], items);
     });
 
-    test("selectNodesRecursive should be ignored when single selection is enabled", (assert) => {
+    test("selectNodesRecursive should be ignored when single selection is enabled", function(assert) {
         const items = [{ text: "Item 1", expanded: true, items: [{ text: "Item 11" }] }];
         const treeView = createInstance({
             items: items,
@@ -454,7 +454,7 @@ module("selection single", () => {
         treeView.checkSelected([0], items);
     });
 
-    test("selectNodesRecursive should work correct on option changing", (assert) => {
+    test("selectNodesRecursive should work correct on option changing", function(assert) {
         const items = [{ id: 1, text: "Item 1", expanded: true, items: [{ id: 11, text: "Item 11", selected: true }] }];
         const treeView = createInstance({
             items: items,
@@ -466,7 +466,7 @@ module("selection single", () => {
         treeView.checkSelected([0, 1], items);
     });
 
-    test("onItemSelectionChanged event should be fired on unselect previosly selected item", (assert) => {
+    test("onItemSelectionChanged event should be fired on unselect previosly selected item", function(assert) {
         let itemSelectionChangedHandler = sinon.spy();
         const treeView = createInstance({
             items: [{ text: "item 1" }, { text: "item 2" }],
@@ -482,7 +482,7 @@ module("selection single", () => {
         assert.deepEqual(itemSelectionChangedHandler.getCall(1).args[0].itemData, { selected: false, text: "item 1" }, "itemSelectionChangedHandler.itemData");
     });
 
-    test("item selection correctly reset when dataSource is filtered", (assert) => {
+    test("item selection correctly reset when dataSource is filtered", function(assert) {
         const items = [{ text: "item 1" }, { text: "item 2" }];
         const treeView = createInstance({
             dataSource: items,
@@ -502,7 +502,7 @@ module("selection single", () => {
         treeView.checkSelected([0], items);
     });
 
-    test("items should be selectable after the search", (assert) => {
+    test("items should be selectable after the search", function(assert) {
         let itemClickHandler = sinon.spy();
         const treeView = createInstance({
             dataSource: [{ text: "Stores" }],

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/virtualMode.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/virtualMode.js
@@ -1102,7 +1102,7 @@ QUnit.test("Expand all method with the virtual mode", function(assert) {
     assert.equal(nodes[0].items[0].items.length, 0, "children count of the item 11");
 });
 
-QUnit.test("load indicator should be located before an item", assert => {
+QUnit.test("load indicator should be located before an item", function(assert) {
     const treeView = new TreeView($("#treeView"), {
         virtualModeEnabled: true,
         items: [
@@ -1448,7 +1448,7 @@ module("Loadindicator", () => {
                 assert.equal($toggleItem.css('display') === 'none', contentReadyCount ? false : true, "toggle item is hidden");
             };
 
-            test(`Loadindicator: ${config}`, () => {
+            test(`Loadindicator: ${config}`, function() {
                 const clock = sinon.useFakeTimers();
 
                 try {


### PR DESCRIPTION
Explanation:
---
> QUnit test and module callbacks can share state by modifying properties of `this` within those callbacks.
> 
> This only works when using function expressions, which allow for dynamic binding of `this` by the QUnit library. Arrow function expressions will not work in this case, because arrow functions will always bind to whatever the value of `this` was in the enclosing scope (in QUnit tests, usually the global object). This means that developers who use arrow function expressions as test or module callbacks will not be able to share state and may encounter other problems.

See https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-arrow-tests.md

Examples:
---
![image](https://user-images.githubusercontent.com/1420883/69558304-06763d00-0fb9-11ea-8b0f-67bbdd0b2ce4.png)

![image](https://user-images.githubusercontent.com/1420883/69558363-23ab0b80-0fb9-11ea-900c-f173e83f7312.png)

![image](https://user-images.githubusercontent.com/1420883/69558440-463d2480-0fb9-11ea-8846-933c88e250e9.png)

etc.