### PR TITLE
ASP.NET: warning about the alternate template syntax

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -71,7 +71,7 @@
 
             if(warnBug17028 && chunks.length > 1) {
                 if(text.indexOf(OPEN_TAG) > -1) {
-                    console.logger.warn('Please use the alternate template syntax: https://community.devexpress.com/blogs/aspnet/archive/2020/01/29/asp-net-core-new-syntax-to-fix-razor-issue.aspx');
+                    console.logger.warn('Please use an alternative template syntax: https://community.devexpress.com/blogs/aspnet/archive/2020/01/29/asp-net-core-new-syntax-to-fix-razor-issue.aspx');
                     warnBug17028 = false;
                 }
             }

--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -12,7 +12,8 @@
                 require('./core/utils/iterator'),
                 require('./core/utils/dom').extractTemplateMarkup,
                 require('./core/utils/string').encodeHtml,
-                require('./core/utils/ajax')
+                require('./core/utils/ajax'),
+                require('./core/utils/console')
             );
         });
     } else {
@@ -25,13 +26,15 @@
             DevExpress.utils.iterator,
             DevExpress.utils.dom.extractTemplateMarkup,
             DevExpress.utils.string.encodeHtml,
-            DevExpress.utils.ajax
+            DevExpress.utils.ajax,
+            DevExpress.utils.console
         );
     }
-})(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils, extractTemplateMarkup, encodeHtml, ajax) {
+})(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils, extractTemplateMarkup, encodeHtml, ajax, console) {
     var templateCompiler = createTemplateCompiler();
     var pendingCreateComponentRoutines = [ ];
     var enableAlternateTemplateTags = true;
+    var warnBug17028 = false;
 
     function createTemplateCompiler() {
         var OPEN_TAG = '<%',
@@ -65,6 +68,13 @@
         return function(text) {
             var bag = ['var _ = [];', 'with(obj||{}) {'],
                 chunks = text.split(enableAlternateTemplateTags ? EXTENDED_OPEN_TAG : OPEN_TAG);
+
+            if(warnBug17028 && chunks.length > 1) {
+                if(text.indexOf(OPEN_TAG) > -1) {
+                    console.logger.warn('Please use the alternate template syntax: https://community.devexpress.com/blogs/aspnet/archive/2020/01/29/asp-net-core-new-syntax-to-fix-razor-issue.aspx');
+                    warnBug17028 = false;
+                }
+            }
 
             acceptText(bag, chunks.shift());
 
@@ -175,6 +185,10 @@
 
         enableAlternateTemplateTags: function(value) {
             enableAlternateTemplateTags = value;
+        },
+
+        warnBug17028: function() {
+            warnBug17028 = true;
         },
 
         createValidationSummaryItems: function(validationGroup, editorNames) {

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -538,7 +538,7 @@
             [1, 2].forEach(i => $('#widget' + i).dxButton({ template: $('#template1') }));
 
             assert.equal(spy.callCount, 1);
-            assert.ok(spy.args[0][0].indexOf('alternate template syntax') > -1);
+            assert.ok(spy.args[0][0].indexOf('alternative template syntax') > -1);
         } finally {
             setTemplateEngine('default');
             spy.restore();

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -525,10 +525,9 @@
 
     QUnit.test('Warn https://github.com/dotnet/aspnetcore/issues/17028', function(assert) {
         aspnet.setTemplateEngine();
+        const spy = sinon.spy(console.logger, 'warn');
         try {
             aspnet.warnBug17028();
-
-            const spy = sinon.spy(console.logger, 'warn');
 
             $('#qunit-fixture').html(`
                 <div id=widget1></div>
@@ -542,6 +541,7 @@
             assert.ok(spy.args[0][0].indexOf('alternate template syntax') > -1);
         } finally {
             setTemplateEngine('default');
+            spy.restore();
         }
     });
 


### PR DESCRIPTION
In ASP.NET Core 3 environment, we'll generate `DevExpress.aspnet.warnBug17028()` to print a single console warning on the first use of `<% ... %>`. 

Issue details:
- https://github.com/dotnet/aspnetcore/issues/17028
- https://community.devexpress.com/blogs/aspnet/archive/2020/01/29/asp-net-core-new-syntax-to-fix-razor-issue.aspx

@MargaritaLoseva please validate the warning text.