### PR TITLE
Renovation: keyboardProcessor refactoring

### DIFF
--- a/js/core/dom_component.js
+++ b/js/core/dom_component.js
@@ -12,7 +12,7 @@ import { grep, noop } from './utils/common';
 import { inArray } from './utils/array';
 import { isString, isDefined } from './utils/type';
 import { hasWindow } from '../core/utils/window';
-import { resize as resizeEvent, visibility as visibilityEvents } from '../events/core/events_engine';
+import { resize as resizeEvent, visibility as visibilityEvents } from '../events/index';
 
 const { abstract } = Component;
 

--- a/js/core/dom_component.js
+++ b/js/core/dom_component.js
@@ -12,7 +12,7 @@ import { grep, noop } from './utils/common';
 import { inArray } from './utils/array';
 import { isString, isDefined } from './utils/type';
 import { hasWindow } from '../core/utils/window';
-import { resize as resizeEvent, visibility as visibilityEvents } from '../events/index';
+import { resize as resizeEvent, visibility as visibilityEvents } from '../events/';
 
 const { abstract } = Component;
 

--- a/js/events/core/events_engine.js
+++ b/js/events/core/events_engine.js
@@ -596,103 +596,6 @@ hookTouchProps(addProperty);
 var beforeSetStrategy = Callbacks();
 var afterSetStrategy = Callbacks();
 
