### PR TITLE
Use 'import' for the 'ui.widgets' and 'ui.widgets.editors' tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/calendar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendar.markup.tests.js
@@ -3,7 +3,7 @@ import dateSerialization from 'core/utils/date_serialization';
 import { isDefined } from 'core/utils/type';
 import config from 'core/config';
 import { isRenderer } from 'core/utils/type';
-import { hasWindow } from 'core/utils/window';
+import windowUtils from 'core/utils/window';
 
 import 'common.css!';
 import 'generic_light.css!';
@@ -43,7 +43,7 @@ QUnit.module('Calendar markup', {
     });
 
     QUnit.test('views are rendered', function(assert) {
-        if(hasWindow()) {
+        if(windowUtils.hasWindow()) {
             assert.equal(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + ' .dx-widget').length, 3, 'all views are rendered');
         } else {
             assert.equal(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + ' .dx-widget').length, 1, 'only one view is rendered');

--- a/testing/tests/DevExpress.ui.widgets.editors/calendar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendar.markup.tests.js
@@ -1,13 +1,13 @@
-const $ = require('jquery');
-const dateSerialization = require('core/utils/date_serialization');
-const isDefined = require('core/utils/type').isDefined;
-const config = require('core/config');
-const isRenderer = require('core/utils/type').isRenderer;
-const hasWindow = require('core/utils/window').hasWindow;
+import $ from 'jquery';
+import dateSerialization from 'core/utils/date_serialization';
+import { isDefined } from 'core/utils/type';
+import config from 'core/config';
+import { isRenderer } from 'core/utils/type';
+import { hasWindow } from 'core/utils/window';
 
-require('common.css!');
-require('generic_light.css!');
-require('ui/calendar');
+import 'common.css!';
+import 'generic_light.css!';
+import 'ui/calendar';
 
 const CALENDAR_CLASS = 'dx-calendar';
 const CALENDAR_NAVIGATOR_CLASS = 'dx-calendar-navigator';

--- a/testing/tests/DevExpress.ui.widgets.editors/calendarView.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendarView.markup.tests.js
@@ -1,12 +1,12 @@
-const $ = require('jquery');
-const dateUtils = require('core/utils/date');
-const BaseView = require('ui/calendar/ui.calendar.base_view');
-const Views = require('ui/calendar/ui.calendar.views');
-const fx = require('animation/fx');
-const dateSerialization = require('core/utils/date_serialization');
+import $ from 'jquery';
+import dateUtils from 'core/utils/date';
+import BaseView from 'ui/calendar/ui.calendar.base_view';
+import Views from 'ui/calendar/ui.calendar.views';
+import fx from 'animation/fx';
+import dateSerialization from 'core/utils/date_serialization';
 
-require('common.css!');
-require('ui/calendar');
+import 'common.css!';
+import 'ui/calendar';
 
 const CALENDAR_EMPTY_CELL_CLASS = 'dx-calendar-empty-cell';
 const CALENDAR_TODAY_CLASS = 'dx-calendar-today';

--- a/testing/tests/DevExpress.ui.widgets.editors/calendarViews.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendarViews.tests.js
@@ -1,12 +1,12 @@
-const $ = require('jquery');
-const noop = require('core/utils/common').noop;
-const dateUtils = require('core/utils/date');
-const BaseView = require('ui/calendar/ui.calendar.base_view');
-const Views = require('ui/calendar/ui.calendar.views');
-const pointerMock = require('../../helpers/pointerMock.js');
-const fx = require('animation/fx');
-const dateSerialization = require('core/utils/date_serialization');
-const dateLocalization = require('localization/date');
+import $ from 'jquery';
+import { noop } from 'core/utils/common';
+import dateUtils from 'core/utils/date';
+import BaseView from 'ui/calendar/ui.calendar.base_view';
+import Views from 'ui/calendar/ui.calendar.views';
+import pointerMock from '../../helpers/pointerMock.js';
+import fx from 'animation/fx';
+import dateSerialization from 'core/utils/date_serialization';
+import dateLocalization from 'localization/date';
 
 require('common.css!');
 require('ui/calendar');

--- a/testing/tests/DevExpress.ui.widgets.editors/calendarViews.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendarViews.tests.js
@@ -8,8 +8,8 @@ import fx from 'animation/fx';
 import dateSerialization from 'core/utils/date_serialization';
 import dateLocalization from 'localization/date';
 
-require('common.css!');
-require('ui/calendar');
+import 'common.css!';
+import 'ui/calendar';
 
 const CALENDAR_EMPTY_CELL_CLASS = 'dx-calendar-empty-cell';
 const CALENDAR_CELL_CLASS = 'dx-calendar-cell';
@@ -98,6 +98,7 @@ QUnit.module('Basics', () => {
         });
 
         assert.notOk(spy.called, 'firstDayOfWeekIndex wasn\'t called');
+        $element.remove();
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/checkbox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/checkbox.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('common.css!');
-require('ui/check_box');
+import 'common.css!';
+import 'ui/check_box';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/colorBox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/colorBox.markup.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const fx = require('animation/fx');
+import $ from 'jquery';
+import fx from 'animation/fx';
 
-require('common.css!');
-require('ui/color_box');
+import 'common.css!';
+import 'ui/color_box';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/colorView.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/colorView.markup.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const fx = require('animation/fx');
+import $ from 'jquery';
+import fx from 'animation/fx';
 
-require('common.css!');
-require('ui/color_box/color_view');
+import 'common.css!';
+import 'ui/color_box/color_view';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/colorView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/colorView.tests.js
@@ -1,15 +1,15 @@
-const $ = require('jquery');
-const noop = require('core/utils/common').noop;
-const Color = require('color');
-const Browser = require('core/utils/browser');
-const pointerMock = require('../../helpers/pointerMock.js');
-const keyboardMock = require('../../helpers/keyboardMock.js');
-const fx = require('animation/fx');
+import $ from 'jquery';
+import { noop } from 'core/utils/common';
+import Color from 'color';
+import Browser from 'core/utils/browser';
+import pointerMock from '../../helpers/pointerMock.js';
+import keyboardMock from '../../helpers/keyboardMock.js';
+import fx from 'animation/fx';
 
 const TEXTEDITOR_INPUT_SELECTOR = '.dx-texteditor-input';
 
-require('common.css!');
-require('ui/color_box/color_view');
+import 'common.css!';
+import 'ui/color_box/color_view';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.markup.tests.js
@@ -1,10 +1,10 @@
-const $ = require('jquery');
-const CustomStore = require('data/custom_store');
-const DropDownBox = require('ui/drop_down_box');
-const isRenderer = require('core/utils/type').isRenderer;
-const config = require('core/config');
+import $ from 'jquery';
+import CustomStore from 'data/custom_store';
+import DropDownBox from 'ui/drop_down_box';
+import { isRenderer } from 'core/utils/type';
+import config from 'core/config';
 
-require('common.css!');
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/editor.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/editor.markup.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const Editor = require('ui/editor/editor');
-const Class = require('core/class');
+import $ from 'jquery';
+import Editor from 'ui/editor/editor';
+import Class from 'core/class';
 
-require('common.css!');
+import 'common.css!';
 
 const READONLY_STATE_CLASS = 'dx-state-readonly';
 

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBox.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
-const NumberBox = require('ui/number_box');
+import $ from 'jquery';
+import NumberBox from 'ui/number_box';
 
-require('common.css!');
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.caret.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.caret.tests.js
@@ -1,4 +1,4 @@
-const maskCaret = require('ui/number_box/number_box.caret');
+import maskCaret from 'ui/number_box/number_box.caret';
 
 QUnit.module('format caret', () => {
     QUnit.test('getCaretWithOffset', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberbox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberbox.tests.js
@@ -1,6 +1,6 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('common.css!');
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =
@@ -13,7 +13,7 @@ QUnit.testStart(function() {
     $('#qunit-fixture').html(markup);
 });
 
-require('./numberBoxParts/common.tests.js');
-require('./numberBoxParts/mask.caret.tests.js');
-require('./numberBoxParts/mask.tests.js');
+import './numberBoxParts/common.tests.js';
+import './numberBoxParts/mask.caret.tests.js';
+import './numberBoxParts/mask.tests.js';
 

--- a/testing/tests/DevExpress.ui.widgets.editors/rangeSlider.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/rangeSlider.markup.tests.js
@@ -1,7 +1,8 @@
-const $ = require('jquery');
-const config = require('core/config');
+import $ from 'jquery';
+import config from 'core/config';
 
-require('ui/range_slider');
+import 'ui/range_slider';
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =
@@ -9,8 +10,6 @@ QUnit.testStart(function() {
 
     $('#qunit-fixture').html(markup);
 });
-
-require('common.css!');
 
 const SLIDER_CLASS = 'dx-slider';
 

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.markup.tests.js
@@ -1,12 +1,12 @@
-const $ = require('jquery');
-const SelectBox = require('ui/select_box');
-const DataSource = require('data/data_source/data_source').DataSource;
-const CustomStore = require('data/custom_store');
-const fx = require('animation/fx');
-const hasWindow = require('core/utils/window').hasWindow;
+import $ from 'jquery';
+import SelectBox from 'ui/select_box';
+import { DataSource } from 'data/data_source/data_source';
+import CustomStore from 'data/custom_store';
+import fx from 'animation/fx';
+import { hasWindow } from 'core/utils/window';
 
-require('common.css!');
-require('generic_light.css!');
+import 'common.css!';
+import 'generic_light.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.markup.tests.js
@@ -3,7 +3,7 @@ import SelectBox from 'ui/select_box';
 import { DataSource } from 'data/data_source/data_source';
 import CustomStore from 'data/custom_store';
 import fx from 'animation/fx';
-import { hasWindow } from 'core/utils/window';
+import windowUtils from 'core/utils/window';
 
 import 'common.css!';
 import 'generic_light.css!';
@@ -59,7 +59,7 @@ QUnit.module('rendering', moduleSetup, () => {
 
         assert.ok($element.hasClass(WIDGET_CLASS));
 
-        if(hasWindow()) {
+        if(windowUtils.hasWindow()) {
             const $list = $element.find('.dx-list'); const $popup = $(instance._popup.$element());
 
             assert.ok($popup.hasClass(POPUP_CLASS));
@@ -78,7 +78,7 @@ QUnit.module('rendering', moduleSetup, () => {
 
         assert.equal($element.find('.' + TEXTEDITOR_INPUT_CLASS).val(), 'second', 'SelectBox has the correct value');
 
-        if(hasWindow()) {
+        if(windowUtils.hasWindow()) {
             const $list = $element.find('.dx-list');
             assert.ok($list.find('.' + LIST_ITEM_CLASS).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'SelectBox has selected class, when value was set');
         }

--- a/testing/tests/DevExpress.ui.widgets.editors/switch.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/switch.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('common.css!');
-require('ui/switch');
+import 'common.css!';
+import 'ui/switch';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/switch.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/switch.tests.js
@@ -1,11 +1,11 @@
-const $ = require('jquery');
-const pointerMock = require('../../helpers/pointerMock.js');
-const keyboardMock = require('../../helpers/keyboardMock.js');
-const fx = require('animation/fx');
+import $ from 'jquery';
+import pointerMock from '../../helpers/pointerMock.js';
+import keyboardMock from '../../helpers/keyboardMock.js';
+import fx from 'animation/fx';
 
-require('common.css!');
-require('generic_light.css!');
-require('ui/switch');
+import 'common.css!';
+import 'generic_light.css!';
+import 'ui/switch';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.markup.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const TagBox = require('ui/tag_box');
-const fx = require('animation/fx');
-const isRenderer = require('core/utils/type').isRenderer;
-const config = require('core/config');
+import $ from 'jquery';
+import TagBox from 'ui/tag_box';
+import fx from 'animation/fx';
+import { isRenderer } from 'core/utils/type';
+import config from 'core/config';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/textArea.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textArea.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('common.css!');
-require('ui/text_area');
+import 'common.css!';
+import 'ui/text_area';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditor.tests.js
@@ -1,6 +1,6 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('common.css!');
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup = '<div id="texteditor"></div>';
@@ -8,6 +8,6 @@ QUnit.testStart(function() {
     $('#qunit-fixture').html(markup);
 });
 
-require('./textEditorParts/markup.tests.js');
-require('./textEditorParts/common.tests.js');
-require('./textEditorParts/mask.tests.js');
+import './textEditorParts/markup.tests.js';
+import './textEditorParts/common.tests.js';
+import './textEditorParts/mask.tests.js';

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/caretWorkaround.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/caretWorkaround.js
@@ -2,7 +2,7 @@ import browser from 'core/utils/browser';
 import devices from 'core/devices';
 import caret from 'ui/text_box/utils.caret';
 
-module.exports = function($input) {
+export default function($input) {
     // NOTE: We decided to return to this problem when next Edge is released
     // Edge sets the caret to the end of the mask editor when iframe is used and focus is triggered by the focus() method
     const isEdge = browser.msie && browser.version >= 15 && browser.version < 19;
@@ -15,4 +15,4 @@ module.exports = function($input) {
         $input.focus();
         caret($input, 0);
     }
-};
+}

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/caretWorkaround.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/caretWorkaround.js
@@ -1,6 +1,6 @@
-const browser = require('core/utils/browser');
-const devices = require('core/devices');
-const caret = require('ui/text_box/utils.caret');
+import browser from 'core/utils/browser';
+import devices from 'core/devices';
+import caret from 'ui/text_box/utils.caret';
 
 module.exports = function($input) {
     // NOTE: We decided to return to this problem when next Edge is released

--- a/testing/tests/DevExpress.ui.widgets.editors/textbox.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textbox.markup.tests.js
@@ -1,9 +1,9 @@
-const $ = require('jquery');
-const devices = require('core/devices');
-const browser = require('core/utils/browser');
+import $ from 'jquery';
+import devices from 'core/devices';
+import browser from 'core/utils/browser';
 
-require('ui/text_box');
-require('common.css!');
+import 'ui/text_box';
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/trackBar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/trackBar.markup.tests.js
@@ -1,6 +1,6 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('ui/track_bar');
+import 'ui/track_bar';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/trackBar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/trackBar.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
-const fx = require('animation/fx');
+import $ from 'jquery';
+import fx from 'animation/fx';
 
-require('ui/track_bar');
+import 'ui/track_bar';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets.editors/validationSummary.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationSummary.tests.js
@@ -1,10 +1,10 @@
-const $ = require('jquery');
-const Class = require('core/class');
-const DefaultAdapter = require('ui/validation/default_adapter');
-const ValidationEngine = require('ui/validation_engine');
-const Validator = require('ui/validator');
+import $ from 'jquery';
+import Class from 'core/class';
+import DefaultAdapter from 'ui/validation/default_adapter';
+import ValidationEngine from 'ui/validation_engine';
+import Validator from 'ui/validator';
 
-require('ui/validation_summary');
+import 'ui/validation_summary';
 
 const Fixture = Class.inherit({
     createSummary: function(container, options) {

--- a/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
@@ -1,27 +1,27 @@
-const $ = require('jquery');
-const Class = require('core/class');
-const ValidationEngine = require('ui/validation_engine');
-const Validator = require('ui/validator');
-const keyboardMock = require('../../helpers/keyboardMock.js');
+import $ from 'jquery';
+import Class from 'core/class';
+import ValidationEngine from 'ui/validation_engine';
+import Validator from 'ui/validator';
+import keyboardMock from '../../helpers/keyboardMock.js';
 
-require('common.css!');
-require('generic_light.css!');
-require('ui/text_box');
-require('ui/date_box');
-require('ui/number_box');
-require('ui/autocomplete');
-require('ui/calendar');
-require('ui/check_box');
-require('ui/drop_down_box');
-require('ui/html_editor');
-require('ui/lookup');
-require('ui/radio_group');
-require('ui/select_box');
-require('ui/tag_box');
-require('ui/text_area');
-require('ui/slider');
-require('ui/range_slider');
-require('ui/switch');
+import 'common.css!';
+import 'generic_light.css!';
+import 'ui/text_box';
+import 'ui/date_box';
+import 'ui/number_box';
+import 'ui/autocomplete';
+import 'ui/calendar';
+import 'ui/check_box';
+import 'ui/drop_down_box';
+import 'ui/html_editor';
+import 'ui/lookup';
+import 'ui/radio_group';
+import 'ui/select_box';
+import 'ui/tag_box';
+import 'ui/text_area';
+import 'ui/slider';
+import 'ui/range_slider';
+import 'ui/switch';
 
 const Fixture = Class.inherit({
     createInstance: function(editor, editorOptions, validatorOptions, keyboard = true) {

--- a/testing/tests/DevExpress.ui.widgets/actionSheet.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/actionSheet.tests.js
@@ -1,11 +1,11 @@
-const $ = require('jquery');
-const fx = require('animation/fx');
-const positionUtils = require('animation/position');
-const holdEvent = require('events/hold');
-const pointerMock = require('../../helpers/pointerMock.js');
+import $ from 'jquery';
+import fx from 'animation/fx';
+import positionUtils from 'animation/position';
+import holdEvent from 'events/hold';
+import pointerMock from '../../helpers/pointerMock.js';
 
-require('common.css!');
-require('ui/action_sheet');
+import 'common.css!';
+import 'ui/action_sheet';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/animator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/animator.tests.js
@@ -1,5 +1,5 @@
-const Animator = require('ui/scroll_view/animator');
-const animationFrame = require('animation/frame');
+import Animator from 'ui/scroll_view/animator';
+import animationFrame from 'animation/frame';
 
 const REQEST_ANIMATION_FRAME_TIMEOUT = 10;
 

--- a/testing/tests/DevExpress.ui.widgets/button.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/button.markup.tests.js
@@ -1,9 +1,9 @@
-const $ = require('jquery');
-const isRenderer = require('core/utils/type').isRenderer;
-const config = require('core/config');
+import $ from 'jquery';
+import { isRenderer } from 'core/utils/type';
+import config from 'core/config';
 
-require('ui/button');
-require('common.css!');
+import 'ui/button';
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/contextMenu.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/contextMenu.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
-const ContextMenu = require('ui/context_menu');
+import $ from 'jquery';
+import ContextMenu from 'ui/context_menu';
 
-require('common.css!');
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/deferRendering.animation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/deferRendering.animation.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const TransitionExecutorModule = require('animation/transition_executor/transition_executor');
+import $ from 'jquery';
+import TransitionExecutorModule from 'animation/transition_executor/transition_executor';
 
-require('common.css!');
-require('ui/defer_rendering');
+import 'common.css!';
+import 'ui/defer_rendering';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/deferRendering.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/deferRendering.tests.js
@@ -1,9 +1,9 @@
-const $ = require('jquery');
-const TransitionExecutorModule = require('animation/transition_executor/transition_executor');
-const dataUtils = require('core/element_data');
+import $ from 'jquery';
+import TransitionExecutorModule from 'animation/transition_executor/transition_executor';
+import dataUtils from 'core/element_data';
 
-require('common.css!');
-require('ui/defer_rendering');
+import 'common.css!';
+import 'ui/defer_rendering';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/filterBuilder.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilder.tests.js
@@ -1,14 +1,14 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('common.css!');
-require('generic_light.css!');
+import 'common.css!';
+import 'generic_light.css!';
 
 QUnit.testStart(function() {
     $('#qunit-fixture').html('<div id="container"></div>');
 });
 
-require('./filterBuilderParts/commonTests.js');
-require('./filterBuilderParts/utilsTests.js');
-require('./filterBuilderParts/eventsTests.js');
-require('./filterBuilderParts/keyboardNavigation.js');
-require('./filterBuilderParts/markupTests.js');
+import './filterBuilderParts/commonTests.js';
+import './filterBuilderParts/utilsTests.js';
+import './filterBuilderParts/eventsTests.js';
+import './filterBuilderParts/keyboardNavigation.js';
+import './filterBuilderParts/markupTests.js';

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/markupTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/markupTests.js
@@ -1,9 +1,10 @@
-const $ = require('jquery');
-const devices = require('core/devices');
-const FILTER_BUILDER_GROUP_CONTENT_CLASS = 'dx-filterbuilder-group-content';
-const fields = require('../../../helpers/filterBuilderTestData.js');
+import $ from 'jquery';
+import devices from 'core/devices';
+import fields from '../../../helpers/filterBuilderTestData.js';
 
-require('ui/filter_builder');
+import 'ui/filter_builder';
+
+const FILTER_BUILDER_GROUP_CONTENT_CLASS = 'dx-filterbuilder-group-content';
 
 QUnit.test('markup init', function(assert) {
     if(devices.real().deviceType !== 'desktop') {

--- a/testing/tests/DevExpress.ui.widgets/listItem.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/listItem.tests.js
@@ -1,5 +1,5 @@
-const $ = require('jquery');
-const List = require('ui/list');
+import $ from 'jquery';
+import List from 'ui/list';
 
 const LIST_ITEM_ICON_CONTAINER_CLASS = 'dx-list-item-icon-container'; const LIST_ITEM_ICON_CLASS = 'dx-list-item-icon'; const LIST_ITEM_CHEVRON_CONTAINER_CLASS = 'dx-list-item-chevron-container'; const LIST_ITEM_CHEVRON_CLASS = 'dx-list-item-chevron';
 

--- a/testing/tests/DevExpress.ui.widgets/listParts/dataSourceFromUrlTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/dataSourceFromUrlTests.js
@@ -1,6 +1,6 @@
-const $ = require('jquery');
-const List = require('ui/list');
-const ajaxMock = require('../../../helpers/ajaxMock.js');
+import $ from 'jquery';
+import List from 'ui/list';
+import ajaxMock from '../../../helpers/ajaxMock.js';
 
 QUnit.module(
     'data source from url',

--- a/testing/tests/DevExpress.ui.widgets/listParts/editingTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/editingTests.js
@@ -1,11 +1,11 @@
-const $ = require('jquery');
-const typeUtils = require('core/utils/type');
-const executeAsyncMock = require('../../../helpers/executeAsyncMock.js');
-const keyboardMock = require('../../../helpers/keyboardMock.js');
-const DataSource = require('data/data_source/data_source').DataSource;
-const ArrayStore = require('data/array_store');
+import $ from 'jquery';
+import typeUtils from 'core/utils/type';
+import executeAsyncMock from '../../../helpers/executeAsyncMock.js';
+import keyboardMock from '../../../helpers/keyboardMock.js';
+import { DataSource } from 'data/data_source/data_source';
+import ArrayStore from 'data/array_store';
 
-require('ui/list');
+import 'ui/list';
 
 const LIST_ITEM_CLASS = 'dx-list-item';
 

--- a/testing/tests/DevExpress.ui.widgets/loadIndicator.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/loadIndicator.markup.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const support = require('core/utils/support');
+import $ from 'jquery';
+import support from 'core/utils/support';
 
-require('common.css!');
-require('ui/load_indicator');
+import 'common.css!';
+import 'ui/load_indicator';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/loadIndicator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/loadIndicator.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const support = require('core/utils/support');
+import $ from 'jquery';
+import support from 'core/utils/support';
 
-require('common.css!');
-require('ui/load_indicator');
+import 'common.css!';
+import 'ui/load_indicator';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/loadPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/loadPanel.tests.js
@@ -1,9 +1,9 @@
-const $ = require('jquery');
-const keyboardMock = require('../../helpers/keyboardMock.js');
-const fx = require('animation/fx');
+import $ from 'jquery';
+import keyboardMock from '../../helpers/keyboardMock.js';
+import fx from 'animation/fx';
 
-require('common.css!');
-require('ui/load_panel');
+import 'common.css!';
+import 'ui/load_panel';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/map.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/map.tests.js
@@ -1,6 +1,6 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('common.css!');
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =
@@ -9,7 +9,7 @@ QUnit.testStart(function() {
     $('#qunit-fixture').html(markup);
 });
 
-require('./mapParts/commonTests.js');
-require('./mapParts/googleStaticTests.js');
-require('./mapParts/googleTests.js');
-require('./mapParts/bingTests.js');
+import './mapParts/commonTests.js';
+import './mapParts/googleStaticTests.js';
+import './mapParts/googleTests.js';
+import './mapParts/bingTests.js';

--- a/testing/tests/DevExpress.ui.widgets/mapParts/bingTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/bingTests.js
@@ -1,13 +1,12 @@
 /* global Microsoft */
 
-const $ = require('jquery');
-const testing = require('./utils.js');
-const BingProvider = require('ui/map/provider.dynamic.bing');
-const ajaxMock = require('../../../helpers/ajaxMock.js');
-const errors = require('ui/widget/ui.errors');
+import $ from 'jquery';
+import testing from './utils.js';
+import BingProvider from 'ui/map/provider.dynamic.bing';
+import ajaxMock from '../../../helpers/ajaxMock.js';
+import errors from 'ui/widget/ui.errors';
 
-
-require('ui/map');
+import 'ui/map';
 
 const LOCATIONS = testing.LOCATIONS;
 const MARKERS = testing.MARKERS;

--- a/testing/tests/DevExpress.ui.widgets/mapParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/commonTests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const testing = require('./utils.js');
-const Map = require('ui/map');
-const GoogleStaticProvider = require('ui/map/provider.google_static');
-const ajaxMock = require('../../../helpers/ajaxMock.js');
+import $ from 'jquery';
+import testing from './utils.js';
+import Map from 'ui/map';
+import GoogleStaticProvider from 'ui/map/provider.google_static';
+import ajaxMock from '../../../helpers/ajaxMock.js';
 
 const MARKERS = testing.MARKERS;
 const ROUTES = testing.ROUTES;

--- a/testing/tests/DevExpress.ui.widgets/mapParts/googleStaticTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/googleStaticTests.js
@@ -1,9 +1,9 @@
-const $ = require('jquery');
-const testing = require('./utils.js');
-const Map = require('ui/map');
-const GoogleStaticProvider = require('ui/map/provider.google_static');
-const Color = require('color');
-const ajaxMock = require('../../../helpers/ajaxMock.js');
+import $ from 'jquery';
+import testing from './utils.js';
+import Map from 'ui/map';
+import GoogleStaticProvider from 'ui/map/provider.google_static';
+import Color from 'color';
+import ajaxMock from '../../../helpers/ajaxMock.js';
 
 const LOCATIONS = testing.LOCATIONS;
 const MARKERS = testing.MARKERS;

--- a/testing/tests/DevExpress.ui.widgets/menu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menu.tests.js
@@ -1,22 +1,22 @@
-const $ = require('jquery');
-const devices = require('core/devices');
-const fx = require('animation/fx');
-const renderer = require('core/renderer');
-const isRenderer = require('core/utils/type').isRenderer;
-const config = require('core/config');
-const Submenu = require('ui/menu/ui.submenu');
-const resizeCallbacks = require('core/utils/resize_callbacks');
-const Menu = require('ui/menu/ui.menu');
-const keyboardMock = require('../../helpers/keyboardMock.js');
-const fixtures = require('../../helpers/positionFixtures.js');
-const CustomStore = require('data/custom_store');
-const ArrayStore = require('data/array_store');
-const eventsEngine = require('events/core/events_engine');
-const DataSource = require('data/data_source/data_source').DataSource;
-const checkStyleHelper = require('../../helpers/checkStyleHelper.js');
+import $ from 'jquery';
+import devices from 'core/devices';
+import fx from 'animation/fx';
+import renderer from 'core/renderer';
+import { isRenderer } from 'core/utils/type';
+import config from 'core/config';
+import Submenu from 'ui/menu/ui.submenu';
+import resizeCallbacks from 'core/utils/resize_callbacks';
+import Menu from 'ui/menu/ui.menu';
+import keyboardMock from '../../helpers/keyboardMock.js';
+import fixtures from '../../helpers/positionFixtures.js';
+import CustomStore from 'data/custom_store';
+import ArrayStore from 'data/array_store';
+import eventsEngine from 'events/core/events_engine';
+import { DataSource } from 'data/data_source/data_source';
+import checkStyleHelper from '../../helpers/checkStyleHelper.js';
 
-require('common.css!');
-require('generic_light.css!');
+import 'common.css!';
+import 'generic_light.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/menu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menu.tests.js
@@ -13,7 +13,7 @@ import CustomStore from 'data/custom_store';
 import ArrayStore from 'data/array_store';
 import eventsEngine from 'events/core/events_engine';
 import { DataSource } from 'data/data_source/data_source';
-import checkStyleHelper from '../../helpers/checkStyleHelper.js';
+import * as checkStyleHelper from '../../helpers/checkStyleHelper.js';
 
 import 'common.css!';
 import 'generic_light.css!';

--- a/testing/tests/DevExpress.ui.widgets/menuBase.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menuBase.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
-const MenuBase = require('ui/context_menu/ui.menu_base');
+import $ from 'jquery';
+import MenuBase from 'ui/context_menu/ui.menu_base';
 
-require('common.css!');
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/multiView.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/multiView.markup.tests.js
@@ -1,6 +1,6 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('ui/multi_view');
+import 'ui/multi_view';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/navBar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/navBar.markup.tests.js
@@ -1,6 +1,6 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('ui/nav_bar');
+import 'ui/nav_bar';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/navbarItem.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/navbarItem.tests.js
@@ -1,5 +1,5 @@
-const $ = require('jquery');
-const NavBar = require('ui/nav_bar');
+import $ from 'jquery';
+import NavBar from 'ui/nav_bar';
 
 QUnit.module('badge builtin', () => {
     const TABS_ITEM_BADGE_CLASS = 'dx-tabs-item-badge'; const NAVBAR_ITEM_BADGE_CLASS = 'dx-navbar-item-badge';

--- a/testing/tests/DevExpress.ui.widgets/optionChanged_bundled.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/optionChanged_bundled.tests.js
@@ -51,7 +51,7 @@ define(function(require) {
             this.$element.remove();
             executeAsyncMock.teardown();
         }
-    }, () => {
+    }, function() {
         const excludedComponents = [
             'dxLayoutManager'
         ];
@@ -142,6 +142,6 @@ define(function(require) {
                 });
             }
         });
-    });
+    }.bind(this));
 });
 

--- a/testing/tests/DevExpress.ui.widgets/pager.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/pager.tests.js
@@ -1,10 +1,10 @@
-const $ = require('jquery');
-const commonUtils = require('core/utils/common');
-const typeUtils = require('core/utils/type');
+import $ from 'jquery';
+import commonUtils from 'core/utils/common';
+import typeUtils from 'core/utils/type';
 
-require('common.css!');
-require('generic_light.css!');
-require('ui/pager');
+import 'common.css!';
+import 'generic_light.css!';
+import 'ui/pager';
 
 const PAGER_LIGHT_MODE_WIDTH = 200;
 

--- a/testing/tests/DevExpress.ui.widgets/progressBar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/progressBar.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('ui/progress_bar');
-require('common.css!');
+import 'ui/progress_bar';
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/progressBar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/progressBar.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const fx = require('animation/fx');
+import $ from 'jquery';
+import fx from 'animation/fx';
 
-require('ui/progress_bar');
-require('common.css!');
+import 'ui/progress_bar';
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/resizable.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/resizable.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('common.css!');
-require('ui/resizable');
+import 'common.css!';
+import 'ui/resizable';
 
 QUnit.testStart(function() {
     const markup = '<div id="resizable" style="height: 50px; width: 50px; position: absolute"></div>';

--- a/testing/tests/DevExpress.ui.widgets/responsiveBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/responsiveBox.tests.js
@@ -1,12 +1,12 @@
-const $ = require('jquery');
-const devices = require('core/devices');
-const registerComponent = require('core/component_registrator');
-const Widget = require('ui/widget/ui.widget');
-const ResponsiveBox = require('ui/responsive_box');
-const responsiveBoxScreenMock = require('../../helpers/responsiveBoxScreenMock.js');
+import $ from 'jquery';
+import devices from 'core/devices';
+import registerComponent from 'core/component_registrator';
+import Widget from 'ui/widget/ui.widget';
+import ResponsiveBox from 'ui/responsive_box';
+import responsiveBoxScreenMock from '../../helpers/responsiveBoxScreenMock.js';
 
-require('common.css!');
-require('ui/box');
+import 'common.css!';
+import 'ui/box';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/selection.test.js
+++ b/testing/tests/DevExpress.ui.widgets/selection.test.js
@@ -1,10 +1,10 @@
-const $ = require('jquery');
-const errors = require('ui/widget/ui.errors');
-const Selection = require('ui/selection/selection');
-const Guid = require('core/guid');
-const DataSource = require('data/data_source/data_source').DataSource;
-const CustomStore = require('data/custom_store');
-const ArrayStore = require('data/array_store');
+import $ from 'jquery';
+import errors from 'ui/widget/ui.errors';
+import Selection from 'ui/selection/selection';
+import Guid from 'core/guid';
+import { DataSource } from 'data/data_source/data_source';
+import CustomStore from 'data/custom_store';
+import ArrayStore from 'data/array_store';
 
 const createDataSource = function(data, storeOptions, dataSourceOptions) {
     const arrayStore = new ArrayStore(storeOptions ? $.extend(true, { data: data }, storeOptions) : data);

--- a/testing/tests/DevExpress.ui.widgets/slideOut.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/slideOut.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('ui/slide_out');
-require('common.css!');
+import 'ui/slide_out';
+import 'common.css!';
 
 const SLIDEOUT_CLASS = 'dx-slideout';
 const SLIDEOUT_ITEM_CONTAINER_CLASS = 'dx-slideout-item-container';

--- a/testing/tests/DevExpress.ui.widgets/slideOut.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/slideOut.tests.js
@@ -1,12 +1,12 @@
-const $ = require('jquery');
-const fx = require('animation/fx');
-const config = require('core/config');
-const typeUtils = require('core/utils/type');
-const hideTopOverlayCallback = require('mobile/hide_top_overlay').hideCallback;
-const pointerMock = require('../../helpers/pointerMock.js');
+import $ from 'jquery';
+import fx from 'animation/fx';
+import config from 'core/config';
+import typeUtils from 'core/utils/type';
+import { hideCallback as hideTopOverlayCallback } from 'mobile/hide_top_overlay';
+import pointerMock from '../../helpers/pointerMock.js';
 
-require('ui/slide_out');
-require('common.css!');
+import 'ui/slide_out';
+import 'common.css!';
 
 const SLIDEOUT_ITEM_CONTAINER_CLASS = 'dx-slideout-item-container';
 const SLIDEOUT_SHIELD = 'dx-slideoutview-shield';

--- a/testing/tests/DevExpress.ui.widgets/slideOutView.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/slideOutView.markup.tests.js
@@ -1,10 +1,10 @@
-const $ = require('jquery');
-const config = require('core/config');
-const typeUtils = require('core/utils/type');
-const windowUtils = require('core/utils/window');
+import $ from 'jquery';
+import config from 'core/config';
+import typeUtils from 'core/utils/type';
+import windowUtils from 'core/utils/window';
 
-require('common.css!');
-require('ui/slide_out_view');
+import 'common.css!';
+import 'ui/slide_out_view';
 
 const SLIDEOUTVIEW_CLASS = 'dx-slideoutview';
 const SLIDEOUTVIEW_WRAPPER_CLASS = 'dx-slideoutview-wrapper';

--- a/testing/tests/DevExpress.ui.widgets/slideOutView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/slideOutView.tests.js
@@ -1,15 +1,15 @@
-const $ = require('jquery');
-const fx = require('animation/fx');
-const translator = require('animation/translator');
-const hideTopOverlayCallback = require('mobile/hide_top_overlay').hideCallback;
-const resizeCallbacks = require('core/utils/resize_callbacks');
-const config = require('core/config');
-const typeUtils = require('core/utils/type');
-const animation = require('ui/slide_out_view').animation;
-const pointerMock = require('../../helpers/pointerMock.js');
+import $ from 'jquery';
+import fx from 'animation/fx';
+import translator from 'animation/translator';
+import { hideCallback as hideTopOverlayCallback } from 'mobile/hide_top_overlay';
+import resizeCallbacks from 'core/utils/resize_callbacks';
+import config from 'core/config';
+import typeUtils from 'core/utils/type';
+import { animation } from 'ui/slide_out_view';
+import pointerMock from '../../helpers/pointerMock.js';
 
-require('common.css!');
-require('ui/slide_out_view');
+import 'common.css!';
+import 'ui/slide_out_view';
 
 const SLIDEOUTVIEW_CLASS = 'dx-slideoutview';
 const SLIDEOUTVIEW_MENU_CONTENT_CLASS = 'dx-slideoutview-menu-content';

--- a/testing/tests/DevExpress.ui.widgets/swipeable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/swipeable.tests.js
@@ -1,8 +1,8 @@
-const $ = require('jquery');
-const noop = require('core/utils/common').noop;
-const Swipeable = require('events/gesture/swipeable');
-const swipeEvents = require('events/swipe');
-const pointerMock = require('../../helpers/pointerMock.js');
+import $ from 'jquery';
+import { noop } from 'core/utils/common';
+import Swipeable from 'events/gesture/swipeable';
+import swipeEvents from 'events/swipe';
+import pointerMock from '../../helpers/pointerMock.js';
 
 QUnit.module('swipeable', {
     beforeEach: function() {

--- a/testing/tests/DevExpress.ui.widgets/tabsItem.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabsItem.tests.js
@@ -1,5 +1,5 @@
-const $ = require('jquery');
-const Tabs = require('ui/tabs');
+import $ from 'jquery';
+import Tabs from 'ui/tabs';
 
 QUnit.module('badge builtin', () => {
     const TABS_ITEM_BADGE_CLASS = 'dx-tabs-item-badge'; const BADGE_CLASS = 'dx-badge';

--- a/testing/tests/DevExpress.ui.widgets/tileView.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tileView.markup.tests.js
@@ -1,7 +1,7 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-require('ui/tile_view');
-require('common.css!');
+import 'ui/tile_view';
+import 'common.css!';
 
 QUnit.testStart(function() {
     const markup =

--- a/testing/tests/DevExpress.ui.widgets/toast.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toast.tests.js
@@ -1,10 +1,10 @@
-const $ = require('jquery');
-const pointerMock = require('../../helpers/pointerMock.js');
-const fx = require('animation/fx');
-const setViewPort = require('core/utils/view_port').value;
-const Toast = require('ui/toast');
+import $ from 'jquery';
+import pointerMock from '../../helpers/pointerMock.js';
+import fx from 'animation/fx';
+import { value as setViewPort } from 'core/utils/view_port';
+import Toast from 'ui/toast';
 
-require('common.css!');
+import 'common.css!';
 
 const TOAST_CLASS = 'dx-toast';
 const TOAST_CLASS_PREFIX = TOAST_CLASS + '-';


### PR DESCRIPTION
I plan to make the same changes to 19.2 and 19.1 as well.

In #11270 , there were widely used arrow functions. If you run a separate test file in IE that contains arrow functions but does not have "import", it will cause an error.