### PR TITLE
Fix call the reset of a widget instance for inherits of Editor in the Form (T835601)

### DIFF
--- a/js/ui/form/ui.form.js
+++ b/js/ui/form/ui.form.js
@@ -12,6 +12,7 @@ import browser from "../../core/utils/browser";
 import { getPublicElement, triggerShownEvent } from "../../core/utils/dom";
 import messageLocalization from "../../localization/message";
 import Widget from "../widget/ui.widget";
+import Editor from "../editor/editor";
 import { defaultScreenFactorFunc, getCurrentScreenFactor, hasWindow } from "../../core/utils/window";
 import ValidationEngine from "../validation_engine";
 import LayoutManager from "./ui.form.layout_manager";
@@ -1642,7 +1643,7 @@ const Form = Widget.inherit({
 
     _resetValues: function() {
         this._itemsRunTimeInfo.each(function(_, itemRunTimeInfo) {
-            if(isDefined(itemRunTimeInfo.widgetInstance) && isDefined(itemRunTimeInfo.item) && itemRunTimeInfo.item.itemType !== "button") {
+            if(isDefined(itemRunTimeInfo.widgetInstance) && itemRunTimeInfo.widgetInstance instanceof Editor) {
                 itemRunTimeInfo.widgetInstance.reset();
                 itemRunTimeInfo.widgetInstance.option("isValid", true);
             }

--- a/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.validationRules.tests.js
@@ -86,9 +86,9 @@ QUnit.testStart(() => {
 
 QUnit.module("Form validation rules");
 
-function getID(form, dataField) {
-    return "dx_" + form.option("formID") + "_" + dataField;
-}
+const getID = (form, dataField) => `dx_${form.option("formID")}_${dataField}`;
+
+const createForm = options => $("#form").dxForm(options).dxForm("instance");
 
 QUnit.test("The validation result is invalid when item has validation rules", assert => {
     const form = $("#form").dxForm({
@@ -393,6 +393,31 @@ QUnit.test("validate -> resetValues old test", assert => {
 
     // assert
     assert.equal($("." + VALIDATION_SUMMARY_ITEM_CLASS).length, 0, "validation summary items");
+});
+
+QUnit.test("validate -> the resetValues method is safely called for all item's types", function(assert) {
+    const form = createForm({
+        formData: { name: "TestName" },
+        items: [{
+            itemType: "tabbed",
+            tabs: [{
+                items: [{
+                    itemType: "group",
+                    items: [{
+                        itemType: "button"
+                    }, {
+                        itemType: "empty"
+                    }, {
+                        dataField: "name"
+                    }]
+                }]
+            }]
+        }]
+    });
+
+    form.resetValues();
+
+    assert.equal(form.getEditor("name").option("value"), "", "value of editor");
 });
 
 QUnit.test("validate -> resetValues when there are invalid validation rules", function(assert) {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
