### PR TITLE
Renovation: Add babel-minify to reduce bundle size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
-    "presets": ["@babel/preset-env"],
+    "presets": ["@babel/preset-env", ["minify", {
+        "builtIns": false,
+        "deadcode": false,
+        "evaluate": false,
+        "flipComparisons": false,
+        "mangle": false,
+        "simplifyComparisons": false
+    }]],
     "plugins": ["transform-es2015-modules-commonjs", "add-module-exports",
       "@babel/plugin-proposal-nullish-coalescing-operator", "@babel/plugin-proposal-optional-chaining"
     ],

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-minify": "^0.5.1",
     "bootstrap": "^4.3.1",
     "cldr-core": "latest",
     "cldr-numbers-full": "latest",


### PR DESCRIPTION
Add https://babeljs.io/docs/en/babel-preset-minify
(bundle size will be reduced by half)