### PR TITLE
Less: change icon mixin from 'selector' to 'parametrized'

### DIFF
--- a/styles/widgets/base/dataGrid.less
+++ b/styles/widgets/base/dataGrid.less
@@ -40,11 +40,11 @@
     background-color: @datagrid-base-background-color;
 
     .dx-sort-up {
-        .dx-icon-sortup;
+        .dx-icon(sortup);
     }
 
     .dx-sort-down {
-        .dx-icon-sortdown;
+        .dx-icon(sortdown);
     }
 
     .dx-sort-down,
@@ -97,7 +97,7 @@
     .dx-header-filter {
         position: relative;
         color: @HEADER_FILTER_COLOR;
-        .dx-icon-filter;
+        .dx-icon(filter);
     }
 
     .dx-header-filter-empty {
@@ -197,7 +197,7 @@
     }
 
     .dx-command-drag .dx-datagrid-drag-icon {
-        .dx-icon-dragvertical;
+        .dx-icon(dragvertical);
     }
 }
 
@@ -236,7 +236,7 @@
 
 .dx-datagrid-adaptive-more {
     cursor: pointer;
-    .dx-icon-more;
+    .dx-icon(more);
     .dx-icon-sizing(21px);
 }
 

--- a/styles/widgets/base/icons.less
+++ b/styles/widgets/base/icons.less
@@ -67,271 +67,209 @@
     }
 }
 
