### PR TITLE
AsyncRule - Fixes reject

### DIFF
--- a/js/ui/validation_engine.js
+++ b/js/ui/validation_engine.js
@@ -341,7 +341,17 @@ class AsyncRuleValidator extends CustomRuleValidator {
         promise.then(function(res) {
             deferred.resolve(res);
         }, function(err) {
-            deferred.resolve(typeUtils.isDefined(err) ? err : false);
+            let res = {
+                isValid: false
+            };
+            if(typeUtils.isDefined(err)) {
+                if(typeUtils.isString(err)) {
+                    res.message = err;
+                } else if(typeUtils.isObject(err) && typeUtils.isDefined(err.message) && typeUtils.isString(err.message)) {
+                    res.message = err.message;
+                }
+            }
+            deferred.resolve(res);
         });
         return deferred.promise();
     }

--- a/testing/tests/DevExpress.ui.widgets.editors/validationEngine.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationEngine.tests.js
@@ -1202,6 +1202,17 @@ QUnit.test("Can be validated negatively with a custom message from validationCal
                     d.reject(customMessage);
                     return d.promise();
                 })
+            },
+            {
+                type: "async",
+                validationCallback: sinon.spy(function() {
+                    const d = new Deferred();
+                    d.reject({
+                        isValid: true,
+                        message: customMessage
+                    });
+                    return d.promise();
+                })
             }
         ],
         result = testAsyncRules(rules, value, assert),
@@ -1211,6 +1222,10 @@ QUnit.test("Can be validated negatively with a custom message from validationCal
         assert.equal(res.brokenRules[0].message, customMessage);
         assert.equal(res.brokenRules[1].message, customMessage);
         assert.equal(res.brokenRules[2].message, customMessage);
+
+        // the fourth rule should be broken even if it was rejected with isValid === true
+        assert.equal(res.brokenRules[3].message, customMessage);
+
         done();
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/validationEngine.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationEngine.tests.js
@@ -1171,27 +1171,50 @@ QUnit.test("Can be validated negatively with custom message", function(assert) {
 
 QUnit.test("Can be validated negatively with a custom message from validationCallback", function(assert) {
     const customMessage = "Value does not satisfy our custom validation scenario",
-        customCallback = sinon.spy(function() {
-            const d = new Deferred();
-            d.resolve({
-                isValid: false,
-                message: customMessage
-            });
-            return d.promise();
-        }),
         value = "Some custom value",
-        rule = {
-            type: "async",
-            validationCallback: customCallback
-        },
-        result = testAsyncRules([rule], value, assert),
+        rules = [
+            {
+                type: "async",
+                validationCallback: sinon.spy(function() {
+                    const d = new Deferred();
+                    d.resolve({
+                        isValid: false,
+                        message: customMessage
+                    });
+                    return d.promise();
+                })
+            },
+            {
+                type: "async",
+                validationCallback: sinon.spy(function() {
+                    const d = new Deferred();
+                    d.reject({
+                        isValid: false,
+                        message: customMessage
+                    });
+                    return d.promise();
+                })
+            },
+            {
+                type: "async",
+                validationCallback: sinon.spy(function() {
+                    const d = new Deferred();
+                    d.reject(customMessage);
+                    return d.promise();
+                })
+            }
+        ],
+        result = testAsyncRules(rules, value, assert),
         done = assert.async();
 
     result.complete.then((res) => {
         assert.equal(res.brokenRules[0].message, customMessage);
+        assert.equal(res.brokenRules[1].message, customMessage);
+        assert.equal(res.brokenRules[2].message, customMessage);
         done();
     });
 });
+
 
 QUnit.test("Default message with name", function(assert) {
     const customCallback = sinon.spy(function() {


### PR DESCRIPTION
Promise.reject can accept only a message for displaying validation message.