### PR TITLE
FileManager - Add public constructor for FileManagerItem class

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/ajaxProvider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/ajaxProvider.tests.js
@@ -38,7 +38,7 @@ QUnit.module('Ajax File Provider', moduleConfig, () => {
             responseText: fileItems
         });
 
-        this.provider.getItems('')
+        this.provider.getItems()
             .done(dirs => {
                 assert.equal(dirs.length, 2);
                 assert.equal(dirs[0].name, 'F1');

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/common.tests.js
@@ -1,20 +1,8 @@
 const { test } = QUnit;
 import { getPathParts, getEscapedFileName } from 'ui/file_manager/ui.file_manager.utils';
+import { FileManagerItem } from 'ui/file_manager/file_provider/file_provider';
 
-const moduleConfig = {
-
-    beforeEach: function() {
-        this.clock = sinon.useFakeTimers();
-        this.clock.tick(400);
-    },
-
-    afterEach: function() {
-        this.clock.restore();
-    }
-
-};
-
-QUnit.module('Commands', moduleConfig, () => {
+QUnit.module('Common tests', () => {
     test('getPathParts() function must correctly separate path string', function(assert) {
         const testData = {
             'Files/Documents': ['Files', 'Documents'],
@@ -54,6 +42,38 @@ QUnit.module('Commands', moduleConfig, () => {
         };
         for(const key in testData) {
             assert.strictEqual(getEscapedFileName(key), testData[key]);
+        }
+    });
+
+    test('create FileManagerItem by public constructor', function(assert) {
+        const testData = {
+            '1': {
+                path: 'folder1',
+                isDir: true,
+                name: 'folder1',
+                key: 'folder1',
+                pathInfo: []
+            },
+            '2': {
+                path: 'folder1/file1',
+                isDir: false,
+                pathKeys: [ '7', '11' ],
+                name: 'file1',
+                key: '11',
+                pathInfo: [ { key: '7', name: 'folder1' }]
+            }
+        };
+
+        for(const key in testData) {
+            const testCase = testData[key];
+
+            const item = new FileManagerItem(testCase.path, testCase.isDir, testCase.pathKeys);
+
+            assert.strictEqual(item.name, testCase.name, `${key}: name correct`);
+            assert.strictEqual(item.key, testCase.key, `${key}: key correct`);
+            assert.strictEqual(item.isDirectory, testCase.isDir, `${key}: isDirectory correct`);
+            assert.strictEqual(item.relativeName, testCase.path, `${key}: relativeName correct`);
+            assert.deepEqual(item.pathInfo, testCase.pathInfo, `${key}: pathInfo correct`);
         }
     });
 


### PR DESCRIPTION
For the `FileManagerItem` class added implementation of the public constructor:
`constructor(path: string, isDirectory: boolean, pathKeys?: string[]) `