### PR TITLE
Fix incorrect RTL appearance for editors with Validator (T851279)

### DIFF
--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -178,6 +178,8 @@ const Validator = DOMComponent.inherit({
         }
     },
 
+    _toggleRTLDirection() {},
+
     _initMarkup() {
         this.$element().addClass(VALIDATOR_CLASS);
         this.callBase();

--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -179,7 +179,7 @@ const Validator = DOMComponent.inherit({
     },
 
     _toggleRTLDirection(isRtl) {
-        const { rtlEnabled } = this.option('adapter')?.editor?.option?.() || { rtlEnabled: isRtl };
+        const rtlEnabled = this.option('adapter')?.editor?.option('rtlEnabled') ?? isRtl;
 
         this.callBase(rtlEnabled);
     },

--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -178,7 +178,11 @@ const Validator = DOMComponent.inherit({
         }
     },
 
-    _toggleRTLDirection() {},
+    _toggleRTLDirection(isRtl) {
+        const { rtlEnabled } = this.option('adapter')?.editor?.option?.() || { rtlEnabled: isRtl };
+
+        this.callBase(rtlEnabled);
+    },
 
     _initMarkup() {
         this.$element().addClass(VALIDATOR_CLASS);

--- a/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validatorIntegration.tests.js
@@ -25,8 +25,8 @@ import 'ui/switch';
 
 const Fixture = Class.inherit({
     createInstance: function(editor, editorOptions, validatorOptions, keyboard = true) {
-        const $element = $('<div/>')[editor](editorOptions).dxValidator(validatorOptions);
-        this.$element = $element;
+        const $element = $('<div/>').appendTo('#qunit-fixture');
+        this.$element = $element[editor](editorOptions).dxValidator(validatorOptions);
 
         this.$input = $element.find('.dx-texteditor-input');
 
@@ -249,6 +249,17 @@ QUnit.module('Regression', {
         this.fixture.validator.reset();
 
         assert.notOk(validationCallback.called, 'validationCallback should not be called');
+    });
+
+    QUnit.test('Validator should not toggle the "dx-rtl" class', function(assert) {
+        this.fixture.createInstance('dxTextBox', { rtlEnabled: true }, {
+            rtlEnabled: false,
+            validationRules: [{
+                type: 'required'
+            }]
+        }, false);
+
+        assert.ok(this.fixture.$element.hasClass('dx-rtl'), 'Root element has the "dx-rtl" class');
     });
 });
 


### PR DESCRIPTION
In case the 'rtlEnabled' option is not set through the `DevExtreme.config()`

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