-.dx-font-icons-list() {
-    .dx-icon-add { .dx-font-icon("\f00b"); }
-    .dx-icon-airplane { .dx-font-icon("\f000"); }
-    .dx-icon-bookmark { .dx-font-icon("\f017"); }
-    .dx-icon-box { .dx-font-icon("\f018"); }
-    .dx-icon-car { .dx-font-icon("\f01b"); }
-    .dx-icon-card { .dx-font-icon("\f019"); }
-    .dx-icon-cart { .dx-font-icon("\f01a"); }
-    .dx-icon-chart { .dx-font-icon("\f01c"); }
-    .dx-icon-check { .dx-font-icon("\f005"); }
-    .dx-icon-clear { .dx-font-icon("\f008"); }
-    .dx-icon-clock { .dx-font-icon("\f01d"); }
-    .dx-icon-close { .dx-font-icon("\f00a"); }
-    .dx-icon-coffee { .dx-font-icon("\f02a"); }
-    .dx-icon-comment { .dx-font-icon("\f01e"); }
+// stylelint-disable property-no-unknown
+@icons: {
+    add: "\f00b";
+    airplane: "\f000";
+    bookmark: "\f017";
+    box: "\f018";
+    car: "\f01b";
+    card: "\f019";
+    cart: "\f01a";
+    chart: "\f01c";
+    check: "\f005";
+    clear: "\f008";
+    clock: "\f01d";
+    close: "\f00a";
+    coffee: "\f02a";
+    comment: "\f01e";
+    doc: "\f021";
+    file: "\f021";
+    download: "\f022";
+    dragvertical: "\f038";
+    edit: "\f023";
+    email: "\f024";
+    event: "\f026";
+    favorites: "\f025";
+    find: "\f027";
+    filter: "\f050";
+    folder: "\f028";
+    activefolder: "\f028";
+    food: "\f029";
+    gift: "\f02b";
+    globe: "\f02c";
+    group: "\f02e";
+    help: "\f02f";
+    home: "\f030";
+    image: "\f031";
+    info: "\f032";
+    key: "\f033";
+    like: "\f034";
+    map: "\f035";
+    menu: "\f00c";
+    message: "\f024";
+    money: "\f036";
+    music: "\f037";
+    overflow: "\f00d";
+    percent: "\f039";
+    photo: "\f03a";
+    plus: "\f00b";
+    minus: "\f074";
+    preferences: "\f03b";
+    product: "\f03c";
+    pulldown: "\f062";
+    refresh: "\f03d";
+    remove: "\f00a";
+    revert: "\f04c";
+    runner: "\f040";
+    save: "\f041";
+    search: "\f027";
+    tags: "\f009";
+    tel: "\f003";
+    tips: "\f004";
+    todo: "\f005";
+    toolbox: "\f007";
+    trash: "\f03e";
+    user: "\f02d";
+    upload: "\f006";
+    floppy: "\f073";
+    arrowleft: "\f011";
+    arrowdown: "\f015";
+    arrowright: "\f00e";
+    arrowup: "\f013";
+    spinleft: "\f04f";
+    spinprev: "\f04f";
+    spinright: "\f04e";
+    spinnext: "\f04e";
+    spindown: "\f001";
+    spinup: "\f002";
+    chevronleft: "\f012";
+    chevronprev: "\f012";
+    back: "\f012";
+    chevronright: "\f010";
+    chevronnext: "\f010";
+    chevrondown: "\f016";
+    chevronup: "\f014";
+    chevrondoubleleft: "\f042";
+    chevrondoubleright: "\f03f";
+    equal: "\f044";
+    notequal: "\f045";
+    less: "\f046";
+    greater: "\f047";
+    lessorequal: "\f048";
+    greaterorequal: "\f049";
+    isblank: "\f075";
+    isnotblank: "\f076";
+    sortup: "\f051";
+    sortdown: "\f052";
+    sortuptext: "\f053";
+    sortdowntext: "\f054";
+    sorted: "\f055";
+    expand: "\f04a";
+    collapse: "\f04b";
+    columnfield: "\f057";
+    rowfield: "\f058";
+    datafield: "\f101";
+    fields: "\f059";
+    fieldchooser: "\f05a";
+    columnchooser: "\f04d";
+    pin: "\f05b";
+    unpin: "\f05c";
+    pinleft: "\f05d";
+    pinright: "\f05e";
+    contains: "\f063";
+    startswith: "\f064";
+    endswith: "\f065";
+    doesnotcontain: "\f066";
+    range: "\f06a";
+    export: "\f05f";
+    exportxlsx: "\f060";
+    exportpdf: "\f061";
+    exportselected: "\f06d";
+    warning: "\f06b";
+    more: "\f06c";
+    square: "\f067";
+    clearsquare: "\f068";
+    repeat: "\f069";
+    selectall: "\f070";
+    unselectall: "\f071";
+    print: "\f072";
+    bold: "\f077";
+    italic: "\f078";
+    underline: "\f079";
+    strike: "\f07a";
+    indent: "\f07b";
+    increaselinespacing: "\f07b";
+    font: "\f11b"; // stylelint-disable-line font-family-no-missing-generic-family-keyword
+    fontsize: "\f07c";
+    shrinkfont: "\f07d";
+    growfont: "\f07e";
+    color: "\f07f";
+    background: "\f080";
+    fill: "\f10d";
+    palette: "\f120";
+    superscript: "\f081";
+    subscript: "\f082";
+    header: "\f083";
+    blockquote: "\f084";
+    formula: "\f056";
+    codeblock: "\f085";
+    orderedlist: "\f086";
+    bulletlist: "\f087";
+    increaseindent: "\f088";
+    decreaseindent: "\f089";
+    decreaselinespacing: "\f106";
+    alignleft: "\f08a";
+    alignright: "\f08b";
+    aligncenter: "\f08c";
+    alignjustify: "\f08d";
+    link: "\f08e";
+    video: "\f08f";
+    mention: "\f090";
+    variable: "\f091";
+    clearformat: "\f092";
+    fullscreen: "\f11a";
+    hierarchy: "\f124";
+    docfile: "\f111";
+    docxfile: "\f110";
+    pdffile: "\f118";
+    pptfile: "\f114";
+    pptxfile: "\f115";
+    rtffile: "\f112";
+    txtfile: "\f113";
+    xlsfile: "\f116";
+    xlsxfile: "\f117";
+    copy: "\f107";
+    cut: "\f10a";
+    paste: "\f108";
+    share: "\f11f";
+    inactivefolder: "\f105";
+    newfolder: "\f123";
+    movetofolder: "\f121";
+    parentfolder: "\f122";
+    rename: "\f109";
+    detailslayout: "\f10b";
+    contentlayout: "\f11e";
+    smalliconslayout: "\f119";
+    mediumiconslayout: "\f10c";
+    undo: "\f04c";
+    redo: "\f093";
+    hidepanel: "\f11c";
+    showpanel: "\f11d";
+}
+// stylelint-enable
 
-    .dx-icon-doc,
-    .dx-icon-file {
-        .dx-font-icon("\f021");
-    }
-    .dx-icon-download { .dx-font-icon("\f022"); }
-    .dx-icon-dragvertical { .dx-font-icon("\f038"); }
-    .dx-icon-edit { .dx-font-icon("\f023"); }
-    .dx-icon-email { .dx-font-icon("\f024"); }
-    .dx-icon-event { .dx-font-icon("\f026"); }
-    .dx-icon-favorites { .dx-font-icon("\f025"); }
-    .dx-icon-find { .dx-font-icon("\f027"); }
-    .dx-icon-filter { .dx-font-icon("\f050"); }
-
-    .dx-icon-folder,
-    .dx-icon-activefolder {
-        .dx-font-icon("\f028");
-    }
-    .dx-icon-food { .dx-font-icon("\f029"); }
-    .dx-icon-gift { .dx-font-icon("\f02b"); }
-    .dx-icon-globe { .dx-font-icon("\f02c"); }
-    .dx-icon-group { .dx-font-icon("\f02e"); }
-    .dx-icon-help { .dx-font-icon("\f02f"); }
-    .dx-icon-home { .dx-font-icon("\f030"); }
-    .dx-icon-image { .dx-font-icon("\f031"); }
-    .dx-icon-info { .dx-font-icon("\f032"); }
-    .dx-icon-key { .dx-font-icon("\f033"); }
-    .dx-icon-like { .dx-font-icon("\f034"); }
-    .dx-icon-map { .dx-font-icon("\f035"); }
-    .dx-icon-menu { .dx-font-icon("\f00c"); }
-    .dx-icon-message { .dx-font-icon("\f024"); }
-    .dx-icon-money { .dx-font-icon("\f036"); }
-    .dx-icon-music { .dx-font-icon("\f037"); }
-    .dx-icon-overflow { .dx-font-icon("\f00d"); }
-    .dx-icon-percent { .dx-font-icon("\f039"); }
-    .dx-icon-photo { .dx-font-icon("\f03a"); }
-    .dx-icon-plus { .dx-font-icon("\f00b"); }
-    .dx-icon-minus { .dx-font-icon("\f074"); }
-    .dx-icon-preferences { .dx-font-icon("\f03b"); }
-    .dx-icon-product { .dx-font-icon("\f03c"); }
-    .dx-icon-pulldown { .dx-font-icon("\f062"); }
-    .dx-icon-refresh { .dx-font-icon("\f03d"); }
-    .dx-icon-remove { .dx-font-icon("\f00a"); }
-    .dx-icon-revert { .dx-font-icon("\f04c"); }
-    .dx-icon-runner { .dx-font-icon("\f040"); }
-    .dx-icon-save { .dx-font-icon("\f041"); }
-    .dx-icon-search { .dx-font-icon("\f027"); }
-    .dx-icon-tags { .dx-font-icon("\f009"); }
-    .dx-icon-tel { .dx-font-icon("\f003"); }
-    .dx-icon-tips { .dx-font-icon("\f004"); }
-    .dx-icon-todo { .dx-font-icon("\f005"); }
-    .dx-icon-toolbox { .dx-font-icon("\f007"); }
-    .dx-icon-trash { .dx-font-icon("\f03e"); }
-    .dx-icon-user { .dx-font-icon("\f02d"); }
-    .dx-icon-upload { .dx-font-icon("\f006"); }
-    .dx-icon-floppy { .dx-font-icon("\f073"); }
-
-    .dx-icon-arrowleft { .dx-font-icon("\f011"); }
-    .dx-icon-arrowdown { .dx-font-icon("\f015"); }
-    .dx-icon-arrowright { .dx-font-icon("\f00e"); }
-    .dx-icon-arrowup { .dx-font-icon("\f013"); }
-
-    .dx-icon-spinleft,
-    .dx-icon-spinprev {
-        .dx-font-icon("\f04f");
-    }
-
-    .dx-icon-spinright,
-    .dx-icon-spinnext {
-        .dx-font-icon("\f04e");
-    }
-
-    .dx-icon-spinnext {
-        .dx-rtl &:before { content: "\f04f"; } //.dx-icon-spinleft
-    }
-
-    .dx-icon-spinprev {
-        .dx-rtl &:before { content: "\f04e"; } //.dx-icon-spinright
-    }
-    .dx-icon-spindown { .dx-font-icon("\f001"); }
-    .dx-icon-spinup { .dx-font-icon("\f002"); }
-
-    .dx-icon-chevronleft,
-    .dx-icon-chevronprev,
-    .dx-icon-back {
-        .dx-font-icon("\f012");
-    }
-
-    .dx-icon-chevronright,
-    .dx-icon-chevronnext {
-        .dx-font-icon("\f010");
-    }
-
-    .dx-icon-chevronnext {
-        .dx-rtl &:before { content: "\f012"; } //.dx-icon-chevronleft
-    }
-
-    .dx-icon-chevronprev {
-        .dx-rtl &:before { content: "\f010"; } //.dx-icon-chevronright
-    }
-    .dx-icon-chevrondown { .dx-font-icon("\f016"); }
-    .dx-icon-chevronup { .dx-font-icon("\f014"); }
-    .dx-icon-chevrondoubleleft { .dx-font-icon("\f042"); }
-    .dx-icon-chevrondoubleright { .dx-font-icon("\f03f"); }
-
-    .dx-icon-equal { .dx-font-icon("\f044"); }
-    .dx-icon-notequal { .dx-font-icon("\f045"); }
-    .dx-icon-less { .dx-font-icon("\f046"); }
-    .dx-icon-greater { .dx-font-icon("\f047"); }
-    .dx-icon-lessorequal { .dx-font-icon("\f048"); }
-    .dx-icon-greaterorequal { .dx-font-icon("\f049"); }
-    .dx-icon-isblank { .dx-font-icon("\f075"); }
-    .dx-icon-isnotblank { .dx-font-icon("\f076"); }
-
-    .dx-icon-sortup { .dx-font-icon("\f051"); }
-    .dx-icon-sortdown { .dx-font-icon("\f052"); }
-    .dx-icon-sortuptext { .dx-font-icon("\f053"); }
-    .dx-icon-sortdowntext { .dx-font-icon("\f054"); }
-    .dx-icon-sorted { .dx-font-icon("\f055"); }
-
-    .dx-icon-expand { .dx-font-icon("\f04a"); }
-    .dx-icon-collapse { .dx-font-icon("\f04b"); }
-
-    .dx-icon-columnfield { .dx-font-icon("\f057"); }
-    .dx-icon-rowfield { .dx-font-icon("\f058"); }
-    .dx-icon-datafield { .dx-font-icon("\f101"); }
-    .dx-icon-fields { .dx-font-icon("\f059"); }
-    .dx-icon-fieldchooser { .dx-font-icon("\f05a"); }
-    .dx-icon-columnchooser { .dx-font-icon("\f04d"); }
-
-    .dx-icon-pin { .dx-font-icon("\f05b"); }
-    .dx-icon-unpin { .dx-font-icon("\f05c"); }
-    .dx-icon-pinleft { .dx-font-icon("\f05d"); }
-    .dx-icon-pinright { .dx-font-icon("\f05e"); }
-
-    .dx-icon-contains { .dx-font-icon("\f063"); }
-    .dx-icon-startswith { .dx-font-icon("\f064"); }
-    .dx-icon-endswith { .dx-font-icon("\f065"); }
-    .dx-icon-doesnotcontain { .dx-font-icon("\f066"); }
-    .dx-icon-range { .dx-font-icon("\f06a"); }
-
-    .dx-icon-export { .dx-font-icon("\f05f"); }
-    .dx-icon-exportxlsx { .dx-font-icon("\f060"); }
-    .dx-icon-exportpdf { .dx-font-icon("\f061"); }
-    .dx-icon-exportselected { .dx-font-icon("\f06d"); }
-
-    .dx-icon-warning { .dx-font-icon("\f06b"); }
-    .dx-icon-more { .dx-font-icon("\f06c"); }
-
-    .dx-icon-square { .dx-font-icon("\f067"); }
-    .dx-icon-clearsquare { .dx-font-icon("\f068"); }
-
-    .dx-icon-back {
-        .dx-rtl &:before { content: "\f010"; } //.dx-icon-chevronright
-    }
-
-    .dx-icon-repeat { .dx-font-icon("\f069"); }
-
-    .dx-icon-selectall { .dx-font-icon("\f070"); }
-    .dx-icon-unselectall { .dx-font-icon("\f071"); }
-    .dx-icon-print { .dx-font-icon("\f072"); }
-
-    .dx-icon-bold { .dx-font-icon("\f077"); }
-    .dx-icon-italic { .dx-font-icon("\f078"); }
-    .dx-icon-underline { .dx-font-icon("\f079"); }
-    .dx-icon-strike { .dx-font-icon("\f07a"); }
-
-    .dx-icon-indent,
-    .dx-icon-increaselinespacing {
-        .dx-font-icon("\f07b");
-    }
-    .dx-icon-font { .dx-font-icon("\f11b"); }
-    .dx-icon-fontsize { .dx-font-icon("\f07c"); }
-    .dx-icon-shrinkfont { .dx-font-icon("\f07d"); }
-    .dx-icon-growfont { .dx-font-icon("\f07e"); }
-    .dx-icon-color { .dx-font-icon("\f07f"); }
-    .dx-icon-background { .dx-font-icon("\f080"); }
-    .dx-icon-fill { .dx-font-icon("\f10d"); }
-    .dx-icon-palette { .dx-font-icon("\f120"); }
-    .dx-icon-superscript { .dx-font-icon("\f081"); }
-    .dx-icon-subscript { .dx-font-icon("\f082"); }
-    .dx-icon-header { .dx-font-icon("\f083"); }
-    .dx-icon-blockquote { .dx-font-icon("\f084"); }
-    .dx-icon-formula { .dx-font-icon("\f056"); }
-    .dx-icon-codeblock { .dx-font-icon("\f085"); }
-    .dx-icon-orderedlist { .dx-font-icon("\f086"); }
-    .dx-icon-bulletlist { .dx-font-icon("\f087"); }
-    .dx-icon-increaseindent { .dx-font-icon("\f088"); }
-    .dx-icon-decreaseindent { .dx-font-icon("\f089"); }
-    .dx-icon-decreaselinespacing { .dx-font-icon("\f106"); }
-    .dx-icon-alignleft { .dx-font-icon("\f08a"); }
-    .dx-icon-alignright { .dx-font-icon("\f08b"); }
-    .dx-icon-aligncenter { .dx-font-icon("\f08c"); }
-    .dx-icon-alignjustify { .dx-font-icon("\f08d"); }
-    .dx-icon-link { .dx-font-icon("\f08e"); }
-    .dx-icon-video { .dx-font-icon("\f08f"); }
-    .dx-icon-mention { .dx-font-icon("\f090"); }
-    .dx-icon-variable { .dx-font-icon("\f091"); }
-    .dx-icon-clearformat { .dx-font-icon("\f092"); }
-    .dx-icon-fullscreen { .dx-font-icon("\f11a"); }
-    .dx-icon-hierarchy { .dx-font-icon("\f124"); }
-
-    .dx-icon-docfile { .dx-font-icon("\f111"); }
-    .dx-icon-docxfile { .dx-font-icon("\f110"); }
-    .dx-icon-pdffile { .dx-font-icon("\f118"); }
-    .dx-icon-pptfile { .dx-font-icon("\f114"); }
-    .dx-icon-pptxfile { .dx-font-icon("\f115"); }
-    .dx-icon-rtffile { .dx-font-icon("\f112"); }
-    .dx-icon-txtfile { .dx-font-icon("\f113"); }
-    .dx-icon-xlsfile { .dx-font-icon("\f116"); }
-    .dx-icon-xlsxfile { .dx-font-icon("\f117"); }
-
-    .dx-icon-copy { .dx-font-icon("\f107"); }
-    .dx-icon-cut { .dx-font-icon("\f10a"); }
-    .dx-icon-paste { .dx-font-icon("\f108"); }
-    .dx-icon-share { .dx-font-icon("\f11f"); }
-
-    .dx-icon-inactivefolder { .dx-font-icon("\f105"); }
-    .dx-icon-newfolder { .dx-font-icon("\f123"); }
-    .dx-icon-movetofolder { .dx-font-icon("\f121"); }
-    .dx-icon-parentfolder { .dx-font-icon("\f122"); }
-    .dx-icon-rename { .dx-font-icon("\f109"); }
-
-    .dx-icon-detailslayout { .dx-font-icon("\f10b"); }
-    .dx-icon-contentlayout { .dx-font-icon("\f11e"); }
-    .dx-icon-smalliconslayout { .dx-font-icon("\f119"); }
-    .dx-icon-mediumiconslayout { .dx-font-icon("\f10c"); }
-
-
-    .dx-icon-undo {
-        .dx-font-icon("\f04c");
-        .dx-rtl &:before { content: "\f093"; } // redo icon
-    }
-
-    .dx-icon-redo {
-        .dx-font-icon("\f093");
-        .dx-rtl &:before { content: "\f04c"; } // undo icon
-    }
-
-    .dx-icon-hidepanel {
-        .dx-font-icon("\f11c");
-        .dx-rtl &:before { content: "\f11d"; } // showpanel icon
-    }
-
-    .dx-icon-showpanel {
-        .dx-font-icon("\f11d");
-        .dx-rtl &:before { content: "\f11c"; } // hidepanel icon
-    }
+.dx-icon(@name) {
+    .dx-font-icon(@icons[$@name]);
 }
 
+.dx-font-icons-list() {
+    each(@icons, {
+        .dx-icon-@{key} {
+            .dx-icon(@key);
+        }
+    });
+}
 
 .dx-font-icons(@font-file: "dxicons", @font-name: "DevExtreme Generic Icons", @font-name-safari: "devextreme_generic_icons") {
     @font-face {
@@ -355,5 +293,40 @@
     }
 
     .dx-font-icons-list();
+}
+
+.dx-rtl {
+    .dx-icon-spinnext:before {
+        content: "\f04f"; //.dx-icon-spinleft
+    }
+
+    .dx-icon-spinprev:before {
+        content: "\f04e"; //.dx-icon-spinright
+    }
+
+    .dx-icon-chevronnext:before {
+        content: "\f012"; //.dx-icon-chevronleft
+    }
+
+    .dx-icon-chevronprev:before,
+    .dx-icon-back:before {
+        content: "\f010"; //.dx-icon-chevronright
+    }
+
+    .dx-icon-undo:before {
+        content: "\f093"; // redo icon
+    }
+
+    .dx-icon-redo:before {
+        content: "\f04c"; // undo icon
+    }
+
+    .dx-icon-hidepanel:before {
+        content: "\f11d"; // showpanel icon
+    }
+
+    .dx-icon-showpanel:before {
+        content: "\f11c"; // hidepanel icon
+    }
 }
 

--- a/styles/widgets/base/pivotGrid.less
+++ b/styles/widgets/base/pivotGrid.less
@@ -42,16 +42,16 @@
     }
 
     .dx-sort-up {
-        .dx-icon-sortup;
+        .dx-icon(sortup);
     }
 
     .dx-sort-down {
-        .dx-icon-sortdown;
+        .dx-icon(sortdown);
     }
 
     .dx-header-filter {
         color: @HEADER_FILTER_COLOR;
-        .dx-icon-filter;
+        .dx-icon(filter);
 
         font-size: @PIVOTGRID_ICON_SIZE;
         width: @PIVOTGRID_ICON_SIZE;

--- a/styles/widgets/base/scheduler.less
+++ b/styles/widgets/base/scheduler.less
@@ -630,7 +630,7 @@
         .dx-scheduler-date-time-indicator {
             margin-left: @SCHEDULER_LEFT_COLUMN_WIDTH;
             height: @SCHEDULER_TIME_INDICATOR_SIZE;
-            .dx-icon-spinright;
+            .dx-icon(spinright);
 
             .dx-scheduler-small & {
                 margin-left: @SCHEDULER_LEFT_COLUMN_WIDTH * @SCHEDULER_SMALL_SIZE_FACTOR;
@@ -672,7 +672,7 @@
         &.dx-rtl {
             .dx-scheduler-date-time-indicator {
                 margin-left: 0;
-                .dx-icon-spinleft;
+                .dx-icon(spinleft);
 
                 &:before {
                     margin-right: -@SCHEDULER_TIME_INDICATOR_LEFT;
@@ -731,7 +731,7 @@
         .dx-scheduler-date-time-indicator {
             width: @SCHEDULER_TIME_INDICATOR_SIZE;
             top: 0;
-            .dx-icon-spindown;
+            .dx-icon(spindown);
 
             &:before {
                 margin-left: -@SCHEDULER_TIME_INDICATOR_TOP;
@@ -1819,12 +1819,12 @@
             position: absolute;
             top: 3px;
             right: @SCHEDULER_REDUCED_ICON_OFFSET;
-            .dx-icon-arrowright;
+            .dx-icon(arrowright);
 
             .dx-rtl & {
                 right: auto;
                 left: 3px;
-                .dx-icon-arrowleft;
+                .dx-icon(arrowleft);
             }
         }
 

--- a/styles/widgets/base/treeList.less
+++ b/styles/widgets/base/treeList.less
@@ -47,7 +47,7 @@
     }
 
     .dx-command-drag .dx-treelist-drag-icon {
-        .dx-icon-dragvertical;
+        .dx-icon(dragvertical);
     }
 }
 
@@ -56,11 +56,11 @@
     background-color: @treelist-base-background-color;
 
     .dx-sort-up {
-        .dx-icon-sortup;
+        .dx-icon(sortup);
     }
 
     .dx-sort-down {
-        .dx-icon-sortdown;
+        .dx-icon(sortdown);
     }
 
     .dx-sort-down,
@@ -97,7 +97,7 @@
     .dx-header-filter {
         position: relative;
         color: @HEADER_FILTER_COLOR;
-        .dx-icon-filter;
+        .dx-icon(filter);
     }
 
     .dx-header-filter-empty {
@@ -227,7 +227,7 @@
 
 .dx-treelist-adaptive-more {
     cursor: pointer;
-    .dx-icon-more;
+    .dx-icon(more);
     .dx-icon-sizing(21px);
 }
 

--- a/styles/widgets/generic/checkBox.generic.less
+++ b/styles/widgets/generic/checkBox.generic.less
@@ -53,14 +53,14 @@
     background-color: @checkbox-bg;
 
     .dx-checkbox-checked & {
-        .dx-icon-check;
+        .dx-icon(check);
 
         color: @checkbox-checked-color;
         .dx-icon-font-centered-sizing(@GENERIC_CHECKBOX_ARROW_ICON_SIZE);
     }
 
     .dx-checkbox-indeterminate & {
-        .dx-icon-square;
+        .dx-icon(square);
 
         color: @checkbox-indeterminate-bg;
         .dx-icon-font-centered-sizing(@GENERIC_CHECKBOX_INTERMIDIATE_ICON_SIZE);

--- a/styles/widgets/generic/contextMenu.generic.less
+++ b/styles/widgets/generic/contextMenu.generic.less
@@ -13,7 +13,7 @@
     }
 
     .dx-menu-item-popout {
-        .dx-icon-spinright;
+        .dx-icon(spinright);
         .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
     }
 

--- a/styles/widgets/generic/dataGrid.generic.less
+++ b/styles/widgets/generic/dataGrid.generic.less
@@ -57,14 +57,14 @@
 }
 
 .dx-datagrid-group-opened {
-    .dx-icon-spindown;
+    .dx-icon(spindown);
     .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
 
     color: @datagrid-spin-icon-color;
 }
 
 .dx-datagrid-group-closed {
-    .dx-icon-spinright;
+    .dx-icon(spinright);
     .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
 
     color: @datagrid-spin-icon-color;

--- a/styles/widgets/generic/dateBox.generic.less
+++ b/styles/widgets/generic/dateBox.generic.less
@@ -146,7 +146,7 @@
 
 .dx-datebox-list {
     .dx-dropdowneditor-icon {
-        .dx-icon-clock;
+        .dx-icon(clock);
         .dx-dropdowneditor-button-icon();
     }
 }

--- a/styles/widgets/generic/dropDownEditor.generic.less
+++ b/styles/widgets/generic/dropDownEditor.generic.less
@@ -58,7 +58,7 @@
 .dx-dropdowneditor-icon {
     border: @GENERIC_BASE_BORDER_WIDTH solid transparent;
     color: @dropdowneditor-icon-color;
-    .dx-icon-spindown;
+    .dx-icon(spindown);
     .dx-dropdowneditor-button-icon();
 }
 

--- a/styles/widgets/generic/gallery.generic.less
+++ b/styles/widgets/generic/gallery.generic.less
@@ -47,7 +47,7 @@
     }
 
     .dx-gallery-nav-button-prev {
-        .dx-icon-chevronleft;
+        .dx-icon(chevronleft);
 
         &:after {
             left: 0;
@@ -61,7 +61,7 @@
     }
 
     .dx-gallery-nav-button-next {
-        .dx-icon-chevronright;
+        .dx-icon(chevronright);
 
         &:after {
             right: 0;

--- a/styles/widgets/generic/gridBase.generic.less
+++ b/styles/widgets/generic/gridBase.generic.less
@@ -87,64 +87,64 @@
         &.dx-context-menu {
             .dx-menu-items-container {
                 .dx-icon-context-menu-sort-asc {
-                    .dx-icon-sortuptext;
+                    .dx-icon(sortuptext);
                     .dx-icon-sizing(16px);
                 }
 
                 .dx-icon-context-menu-sort-desc {
-                    .dx-icon-sortdowntext;
+                    .dx-icon(sortdowntext);
                     .dx-icon-sizing(16px);
                 }
             }
         }
 
         .dx-icon-filter-operation-equals {
-            .dx-icon-equal;
+            .dx-icon(equal);
         }
 
         .dx-icon-filter-operation-default {
-            .dx-icon-find;
+            .dx-icon(find);
             .dx-icon-sizing(12px);
         }
 
         .dx-icon-filter-operation-not-equals {
-            .dx-icon-notequal;
+            .dx-icon(notequal);
         }
 
         .dx-icon-filter-operation-less {
-            .dx-icon-less;
+            .dx-icon(less);
         }
 
         .dx-icon-filter-operation-less-equal {
-            .dx-icon-lessorequal;
+            .dx-icon(lessorequal);
         }
 
         .dx-icon-filter-operation-greater {
-            .dx-icon-greater;
+            .dx-icon(greater);
         }
 
         .dx-icon-filter-operation-greater-equal {
-            .dx-icon-greaterorequal;
+            .dx-icon(greaterorequal);
         }
 
         .dx-icon-filter-operation-contains {
-            .dx-icon-contains;
+            .dx-icon(contains);
         }
 
         .dx-icon-filter-operation-not-contains {
-            .dx-icon-doesnotcontain;
+            .dx-icon(doesnotcontain);
         }
 
         .dx-icon-filter-operation-starts-with {
-            .dx-icon-startswith;
+            .dx-icon(startswith);
         }
 
         .dx-icon-filter-operation-ends-with {
-            .dx-icon-endswith;
+            .dx-icon(endswith);
         }
 
         .dx-icon-filter-operation-between {
-            .dx-icon-range;
+            .dx-icon(range);
         }
     }
 
@@ -182,7 +182,7 @@
             .dx-closebutton {
                 float: right;
                 margin: @GENERIC_GRID_BASE_CELL_PADDING + 2px;
-                .dx-icon-close;
+                .dx-icon(close);
                 .dx-icon-sizing(14px);
             }
 
@@ -600,46 +600,46 @@
     }
 
     .dx-icon-column-chooser {
-        .dx-icon-columnchooser;
+        .dx-icon(columnchooser);
         .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
     }
 
     .dx-@{widgetName}-addrow-button {
         .dx-icon-edit-button-addrow {
-            .dx-icon-add;
+            .dx-icon(add);
             .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
         }
     }
 
     .dx-@{widgetName}-cancel-button {
         .dx-icon-edit-button-cancel {
-            .dx-icon-revert;
+            .dx-icon(revert);
             .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
         }
     }
 
     .dx-@{widgetName}-save-button {
         .dx-icon-edit-button-save {
-            .dx-icon-save;
+            .dx-icon(save);
             .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
         }
     }
 
     .dx-apply-button {
         .dx-icon-apply-filter {
-            .dx-icon-filter;
+            .dx-icon(filter);
             .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
         }
     }
 
     .dx-@{widgetName}-export-button {
         .dx-icon-export-to {
-            .dx-icon-export;
+            .dx-icon(export);
             .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
         }
 
         .dx-icon-export-excel-button {
-            .dx-icon-xlsxfile;
+            .dx-icon(xlsxfile);
             .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
         }
     }

--- a/styles/widgets/generic/list.generic.less
+++ b/styles/widgets/generic/list.generic.less
@@ -52,7 +52,7 @@
         transform: rotate(0);
     }
 
-    .dx-icon-chevronnext;
+    .dx-icon(chevronnext);
     .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE);
 
     margin-left: -5px;
@@ -319,7 +319,7 @@
         }
 
         .dx-list-reorder-handle {
-            .dx-icon-dragvertical;
+            .dx-icon(dragvertical);
             .dx-icon-sizing(@GENERIC_BASE_ICON_SIZE, @GENERIC_BASE_ICON_SIZE * 1.6);
         }
     }

--- a/styles/widgets/generic/lookup.generic.less
+++ b/styles/widgets/generic/lookup.generic.less
@@ -66,7 +66,7 @@
 }
 
 .dx-lookup-arrow {
-    .dx-icon-spinnext;
+    .dx-icon(spinnext);
 
     width: @GENERIC_BASE_INLINE_BORDEREDWIDGET_INNER_SIZE;
     color: @lookup-icon-color;

--- a/styles/widgets/generic/menu.generic.less
+++ b/styles/widgets/generic/menu.generic.less
@@ -46,14 +46,14 @@
 
     .dx-menu-horizontal {
         .dx-menu-item-popout {
-            .dx-icon-spindown;
+            .dx-icon(spindown);
             .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
         }
     }
 
     .dx-menu-vertical {
         .dx-menu-item-popout {
-            .dx-icon-spinright;
+            .dx-icon(spinright);
             .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
         }
     }

--- a/styles/widgets/generic/numberBox.generic.less
+++ b/styles/widgets/generic/numberBox.generic.less
@@ -21,13 +21,13 @@
 }
 
 .dx-numberbox-spin-up-icon {
-    .dx-icon-spinup;
+    .dx-icon(spinup);
 
     color: @numberbox-spin-icon-color;
 }
 
 .dx-numberbox-spin-down-icon {
-    .dx-icon-spindown;
+    .dx-icon(spindown);
 
     color: @numberbox-spin-icon-color;
 }

--- a/styles/widgets/generic/pager.generic.less
+++ b/styles/widgets/generic/pager.generic.less
@@ -60,11 +60,11 @@
         }
 
         .dx-prev-button {
-            .dx-icon-chevronleft;
+            .dx-icon(chevronleft);
         }
 
         .dx-next-button {
-            .dx-icon-chevronright;
+            .dx-icon(chevronright);
         }
 
         .dx-prev-button,

