### PR TITLE
Fix an error occurs on an attempt to switch to the Agenda view (T847884)

### DIFF
--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -1258,6 +1258,8 @@ const Scheduler = Widget.inherit({
                 break;
             case 'currentView':
                 this._processCurrentView();
+                this.getLayoutManager().initRenderingStrategy(this._getAppointmentsRenderingStrategy());
+
                 this._appointments.option({
                     items: [],
                     allowDrag: this._allowDragging(),
@@ -1266,7 +1268,6 @@ const Scheduler = Widget.inherit({
                 });
 
                 this._postponeResourceLoading().done((resources) => {
-                    this.getLayoutManager().initRenderingStrategy(this._getAppointmentsRenderingStrategy());
                     this._refreshWorkSpace(resources);
                     this._updateHeader();
                     this._filterAppointmentsByDate();

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
@@ -2982,6 +2982,56 @@ QUnit.testStart(function() {
         });
     });
 
+    QUnit.test('agenda should be rendered correctly after changing groups on view changing(T847884)', function(assert) {
+        const priorityData = [
+            {
+                text: 'Low Priority',
+                id: 1,
+                color: '#1e90ff'
+            }, {
+                text: 'High Priority',
+                id: 2,
+                color: '#ff9747'
+            }
+        ];
+
+        this.createInstance({
+            dataSource: [
+                {
+                    text: 'Upgrade Personal Computers',
+                    priorityId: 1,
+                    startDate: new Date(2018, 4, 21, 9),
+                    endDate: new Date(2018, 4, 21, 11, 30)
+                }],
+            views: ['week', 'agenda'],
+            onOptionChanged: function(e) {
+                if(e.name === 'currentView') {
+                    e.component._customUpdate = true;
+                    e.component.beginUpdate();
+                    e.component.option('groups', []);
+                }
+                if(e.name === 'groups' && e.component._customUpdate === true) {
+                    e.component._customUpdate = false;
+                    e.component.endUpdate();
+                }
+            },
+            currentView: 'week',
+            currentDate: new Date(2018, 4, 21),
+            groups: ['priorityId'],
+            resources: [
+                {
+                    fieldExpr: 'priorityId',
+                    allowMultiple: false,
+                    dataSource: priorityData,
+                    label: 'Priority'
+                }
+            ]
+        });
+
+        this.instance.option('currentView', 'agenda');
+        assert.ok(true, 'currentView was changed to agenda correctly');
+    });
+
     QUnit.test('onAppointmentRendered should not contain information about particular appt resources if there are not groups(T413561)', function(assert) {
         const workSpaceSpy = sinon.spy(dxSchedulerWorkSpace.prototype, 'getCellDataByCoordinates');
 


### PR DESCRIPTION
The 'Cannot read property 'bind' of undefined' error occurs on an attempt to switch to the Agenda view if grouping is changed dynamically