### PR TITLE
QUnit: Check for Sinon fake timers

### DIFF
--- a/testing/helpers/qunitExtensions.js
+++ b/testing/helpers/qunitExtensions.js
@@ -571,3 +571,19 @@
         log.clear();
     });
 })();
+
+(function checkSinonFakeTimers() {
+
+    QUnit.testStart(function() {
+        var dateOnTestStart = Date,
+            after = QUnit.config.current.after;
+
+        QUnit.config.current.after = function() {
+            if(dateOnTestStart !== Date) {
+                QUnit.pushFailure('Not restored Sinon timers detected!', this.stack);
+            }
+            return after.apply(this, arguments);
+        };
+    });
+
+})();


### PR DESCRIPTION
This extension detects cases where fake Sinon timers are not restored in a test. These cases can lead to unexpected test dependencies on each other.

Based on #11143, #11172, #11173, #11174, #11175, #11176.

How it looks:
![image](https://user-images.githubusercontent.com/1420883/71107505-41434d80-21d2-11ea-8bff-a7d17914a8c0.png)