--- a/styles/widgets/generic/pivotGrid.generic.less
+++ b/styles/widgets/generic/pivotGrid.generic.less
@@ -28,7 +28,7 @@
     }
 
     .dx-expand-icon-container {
-        .dx-icon-spinright;
+        .dx-icon(spinright);
 
         &:before {
             visibility: hidden;
@@ -36,14 +36,14 @@
     }
 
     .dx-pivotgrid-collapsed .dx-expand {
-        .dx-icon-spinright;
+        .dx-icon(spinright);
         .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
 
         color: @pivotgrid-spin-icon-color;
     }
 
     .dx-pivotgrid-expanded .dx-expand {
-        .dx-icon-spindown;
+        .dx-icon(spindown);
         .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
 
         color: @pivotgrid-spin-icon-color;

--- a/styles/widgets/generic/textBox.generic.less
+++ b/styles/widgets/generic/textBox.generic.less
@@ -2,7 +2,7 @@
 
 .dx-searchbox {
     .dx-icon-search {
-        .dx-icon-search;
+        .dx-icon(search);
         .dx-texteditor-icon();
 
         font-size: @GENERIC_TEXTEDITOR_ICON_SIZE - 1;

--- a/styles/widgets/generic/treeList.generic.less
+++ b/styles/widgets/generic/treeList.generic.less
@@ -15,7 +15,7 @@
         position: relative;
         display: inline-block;
         width: @TREELIST_EMPTY_SPACE_WIDTH;
-        .dx-icon-spinright;
+        .dx-icon(spinright);
 
         &:before {
             visibility: hidden;
@@ -27,7 +27,7 @@
     }
 
     .dx-treelist-expanded span {
-        .dx-icon-spindown;
+        .dx-icon(spindown);
         .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
 
         cursor: pointer;
@@ -40,7 +40,7 @@
     }
 
     .dx-treelist-collapsed span {
-        .dx-icon-spinright;
+        .dx-icon(spinright);
         .dx-icon-font-centered-sizing(@GENERIC_BASE_ICON_SIZE);
 
         cursor: pointer;

--- a/styles/widgets/generic/treeView.generic.less
+++ b/styles/widgets/generic/treeView.generic.less
@@ -201,7 +201,7 @@
 }
 
 .dx-treeview-toggle-item-visibility {
-    .dx-icon-spinright;
+    .dx-icon(spinright);
     .dx-icon-font-centered-sizing(@GENERIC_TREEVIEW_ARROW_ICON_SIZE);
 
     color: @treeview-spin-icon-color;
@@ -211,7 +211,7 @@
     left: @GENERIC_TREEVIEW_TOGGLE_ITEM_VISIBILITY_OFFSET;
 
     &.dx-treeview-toggle-item-visibility-opened {
-        .dx-icon-spindown;
+        .dx-icon(spindown);
         .dx-icon-font-centered-sizing(@GENERIC_TREEVIEW_ARROW_ICON_SIZE);
     }
 }

--- a/styles/widgets/ios7/checkBox.ios7.less
+++ b/styles/widgets/ios7/checkBox.ios7.less
@@ -33,7 +33,7 @@
     border-radius: @IOS7_CHECKBOX_BORDER_RADIUS_ICON_SIZE;
 
     .dx-checkbox-checked & {
-        .dx-icon-check;
+        .dx-icon(check);
 
         color: @IOS7_CHECKBOX_BACKGROUND_COLOR;
         .dx-icon-font-centered-sizing(@IOS7_CHECKBOX_CHECKED_ICON_SIZE);

--- a/styles/widgets/ios7/contextMenu.ios7.less
+++ b/styles/widgets/ios7/contextMenu.ios7.less
@@ -61,7 +61,7 @@
         }
 
         .dx-menu-item-popout {
-            .dx-icon-chevronright;
+            .dx-icon(chevronright);
             .dx-icon-font-centered-sizing(@IOS7_MENU_ARROW_ICON_SIZE);
 
             .dx-rtl &,

--- a/styles/widgets/ios7/dataGrid.ios7.less
+++ b/styles/widgets/ios7/dataGrid.ios7.less
@@ -50,12 +50,12 @@
 }
 
 .dx-datagrid-group-opened {
-    .dx-icon-chevrondown;
+    .dx-icon(chevrondown);
     .dx-icon-sizing(@GRID_BASE_GROUP_COLUMN_ICONS_SIZE);
 }
 
 .dx-datagrid-group-closed {
-    .dx-icon-chevronright;
+    .dx-icon(chevronright);
     .dx-icon-sizing(@GRID_BASE_GROUP_COLUMN_ICONS_SIZE);
 }
 

--- a/styles/widgets/ios7/dropDownEditor.ios7.less
+++ b/styles/widgets/ios7/dropDownEditor.ios7.less
@@ -42,7 +42,7 @@
 }
 
 .dx-dropdowneditor-icon {
-    .dx-icon-chevrondown;
+    .dx-icon(chevrondown);
 
     .dx-icon-font-centered-sizing(16px);
 

--- a/styles/widgets/ios7/gallery.ios7.less
+++ b/styles/widgets/ios7/gallery.ios7.less
@@ -7,11 +7,11 @@
 }
 
 .dx-gallery-nav-button-prev {
-    .dx-icon-chevronleft;
+    .dx-icon(chevronleft);
 }
 
 .dx-gallery-nav-button-next {
-    .dx-icon-chevronright;
+    .dx-icon(chevronright);
 }
 
 // stylelint-disable-next-line no-duplicate-selectors

--- a/styles/widgets/ios7/gridBase.ios7.less
+++ b/styles/widgets/ios7/gridBase.ios7.less
@@ -52,12 +52,12 @@
         .dx-menu-items-container {
             .dx-menu-item {
                 .dx-icon-context-menu-sort-asc {
-                    .dx-icon-sortuptext;
+                    .dx-icon(sortuptext);
                     .dx-icon-sizing(@GRID_BASE_CONTEXT_MENU_SORT_ICON_SIZE);
                 }
 
                 .dx-icon-context-menu-sort-desc {
-                    .dx-icon-sortdowntext;
+                    .dx-icon(sortdowntext);
                     .dx-icon-sizing(@GRID_BASE_CONTEXT_MENU_SORT_ICON_SIZE);
                 }
             }
@@ -68,51 +68,51 @@
         }
 
         .dx-icon-filter-operation-equals {
-            .dx-icon-equal;
+            .dx-icon(equal);
         }
 
         .dx-icon-filter-operation-default {
-            .dx-icon-find;
+            .dx-icon(find);
         }
 
         .dx-icon-filter-operation-not-equals {
-            .dx-icon-notequal;
+            .dx-icon(notequal);
         }
 
         .dx-icon-filter-operation-less {
-            .dx-icon-less;
+            .dx-icon(less);
         }
 
         .dx-icon-filter-operation-less-equal {
-            .dx-icon-lessorequal;
+            .dx-icon(lessorequal);
         }
 
         .dx-icon-filter-operation-greater {
-            .dx-icon-greater;
+            .dx-icon(greater);
         }
 
         .dx-icon-filter-operation-greater-equal {
-            .dx-icon-greaterorequal;
+            .dx-icon(greaterorequal);
         }
 
         .dx-icon-filter-operation-contains {
-            .dx-icon-contains;
+            .dx-icon(contains);
         }
 
         .dx-icon-filter-operation-not-contains {
-            .dx-icon-doesnotcontain;
+            .dx-icon(doesnotcontain);
         }
 
         .dx-icon-filter-operation-starts-with {
-            .dx-icon-startswith;
+            .dx-icon(startswith);
         }
 
         .dx-icon-filter-operation-ends-with {
-            .dx-icon-endswith;
+            .dx-icon(endswith);
         }
 
         .dx-icon-filter-operation-between {
-            .dx-icon-range;
+            .dx-icon(range);
         }
     }
 
@@ -184,7 +184,7 @@
             .dx-closebutton {
                 float: right;
                 margin: @GRID_BASE_CELL_PADDING + 1px;
-                .dx-icon-close;
+                .dx-icon(close);
                 .dx-icon-sizing(24px);
             }
 
@@ -503,32 +503,32 @@
 
     .dx-@{widgetName}-toolbar-button {
         .dx-icon-column-chooser {
-            .dx-icon-columnchooser;
+            .dx-icon(columnchooser);
         }
 
         .dx-icon-edit-button-addrow {
-            .dx-icon-add;
+            .dx-icon(add);
         }
 
 
         .dx-icon-edit-button-cancel {
-            .dx-icon-revert;
+            .dx-icon(revert);
         }
 
         .dx-icon-edit-button-save {
-            .dx-icon-save;
+            .dx-icon(save);
         }
 
         .dx-icon-apply-filter {
-            .dx-icon-filter;
+            .dx-icon(filter);
         }
 
         .dx-icon-export-to {
-            .dx-icon-export;
+            .dx-icon(export);
         }
 
         .dx-icon-export-excel-button {
-            .dx-icon-xlsxfile;
+            .dx-icon(xlsxfile);
         }
 
         .dx-icon {

--- a/styles/widgets/ios7/list.ios7.less
+++ b/styles/widgets/ios7/list.ios7.less
@@ -242,7 +242,7 @@
     }
 
     .dx-list-reorder-handle {
-        .dx-icon-dragvertical;
+        .dx-icon(dragvertical);
         .dx-icon-font-centered-sizing(25px);
 
         position: relative;

--- a/styles/widgets/ios7/lookup.ios7.less
+++ b/styles/widgets/ios7/lookup.ios7.less
@@ -30,7 +30,7 @@
 }
 
 .dx-lookup-arrow {
-    .dx-icon-chevronnext;
+    .dx-icon(chevronnext);
     .dx-icon-font-centered-sizing(16px);
 
     font-weight: 600;

--- a/styles/widgets/ios7/numberBox.ios7.less
+++ b/styles/widgets/ios7/numberBox.ios7.less
@@ -16,11 +16,11 @@
 }
 
 .dx-numberbox-spin-up-icon {
-    .dx-icon-spinup;
+    .dx-icon(spinup);
 }
 
 .dx-numberbox-spin-down-icon {
-    .dx-icon-spindown;
+    .dx-icon(spindown);
 }
 
 .dx-numberbox-spin-up-icon,

--- a/styles/widgets/ios7/pager.ios7.less
+++ b/styles/widgets/ios7/pager.ios7.less
@@ -14,11 +14,11 @@
 
     .dx-pages {
         .dx-prev-button {
-            .dx-icon-chevronleft;
+            .dx-icon(chevronleft);
         }
 
         .dx-next-button {
-            .dx-icon-chevronright;
+            .dx-icon(chevronright);
         }
 
         .dx-prev-button,

--- a/styles/widgets/ios7/pivotGrid.ios7.less
+++ b/styles/widgets/ios7/pivotGrid.ios7.less
@@ -12,10 +12,10 @@
 }
 
 .dx-pivotgrid-collapsed .dx-expand {
-    .dx-icon-chevronright;
+    .dx-icon(chevronright);
 }
 
 
 .dx-pivotgrid-expanded .dx-expand {
-    .dx-icon-chevrondown;
+    .dx-icon(chevrondown);
 }

--- a/styles/widgets/ios7/treeList.ios7.less
+++ b/styles/widgets/ios7/treeList.ios7.less
@@ -16,7 +16,7 @@
 
 .dx-treelist-rowsview {
     .dx-treelist-empty-space {
-        .dx-icon-spinright;
+        .dx-icon(spinright);
 
         position: relative;
         display: inline-block;
@@ -29,7 +29,7 @@
     }
 
     .dx-treelist-expanded span {
-        .dx-icon-chevrondown;
+        .dx-icon(chevrondown);
         .dx-icon-font-centered-sizing(@GRID_BASE_GROUP_COLUMN_ICONS_SIZE);
 
         font-size: 0;
@@ -47,7 +47,7 @@
     }
 
     .dx-treelist-collapsed span {
-        .dx-icon-chevronright;
+        .dx-icon(chevronright);
         .dx-icon-font-centered-sizing(@GRID_BASE_GROUP_COLUMN_ICONS_SIZE);
 
         font-size: 0;

--- a/styles/widgets/ios7/treeView.ios7.less
+++ b/styles/widgets/ios7/treeView.ios7.less
@@ -97,7 +97,7 @@
 }
 
 .dx-treeview-toggle-item-visibility {
-    .dx-icon-chevronright;
+    .dx-icon(chevronright);
     .dx-icon-font-centered-sizing(@IOS7_TREEVIEW_ARROW_ICON_SIZE);
 
     width: 21px;
@@ -106,7 +106,7 @@
     left: 0;
 
     &.dx-treeview-toggle-item-visibility-opened {
-        .dx-icon-chevrondown;
+        .dx-icon(chevrondown);
     }
 }
 

--- a/styles/widgets/material/checkBox.material.less
+++ b/styles/widgets/material/checkBox.material.less
@@ -97,7 +97,7 @@
         background-color: @checkbox-bg;
         border: none;
 
-        .dx-icon-check;
+        .dx-icon(check);
         .dx-icon-font-centered-sizing(@MATERIAL_CHECKBOX_ARROW_ICON_SIZE);
     }
 

--- a/styles/widgets/material/contextMenu.material.less
+++ b/styles/widgets/material/contextMenu.material.less
@@ -27,7 +27,7 @@
 
                 .dx-menu-item-popout {
                     color: @base-icon-color;
-                    .dx-icon-spinright;
+                    .dx-icon(spinright);
                     .dx-icon-font-centered-sizing(@MATERIAL_BASE_ICON_SIZE);
                 }
             }

--- a/styles/widgets/material/dataGrid.material.less
+++ b/styles/widgets/material/dataGrid.material.less
@@ -62,14 +62,14 @@
 }
 
 .dx-datagrid-group-opened {
-    .dx-icon-chevrondown;
+    .dx-icon(chevrondown);
     .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
 
     color: @datagrid-chevron-icon-color;
 }
 
 .dx-datagrid-group-closed {
-    .dx-icon-chevronright;
+    .dx-icon(chevronright);
     .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
 
     color: @datagrid-chevron-icon-color;

--- a/styles/widgets/material/dateBox.material.less
+++ b/styles/widgets/material/dateBox.material.less
@@ -55,7 +55,7 @@
 
 .dx-datebox-calendar {
     .dx-dropdowneditor-icon {
-        .dx-icon-spindown;
+        .dx-icon(spindown);
         .dx-dropdowneditor-button-icon();
     }
 
@@ -145,7 +145,7 @@
 
 .dx-datebox-list {
     .dx-dropdowneditor-icon {
-        .dx-icon-spindown;
+        .dx-icon(spindown);
         .dx-dropdowneditor-button-icon();
     }
 }

--- a/styles/widgets/material/dropDownEditor.material.less
+++ b/styles/widgets/material/dropDownEditor.material.less
@@ -41,7 +41,7 @@
 
 .dx-dropdowneditor-icon {
     color: @dropdowneditor-icon-color;
-    .dx-icon-spindown;
+    .dx-icon(spindown);
     .dx-dropdowneditor-button-icon();
 }
 
@@ -102,7 +102,7 @@
     .dx-dropdowneditor-icon {
         color: @dropdowneditor-icon-active-color;
         opacity: 1;
-        .dx-icon-spinup;
+        .dx-icon(spinup);
         .dx-dropdowneditor-button-icon();
     }
 }

--- a/styles/widgets/material/gallery.material.less
+++ b/styles/widgets/material/gallery.material.less
@@ -51,7 +51,7 @@
     }
 
     .dx-gallery-nav-button-prev {
-        .dx-icon-chevronleft;
+        .dx-icon(chevronleft);
 
         &:after {
             left: @MATERIAL_GALLERY_BUTTON_PADDING;
@@ -65,7 +65,7 @@
     }
 
     .dx-gallery-nav-button-next {
-        .dx-icon-chevronright;
+        .dx-icon(chevronright);
 
         &:after {
             right: @MATERIAL_GALLERY_BUTTON_PADDING;

--- a/styles/widgets/material/gridBase.material.less
+++ b/styles/widgets/material/gridBase.material.less
@@ -154,12 +154,12 @@
         &.dx-context-menu {
             .dx-menu-items-container {
                 .dx-icon-context-menu-sort-asc {
-                    .dx-icon-sortuptext;
+                    .dx-icon(sortuptext);
                     .dx-icon-sizing(@MATERIAL_GRID_BASE_FILTER_ICON_SIZE - 4);
                 }
 
                 .dx-icon-context-menu-sort-desc {
-                    .dx-icon-sortdowntext;
+                    .dx-icon(sortdowntext);
                     .dx-icon-sizing(@MATERIAL_GRID_BASE_FILTER_ICON_SIZE - 4);
                 }
 
@@ -180,51 +180,51 @@
         }
 
         .dx-icon-filter-operation-equals {
-            .dx-icon-equal;
+            .dx-icon(equal);
         }
 
         .dx-icon-filter-operation-default {
-            .dx-icon-find;
+            .dx-icon(find);
         }
 
         .dx-icon-filter-operation-not-equals {
-            .dx-icon-notequal;
+            .dx-icon(notequal);
         }
 
         .dx-icon-filter-operation-less {
-            .dx-icon-less;
+            .dx-icon(less);
         }
 
         .dx-icon-filter-operation-less-equal {
-            .dx-icon-lessorequal;
+            .dx-icon(lessorequal);
         }
 
         .dx-icon-filter-operation-greater {
-            .dx-icon-greater;
+            .dx-icon(greater);
         }
 
         .dx-icon-filter-operation-greater-equal {
-            .dx-icon-greaterorequal;
+            .dx-icon(greaterorequal);
         }
 
         .dx-icon-filter-operation-contains {
-            .dx-icon-contains;
+            .dx-icon(contains);
         }
 
         .dx-icon-filter-operation-not-contains {
-            .dx-icon-doesnotcontain;
+            .dx-icon(doesnotcontain);
         }
 
         .dx-icon-filter-operation-starts-with {
-            .dx-icon-startswith;
+            .dx-icon(startswith);
         }
 
         .dx-icon-filter-operation-ends-with {
-            .dx-icon-endswith;
+            .dx-icon(endswith);
         }
 
         .dx-icon-filter-operation-between {
-            .dx-icon-range;
+            .dx-icon(range);
         }
 
         .dx-column-indicators {
@@ -281,7 +281,7 @@
             .dx-closebutton {
                 float: right;
                 margin: @MATERIAL_GRID_BASE_CELL_VERTICAL_PADDING + 2px;
-                .dx-icon-close;
+                .dx-icon(close);
                 .dx-icon-sizing(14px);
             }
 
@@ -780,45 +780,45 @@
     }
 
     .dx-icon-column-chooser {
-        .dx-icon-columnchooser;
+        .dx-icon(columnchooser);
     }
 
     .dx-@{widgetName}-addrow-button {
         .dx-icon-edit-button-addrow {
-            .dx-icon-add;
+            .dx-icon(add);
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
         }
     }
 
     .dx-@{widgetName}-cancel-button {
         .dx-icon-edit-button-cancel {
-            .dx-icon-revert;
+            .dx-icon(revert);
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
         }
     }
 
     .dx-@{widgetName}-save-button {
         .dx-icon-edit-button-save {
-            .dx-icon-save;
+            .dx-icon(save);
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
         }
     }
 
     .dx-apply-button {
         .dx-icon-apply-filter {
-            .dx-icon-filter;
+            .dx-icon(filter);
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
         }
     }
 
     .dx-@{widgetName}-export-button {
         .dx-icon-export-to {
-            .dx-icon-export;
+            .dx-icon(export);
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
         }
 
         .dx-icon-export-excel-button {
-            .dx-icon-xlsxfile;
+            .dx-icon(xlsxfile);
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
         }
     }

--- a/styles/widgets/material/list.material.less
+++ b/styles/widgets/material/list.material.less
@@ -59,7 +59,7 @@
         transform: rotate(0);
     }
 
-    .dx-icon-chevronnext;
+    .dx-icon(chevronnext);
     .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE);
 
     margin-left: -5px;
@@ -204,7 +204,7 @@
         &.dx-list-group-collapsed {
             .dx-list-group-header-indicator {
                 .dx-list-collapsible-groups & {
-                    .dx-icon-chevrondown;
+                    .dx-icon(chevrondown);
 
                     font-size: @MATERIAL_BASE_ICON_SIZE;
                 }
@@ -239,7 +239,7 @@
             color: @list-header-indicator-color;
 
             .dx-list-collapsible-groups & {
-                .dx-icon-chevronup;
+                .dx-icon(chevronup);
 
                 font-size: @MATERIAL_BASE_ICON_SIZE;
                 float: right;
@@ -420,7 +420,7 @@
         }
 
         .dx-list-reorder-handle {
-            .dx-icon-dragvertical;
+            .dx-icon(dragvertical);
 
             color: fade(@base-icon-color, 27%);
             .dx-icon-sizing(@MATERIAL_BASE_ICON_SIZE, @MATERIAL_BASE_ICON_SIZE * 1.6);
@@ -432,7 +432,7 @@
     }
 
     .dx-list-slide-menu-button-delete {
-        .dx-icon-trash;
+        .dx-icon(trash);
 
         color: @base-inverted-text-color;
         border: 1px solid @list-button-delete-shadow-color;

--- a/styles/widgets/material/lookup.material.less
+++ b/styles/widgets/material/lookup.material.less
@@ -148,7 +148,7 @@
 }
 
 .dx-lookup-arrow {
-    .dx-icon-spindown;
+    .dx-icon(spindown);
 
     width: @MATERIAL_BASE_ICON_SIZE;
     color: @lookup-icon-color;

--- a/styles/widgets/material/numberBox.material.less
+++ b/styles/widgets/material/numberBox.material.less
@@ -24,13 +24,13 @@
 }
 
 .dx-numberbox-spin-up-icon {
-    .dx-icon-spinup;
+    .dx-icon(spinup);
 
     color: @numberbox-spin-icon-color;
 }
 
 .dx-numberbox-spin-down-icon {
-    .dx-icon-spindown;
+    .dx-icon(spindown);
 
     color: @numberbox-spin-icon-color;
 }

--- a/styles/widgets/material/pager.material.less
+++ b/styles/widgets/material/pager.material.less
@@ -60,11 +60,11 @@
         }
 
         .dx-prev-button {
-            .dx-icon-chevronleft;
+            .dx-icon(chevronleft);
         }
 
         .dx-next-button {
-            .dx-icon-chevronright;
+            .dx-icon(chevronright);
         }
 
         .dx-prev-button,

--- a/styles/widgets/material/pivotGrid.material.less
+++ b/styles/widgets/material/pivotGrid.material.less
@@ -102,7 +102,7 @@
 
     .dx-expand-icon-container {
         margin: 0 10px 0 5px;
-        .dx-icon-chevronright;
+        .dx-icon(chevronright);
 
         font-size: @MATERIAL_PIVOTGRID_HEADERS_FONT_SIZE;
 
@@ -112,14 +112,14 @@
     }
 
     .dx-pivotgrid-collapsed .dx-expand {
-        .dx-icon-chevronright;
+        .dx-icon(chevronright);
         .dx-icon-font-centered-sizing(@MATERIAL_PIVOTGRID_CHEVRON_ICON_SIZE);
 
         color: @pivotgrid-chevron-icon-color;
     }
 
     .dx-pivotgrid-expanded .dx-expand {
-        .dx-icon-chevrondown;
+        .dx-icon(chevrondown);
         .dx-icon-font-centered-sizing(@MATERIAL_PIVOTGRID_CHEVRON_ICON_SIZE);
 
         color: @pivotgrid-chevron-icon-color;
@@ -139,7 +139,7 @@
     .dx-area {
         .dx-area-icon-filter {
             background: none;
-            .dx-icon-filter;
+            .dx-icon(filter);
 
             width: 14px;
             height: 14px;

--- a/styles/widgets/material/tagBox.material.less
+++ b/styles/widgets/material/tagBox.material.less
@@ -106,7 +106,7 @@
     height: 100%;
     right: @MATERIAL_TAGBOX_REMOVE_BUTTON_RIGHT;
 
-    .dx-icon-clear;
+    .dx-icon(clear);
 
     font-size: 10px;
 

--- a/styles/widgets/material/textBox.material.less
+++ b/styles/widgets/material/textBox.material.less
@@ -2,7 +2,7 @@
 
 .dx-searchbox {
     .dx-icon-search {
-        .dx-icon-search;
+        .dx-icon(search);
         .dx-texteditor-icon();
 
         &:before {

--- a/styles/widgets/material/treeList.material.less
+++ b/styles/widgets/material/treeList.material.less
@@ -14,7 +14,7 @@
         position: relative;
         top: -2px;
         display: inline-block;
-        .dx-icon-chevronup;
+        .dx-icon(chevronup);
 
         width: @TREELIST_EMPTY_SPACE_WIDTH;
 
@@ -28,7 +28,7 @@
     }
 
     .dx-treelist-expanded span {
-        .dx-icon-chevrondown;
+        .dx-icon(chevrondown);
         .dx-icon-font-centered-sizing(@MATERIAL_BASE_ICON_SIZE);
 
         cursor: pointer;
@@ -41,7 +41,7 @@
     }
 
     .dx-treelist-collapsed span {
-        .dx-icon-chevronright;
+        .dx-icon(chevronright);
         .dx-icon-font-centered-sizing(@MATERIAL_BASE_ICON_SIZE);
 
         cursor: pointer;

--- a/styles/widgets/material/treeView.material.less
+++ b/styles/widgets/material/treeView.material.less
@@ -162,7 +162,7 @@
 }
 
 .dx-treeview-toggle-item-visibility {
-    .dx-icon-chevronright;
+    .dx-icon(chevronright);
     .dx-icon-font-centered-sizing(@MATERIAL_BASE_ICON_SIZE);
 
     color: @treeview-spin-icon-color;
@@ -172,7 +172,7 @@
     left: 0;
 
     &.dx-treeview-toggle-item-visibility-opened {
-        .dx-icon-chevrondown;
+        .dx-icon(chevrondown);
         .dx-icon-font-centered-sizing(@MATERIAL_BASE_ICON_SIZE);
     }
 }


### PR DESCRIPTION
It is not possible to use a selector as mixin in sass. That's why we create .dx-icon(@icon) mixin. 
