### PR TITLE
DataGrid: Restore sinon timers after component modules dispose in keyboard tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigationParts/keyboardKeys.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigationParts/keyboardKeys.tests.js
@@ -42,10 +42,11 @@ QUnit.module('Keyboard keys', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
-        this.clock.restore();
         if(this.dispose) {
             this.dispose();
         }
+
+        this.clock.restore();
     }
 }, function() {
     QUnit.testInActiveWindow('Save focusedCellPosition by click on self', function(assert) {


### PR DESCRIPTION
Cherry-pick #11159.