### PR TITLE
Rid of unexpected borders for the DataGrid selected rows in generic light and dark themes (T853231)

### DIFF
--- a/styles/widgets/generic/color-schemes/dark/generic.dark.less
+++ b/styles/widgets/generic/color-schemes/dark/generic.dark.less
@@ -1072,7 +1072,7 @@
 * @name 55. Selected row background color
 * @type color
 */
-@datagrid-selection-bg: @base-select-bg;
+@datagrid-selection-bg: #444;
 
 /**
 * @name 60. Selected row border color

--- a/styles/widgets/generic/color-schemes/light/generic.light.less
+++ b/styles/widgets/generic/color-schemes/light/generic.light.less
@@ -1067,7 +1067,7 @@
 * @name 55. Selected row background color
 * @type color
 */
-@datagrid-selection-bg: @base-select-bg;
+@datagrid-selection-bg: #e6e6e6;
 
 /**
 * @name 60. Selected row border color


### PR DESCRIPTION
We can use static colors for grids base selection because of base-select-bg is not editable by ThemeBuilder
Result color constants have been calculated as
```

rgb(
    red(@base-select-bg) * alpha(@base-select-bg) + (1 - alpha(@base-select-bg)) * red(@base-bg),
    green(@base-select-bg) * alpha(@base-select-bg) + (1 - alpha(@base-select-bg)) * green(@base-bg),
    blue(@base-select-bg) * alpha(@base-select-bg) + (1 - alpha(@base-select-bg)) * blue(@base-bg)
);

```