### PR TITLE
Don't build all themes in TEST_CI mode

### DIFF
--- a/build/gulp/style-compiler.js
+++ b/build/gulp/style-compiler.js
@@ -20,6 +20,15 @@ const autoPrefix = new LessAutoPrefix({ browsers: browsersList });
 const cssArtifactsPath = path.join(process.cwd(), 'artifacts', 'css');
 const commentsRegex = /\s*\/\*[\S\s]*?\*\//g;
 
+const DEFAULT_DEV_BUNDLE_NAMES = [
+    'common',
+    'light',
+    'material.blue.light',
+    'ios7.default'
+];
+
+const getBundleSourcePath = name => `styles/bundles/dx.${name}.less`;
+
 const compileBundles = (bundles) => {
     const paths = path.join(process.cwd(), 'styles');
 
@@ -49,16 +58,12 @@ gulp.task('copy-fonts-and-icons', () => {
 });
 
 gulp.task('style-compiler-themes', gulp.parallel(
-    () => compileBundles('styles/bundles/*.less'),
+    () => compileBundles(getBundleSourcePath('*')),
     'copy-fonts-and-icons'
 ));
 
 gulp.task('style-compiler-themes-ci', gulp.parallel(
-    () => compileBundles([
-        'styles/bundles/dx.common.less',
-        'styles/bundles/dx.light.less',
-        'styles/bundles/dx.material.blue.light.less',
-    ]),
+    () => compileBundles(DEFAULT_DEV_BUNDLE_NAMES.map(getBundleSourcePath)),
     'copy-fonts-and-icons'
 ));
 
@@ -69,13 +74,13 @@ gulp.task('style-compiler-themes-dev', () => {
     const bundles = (
         bundlesArg
             ? bundlesArg.split(',')
-            : ['common', 'light', 'material.blue.light'])
+            : DEFAULT_DEV_BUNDLE_NAMES)
         .map((bundle) => {
-            const bundleName = `styles/bundles/dx.${bundle}.less`;
-            if(fs.existsSync(bundleName)) {
-                return bundleName;
+            const sourcePath = getBundleSourcePath(bundle);
+            if(fs.existsSync(sourcePath)) {
+                return sourcePath;
             }
-            console.log(`${bundleName} file does not exists`);
+            console.log(`${sourcePath} file does not exists`);
             return null;
         });
 

--- a/build/gulp/style-compiler.js
+++ b/build/gulp/style-compiler.js
@@ -48,9 +48,19 @@ gulp.task('copy-fonts-and-icons', () => {
         .pipe(gulp.dest(cssArtifactsPath));
 });
 
-gulp.task('style-compiler-styles', () => compileBundles('styles/bundles/*.less'));
+gulp.task('style-compiler-themes', gulp.parallel(
+    () => compileBundles('styles/bundles/*.less'),
+    'copy-fonts-and-icons'
+));
 
-gulp.task('style-compiler-themes', gulp.parallel('style-compiler-styles', 'copy-fonts-and-icons'));
+gulp.task('style-compiler-themes-ci', gulp.parallel(
+    () => compileBundles([
+        'styles/bundles/dx.common.less',
+        'styles/bundles/dx.light.less',
+        'styles/bundles/dx.material.blue.light.less',
+    ]),
+    'copy-fonts-and-icons'
+));
 
 gulp.task('style-compiler-themes-dev', () => {
     const args = parseArguments(process.argv);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,11 +31,10 @@ if(TEST_CI) {
 }
 
 function createStyleCompilerBatch() {
-    const tasks = ['style-compiler-themes'];
-    if(!TEST_CI) {
-        tasks.push('style-compiler-tb-assets');
-    }
-    return gulp.series(tasks);
+    return gulp.series(TEST_CI
+        ? ['style-compiler-themes-ci']
+        : ['style-compiler-themes', 'style-compiler-tb-assets']
+    );
 }
 
 function createMiscBatch() {


### PR DESCRIPTION
We used to do this in the old ~good~ style-compiler: 
https://github.com/DevExpress/DevExtreme/blob/26dc16cfc6b742e0f4dc9c3e7531b7177bb039d2/build/style-compiler/LessAggregation.cs#L207

Let's revive.
