### PR TITLE
Set opaque colors for contained buttons in button group (T835256)

### DIFF
--- a/styles/widgets/generic/buttonGroup.generic.less
+++ b/styles/widgets/generic/buttonGroup.generic.less
@@ -64,28 +64,29 @@
 
         &.dx-button-mode-contained {
             &.dx-button-normal {
-                &.dx-state-hover {
-                    background-color: @button-normal-contained-bg-hover;
-                }
+                background-color: @button-normal-bg;
 
-                &.dx-state-focused {
-                    background-color: @button-normal-contained-bg-focused;
+                .dx-buttongroup-item-states(@button-normal-contained-bg-hover, @button-normal-contained-bg-focused);
+
+                &.dx-item-selected {
+                    background-color: @button-group-normal-contained-selected-bg;
+
+                    .dx-buttongroup-item-states(@button-group-normal-contained-selected-bg-hover, @button-group-normal-contained-selected-bg-focused);
+
+                    &,
+                    & .dx-icon {
+                        color: @button-group-normal-selected-color;
+                    }
                 }
             }
 
             &:not(.dx-item-selected) {
-                background-color: transparent;
+                background-color: @button-normal-bg;
 
                 &.dx-button-default {
                     border-color: @button-default-border-color;
 
-                    &.dx-state-hover {
-                        background-color: @button-default-outlined-bg-hover;
-                    }
-
-                    &.dx-state-focused {
-                        background-color: @button-default-outlined-bg-focused;
-                    }
+                    .dx-buttongroup-item-states(@button-normal-contained-bg-hover, @button-normal-contained-bg-focused);
 
                     &,
                     & .dx-icon {
@@ -96,13 +97,7 @@
                 &.dx-button-success {
                     border-color: @button-success-border-color;
 
-                    &.dx-state-hover {
-                        background-color: @button-success-outlined-bg-hover;
-                    }
-
-                    &.dx-state-focused {
-                        background-color: @button-success-outlined-bg-focused;
-                    }
+                    .dx-buttongroup-item-states(@button-normal-contained-bg-hover, @button-normal-contained-bg-focused);
 
                     &,
                     & .dx-icon {
@@ -113,13 +108,7 @@
                 &.dx-button-danger {
                     border-color: @button-danger-border-color;
 
-                    &.dx-state-hover {
-                        background-color: @button-danger-outlined-bg-hover;
-                    }
-
-                    &.dx-state-focused {
-                        background-color: @button-danger-outlined-bg-focused;
-                    }
+                    .dx-buttongroup-item-states(@button-normal-contained-bg-hover, @button-normal-contained-bg-focused);
 
                     &,
                     & .dx-icon {
@@ -130,141 +119,62 @@
         }
 
         &.dx-button-mode-outlined {
-            &.dx-state-hover {
-                background-color: @button-normal-outlined-bg-hover;
-            }
-
-            &.dx-state-focused {
-                background-color: @button-normal-outlined-bg-focused;
-            }
+            .dx-buttongroup-item-states(@button-normal-outlined-bg-hover, @button-normal-outlined-bg-focused);
 
             &.dx-button-default {
-                &.dx-state-hover {
-                    background-color: @button-default-outlined-bg-hover;
-                }
-
-                &.dx-state-focused {
-                    background-color: @button-default-outlined-bg-focused;
-                }
+                .dx-buttongroup-item-states(@button-default-outlined-bg-hover, @button-default-outlined-bg-focused);
             }
 
             &.dx-button-success {
-                &.dx-state-hover {
-                    background-color: @button-success-outlined-bg-hover;
-                }
-
-                &.dx-state-focused {
-                    background-color: @button-success-outlined-bg-focused;
-                }
+                .dx-buttongroup-item-states(@button-success-outlined-bg-hover, @button-success-outlined-bg-focused);
             }
 
             &.dx-button-danger {
-                &.dx-state-hover {
-                    background-color: @button-danger-outlined-bg-hover;
-                }
-
-                &.dx-state-focused {
-                    background-color: @button-danger-outlined-bg-focused;
-                }
+                .dx-buttongroup-item-states(@button-danger-outlined-bg-hover, @button-danger-outlined-bg-focused);
             }
         }
 
         &.dx-button-mode-text {
-            &.dx-state-hover {
-                background-color: @button-normal-text-bg-hover;
-            }
-
-            &.dx-state-focused {
-                background-color: @button-normal-text-bg-focused;
-            }
+            .dx-buttongroup-item-states(@button-normal-text-bg-hover, @button-normal-text-bg-focused);
 
             &.dx-button-default {
-                &.dx-state-hover {
-                    background-color: @button-default-text-bg-hover;
-                }
-
-                &.dx-state-focused {
-                    background-color: @button-default-text-bg-focused;
-                }
+                .dx-buttongroup-item-states(@button-default-text-bg-hover, @button-default-text-bg-focused);
             }
 
             &.dx-button-success {
-                &.dx-state-hover {
-                    background-color: @button-success-text-bg-hover;
-                }
-
-                &.dx-state-focused {
-                    background-color: @button-success-text-bg-focused;
-                }
+                .dx-buttongroup-item-states(@button-success-text-bg-hover, @button-success-text-bg-focused);
             }
 
             &.dx-button-danger {
-                &.dx-state-hover {
-                    background-color: @button-danger-text-bg-hover;
-                }
-
-                &.dx-state-focused {
-                    background-color: @button-danger-text-bg-focused;
-                }
-            }
-        }
-
-        &.dx-item-selected {
-            &.dx-button-normal {
-                background-color: @button-group-normal-selected-bg;
-
-                &.dx-state-hover {
-                    background-color: @button-group-normal-selected-bg-hover;
-                }
-
-                &.dx-state-focused {
-                    background-color: @button-group-normal-selected-bg-focused;
-                }
-
-                &,
-                & .dx-icon {
-                    color: @button-group-normal-selected-color;
-                }
+                .dx-buttongroup-item-states(@button-danger-text-bg-hover, @button-danger-text-bg-focused);
             }
         }
 
         &.dx-button-mode-outlined,
         &.dx-button-mode-text {
             &.dx-item-selected {
+                &.dx-button-normal {
+                    background-color: @button-group-normal-selected-bg;
+
+                    .dx-buttongroup-item-states(@button-group-normal-selected-bg-hover, @button-group-normal-selected-bg-focused);
+                }
+
                 &.dx-button-success {
                     background-color: @button-group-success-selected-bg;
 
-                    &.dx-state-hover {
-                        background-color: @button-group-success-selected-bg-hover;
-                    }
-
-                    &.dx-state-focused {
-                        background-color: @button-group-success-selected-bg-focused;
-                    }
+                    .dx-buttongroup-item-states(@button-group-success-selected-bg-hover, @button-group-success-selected-bg-focused);
                 }
 
                 &.dx-button-default {
                     background-color: @button-group-default-selected-bg;
 
-                    &.dx-state-hover {
-                        background-color: @button-group-default-selected-bg-hover;
-                    }
-
-                    &.dx-state-focused {
-                        background-color: @button-group-default-selected-bg-focused;
-                    }
+                    .dx-buttongroup-item-states(@button-group-default-selected-bg-hover, @button-group-default-selected-bg-focused);
                 }
 
                 &.dx-button-danger {
                     background-color: @button-group-danger-selected-bg;
 
-                    &.dx-state-hover {
-                        background-color: @button-group-danger-selected-bg-hover;
-                    }
-
-                    &.dx-state-focused {
-                        background-color: @button-group-danger-selected-bg-focused;
-                    }
+                    .dx-buttongroup-item-states(@button-group-danger-selected-bg-hover, @button-group-danger-selected-bg-focused);
                 }
 
                 &.dx-button-success,

--- a/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
+++ b/styles/widgets/generic/color-schemes/carmine/generic.carmine.less
@@ -409,6 +409,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: darken(@button-normal-bg, 17%);
+@button-group-normal-contained-selected-bg-hover: darken(@button-group-normal-contained-selected-bg, -6%);
+@button-group-normal-contained-selected-bg-focused: darken(@button-group-normal-contained-selected-bg, -3%);
+
 /**
 * @name 20. Selected item background color
 * @type color

--- a/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
+++ b/styles/widgets/generic/color-schemes/contrast/generic.contrast.less
@@ -314,6 +314,7 @@
 
 // ButtonGroup
 
+@button-group-normal-contained-selected-bg: @base-inverted-bg;
 @button-group-normal-selected-bg: @base-inverted-bg;
 @button-group-default-selected-bg: @base-default;
 @button-group-danger-selected-bg: @base-danger;
@@ -324,11 +325,13 @@
 @button-group-danger-selected-color: @base-inverted-text-color;
 @button-group-success-selected-color: @base-inverted-text-color;
 
+@button-group-normal-contained-selected-bg-hover: @base-inverted-bg;
 @button-group-normal-selected-bg-hover: @base-inverted-bg;
 @button-group-default-selected-bg-hover: @base-inverted-bg;
 @button-group-danger-selected-bg-hover: @base-inverted-bg;
 @button-group-success-selected-bg-hover: @base-inverted-bg;
 
+@button-group-normal-contained-selected-bg-focused: @base-inverted-bg;
 @button-group-normal-selected-bg-focused: @base-inverted-bg;
 @button-group-default-selected-bg-focused: @base-inverted-bg;
 @button-group-danger-selected-bg-focused: @base-inverted-bg;

--- a/styles/widgets/generic/color-schemes/dark/generic.dark.less
+++ b/styles/widgets/generic/color-schemes/dark/generic.dark.less
@@ -409,6 +409,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: lighten(@button-normal-bg, 17%);
+@button-group-normal-contained-selected-bg-hover: lighten(@button-group-normal-contained-selected-bg, -6%);
+@button-group-normal-contained-selected-bg-focused: lighten(@button-group-normal-contained-selected-bg, -3%);
+
 /**
 * @name 20. Selected item background color
 * @type color

--- a/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
+++ b/styles/widgets/generic/color-schemes/darkmoon/generic.darkmoon.less
@@ -421,6 +421,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: lighten(@button-normal-bg, 17%);
+@button-group-normal-contained-selected-bg-hover: lighten(@button-group-normal-contained-selected-bg, -6%);
+@button-group-normal-contained-selected-bg-focused: lighten(@button-group-normal-contained-selected-bg, -3%);
+
 /**
 * @name 20. Selected item background color
 * @type color

--- a/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
+++ b/styles/widgets/generic/color-schemes/darkviolet/generic.darkviolet.less
@@ -416,6 +416,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: lighten(@button-normal-bg, 17%);
+@button-group-normal-contained-selected-bg-hover: lighten(@button-normal-bg, 27.5%);
+@button-group-normal-contained-selected-bg-focused: lighten(@button-normal-bg, 34.5%);
+
 /**
 * @name 20. Selected item background color
 * @type color

--- a/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
+++ b/styles/widgets/generic/color-schemes/greenmist/generic.greenmist.less
@@ -413,6 +413,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: darken(@button-normal-bg, 17%);
+@button-group-normal-contained-selected-bg-hover: darken(@button-group-normal-contained-selected-bg, -6%);
+@button-group-normal-contained-selected-bg-focused: darken(@button-group-normal-contained-selected-bg, -3%);
+
 /**
 * @name 20. Selected item background color
 * @type color

--- a/styles/widgets/generic/color-schemes/light/generic.light.less
+++ b/styles/widgets/generic/color-schemes/light/generic.light.less
@@ -409,6 +409,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: darken(@button-normal-bg, 17%);
+@button-group-normal-contained-selected-bg-hover: darken(@button-group-normal-contained-selected-bg, -6%);
+@button-group-normal-contained-selected-bg-focused: darken(@button-group-normal-contained-selected-bg, -3%);
+
 /**
 * @name 20. Selected item background color
 * @type color

--- a/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
+++ b/styles/widgets/generic/color-schemes/softblue/generic.softblue.less
@@ -420,6 +420,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: darken(@button-normal-bg, 17%);
+@button-group-normal-contained-selected-bg-hover: darken(@button-group-normal-contained-selected-bg, -6%);
+@button-group-normal-contained-selected-bg-focused: darken(@button-group-normal-contained-selected-bg, -3%);
+
 /**
 * @name 20. Selected item background color
 * @type color

--- a/styles/widgets/material/buttonGroup.material.less
+++ b/styles/widgets/material/buttonGroup.material.less
@@ -43,6 +43,16 @@
     }
 }
 
+.dx-buttongroup-item-states(@hover-color, @focused-color) {
+    &.dx-state-hover {
+        background-color: @hover-color;
+    }
+
+    &.dx-state-focused {
+        background-color: @focused-color;
+    }
+}
+
 .dx-buttongroup-item {
     &.dx-button {
         &.dx-button-mode-contained,
@@ -58,12 +68,19 @@
 
         &.dx-button-mode-contained {
             &.dx-button-normal {
-                &.dx-state-focused {
-                    background-color: @button-normal-focused-bg;
-                }
+                background-color: @button-normal-bg;
 
-                &.dx-state-hover {
-                    background-color: @button-normal-hover-bg;
+                .dx-buttongroup-item-states(@button-normal-hover-bg, @button-normal-focused-bg);
+
+                &.dx-item-selected {
+                    background-color: @button-group-normal-contained-selected-bg;
+
+                    .dx-buttongroup-item-states(@button-group-normal-contained-selected-bg-hover, @button-group-normal-contained-selected-bg-focused);
+
+                    &,
+                    & .dx-icon {
+                        color: @button-group-normal-selected-color;
+                    }
                 }
             }
 
@@ -71,13 +88,7 @@
                 background-color: @button-normal-bg;
 
                 &.dx-button-success {
-                    &.dx-state-focused {
-                        background-color: @button-success-outlined-focused-bg;
-                    }
-
-                    &.dx-state-hover {
-                        background-color: @button-success-outlined-hover-bg;
-                    }
+                    .dx-buttongroup-item-states(@button-group-success-contained-hover-bg, @button-group-success-contained-focused-bg);
 
                     &,
                     & .dx-icon {
@@ -86,13 +97,7 @@
                 }
 
                 &.dx-button-default {
-                    &.dx-state-focused {
-                        background-color: @button-default-outlined-focused-bg;
-                    }
-
-                    &.dx-state-hover {
-                        background-color: @button-default-outlined-hover-bg;
-                    }
+                    .dx-buttongroup-item-states(@button-group-default-contained-hover-bg, @button-group-default-contained-focused-bg);
 
                     &,
                     & .dx-icon {
@@ -101,13 +106,7 @@
                 }
 
                 &.dx-button-danger {
-                    &.dx-state-focused {
-                        background-color: @button-danger-outlined-focused-bg;
-                    }
-
-                    &.dx-state-hover {
-                        background-color: @button-danger-outlined-hover-bg;
-                    }
+                    .dx-buttongroup-item-states(@button-group-danger-contained-hover-bg, @button-group-danger-contained-focused-bg);
 
                     &,
                     & .dx-icon {
@@ -118,117 +117,55 @@
         }
 
         &.dx-button-mode-outlined {
-            &.dx-state-focused {
-                background-color: @button-normal-outlined-focused-bg;
-            }
-
-            &.dx-state-hover {
-                background-color: @button-normal-outlined-hover-bg;
-            }
+            .dx-buttongroup-item-states(@button-normal-outlined-hover-bg, @button-normal-outlined-focused-bg);
 
             &.dx-button-success {
-                &.dx-state-focused {
-                    background-color: @button-success-outlined-focused-bg;
-                }
-
-                &.dx-state-hover {
-                    background-color: @button-success-outlined-hover-bg;
-                }
+                .dx-buttongroup-item-states(@button-success-outlined-hover-bg, @button-success-outlined-focused-bg);
             }
 
             &.dx-button-default {
-                &.dx-state-focused {
-                    background-color: @button-default-outlined-focused-bg;
-                }
-
-                &.dx-state-hover {
-                    background-color: @button-default-outlined-hover-bg;
-                }
+                .dx-buttongroup-item-states(@button-default-outlined-hover-bg, @button-default-outlined-focused-bg);
             }
 
             &.dx-button-danger {
-                &.dx-state-focused {
-                    background-color: @button-danger-outlined-focused-bg;
-                }
-
-                &.dx-state-hover {
-                    background-color: @button-danger-outlined-hover-bg;
-                }
+                .dx-buttongroup-item-states(@button-danger-outlined-hover-bg, @button-danger-outlined-focused-bg);
             }
         }
 
         &.dx-button-mode-text {
-            &.dx-state-focused {
-                background-color: @button-normal-text-focused-bg;
-            }
-
-            &.dx-state-hover {
-                background-color: @button-normal-text-hover-bg;
-            }
+            .dx-buttongroup-item-states(@button-normal-text-hover-bg, @button-normal-text-focused-bg);
 
             &.dx-button-success {
-                &.dx-state-focused {
-                    background-color: @button-success-text-focused-bg;
-                }
-
-                &.dx-state-hover {
-                    background-color: @button-success-text-hover-bg;
-                }
+                .dx-buttongroup-item-states(@button-success-text-hover-bg, @button-success-text-focused-bg);
             }
 
             &.dx-button-default {
-                &.dx-state-focused {
-                    background-color: @button-default-text-focused-bg;
-                }
-
-                &.dx-state-hover {
-                    background-color: @button-default-text-hover-bg;
-                }
+                .dx-buttongroup-item-states(@button-default-text-hover-bg, @button-default-text-focused-bg);
             }
 
             &.dx-button-danger {
-                &.dx-state-focused {
-                    background-color: @button-danger-text-focused-bg;
-                }
-
-                &.dx-state-hover {
-                    background-color: @button-danger-text-hover-bg;
-                }
-            }
-        }
-
-        &.dx-item-selected {
-            &.dx-button-normal {
-                background-color: @button-group-normal-selected-bg;
-
-                &.dx-state-focused {
-                    background-color: @button-group-normal-selected-bg-focused;
-                }
-
-                &.dx-state-hover {
-                    background-color: @button-group-normal-selected-bg-hover;
-                }
-
-                &,
-                & .dx-icon {
-                    color: @button-group-normal-selected-color;
-                }
+                .dx-buttongroup-item-states(@button-danger-text-hover-bg, @button-danger-text-focused-bg);
             }
         }
 
         &.dx-button-mode-outlined,
         &.dx-button-mode-text {
             &.dx-item-selected {
+                &.dx-button-normal {
+                    background-color: @button-group-normal-selected-bg;
+
+                    .dx-buttongroup-item-states(@button-group-normal-selected-bg-hover, @button-group-normal-selected-bg-focused);
+
+                    &,
+                    & .dx-icon {
+                        color: @button-group-normal-selected-color;
+                    }
+                }
+
                 &.dx-button-success {
                     background-color: @button-group-success-selected-bg;
 
-                    &.dx-state-focused {
-                        background-color: @button-group-success-selected-bg-focused;
-                    }
-
-                    &.dx-state-hover {
-                        background-color: @button-group-success-selected-bg-hover;
-                    }
+                    .dx-buttongroup-item-states(@button-group-success-selected-bg-hover, @button-group-success-selected-bg-focused);
 
                     &,
                     & .dx-icon {
@@ -239,13 +176,7 @@
                 &.dx-button-default {
                     background-color: @button-group-default-selected-bg;
 
-                    &.dx-state-focused {
-                        background-color: @button-group-default-selected-bg-focused;
-                    }
-
-                    &.dx-state-hover {
-                        background-color: @button-group-default-selected-bg-hover;
-                    }
+                    .dx-buttongroup-item-states(@button-group-default-selected-bg-hover, @button-group-default-selected-bg-focused);
 
                     &,
                     & .dx-icon {
@@ -256,13 +187,7 @@
                 &.dx-button-danger {
                     background-color: @button-group-danger-selected-bg;
 
-                    &.dx-state-focused {
-                        background-color: @button-group-danger-selected-bg-focused;
-                    }
-
-                    &.dx-state-hover {
-                        background-color: @button-group-danger-selected-bg-hover;
-                    }
+                    .dx-buttongroup-item-states(@button-group-danger-selected-bg-hover, @button-group-danger-selected-bg-focused);
 
                     &,
                     & .dx-icon {

--- a/styles/widgets/material/color-schemes/material.dark.less
+++ b/styles/widgets/material/color-schemes/material.dark.less
@@ -430,6 +430,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: lighten(@button-normal-bg, 18%);
+@button-group-normal-contained-selected-bg-hover: lighten(@button-group-normal-contained-selected-bg, -6%);
+@button-group-normal-contained-selected-bg-focused: lighten(@button-group-normal-contained-selected-bg, -6%);
+
 /**
 * @name 20. Selected item background color
 * @type color
@@ -456,6 +460,9 @@
 @button-group-default-selected-bg-hover: fade(@button-group-default-selected-bg, 14%);
 @button-group-default-selected-bg-focused: fade(@button-group-default-selected-bg, 14%);
 
+@button-group-default-contained-hover-bg: mix(@button-normal-bg, @button-default-bg, 92%);
+@button-group-default-contained-focused-bg: mix(@button-normal-bg, @button-default-bg, 92%);
+
 // Danger Button
 
 /**
@@ -473,6 +480,9 @@
 @button-group-danger-selected-bg-hover: fade(@button-group-danger-selected-bg, 14%);
 @button-group-danger-selected-bg-focused: fade(@button-group-danger-selected-bg, 14%);
 
+@button-group-danger-contained-hover-bg: mix(@button-normal-bg, @button-danger-bg, 92%);
+@button-group-danger-contained-focused-bg: mix(@button-normal-bg, @button-danger-bg, 92%);
+
 // Success Button
 
 /**
@@ -489,6 +499,9 @@
 
 @button-group-success-selected-bg-hover: fade(@button-group-success-selected-bg, 14%);
 @button-group-success-selected-bg-focused: fade(@button-group-success-selected-bg, 14%);
+
+@button-group-success-contained-hover-bg: mix(@button-normal-bg, @button-success-bg, 92%);
+@button-group-success-contained-focused-bg: mix(@button-normal-bg, @button-success-bg, 92%);
 
 // Checkbox
 

--- a/styles/widgets/material/color-schemes/material.light.less
+++ b/styles/widgets/material/color-schemes/material.light.less
@@ -421,6 +421,10 @@
 */
 @button-group-normal-selected-color: @base-text-color;
 
+@button-group-normal-contained-selected-bg: darken(@button-normal-bg, 18%);
+@button-group-normal-contained-selected-bg-hover: darken(@button-group-normal-contained-selected-bg, -6%);
+@button-group-normal-contained-selected-bg-focused: darken(@button-group-normal-contained-selected-bg, -6%);
+
 /**
 * @name 20. Selected item background color
 * @type color
@@ -447,6 +451,9 @@
 @button-group-default-selected-bg-hover: fade(@button-group-default-selected-bg, 14%);
 @button-group-default-selected-bg-focused: fade(@button-group-default-selected-bg, 14%);
 
+@button-group-default-contained-hover-bg: lighten(@button-default-bg, 43.5%);
+@button-group-default-contained-focused-bg: lighten(@button-default-bg, 43.5%);
+
 // Danger Button
 
 /**
@@ -464,6 +471,9 @@
 @button-group-danger-selected-bg-hover: fade(@button-group-danger-selected-bg, 14%);
 @button-group-danger-selected-bg-focused: fade(@button-group-danger-selected-bg, 14%);
 
+@button-group-danger-contained-hover-bg: lighten(@button-danger-bg, 38.3%);
+@button-group-danger-contained-focused-bg: lighten(@button-danger-bg, 38.3%);
+
 // Success Button
 
 /**
@@ -480,6 +490,9 @@
 
 @button-group-success-selected-bg-hover: fade(@button-group-success-selected-bg, 14%);
 @button-group-success-selected-bg-focused: fade(@button-group-success-selected-bg, 14%);
+
+@button-group-success-contained-hover-bg: lighten(@button-success-bg, 43.5%);
+@button-group-success-contained-focused-bg: lighten(@button-success-bg, 43.5%);
 
 // Checkbox
 


### PR DESCRIPTION
Contained buttons should have a background color. And should not be transparent.

+ smal refactoring with .dx-buttongroup-item-states mixin
