### PR TITLE
QUnit: Clean up extensions

### DIFF
--- a/testing/.eslintrc
+++ b/testing/.eslintrc
@@ -21,6 +21,7 @@
         "qunit/no-commented-tests": "warn",
         "qunit/no-identical-names": "warn",
         "qunit/no-ok-equality": "warn",
-        "qunit/no-only": "error"
+        "qunit/no-only": "error",
+        "qunit/no-setup-teardown": "error"
     }
 }

--- a/testing/tests/DevExpress.viz.charts/chartAxisDrawing.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chartAxisDrawing.tests.js
@@ -10,14 +10,12 @@ import titleModule from 'viz/core/title';
 import rendererModule from 'viz/core/renderers/renderer';
 import multiAxesSynchronizer from 'viz/chart_components/multi_axes_synchronizer';
 
-$('<div id="test-container">').appendTo('#qunit-fixture');
-
 rendererModule.Renderer = sinon.stub();
 
 const environment = {
     beforeEach: function() {
         this.renderer = new vizMocks.Renderer();
-        this.container = createTestContainer('#test-container', { width: 800, height: 600 });
+        this.container = $(createTestContainer('#qunit-fixture', { width: '800px', height: '600px' }));
         rendererModule.Renderer.onCall(0).returns(this.renderer);
         rendererModule.Renderer.onCall(1).returns(new vizMocks.Renderer());
         rendererModule.Renderer.onCall(2).returns(new vizMocks.Renderer());
@@ -66,7 +64,6 @@ const environment = {
         });
     },
     afterEach: function() {
-        this.container.remove();
         this.renderer = null;
         rendererModule.Renderer.reset();
         this.axisStub.restore();

--- a/testing/tests/DevExpress.viz.gauges/barGauge.tests.js
+++ b/testing/tests/DevExpress.viz.gauges/barGauge.tests.js
@@ -98,7 +98,7 @@ QUnit.begin(function() {
 
 const environment = {
     beforeEach: function() {
-        this.$container = createTestContainer('#test-container', { width: 400, height: 300 });
+        this.$container = $(createTestContainer('#test-container', { width: '400px', height: '300px' }));
     },
     afterEach: function() {
         this.$container.remove();

--- a/testing/tests/DevExpress.viz.gauges/circularGauge.tests.js
+++ b/testing/tests/DevExpress.viz.gauges/circularGauge.tests.js
@@ -123,7 +123,7 @@ const TestPointerElement = TestElement.inherit({
     const environment = {
         beforeEach: function() {
             this.renderer = new vizMocks.Renderer();
-            this.container = createTestContainer('#test-container', { width: 800, height: 600 });
+            this.container = $(createTestContainer('#test-container', { width: '800px', height: '600px' }));
             rendererModule.Renderer.onCall(0).returns(this.renderer);
             const tooltipRender = new vizMocks.Renderer();
             rendererModule.Renderer.onCall(1).returns(tooltipRender);

--- a/testing/tests/DevExpress.viz.gauges/common.tests.js
+++ b/testing/tests/DevExpress.viz.gauges/common.tests.js
@@ -183,7 +183,7 @@ const environment = {
         rangeModule.Range.reset();
         axisModule.Axis.reset();
         this.renderer = new vizMocks.Renderer();
-        this.container = createTestContainer('#test-container', { width: 800, height: 600 });
+        this.container = $(createTestContainer('#test-container', { width: '800px', height: '600px' }));
     },
     createTestGauge: function(options) {
         return new dxTestGauge(this.container, $.extend(true, {}, {

--- a/testing/tests/DevExpress.viz.gauges/linearGauge.tests.js
+++ b/testing/tests/DevExpress.viz.gauges/linearGauge.tests.js
@@ -121,7 +121,7 @@ const TestPointerElement = TestElement.inherit({
     const environment = {
         beforeEach: function() {
             this.renderer = new vizMocks.Renderer();
-            this.container = createTestContainer('#test-container', { width: 800, height: 600 });
+            this.container = $(createTestContainer('#test-container', { width: '800px', height: '600px' }));
             rendererModule.Renderer.onCall(0).returns(this.renderer);
             const tooltipRenderer = new vizMocks.Renderer();
             rendererModule.Renderer.onCall(1).returns(tooltipRenderer);

--- a/testing/tests/DevExpress.viz.rangeSelector/rangeSelectorParts/commons.js
+++ b/testing/tests/DevExpress.viz.rangeSelector/rangeSelectorParts/commons.js
@@ -1,5 +1,6 @@
 /* global createTestContainer */
 
+const $ = require('jquery');
 const themeManagerModule = require('viz/core/base_theme_manager');
 const rangeViewModule = require('viz/range_selector/range_view');
 const slidersControllerModule = require('viz/range_selector/sliders_controller');
@@ -56,7 +57,7 @@ exports.returnValue = returnValue;
 
 exports.environment = {
     beforeEach: function() {
-        this.$container = createTestContainer('#test-container', { width: 300, height: 150 });
+        this.$container = $(createTestContainer('#qunit-fixture', { width: '300px', height: '150px' }));
         this.StubAxis = StubAxis;
 
         this.renderer = new vizMocks.Renderer();
@@ -86,7 +87,6 @@ exports.environment = {
     },
 
     afterEach: function() {
-        this.$container.remove();
         axisModule.Axis.restore();
     },
 

--- a/testing/tests/DevExpress.viz.sparklines/baseSparklineTooltipEvents.tests.js
+++ b/testing/tests/DevExpress.viz.sparklines/baseSparklineTooltipEvents.tests.js
@@ -31,7 +31,7 @@ const environment = {
     beforeEach: function() {
         baseSparkline._DEBUG_reset();
         // this._originalRendererType = dxSparkline.prototype._rendererType;
-        this.$container = createTestContainer('#container');
+        this.$container = $(createTestContainer('#container'));
         this.createSparkline = function(options) {
             return this.$container.dxSparkline(options).dxSparkline('instance');
         };

--- a/testing/tests/DevExpress.viz.sparklines/bullet.tests.js
+++ b/testing/tests/DevExpress.viz.sparklines/bullet.tests.js
@@ -42,7 +42,7 @@ tooltipModule.Tooltip = sinon.spy(function() {
 
 const environment = {
     beforeEach: function() {
-        this.$container = createTestContainer('#container');
+        this.$container = $(createTestContainer('#container'));
         this.resetTranslators();
         this.tooltip = new StubTooltip();
     },

--- a/testing/tests/DevExpress.viz.sparklines/bulletTooltip.tests.js
+++ b/testing/tests/DevExpress.viz.sparklines/bulletTooltip.tests.js
@@ -46,7 +46,7 @@ const environment = {
             font: {}
         });
         this.renderer = new vizMocks.Renderer();
-        this.$container = createTestContainer('#container');
+        this.$container = $(createTestContainer('#container'));
         this.createBullet = function(options) {
             return this.$container.dxBullet($.extend(true, {
                 tooltip: {

--- a/testing/tests/DevExpress.viz.sparklines/sparkline.tests.js
+++ b/testing/tests/DevExpress.viz.sparklines/sparkline.tests.js
@@ -51,7 +51,7 @@ QUnit.begin(function() {
         beforeEach: function() {
             this.clock = sinon.useFakeTimers();
 
-            this.$container = createTestContainer('#container');
+            this.$container = $(createTestContainer('#container'));
             this.renderer = new vizMocks.Renderer();
             this.translator = new FakeTranslator();
             this.series = new StubSeries();

--- a/testing/tests/DevExpress.viz.sparklines/sparklineTooltip.tests.js
+++ b/testing/tests/DevExpress.viz.sparklines/sparklineTooltip.tests.js
@@ -48,7 +48,7 @@ const environment = {
             font: {}
         });
 
-        this.$container = createTestContainer('#container');
+        this.$container = $(createTestContainer('#container'));
         this.createSparkline = function(options) {
             return this.$container.dxSparkline($.extend(true, {
                 tooltip: {


### PR DESCRIPTION
- Get rid of jQuery when possible (suggested by @nightskylark in https://github.com/DevExpress/DevExtreme/pull/11617#issuecomment-577047753). jQuery is used only in [this function](https://github.com/DevExpress/DevExtreme/compare/20_1...San4es:qunit-extensions-clean-up?expand=1#diff-395f1784c7d28a690e6152a12d8abe03L161) now.
- Replace [QUnit.module override](https://github.com/DevExpress/DevExtreme/compare/20_1...San4es:qunit-extensions-clean-up?expand=1#diff-395f1784c7d28a690e6152a12d8abe03L7-L12) with the ["qunit/no-setup-teardown" rule](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-setup-teardown.md) for ESLint.
- Remove `QUnit.assert.assertPerformance` and `window.waitTimeout` because they are unused anymore.
- Remove `console.time` and `console.timeEnd` polyfills (see https://caniuse.com/#feat=console-time).