### PR TITLE
FileManager - Update FileSystemProviderBase.getItems() method signature

### DIFF
--- a/js/file_management/custom_provider.js
+++ b/js/file_management/custom_provider.js
@@ -35,8 +35,9 @@ class CustomFileSystemProvider extends FileSystemProviderBase {
         this._uploadChunkSize = options.uploadChunkSize;
     }
 
-    getItems(pathInfo) {
-        return this._executeActionAsDeferred(() => this._getItemsFunction(pathInfo), true)
+    getItems(parentDir) {
+        const pathInfo = parentDir.getFullPathInfo();
+        return this._executeActionAsDeferred(() => this._getItemsFunction(parentDir), true)
             .then(dataItems => this._convertDataObjectsToFileItems(dataItems, pathInfo));
     }
 

--- a/js/file_management/file_system_item.js
+++ b/js/file_management/file_system_item.js
@@ -48,8 +48,7 @@ class FileSystemItem {
     }
 
     _initialize(isDirectory) {
-        this.isDirectory = isDirectory || false;
-        this.isRoot = false;
+        this.isDirectory = !!isDirectory;
 
         this.size = 0;
         this.dateModified = new Date();
@@ -60,11 +59,19 @@ class FileSystemItem {
 
     getFullPathInfo() {
         const pathInfo = [...this.pathInfo];
-        !this.isRoot && pathInfo.push({
-            key: this.key,
-            name: this.name
-        });
+
+        if(!this.isRoot()) {
+            pathInfo.push({
+                key: this.key,
+                name: this.name
+            });
+        }
+
         return pathInfo;
+    }
+
+    isRoot() {
+        return this.path === '';
     }
 
     getExtension() {
@@ -94,14 +101,4 @@ class FileSystemItem {
     }
 }
 
-class FileSystemRootItem extends FileSystemItem {
-    constructor() {
-        super(null, 'Files', true);
-        this.key = '__dxfmroot_394CED1B-58CF-4925-A5F8-042BC0822B31_51558CB8-C170-4655-A9E0-C454ED8EA2C1';
-        this.relativeName = '';
-        this.isRoot = true;
-    }
-}
-
 module.exports = FileSystemItem;
-module.exports.FileSystemRootItem = FileSystemRootItem;

--- a/js/file_management/object_provider.js
+++ b/js/file_management/object_provider.js
@@ -53,8 +53,8 @@ class ObjectFileSystemProvider extends FileSystemProviderBase {
         this._data = initialArray || [ ];
     }
 
-    getItems(pathInfo) {
-        return this._executeActionAsDeferred(() => this._getItems(pathInfo), true);
+    getItems(parentDir) {
+        return this._executeActionAsDeferred(() => this._getItems(parentDir), true);
     }
 
     renameItem(item, name) {
@@ -274,7 +274,8 @@ class ObjectFileSystemProvider extends FileSystemProviderBase {
         return dataItems;
     }
 
-    _getItems(pathInfo) {
+    _getItems(parentDir) {
+        const pathInfo = parentDir.getFullPathInfo();
         const parentDirKey = pathInfo && pathInfo.length > 0 ? pathInfo[pathInfo.length - 1].key : null;
         let dirFileObjects = this._data;
         if(parentDirKey) {
@@ -342,7 +343,7 @@ class ObjectFileSystemProvider extends FileSystemProviderBase {
     }
 
     _updateHasSubDirs(dir) {
-        if(dir && !dir.isRoot) {
+        if(dir && !dir.isRoot()) {
             dir.hasSubDirs = this._hasSubDirs(dir.dataItem);
         }
     }
@@ -367,7 +368,7 @@ class ObjectFileSystemProvider extends FileSystemProviderBase {
     }
 
     _isFileItemExists(fileItem) {
-        return fileItem.isDirectory && fileItem.isRoot || !!this._findFileItemObj(fileItem.getFullPathInfo());
+        return fileItem.isDirectory && fileItem.isRoot() || !!this._findFileItemObj(fileItem.getFullPathInfo());
     }
 
     _createFileReader() {

--- a/js/file_management/provider_base.d.ts
+++ b/js/file_management/provider_base.d.ts
@@ -59,12 +59,12 @@ export default class FileSystemProviderBase {
     /**
      * @docid FileSystemProviderBaseMethods.getItems
      * @publicName getItems()
-     * @param1 pathInfo:object
+     * @param1 parentDirectory:FileSystemItem
      * @return Promise<Array<object>>
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    getItems(pathInfo: any): Promise<Array<any>> & JQueryPromise<Array<any>>;
+    getItems(parentDirectory: FileSystemItem): Promise<Array<any>> & JQueryPromise<Array<any>>;
 
     /**
      * @docid FileSystemProviderBaseMethods.renameItem

--- a/js/file_management/provider_base.js
+++ b/js/file_management/provider_base.js
@@ -21,23 +21,23 @@ class FileSystemProviderBase {
         this._thumbnailGetter = compileGetter(options.thumbnailExpr || 'thumbnail');
     }
 
-    getItems(pathInfo) {
+    getItems(parentDirectory) {
         return [];
     }
 
     renameItem(item, name) {
     }
 
-    createDirectory(parentFolder, name) {
+    createDirectory(parentDirectory, name) {
     }
 
     deleteItems(items) {
     }
 
-    moveItems(items, destinationFolder) {
+    moveItems(items, destinationDirectory) {
     }
 
-    copyItems(items, destinationFolder) {
+    copyItems(items, destinationDirectory) {
     }
 
     uploadFileChunk(fileData, chunksInfo, destinationDirectory) {

--- a/js/file_management/remote_provider.js
+++ b/js/file_management/remote_provider.js
@@ -22,7 +22,8 @@ class RemoteFileSystemProvider extends FileSystemProviderBase {
         this._hasSubDirsGetter = compileGetter(options.hasSubDirectoriesExpr || 'hasSubDirectories');
     }
 
-    getItems(pathInfo) {
+    getItems(parentDir) {
+        const pathInfo = parentDir.getFullPathInfo();
         return this._getEntriesByPath(pathInfo)
             .then(result => this._convertDataObjectsToFileItems(result.result, pathInfo));
     }
@@ -39,7 +40,7 @@ class RemoteFileSystemProvider extends FileSystemProviderBase {
             pathInfo: parentDir.getFullPathInfo(),
             name
         }).done(() => {
-            if(parentDir && !parentDir.isRoot) {
+            if(parentDir && !parentDir.isRoot()) {
                 parentDir.hasSubDirs = true;
             }
         });

--- a/js/ui/file_manager/file_items_controller.js
+++ b/js/ui/file_manager/file_items_controller.js
@@ -1,5 +1,5 @@
 import FileSystemProviderBase from '../../file_management/provider_base';
-import FileSystemItem, { FileSystemRootItem } from '../../file_management/file_system_item';
+import FileSystemItem from '../../file_management/file_system_item';
 import ObjectFileSystemProvider from '../../file_management/object_provider';
 import RemoteFileSystemProvider from '../../file_management/remote_provider';
 import CustomFileSystemProvider from '../../file_management/custom_provider';
@@ -11,15 +11,15 @@ import { Deferred, when } from '../../core/utils/deferred';
 import { find } from '../../core/utils/array';
 import { extend } from '../../core/utils/extend';
 
+const DEFAULT_ROOT_FILE_SYSTEM_ITEM_NAME = 'Files';
+
 export default class FileItemsController {
 
     constructor(options) {
         options = options || {};
         this._options = extend({ }, options);
 
-        const rootDirectory = this._createRootDirectory(options.rootText);
-        this._rootDirectoryInfo = this._createDirectoryInfo(rootDirectory, null);
-
+        this._rootDirectoryInfo = this._createRootDirectoryInfo(options.rootText);
         this._currentDirectoryInfo = this._rootDirectoryInfo;
 
         this._defaultIconMap = this._createDefaultIconMap();
@@ -84,7 +84,7 @@ export default class FileItemsController {
     getCurrentPath() {
         let currentPath = '';
         let directory = this.getCurrentDirectory();
-        while(directory && !directory.fileItem.isRoot) {
+        while(directory && !directory.fileItem.isRoot()) {
             const escapedName = getEscapedFileName(directory.fileItem.name);
             currentPath = pathCombine(escapedName, currentPath);
             directory = directory.parentDirectory;
@@ -133,14 +133,13 @@ export default class FileItemsController {
                 .promise();
         }
 
-        const dirKey = parentDirectoryInfo.fileItem.key;
+        const dirKey = parentDirectoryInfo.getInternalKey();
         let loadItemsDeferred = this._loadedItems[dirKey];
         if(loadItemsDeferred) {
             return loadItemsDeferred;
         }
 
-        const pathInfo = this._getPathInfo(parentDirectoryInfo);
-        loadItemsDeferred = this._getFileItems(pathInfo)
+        loadItemsDeferred = this._getFileItems(parentDirectoryInfo)
             .then(fileItems => {
                 parentDirectoryInfo.items = fileItems.map(fileItem =>
                     fileItem.isDirectory && this._createDirectoryInfo(fileItem, parentDirectoryInfo) || this._createFileInfo(fileItem, parentDirectoryInfo)
@@ -157,8 +156,8 @@ export default class FileItemsController {
         return loadItemsDeferred;
     }
 
-    _getFileItems(pathInfo) {
-        return when(this._fileProvider.getItems(pathInfo))
+    _getFileItems(parentDirectoryInfo) {
+        return when(this._fileProvider.getItems(parentDirectoryInfo.fileItem))
             .then(fileItems => this._securityController.getAllowedItems(fileItems));
     }
 
@@ -395,7 +394,7 @@ export default class FileItemsController {
     _createDirectoryInfo(fileItem, parentDirectoryInfo) {
         return extend(this._createFileInfo(fileItem, parentDirectoryInfo), {
             icon: 'folder',
-            expanded: fileItem.isRoot,
+            expanded: fileItem.isRoot(),
             items: [ ]
         });
     }
@@ -404,7 +403,13 @@ export default class FileItemsController {
         return {
             fileItem,
             parentDirectory: parentDirectoryInfo,
-            icon: this._getFileItemDefaultIcon(fileItem)
+            icon: this._getFileItemDefaultIcon(fileItem),
+            getInternalKey() {
+                return `FIK_${this.fileItem.key}`;
+            },
+            getDisplayName() {
+                return this.displayName || this.fileItem.name;
+            }
         };
     }
 
@@ -443,10 +448,12 @@ export default class FileItemsController {
         return result;
     }
 
-    _createRootDirectory(text) {
-        const root = new FileSystemRootItem();
-        root.name = text || '';
-        return root;
+    _createRootDirectoryInfo(text) {
+        const rootDirectory = new FileSystemItem(null, '', true);
+
+        const result = this._createDirectoryInfo(rootDirectory, null);
+        result.displayName = text || DEFAULT_ROOT_FILE_SYSTEM_ITEM_NAME;
+        return result;
     }
 
     _raiseSelectedDirectoryChanged(directoryInfo) {
@@ -498,7 +505,7 @@ export default class FileItemsController {
 
     _getPathInfo(directoryInfo) {
         const pathInfo = [ ];
-        for(let dirInfo = directoryInfo; dirInfo && !dirInfo.fileItem.isRoot; dirInfo = dirInfo.parentDirectory) {
+        for(let dirInfo = directoryInfo; dirInfo && !dirInfo.fileItem.isRoot(); dirInfo = dirInfo.parentDirectory) {
             pathInfo.unshift({
                 key: dirInfo.fileItem.key,
                 name: dirInfo.fileItem.name

--- a/js/ui/file_manager/ui.file_manager.breadcrumbs.js
+++ b/js/ui/file_manager/ui.file_manager.breadcrumbs.js
@@ -70,7 +70,7 @@ class FileManagerBreadcrumbs extends Widget {
 
         dirLine.forEach((dir, index) => {
             result.push({
-                text: dir.fileItem.name,
+                text: dir.getDisplayName(),
                 directory: dir,
                 isPathItem: true
             });

--- a/js/ui/file_manager/ui.file_manager.command_manager.js
+++ b/js/ui/file_manager/ui.file_manager.command_manager.js
@@ -131,7 +131,7 @@ export class FileManagerCommandManager {
         }
 
         const itemsLength = itemInfos && itemInfos.length || 0;
-        if(itemsLength === 0 || itemInfos.some(item => item.fileItem.isRoot || item.fileItem.isParentFolder)) {
+        if(itemsLength === 0 || itemInfos.some(item => item.fileItem.isRoot() || item.fileItem.isParentFolder)) {
             return false;
         }
 

--- a/js/ui/file_manager/ui.file_manager.editing.js
+++ b/js/ui/file_manager/ui.file_manager.editing.js
@@ -438,7 +438,7 @@ class FileManagerActionContext {
         this._onlyFiles = !this._actionMetadata.affectsAllItems && this._itemInfos.every(info => !info.fileItem.isDirectory);
         this._items = this._itemInfos.map(itemInfo => itemInfo.fileItem);
         this._multipleItems = this._items.length > 1;
-        this._location = directoryInfo.fileItem.name;
+        this._location = directoryInfo.getDisplayName();
 
         this._singleRequest = true;
 

--- a/js/ui/file_manager/ui.file_manager.files_tree_view.js
+++ b/js/ui/file_manager/ui.file_manager.files_tree_view.js
@@ -32,9 +32,9 @@ class FileManagerFilesTreeView extends Widget {
             rootValue: '',
             createChildren: this._onFilesTreeViewCreateSubDirectories.bind(this),
             itemTemplate: this._createFilesTreeViewItemTemplate.bind(this),
-            keyExpr: 'fileItem.key',
-            parentIdExpr: 'parentDirectory.fileItem.key',
-            displayExpr: 'fileItem.name',
+            keyExpr: 'getInternalKey',
+            parentIdExpr: 'parentDirectory.getInternalKey',
+            displayExpr: itemInfo => itemInfo.getDisplayName(),
             hasItemsExpr: 'fileItem.hasSubDirs',
             onItemClick: this._createActionByOption('onDirectoryClick'),
             onItemExpanded: e => this._onFilesTreeViewItemExpanded(e),
@@ -100,7 +100,7 @@ class FileManagerFilesTreeView extends Widget {
         const $image = getImageContainer(itemData.icon);
 
         const $text = $('<span>')
-            .text(itemData.fileItem.name)
+            .text(itemData.getDisplayName())
             .addClass(FILE_MANAGER_DIRS_TREE_ITEM_TEXT_CLASS);
 
         const $button = $('<div>');
@@ -134,7 +134,7 @@ class FileManagerFilesTreeView extends Widget {
 
     _updateFocusedElement() {
         const directoryInfo = this._getCurrentDirectory();
-        const $element = this._getItemElementByKey(directoryInfo.fileItem.key);
+        const $element = this._getItemElementByKey(directoryInfo.getInternalKey());
         if(this._$focusedElement) {
             this._$focusedElement.toggleClass(FILE_MANAGER_DIRS_TREE_FOCUSED_ITEM_CLASS, false);
         }
@@ -201,7 +201,7 @@ class FileManagerFilesTreeView extends Widget {
         if(!directoryInfo || directoryInfo.items.length === 0) {
             return deferred.reject().promise();
         }
-        const treeViewNode = this._filesTreeView._dataAdapter.getNodeByKey(directoryInfo.fileItem.key);
+        const treeViewNode = this._filesTreeView._dataAdapter.getNodeByKey(directoryInfo.getInternalKey());
         if(!treeViewNode) {
             return deferred.reject().promise();
         }
@@ -210,7 +210,7 @@ class FileManagerFilesTreeView extends Widget {
         }
 
         treeViewNode.expandedDeferred = deferred;
-        this._filesTreeView.expandItem(directoryInfo.fileItem.key);
+        this._filesTreeView.expandItem(directoryInfo.getInternalKey());
         return deferred.promise();
     }
 

--- a/js/ui/file_manager/ui.file_manager.js
+++ b/js/ui/file_manager/ui.file_manager.js
@@ -302,7 +302,7 @@ class FileManager extends Widget {
             ? this._controller.getDirectoryContents(selectedDir)
             : this._controller.getFiles(selectedDir);
 
-        if(this.option('itemView.showParentFolder') && !selectedDir.fileItem.isRoot) {
+        if(this.option('itemView.showParentFolder') && !selectedDir.fileItem.isRoot()) {
             const parentDirItem = selectedDir.fileItem.createClone();
             parentDirItem.isParentFolder = true;
             parentDirItem.name = '..';

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/customProvider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/customProvider.tests.js
@@ -32,11 +32,13 @@ QUnit.module('Custom file provider', moduleConfig, () => {
     test('get directory file items', function(assert) {
         const done = assert.async();
 
-        this.provider.getItems(filesPathInfo)
+        const filesDir = new FileSystemItem('Root/Files', true);
+
+        this.provider.getItems(filesDir)
             .done(items => {
                 assert.deepEqual(items, fileSystemItems, 'items acquired');
                 assert.strictEqual(this.options.getItems.callCount, 1, 'getItems called once');
-                assert.deepEqual(this.options.getItems.args[0][0], filesPathInfo, 'getItems arguments are valid');
+                assert.deepEqual(this.options.getItems.args[0][0], filesDir, 'getItems arguments are valid');
                 done();
             });
     });

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/fileItemsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/fileItemsController.tests.js
@@ -490,14 +490,19 @@ QUnit.module('FileItemsController tests', moduleConfig, () => {
         this.clock.tick(100);
     });
 
-    test('root direcotry key is unique', function(assert) {
+    test('root directory object has valid properties', function(assert) {
         const rootDir = this.controller.getCurrentDirectory();
-        const rootKey = rootDir.fileItem.key;
+        const rootItem = rootDir.fileItem;
 
-        assert.ok(isString(rootKey), 'root key has type of string');
-        assert.ok(rootKey.length > 10, 'root key contains many characters');
-        assert.strictEqual(rootKey.indexOf('Files'), -1, 'root key doesn\'t contain root directory name');
-        assert.strictEqual(rootKey.indexOf('__dxfmroot_'), 0, 'root key starts with internal prefix');
+        assert.strictEqual(rootItem.key, '', 'root key is empty string');
+        assert.strictEqual(rootItem.path, '', 'root path is empty string');
+        assert.strictEqual(rootItem.name, '', 'root name is empty string');
+        assert.strictEqual(rootDir.getDisplayName(), 'Files', 'root info name has default value');
+
+        assert.ok(isString(rootDir.getInternalKey()), 'root info key has type of string');
+        assert.ok(rootDir.getInternalKey(), 'root info key is not empty');
+
+        assert.ok(rootItem.isRoot(), 'root has root flag');
     });
 
 });

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
@@ -240,7 +240,7 @@ QUnit.module('Navigation operations', moduleConfig, () => {
         let dir = inst.getCurrentDirectory();
         assert.strictEqual(dir.relativeName, '', 'directory has empty relative name');
         assert.ok(dir.isDirectory, 'directory has directory flag');
-        assert.ok(dir.isRoot, 'directory has root flag');
+        assert.ok(dir.isRoot(), 'directory has root flag');
 
         inst.option('currentPath', 'Folder 1/Folder 1.1');
         this.clock.tick(800);
@@ -248,7 +248,7 @@ QUnit.module('Navigation operations', moduleConfig, () => {
         dir = inst.getCurrentDirectory();
         assert.strictEqual(dir.relativeName, 'Folder 1/Folder 1.1', 'directory has correct relative name');
         assert.ok(dir.isDirectory, 'directory has directory flag');
-        assert.notOk(dir.isRoot, 'directory has not root flag');
+        assert.notOk(dir.isRoot(), 'directory has not root flag');
     });
 
     test('change current directory by public API', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/remoteProvider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/remoteProvider.tests.js
@@ -40,12 +40,9 @@ QUnit.module('Remote Provider', moduleConfig, () => {
             callback: request => assert.equal(request.method, 'GET')
         });
 
-        const pathInfo = [
-            { key: 'Root', name: 'Root' },
-            { key: 'Root/Files', name: 'Files' }
-        ];
+        const filesDir = new FileSystemItem('Root/Files', true);
 
-        this.provider.getItems(pathInfo)
+        this.provider.getItems(filesDir)
             .done(folders => {
                 assert.deepEqual(folders, fileSystemItems, 'folders received');
                 done();

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1748,7 +1748,7 @@ declare module DevExpress.fileManagement {
         /** @name FileSystemProviderBase.downloadItems() */
         downloadItems(items: Array<FileSystemItem>): any;
         /** @name FileSystemProviderBase.getItems() */
-        getItems(pathInfo: any): Promise<Array<any>> & JQueryPromise<Array<any>>;
+        getItems(parentDirectory: FileSystemItem): Promise<Array<any>> & JQueryPromise<Array<any>>;
         /** @name FileSystemProviderBase.getItemsContent() */
         getItemsContent(items: Array<FileSystemItem>): Promise<any> & JQueryPromise<any>;
         /** @name FileSystemProviderBase.moveItems() */


### PR DESCRIPTION
Updated from:
`FileSystemProviderBase.getItems(pathInfo: object)`
to
`getItems(parentDirectory: FileSystemItem)`