-function addNamespace(event, namespace) {
-    return namespace ? eventsEngine.addNamespace(event, namespace) : event;
-}
-
-eventsEngine.hover = {
-    on: ($el, start, end, { selector, namespace }) => {
-        eventsEngine.on($el, addNamespace('dxhoverend', namespace), selector, event => end(event));
-        eventsEngine.on($el, addNamespace('dxhoverstart', namespace), selector, event => {
-            start.execute({ element: event.target, event });
-        });
-    },
-
-    off: ($el, { selector, namespace }) => {
-        eventsEngine.off($el, addNamespace('dxhoverstart', namespace), selector);
-        eventsEngine.off($el, addNamespace('dxhoverend', namespace), selector);
-    }
-};
-
-eventsEngine.visibility = {
-    on: ($el, shown, hiding, { namespace }) => {
-        eventsEngine.on($el, addNamespace('dxhiding', namespace), hiding);
-        eventsEngine.on($el, addNamespace('dxshown', namespace), shown);
-    },
-
-    off: ($el, { namespace }) => {
-        eventsEngine.off($el, addNamespace('dxhiding', namespace));
-        eventsEngine.off($el, addNamespace('dxshown', namespace));
-    }
-};
-
-eventsEngine.focus = {
-    on: ($el, focusIn, focusOut, { namespace, isFocusable }) => {
-        eventsEngine.on($el, addNamespace('focusin', namespace), focusIn);
-        eventsEngine.on($el, addNamespace('focusout', namespace), focusOut);
-
-        if(domAdapter.hasDocumentProperty('onbeforeactivate')) {
-            eventsEngine.on($el, addNamespace('beforeactivate', namespace),
-                e => isFocusable(e.target) || e.preventDefault()
-            );
-        }
-    },
-
-    off: ($el, { namespace }) => {
-        eventsEngine.off($el, addNamespace('focusin', namespace));
-        eventsEngine.off($el, addNamespace('focusout', namespace));
-
-        if(domAdapter.hasDocumentProperty('onbeforeactivate')) {
-            eventsEngine.off($el, addNamespace('beforeactivate', namespace));
-        }
-    }
-};
-
-eventsEngine.dxClick = {
-    on: ($el, click, { namespace } = {}) => {
-        eventsEngine.on($el, addNamespace('dxclick', namespace), click);
-    },
-    off: ($el, { namespace } = {}) => {
-        eventsEngine.off($el, addNamespace('dxclick', namespace));
-    }
-};
-
-eventsEngine.click = {
-    on: ($el, click, { namespace } = {}) => {
-        eventsEngine.on($el, addNamespace('click', namespace), click);
-    },
-    off: ($el, { namespace } = {}) => {
-        eventsEngine.off($el, addNamespace('click', namespace));
-    }
-};
-
-eventsEngine.resize = {
-    on: ($el, resize, { namespace } = {}) => {
-        eventsEngine.on($el, addNamespace('dxresize', namespace), resize);
-    },
-    off: ($el, { namespace } = {}) => {
-        eventsEngine.off($el, addNamespace('dxresize', namespace));
-    }
-};
-
-eventsEngine.active = {
-    on: ($el, active, inactive, opts) => {
-        const { selector, showTimeout, hideTimeout, namespace } = opts;
-
-        eventsEngine.on($el, addNamespace('dxactive', namespace), selector, { timeout: showTimeout },
-            event => active.execute({ event, element: event.currentTarget })
-        );
-        eventsEngine.on($el, addNamespace('dxinactive', namespace), selector, { timeout: hideTimeout },
-            event => inactive.execute({ event, element: event.currentTarget })
-        );
-    },
-
-    off: ($el, { namespace, selector }) => {
-        eventsEngine.off($el, addNamespace('dxactive', namespace), selector);
-        eventsEngine.off($el, addNamespace('dxinactive', namespace), selector);
-    }
-};
-
 eventsEngine.set = function(engine) {
     beforeSetStrategy.fire();
     eventsEngine.inject(engine);
@@ -734,7 +637,7 @@ eventsEngine.addNamespace = (eventNames, namespace) => {
     if(typeof eventNames === 'string') {
         return eventNames.indexOf(' ') === -1 ?
             `${eventNames}.${namespace}` :
-            addNamespace(eventNames.split(/\s+/g), namespace);
+            eventsEngine.addNamespace(eventNames.split(/\s+/g), namespace);
     }
 
     return eventNames

--- a/js/events/core/events_engine.js
+++ b/js/events/core/events_engine.js
@@ -629,20 +629,4 @@ eventsEngine.elementDataMap = elementDataMap;
 eventsEngine.detectPassiveEventHandlersSupport = detectPassiveEventHandlersSupport;
 ///#ENDDEBUG
 
-eventsEngine.addNamespace = (eventNames, namespace) => {
-    if(!namespace) {
-        throw errors.Error('E0017');
-    }
-
-    if(typeof eventNames === 'string') {
-        return eventNames.indexOf(' ') === -1 ?
-            `${eventNames}.${namespace}` :
-            eventsEngine.addNamespace(eventNames.split(/\s+/g), namespace);
-    }
-
-    return eventNames
-        .map(eventName => `${eventName}.${namespace}`)
-        .join(' ');
-};
-
 module.exports = eventsEngine;

--- a/js/events/core/keyboard_processor.js
+++ b/js/events/core/keyboard_processor.js
@@ -2,7 +2,6 @@ import $ from "../../core/renderer";
 import eventsEngine from "../../events/core/events_engine";
 import Class from "../../core/class";
 import { inArray } from "../../core/utils/array";
-import { each } from "../../core/utils/iterator";
 import { addNamespace, normalizeKeyName } from "../../events/utils";
 
 const COMPOSITION_START_EVENT = "compositionstart";
@@ -24,8 +23,7 @@ const KeyboardProcessor = Class.inherit({
             this._focusTarget = options.focusTarget;
         }
         this._handler = options.handler;
-        this._context = options.context;
-        this._childProcessors = [];
+
         if(this._element) {
             this._processFunction = (e) => {
                 const isNotFocusTarget = this._focusTarget && this._focusTarget !== e.target && inArray(e.target, this._focusTarget) < 0;
@@ -52,37 +50,10 @@ const KeyboardProcessor = Class.inherit({
         }
         this._element = undefined;
         this._handler = undefined;
-        this._context = undefined;
-        this._childProcessors = undefined;
-    },
-
-    clearChildren: function() {
-        this._childProcessors = [];
-    },
-
-    push: function(child) {
-        if(!this._childProcessors) {
-            this.clearChildren();
-        }
-
-        this._childProcessors.push(child);
-        return child;
-    },
-
-    attachChildProcessor: function() {
-        const childProcessor = new KeyboardProcessor();
-        this._childProcessors.push(childProcessor);
-        return childProcessor;
-    },
-
-    reinitialize: function(childHandler, childContext) {
-        this._context = childContext;
-        this._handler = childHandler;
-        return this;
     },
 
     process: function(e) {
-        const args = {
+        this._handler({
             keyName: normalizeKeyName(e),
             key: e.key,
             code: e.code,
@@ -93,15 +64,7 @@ const KeyboardProcessor = Class.inherit({
             alt: e.altKey,
             which: e.which,
             originalEvent: e
-        };
-
-        const handlerResult = this._handler && this._handler.call(this._context, args);
-
-        if(handlerResult && this._childProcessors) {
-            each(this._childProcessors, (index, childProcessor) => {
-                childProcessor.process(e);
-            });
-        }
+        });
     },
 
     toggleProcessing: function({ type }) {

--- a/js/events/index.js
+++ b/js/events/index.js
@@ -33,7 +33,6 @@ export const resize = {
     }
 };
 
-
 export const hover = {
     on: ($el, start, end, { selector, namespace }) => {
         eventsEngine.on($el, addNamespace('dxhoverend', namespace), selector, event => end(event));
@@ -100,18 +99,20 @@ export const click = {
     }
 };
 
+let index = 0;
 const keyboardProcessors = {};
+const getKeyboardProcessorId = () => `keyboardProcessorId${index++}`;
 
 export const keyboard = {
     on: (element, focusTarget, handler) => {
-        const listenerId = Symbol('listenerId');
+        const listenerId = getKeyboardProcessorId();
 
         keyboardProcessors[listenerId] = new KeyboardProcessor({ element, focusTarget, handler });
 
         return listenerId;
     },
 
-    off: (listenerId) => {
+    off: listenerId => {
         if(listenerId && keyboardProcessors[listenerId]) {
             keyboardProcessors[listenerId].dispose();
             delete keyboardProcessors[listenerId];
@@ -119,5 +120,5 @@ export const keyboard = {
     },
 
     // NOTE: For tests
-    _getProcessor: (listenerId) => keyboardProcessors[listenerId]
+    _getProcessor: listenerId => keyboardProcessors[listenerId]
 };

--- a/js/events/index.js
+++ b/js/events/index.js
@@ -1,0 +1,123 @@
+import domAdapter from '../core/dom_adapter';
+import eventsEngine from './core/events_engine';
+import KeyboardProcessor from './core/keyboard_processor';
+
+function addNamespace(event, namespace) {
+    return namespace ? eventsEngine.addNamespace(event, namespace) : event;
+}
+
+export const active = {
+    on: ($el, active, inactive, opts) => {
+        const { selector, showTimeout, hideTimeout, namespace } = opts;
+
+        eventsEngine.on($el, addNamespace('dxactive', namespace), selector, { timeout: showTimeout },
+            event => active.execute({ event, element: event.currentTarget })
+        );
+        eventsEngine.on($el, addNamespace('dxinactive', namespace), selector, { timeout: hideTimeout },
+            event => inactive.execute({ event, element: event.currentTarget })
+        );
+    },
+
+    off: ($el, { namespace, selector }) => {
+        eventsEngine.off($el, addNamespace('dxactive', namespace), selector);
+        eventsEngine.off($el, addNamespace('dxinactive', namespace), selector);
+    }
+};
+
+export const resize = {
+    on: ($el, resize, { namespace } = {}) => {
+        eventsEngine.on($el, addNamespace('dxresize', namespace), resize);
+    },
+    off: ($el, { namespace } = {}) => {
+        eventsEngine.off($el, addNamespace('dxresize', namespace));
+    }
+};
+
+
+export const hover = {
+    on: ($el, start, end, { selector, namespace }) => {
+        eventsEngine.on($el, addNamespace('dxhoverend', namespace), selector, event => end(event));
+        eventsEngine.on($el, addNamespace('dxhoverstart', namespace), selector, event => {
+            start.execute({ element: event.target, event });
+        });
+    },
+
+    off: ($el, { selector, namespace }) => {
+        eventsEngine.off($el, addNamespace('dxhoverstart', namespace), selector);
+        eventsEngine.off($el, addNamespace('dxhoverend', namespace), selector);
+    }
+};
+
+export const visibility = {
+    on: ($el, shown, hiding, { namespace }) => {
+        eventsEngine.on($el, addNamespace('dxhiding', namespace), hiding);
+        eventsEngine.on($el, addNamespace('dxshown', namespace), shown);
+    },
+
+    off: ($el, { namespace }) => {
+        eventsEngine.off($el, addNamespace('dxhiding', namespace));
+        eventsEngine.off($el, addNamespace('dxshown', namespace));
+    }
+};
+
+export const focus = {
+    on: ($el, focusIn, focusOut, { namespace, isFocusable }) => {
+        eventsEngine.on($el, addNamespace('focusin', namespace), focusIn);
+        eventsEngine.on($el, addNamespace('focusout', namespace), focusOut);
+
+        if(domAdapter.hasDocumentProperty('onbeforeactivate')) {
+            eventsEngine.on($el, addNamespace('beforeactivate', namespace),
+                e => isFocusable(e.target) || e.preventDefault()
+            );
+        }
+    },
+
+    off: ($el, { namespace }) => {
+        eventsEngine.off($el, addNamespace('focusin', namespace));
+        eventsEngine.off($el, addNamespace('focusout', namespace));
+
+        if(domAdapter.hasDocumentProperty('onbeforeactivate')) {
+            eventsEngine.off($el, addNamespace('beforeactivate', namespace));
+        }
+    }
+};
+
+export const dxClick = {
+    on: ($el, click, { namespace } = {}) => {
+        eventsEngine.on($el, addNamespace('dxclick', namespace), click);
+    },
+    off: ($el, { namespace } = {}) => {
+        eventsEngine.off($el, addNamespace('dxclick', namespace));
+    }
+};
+
+export const click = {
+    on: ($el, click, { namespace } = {}) => {
+        eventsEngine.on($el, addNamespace('click', namespace), click);
+    },
+    off: ($el, { namespace } = {}) => {
+        eventsEngine.off($el, addNamespace('click', namespace));
+    }
+};
+
+const keyboardProcessors = {};
+
+export const keyboard = {
+    on: (element, focusTarget, handler) => {
+        const listenerId = Symbol('listenerId');
+
+        keyboardProcessors[listenerId] = new KeyboardProcessor({ element, focusTarget, handler });
+
+        return listenerId;
+    },
+
+    off: (listenerId) => {
+        if(listenerId && keyboardProcessors[listenerId]) {
+            keyboardProcessors[listenerId].dispose();
+            delete keyboardProcessors[listenerId];
+        }
+    },
+
+    // NOTE: For tests
+    _getProcessor: (listenerId) => keyboardProcessors[listenerId]
+};

--- a/js/events/index.js
+++ b/js/events/index.js
@@ -1,9 +1,10 @@
 import domAdapter from '../core/dom_adapter';
 import eventsEngine from './core/events_engine';
 import KeyboardProcessor from './core/keyboard_processor';
+import { addNamespace as pureAddNamespace } from './utils';
 
 function addNamespace(event, namespace) {
-    return namespace ? eventsEngine.addNamespace(event, namespace) : event;
+    return namespace ? pureAddNamespace(event, namespace) : event;
 }
 
 export const active = {

--- a/js/events/index.js
+++ b/js/events/index.js
@@ -102,11 +102,11 @@ export const click = {
 
 let index = 0;
 const keyboardProcessors = {};
-const getKeyboardProcessorId = () => `keyboardProcessorId${index++}`;
+const generateListenerId = () => `keyboardProcessorId${index++}`;
 
 export const keyboard = {
     on: (element, focusTarget, handler) => {
-        const listenerId = getKeyboardProcessorId();
+        const listenerId = generateListenerId();
 
         keyboardProcessors[listenerId] = new KeyboardProcessor({ element, focusTarget, handler });
 

--- a/js/events/utils/add_namespace.js
+++ b/js/events/utils/add_namespace.js
@@ -5,15 +5,15 @@ const addNamespace = (eventNames, namespace) => {
         throw errors.Error('E0017');
     }
 
-    if(typeof eventNames === 'string') {
-        return eventNames.indexOf(' ') === -1 ?
-            `${eventNames}.${namespace}` :
-            addNamespace(eventNames.split(/\s+/g), namespace);
+    if(Array.isArray(eventNames)) {
+        return eventNames
+            .map(eventName => `${eventName}.${namespace}`)
+            .join(' ');
+    } else if(eventNames.indexOf(' ') !== -1) {
+        return addNamespace(eventNames.split(/\s+/g), namespace);
     }
 
-    return eventNames
-        .map(eventName => `${eventName}.${namespace}`)
-        .join(' ');
+    return `${eventNames}.${namespace}`;
 };
 
 export default addNamespace;

--- a/js/events/utils/add_namespace.js
+++ b/js/events/utils/add_namespace.js
@@ -7,9 +7,11 @@ const addNamespace = (eventNames, namespace) => {
 
     if(Array.isArray(eventNames)) {
         return eventNames
-            .map(eventName => `${eventName}.${namespace}`)
+            .map(eventName => addNamespace(eventName, namespace))
             .join(' ');
-    } else if(eventNames.indexOf(' ') !== -1) {
+    }
+
+    if(eventNames.indexOf(' ') !== -1) {
         return addNamespace(eventNames.split(/\s+/g), namespace);
     }
 

--- a/js/events/utils/add_namespace.js
+++ b/js/events/utils/add_namespace.js
@@ -1,0 +1,19 @@
+import errors from '../../core/errors';
+
+const addNamespace = (eventNames, namespace) => {
+    if(!namespace) {
+        throw errors.Error('E0017');
+    }
+
+    if(typeof eventNames === 'string') {
+        return eventNames.indexOf(' ') === -1 ?
+            `${eventNames}.${namespace}` :
+            addNamespace(eventNames.split(/\s+/g), namespace);
+    }
+
+    return eventNames
+        .map(eventName => `${eventName}.${namespace}`)
+        .join(' ');
+};
+
+export default addNamespace;

--- a/js/events/utils/index.js
+++ b/js/events/utils/index.js
@@ -1,8 +1,9 @@
-import $ from "../core/renderer";
-import eventsEngine from "./core/events_engine";
-import { focused } from "../ui/widget/selectors";
-import { extend } from "../core/utils/extend";
-import { each } from "../core/utils/iterator";
+import $ from "../../core/renderer";
+import addNamespace from "./add_namespace";
+import eventsEngine from "../core/events_engine";
+import { each } from "../../core/utils/iterator";
+import { extend } from "../../core/utils/extend";
+import { focused } from "../../ui/widget/selectors";
 
 const KEY_MAP = {
     "backspace": "backspace",
@@ -250,7 +251,7 @@ module.exports = {
     createEvent: createEvent,
     fireEvent: fireEvent,
 
-    addNamespace: eventsEngine.addNamespace,
+    addNamespace: addNamespace,
     setEventFixMethod: setEventFixMethod,
 
     normalizeKeyName: normalizeKeyName,

--- a/js/events/utils/index.js
+++ b/js/events/utils/index.js
@@ -121,13 +121,17 @@ export const eventDelta = (from, to) => ({
 });
 
 export const hasTouches = e => {
+    const { originalEvent, pointers } = e;
+
     if(isNativeTouchEvent(e)) {
-        return (e.originalEvent.touches || []).length;
-    } else if(isDxEvent(e)) {
-        return (e.pointers || []).length;
-    } else {
-        return 0;
+        return (originalEvent.touches || []).length;
     }
+
+    if(isDxEvent(e)) {
+        return (pointers || []).length;
+    }
+
+    return 0;
 };
 
 export const needSkipEvent = e => {

--- a/js/ui/accordion.js
+++ b/js/ui/accordion.js
@@ -9,7 +9,7 @@ import { getPublicElement } from "../core/utils/dom";
 import iteratorUtils from "../core/utils/iterator";
 import { isPlainObject, isDefined } from "../core/utils/type";
 import registerComponent from "../core/component_registrator";
-import eventUtils from "../events/utils";
+import * as eventUtils from "../events/utils";
 import CollectionWidget from "./collection/ui.collection_widget.live_update";
 import { when, Deferred } from "../core/utils/deferred";
 import { BindableTemplate } from "../core/templates/bindable_template";

--- a/js/ui/button.js
+++ b/js/ui/button.js
@@ -6,7 +6,7 @@ import themes from './themes';
 import Action from '../core/action';
 import ValidationEngine from './validation_engine';
 import Widget from './widget/ui.widget';
-import { active as activeEvents, click as clickEvent, dxClick as dxClickEvent } from '../events/core/events_engine';
+import { active as activeEvents, click as clickEvent, dxClick as dxClickEvent } from '../events/index';
 import { extend } from '../core/utils/extend';
 import { FunctionTemplate } from '../core/templates/function_template';
 import { getImageContainer, getImageSourceType } from '../core/utils/icon';

--- a/js/ui/button.js
+++ b/js/ui/button.js
@@ -6,7 +6,7 @@ import themes from './themes';
 import Action from '../core/action';
 import ValidationEngine from './validation_engine';
 import Widget from './widget/ui.widget';
-import { active as activeEvents, click as clickEvent, dxClick as dxClickEvent } from '../events/index';
+import { active as activeEvents, click as clickEvent, dxClick as dxClickEvent } from '../events/';
 import { extend } from '../core/utils/extend';
 import { FunctionTemplate } from '../core/templates/function_template';
 import { getImageContainer, getImageSourceType } from '../core/utils/icon';

--- a/js/ui/calendar/ui.calendar.base_view.js
+++ b/js/ui/calendar/ui.calendar.base_view.js
@@ -222,11 +222,6 @@ var BaseView = Widget.inherit({
         $newContouredCell.addClass(CALENDAR_CONTOURED_DATE_CLASS);
     },
 
-    _dispose: function() {
-        this._keyboardProcessor = undefined;
-        this.callBase();
-    },
-
     _changeValue: function(cellDate) {
         if(cellDate) {
             var value = this.option("value"),

--- a/js/ui/calendar/ui.calendar.js
+++ b/js/ui/calendar/ui.calendar.js
@@ -625,13 +625,16 @@ var Calendar = Editor.inherit({
         }
     },
 
+    _getKeyboardListeners() {
+        return this.callBase().concat([this._view]);
+    },
+
     _renderViews: function() {
         this.$element().addClass(CALENDAR_VIEW_CLASS + "-" + this.option("zoomLevel"));
 
         var currentDate = this.option("currentDate");
 
         this._view = this._renderSpecificView(currentDate);
-        this._view.option("_keyboardProcessor", this._viewKeyboardProcessor);
 
         if(windowUtils.hasWindow()) {
             var beforeDate = this._getDateByOffset(-1, currentDate);

--- a/js/ui/collection/ui.collection_widget.base.js
+++ b/js/ui/collection/ui.collection_widget.base.js
@@ -11,7 +11,7 @@ import iteratorUtils from "../../core/utils/iterator";
 import Action from "../../core/action";
 import Guid from "../../core/guid";
 import Widget from "../widget/ui.widget";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import pointerEvents from "../../events/pointer";
 import DataHelperMixin from "../../data_helper";
 import CollectionWidgetItem from "./item";

--- a/js/ui/color_box/color_box.js
+++ b/js/ui/color_box/color_box.js
@@ -264,8 +264,7 @@ var ColorBox = DropDownEditor.inherit({
                 }
 
                 that._applyNewColor(args.value);
-            },
-            _keyboardProcessor: that._colorViewProcessor
+            }
         };
     },
 
@@ -319,12 +318,8 @@ var ColorBox = DropDownEditor.inherit({
         this.callBase();
     },
 
-    _attachChildKeyboardEvents: function() {
-        this._colorViewProcessor = this._keyboardProcessor.attachChildProcessor();
-        if(this._colorView) {
-            this._colorView.option("_keyboardProcessor", this._colorViewProcessor);
-            return;
-        }
+    _getKeyboardListeners() {
+        return this.callBase().concat([this._colorView]);
     },
 
     _init: function() {

--- a/js/ui/color_box/color_view.js
+++ b/js/ui/color_box/color_view.js
@@ -582,7 +582,8 @@ var ColorView = Editor.inherit({
 
         var editorOptions = extend({
             value: options.value,
-            onValueChanged: options.onValueChanged
+            onValueChanged: options.onValueChanged,
+            onKeyboardHandled: opts => this._keyboardHandler(opts)
         }, {
             stylingMode: this.option("stylingMode")
         });
@@ -595,8 +596,6 @@ var ColorView = Editor.inherit({
 
         var editor = new editorType($editor, editorOptions);
 
-        this._attachKeyboardProcessorToEditor(editor);
-
         editor.registerKeyHandler("enter", (function(e) {
             this._fireEnterKeyPressed(e);
         }).bind(this));
@@ -604,16 +603,6 @@ var ColorView = Editor.inherit({
         this.setAria("label", options.labelAriaText, $editor);
 
         return $label;
-    },
-
-    _attachKeyboardProcessorToEditor: function(editor) {
-        var keyboardProcessor = editor._keyboardProcessor;
-
-        if(keyboardProcessor) {
-            keyboardProcessor
-                .attachChildProcessor()
-                .reinitialize(this._keyboardHandler, this);
-        }
     },
 
     hexInputOptions: function() {

--- a/js/ui/context_menu/ui.context_menu.js
+++ b/js/ui/context_menu/ui.context_menu.js
@@ -418,7 +418,7 @@ class ContextMenu extends MenuBase {
     }
 
     _attachKeyboardEvents() {
-        !this._keyboardProcessor && this._focusTarget().length && super._attachKeyboardEvents();
+        !this._keyboardListenerId && this._focusTarget().length && super._attachKeyboardEvents();
     }
 
     _renderContextMenuOverlay() {

--- a/js/ui/date_box/ui.date_box.base.js
+++ b/js/ui/date_box/ui.date_box.base.js
@@ -462,8 +462,8 @@ var DateBox = DropDownEditor.inherit({
         };
     },
 
-    _attachChildKeyboardEvents: function() {
-        this._strategy.attachKeyboardEvents(this._keyboardProcessor);
+    _getKeyboardListeners() {
+        return this.callBase().concat([this._strategy && this._strategy.getKeyboardListener()]);
     },
 
     _renderPopup: function() {

--- a/js/ui/date_box/ui.date_box.strategy.calendar.js
+++ b/js/ui/date_box/ui.date_box.strategy.calendar.js
@@ -53,13 +53,16 @@ var CalendarStrategy = DateBoxStrategy.inherit({
         return Calendar;
     },
 
+    getKeyboardListener() {
+        return this._widget;
+    },
+
     _getWidgetOptions: function() {
         var disabledDates = this.dateBox.option("disabledDates");
 
         return extend(this.dateBox.option("calendarOptions"), {
             value: this.dateBoxValue() || null,
             dateSerializationFormat: null,
-            _keyboardProcessor: this._widgetKeyboardProcessor,
             min: this.dateBox.dateOption("min"),
             max: this.dateBox.dateOption("max"),
             onValueChanged: this._valueChangedHandler.bind(this),

--- a/js/ui/date_box/ui.date_box.strategy.js
+++ b/js/ui/date_box/ui.date_box.strategy.js
@@ -40,11 +40,9 @@ var DateBoxStrategy = Class.inherit({
 
     supportedKeys: noop,
 
-    customizeButtons: noop,
+    getKeyboardListener: noop,
 
-    attachKeyboardEvents: function(keyboardProcessor) {
-        this._widgetKeyboardProcessor = keyboardProcessor.attachChildProcessor();
-    },
+    customizeButtons: noop,
 
     getParsedText: function(text, format) {
         var value = dateLocalization.parse(text, format);

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -75,10 +75,7 @@ var ListStrategy = DateBoxStrategy.inherit({
     },
 
     _getWidgetOptions: function() {
-        var keyboardProcessor = this.dateBox._keyboardProcessor;
-
         return {
-            _keyboardProcessor: keyboardProcessor ? keyboardProcessor.attachChildProcessor() : null,
             itemTemplate: this._timeListItemTemplate.bind(this),
             onItemClick: this._listItemClickHandler.bind(this),
             tabIndex: -1,
@@ -249,12 +246,8 @@ var ListStrategy = DateBoxStrategy.inherit({
         this.dateBoxValue(date);
     },
 
-    attachKeyboardEvents: function(keyboardProcessor) {
-        var child = keyboardProcessor.attachChildProcessor();
-
-        if(this._widget) {
-            this._widget.option("_keyboardProcessor", child);
-        }
+    getKeyboardListener() {
+        return this._widget;
     },
 
     _dimensionChanged: function() {

--- a/js/ui/date_box/ui.time_view.js
+++ b/js/ui/date_box/ui.time_view.js
@@ -170,26 +170,16 @@ const TimeView = Editor.inherit({
         }).$element();
     },
 
-    _attachKeyboardProcessorToEditor: function(editor) {
-        const keyboardProcessor = editor._keyboardProcessor;
-
-        if(keyboardProcessor) {
-            keyboardProcessor
-                .attachChildProcessor()
-                .reinitialize(this._keyboardHandler, this);
-        }
-    },
-
     _createHourBox: function() {
         const editor = this._hourBox = this._createComponent($("<div>"), NumberBox, extend({
             min: -1,
             max: 24,
             value: this._getValue().getHours(),
             onValueChanged: this._onHourBoxValueChanged.bind(this),
+            onKeyboardHandled: opts => this._keyboardHandler(opts)
         }, this._getNumberBoxConfig()));
 
         editor.setAria("label", "hours");
-        this._attachKeyboardProcessorToEditor(editor);
     },
 
     _isPM: function() {
@@ -220,6 +210,7 @@ const TimeView = Editor.inherit({
             min: -1,
             max: 60,
             value: this._getValue().getMinutes(),
+            onKeyboardHandled: opts => this._keyboardHandler(opts),
             onValueChanged: ({ value, component }) => {
                 const newMinutes = (60 + value) % 60;
                 component.option("value", newMinutes);
@@ -232,7 +223,6 @@ const TimeView = Editor.inherit({
         }, this._getNumberBoxConfig()));
 
         editor.setAria("label", "minutes");
-        this._attachKeyboardProcessorToEditor(editor);
     },
 
     _createFormat12Box: function() {
@@ -244,6 +234,7 @@ const TimeView = Editor.inherit({
             ],
             valueExpr: "value",
             displayExpr: "text",
+            onKeyboardHandled: opts => this._keyboardHandler(opts),
             onValueChanged: ({ value }) => {
                 const hours = this._getValue().getHours();
                 const time = new Date(this._getValue());
@@ -256,7 +247,6 @@ const TimeView = Editor.inherit({
             stylingMode: this.option("stylingMode")
         });
 
-        this._attachKeyboardProcessorToEditor(editor);
         editor.setAria("label", "type");
     },
 

--- a/js/ui/diagram/diagram.panel.js
+++ b/js/ui/diagram/diagram.panel.js
@@ -1,7 +1,7 @@
 import $ from "../../core/renderer";
 import Widget from "../widget/ui.widget";
 import eventsEngine from "../../events/core/events_engine";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import pointerEvents from "../../events/pointer";
 
 const POINTERUP_EVENT_NAME = eventUtils.addNamespace(pointerEvents.up, "dxDiagramPanel");

--- a/js/ui/diagram/ui.diagram.js
+++ b/js/ui/diagram/ui.diagram.js
@@ -20,7 +20,7 @@ import Tooltip from "../tooltip";
 import { getDiagram } from "./diagram_importer";
 import { hasWindow, getWindow } from "../../core/utils/window";
 import eventsEngine from "../../events/core/events_engine";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import messageLocalization from "../../localization/message";
 import numberLocalization from "../../localization/number";
 import DiagramDialogManager from "./ui.diagram.dialogmanager";

--- a/js/ui/drop_down_box.js
+++ b/js/ui/drop_down_box.js
@@ -11,7 +11,7 @@ import { extend } from "../core/utils/extend";
 import { getElementMaxHeightByWindow } from "../ui/overlay/utils";
 import registerComponent from "../core/component_registrator";
 import { normalizeKeyName } from "../events/utils";
-import { keyboard } from "../events/index";
+import { keyboard } from "../events/";
 
 var DROP_DOWN_BOX_CLASS = "dx-dropdownbox",
     ANONYMOUS_TEMPLATE_NAME = "content";

--- a/js/ui/drop_down_box.js
+++ b/js/ui/drop_down_box.js
@@ -4,7 +4,6 @@ import { ensureDefined, noop, grep } from "../core/utils/common";
 import { isObject } from "../core/utils/type";
 import { map } from "../core/utils/iterator";
 import selectors from "./widget/selectors";
-import KeyboardProcessor from "./widget/ui.keyboard_processor";
 import { when, Deferred } from "../core/utils/deferred";
 import $ from "../core/renderer";
 import eventsEngine from "../events/core/events_engine";
@@ -12,6 +11,7 @@ import { extend } from "../core/utils/extend";
 import { getElementMaxHeightByWindow } from "../ui/overlay/utils";
 import registerComponent from "../core/component_registrator";
 import { normalizeKeyName } from "../events/utils";
+import { keyboard } from "../events/index";
 
 var DROP_DOWN_BOX_CLASS = "dx-dropdownbox",
     ANONYMOUS_TEMPLATE_NAME = "content";
@@ -249,11 +249,7 @@ var DropDownBox = DropDownEditor.inherit({
         this.callBase();
 
         if(this.option("focusStateEnabled")) {
-            this._popup._keyboardProcessor.push(new KeyboardProcessor({
-                element: this.content(),
-                handler: this._popupElementTabHandler,
-                context: this
-            }));
+            keyboard.on(this.content(), null, e => this._popupElementTabHandler(e));
         }
     },
 
@@ -266,6 +262,8 @@ var DropDownBox = DropDownEditor.inherit({
     },
 
     _popupConfig: function() {
+        const { focusStateEnabled } = this.option();
+
         return extend(this.callBase(), {
             width: function() {
                 return this.$element().outerWidth();
@@ -273,7 +271,8 @@ var DropDownBox = DropDownEditor.inherit({
             height: "auto",
             tabIndex: -1,
             dragEnabled: false,
-            focusStateEnabled: this.option("focusStateEnabled"),
+            focusStateEnabled,
+            onKeyboardHandled: opts => this.option("focusStateEnabled") && this._popupElementTabHandler(opts),
             maxHeight: function() {
                 return getElementMaxHeightByWindow(this.$element());
             }.bind(this)

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -390,7 +390,7 @@ var DropDownEditor = TextBox.inherit({
         var isFocused = focused(this._input());
         var $container = this._$container;
 
-        this._disposeKeyboardProcessor();
+        this._detachKeyboardEvents();
 
         // NOTE: to prevent buttons disposition
         var beforeButtonsContainerParent = this._$beforeButtonsContainer && this._$beforeButtonsContainer[0].parentNode;

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -555,11 +555,10 @@ var DropDownList = DropDownEditor.inherit({
         this._renderList();
     },
 
-    _attachChildKeyboardEvents: function() {
-        if(!this._canListHaveFocus()) {
-            this._childKeyboardProcessor = this._keyboardProcessor.attachChildProcessor();
-            this._setListOption("_keyboardProcessor", this._childKeyboardProcessor);
-        }
+    _getKeyboardListeners() {
+        const canListHaveFocus = this._canListHaveFocus();
+
+        return this.callBase().concat([!canListHaveFocus && this._list]);
     },
 
     _fireContentReadyAction: commonUtils.noop,
@@ -642,14 +641,12 @@ var DropDownList = DropDownEditor.inherit({
             groupTemplate: this.option("groupTemplate"),
             onItemClick: this._listItemClickAction.bind(this),
             dataSource: this._getDataSource(),
-            _keyboardProcessor: this._childKeyboardProcessor,
             hoverStateEnabled: this._isDesktopDevice() ? this.option("hoverStateEnabled") : false,
             focusStateEnabled: this._isDesktopDevice() ? this.option("focusStateEnabled") : false
         };
 
         if(!this._canListHaveFocus()) {
             options.tabIndex = null;
-            options._keyboardProcessor = this._childKeyboardProcessor;
         }
 
         return options;

--- a/js/ui/drop_down_menu.js
+++ b/js/ui/drop_down_menu.js
@@ -408,7 +408,6 @@ var DropDownMenu = Widget.inherit({
 
     _listOptions: function() {
         return {
-            _keyboardProcessor: this._listProcessor,
             pageLoadMode: "scrollBottom",
             indicateLoading: false,
             noDataText: "",
@@ -435,18 +434,8 @@ var DropDownMenu = Widget.inherit({
         delete this._deferRendering;
     },
 
-    _attachKeyboardEvents: function() {
-        this.callBase.apply(this, arguments);
-
-        this._listProcessor = this._keyboardProcessor && this._keyboardProcessor.attachChildProcessor();
-        if(this._list) {
-            this._list.option("_keyboardProcessor", this._listProcessor);
-        }
-    },
-
-    _cleanFocusState: function() {
-        this.callBase.apply(this, arguments);
-        delete this._listProcessor;
+    _getKeyboardListeners() {
+        return this.callBase().concat([this._list]);
     },
 
     _toggleVisibility: function(visible) {

--- a/js/ui/editor/editor.js
+++ b/js/ui/editor/editor.js
@@ -1,7 +1,6 @@
 import $ from "../../core/renderer";
 import dataUtils from "../../core/element_data";
 import Callbacks from "../../core/utils/callbacks";
-import commonUtils from "../../core/utils/common";
 import windowUtils from "../../core/utils/window";
 import { addNamespace, normalizeKeyName } from "../../events/utils";
 import { getDefaultAlignment } from "../../core/utils/position";
@@ -152,18 +151,10 @@ const Editor = Widget.inherit({
     },
 
     _attachKeyboardEvents: function() {
-        if(this.option("readOnly")) {
-            return;
-        }
-
-        this.callBase();
-
-        if(this._keyboardProcessor) {
-            this._attachChildKeyboardEvents();
+        if(!this.option("readOnly")) {
+            this.callBase();
         }
     },
-
-    _attachChildKeyboardEvents: commonUtils.noop,
 
     _setOptionsByReference: function() {
         this.callBase();

--- a/js/ui/file_uploader.js
+++ b/js/ui/file_uploader.js
@@ -15,7 +15,7 @@ import Button from "./button";
 import ProgressBar from "./progress_bar";
 import browser from "../core/utils/browser";
 import devices from "../core/devices";
-import eventUtils from "../events/utils";
+import * as eventUtils from "../events/utils";
 import clickEvent from "../events/click";
 import messageLocalization from "../localization/message";
 import themes from "./themes";

--- a/js/ui/grid_core/ui.grid_core.adaptivity.js
+++ b/js/ui/grid_core/ui.grid_core.adaptivity.js
@@ -1,6 +1,6 @@
 import $ from "../../core/renderer";
 import eventsEngine from "../../events/core/events_engine";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import clickEvent from "../../events/click";
 import typeUtils from "../../core/utils/type";
 import browser from "../../core/utils/browser";

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -6,13 +6,13 @@ import { focusAndSelectElement, getWidgetInstance } from "./ui.grid_core.utils";
 import { isDefined } from "../../core/utils/type";
 import { inArray } from "../../core/utils/array";
 import { focused } from "../widget/selectors";
-import KeyboardProcessor from "../widget/ui.keyboard_processor";
 import eventUtils from "../../events/utils";
 import pointerEvents from "../../events/pointer";
 import { noop } from "../../core/utils/common";
 import { selectView } from "../shared/accessibility";
 import { isElementInCurrentGrid } from "./ui.grid_core.utils";
 import browser from "../../core/utils/browser";
+import { keyboard } from "../../events/index";
 
 
 var ROWS_VIEW_CLASS = "rowsview",
@@ -140,7 +140,7 @@ var KeyboardNavigationController = core.ViewController.inherit({
             eventsEngine.off($element, eventUtils.addNamespace(pointerEvents.up, "dxDataGridKeyboardNavigation"), clickAction);
             eventsEngine.on($element, eventUtils.addNamespace(pointerEvents.up, "dxDataGridKeyboardNavigation"), clickSelector, clickAction);
 
-            that._initKeyDownProcessor(that, $element, that._keyDownHandler);
+            that._initKeyDownProcessor($element, e => that._keyDownHandler(e));
 
             if(isFocusedViewCorrect && isFocusedElementCorrect) {
                 needUpdateFocus = that._isNeedFocus ? !isAppend : that._isHiddenFocus && isFullUpdate;
@@ -149,22 +149,15 @@ var KeyboardNavigationController = core.ViewController.inherit({
         });
     },
 
-    _initKeyDownProcessor: function(context, element, handler) {
-        if(this._keyDownProcessor) {
-            this._keyDownProcessor.dispose();
-            this._keyDownProcessor = null;
-        }
-        this._keyDownProcessor = new KeyboardProcessor({
-            element: element,
-            context: context,
-            handler: handler
-        });
+    _initKeyDownProcessor: function(element, handler) {
+        keyboard.off(this._keyDownListener);
+        this._keyDownListener = keyboard.on(element, null, handler);
     },
 
     dispose: function() {
         this.callBase();
         this._focusedView = null;
-        this._keyDownProcessor && this._keyDownProcessor.dispose();
+        keyboard.off(this._keyDownListener);
         eventsEngine.off(domAdapter.getDocument(), eventUtils.addNamespace(pointerEvents.down, "dxDataGridKeyboardNavigation"), this._documentClickHandler);
     },
     // #endregion Initialization

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -140,7 +140,7 @@ var KeyboardNavigationController = core.ViewController.inherit({
             eventsEngine.off($element, eventUtils.addNamespace(pointerEvents.up, "dxDataGridKeyboardNavigation"), clickAction);
             eventsEngine.on($element, eventUtils.addNamespace(pointerEvents.up, "dxDataGridKeyboardNavigation"), clickSelector, clickAction);
 
-            that._initKeyDownProcessor($element, e => that._keyDownHandler(e));
+            that._initKeyDownHandler($element, e => that._keyDownHandler(e));
 
             if(isFocusedViewCorrect && isFocusedElementCorrect) {
                 needUpdateFocus = that._isNeedFocus ? !isAppend : that._isHiddenFocus && isFullUpdate;
@@ -149,7 +149,7 @@ var KeyboardNavigationController = core.ViewController.inherit({
         });
     },
 
-    _initKeyDownProcessor: function(element, handler) {
+    _initKeyDownHandler: function(element, handler) {
         keyboard.off(this._keyDownListener);
         this._keyDownListener = keyboard.on(element, null, handler);
     },

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -12,7 +12,7 @@ import { noop } from "../../core/utils/common";
 import { selectView } from "../shared/accessibility";
 import { isElementInCurrentGrid } from "./ui.grid_core.utils";
 import browser from "../../core/utils/browser";
-import { keyboard } from "../../events/index";
+import { keyboard } from "../../events/";
 
 
 var ROWS_VIEW_CLASS = "rowsview",

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -6,7 +6,7 @@ import { focusAndSelectElement, getWidgetInstance } from "./ui.grid_core.utils";
 import { isDefined } from "../../core/utils/type";
 import { inArray } from "../../core/utils/array";
 import { focused } from "../widget/selectors";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import pointerEvents from "../../events/pointer";
 import { noop } from "../../core/utils/common";
 import { selectView } from "../shared/accessibility";

--- a/js/ui/html_editor/modules/mentions.js
+++ b/js/ui/html_editor/modules/mentions.js
@@ -3,7 +3,7 @@ import { compileGetter } from "../../../core/utils/data";
 import { isString } from "../../../core/utils/type";
 import { extend } from "../../../core/utils/extend";
 import { getPublicElement } from "../../../core/utils/dom";
-import { Event as dxEvent } from "../../../events";
+import { Event as dxEvent } from "../../../events/core/events_engine";
 
 import PopupModule from "./popup";
 import Mention from "../formats/mention";

--- a/js/ui/list/ui.list.edit.js
+++ b/js/ui/list/ui.list.edit.js
@@ -62,8 +62,8 @@ const ListEdit = ListBase.inherit({
 
         return extend({}, parent, {
             del: deleteFocusedItem,
-            upArrow: (e) => moveFocusedItem(e, true),
-            downArrow: moveFocusedItem,
+            upArrow: e => moveFocusedItem(e, true),
+            downArrow: e => moveFocusedItem(e),
             enter,
             space
         });

--- a/js/ui/lookup.js
+++ b/js/ui/lookup.js
@@ -954,15 +954,6 @@ var Lookup = DropDownList.inherit({
         this._renderSearch();
     },
 
-    _attachSearchChildProcessor: function(searchComponent) {
-        this._listKeyboardProcessor = this._listKeyboardProcessor || searchComponent._keyboardProcessor.attachChildProcessor();
-        this._setListOption("_keyboardProcessor", this._listKeyboardProcessor);
-    },
-
-    _detachSearchChildProcessor: function() {
-        this._setListOption("_keyboardProcessor", null);
-    },
-
     _renderSearch: function() {
         var isSearchEnabled = this.option("searchEnabled");
 
@@ -977,12 +968,13 @@ var Lookup = DropDownList.inherit({
             var currentDevice = devices.current(),
                 searchMode = currentDevice.android && currentDevice.version[0] >= 5 ? "text" : "search";
 
+            let isKeyboardListeningEnabled = false;
+
             this._searchBox = this._createComponent($searchBox, TextBox, {
-                onDisposing: function() {
-                    this._detachSearchChildProcessor();
-                }.bind(this),
-                onFocusIn: this._searchFocusHandler.bind(this),
-                onFocusOut: this._searchBlurHandler.bind(this),
+                onDisposing: () => isKeyboardListeningEnabled = false,
+                onFocusIn: () => isKeyboardListeningEnabled = true,
+                onFocusOut: () => isKeyboardListeningEnabled = false,
+                onKeyboardHandled: opts => isKeyboardListeningEnabled && this._list._keyboardHandler(opts),
                 mode: searchMode,
                 showClearButton: true,
                 valueChangeEvent: this.option("valueChangeEvent"),
@@ -995,14 +987,6 @@ var Lookup = DropDownList.inherit({
 
             this._setSearchPlaceholder();
         }
-    },
-
-    _searchFocusHandler: function(e) {
-        this._attachSearchChildProcessor(e.component);
-    },
-
-    _searchBlurHandler: function() {
-        this._detachSearchChildProcessor();
     },
 
     _removeSearch: function() {
@@ -1080,7 +1064,6 @@ var Lookup = DropDownList.inherit({
             onPageLoading: this.option("onPageLoading"),
             pageLoadMode: this.option("pageLoadMode"),
             nextButtonText: this.option("nextButtonText"),
-            _keyboardProcessor: this._listKeyboardProcessor,
             onSelectionChanged: this._getSelectionChangedHandler()
         });
     },
@@ -1105,8 +1088,6 @@ var Lookup = DropDownList.inherit({
             eventsEngine.trigger(this._$list, "focus");
         }
     },
-
-    _attachChildKeyboardEvents: commonUtils.noop,
 
     _focusTarget: function() {
         return this._$field;

--- a/js/ui/menu/ui.menu.js
+++ b/js/ui/menu/ui.menu.js
@@ -520,7 +520,7 @@ class Menu extends MenuBase {
     }
 
     _keyboardHandler(e) {
-        return this._visibleSubmenu ? true : super._keyboardHandler(e);
+        return super._keyboardHandler(e, !!this._visibleSubmenu);
     }
 
     _renderContainer() {
@@ -541,14 +541,16 @@ class Menu extends MenuBase {
         return submenu;
     }
 
+    _getKeyboardListeners() {
+        return super._getKeyboardListeners().concat(this._submenus);
+    }
+
     _createSubmenu(node, $rootItem) {
         const $submenuContainer = $("<div>").addClass(DX_CONTEXT_MENU_CLASS)
             .appendTo($rootItem);
 
-        const childKeyboardProcessor = this._keyboardProcessor && this._keyboardProcessor.attachChildProcessor(),
-            items = this._getChildNodes(node),
+        const items = this._getChildNodes(node),
             result = this._createComponent($submenuContainer, Submenu, extend(this._getSubmenuOptions(), {
-                _keyboardProcessor: childKeyboardProcessor,
                 _dataAdapter: this._dataAdapter,
                 _parentKey: node.internalFields.key,
                 items: items,

--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -24,7 +24,7 @@ var $ = require("../../core/renderer"),
     browser = require("../../core/utils/browser"),
     registerComponent = require("../../core/component_registrator"),
     Widget = require("../widget/ui.widget"),
-    keyboard = require("../../events/index").keyboard,
+    keyboard = require("../../events/").keyboard,
 
     selectors = require("../widget/selectors"),
     dragEvents = require("../../events/drag"),

--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -24,7 +24,8 @@ var $ = require("../../core/renderer"),
     browser = require("../../core/utils/browser"),
     registerComponent = require("../../core/component_registrator"),
     Widget = require("../widget/ui.widget"),
-    KeyboardProcessor = require("../widget/ui.keyboard_processor"),
+    keyboard = require("../../events/index").keyboard,
+
     selectors = require("../widget/selectors"),
     dragEvents = require("../../events/drag"),
     eventUtils = require("../../events/utils"),
@@ -1406,11 +1407,11 @@ var Overlay = Widget.inherit({
     },
 
     _attachKeyboardEvents: function() {
-        this._keyboardProcessor = new KeyboardProcessor({
-            element: this._$content,
-            handler: this._keyboardHandler,
-            context: this
-        });
+        this._keyboardListenerId = keyboard.on(
+            this._$content,
+            null,
+            opts => this._keyboardHandler(opts)
+        );
     },
 
     _keyboardHandler: function(options) {

--- a/js/ui/scheduler/ui.scheduler.appointment.js
+++ b/js/ui/scheduler/ui.scheduler.appointment.js
@@ -6,7 +6,7 @@ import { extend } from "../../core/utils/extend";
 import registerComponent from "../../core/component_registrator";
 import tooltip from "../tooltip/ui.tooltip";
 import publisherMixin from "./ui.scheduler.publisher_mixin";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import pointerEvents from "../../events/pointer";
 import DOMComponent from "../../core/dom_component";
 import Resizable from "../resizable";

--- a/js/ui/scheduler/ui.scheduler.appointments.js
+++ b/js/ui/scheduler/ui.scheduler.appointments.js
@@ -15,7 +15,7 @@ import recurrenceUtils from "./utils.recurrence";
 import registerComponent from "../../core/component_registrator";
 import publisherMixin from "./ui.scheduler.publisher_mixin";
 import Appointment from "./ui.scheduler.appointment";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import dblclickEvent from "../../events/double_click";
 import dateLocalization from "../../localization/date";
 import messageLocalization from "../../localization/message";

--- a/js/ui/scheduler/ui.scheduler.navigator.js
+++ b/js/ui/scheduler/ui.scheduler.navigator.js
@@ -424,8 +424,7 @@ var SchedulerNavigator = Widget.inherit({
                 this._popover.hide();
             }).bind(this),
             hasFocus: function() { return true; },
-            tabIndex: null,
-            _keyboardProcessor: this._calendarKeyboardProcessor
+            tabIndex: null
         };
     },
 
@@ -438,9 +437,12 @@ var SchedulerNavigator = Widget.inherit({
 
         this._caption.option({
             text: caption,
-            onClick: (function() {
-                this._popover.toggle();
-            }).bind(this)
+            onKeyboardHandled: opts => {
+                this.option("focusStateEnabled") &&
+                    !this.option("disabled") &&
+                    this._calendar._keyboardHandler(opts);
+            },
+            onClick: () => this._popover.toggle()
         });
     },
 
@@ -448,9 +450,6 @@ var SchedulerNavigator = Widget.inherit({
         if(!this.option("focusStateEnabled") || this.option("disabled")) {
             return;
         }
-
-        this._calendarKeyboardProcessor = this._caption._keyboardProcessor.attachChildProcessor();
-        this._setCalendarOption("_keyboardProcessor", this._calendarKeyboardProcessor);
 
         var that = this,
             executeHandler = function() {

--- a/js/ui/scroll_view/ui.scrollable.js
+++ b/js/ui/scroll_view/ui.scrollable.js
@@ -12,7 +12,7 @@ import devices from "../../core/devices";
 import registerComponent from "../../core/component_registrator";
 import DOMComponent from "../../core/dom_component";
 import selectors from "../widget/selectors";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import scrollEvents from "./ui.events.emitter.gesture.scroll";
 import simulatedStrategy from "./ui.scrollable.simulated";
 import NativeStrategy from "./ui.scrollable.native";

--- a/js/ui/scroll_view/ui.scrollable.native.js
+++ b/js/ui/scroll_view/ui.scrollable.native.js
@@ -1,6 +1,6 @@
 import $ from "../../core/renderer";
 import eventsEngine from "../../events/core/events_engine";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import { noop } from "../../core/utils/common";
 import { each } from "../../core/utils/iterator";
 import devices from "../../core/devices";

--- a/js/ui/scroll_view/ui.scrollbar.js
+++ b/js/ui/scroll_view/ui.scrollbar.js
@@ -4,7 +4,7 @@ import eventsEngine from "../../events/core/events_engine";
 import readyCallback from "../../core/utils/ready_callbacks";
 import translator from "../../animation/translator";
 import Widget from "../widget/ui.widget";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import commonUtils from "../../core/utils/common";
 import { isPlainObject } from "../../core/utils/type";
 import { extend } from "../../core/utils/extend";

--- a/js/ui/shared/accessibility.js
+++ b/js/ui/shared/accessibility.js
@@ -1,6 +1,6 @@
 import $ from "../../core/renderer";
 import eventsEngine from "../../events/core/events_engine";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import { extend } from "../../core/utils/extend";
 
 const FOCUS_STATE_CLASS = "dx-state-focused",

--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -51,7 +51,7 @@ const TagBox = SelectBox.inherit({
 
     _supportedKeys: function() {
         const parent = this.callBase();
-        const sendToList = (e) => this._list._keyboardProcessor.process(e);
+        const sendToList = options => this._list._keyboardHandler(options);
 
         return extend({}, parent, {
             backspace: function(e) {
@@ -77,13 +77,11 @@ const TagBox = SelectBox.inherit({
                 this._removeTagElement($tagToDelete);
                 delete this._preserveFocusedTag;
             },
-            upArrow: (e) => {
-                const handler = e.altKey || !this._list ? parent.upArrow : sendToList;
-                return handler.apply(this, arguments);
+            upArrow: (e, opts) => {
+                return e.altKey || !this._list ? parent.upArrow.call(this, e) : sendToList(opts);
             },
-            downArrow: (e) => {
-                const handler = e.altKey || !this._list ? parent.downArrow : sendToList;
-                return handler.apply(this, arguments);
+            downArrow: (e, opts) => {
+                return e.altKey || !this._list ? parent.downArrow.call(this, e) : sendToList(opts);
             },
             del: function(e) {
                 if(!this._$focusedTag || !this._isCaretAtTheStart()) {
@@ -102,7 +100,7 @@ const TagBox = SelectBox.inherit({
                 this._removeTagElement($tagToDelete);
                 delete this._preserveFocusedTag;
             },
-            enter: function(e) {
+            enter: function(e, options) {
                 const isListItemFocused = this._list && this._list.option("focusedElement") !== null;
                 const isCustomItem = this.option("acceptCustomValue") && !isListItemFocused;
 
@@ -113,16 +111,16 @@ const TagBox = SelectBox.inherit({
                 }
 
                 if(this.option("opened")) {
-                    sendToList(e);
+                    sendToList(options);
                     e.preventDefault();
                 }
             },
-            space: function(e) {
+            space: function(e, options) {
                 const isOpened = this.option("opened");
                 const isInputActive = this._shouldRenderSearchEvent();
 
                 if(isOpened && !isInputActive) {
-                    sendToList(e);
+                    sendToList(options);
                     e.preventDefault();
                 }
             },

--- a/js/ui/text_area.js
+++ b/js/ui/text_area.js
@@ -5,7 +5,7 @@ import windowUtils from "../core/utils/window";
 import registerComponent from "../core/component_registrator";
 import { extend } from "../core/utils/extend";
 import { isDefined } from "../core/utils/type";
-import eventUtils from "../events/utils";
+import * as eventUtils from "../events/utils";
 import pointerEvents from "../events/pointer";
 import scrollEvents from "../ui/scroll_view/ui.events.emitter.gesture.scroll";
 import sizeUtils from "../core/utils/size";

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -9,7 +9,7 @@ import { inArray } from "../../core/utils/array";
 import { each } from "../../core/utils/iterator";
 import themes from "../themes";
 import Editor from "../editor/editor";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import pointerEvents from "../../events/pointer";
 import ClearButton from "./ui.text_editor.clear";
 import TextEditorButtonCollection from "./texteditor_button_collection/index";

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -1,6 +1,6 @@
 var $ = require("../../core/renderer"),
     eventsEngine = require("../../events/core/events_engine"),
-    events = require("../../events/index"),
+    events = require("../../events/"),
     Action = require("../../core/action"),
     extend = require("../../core/utils/extend").extend,
     inArray = require("../../core/utils/array").inArray,
@@ -8,7 +8,6 @@ var $ = require("../../core/renderer"),
     commonUtils = require("../../core/utils/common"),
     typeUtils = require("../../core/utils/type"),
     DOMComponentWithTemplate = require("../../core/dom_component_with_template"),
-    keyboard = require("../../events/index").keyboard,
     selectors = require("./selectors"),
     eventUtils = require("../../events/utils");
 
@@ -16,7 +15,7 @@ require("../../events/click");
 require("../../events/hover");
 require("../../events/core/emitter.feedback");
 
-const { hover, focus, active, dxClick } = events;
+const { hover, focus, active, dxClick, keyboard } = events;
 
 var WIDGET_CLASS = "dx-widget",
     ACTIVE_STATE_CLASS = "dx-state-active",

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -133,8 +133,6 @@ var Widget = DOMComponentWithTemplate.inherit({
             * @hidden
             */
             onFocusOut: null,
-
-            _listenerId: Symbol('listenerId'),
             onKeyboardHandled: null,
 
             /**
@@ -298,7 +296,7 @@ var Widget = DOMComponentWithTemplate.inherit({
     _dispose: function() {
         this._contentReadyAction = null;
         this._keyboardHandledAction = null;
-        this._disposeKeyboardProcessor();
+        this._detachKeyboardEvents();
 
         this.callBase();
     },
@@ -444,7 +442,7 @@ var Widget = DOMComponentWithTemplate.inherit({
     },
 
     _attachKeyboardEvents: function() {
-        this._disposeKeyboardProcessor();
+        this._detachKeyboardEvents();
 
         const { focusStateEnabled, onKeyboardHandled } = this.option();
         const hasChildListeners = this._getKeyboardListeners().length;
@@ -497,10 +495,10 @@ var Widget = DOMComponentWithTemplate.inherit({
         this._toggleFocusClass(false);
         $element.removeAttr("tabIndex");
 
-        this._disposeKeyboardProcessor();
+        this._detachKeyboardEvents();
     },
 
-    _disposeKeyboardProcessor() {
+    _detachKeyboardEvents() {
         keyboard.off(this._keyboardListenerId);
         this._keyboardListenerId = null;
     },

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -182,11 +182,6 @@ var Widget = DOMComponentWithTemplate.inherit({
     _init: function() {
         this.callBase();
         this._initContentReadyAction();
-        this._initKeyboardHandledAction();
-    },
-
-    _initKeyboardHandledAction() {
-        this._keyboardHandledAction = this._createActionByOption('onKeyboardHandled');
     },
 
     _clearInnerOptionCache: function(optionContainer) {
@@ -294,7 +289,6 @@ var Widget = DOMComponentWithTemplate.inherit({
 
     _dispose: function() {
         this._contentReadyAction = null;
-        this._keyboardHandledAction = null;
         this._detachKeyboardEvents();
 
         this.callBase();
@@ -474,9 +468,11 @@ var Widget = DOMComponentWithTemplate.inherit({
         }
 
         const keyboardListeners = this._getKeyboardListeners();
+        const { onKeyboardHandled } = this.option();
 
         keyboardListeners.forEach(listener => listener && listener._keyboardHandler(options));
-        this._keyboardHandledAction(options);
+
+        onKeyboardHandled && onKeyboardHandled(options);
 
         return true;
     },
@@ -654,7 +650,6 @@ var Widget = DOMComponentWithTemplate.inherit({
                 }
                 break;
             case "onKeyboardHandled":
-                this._initKeyboardHandledAction();
                 this._attachKeyboardEvents();
                 break;
             case "onContentReady":

--- a/js/viz/chart_components/scroll_bar.js
+++ b/js/viz/chart_components/scroll_bar.js
@@ -1,5 +1,5 @@
 import eventsEngine from "../../events/core/events_engine";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import { extend } from "../../core/utils/extend";
 import translator2DModule from "../translators/translator2d";
 import { isDefined } from "../../core/utils/type";

--- a/js/viz/vector_map/tracker.js
+++ b/js/viz/vector_map/tracker.js
@@ -2,7 +2,7 @@ import eventsEngine from "../../events/core/events_engine";
 import windowUtils from "../../core/utils/window";
 import domAdapter from "../../core/dom_adapter";
 import eventEmitterModule from "./event_emitter";
-import eventUtils from "../../events/utils";
+import * as eventUtils from "../../events/utils";
 import { name as wheelEventName } from "../../events/core/wheel";
 import { parseScalar } from "../core/utils";
 

--- a/testing/functional/tests/editors/list.ts
+++ b/testing/functional/tests/editors/list.ts
@@ -5,7 +5,7 @@ import List from '../../model/list';
 fixture `List`
     .page(url(__dirname, './pages/t718398.html'));
 
-test("Should focus first item after changing selection mode (T811770)", async t => {
+test('Should focus first item after changing selection mode (T811770)', async t => {
     const list = new List('#list');
     const input = Selector('#input');
     const switchSelectionMode = Selector('#button');
@@ -24,7 +24,7 @@ test("Should focus first item after changing selection mode (T811770)", async t 
         .expect(firstItemRadioButton.isFocused).ok();
 });
 
-test("List selection should work with keyboard arrows (T718398)", async t => {
+test('List selection should work with keyboard arrows (T718398)', async t => {
     const list = new List('#list');
     const input = Selector('#input');
     const firstItemCheckBox = list.getItem().checkBox;
@@ -75,7 +75,7 @@ test("List selection should work with keyboard arrows (T718398)", async t => {
         .expect(secondItemCheckBox.isFocused).notOk();
 });
 
-test("Should save focused checkbox", async t => {
+test('Should save focused checkbox', async t => {
     const list = new List('#list');
     const input = Selector('#input');
     const secondItemCheckBox = list.getItem(1).checkBox;
@@ -115,7 +115,7 @@ test("Should save focused checkbox", async t => {
 fixture `List T727360`
     .page(url(__dirname, './pages/t727360.html'));
 
-test("Grouped list can not reorder items (T727360)", async t => {
+test('Grouped list can not reorder items (T727360)', async t => {
     const list = new List('#list');
     const firstGroup = list.getGroup();
     const secondGroup = list.getGroup(1);
@@ -147,7 +147,7 @@ test("Grouped list can not reorder items (T727360)", async t => {
 fixture `List T815151`
     .page(url(__dirname, './pages/t815151.html'));
 
-test("Disabled item should not have focus (T815151)", async t => {
+test('Disabled item should not have focus (T815151)', async t => {
     const list = new List('#list');
     const { searchInput } = list;
     const firstItem = list.getItem();
@@ -155,8 +155,10 @@ test("Disabled item should not have focus (T815151)", async t => {
     const disableFirstItem = Selector('#disable');
 
     await t
-        .click(firstItem.element)
+        .click(searchInput)
+        .pressKey('tab')
         .expect(firstItem.isFocused).ok()
+        .expect(secondItem.isFocused).notOk()
 
         .click(disableFirstItem)
         .expect(firstItem.isDisabled).ok()

--- a/testing/helpers/grid/keyboardNavigationHelper.js
+++ b/testing/helpers/grid/keyboardNavigationHelper.js
@@ -7,7 +7,7 @@ import {
     MockColumnsController,
     MockSelectionController } from "../dataGridMocks.js";
 import pointerEvents from "events/pointer";
-import { keyboard } from "events/index";
+import { keyboard } from "events/";
 import DataGridWrapper from "../wrappers/dataGridWrappers.js";
 
 export const dataGridWrapper = new DataGridWrapper("#container");

--- a/testing/helpers/grid/keyboardNavigationHelper.js
+++ b/testing/helpers/grid/keyboardNavigationHelper.js
@@ -1,6 +1,6 @@
 import $ from "jquery";
 import devices from "core/devices";
-import eventUtils from "events/utils";
+import * as eventUtils from "events/utils";
 import {
     setupDataGridModules,
     MockDataController,

--- a/testing/helpers/grid/keyboardNavigationHelper.js
+++ b/testing/helpers/grid/keyboardNavigationHelper.js
@@ -7,6 +7,7 @@ import {
     MockColumnsController,
     MockSelectionController } from "../dataGridMocks.js";
 import pointerEvents from "events/pointer";
+import { keyboard } from "events/index";
 import DataGridWrapper from "../wrappers/dataGridWrappers.js";
 
 export const dataGridWrapper = new DataGridWrapper("#container");
@@ -121,7 +122,10 @@ export function triggerKeyDown(key, ctrl, shift, target, result) {
         shift = ctrl.shift;
         ctrl = ctrl.ctrl;
     }
-    this.keyboardNavigationController._keyDownProcessor.process({
+
+    const keyboardListenerId = this.keyboardNavigationController._keyDownListener;
+
+    keyboard._getProcessor(keyboardListenerId).process({
         key: KEYS[key] || key,
         keyName: key,
         ctrlKey: ctrl,

--- a/testing/runner/Views/Main/RunSuite.cshtml
+++ b/testing/runner/Views/Main/RunSuite.cshtml
@@ -194,6 +194,12 @@
                     'systemjs-babel-build': '@Url.Content("~/node_modules/systemjs-plugin-babel/systemjs-babel-browser.js")'
                 },
                 packages: {
+                    'events/utils': {
+                        main: 'index'
+                    },
+                    'events/': {
+                        main: 'index'
+                    },
                     '': {
                         defaultExtension: 'js'
                     },

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -70,6 +70,7 @@ import config from "core/config";
 import keyboardMock from "../../helpers/keyboardMock.js";
 import pointerMock from "../../helpers/pointerMock.js";
 import pointerEvents from "events/pointer";
+import { keyboard } from "events/index";
 import ajaxMock from "../../helpers/ajaxMock.js";
 import themes from "ui/themes";
 import DataGridWrapper from "../../helpers/wrappers/dataGridWrappers.js";
@@ -13847,7 +13848,9 @@ QUnit.testInActiveWindow("'Form' edit mode correctly change focus after edit a f
                 }, "lastName"]
         }),
         triggerTabPress = function(target) {
-            dataGrid.getController("keyboardNavigation")._keyDownProcessor.process({
+            const keyboardListenerId = dataGrid.getController("keyboardNavigation")._keyDownListener;
+
+            keyboard._getProcessor(keyboardListenerId).process({
                 key: "Tab",
                 keyName: "tab",
                 target: target && target[0] || target,

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -70,7 +70,7 @@ import config from "core/config";
 import keyboardMock from "../../helpers/keyboardMock.js";
 import pointerMock from "../../helpers/pointerMock.js";
 import pointerEvents from "events/pointer";
-import { keyboard } from "events/index";
+import { keyboard } from "events/";
 import ajaxMock from "../../helpers/ajaxMock.js";
 import themes from "ui/themes";
 import DataGridWrapper from "../../helpers/wrappers/dataGridWrappers.js";

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
@@ -16,7 +16,7 @@ import $ from "jquery";
 import eventUtils from "events/utils";
 import ArrayStore from "data/array_store";
 import pointerEvents from "events/pointer";
-import { keyboard } from "events/index";
+import { keyboard } from "events/";
 import { setupDataGridModules, generateItems } from "../../helpers/dataGridMocks.js";
 import DataGridWrapper from "../../helpers/wrappers/dataGridWrappers.js";
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
@@ -13,7 +13,7 @@ import "ui/data_grid/ui.data_grid";
 import "data/odata/store";
 
 import $ from "jquery";
-import eventUtils from "events/utils";
+import * as eventUtils from "events/utils";
 import ArrayStore from "data/array_store";
 import pointerEvents from "events/pointer";
 import { keyboard } from "events/";

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
@@ -16,6 +16,7 @@ import $ from "jquery";
 import eventUtils from "events/utils";
 import ArrayStore from "data/array_store";
 import pointerEvents from "events/pointer";
+import { keyboard } from "events/index";
 import { setupDataGridModules, generateItems } from "../../helpers/dataGridMocks.js";
 import DataGridWrapper from "../../helpers/wrappers/dataGridWrappers.js";
 
@@ -59,7 +60,10 @@ function triggerKeyDown(key, ctrl, shift, target, result) {
         shift = ctrl.shift;
         ctrl = ctrl.ctrl;
     }
-    this.keyboardNavigationController._keyDownProcessor.process({
+
+    const keyboardListenerId = this.keyboardNavigationController._keyDownListener;
+
+    keyboard._getProcessor(keyboardListenerId).process({
         key: KEYS[key],
         keyName: key,
         ctrlKey: ctrl,

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigationParts/keyboardController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigationParts/keyboardController.tests.js
@@ -450,34 +450,6 @@ QUnit.module("Keyboard navigation", {
         assert.ok(!isFocused, "headers view is not focused");
     });
 
-    QUnit.testInActiveWindow("KeyDownProcessor is disposed when controller is initialized", function(assert) {
-        // arrange
-        var navigationController,
-            isDisposeCalled = false,
-            $rowsElement = $("<div />").append($("<tr class='dx-row'><td/></tr>"));
-
-        this.getView("rowsView").element = function() {
-            return $rowsElement;
-        };
-
-        // act
-        navigationController = new KeyboardNavigationController(this.component);
-        navigationController.init();
-
-        navigationController._keyDownProcessor = {
-            dispose: function() {
-                isDisposeCalled = true;
-            }
-        };
-
-        callViewsRenderCompleted(this.component._views);
-
-        $($rowsElement.find("td")[0]).trigger(CLICK_EVENT);
-
-        // assert
-        assert.ok(isDisposeCalled, "keyDownProcessor is disposed");
-    });
-
     QUnit.testInActiveWindow("Focus by click is not applied when editing is enabled (T311207)", function(assert) {
         // arrange
         var navigationController,

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigationParts/keyboardController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigationParts/keyboardController.tests.js
@@ -8,7 +8,7 @@ import keyboardNavigationModule from "ui/grid_core/ui.grid_core.keyboard_navigat
 import commonUtils from "core/utils/common";
 import typeUtils from "core/utils/type";
 import publicComponentUtils from "core/utils/public_component";
-import eventUtils from "events/utils";
+import * as eventUtils from "events/utils";
 import eventsEngine from "events/core/events_engine";
 import pointerEvents from "events/pointer";
 import { MockDataController, MockColumnsController, MockEditingController } from "../../../helpers/dataGridMocks.js";

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
@@ -17,7 +17,7 @@ import "ui/data_grid/ui.data_grid";
 import $ from "jquery";
 import { setupDataGridModules, MockDataController } from "../../helpers/dataGridMocks.js";
 import dataUtils from "core/element_data";
-import eventUtils from "events/utils";
+import * as eventUtils from "events/utils";
 
 import Pager from "ui/pager";
 

--- a/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
@@ -4,7 +4,6 @@ import translator from "animation/translator";
 import dateUtils from "core/utils/date";
 import dateSerialization from "core/utils/date_serialization";
 import { noop } from "core/utils/common";
-import KeyboardProcessor from "events/core/keyboard_processor";
 import swipeEvents from "events/swipe";
 import fx from "animation/fx";
 import Views from "ui/calendar/ui.calendar.views";
@@ -734,39 +733,17 @@ QUnit.module("Keyboard navigation", {
         this.clock.restore();
     }
 }, () => {
-    QUnit.test("when a KeyboardProcessor instance is not passed into the constructor, rootElement must have a tabindex of 0", function(assert) {
+    QUnit.test("rootElement must have a tabindex of 0 by default", function(assert) {
         assert.equal(this.$element.attr("tabindex"), 0);
     });
 
-    QUnit.test("calendar should not dispose a keyDownProcessor passed via the constructor", function(assert) {
-        let disposeCount = 0;
-        const disposeMock = () => {
-            ++disposeCount;
-        };
-        const keyDownProcessor = new KeyboardProcessor({});
-
-        keyDownProcessor.dispose = disposeMock;
-
-        this.reinit({
-            keyDownProcessor: keyDownProcessor
-        });
-
-        this.calendar._clean();
-        assert.strictEqual(disposeCount, 0);
-    });
-
-    QUnit.test("when a KeyboardProcessor instance is passed into the constructor, the main table must not have tabindex", function(assert) {
-        this.reinit({
-            keyDownProcessor: new KeyboardProcessor({})
-        });
-
+    QUnit.test("The main table must not have tabindex by default", function(assert) {
+        this.reinit();
         assert.ok(!this.$element.find("table").attr("tabindex"));
     });
 
     QUnit.test("click must not focus the main table if it does have tabindex", function(assert) {
-        this.reinit({
-            keyDownProcessor: new KeyboardProcessor()
-        });
+        this.reinit();
 
         const $cell = $(getCurrentViewInstance(this.calendar).$element().find("table").find("td")[0]);
         assert.ok(!this.$element.find("table").attr("tabindex"));
@@ -1168,7 +1145,7 @@ QUnit.module("Calendar footer", {
             showTodayButton: true
         }).dxCalendar("instance");
 
-        this.reinit = (options) => {
+        this.reinit = (options = {}) => {
             this.$element.remove();
             this.$element = $("<div>").appendTo("body");
             this.calendar = this.$element.dxCalendar(options).dxCalendar("instance");

--- a/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
@@ -4,7 +4,7 @@ import translator from "animation/translator";
 import dateUtils from "core/utils/date";
 import dateSerialization from "core/utils/date_serialization";
 import { noop } from "core/utils/common";
-import KeyboardProcessor from "ui/widget/ui.keyboard_processor";
+import KeyboardProcessor from "events/core/keyboard_processor";
 import swipeEvents from "events/swipe";
 import fx from "animation/fx";
 import Views from "ui/calendar/ui.calendar.views";
@@ -1070,23 +1070,15 @@ QUnit.module("Keyboard navigation", {
 
         this.$element.remove();
         this.$element = $("<div>").appendTo("body");
-
-        const kb = new KeyboardProcessor({
-            element: this.$element,
-            handler: noop
-        });
-
         this.$element.dxCalendar({
-            _keyboardProcessor: kb,
             value: new Date(2013, 11, 15),
             focusStateEnabled: true
         });
 
         this.$element
-            .on("keydown.TEST", (e) => {
+            .on("keydown.TEST", e => {
                 assert.ok(e.isDefaultPrevented());
             })
-            .find("[data-value='2013/12/15']")
             .trigger($.Event("keydown", { key: LEFT_ARROW_KEY_CODE }))
             .trigger($.Event("keydown", { key: UP_ARROW_KEY_CODE }))
             .trigger($.Event("keydown", { key: RIGHT_ARROW_KEY_CODE }))

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -700,11 +700,7 @@ QUnit.test("Enter and escape key press does not prevent default when popup in no
 QUnit.test("Escape key press should be handled by a children keyboard processor", function(assert) {
     const handler = sinon.stub();
 
-    this.dropDownEditor
-        ._keyboardProcessor
-        .attachChildProcessor()
-        .reinitialize(handler, this.dropDownEditor);
-
+    this.dropDownEditor.option('onKeyboardHandled', handler);
     this.keyboard.keyDown("esc");
 
     assert.ok(handler.calledOnce, "Children keyboard processor can process the 'esc' key pressing");

--- a/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
@@ -99,14 +99,13 @@ QUnit.module("Editor", {
         editor.option("value", newValue);
     });
 
-    QUnit.test("keyboardProcessor is not defined for readOnly editor", function(assert) {
+    QUnit.test("should detach keyboard handler if readOnly is false", function(assert) {
         const editor = this.fixture.createEditor({ focusStateEnabled: true, readOnly: true });
 
-        assert.notOk(editor._keyboardListenerId, "keyboardProcessor is not defined after init");
+        assert.notOk(editor._keyboardListenerId);
 
         editor.option("readOnly", false);
-
-        assert.ok(editor._keyboardListenerId, "keyboardProcessor is defined");
+        assert.ok(editor._keyboardListenerId);
     });
 
     QUnit.test("If _valueChangeEventInstance is present, the onValueChanged must receive it as a Event argument; and then _valueChangeEventInstance must be reset", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/editor.tests.js
@@ -102,11 +102,11 @@ QUnit.module("Editor", {
     QUnit.test("keyboardProcessor is not defined for readOnly editor", function(assert) {
         const editor = this.fixture.createEditor({ focusStateEnabled: true, readOnly: true });
 
-        assert.strictEqual(editor._keyboardProcessor, undefined, "keyboardProcessor is not defined after init");
+        assert.notOk(editor._keyboardListenerId, "keyboardProcessor is not defined after init");
 
         editor.option("readOnly", false);
 
-        assert.ok(editor._keyboardProcessor, "keyboardProcessor is defined");
+        assert.ok(editor._keyboardListenerId, "keyboardProcessor is defined");
     });
 
     QUnit.test("If _valueChangeEventInstance is present, the onValueChanged must receive it as a Event argument; and then _valueChangeEventInstance must be reset", function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/mentionModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/mentionModule.tests.js
@@ -6,7 +6,7 @@ import Mentions from "ui/html_editor/modules/mentions";
 import { noop } from "core/utils/common";
 import devices from "core/devices";
 import browser from "core/utils/browser";
-import { Event as dxEvent } from "events";
+import { Event as dxEvent } from "events/core/events_engine";
 
 const SUGGESTION_LIST_CLASS = "dx-suggestion-list";
 const LIST_ITEM_CLASS = "dx-list-item";

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -4405,23 +4405,17 @@ QUnit.module("keyboard navigation", moduleSetup, () => {
     });
 
     QUnit.test("Escape key press should be handled by a children keyboard processor", function(assert) {
-
+        const handler = sinon.stub();
         const $element = $("#selectBox").dxSelectBox({
             dataSource: [0, 1, 2],
             value: 1,
             focusStateEnabled: true,
             opened: false,
-            deferRendering: true
+            deferRendering: true,
+            onKeyboardHandled: handler
         });
-        const instance = $element.dxSelectBox("instance");
         const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
         const keyboard = keyboardMock($input);
-        const handler = sinon.stub();
-
-        instance
-            ._keyboardProcessor
-            .attachChildProcessor()
-            .reinitialize(handler, instance);
 
         keyboard.keyDown("esc");
 

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
@@ -246,10 +246,10 @@ QUnit.module("Rendering", moduleConfig, () => {
         assert.ok(contextMenu.option("visible"), "context menu is shown after detached target been attached");
     });
 
-    QUnit.test("not create keyboardProcessor on rendering", function(assert) {
+    QUnit.test("not attach keyboard handler on rendering", function(assert) {
         const instance = new ContextMenu(this.$element, {});
 
-        assert.notOk(instance._keyboardListenerId, "keyboard processor is undefined");
+        assert.notOk(instance._keyboardListenerId);
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
@@ -249,7 +249,7 @@ QUnit.module("Rendering", moduleConfig, () => {
     QUnit.test("not create keyboardProcessor on rendering", function(assert) {
         const instance = new ContextMenu(this.$element, {});
 
-        assert.notOk(instance._keyboardProcessor, "keyboard processor is undefined");
+        assert.notOk(instance._keyboardListenerId, "keyboard processor is undefined");
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.tests.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 import devices from "core/devices";
 import fx from "animation/fx";
 import ContextMenu from "ui/context_menu";
-import eventUtils from "events/utils";
+import * as eventUtils from "events/utils";
 import contextMenuEvent from "events/contextmenu";
 import { isRenderer } from "core/utils/type";
 import config from "core/config";

--- a/testing/tests/DevExpress.ui.widgets/optionChanged_bundled.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/optionChanged_bundled.tests.js
@@ -38,8 +38,7 @@ define(function(require) {
                     name === "validationMessageOffset" ||
                     name === "templatesRenderAsynchronously" ||
                     name === "ignoreChildEvents" ||
-                    name === "_checkParentVisibility" ||
-                    name === "_listenerId") {
+                    name === "_checkParentVisibility") {
                     return;
                 }
                 this.QUnitAssert.ok(false, "Option '" + name + "' is not processed after runtime change");

--- a/testing/tests/DevExpress.ui.widgets/optionChanged_bundled.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/optionChanged_bundled.tests.js
@@ -38,7 +38,8 @@ define(function(require) {
                     name === "validationMessageOffset" ||
                     name === "templatesRenderAsynchronously" ||
                     name === "ignoreChildEvents" ||
-                    name === "_checkParentVisibility") {
+                    name === "_checkParentVisibility" ||
+                    name === "_listenerId") {
                     return;
                 }
                 this.QUnitAssert.ok(false, "Option '" + name + "' is not processed after runtime change");

--- a/testing/tests/DevExpress.ui/keyboardProcessor.tests.js
+++ b/testing/tests/DevExpress.ui/keyboardProcessor.tests.js
@@ -1,5 +1,5 @@
 import $ from "jquery";
-import KeyboardProcessor from "ui/widget/ui.keyboard_processor";
+import KeyboardProcessor from "events/core/keyboard_processor";
 
 const { test } = QUnit;
 
@@ -35,24 +35,6 @@ QUnit.module("keyboardProcessor", {
 
     test("Calling process should invoke the handler and pass the original event, key name and ctrl status as arguments", function(assert) {
         this.processor = new KeyboardProcessor({ handler: this.createAssertionHandler(assert) });
-        this.processor.process(this.keyDownEvent);
-    });
-
-    test("keyboardProcessor should invoke the process of each childProcessor if the handler returns true", function(assert) {
-        assert.expect(2 * this.assertionHandlerAssertCount);
-        this.processor = new KeyboardProcessor({ element: this.element, handler: function() { return true; } });
-
-        const childProcessorA = this.processor.attachChildProcessor();
-        const childProcessorB = this.processor.attachChildProcessor();
-
-        childProcessorA.reinitialize(this.createAssertionHandler(assert));
-        childProcessorB.reinitialize(this.createAssertionHandler(assert));
-        this.element.trigger(this.keyDownEvent);
-    });
-
-    test("Specifying context should invoke handler in it", function(assert) {
-        const context = { keyDownHandler: function() { assert.strictEqual(this, context); } };
-        this.processor = new KeyboardProcessor({ handler: context.keyDownHandler, context: context });
         this.processor.process(this.keyDownEvent);
     });
 


### PR DESCRIPTION
- Get rid of keyboard processors transfering from widget to widget
- Use simple api for keyboard events: 
```javascript
const id = keyboard.on(element, () => ...);
...
keyboard.off(id);
```
- Use keyboard processor as an internal tool
- Add private `onKeyboardHandled` event to catch child widget keyboard events