### PR TITLE
CI: Skip unnecessary Gulp tasks for functional tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       run: node .\node_modules\gulp\bin\gulp.js transpile-tests
     - name: Run npm run build
       env:
-        DEVEXTREME_QUNIT_CI: true
+        DEVEXTREME_TEST_CI: true
       run: npm run build
     - name: Run QUnit tests
       env:

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -139,6 +139,8 @@ function run_test_themebuilder {
 }
 
 function run_test_functional {
+	export DEVEXTREME_QUNIT_CI=true
+	
     npm i
     npm run build
 

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -34,7 +34,7 @@ function run_ts {
 }
 
 function run_test {
-    export DEVEXTREME_QUNIT_CI=true
+    export DEVEXTREME_TEST_CI=true
 
     local port=`node -e "console.log(require('./ports.json').qunit)"`
     local url="http://localhost:$port/run?notimers=true"
@@ -139,8 +139,8 @@ function run_test_themebuilder {
 }
 
 function run_test_functional {
-	export DEVEXTREME_QUNIT_CI=true
-	
+    export DEVEXTREME_TEST_CI=true
+
     npm i
     npm run build
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,16 +22,16 @@ require('./build/gulp/ts');
 require('./build/gulp/localization');
 require('./build/gulp/style-compiler');
 
-const QUNIT_CI = Boolean(process.env['DEVEXTREME_QUNIT_CI']);
+const TEST_CI = Boolean(process.env['DEVEXTREME_TEST_CI']);
 const DOCKER_CI = Boolean(process.env['DEVEXTREME_DOCKER_CI']);
 
-if(QUNIT_CI) {
-    console.warn('Using QUnit CI mode!');
+if(TEST_CI) {
+    console.warn('Using test CI mode!');
 }
 
 function createStyleCompilerBatch() {
     const tasks = ['style-compiler-themes'];
-    if(!QUNIT_CI) {
+    if(!TEST_CI) {
         tasks.push('style-compiler-tb-assets');
     }
     return gulp.series(tasks);
@@ -39,7 +39,7 @@ function createStyleCompilerBatch() {
 
 function createMiscBatch() {
     const tasks = ['vectormap', 'vendor'];
-    if(!QUNIT_CI) {
+    if(!TEST_CI) {
         tasks.push('aspnet', 'ts');
     }
     return gulp.parallel(tasks);
@@ -47,7 +47,7 @@ function createMiscBatch() {
 
 function createMainBatch() {
     const tasks = ['js-bundles-debug'];
-    if(!QUNIT_CI) {
+    if(!TEST_CI) {
         tasks.push('js-bundles-prod');
     }
     tasks.push('style-compiler-batch', 'misc-batch');
@@ -58,7 +58,7 @@ function createMainBatch() {
 
 function createDefaultBatch() {
     const tasks = [ 'clean', 'localization', createMainBatch() ];
-    if(!QUNIT_CI) {
+    if(!TEST_CI) {
         tasks.push('npm', 'themebuilder-npm');
     }
     return gulp.series(tasks);


### PR DESCRIPTION
- Rename `DEVEXTREME_QUNIT_CI` to `DEVEXTREME_TEST_CI`
- Set `DEVEXTREME_TEST_CI` for functional tests to skip unnecessary Gulp tasks
