### PR TITLE
DataGrid: Restore sinon timers after component modules dispose in keyboard tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.tests.js
@@ -1052,8 +1052,8 @@ QUnit.module("Keyboard keys", {
         that.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
-        this.clock.restore();
         this.dispose && this.dispose();
+        this.clock.restore();
     }
 });
 


### PR DESCRIPTION
Cherry-pick #11159.