### PR TITLE
Enable autofix lint on save for VS code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": [ "dbaeumer.vscode-eslint" ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
+}


### PR DESCRIPTION
Recommend to install `eslint` extension for the vscode
![recommendation-hint](https://user-images.githubusercontent.com/2280467/72534419-d2681b80-3887-11ea-8839-a9e11fc16a1f.png)
![recommendation-list](https://user-images.githubusercontent.com/2280467/72534431-d5630c00-3887-11ea-8ed3-d895b9cc1253.png)
Eslint will show hints
![lint-hint](https://user-images.githubusercontent.com/2280467/72534436-d85dfc80-3887-11ea-9ce2-c3d9a4d8ae93.png)
VS code will fix lint on file saving.
![auto-save](https://user-images.githubusercontent.com/2280467/72534445-db58ed00-3887-11ea-9ef5-f7af85a790dc.gif)
