### PR TITLE
Accordion - center a dxButton icon in a custom itemTitleTemplate (T851081) (#11547)

### DIFF
--- a/styles/widgets/generic/accordion.generic.less
+++ b/styles/widgets/generic/accordion.generic.less
@@ -94,7 +94,6 @@
 
     .dx-icon {
         .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
-        .dx-icon-margin(@GENERIC_BASE_ICON_SIZE/2);
 
         display: inline-block;
         color: @accordion-icon-color;

--- a/testing/runner/Views/Main/RunSuite.cshtml
+++ b/testing/runner/Views/Main/RunSuite.cshtml
@@ -184,6 +184,7 @@
                     'common.css': '@Url.Content("~/artifacts/css/dx.common.css")',
 
                     'generic_light.css': '@Url.Content("~/artifacts/css/dx.light.css")',
+                    'material_blue_light.css': '@Url.Content("~/artifacts/css/dx.material.blue.light.css")',
                     'ios7_default.css': '@Url.Content("~/artifacts/css/dx.ios7.default.css")',
 
                     // SystemJS plugins

--- a/testing/tests/DevExpress.ui.widgets/accordion.genericTheme.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.genericTheme.tests.js
@@ -1,0 +1,5 @@
+import 'common.css!';
+import 'generic_light.css!';
+
+import { runThemesSharedTests } from './accordionParts/accordion.themes.sharedTests.js';
+runThemesSharedTests('generic_light');

--- a/testing/tests/DevExpress.ui.widgets/accordion.materialTheme.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.materialTheme.tests.js
@@ -1,0 +1,5 @@
+import 'common.css!';
+import 'material_blue_light.css!';
+
+import { runThemesSharedTests } from './accordionParts/accordion.themes.sharedTests.js';
+runThemesSharedTests('material_blue_light');

--- a/testing/tests/DevExpress.ui.widgets/accordionParts/accordion.themes.sharedTests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordionParts/accordion.themes.sharedTests.js
@@ -4,10 +4,10 @@ import 'ui/button';
 
 export const runThemesSharedTests = function(moduleNamePostfix) {
     QUnit.module('Scenarios.' + moduleNamePostfix, {
-        beforeEach: () => {
+        beforeEach: function() {
             $('#qunit-fixture').html('<div id="accordion"></div>');
         }
-    }, () => {
+    }, function() {
         QUnit.test('itemTitleTemplate: dxButton { icon }', function(assert) {
             $('#accordion').dxAccordion({
                 dataSource: [{ }],

--- a/testing/tests/DevExpress.ui.widgets/accordionParts/accordion.themes.sharedTests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordionParts/accordion.themes.sharedTests.js
@@ -1,0 +1,26 @@
+import $ from 'jquery';
+import 'ui/accordion';
+import 'ui/button';
+
+export const runThemesSharedTests = function(moduleNamePostfix) {
+    QUnit.module('Scenarios.' + moduleNamePostfix, {
+        beforeEach: () => {
+            $('#qunit-fixture').html('<div id="accordion"></div>');
+        }
+    }, () => {
+        QUnit.test('itemTitleTemplate: dxButton { icon }', function(assert) {
+            $('#accordion').dxAccordion({
+                dataSource: [{ }],
+                itemTitleTemplate: function() {
+                    return $('<div>').dxButton({ icon: 'myIcon' });
+                }
+            });
+
+            const iconRect = document.querySelector('.dx-icon-myIcon').getBoundingClientRect();
+            const iconParentRect = document.querySelector('.dx-icon-myIcon').parentElement.getBoundingClientRect();
+
+            assert.roughEqual(iconRect.left - iconParentRect.left, iconParentRect.right - iconRect.right, 0.1, `correct horizontal centering ${JSON.stringify(iconRect)} in ${JSON.stringify(iconParentRect)}`);
+            assert.roughEqual(iconRect.top - iconParentRect.top, iconParentRect.bottom - iconRect.bottom, 0.1, `correct vertical centering ${JSON.stringify(iconRect)} in ${JSON.stringify(iconParentRect)}`);
+        });
+    });
+};


### PR DESCRIPTION
* Accordion - center a dxButton icon in a custom itemTitleTemplate

* Rename in accordance with the existing scrollable.genericTheme.tests.js file

* Rename files by template

(cherry picked from commit dabc00674e31e142e6e47bf1ed767e1ca0580fd5)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
