### PR TITLE
Use button as focusout relatedTarget in tagBox test to fix tests on IOS devices

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -4089,6 +4089,7 @@ QUnit.module('applyValueMode = \'useButtons\'', {
         });
 
         const $input = this.$element.find(`.${TEXTBOX_CLASS}`);
+        const $doneButton = $('.dx-button.dx-popup-done');
 
         keyboardMock($input)
             .focus()
@@ -4096,8 +4097,8 @@ QUnit.module('applyValueMode = \'useButtons\'', {
 
         $('.dx-list-select-all-checkbox').trigger('dxclick');
 
-        $($input).trigger($.Event('focusout', { relatedTarget: $('.dx-popup-bottom').get(0) }));
-        $('.dx-button.dx-popup-done').trigger('dxclick');
+        $($input).trigger($.Event('focusout', { relatedTarget: $doneButton.get(0) }));
+        $doneButton.trigger('dxclick');
 
         assert.deepEqual(this.instance.option('value'), ['ac', 'bc'], 'value is applied correctly');
     });


### PR DESCRIPTION
Fix ios tests with jquery after #11185. JQuery pass only focusable elements as the relatedTarget  to the event in IOS
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
