### PR TITLE
DataGrid: Replace tearDown with afterEach hook in keyboard navigation tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.tests.js
@@ -5007,7 +5007,7 @@ QUnit.module("Rows view", {
 
         this.clock = sinon.useFakeTimers();
     },
-    tearDown: function() {
+    afterEach: function() {
         this.clock.restore();
     }
 });


### PR DESCRIPTION
Cherry-pick #11143.