### PR TITLE
DataGrid: Restore Sinon timers correctly in tests (#11173)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -3883,11 +3883,8 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
             return dataItems;
         };
 
-        this.clock = sinon.useFakeTimers();
-    }, afterEach: function() {
-        teardownModule.call(this);
-        this.clock.restore();
-    }
+    },
+    afterEach: teardownModule
 });
 
 QUnit.test('load first page', function(assert) {
@@ -4738,12 +4735,8 @@ QUnit.module('Infinite scrolling (ScrollingDataSource)', {
             });
             return dataItems;
         };
-
-        this.clock = sinon.useFakeTimers();
-    }, afterEach: function() {
-        teardownModule.call(this);
-        this.clock.restore();
-    }
+    },
+    afterEach: teardownModule
 });
 
 QUnit.test('not update pageSize on viewportSize', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
@@ -2925,6 +2925,9 @@ QUnit.test('Export to Excel button call`s exportTo when the button text is local
 QUnit.module('Real dataGrid ExportController tests', {
     beforeEach: function() {
         this.clock = sinon.useFakeTimers();
+    },
+    afterEach: function() {
+        this.clock.restore();
     }
 });
 


### PR DESCRIPTION
Cherry-pick #11173.