### PR TITLE
Renovation: Implement default button behavior

### DIFF
--- a/js/renovation/button.tsx
+++ b/js/renovation/button.tsx
@@ -104,4 +104,7 @@ export default class Button extends Widget {
     @Prop() stylingMode?: string;
     @Prop() text?: string;
     @Prop() type?: string;
+    @Prop() focusStateEnabled?: boolean = true;
+    @Prop() activeStateEnabled?: boolean = true;
+    @Prop() hoverStateEnabled?: boolean = true;
 }

--- a/js/renovation/dist/button.j.jsx
+++ b/js/renovation/dist/button.j.jsx
@@ -39,7 +39,9 @@ class Button extends Widget {
 
     _getDefaultOptions() {
         return extend(super._getDefaultOptions(), {
-            focusStateEnabled: true
+            focusStateEnabled: true,
+            activeStateEnabled: true,
+            hoverStateEnabled: true,
         });
     }
 }

--- a/js/renovation/widget.tsx
+++ b/js/renovation/widget.tsx
@@ -205,7 +205,7 @@ export default class Widget {
     }
 
     @Effect()
-    clickEffect() {
+    accessKeyEffect() {
         const namespace = 'UIFeedback';
         const isFocusable = this.focusStateEnabled && !this.disabled;
         const canBeFocusedByKey = isFocusable && this.accessKey;
@@ -215,7 +215,6 @@ export default class Widget {
                 e.stopImmediatePropagation();
                 this._focused = true;
             }
-            this.onClick!(this.clickArgs);
         }, { namespace });
 
         return () => dxClick.off(this.widgetRef, { namespace });
@@ -263,6 +262,18 @@ export default class Widget {
         }
 
         return () => active.off(this.widgetRef, { selector, namespace });
+    }
+
+    @Effect()
+    clickEffect() {
+        const namespace = 'UIFeedback';
+
+        dxClick.on(this.widgetRef,
+            () => this.onClick!(this.clickArgs),
+            { namespace }
+        );
+
+        return () => dxClick.off(this.widgetRef, { namespace });
     }
 
     @Effect()

--- a/js/renovation/widget.tsx
+++ b/js/renovation/widget.tsx
@@ -270,7 +270,7 @@ export default class Widget {
 
     @Effect()
     clickEffect() {
-        const namespace = 'UIFeedback';
+        const namespace = this.name;
 
         dxClick.on(this.widgetRef,
             () => this.onClick!(this.clickArgs),

--- a/testing/jest/button.tests.tsx
+++ b/testing/jest/button.tests.tsx
@@ -10,6 +10,27 @@ const render = (props = {}) => {
 
 describe('Button', () => {
     describe('Props', () => {
+        describe('default props', () => {
+            it('should be initialized with default props', () => {
+                const button = render();
+
+                expect(button.props().focusStateEnabled).toBe(true);
+                expect(button.props().activeStateEnabled).toBe(true);
+                expect(button.props().hoverStateEnabled).toBe(true);
+            });
+
+            it('should be clickable with onClick only', () => {
+                const clickHandler = jest.fn();
+                const button = render({ onClick: clickHandler });
+
+                expect(clickHandler).toHaveBeenCalledTimes(0);
+
+                button.simulate('click');
+
+                expect(clickHandler).toHaveBeenCalledTimes(1);
+            })
+        });
+
         describe('stylingMode', () => {
             it('should use "contained" as a default value', () => {
                 const button = render();

--- a/testing/jest/button.tests.tsx
+++ b/testing/jest/button.tests.tsx
@@ -10,16 +10,8 @@ const render = (props = {}) => {
 
 describe('Button', () => {
     describe('Props', () => {
-        describe('default props', () => {
-            it('should be initialized with default props', () => {
-                const button = render();
-
-                expect(button.props().focusStateEnabled).toBe(true);
-                expect(button.props().activeStateEnabled).toBe(true);
-                expect(button.props().hoverStateEnabled).toBe(true);
-            });
-
-            it('should be clickable with onClick only', () => {
+        describe('onClick', () => {
+            it('should be clickable with onClick property only', () => {
                 const clickHandler = jest.fn();
                 const button = render({ onClick: clickHandler });
 


### PR DESCRIPTION
Implemen base behavior of button:
1) hoverStateEnabled = true
2) activeStateEnabled = true
3) possible to click on button without `accessKey` property

Will be compatible with focus (#11711) after generator fix.