### PR TITLE
Renovation: window refactor

### DIFF
--- a/js/core/utils/window.js
+++ b/js/core/utils/window.js
@@ -2,49 +2,40 @@
 
 const domAdapter = require('../dom_adapter');
 
-const hasWindow = typeof window !== 'undefined';
-let windowObject = hasWindow && window;
+const windowObject = window ?? { window: windowObject };
 
-if(!windowObject) {
-    windowObject = {};
-    windowObject.window = windowObject;
-}
+const hasWindow = () => typeof window !== 'undefined';
+
+const getWindow = () => windowObject;
+
+const hasProperty = (prop) => hasWindow() && prop in windowObject;
+
+const defaultScreenFactorFunc = (width) => {
+    if(width < 768) {
+        return 'xs';
+    } else if(width < 992) {
+        return 'sm';
+    } else if(width < 1200) {
+        return 'md';
+    } else {
+        return 'lg';
+    }
+};
+
+const getCurrentScreenFactor = (screenFactorCallback) => {
+    const screenFactorFunc = screenFactorCallback || defaultScreenFactorFunc;
+    const windowWidth = domAdapter.getDocumentElement()['clientWidth'];
+
+    return screenFactorFunc(windowWidth);
+};
+
+const getNavigator = () => hasWindow() ? windowObject.navigator : { userAgent: '' };
 
 module.exports = {
-    hasWindow: function() {
-        return hasWindow;
-    },
-
-    getWindow: function() {
-        return windowObject;
-    },
-
-    hasProperty: function(prop) {
-        return this.hasWindow() && prop in windowObject;
-    },
-
-    defaultScreenFactorFunc: function(width) {
-        if(width < 768) {
-            return 'xs';
-        } else if(width < 992) {
-            return 'sm';
-        } else if(width < 1200) {
-            return 'md';
-        } else {
-            return 'lg';
-        }
-    },
-
-    getCurrentScreenFactor: function(screenFactorCallback) {
-        const screenFactorFunc = screenFactorCallback || this.defaultScreenFactorFunc;
-        const windowWidth = domAdapter.getDocumentElement()['clientWidth'];
-
-        return screenFactorFunc(windowWidth);
-    },
-
-    getNavigator: function() {
-        return this.hasWindow() ? windowObject.navigator : {
-            userAgent: ''
-        };
-    }
+    hasWindow,
+    getWindow,
+    hasProperty,
+    defaultScreenFactorFunc,
+    getCurrentScreenFactor,
+    getNavigator
 };


### PR DESCRIPTION
Get rid of using `this` in `window` (allow named export for all functions)