### PR TITLE
CI: QUnit runner watchdog

### DIFF
--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -201,11 +201,12 @@ function start_runner_watchdog {
     while true; do
         [ -f "$PWD/testing/Results.xml" ] && break;
 
-        sleep 300
+        sleep 10
 
         if [ ! -f $last_suite_time_file ] || [ $(cat $last_suite_time_file) == $last_suite_time ]; then
             echo "Runner stalled"
             kill -TERM $$
+            break
         fi
 
         last_suite_time=$(cat $last_suite_time_file)

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -204,9 +204,9 @@ function start_runner_watchdog {
         if [ ! -f $last_suite_time_file ] || [ $(cat $last_suite_time_file) == $last_suite_time ]; then
             echo "Runner stalled"
             kill -9 $1
+        else
+            last_suite_time=$(cat $last_suite_time_file)
         fi
-
-        last_suite_time=$(cat $last_suite_time_file)
     done &
 }
 

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -199,14 +199,11 @@ function start_runner_watchdog {
     local last_suite_time=unknown
 
     while true; do
-        [ -f "$PWD/testing/Results.xml" ] && break;
-
         sleep 10
 
         if [ ! -f $last_suite_time_file ] || [ $(cat $last_suite_time_file) == $last_suite_time ]; then
             echo "Runner stalled"
             kill -9 $1
-            break
         fi
 
         last_suite_time=$(cat $last_suite_time_file)

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -161,7 +161,7 @@ function run_test {
 
     esac
 
-    start_runner_watchdog
+    start_runner_watchdog $runner_pid
     wait $runner_pid || runner_result=1
     exit $runner_result
 }
@@ -205,7 +205,7 @@ function start_runner_watchdog {
 
         if [ ! -f $last_suite_time_file ] || [ $(cat $last_suite_time_file) == $last_suite_time ]; then
             echo "Runner stalled"
-            kill -TERM $$
+            kill -9 $1
             break
         fi
 

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -199,7 +199,7 @@ function start_runner_watchdog {
     local last_suite_time=unknown
 
     while true; do
-        sleep 10
+        sleep 300
 
         if [ ! -f $last_suite_time_file ] || [ $(cat $last_suite_time_file) == $last_suite_time ]; then
             echo "Runner stalled"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "string-replace-loader": "^2.1.1",
     "stylelint": "9.9.0",
     "stylelint-config-standard": "^18.3.0",
-    "systemjs": "6.2.2",
+    "systemjs": "<=0.19.41",
     "systemjs-plugin-babel": "0.0.25",
     "systemjs-plugin-css": "0.1.33",
     "systemjs-plugin-json": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "string-replace-loader": "^2.1.1",
     "stylelint": "9.9.0",
     "stylelint-config-standard": "^18.3.0",
-    "systemjs": "<=0.19.41",
+    "systemjs": "6.2.2",
     "systemjs-plugin-babel": "0.0.25",
     "systemjs-plugin-css": "0.1.33",
     "systemjs-plugin-json": "0.2.2",

--- a/testing/runner/Controllers/MainController.cs
+++ b/testing/runner/Controllers/MainController.cs
@@ -112,6 +112,9 @@ namespace Runner.Controllers
                 }
                 Console.ResetColor();
                 Console.WriteLine("] " + name);
+
+                if (_runFlags.IsContinuousIntegration)
+                    IOFile.WriteAllText(Path.Combine(_env.ContentRootPath, "testing/LastSuiteTime.txt"), DateTime.Now.ToString("s"));
             }
         }
 


### PR DESCRIPTION
Inspired by timeouts of https://github.com/San4es/DevExtreme/pull/45

Watchdog will bite the runner process if no 'suite finalized' notification is received for too long:
![killbill](https://user-images.githubusercontent.com/4426185/74056252-b1ac6500-49f2-11ea-992f-2812befb65b0.png)

Which timeout do you think we need? 5 min? 10 min?