### PR TITLE
dropDownButton: fix regression after #11239

### DIFF
--- a/styles/widgets/generic/dropDownButton.generic.less
+++ b/styles/widgets/generic/dropDownButton.generic.less
@@ -14,8 +14,13 @@
 }
 
 .dx-dropdownbutton-toggle {
-    flex: 0 0 20px;
+    display: flex;
+    flex: 0 0 auto;
     max-width: 20px;
+
+    .dx-button-content {
+        flex: 0 0 20px;
+    }
 }
 
 .dx-dropdownbutton-action {


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/37047972/71546377-4c9f3180-29a7-11ea-8d99-e03df13049aa.png)
after: 
![image](https://user-images.githubusercontent.com/37047972/71546368-3abd8e80-29a7-11ea-8282-2a36825dcc93.png)