### PR TITLE
FileManager: Fix expected and actual args order in test assertions (#10712)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/arrayProvider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/arrayProvider.tests.js
@@ -62,7 +62,7 @@ QUnit.module('Array File Provider', moduleConfig, () => {
 
         let pathInfo = [ { key: 'F1', name: 'F1' } ];
         items = this.provider.getItems(pathInfo);
-        assert.equal(3, items.length);
+        assert.equal(items.length, 3);
         assert.equal(items[0].name, 'F1.1');
         assert.notOk(items[0].hasSubDirs);
         assert.equal(items[1].name, 'F1.2');
@@ -292,14 +292,14 @@ QUnit.module('Array File Provider', moduleConfig, () => {
 
     test('delete directory', function(assert) {
         let fileItems = this.provider.getItems();
-        assert.equal('F1', fileItems[0].name);
-        assert.equal('F2', fileItems[1].name);
-        assert.equal(2, fileItems.length);
+        assert.equal(fileItems[0].name, 'F1');
+        assert.equal(fileItems[1].name, 'F2');
+        assert.equal(fileItems.length, 2);
 
         this.provider.deleteItems([ fileItems[0] ]);
         fileItems = this.provider.getItems();
-        assert.equal('F2', fileItems[0].name);
-        assert.equal(1, fileItems.length);
+        assert.equal(fileItems[0].name, 'F2');
+        assert.equal(fileItems.length, 1);
     });
 
     test('throw exception if remove unexisting directory', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
@@ -139,7 +139,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
 
         const $input = $(`.${Consts.DIALOG_CLASS} .${Consts.TEXT_EDITOR_INPUT_CLASS}`);
         assert.ok($input.has(':focus'), 'dialog\'s input element should be focused');
-        assert.equal('Untitled directory', $input.val(), 'input has default value');
+        assert.equal($input.val(), 'Untitled directory', 'input has default value');
 
         $input.val('Test 4');
         $input.trigger('change');
@@ -165,7 +165,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
 
         const $input = $(`.${Consts.DIALOG_CLASS} .${Consts.TEXT_EDITOR_INPUT_CLASS}`);
         assert.ok($input.has(':focus'), 'dialog\'s input element should be focused');
-        assert.equal('Untitled directory', $input.val(), 'input has default value');
+        assert.equal($input.val(), 'Untitled directory', 'input has default value');
 
         $input.val('Test 4');
         $input.trigger('change');

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/fileItemsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/fileItemsController.tests.js
@@ -372,11 +372,11 @@ QUnit.module('FileItemsController tests', moduleConfig, () => {
 
         this.controller.setCurrentPath('F2/F2.1')
             .then(() => {
-                assert.equal('F2/F2.1', this.controller.getCurrentPath());
+                assert.equal(this.controller.getCurrentPath(), 'F2/F2.1');
 
                 const currentDir = this.controller.getCurrentDirectory();
-                assert.equal('F2/F2.1', currentDir.fileItem.key);
-                assert.equal('F2.1', currentDir.fileItem.name);
+                assert.equal(currentDir.fileItem.key, 'F2/F2.1');
+                assert.equal(currentDir.fileItem.name, 'F2.1');
 
                 assert.notOk(currentDir.expanded);
 

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
@@ -253,7 +253,7 @@ QUnit.module('Navigation operations', moduleConfig, () => {
 
     test('change current directory by public API', function(assert) {
         const inst = this.wrapper.getInstance();
-        assert.equal('', inst.option('currentPath'));
+        assert.equal(inst.option('currentPath'), '');
 
         const that = this;
         let onCurrentDirectoryChangedCounter = 0;
@@ -265,7 +265,7 @@ QUnit.module('Navigation operations', moduleConfig, () => {
         this.clock.tick(800);
 
         assert.equal(onCurrentDirectoryChangedCounter, 1);
-        assert.equal('Folder 1/Folder 1.1', inst.option('currentPath'), 'The option \'currentPath\' was changed');
+        assert.equal(inst.option('currentPath'), 'Folder 1/Folder 1.1', 'The option \'currentPath\' was changed');
 
         const $folder1Node = that.wrapper.getFolderNode(1);
         assert.equal($folder1Node.find('span').text(), 'Folder 1');


### PR DESCRIPTION
Cherry-pick #10712.
