### PR TITLE
ASP.NET template engine: allow non-String IDs in createComponent

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -130,7 +130,7 @@
     }
 
     function createComponent(name, options, id, validatorOptions) {
-        var selector = "#" + id.replace(/[^\w-]/g, "\\$&");
+        var selector = "#" + String(id).replace(/[^\w-]/g, "\\$&");
         pendingCreateComponentRoutines.push(function() {
             var $component = $(selector)[name](options);
             if($.isPlainObject(validatorOptions)) {

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -491,4 +491,30 @@
         }
     });
 
+    QUnit.test("T836885", function(assert) {
+        aspnet.setTemplateEngine();
+
+        try {
+            $("#qunit-fixture").html(
+                '<div id=list1></div>' +
+                '<script id="list1_itemTemplate" type="text/html">' +
+                '  <div id="<%= key %>"></div><% DevExpress.aspnet.createComponent("dxTextBox", { }, key) %>' +
+                '</script>'
+            );
+
+            // Per https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute
+            // "IDs can consist of just digits"
+            var NUMERIC_ID = 20191205;
+
+            $("#list1").dxList({
+                items: [ { key: NUMERIC_ID } ],
+                itemTemplate: $("#list1_itemTemplate")
+            });
+
+            assert.ok($("#" + NUMERIC_ID).dxTextBox("instance"));
+        } finally {
+            setTemplateEngine("default");
+        }
+    });
+
 }));


### PR DESCRIPTION
This is a cherry-pick of [#10981](https://github.com/DevExpress/DevExtreme/pull/10981)