### PR TITLE
Export - In DataGrid/Pivot, 'export' menu item image is shown with incorrect size (T827793) (#10936)

### DIFF
--- a/js/ui/data_grid/ui.data_grid.export.js
+++ b/js/ui/data_grid/ui.data_grid.export.js
@@ -16,7 +16,7 @@ import { when, Deferred } from "../../core/utils/deferred";
 var DATAGRID_EXPORT_MENU_CLASS = "dx-datagrid-export-menu",
     DATAGRID_EXPORT_BUTTON_CLASS = "dx-datagrid-export-button",
     DATAGRID_EXPORT_ICON = "export-to",
-    DATAGRID_EXPORT_EXCEL_ICON = "exportxlsx",
+    DATAGRID_EXPORT_EXCEL_ICON = "xlsxfile",
     DATAGRID_EXPORT_SELECTED_ICON = "exportselected",
     DATAGRID_EXPORT_EXCEL_BUTTON_ICON = "export-excel-button",
 

--- a/js/ui/pivot_grid/ui.pivot_grid.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.js
@@ -1258,7 +1258,7 @@ var PivotGrid = Widget.inherit({
         if(that.option("export.enabled")) {
             items.push({
                 beginGroup: true,
-                icon: "exportxlsx",
+                icon: "xlsxfile",
                 text: texts.exportToExcel,
                 onItemClick: function() {
                     that.exportToExcel();
@@ -1421,7 +1421,7 @@ var PivotGrid = Widget.inherit({
                 .appendTo($toolbarContainer)
                 .addClass("dx-pivotgrid-export-button");
             let buttonOptions = {
-                icon: "exportxlsx",
+                icon: "xlsxfile",
                 hint: this.option("texts.exportToExcel"),
                 onClick: () => {
                     this.exportToExcel();

--- a/styles/widgets/base/dataGrid.less
+++ b/styles/widgets/base/dataGrid.less
@@ -236,16 +236,6 @@
     .dx-base-typography();
 }
 
-.dx-datagrid-export-menu {
-    .dx-menu-item .dx-icon-exportxlsx {
-        .dx-icon-sizing(16px);
-    }
-
-    .dx-menu-item .dx-icon-exportselected {
-        .dx-icon-sizing(16px);
-    }
-}
-
 .dx-datagrid-adaptive-more {
     cursor: pointer;
     .dx-icon-more;

--- a/styles/widgets/base/pivotGrid.less
+++ b/styles/widgets/base/pivotGrid.less
@@ -428,9 +428,6 @@
         width: @PIVOTGRID_ICON_SIZE;
     }
 
-    .dx-menu-item .dx-icon {
-        .dx-icon-sizing(16px);
-    }
 
     .dx-popup-content {
         padding: @PIVOTGRID_COMMON_LEFT_RIGHT_PADDING;

--- a/styles/widgets/generic/gridBase.generic.less
+++ b/styles/widgets/generic/gridBase.generic.less
@@ -640,7 +640,7 @@
         }
 
         .dx-icon-export-excel-button {
-            .dx-icon-exportxlsx;
+            .dx-icon-xlsxfile;
             .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
         }
     }

--- a/styles/widgets/ios7/gridBase.ios7.less
+++ b/styles/widgets/ios7/gridBase.ios7.less
@@ -528,7 +528,7 @@
         }
 
         .dx-icon-export-excel-button {
-            .dx-icon-exportxlsx;
+            .dx-icon-xlsxfile;
         }
 
         .dx-icon {

--- a/styles/widgets/material/gridBase.material.less
+++ b/styles/widgets/material/gridBase.material.less
@@ -821,13 +821,13 @@
         }
 
         .dx-icon-export-excel-button {
-            .dx-icon-exportxlsx;
+            .dx-icon-xlsxfile;
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
         }
     }
 
     .dx-datagrid-export-menu {
-        .dx-menu-item .dx-icon-exportxlsx {
+        .dx-menu-item .dx-icon-xlsxfile {
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
         }
 

--- a/testing/helpers/checkDxFontIconHelper.js
+++ b/testing/helpers/checkDxFontIconHelper.js
@@ -1,0 +1,14 @@
+
+export const DX_ICON_EXPORT_SELECTED_CONTENT_CODE = 61549; // .dx-font-icon("\f06d")
+export const DX_ICON_XLSX_FILE_CONTENT_CODE = 61719; // .dx-font-icon("\f117")
+
+export function checkDxFontIcon(assert, dxIconSelector, expectedIconCode) {
+    const GENERIC_BASE_ICON_SIZE = 18;
+
+    var iconBeforeElementStyle = getComputedStyle(document.querySelector(dxIconSelector), ":before");
+    assert.strictEqual(iconBeforeElementStyle.content.charCodeAt(1), expectedIconCode, `icon code (${dxIconSelector})`);
+    var iconElementStyle = getComputedStyle(document.querySelector(dxIconSelector));
+    assert.strictEqual(iconElementStyle.width, GENERIC_BASE_ICON_SIZE + "px", `icon element width (${dxIconSelector})`);
+    assert.strictEqual(iconElementStyle.height, GENERIC_BASE_ICON_SIZE + "px", `icon element height (${dxIconSelector})`);
+}
+

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -73,6 +73,7 @@ import pointerEvents from "events/pointer";
 import ajaxMock from "../../helpers/ajaxMock.js";
 import themes from "ui/themes";
 import DataGridWrapper from "../../helpers/wrappers/dataGridWrappers.js";
+import { checkDxFontIcon, DX_ICON_XLSX_FILE_CONTENT_CODE, DX_ICON_EXPORT_SELECTED_CONTENT_CODE } from "../../helpers/checkDxFontIconHelper.js";
 
 var DX_STATE_HOVER_CLASS = "dx-state-hover",
     TEXTEDITOR_INPUT_SELECTOR = ".dx-texteditor-input",
@@ -1929,26 +1930,29 @@ QUnit.test("Cursor should switch style when it was moved to columns separator if
     assert.equal(columnsSeparator.css("cursor"), "col-resize", "cursor style");
 });
 
-// T757579
-QUnit.test("Export icons must be the same size", function(assert) {
-    // arrange
+QUnit.test("export.enabled: true, allowExportSelectedData: true -> check export menu icons (T757579)", function(assert) {
     $("#dataGrid").dxDataGrid({
-        dataSource: [],
-        "export": {
+        export: {
             enabled: true,
-            fileName: "Test",
             allowExportSelectedData: true
         }
     });
 
-    // act
     $(".dx-datagrid-export-button").trigger("dxclick");
-    var exportAllButton = $(".dx-icon-exportxlsx");
-    var exportSelectedButton = $(".dx-icon-exportselected");
 
-    // assert
-    assert.equal(exportAllButton.width(), exportSelectedButton.width(), "same width");
-    assert.equal(exportAllButton.height(), exportSelectedButton.height(), "same height");
+    checkDxFontIcon(assert, ".dx-icon-xlsxfile", DX_ICON_XLSX_FILE_CONTENT_CODE);
+    checkDxFontIcon(assert, ".dx-icon-exportselected", DX_ICON_EXPORT_SELECTED_CONTENT_CODE);
+});
+
+QUnit.test("export.enabled: true, allowExportSelectedData: false -> check export menu icons (T827793)", function(assert) {
+    $("#dataGrid").dxDataGrid({
+        export: {
+            enabled: true,
+            allowExportSelectedData: false
+        }
+    });
+
+    checkDxFontIcon(assert, ".dx-datagrid-export-button .dx-icon", DX_ICON_XLSX_FILE_CONTENT_CODE);
 });
 
 // T571282, T835869

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
@@ -2457,7 +2457,7 @@ QUnit.test("Export's fake menu buttons has a correct markup", function(assert) {
     var $firstItem = renderFakeButtonSpy.getCall(0).args[1],
         $secondItem = renderFakeButtonSpy.getCall(1).args[1];
 
-    assert.equal($firstItem.find(checkingSelector.replace("dx-icon", "dx-icon.dx-icon-exportxlsx")).length, 1);
+    assert.equal($firstItem.find(checkingSelector.replace("dx-icon", "dx-icon.dx-icon-xlsxfile")).length, 1);
     assert.equal($secondItem.find(checkingSelector.replace("dx-icon", "dx-icon.dx-icon-exportselected")).length, 1);
 });
 

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/export.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/export.tests.js
@@ -3,8 +3,11 @@ import { DataProvider } from "ui/pivot_grid/ui.pivot_grid.export";
 import clientExporter from "exporter";
 import dateLocalization from "localization/date";
 import executeAsyncMock from "../../helpers/executeAsyncMock.js";
+import { checkDxFontIcon, DX_ICON_XLSX_FILE_CONTENT_CODE } from "../../helpers/checkDxFontIconHelper.js";
 
 import "ui/pivot_grid/ui.pivot_grid";
+import "common.css!";
+import "generic_light.css!";
 
 QUnit.testStart(function() {
     var markup =
@@ -320,6 +323,9 @@ QUnit.test("Context menu with export", function(assert) {
 
     // assert
     assert.equal($(".dx-menu-item-text").eq(1).text(), "Export to Excel file");
+
+    checkDxFontIcon(assert, ".dx-context-menu .dx-menu-item .dx-icon-xlsxfile", DX_ICON_XLSX_FILE_CONTENT_CODE);
+    checkDxFontIcon(assert, ".dx-pivotgrid-export-button .dx-icon-xlsxfile", DX_ICON_XLSX_FILE_CONTENT_CODE);
 });
 
 QUnit.test("Hide export from the context menu when the export.enabled option is disabled", function(assert) {


### PR DESCRIPTION
* Try change export to xlsx icon

* Add tests for PivotGrid, extract checkDxFontIcon function

* Redirect style settings to '.dx-icon-xlsxfile' element. Change grid.export icon to xlsxfile for ios environment.

(cherry picked from commit bd23eaf5daef700f2f45621528670f932323726c)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
