### PR TITLE
ResponsiveBox - change default strategy for IE 11 and Edge browsers (T823974) -  rollback

### DIFF
--- a/js/ui/box.js
+++ b/js/ui/box.js
@@ -528,7 +528,7 @@ class Box extends CollectionWidget {
                     return browser["msie"];
                 },
                 options: {
-                    _layoutStrategy: "flex"
+                    _layoutStrategy: "fallback"
                 }
             }
         ]);

--- a/testing/tests/DevExpress.ui/defaultOptions.tests.js
+++ b/testing/tests/DevExpress.ui/defaultOptions.tests.js
@@ -155,7 +155,7 @@ testComponentDefaults(DateBox,
 
 testComponentDefaults(Box,
     {},
-    { _layoutStrategy: 'flex' },
+    { _layoutStrategy: 'fallback' },
     function() {
         this._origMSIE = browser.msie;
         browser.msie = true;


### PR DESCRIPTION
Revert flex strategy