### PR TITLE
Gulp: use 'gulp.series' in the single process branch of createMainBatch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,7 @@ function createMainBatch() {
     }
     tasks.push('style-compiler-batch', 'misc-batch');
     return DOCKER_CI
-        ? gulp.parallel(tasks)
+        ? gulp.series(tasks)
         : (callback) => multiProcess(tasks, callback, true);
 }
 


### PR DESCRIPTION
Fixes Gulp failures such as:

    [08:39:37] Error in plugin 'webpack-stream'
	Message:
	    ./artifacts/transpiled/ui/scheduler/workspaces/ui.scheduler.work_space.js
	Module parse failed: Unexpected token (202:11)
	You may need an appropriate loader to handle this file type.
	|   _getRightCell: function _getRightCell(isMultiSelection) {
	|     if (!isDefined(this._$focusedCell)) {
	|       retur
	 @ ./artifacts/transpiled/ui/scheduler/workspaces/ui.scheduler.agenda.js 15:25-61 
---

Additional details:
- https://github.com/shama/webpack-stream/issues/201#issuecomment-454066502
- `gulp.parallel` doesn't make much sense for these resource-intensive tasks in the single process mode