### PR TITLE
dxdblclick: Inrease timeout to 500ms

### DIFF
--- a/js/events/double_click.js
+++ b/js/events/double_click.js
@@ -10,7 +10,7 @@ var DBLCLICK_EVENT_NAME = "dxdblclick",
     DBLCLICK_NAMESPACE = "dxDblClick",
     NAMESPACED_CLICK_EVENT = eventUtils.addNamespace(clickEvent.name, DBLCLICK_NAMESPACE),
 
-    DBLCLICK_TIMEOUT = 300;
+    DBLCLICK_TIMEOUT = 500;
 
 
 var DblClick = Class.inherit({

--- a/testing/tests/DevExpress.ui.events/dblclick.tests.js
+++ b/testing/tests/DevExpress.ui.events/dblclick.tests.js
@@ -37,7 +37,7 @@ QUnit.test("dxdblclick should bubble up", function(assert) {
 
 QUnit.module("timeout", moduleConfig);
 
-QUnit.test("dxdblclick should be fired if element clicked twice with timeout < 300ms", function(assert) {
+QUnit.test("dxdblclick should be fired if element clicked twice with timeout < 500ms", function(assert) {
     assert.expect(1);
 
     var $element = $("#element").on(dblclickEvent.name, function(e) {
@@ -45,12 +45,12 @@ QUnit.test("dxdblclick should be fired if element clicked twice with timeout < 3
         }),
         pointer = pointerMock($element).start();
 
-    pointer.click().wait(299);
-    this.clock.tick(299);
+    pointer.click().wait(499);
+    this.clock.tick(499);
     pointer.click();
 });
 
-QUnit.test("dxdblclick should not be fired if element clicked twice with timeout > 300ms", function(assert) {
+QUnit.test("dxdblclick should not be fired if element clicked twice with timeout > 500ms", function(assert) {
     assert.expect(0);
 
     var $element = $("#element").on(dblclickEvent.name, function(e) {
@@ -58,8 +58,8 @@ QUnit.test("dxdblclick should not be fired if element clicked twice with timeout
         }),
         pointer = pointerMock($element).start();
 
-    pointer.click().wait(301);
-    this.clock.tick(301);
+    pointer.click().wait(501);
+    this.clock.tick(501);
     pointer.click();
 });
 


### PR DESCRIPTION
Motivation:
---
- Windows has 500ms timeout by default (https://docs.microsoft.com/ru-ru/windows/win32/api/winuser/nf-winuser-setdoubleclicktime).
- https://github.com/DevExpress/testcafe-studio/issues/2874
