### PR TITLE
DataGrid: Replace tearDown with afterEach hook in keyboard navigation tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigationParts/rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigationParts/rowsView.tests.js
@@ -71,7 +71,7 @@ QUnit.module("Rows view", {
 
         this.clock = sinon.useFakeTimers();
     },
-    tearDown: function() {
+    afterEach: function() {
         this.clock.restore();
     }
 }, function() {


### PR DESCRIPTION
Cherry-pick #11143.