### PR TITLE
Toolbar - fix changing location property at runtime (T844890)

### DIFF
--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -324,18 +324,24 @@ var Toolbar = ToolbarBase.inherit({
     _itemOptionChanged: function(item, property, value) {
         if(this._isMenuItem(item)) {
             this._menuStrategy.renderMenuItems();
+        } else if(this._isToolbarItem(item)) {
+            this.callBase(item, property, value);
         } else {
             this.callBase(item, property, value);
             this._menuStrategy.renderMenuItems();
+        }
 
-            if(property === 'location') {
-                this.repaint();
-            }
+        if(property === 'location') {
+            this.repaint();
         }
     },
 
     _isMenuItem: function(itemData) {
         return itemData.location === 'menu' || itemData.locateInMenu === 'always';
+    },
+
+    _isToolbarItem: function(itemData) {
+        return itemData.location === undefined || itemData.locateInMenu === 'never';
     },
 
     _optionChanged: function(args) {

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -324,20 +324,18 @@ var Toolbar = ToolbarBase.inherit({
     _itemOptionChanged: function(item, property, value) {
         if(this._isMenuItem(item)) {
             this._menuStrategy.renderMenuItems();
-        } else if(this._isToolbarItem(item)) {
-            this.callBase(item, property, value);
         } else {
             this.callBase(item, property, value);
             this._menuStrategy.renderMenuItems();
+
+            if(property === 'location') {
+                this.repaint();
+            }
         }
     },
 
     _isMenuItem: function(itemData) {
         return itemData.location === 'menu' || itemData.locateInMenu === 'always';
-    },
-
-    _isToolbarItem: function(itemData) {
-        return itemData.location === undefined || itemData.locateInMenu === 'never';
     },
 
     _optionChanged: function(args) {

--- a/playground/jquery.html
+++ b/playground/jquery.html
@@ -22,53 +22,14 @@
     <script type="text/javascript" src="../artifacts/js/dx.all.debug.js"></script>
 </head>
 <body>
-    <input type="button" value="Change item location" onclick="clickHandler1();" />
-    <input type="button" value="Change item visible" onclick="clickHandler2();" />
-    <div class="dx-viewport demo-container">
-        <div id="toolbar1"></div>
-        <div id="toolbar2"></div>
-    </div>
-
-
+    <div id="button"></div>
     <script>
-function clickHandler1(){
-  toolbar = $("#toolbar2").dxToolbar('instance');
-  debugger;  
-  var items = toolbar.option('items');
-  //items[0].location = 'after';
-  toolbar.option('items[0].location', 'before'); 
-  //toolbar.repaint();
-}
-
-function clickHandler2(){
-  toolbar = $("#toolbar2").dxToolbar('instance');
-  debugger;  
-  var items = toolbar.option('items');
-  //items[0].visible = false;
-  toolbar.option('items[0].visible', false); 
-  //toolbar.repaint();  
-}
-
-$(function(){
-    $("#toolbar1").dxToolbar({
-        width: 1,
-        items: [{
-                        locateInMenu: 'auto', 
-                        location: 'after',
-                        text: 'toolbar item'
-
-                    }]
+        $(function() {
+            $("#button").dxButton({
+                text: 'Click me!',
+                onClick: function() { alert("clicked"); }
             });
-    $("#toolbar2").dxToolbar({
-        width: 1000,
-        items: [{
-                        locateInMenu: 'auto', 
-                        location: 'after',
-                        text: 'toolbar item'
-
-                    }]
-            });            
-});
+        });
     </script>
 </body>
 </html>

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -137,11 +137,11 @@ function checkItemsLocation($toolbarElement, expectedBeforeItemsCount, expectedC
     const $beforeItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
     const $centerItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
     const $afterItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $menuElement = $toolbarElement.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
+    const $menuItems = $toolbarElement.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
     QUnit.assert.equal($beforeItems.length, expectedBeforeItemsCount, 'items count with before location value');
     QUnit.assert.equal($centerItems.length, expectedCenterItemsCount, 'items count with center location value');
     QUnit.assert.equal($afterItems.length, expectedAfterItemsCount, 'items count with after location value');
-    QUnit.assert.equal($menuElement.length, expectedMenuItemsCount, 'menu element');
+    QUnit.assert.equal($menuItems.length, expectedMenuItemsCount, 'menu element');
 }
 
 ['before', 'center', 'after', undefined].forEach((location) => {

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -138,9 +138,9 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
 
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
-        [10 /* not enough space to show items */, 1000 /* enough space to show items */].forEach((toolbarWidth) => {
+        const ITEM_WIDTH = 100;
+        [10, 1000].forEach((toolbarWidth) => {
             QUnit.test(`Change item location at runtime (T844890), location: ${location}, locateInMenu: ${locateInMenu}, width: ${toolbarWidth}`, function(assert) {
-                const ITEM_WIDTH = 100;
                 const $toolbar = this.element.dxToolbar({
                         items: [ { text: 'toolbar item', locateInMenu: locateInMenu, location: location, width: ITEM_WIDTH } ],
                         width: toolbarWidth

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -160,13 +160,13 @@ function checkItemsLocation($toolbarElement, expectedBeforeItemsCount, expectedC
                     expectedCenterItemsCount = 0,
                     expectedAfterItemsCount = 0,
                     expectedMenuItemsCount = 0,
-                    isMenuMode = (locateInMenu === 'always' || locateInMenu === 'auto' && width < 100);
+                    isMenuMode = locateInMenu === 'always' || (locateInMenu === 'auto' && width < 100);
 
                 if(isMenuMode) {
                     expectedMenuItemsCount = 1;
                 } else {
                     expectedBeforeItemsCount = location === 'before' ? 1 : 0;
-                    expectedCenterItemsCount = location === 'center' || location === undefined ? 1 : 0;
+                    expectedCenterItemsCount = (location === 'center' || location === undefined) ? 1 : 0;
                     expectedAfterItemsCount = location === 'after' ? 1 : 0;
                 }
 

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -133,53 +133,51 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
     assert.equal(margin, '0px auto', 'aligned by center');
 });
 
-function checkItemsLocation($toolbarElement, expectedBeforeItemsCount, expectedCenterItemsCount, expectedAfterItemsCount, expectedMenuItemsCount) {
+function checkItemsLocation($toolbarElement, expected) {
     const $beforeItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
     const $centerItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
     const $afterItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
     const $menuItems = $toolbarElement.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
-    QUnit.assert.equal($beforeItems.length, expectedBeforeItemsCount, 'items count with before location value');
-    QUnit.assert.equal($centerItems.length, expectedCenterItemsCount, 'items count with center location value');
-    QUnit.assert.equal($afterItems.length, expectedAfterItemsCount, 'items count with after location value');
-    QUnit.assert.equal($menuItems.length, expectedMenuItemsCount, 'menu element');
+    QUnit.assert.equal($beforeItems.length, expected.before, 'items count with before location value');
+    QUnit.assert.equal($centerItems.length, expected.center, 'items count with center location value');
+    QUnit.assert.equal($afterItems.length, expected.after, 'items count with after location value');
+    QUnit.assert.equal($menuItems.length, expected.menu, 'menu element');
 }
 
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
         [1, 10000].forEach((width) => {
             QUnit.test(`Change item location at runtime -> location: ${location}, locateInMenu: ${locateInMenu}, width: ${width} (T844890)`, function(assert) {
-                const $toolbarElement = this.element.dxToolbar({
+                const $toolbar = this.element.dxToolbar({
                         items: [
                             { text: 'toolbar item', locateInMenu: locateInMenu, location: location },
                         ],
                         width: width
                     }),
-                    toolbar = $toolbarElement.dxToolbar('instance');
+                    toolbar = $toolbar.dxToolbar('instance');
 
-                let expectedBeforeItemsCount = 0,
-                    expectedCenterItemsCount = 0,
-                    expectedAfterItemsCount = 0,
-                    expectedMenuItemsCount = 0,
-                    isMenuMode = locateInMenu === 'always' || (locateInMenu === 'auto' && width < 100);
+                const getExpectedToolbarItems = (location, locateInMenu) => {
+                    const result = { before: 0, center: 0, after: 0, menu: 0 };
+                    if(locateInMenu === 'always' || (locateInMenu === 'auto' && width < 100)) {
+                        result.menu = 1;
+                    } else {
+                        result.before = location === 'before' ? 1 : 0;
+                        result.center = (location === 'center' || location === undefined) ? 1 : 0;
+                        result.after = location === 'after' ? 1 : 0;
+                    }
+                    return result;
+                };
 
-                if(isMenuMode) {
-                    expectedMenuItemsCount = 1;
-                } else {
-                    expectedBeforeItemsCount = location === 'before' ? 1 : 0;
-                    expectedCenterItemsCount = (location === 'center' || location === undefined) ? 1 : 0;
-                    expectedAfterItemsCount = location === 'after' ? 1 : 0;
-                }
-
-                checkItemsLocation($toolbarElement, expectedBeforeItemsCount, expectedCenterItemsCount, expectedAfterItemsCount, expectedMenuItemsCount);
+                checkItemsLocation($toolbar, getExpectedToolbarItems(location, locateInMenu));
 
                 toolbar.option('items[0].location', 'center');
-                checkItemsLocation($toolbarElement, 0, isMenuMode ? 0 : 1, 0, isMenuMode ? 1 : 0);
+                checkItemsLocation($toolbar, getExpectedToolbarItems('center', locateInMenu));
 
                 toolbar.option('items[0].location', 'after');
-                checkItemsLocation($toolbarElement, 0, 0, isMenuMode ? 0 : 1, isMenuMode ? 1 : 0);
+                checkItemsLocation($toolbar, getExpectedToolbarItems('after', locateInMenu));
 
                 toolbar.option('items[0].location', 'before');
-                checkItemsLocation($toolbarElement, isMenuMode ? 0 : 1, 0, 0, isMenuMode ? 1 : 0);
+                checkItemsLocation($toolbar, getExpectedToolbarItems('before', locateInMenu));
             });
         });
     });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -150,7 +150,7 @@ function checkItemsLocation($toolbar, expected) {
 
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
-        [10, 1000].forEach((toolbarWidth) => {
+        [10 /* not enough space to show items */, 1000 /* enough space to show items */].forEach((toolbarWidth) => {
             QUnit.test(`Change item location at runtime (T844890), location: ${location}, locateInMenu: ${locateInMenu}, width: ${toolbarWidth}`, function(assert) {
                 const ITEM_WIDTH = 100;
                 const $toolbar = this.element.dxToolbar({

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -133,20 +133,20 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
     assert.equal(margin, '0px auto', 'aligned by center');
 });
 
-function checkItemsLocation($toolbarElement, expectedItemsCountWithBeforeLocation, expectedItemsCountWithCenterLocation, expectedItemsCountWithAfterLocation, expectedMenuItemsCount) {
-    const $itemsWithBeforeLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $itemsWithCenterLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $itemsWithAfterLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+function checkItemsLocation($toolbarElement, expectedBeforeItemsCount, expectedCenterItemsCount, expectedAfterItemsCount, expectedMenuItemsCount) {
+    const $beforeItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+    const $centerItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+    const $afterItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
     const $menuElement = $toolbarElement.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
-    QUnit.assert.equal($itemsWithBeforeLocation.length, expectedItemsCountWithBeforeLocation, 'items count with before location value');
-    QUnit.assert.equal($itemsWithCenterLocation.length, expectedItemsCountWithCenterLocation, 'items count with center location value');
-    QUnit.assert.equal($itemsWithAfterLocation.length, expectedItemsCountWithAfterLocation, 'items count with after location value');
+    QUnit.assert.equal($beforeItems.length, expectedBeforeItemsCount, 'items count with before location value');
+    QUnit.assert.equal($centerItems.length, expectedCenterItemsCount, 'items count with center location value');
+    QUnit.assert.equal($afterItems.length, expectedAfterItemsCount, 'items count with after location value');
     QUnit.assert.equal($menuElement.length, expectedMenuItemsCount, 'menu element');
 }
 
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
-        [1, 10000, undefined].forEach((width) => {
+        [1, 10000].forEach((width) => {
             QUnit.test(`Change item location at runtime -> location: ${location}, locateInMenu: ${locateInMenu}, width: ${width} (T844890)`, function(assert) {
                 const $toolbarElement = this.element.dxToolbar({
                         items: [
@@ -156,21 +156,21 @@ function checkItemsLocation($toolbarElement, expectedItemsCountWithBeforeLocatio
                     }),
                     toolbar = $toolbarElement.dxToolbar('instance');
 
-                let expectedItemsCountWithBeforeLocation = 0,
-                    expectedItemsCountWithCenterLocation = 0,
-                    expectedItemsCountWithAfterLocation = 0,
+                let expectedBeforeItemsCount = 0,
+                    expectedCenterItemsCount = 0,
+                    expectedAfterItemsCount = 0,
                     expectedMenuItemsCount = 0,
                     isMenuMode = (locateInMenu === 'always' || locateInMenu === 'auto' && width < 100);
 
                 if(isMenuMode) {
                     expectedMenuItemsCount = 1;
                 } else {
-                    expectedItemsCountWithBeforeLocation = location === 'before' ? 1 : 0;
-                    expectedItemsCountWithCenterLocation = location === 'center' || location === undefined ? 1 : 0;
-                    expectedItemsCountWithAfterLocation = location === 'after' ? 1 : 0;
+                    expectedBeforeItemsCount = location === 'before' ? 1 : 0;
+                    expectedCenterItemsCount = location === 'center' || location === undefined ? 1 : 0;
+                    expectedAfterItemsCount = location === 'after' ? 1 : 0;
                 }
 
-                checkItemsLocation($toolbarElement, expectedItemsCountWithBeforeLocation, expectedItemsCountWithCenterLocation, expectedItemsCountWithAfterLocation, expectedMenuItemsCount);
+                checkItemsLocation($toolbarElement, expectedBeforeItemsCount, expectedCenterItemsCount, expectedAfterItemsCount, expectedMenuItemsCount);
 
                 toolbar.option('items[0].location', 'center');
                 checkItemsLocation($toolbarElement, 0, isMenuMode ? 0 : 1, 0, isMenuMode ? 1 : 0);

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -133,32 +133,56 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
     assert.equal(margin, '0px auto', 'aligned by center');
 });
 
-function checkItemsLocation($toolbarElement, expectedItemsCountWithBeforeLocation, expectedItemsCountWithCenterLocation, expectedItemsCountWithAfterLocation) {
-    const $itemsWithBeforeLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS);
-    const $itemsWithCenterLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS);
-    const $itemsWithAfterLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS);
+function checkItemsLocation($toolbarElement, expectedItemsCountWithBeforeLocation, expectedItemsCountWithCenterLocation, expectedItemsCountWithAfterLocation, expectedMenuItemsCount) {
+    const $itemsWithBeforeLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+    const $itemsWithCenterLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+    const $itemsWithAfterLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+    const $menuElement = $toolbarElement.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
     QUnit.assert.equal($itemsWithBeforeLocation.length, expectedItemsCountWithBeforeLocation, 'items count with before location value');
     QUnit.assert.equal($itemsWithCenterLocation.length, expectedItemsCountWithCenterLocation, 'items count with center location value');
     QUnit.assert.equal($itemsWithAfterLocation.length, expectedItemsCountWithAfterLocation, 'items count with after location value');
+    QUnit.assert.equal($menuElement.length, expectedMenuItemsCount, 'menu element');
 }
 
-QUnit.test('Change item location at runtime (T844890)', function(assert) {
-    const $toolbarElement = this.element.dxToolbar({
-            items: [
-                { location: 'before', text: 'toolbar item' },
-            ]
-        }),
-        toolbar = $toolbarElement.dxToolbar('instance');
-    checkItemsLocation($toolbarElement, 1, 0, 0);
+['before', 'center', 'after', undefined].forEach((location) => {
+    ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
+        [1, 10000, undefined].forEach((width) => {
+            QUnit.test(`Change item location at runtime -> location: ${location}, locateInMenu: ${locateInMenu}, width: ${width} (T844890)`, function(assert) {
+                const $toolbarElement = this.element.dxToolbar({
+                        items: [
+                            { text: 'toolbar item', locateInMenu: locateInMenu, location: location },
+                        ],
+                        width: width
+                    }),
+                    toolbar = $toolbarElement.dxToolbar('instance');
 
-    toolbar.option('items[0].location', 'center');
-    checkItemsLocation($toolbarElement, 0, 1, 0);
+                let expectedItemsCountWithBeforeLocation = 0,
+                    expectedItemsCountWithCenterLocation = 0,
+                    expectedItemsCountWithAfterLocation = 0,
+                    expectedMenuItemsCount = 0,
+                    isMenuMode = (locateInMenu === 'always' || locateInMenu === 'auto' && width < 100);
 
-    toolbar.option('items[0].location', 'after');
-    checkItemsLocation($toolbarElement, 0, 0, 1);
+                if(isMenuMode) {
+                    expectedMenuItemsCount = 1;
+                } else {
+                    expectedItemsCountWithBeforeLocation = location === 'before' ? 1 : 0;
+                    expectedItemsCountWithCenterLocation = location === 'center' || location === undefined ? 1 : 0;
+                    expectedItemsCountWithAfterLocation = location === 'after' ? 1 : 0;
+                }
 
-    toolbar.option('items[0].location', 'before');
-    checkItemsLocation($toolbarElement, 1, 0, 0);
+                checkItemsLocation($toolbarElement, expectedItemsCountWithBeforeLocation, expectedItemsCountWithCenterLocation, expectedItemsCountWithAfterLocation, expectedMenuItemsCount);
+
+                toolbar.option('items[0].location', 'center');
+                checkItemsLocation($toolbarElement, 0, isMenuMode ? 0 : 1, 0, isMenuMode ? 1 : 0);
+
+                toolbar.option('items[0].location', 'after');
+                checkItemsLocation($toolbarElement, 0, 0, isMenuMode ? 0 : 1, isMenuMode ? 1 : 0);
+
+                toolbar.option('items[0].location', 'before');
+                checkItemsLocation($toolbarElement, isMenuMode ? 0 : 1, 0, 0, isMenuMode ? 1 : 0);
+            });
+        });
+    });
 });
 
 

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -138,34 +138,41 @@ function checkItemsLocation($toolbarElement, expected) {
     const $centerItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
     const $afterItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
     const $menuItems = $toolbarElement.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
-    QUnit.assert.equal($beforeItems.length, expected.before, 'items count with before location value');
-    QUnit.assert.equal($centerItems.length, expected.center, 'items count with center location value');
-    QUnit.assert.equal($afterItems.length, expected.after, 'items count with after location value');
-    QUnit.assert.equal($menuItems.length, expected.menu, 'menu element');
+    QUnit.assert.equal($beforeItems.length, expected.beforeItemsCount, 'items count with before location value');
+    QUnit.assert.equal($centerItems.length, expected.centerItemsCount, 'items count with center location value');
+    QUnit.assert.equal($afterItems.length, expected.afterItemsCount, 'items count with after location value');
+    QUnit.assert.equal($menuItems.length, expected.menuItemsCount, 'menu items count');
 }
 
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
         [10, 1000].forEach((width) => {
             QUnit.test(`Change item location at runtime -> location: ${location}, locateInMenu: ${locateInMenu}, width: ${width} (T844890)`, function(assert) {
+                const TOOLBAR_ITEM_WIDTH = 100;
                 const $toolbar = this.element.dxToolbar({
                         items: [
-                            { text: 'toolbar item', locateInMenu: locateInMenu, location: location },
+                            { text: 'toolbar item', locateInMenu: locateInMenu, location: location, width: TOOLBAR_ITEM_WIDTH },
                         ],
                         width: width
                     }),
                     toolbar = $toolbar.dxToolbar('instance');
 
                 const getExpectedToolbarItems = (location, locateInMenu) => {
-                    const result = { before: 0, center: 0, after: 0, menu: 0 };
-                    if(locateInMenu === 'always' || (locateInMenu === 'auto' && width < 100)) {
-                        result.menu = 1;
-                    } else {
-                        result.before = location === 'before' ? 1 : 0;
-                        result.center = (location === 'center' || location === undefined) ? 1 : 0;
-                        result.after = location === 'after' ? 1 : 0;
+                    if(locateInMenu === 'always' || (locateInMenu === 'auto' && width < TOOLBAR_ITEM_WIDTH)) {
+                        return {
+                            menuItemsCount: 1,
+                            beforeItemsCount: 0,
+                            centerItemsCount: 0,
+                            afterItemsCount: 0
+                        };
                     }
-                    return result;
+
+                    return {
+                        menuItemsCount: 0,
+                        beforeItemsCount: location === 'before' ? 1 : 0,
+                        centerItemsCount: (location === 'center' || location === undefined) ? 1 : 0,
+                        afterItemsCount: location === 'after' ? 1 : 0
+                    };
                 };
 
                 checkItemsLocation($toolbar, getExpectedToolbarItems(location, locateInMenu));

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -166,8 +166,9 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
                     }
                 };
 
-                const defaultLocation = location || 'center';
-                checkItemsLocation($toolbar, { [defaultLocation]: 1 });
+                const expectedInitial = {};
+                expectedInitial[location || 'center'] = 1;
+                checkItemsLocation($toolbar, expectedInitial);
 
                 toolbar.option('items[0].location', 'center');
                 checkItemsLocation($toolbar, { center: 1 });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -166,7 +166,8 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
                     }
                 };
 
-                checkItemsLocation($toolbar, { [location]: 1 });
+                const defaultLocation = location || 'center';
+                checkItemsLocation($toolbar, { [defaultLocation]: 1 });
 
                 toolbar.option('items[0].location', 'center');
                 checkItemsLocation($toolbar, { center: 1 });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -147,7 +147,7 @@ function checkItemsLocation($toolbar, expected) {
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
         [10, 1000].forEach((toolbarWidth) => {
-            QUnit.test(`Change item location at runtime -> location: ${location}, locateInMenu: ${locateInMenu}, width: ${toolbarWidth} (T844890)`, function(assert) {
+            QUnit.test(`Change item location at runtime (T844890), location: ${location}, locateInMenu: ${locateInMenu}, width: ${toolbarWidth}`, function(assert) {
                 const ITEM_WIDTH = 100;
                 const $toolbar = this.element.dxToolbar({
                         items: [

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -133,11 +133,11 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
     assert.equal(margin, '0px auto', 'aligned by center');
 });
 
-function checkItemsLocation($toolbarElement, expected) {
-    const $beforeItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $centerItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $afterItems = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $menuItems = $toolbarElement.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
+function checkItemsLocation($toolbar, expected) {
+    const $beforeItems = $toolbar.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+    const $centerItems = $toolbar.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+    const $afterItems = $toolbar.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
+    const $menuItems = $toolbar.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
     QUnit.assert.equal($beforeItems.length, expected.beforeItemsCount, 'items count with before location value');
     QUnit.assert.equal($centerItems.length, expected.centerItemsCount, 'items count with center location value');
     QUnit.assert.equal($afterItems.length, expected.afterItemsCount, 'items count with after location value');

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -146,19 +146,19 @@ function checkItemsLocation($toolbarElement, expected) {
 
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
-        [10, 1000].forEach((width) => {
-            QUnit.test(`Change item location at runtime -> location: ${location}, locateInMenu: ${locateInMenu}, width: ${width} (T844890)`, function(assert) {
-                const TOOLBAR_ITEM_WIDTH = 100;
+        [10, 1000].forEach((toolbarWidth) => {
+            QUnit.test(`Change item location at runtime -> location: ${location}, locateInMenu: ${locateInMenu}, width: ${toolbarWidth} (T844890)`, function(assert) {
+                const ITEM_WIDTH = 100;
                 const $toolbar = this.element.dxToolbar({
                         items: [
-                            { text: 'toolbar item', locateInMenu: locateInMenu, location: location, width: TOOLBAR_ITEM_WIDTH },
+                            { text: 'toolbar item', locateInMenu: locateInMenu, location: location, width: ITEM_WIDTH },
                         ],
-                        width: width
+                        width: toolbarWidth
                     }),
                     toolbar = $toolbar.dxToolbar('instance');
 
                 const getExpectedToolbarItems = (location, locateInMenu) => {
-                    if(locateInMenu === 'always' || (locateInMenu === 'auto' && width < TOOLBAR_ITEM_WIDTH)) {
+                    if(locateInMenu === 'always' || (locateInMenu === 'auto' && toolbarWidth < ITEM_WIDTH)) {
                         return {
                             menuItemsCount: 1,
                             beforeItemsCount: 0,

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -136,18 +136,6 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
     assert.equal(margin, '0px auto', 'aligned by center');
 });
 
-function checkItemsLocation($toolbar, expected) {
-    const $beforeItems = $toolbar.find(`.${TOOLBAR_BEFORE_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
-    const $centerItems = $toolbar.find(`.${TOOLBAR_CENTER_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
-    const $afterItems = $toolbar.find(`.${TOOLBAR_AFTER_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
-    const $menuItems = $toolbar.find(`.${TOOLBAR_MENU_CONTAINER_CLASS}`).not(`.${INVISIBLE_STATE_CLASS}`);
-
-    QUnit.assert.equal($beforeItems.length, expected.beforeItemsCount || 0, 'items count with before location value');
-    QUnit.assert.equal($centerItems.length, expected.centerItemsCount || 0, 'items count with center location value');
-    QUnit.assert.equal($afterItems.length, expected.afterItemsCount || 0, 'items count with after location value');
-    QUnit.assert.equal($menuItems.length, expected.menuItemsCount || 0, 'menu items count');
-}
-
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
         [10 /* not enough space to show items */, 1000 /* enough space to show items */].forEach((toolbarWidth) => {
@@ -159,28 +147,35 @@ function checkItemsLocation($toolbar, expected) {
                     }),
                     toolbar = $toolbar.dxToolbar('instance');
 
-                const getExpectedCountConfig = (location) => {
-                    if(locateInMenu === 'always' || (locateInMenu === 'auto' && toolbarWidth < ITEM_WIDTH)) {
-                        return { menuItemsCount: 1 };
-                    }
+                const checkItemsLocation = ($toolbar, expected) => {
+                    const $beforeItems = $toolbar.find(`.${TOOLBAR_BEFORE_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
+                    const $centerItems = $toolbar.find(`.${TOOLBAR_CENTER_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
+                    const $afterItems = $toolbar.find(`.${TOOLBAR_AFTER_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
+                    const $menuItems = $toolbar.find(`.${TOOLBAR_MENU_CONTAINER_CLASS}`).not(`.${INVISIBLE_STATE_CLASS}`);
 
-                    return {
-                        beforeItemsCount: location === 'before' ? 1 : 0,
-                        centerItemsCount: (location === 'center' || location === undefined) ? 1 : 0,
-                        afterItemsCount: location === 'after' ? 1 : 0
-                    };
+                    if(locateInMenu === 'always' || (locateInMenu === 'auto' && toolbarWidth < ITEM_WIDTH)) {
+                        QUnit.assert.equal($menuItems.length, 1, 'menu items count for ');
+                        QUnit.assert.equal($beforeItems.length, 0, 'items count with before location value');
+                        QUnit.assert.equal($centerItems.length, 0, 'items count with center location value');
+                        QUnit.assert.equal($afterItems.length, 0, 'items count with after location value');
+                    } else {
+                        QUnit.assert.equal($menuItems.length, 0, 'menu items count');
+                        QUnit.assert.equal($beforeItems.length, expected.before || 0, 'items count with before location value');
+                        QUnit.assert.equal($centerItems.length, expected.center || 0, 'items count with center location value');
+                        QUnit.assert.equal($afterItems.length, expected.after || 0, 'items count with after location value');
+                    }
                 };
 
-                checkItemsLocation($toolbar, getExpectedCountConfig(location));
+                checkItemsLocation($toolbar, { [location]: 1 });
 
                 toolbar.option('items[0].location', 'center');
-                checkItemsLocation($toolbar, getExpectedCountConfig('center'));
+                checkItemsLocation($toolbar, { center: 1 });
 
                 toolbar.option('items[0].location', 'after');
-                checkItemsLocation($toolbar, getExpectedCountConfig('after'));
+                checkItemsLocation($toolbar, { after: 1 });
 
                 toolbar.option('items[0].location', 'before');
-                checkItemsLocation($toolbar, getExpectedCountConfig('before'));
+                checkItemsLocation($toolbar, { before: 1 });
             });
         });
     });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -142,10 +142,10 @@ function checkItemsLocation($toolbar, expected) {
     const $afterItems = $toolbar.find(`.${TOOLBAR_AFTER_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
     const $menuItems = $toolbar.find(`.${TOOLBAR_MENU_CONTAINER_CLASS}`).not(`.${INVISIBLE_STATE_CLASS}`);
 
-    QUnit.assert.equal($beforeItems.length, expected.beforeItemsCount, 'items count with before location value');
-    QUnit.assert.equal($centerItems.length, expected.centerItemsCount, 'items count with center location value');
-    QUnit.assert.equal($afterItems.length, expected.afterItemsCount, 'items count with after location value');
-    QUnit.assert.equal($menuItems.length, expected.menuItemsCount, 'menu items count');
+    QUnit.assert.equal($beforeItems.length, expected.beforeItemsCount || 0, 'items count with before location value');
+    QUnit.assert.equal($centerItems.length, expected.centerItemsCount || 0, 'items count with center location value');
+    QUnit.assert.equal($afterItems.length, expected.afterItemsCount || 0, 'items count with after location value');
+    QUnit.assert.equal($menuItems.length, expected.menuItemsCount || 0, 'menu items count');
 }
 
 ['before', 'center', 'after', undefined].forEach((location) => {
@@ -154,41 +154,33 @@ function checkItemsLocation($toolbar, expected) {
             QUnit.test(`Change item location at runtime (T844890), location: ${location}, locateInMenu: ${locateInMenu}, width: ${toolbarWidth}`, function(assert) {
                 const ITEM_WIDTH = 100;
                 const $toolbar = this.element.dxToolbar({
-                        items: [
-                            { text: 'toolbar item', locateInMenu: locateInMenu, location: location, width: ITEM_WIDTH },
-                        ],
+                        items: [ { text: 'toolbar item', locateInMenu: locateInMenu, location: location, width: ITEM_WIDTH } ],
                         width: toolbarWidth
                     }),
                     toolbar = $toolbar.dxToolbar('instance');
 
-                const getExpectedCountConfig = (location, locateInMenu) => {
+                const getExpectedCountConfig = (location) => {
                     if(locateInMenu === 'always' || (locateInMenu === 'auto' && toolbarWidth < ITEM_WIDTH)) {
-                        return {
-                            menuItemsCount: 1,
-                            beforeItemsCount: 0,
-                            centerItemsCount: 0,
-                            afterItemsCount: 0
-                        };
+                        return { menuItemsCount: 1 };
                     }
 
                     return {
-                        menuItemsCount: 0,
                         beforeItemsCount: location === 'before' ? 1 : 0,
                         centerItemsCount: (location === 'center' || location === undefined) ? 1 : 0,
                         afterItemsCount: location === 'after' ? 1 : 0
                     };
                 };
 
-                checkItemsLocation($toolbar, getExpectedCountConfig(location, locateInMenu));
+                checkItemsLocation($toolbar, getExpectedCountConfig(location));
 
                 toolbar.option('items[0].location', 'center');
-                checkItemsLocation($toolbar, getExpectedCountConfig('center', locateInMenu));
+                checkItemsLocation($toolbar, getExpectedCountConfig('center'));
 
                 toolbar.option('items[0].location', 'after');
-                checkItemsLocation($toolbar, getExpectedCountConfig('after', locateInMenu));
+                checkItemsLocation($toolbar, getExpectedCountConfig('after'));
 
                 toolbar.option('items[0].location', 'before');
-                checkItemsLocation($toolbar, getExpectedCountConfig('before', locateInMenu));
+                checkItemsLocation($toolbar, getExpectedCountConfig('before'));
             });
         });
     });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -30,9 +30,12 @@ $('#qunit-fixture').html('<style>\
 
 const TOOLBAR_CLASS = 'dx-toolbar';
 const TOOLBAR_ITEM_CLASS = 'dx-toolbar-item';
+const TOOLBAR_ITEM_INVISIBLE_CLASS = 'dx-toolbar-item-invisible';
+const TOOLBAR_MENU_CONTAINER_CLASS = 'dx-toolbar-menu-container';
 const TOOLBAR_BEFORE_CONTAINER_CLASS = 'dx-toolbar-before';
 const TOOLBAR_AFTER_CONTAINER_CLASS = 'dx-toolbar-after';
 const TOOLBAR_CENTER_CONTAINER_CLASS = 'dx-toolbar-center';
+const INVISIBLE_STATE_CLASS = 'dx-state-invisible';
 const TOOLBAR_LABEL_CLASS = 'dx-toolbar-label';
 const TOOLBAR_MENU_BUTTON_CLASS = 'dx-toolbar-menu-button';
 const TOOLBAR_MENU_SECTION_CLASS = 'dx-toolbar-menu-section';
@@ -134,10 +137,11 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
 });
 
 function checkItemsLocation($toolbar, expected) {
-    const $beforeItems = $toolbar.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $centerItems = $toolbar.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $afterItems = $toolbar.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS).not('.dx-toolbar-item-invisible');
-    const $menuItems = $toolbar.find('.dx-toolbar-menu-container').not('.dx-state-invisible');
+    const $beforeItems = $toolbar.find(`.${TOOLBAR_BEFORE_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
+    const $centerItems = $toolbar.find(`.${TOOLBAR_CENTER_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
+    const $afterItems = $toolbar.find(`.${TOOLBAR_AFTER_CONTAINER_CLASS} .${TOOLBAR_ITEM_CLASS}`).not(`.${TOOLBAR_ITEM_INVISIBLE_CLASS}`);
+    const $menuItems = $toolbar.find(`.${TOOLBAR_MENU_CONTAINER_CLASS}`).not(`.${INVISIBLE_STATE_CLASS}`);
+
     QUnit.assert.equal($beforeItems.length, expected.beforeItemsCount, 'items count with before location value');
     QUnit.assert.equal($centerItems.length, expected.centerItemsCount, 'items count with center location value');
     QUnit.assert.equal($afterItems.length, expected.afterItemsCount, 'items count with after location value');

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -133,6 +133,35 @@ QUnit.test('Center element has correct margin with RTL', function(assert) {
     assert.equal(margin, '0px auto', 'aligned by center');
 });
 
+function checkItemsLocation($toolbarElement, expectedItemsCountWithBeforeLocation, expectedItemsCountWithCenterLocation, expectedItemsCountWithAfterLocation) {
+    const $itemsWithBeforeLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-before .' + TOOLBAR_ITEM_CLASS);
+    const $itemsWithCenterLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-center .' + TOOLBAR_ITEM_CLASS);
+    const $itemsWithAfterLocation = $toolbarElement.find('.' + TOOLBAR_CLASS + '-after .' + TOOLBAR_ITEM_CLASS);
+    QUnit.assert.equal($itemsWithBeforeLocation.length, expectedItemsCountWithBeforeLocation, 'items count with before location value');
+    QUnit.assert.equal($itemsWithCenterLocation.length, expectedItemsCountWithCenterLocation, 'items count with center location value');
+    QUnit.assert.equal($itemsWithAfterLocation.length, expectedItemsCountWithAfterLocation, 'items count with after location value');
+}
+
+QUnit.test('Change item location at runtime (T844890)', function(assert) {
+    const $toolbarElement = this.element.dxToolbar({
+            items: [
+                { location: 'before', text: 'toolbar item' },
+            ]
+        }),
+        toolbar = $toolbarElement.dxToolbar('instance');
+    checkItemsLocation($toolbarElement, 1, 0, 0);
+
+    toolbar.option('items[0].location', 'center');
+    checkItemsLocation($toolbarElement, 0, 1, 0);
+
+    toolbar.option('items[0].location', 'after');
+    checkItemsLocation($toolbarElement, 0, 0, 1);
+
+    toolbar.option('items[0].location', 'before');
+    checkItemsLocation($toolbarElement, 1, 0, 0);
+});
+
+
 QUnit.test('buttons has text style in Material', function(assert) {
     var origIsMaterial = themes.isMaterial;
     themes.isMaterial = function() { return true; };
@@ -338,11 +367,11 @@ QUnit.module('disabled state', () => {
                     [true, false].forEach((changeDisabledOrder) => {
                         ['never', 'always'].forEach((locateInMenu) => {
                             QUnit.test(`new dxToolbar({
-                                    toolbar.disabled: ${isToolbarDisabled}, 
-                                    button.disabled: ${isButtonDisabled}), 
-                                    toolbar.disabled new: ${isToolbarDisabledNew}, 
-                                    button.disabled new: ${isButtonDisabledNew}, 
-                                    changeDisableOrder: ${changeDisabledOrder}, 
+                                    toolbar.disabled: ${isToolbarDisabled},
+                                    button.disabled: ${isButtonDisabled}),
+                                    toolbar.disabled new: ${isToolbarDisabledNew},
+                                    button.disabled new: ${isButtonDisabledNew},
+                                    changeDisableOrder: ${changeDisabledOrder},
                                     locateInMenu: ${locateInMenu}`,
                             function(assert) {
                                 let itemClickHandler = sinon.spy();

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -157,7 +157,7 @@ function checkItemsLocation($toolbarElement, expected) {
                     }),
                     toolbar = $toolbar.dxToolbar('instance');
 
-                const getExpectedToolbarItems = (location, locateInMenu) => {
+                const getExpectedCountConfig = (location, locateInMenu) => {
                     if(locateInMenu === 'always' || (locateInMenu === 'auto' && toolbarWidth < ITEM_WIDTH)) {
                         return {
                             menuItemsCount: 1,
@@ -175,16 +175,16 @@ function checkItemsLocation($toolbarElement, expected) {
                     };
                 };
 
-                checkItemsLocation($toolbar, getExpectedToolbarItems(location, locateInMenu));
+                checkItemsLocation($toolbar, getExpectedCountConfig(location, locateInMenu));
 
                 toolbar.option('items[0].location', 'center');
-                checkItemsLocation($toolbar, getExpectedToolbarItems('center', locateInMenu));
+                checkItemsLocation($toolbar, getExpectedCountConfig('center', locateInMenu));
 
                 toolbar.option('items[0].location', 'after');
-                checkItemsLocation($toolbar, getExpectedToolbarItems('after', locateInMenu));
+                checkItemsLocation($toolbar, getExpectedCountConfig('after', locateInMenu));
 
                 toolbar.option('items[0].location', 'before');
-                checkItemsLocation($toolbar, getExpectedToolbarItems('before', locateInMenu));
+                checkItemsLocation($toolbar, getExpectedCountConfig('before', locateInMenu));
             });
         });
     });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -146,7 +146,7 @@ function checkItemsLocation($toolbarElement, expected) {
 
 ['before', 'center', 'after', undefined].forEach((location) => {
     ['never', 'auto', 'always', undefined].forEach((locateInMenu) => {
-        [1, 10000].forEach((width) => {
+        [10, 1000].forEach((width) => {
             QUnit.test(`Change item location at runtime -> location: ${location}, locateInMenu: ${locateInMenu}, width: ${width} (T844890)`, function(assert) {
                 const $toolbar = this.element.dxToolbar({
                         items: [


### PR DESCRIPTION
1) Fix changing location property at runtime
2) Small refactoring: method _isToolbarItem always returns "false" value 