### PR TITLE
Support debugging in the ES6 code 

### DIFF
--- a/build/gulp/js-bundles.js
+++ b/build/gulp/js-bundles.js
@@ -7,7 +7,6 @@ const named = require('vinyl-named');
 const webpack = require('webpack');
 const lazyPipe = require('lazypipe');
 const webpackStream = require('webpack-stream');
-const args = require('yargs').argv;
 
 const webpackConfig = require('../../webpack.config.js');
 const webpackConfigDev = require('../../webpack.config.dev.js');
@@ -70,7 +69,7 @@ const createDebugBundlesStream = function(watch) {
     debugConfig.output = Object.assign({}, webpackConfig.output);
     debugConfig.output['pathinfo'] = true;
     if(!context.uglify) {
-        debugConfig.devtool = args.sourceMap ? 'eval-source-map' : 'eval';
+        debugConfig.devtool = 'eval-source-map';
     }
 
     return gulp.src(bundles)

--- a/build/gulp/js-bundles.js
+++ b/build/gulp/js-bundles.js
@@ -7,6 +7,7 @@ const named = require('vinyl-named');
 const webpack = require('webpack');
 const lazyPipe = require('lazypipe');
 const webpackStream = require('webpack-stream');
+const args = require('yargs').argv;
 
 const webpackConfig = require('../../webpack.config.js');
 const webpackConfigDev = require('../../webpack.config.dev.js');
@@ -69,7 +70,7 @@ const createDebugBundlesStream = function(watch) {
     debugConfig.output = Object.assign({}, webpackConfig.output);
     debugConfig.output['pathinfo'] = true;
     if(!context.uglify) {
-        debugConfig.devtool = 'eval';
+        debugConfig.devtool = args.sourceMap ? 'eval-source-map' : 'eval';
     }
 
     return gulp.src(bundles)

--- a/build/gulp/transpile.js
+++ b/build/gulp/transpile.js
@@ -5,6 +5,7 @@ const replace = require('gulp-replace');
 const plumber = require('gulp-plumber');
 const path = require('path');
 const notify = require('gulp-notify');
+const sourceMaps = require('gulp-sourcemaps');
 
 const context = require('./context.js');
 
@@ -18,7 +19,9 @@ const VERSION_FILE_PATH = 'core/version.js';
 
 gulp.task('transpile', gulp.series('bundler-config', function() {
     return gulp.src(SRC)
+        .pipe(sourceMaps.init())
         .pipe(babel())
+        .pipe(sourceMaps.write())
         .pipe(gulp.dest(context.TRANSPILED_PATH));
 }));
 
@@ -30,11 +33,13 @@ gulp.task('version-replace', gulp.series('transpile', function() {
 
 gulp.task('transpile-watch', gulp.series('version-replace', function() {
     return watch(SRC)
+        .pipe(sourceMaps.init())
         .pipe(plumber({
             errorHandler: notify.onError('Error: <%= error.message %>')
                 .bind() // bind call is necessary to prevent firing 'end' event in notify.onError implementation
         }))
         .pipe(babel())
+        .pipe(sourceMaps.write())
         .pipe(gulp.dest(context.TRANSPILED_PATH));
 }));
 

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "build-themes": "gulp style-compiler-themes",
     "build-themebuilder-assets": "gulp style-compiler-tb-assets",
     "dev": "gulp dev",
+    "dev-map": "gulp dev --sourceMap",
     "test-env": "node testing/launch",
     "update-ts": "dx-tools update-ts-bundle",
     "internal-tool": "dx-tools",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "build-themes": "gulp style-compiler-themes",
     "build-themebuilder-assets": "gulp style-compiler-tb-assets",
     "dev": "gulp dev",
-    "dev-map": "gulp dev --sourceMap",
     "test-env": "node testing/launch",
     "update-ts": "dx-tools update-ts-bundle",
     "internal-tool": "dx-tools",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-replace-async": "0.0.1",
+    "gulp-sourcemaps": "^2.6.5",
     "gulp-tap": "^1.0.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^5.0.0",


### PR DESCRIPTION
This PR resolve problems with debugging our code after used the Babel library in the tests and the playground. 

What was done:
1. The devtool option of the WebPack is changed for using the source map
2. Use the gulp-sourcemaps package for debugging tests.

