### PR TITLE
Fix DropDownEditor fieldTemplate containing masked TextBox (T846289)

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -363,6 +363,14 @@ var DropDownEditor = TextBox.inherit({
         return this.option('fieldTemplate') && this._getTemplateByOption('fieldTemplate');
     },
 
+    _renderMask: function() {
+        if(this.option('fieldTemplate')) {
+            return;
+        }
+
+        this.callBase();
+    },
+
     _renderField: function() {
         const fieldTemplate = this._getFieldTemplate();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -1129,7 +1129,9 @@ QUnit.test('fieldTemplate item element should have 100% width with field templat
 
 QUnit.testInActiveWindow('fieldTemplate can contain a masked TextBox', function(assert) {
     let keyboard;
-    const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+    let $input;
+
+    $('#dropDownEditorLazy').dxDropDownEditor({
         dataSource: [1, 2],
         fieldTemplate: (value, $element) => {
             const textBox = $('<div>')
@@ -1140,11 +1142,11 @@ QUnit.testInActiveWindow('fieldTemplate can contain a masked TextBox', function(
                 })
                 .dxTextBox('instance');
 
-            keyboard = new keyboardMock(textBox._input(), true);
+            $input = textBox._input();
+            keyboard = new keyboardMock($input, true);
             caretWorkaround($input);
         }
     });
-    const $input = $dropDownEditor.find(`.${TEXT_EDITOR_INPUT_CLASS}`);
 
     keyboard.type('z5');
     assert.strictEqual($input.val(), '5-_', 'Masked TextBox works fine');

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -9,6 +9,7 @@ import support from 'core/utils/support';
 import DropDownEditor from 'ui/drop_down_editor/ui.drop_down_editor';
 import Overlay from 'ui/overlay';
 import { isRenderer } from 'core/utils/type';
+import caretWorkaround from './textEditorParts/caretWorkaround.js';
 
 import 'common.css!';
 
@@ -1124,6 +1125,29 @@ QUnit.test('fieldTemplate item element should have 100% width with field templat
     const $fieldTemplateWrapper = $dropDownEditor.find(`.${DROP_DOWN_EDITOR_FIELD_TEMPLATE_WRAPPER}`);
     const $input = $dropDownEditor.find(`.${TEXT_EDITOR_INPUT_CLASS}`);
     assert.roughEqual($fieldTemplateWrapper.outerWidth(), $input.outerWidth(), 1);
+});
+
+QUnit.testInActiveWindow('fieldTemplate can contain a masked TextBox', function(assert) {
+    let keyboard;
+    const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+        dataSource: [1, 2],
+        fieldTemplate: (value, $element) => {
+            const textBox = $('<div>')
+                .appendTo($element)
+                .dxTextBox({
+                    mask: '0-0',
+                    value
+                })
+                .dxTextBox('instance');
+
+            keyboard = new keyboardMock(textBox._input(), true);
+            caretWorkaround($input);
+        }
+    });
+    const $input = $dropDownEditor.find(`.${TEXT_EDITOR_INPUT_CLASS}`);
+
+    keyboard.type('z5');
+    assert.strictEqual($input.val(), '5-_', 'Masked TextBox works fine');
 });
 
 QUnit.module('options');


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
