### PR TITLE
Declare component_registrator as a module

### DIFF
--- a/build/gulp/modules_metadata.json
+++ b/build/gulp/modules_metadata.json
@@ -25,6 +25,12 @@
     }
   },
   {
+    "name": "core/component_registrator",
+    "exports": {
+      "default": { "path": "registerComponent" }
+    }
+  },
+  {
     "name": "core/config",
     "exports": {
       "default": { "path": "config" }


### PR DESCRIPTION
`registerComponent` is not a public function, this will only add `default` export required for internal usage (dashboards)