### PR TITLE
DOTNET_USE_POLLING_FILE_WATCHER=true (docker-ci)

### DIFF
--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -6,6 +6,7 @@ trap "echo 'Interrupted!' && kill -9 0" TERM INT
 
 export DEVEXTREME_DOCKER_CI=true
 export NUGET_PACKAGES=$PWD/dotnet_packages
+export DOTNET_USE_POLLING_FILE_WATCHER=true
 
 function run_lint {
     npm i eslint eslint-plugin-spellcheck eslint-plugin-qunit stylelint stylelint-config-standard npm-run-all babel-eslint


### PR DESCRIPTION
Got this error:
```
Application startup exception: System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached.
   at System.IO.FileSystemWatcher.StartRaisingEvents()
   at System.IO.FileSystemWatcher.StartRaisingEventsIfNotDisposed()
   at System.IO.FileSystemWatcher.set_EnableRaisingEvents(Boolean value)
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.TryEnableFileSystemWatcher()
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.CreateFileChangeToken(String filter)
   at Microsoft.AspNetCore.Mvc.RazorPages.Internal.PageActionDescriptorChangeProvider.GetChangeToken()
   at Microsoft.Extensions.Primitives.ChangeToken.OnChange(Func`1 changeTokenProducer, Action changeTokenConsumer)
   at Microsoft.AspNetCore.Mvc.Internal.ActionDescriptorCollectionProvider..ctor(IEnumerable`1 actionDescriptorProviders, IEnumerable`1 actionDescriptorChangeProviders)
--- End of stack trace from previous location where exception was thrown ---
   . . .
   at Microsoft.AspNetCore.Builder.MvcApplicationBuilderExtensions.UseMvc(IApplicationBuilder app, Action`1 configureRoutes)
   at Runner.Program.<>c__DisplayClass0_1.<Main>b__1(IApplicationBuilder app) in /drone/src/github.com/AlekseyMartynov/DevExtreme/testing/runner/Program.cs:line 49
   at Microsoft.AspNetCore.Hosting.Internal.WebHost.BuildApplication()
The configured user limit (128) on the number of inotify instances has been reached.
```

Relevant issues:
- https://github.com/dotnet/aspnetcore/issues/7531
- https://github.com/dotnet/aspnetcore/issues/8449
- https://github.com/dotnet/runtime/issues/27272

From https://github.com/aspnet/Announcements/issues/186:
> The polling file watchers are mostly used in Docker when running code from a shared volume.

This is our case (`testing/runner` runs from a volume).

Official SDK images have this flag enabled: https://github.com/dotnet/dotnet-docker/pull/428