### PR TITLE
Form - fix labels width, if group container has colSpan property  (T857646)

### DIFF
--- a/js/ui/form/ui.form.js
+++ b/js/ui/form/ui.form.js
@@ -49,6 +49,7 @@ const FIELD_ITEM_LABEL_CONTENT_CLASS = 'dx-field-item-label-content';
 const FIELD_ITEM_TAB_CLASS = 'dx-field-item-tab';
 const FORM_FIELD_ITEM_COL_CLASS = 'dx-col-';
 const GROUP_COL_COUNT_CLASS = 'dx-group-colcount-';
+const GROUP_COL_COUNT_ATTR = 'group-col-count';
 const FIELD_ITEM_CONTENT_CLASS = 'dx-field-item-content';
 const FORM_VALIDATION_SUMMARY = 'dx-form-validation-summary';
 
@@ -252,20 +253,8 @@ const Form = Widget.inherit({
         });
     },
 
-    _getColCount: function($element) {
-        let index = 0;
-        let isColsExist = true;
-        let $cols;
-
-        while(isColsExist) {
-            $cols = $element.find('.' + FORM_FIELD_ITEM_COL_CLASS + index);
-            if(!$cols.length) {
-                isColsExist = false;
-            } else {
-                index++;
-            }
-        }
-        return index;
+    _getGroupColCount: function($element) {
+        return parseInt($element.attr(GROUP_COL_COUNT_ATTR));
     },
 
     _createHiddenElement: function(rootLayoutManager) {
@@ -336,7 +325,7 @@ const Form = Widget.inherit({
     },
 
     _applyLabelsWidth: function($container, excludeTabbed, inOneColumn, colCount) {
-        colCount = inOneColumn ? 1 : colCount || this._getColCount($container);
+        colCount = inOneColumn ? 1 : colCount || this._getGroupColCount($container);
         const applyLabelsOptions = {
             excludeTabbed: excludeTabbed,
             inOneColumn: inOneColumn
@@ -382,7 +371,7 @@ const Form = Widget.inherit({
 
             for(groupsColIndex = 0; groupsColIndex < this._groupsColCount.length; groupsColIndex++) {
                 $groupsByCol = this._getGroupElementsInColumn($container, colIndex, this._groupsColCount[groupsColIndex]);
-                const groupColCount = this._getColCount($groupsByCol);
+                const groupColCount = this._getGroupColCount($groupsByCol);
 
                 for(groupColIndex = 1; groupColIndex < groupColCount; groupColIndex++) {
                     this._applyLabelsWidthByCol($groupsByCol, groupColIndex, applyLabelsOptions);
@@ -699,6 +688,7 @@ const Form = Widget.inherit({
                 this._groupsColCount.push(colCount);
             }
             $group.addClass(GROUP_COL_COUNT_CLASS + colCount);
+            $group.attr(GROUP_COL_COUNT_ATTR, colCount);
         }
     },
 

--- a/testing/helpers/FormLayoutTestWrapper.js
+++ b/testing/helpers/FormLayoutTestWrapper.js
@@ -1,0 +1,41 @@
+import $ from 'jquery';
+
+class FormLayoutTestWrapper {
+    constructor(colCount, options, items) {
+        const wrapperOptions = $.extend({}, options, {
+            width: 1000,
+            screenByWidth: () => {
+                return 'md';
+            },
+            colCountByScreen: {
+                md: colCount
+            },
+            items
+        });
+
+        const $form = $('#form').dxForm(wrapperOptions);
+        $form.find('*').css('font-family', 'Helvetica');
+
+        this.epsilon = 3.5;
+        this.$form = $form;
+    }
+
+    checkFormSize(expectedWidth, expectedHeight) {
+        const elementRect = this.$form.get(0).getBoundingClientRect();
+        QUnit.assert.roughEqual(elementRect.width, expectedWidth, this.epsilon, 'form width');
+        QUnit.assert.roughEqual(elementRect.height, expectedHeight, this.epsilon, 'form height');
+    }
+
+    checkElementPosition($element, expectedTop, expectedLeft, expectedWidth, expectedHeight) {
+        const elementRect = $element.get(0).getBoundingClientRect();
+        const containerRect = this.$form.get(0).getBoundingClientRect();
+
+        QUnit.assert.roughEqual(elementRect.top - containerRect.top, expectedTop, this.epsilon, 'top element offset');
+        QUnit.assert.roughEqual(elementRect.left - containerRect.left, expectedLeft, this.epsilon, 'left element offset');
+
+        QUnit.assert.roughEqual(elementRect.width, expectedWidth, this.epsilon, 'element width');
+        QUnit.assert.roughEqual(elementRect.height, expectedHeight, this.epsilon, 'element height');
+    }
+}
+
+export default FormLayoutTestWrapper;

--- a/testing/tests/DevExpress.ui.widgets.form/form.materialTheme.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.materialTheme.tests.js
@@ -5,6 +5,7 @@ import 'ui/form/ui.form';
 
 import 'common.css!';
 import 'material_blue_light.css!';
+import FormLayoutTestWrapper from '../../helpers/FormLayoutTestWrapper.js';
 
 QUnit.testStart(function() {
     const markup = '<div id="form"></div>';
@@ -12,38 +13,7 @@ QUnit.testStart(function() {
 });
 
 QUnit.module('Form scenarios', () => {
-    function createForm(colCount, items) {
-        const $form = $('#form').dxForm({
-            width: 1000,
-            screenByWidth: () => {
-                return 'xs';
-            },
-            colCountByScreen: {
-                xs: colCount
-            },
-            items
-        });
-
-        $form.find('*').css('font-family', 'Helvetica');
-
-        return $form;
-    }
-
-    function checkPosition($container, $element, expected) {
-        const elementRect = $element.get(0).getBoundingClientRect();
-
-        const epsilon = 0.1;
-        if($container != null) {
-            const containerRect = $container.get(0).getBoundingClientRect();
-            QUnit.assert.roughEqual(elementRect.top - containerRect.top, expected.top, epsilon, 'top element offset');
-            QUnit.assert.roughEqual(elementRect.left - containerRect.left, expected.left, epsilon, 'left element offset');
-        }
-
-        QUnit.assert.roughEqual(elementRect.width, expected.width, epsilon, 'element width');
-        QUnit.assert.roughEqual(elementRect.height, expected.height, epsilon, 'element height');
-    }
-
-    function testOrSkip(name, callback) {
+    function testChromeOnly(name, callback) {
         if(!browser.chrome) {
             return;
         }
@@ -51,32 +21,33 @@ QUnit.module('Form scenarios', () => {
         QUnit.test(name, callback);
     }
 
-    testOrSkip('1 column -> [item1]', function(assert) {
-        const $form = createForm(1, ['item1']);
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 75 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 1000, height: 31 });
+    testChromeOnly('1 column -> [item1]', function(assert) {
+        const wrapper = new FormLayoutTestWrapper(1, {}, ['item1']);
+        wrapper.checkFormSize(1000, 75);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 1000, 31);
     });
 
     function test_1Column_2ItemsLayout(items) {
-        const $form = createForm(1, items);
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 1000, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 85, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 119, left: 0, width: 1000, height: 31 });
+        const wrapper = new FormLayoutTestWrapper(1, {}, items);
+        wrapper.checkFormSize(1000, 160);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 1000, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 85, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 119, 0, 1000, 31);
     }
 
-    testOrSkip('1 column -> [item1, item2]', function(assert) {
+    testChromeOnly('1 column -> [item1, item2]', function(assert) {
         test_1Column_2ItemsLayout(['item1', 'item2']);
     });
 
-    testOrSkip('1 column -> [item1, { group [{ item2 }] ]', function(assert) {
+    testChromeOnly('1 column -> [item1, { group [{ item2 }] ]', function(assert) {
         test_1Column_2ItemsLayout([
             'item1',
             { itemType: 'group', items: ['item2'] }]);
     });
 
-    testOrSkip('1 column -> [item1, { group [{ group [{ item2 }] }] ]', function(assert) {
+    testChromeOnly('1 column -> [item1, { group [{ group [{ item2 }] }] ]', function(assert) {
         test_1Column_2ItemsLayout([
             'item1',
             { itemType: 'group', items: [{ itemType: 'group', items: ['item2'] }] }
@@ -84,21 +55,21 @@ QUnit.module('Form scenarios', () => {
     });
 
     function test_1Column_3ItemsLayout(items) {
-        const $form = createForm(1, items);
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 245 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 1000, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 85, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 119, left: 0, width: 1000, height: 31 });
-        checkPosition($form, $form.find('[for$="item3"]'), { top: 170, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item3"]'), { top: 204, left: 0, width: 1000, height: 31 });
+        const wrapper = new FormLayoutTestWrapper(1, {}, items);
+        wrapper.checkFormSize(1000, 245);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 1000, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 85, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 119, 0, 1000, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item3"]'), 170, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item3"]'), 204, 0, 1000, 31);
     }
 
-    testOrSkip('1 column -> [item1, item2, item3]', function(assert) {
+    testChromeOnly('1 column -> [item1, item2, item3]', function(assert) {
         test_1Column_3ItemsLayout(['item1', 'item2', 'item3']);
     });
 
-    testOrSkip('1 column -> [item1, { group [{ group [{ item2 }] }], item3]', function(assert) {
+    testChromeOnly('1 column -> [item1, { group [{ group [{ item2 }] }], item3]', function(assert) {
         test_1Column_3ItemsLayout([
             'item1',
             { itemType: 'group', items: [{ itemType: 'group', items: ['item2'] }] },
@@ -106,7 +77,7 @@ QUnit.module('Form scenarios', () => {
         ]);
     });
 
-    testOrSkip('1 column -> [item1, { group [{ group [{ group [{item2 }] }] }], item3]', function(assert) {
+    testChromeOnly('1 column -> [item1, { group [{ group [{ group [{item2 }] }] }], item3]', function(assert) {
         test_1Column_3ItemsLayout([
             'item1',
             { itemType: 'group', items: [{ itemType: 'group', items: [{ itemType: 'group', items: ['item2'] }] }] },
@@ -114,8 +85,8 @@ QUnit.module('Form scenarios', () => {
         ]);
     });
 
-    testOrSkip('1 column -> [item1, { group [{ tabbed [{ item2 }] }] }]', function(assert) {
-        const $form = createForm(1, [
+    testChromeOnly('1 column -> [item1, { group [{ tabbed [{ item2 }] }] }]', function(assert) {
+        const wrapper = new FormLayoutTestWrapper(1, {}, [
             'item1',
             { itemType: 'group', caption: 'Contact Information',
                 items: [ { itemType: 'tabbed',
@@ -123,15 +94,15 @@ QUnit.module('Form scenarios', () => {
                     tabs: [ { title: 'item2', items: ['item2'] }]
                 }]
             }]);
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 320 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 1000, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 205, left: 20, width: 960, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 239, left: 20, width: 960, height: 31 });
+        wrapper.checkFormSize(1000, 320);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 1000, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 205, 20, 960, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 239, 20, 960, 31);
     });
 
-    testOrSkip('1 column -> [item1, { group [{ tabbed [{ item2 }] }] }, item3]', function(assert) {
-        const $form = createForm(1, [
+    testChromeOnly('1 column -> [item1, { group [{ tabbed [{ item2 }] }] }, item3]', function(assert) {
+        const wrapper = new FormLayoutTestWrapper(1, {}, [
             'item1',
             {
                 itemType: 'group',
@@ -149,50 +120,50 @@ QUnit.module('Form scenarios', () => {
             },
             'item3']);
 
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 405 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 1000, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 205, left: 20, width: 960, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 239, left: 20, width: 960, height: 31 });
-        checkPosition($form, $form.find('[for$="item3"]'), { top: 330, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item3"]'), { top: 364, left: 0, width: 1000, height: 31 });
+        wrapper.checkFormSize(1000, 405);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 1000, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 205, 20, 960, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 239, 20, 960, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item3"]'), 330, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item3"]'), 364, 0, 1000, 31);
     });
 
     function test_2Column_2ItemsLayout(items) {
-        const $form = createForm(2, items);
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 75 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 480, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 0, left: 520, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 34, left: 520, width: 480, height: 31 });
+        const wrapper = new FormLayoutTestWrapper(2, {}, items);
+        wrapper.checkFormSize(1000, 75);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 480, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 0, 520, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 34, 520, 480, 31);
     }
 
-    testOrSkip('2 columns -> [item1, item2]', function(assert) {
+    testChromeOnly('2 columns -> [item1, item2]', function(assert) {
         test_2Column_2ItemsLayout(['item1', 'item2']);
     });
 
-    testOrSkip('2 columns -> [item1, { group [{ item2 }] }]', function(assert) {
+    testChromeOnly('2 columns -> [item1, { group [{ item2 }] }]', function(assert) {
         test_2Column_2ItemsLayout([
             'item1',
             { itemType: 'group', items: ['item2'] }
         ]);
     });
 
-    testOrSkip('2 columns -> [item1, { group [{ group [{ item2 }] }] }]', function(assert) {
+    testChromeOnly('2 columns -> [item1, { group [{ group [{ item2 }] }] }]', function(assert) {
         test_2Column_2ItemsLayout([
             'item1',
             { itemType: 'group', items: [{ itemType: 'group', items: ['item2'] }] }
         ]);
     });
 
-    testOrSkip('2 columns -> [{ group [{ item1 }], { group [{ item2 }]]', function(assert) {
+    testChromeOnly('2 columns -> [{ group [{ item1 }], { group [{ item2 }]]', function(assert) {
         test_2Column_2ItemsLayout([
             { itemType: 'group', items: ['item1'] },
             { itemType: 'group', items: ['item2'] }
         ]);
     });
 
-    testOrSkip('2 columns -> [{ group [{ { group [{ item1 }] }], { group [{ { group [{ item2 }] }]]', function(assert) {
+    testChromeOnly('2 columns -> [{ group [{ { group [{ item1 }] }], { group [{ { group [{ item2 }] }]]', function(assert) {
         test_2Column_2ItemsLayout([
             { itemType: 'group', items: [{ itemType: 'group', items: ['item1'] }] },
             { itemType: 'group', items: [{ itemType: 'group', items: ['item2'] }] }
@@ -200,17 +171,17 @@ QUnit.module('Form scenarios', () => {
     });
 
     function test_2Columns_3ItemsLayout(items) {
-        const $form = createForm(2, items);
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 160 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 480, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 0, left: 520, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 34, left: 520, width: 480, height: 31 });
-        checkPosition($form, $form.find('[for$="item3"]'), { top: 85, left: 0, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item3"]'), { top: 119, left: 0, width: 480, height: 31 });
+        const wrapper = new FormLayoutTestWrapper(2, {}, items);
+        wrapper.checkFormSize(1000, 160);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 480, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 0, 520, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 34, 520, 480, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item3"]'), 85, 0, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item3"]'), 119, 0, 480, 31);
     }
 
-    testOrSkip('2 columns -> [item1, { group [{ group [{ item2 }] }], item3]', function(assert) {
+    testChromeOnly('2 columns -> [item1, { group [{ group [{ item2 }] }], item3]', function(assert) {
         test_2Columns_3ItemsLayout([
             'item1',
             { itemType: 'group', items: [{ itemType: 'group', items: ['item2'] }] },
@@ -218,7 +189,7 @@ QUnit.module('Form scenarios', () => {
         ]);
     });
 
-    testOrSkip('2 columns -> [{ group [{ { group [{ item1 }] }], { group [{ { group [{ item2 }] }], { group [{ item3 }] }]', function(assert) {
+    testChromeOnly('2 columns -> [{ group [{ { group [{ item1 }] }], { group [{ { group [{ item2 }] }], { group [{ item3 }] }]', function(assert) {
         test_2Columns_3ItemsLayout([
             { itemType: 'group', items: [{ itemType: 'group', items: ['item1'] }] },
             { itemType: 'group', items: [{ itemType: 'group', items: ['item2'] }] },
@@ -227,25 +198,25 @@ QUnit.module('Form scenarios', () => {
         ]);
     });
 
-    testOrSkip('2 columns -> [{ group [{ item1 }], { group [{ item2 }], { group colspan:3 [{ item3 }] ]', function(assert) {
-        const $form = createForm(2, [
+    testChromeOnly('2 columns -> [{ group [{ item1 }], { group [{ item2 }], { group colspan:3 [{ item3 }] ]', function(assert) {
+        const wrapper = new FormLayoutTestWrapper(2, {}, [
             { itemType: 'group', colSpan: 1, items: ['item1'] },
             { itemType: 'group', colSpan: 1, items: ['item2'] },
             { itemType: 'group', colSpan: 2, items: ['item3']
             }
         ]);
 
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 160 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 480, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 0, left: 520, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 34, left: 520, width: 480, height: 31 });
-        checkPosition($form, $form.find('[for$="item3"]'), { top: 85, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item3"]'), { top: 119, left: 0, width: 1000, height: 31 });
+        wrapper.checkFormSize(1000, 160);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 480, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 0, 520, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 34, 520, 480, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item3"]'), 85, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item3"]'), 119, 0, 1000, 31);
     });
 
-    testOrSkip('2 column -> [item1, { group [{ tabbed [{ item2 }] }] }]', function(assert) {
-        const $form = createForm(2, [
+    testChromeOnly('2 column -> [item1, { group [{ tabbed [{ item2 }] }] }]', function(assert) {
+        const wrapper = new FormLayoutTestWrapper(2, {}, [
             'item1',
             { itemType: 'group', caption: 'Contact Information',
                 items: [{
@@ -256,15 +227,15 @@ QUnit.module('Form scenarios', () => {
             }
         ]);
 
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 235 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 480, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 120, left: 540, width: 440, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 154, left: 540, width: 440, height: 31 });
+        wrapper.checkFormSize(1000, 235);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 480, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 120, 540, 440, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 154, 540, 440, 31);
     });
 
-    testOrSkip('2 column -> [item1, { group [{ tabbed [{ item2 }] }] }, item3]', function(assert) {
-        const $form = createForm(2, [
+    testChromeOnly('2 column -> [item1, { group [{ tabbed [{ item2 }] }] }, item3]', function(assert) {
+        const wrapper = new FormLayoutTestWrapper(2, {}, [
             'item1',
             { itemType: 'group', caption: 'Contact Information',
                 items: [{
@@ -275,28 +246,28 @@ QUnit.module('Form scenarios', () => {
             },
             'item3']);
 
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 320 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 480, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 120, left: 540, width: 440, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 154, left: 540, width: 440, height: 31 });
-        checkPosition($form, $form.find('[for$="item3"]'), { top: 245, left: 0, width: 480, height: 34 });
-        checkPosition($form, $form.find('[id$="item3"]'), { top: 279, left: 0, width: 480, height: 31 });
+        wrapper.checkFormSize(1000, 320);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 480, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 120, 540, 440, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 154, 540, 440, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item3"]'), 245, 0, 480, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item3"]'), 279, 0, 480, 31);
     });
 
-    testOrSkip('4 columns -> [{ group colSpan:3 [{ item1 }], { group colSpan:1 [{ item2 }], { group colspan:4 [{ item3 }] ]', function(assert) {
-        const $form = createForm(4, [
+    testChromeOnly('4 columns -> [{ group colSpan:3 [{ item1 }], { group colSpan:1 [{ item2 }], { group colspan:4 [{ item3 }] ]', function(assert) {
+        const wrapper = new FormLayoutTestWrapper(4, {}, [
             { itemType: 'group', colSpan: 3, items: ['item1'] },
             { itemType: 'group', colSpan: 1, items: ['item2'] },
             { itemType: 'group', colSpan: 4, items: ['item3'] }
         ]);
 
-        checkPosition(null, $form, { top: 0, left: 0, width: 1000, height: 160 });
-        checkPosition($form, $form.find('[for$="item1"]'), { top: 0, left: 0, width: 730, height: 34 });
-        checkPosition($form, $form.find('[id$="item1"]'), { top: 34, left: 0, width: 730, height: 31 });
-        checkPosition($form, $form.find('[for$="item2"]'), { top: 0, left: 770, width: 230, height: 34 });
-        checkPosition($form, $form.find('[id$="item2"]'), { top: 34, left: 770, width: 230, height: 31 });
-        checkPosition($form, $form.find('[for$="item3"]'), { top: 85, left: 0, width: 1000, height: 34 });
-        checkPosition($form, $form.find('[id$="item3"]'), { top: 119, left: 0, width: 1000, height: 31 });
+        wrapper.checkFormSize(1000, 160);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item1"]'), 0, 0, 730, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item1"]'), 34, 0, 730, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item2"]'), 0, 770, 230, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item2"]'), 34, 770, 230, 31);
+        wrapper.checkElementPosition(wrapper.$form.find('[for$="item3"]'), 85, 0, 1000, 34);
+        wrapper.checkElementPosition(wrapper.$form.find('[id$="item3"]'), 119, 0, 1000, 31);
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.form/form.scenarios.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.scenarios.tests.js
@@ -1601,7 +1601,7 @@ function test_3Columns_4Items_NotAlignedLabels(wrapper) {
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
                         wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
-                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 609, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 610, 34);
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
                         wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
                     }
@@ -1629,7 +1629,7 @@ function test_3Columns_4Items_NotAlignedLabels(wrapper) {
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
                         wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
-                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 609, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 610, 34);
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
                         wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
                     }
@@ -1657,7 +1657,7 @@ function test_3Columns_4Items_NotAlignedLabels(wrapper) {
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
                         wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
-                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 609, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 610, 34);
                         wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
                         wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
                     }

--- a/testing/tests/DevExpress.ui.widgets.form/form.scenarios.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.scenarios.tests.js
@@ -1,0 +1,1668 @@
+import $ from 'jquery';
+import FormLayoutTestWrapper from '../../helpers/FormLayoutTestWrapper.js';
+import browser from 'core/utils/browser';
+import 'ui/form/ui.form';
+
+import 'common.css!';
+import 'generic_light.css!';
+
+QUnit.testStart(function() {
+    const markup = '<div id="form"></div>';
+
+    $('#qunit-fixture').html(markup);
+});
+
+function test_1Column_1Item(wrapper) {
+    wrapper.checkFormSize(1000, 36);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 0, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 41, 958, 34);
+}
+
+function test_1Column_2Items_AlignedLabels(wrapper) {
+    wrapper.checkFormSize(1000, 82);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 0, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 75, 923, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 923, 34);
+}
+
+function test_1Column_2Items_NotAlignedLabels(wrapper) {
+    wrapper.checkFormSize(1000, 82);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 0, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 41, 958, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 923, 34);
+}
+
+function test_2Columns_2Items_AlignedLabels(wrapper) {
+    wrapper.checkFormSize(1000, 36);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 0, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 75, 411, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 8, 515, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 1, 588, 411, 34);
+}
+
+function test_2Columns_2Items_NotAlignedLabels(wrapper) {
+    wrapper.checkFormSize(1000, 36);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 0, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 41, 444, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 8, 515, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 1, 588, 411, 34);
+}
+
+function test_2Columns_4Items_AlignedLabels(wrapper) {
+    wrapper.checkFormSize(1000, 82);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 443, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 518, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 588, 409, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 443, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 518, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 588, 409, 34);
+}
+
+function test_2Columns_4Items_NotAlignedLabels(wrapper) {
+    wrapper.checkFormSize(1000, 82);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 457, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 518, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 554, 442, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 443, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 518, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 588, 409, 34);
+}
+
+function test_3Columns_4Items_AlignedLabels(wrapper) {
+    wrapper.checkFormSize(1000, 82);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 229, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 754, 244, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+}
+
+function test_3Columns_4Items_NotAlignedLabels(wrapper) {
+    wrapper.checkFormSize(1000, 82);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+}
+
+[true, false].forEach(alignItemLabels => {
+    [true, false].forEach(alignItemLabelsInAllGroups => {
+        QUnit.module(`Items layout and labels alignment. alignItemLabels: ${alignItemLabels}, alignItemLabelsInAllGroups: ${alignItemLabelsInAllGroups}`, () => {
+            if(!browser.chrome) {
+                return;
+            }
+
+            QUnit.test('1 column -> [text]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, ['text']);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('1 column-> [text, longText]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, ['text', 'longText']);
+                if(alignItemLabels) {
+                    test_1Column_2Items_AlignedLabels(wrapper);
+                } else {
+                    test_1Column_2Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('1 column-> [text, group[longText]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    'text',
+                    { itemType: 'group', items: ['longText'] }]);
+                test_1Column_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('1 column-> [group[text], longText]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { itemType: 'group', items: ['text'] },
+                    'longText']);
+                test_1Column_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('1 column-> [group[text], group[longText]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { itemType: 'group', items: ['text'] },
+                    { itemType: 'group', items: ['longText'] }]);
+                if(alignItemLabelsInAllGroups) {
+                    test_1Column_2Items_AlignedLabels(wrapper);
+                } else {
+                    test_1Column_2Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('1 column-> [group.alignItemLabels: false [text, longText]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { itemType: 'group', alignItemLabels: false, items: ['text', 'longText'] }]);
+                test_1Column_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('1 column-> [group.alignItemLabels: true [text, longText]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { itemType: 'group', alignItemLabels: true, items: ['text', 'longText'] }]);
+                test_1Column_2Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> form.colCount:2 [text.colSpan: 1, longText.colSpan: 1]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> form.colCount:2 [text.colSpan: 1, longText.colSpan: 2]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> form.colCount:2 [text.colSpan: 1, group.colSpan: 2[longText]]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'text', colSpan: 1 }, { itemType: 'group', colSpan: 1, items: ['longText'] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [text.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [{ dataField: 'text', colSpan: 2 }]);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [text.colSpan: 2, longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [{ dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }]);
+                test_1Column_2Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 2.colCount: 1 [text.colSpan: 1]]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 2, colCount: 1, items: [{ dataField: 'text', colSpan: 1 }] }]);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 2.colCount: 1 [text.colSpan: 2]]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 2, colCount: 1, items: [{ dataField: 'text', colSpan: 2 }] }]);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 2.colCount: 2 [text.colSpan: 2]]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 2, colCount: 2, items: [{ dataField: 'text', colSpan: 2 }] }]);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 1 [text.colSpan: 1], longText.colSpan: 1]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 1 } ]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 1 [text.colSpan: 1], group.colSpan: 1 [longText.colSpan: 1]]]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { itemType: 'group', colSpan: 1, items: [{ dataField: 'longText', colSpan: 1 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 1 [text.colSpan: 1], longText.colSpan: 1]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 1 }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 1 [text.colSpan: 2], longText.colSpan: 1]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 2 }] }, { dataField: 'longText', colSpan: 1 }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 1 [text.colSpan: 1], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 2 } ]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 1 [text.colSpan: 1], group.colSpan: 1 [longText.colSpan: 1]]]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { itemType: 'group', colSpan: 1, items: [{ dataField: 'longText', colSpan: 2 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 1 [text.colSpan: 1], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 2 }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 1 [text.colSpan: 2], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 2 }] }, { dataField: 'longText', colSpan: 2 }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 2.colCount: 1 [text.colSpan: 1], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 2, colCount: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 2 }]);
+                test_1Column_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [group.colSpan: 2.colCount: 2 [text.colSpan: 2], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups },
+                    [ { itemType: 'group', colSpan: 2, colCount: 2, items: [{ dataField: 'text', colSpan: 2 }] }, { dataField: 'longText', colSpan: 2 }]);
+                test_1Column_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [text.colSpan: 1, longText.colSpan: 1]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [text.colSpan: 1, longText.colSpan: 2]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [text.colSpan: 1, group.colSpan: 2[longText]]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'text', colSpan: 1 }, { itemType: 'group', colSpan: 1, items: ['longText'] }] }]);
+                test_2Columns_2Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [text.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'text', colSpan: 2 }] }]);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [text.colSpan: 2, longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }] }]);
+                test_1Column_2Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 2.colCount: 1 [text.colSpan: 1]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 2, colCount: 1, items: [{ dataField: 'text', colSpan: 1 }] }] }]);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 2.colCount: 1 [text.colSpan: 2]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 2, colCount: 1, items: [{ dataField: 'text', colSpan: 2 }] }] }]);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 2.colCount: 2 [text.colSpan: 2]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 2, colCount: 2, items: [{ dataField: 'text', colSpan: 2 }] }] }]);
+                test_1Column_1Item(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 1 [text.colSpan: 1], longText.colSpan: 1]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 1 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 1 [text.colSpan: 1], group.colSpan: 1 [longText.colSpan: 1]]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { itemType: 'group', colSpan: 1, items: [{ dataField: 'longText', colSpan: 1 }] }] }]);
+                if(alignItemLabelsInAllGroups) {
+                    test_2Columns_2Items_AlignedLabels(wrapper);
+                } else {
+                    test_2Columns_2Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 1 [text.colSpan: 1], longText.colSpan: 1]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 1 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 1 [text.colSpan: 2], longText.colSpan: 1]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 2 }] }, { dataField: 'longText', colSpan: 1 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 1 [text.colSpan: 1], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 2 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 1 [text.colSpan: 1], group.colSpan: 1 [longText.colSpan: 2]]]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { itemType: 'group', colSpan: 1, items: [{ dataField: 'longText', colSpan: 2 }] }] }]);
+                if(alignItemLabelsInAllGroups) {
+                    test_2Columns_2Items_AlignedLabels(wrapper);
+                } else {
+                    test_2Columns_2Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 1 [text.colSpan: 1], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 2 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 1 [text.colSpan: 2], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 1, items: [{ dataField: 'text', colSpan: 2 }] }, { dataField: 'longText', colSpan: 2 }] }]);
+                test_2Columns_2Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 2.colCount: 1 [text.colSpan: 1], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 2, colCount: 1, items: [{ dataField: 'text', colSpan: 1 }] }, { dataField: 'longText', colSpan: 2 }] }]);
+                if(alignItemLabelsInAllGroups) {
+                    test_1Column_2Items_AlignedLabels(wrapper);
+                } else {
+                    test_1Column_2Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 2.colCount: 1 [text.colSpan: 2], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 2, colCount: 1, items: [{ dataField: 'text', colSpan: 2 }] }, { dataField: 'longText', colSpan: 2 }] }]);
+                if(alignItemLabelsInAllGroups) {
+                    test_1Column_2Items_AlignedLabels(wrapper);
+                } else {
+                    test_1Column_2Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 2.colCount: 2 [text.colSpan: 2], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 2, colCount: 2, items: [{ dataField: 'text', colSpan: 2 }] }, { dataField: 'longText', colSpan: 2 }] }]);
+                if(alignItemLabelsInAllGroups) {
+                    test_1Column_2Items_AlignedLabels(wrapper);
+                } else {
+                    test_1Column_2Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('2 column-> group.colCount:2 [group.colSpan: 2.colCount: 2 [group.text], longText.colSpan: 2]', function() {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { itemType: 'group', colSpan: 2, colCount: 2, items: [
+                        { itemType: 'group', colSpan: 2, colCount: 2, items: [ { dataField: 'text', colSpan: 2 }] },
+                        { itemType: 'group', colSpan: 2, colCount: 2, items: [ { dataField: 'longText', colSpan: 2 }] }] }] }]);
+                if(alignItemLabelsInAllGroups) {
+                    test_1Column_2Items_AlignedLabels(wrapper);
+                } else {
+                    test_1Column_2Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a, abc, text, longText ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a' }, { dataField: 'abc' }, { dataField: 'text' }, { dataField: 'longText' }]);
+                if(alignItemLabels) {
+                    test_2Columns_4Items_AlignedLabels(wrapper);
+                } else {
+                    test_2Columns_4Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:1, abc.colSpan:1, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored - test_2Columns_4Items_NotAlignedLabels(wrapper);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:1, abc.colSpan:1, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }]);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored - test_2Columns_4Items_NotAlignedLabels(wrapper);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:1, abc.colSpan:1, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 128);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 555, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 923, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 409, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:1, abc.colSpan:2, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored - test_2Columns_4Items_NotAlignedLabels(wrapper);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:1, abc.colSpan:2, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }]);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored - test_2Columns_4Items_NotAlignedLabels(wrapper);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:1, abc.colSpan:2, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 128);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 75, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 409, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:1, abc.colSpan:2, text,colSpan:2, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }]);
+
+                wrapper.checkFormSize(1000, 128);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 75, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 924, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:2, abc.colSpan:1, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 128);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 923, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 409, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:2, abc.colSpan:1, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }]);
+
+                wrapper.checkFormSize(1000, 128);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 923, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 924, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:2, abc.colSpan:1, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 128);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 923, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 409, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:2, abc.colSpan:2, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 128);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 958, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 41, 958, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 100, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 93, 41, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 515, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 588, 409, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:2, abc.colSpan:2, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }]);
+
+                wrapper.checkFormSize(1000, 128);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 958, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 41, 958, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 100, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 93, 41, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 515, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 588, 409, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:2, abc.colSpan:2, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 174);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 93, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 146, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 139, 75, 409, 34);
+            });
+
+            QUnit.test('2 column -> form.colCount:2 [a.colSpan:2, abc.colSpan:2, text,colSpan:2, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(2, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }]);
+
+                wrapper.checkFormSize(1000, 174);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 93, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 146, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 139, 75, 924, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2.alignItemLabels:false  [a, abc, text, longText ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{
+                    itemType: 'group', colCount: 2, alignItemLabels: false, items: [
+                        { dataField: 'a' }, { dataField: 'abc' }, { dataField: 'text' }, { dataField: 'longText' }]
+                }]);
+                test_2Columns_4Items_NotAlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2.alignItemLabels:true  [a, abc, text, longText ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{
+                    itemType: 'group', colCount: 2, alignItemLabels: true, items: [
+                        { dataField: 'a' }, { dataField: 'abc' }, { dataField: 'text' }, { dataField: 'longText' }]
+                }]);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:1, abc.colSpan:1, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] } ]);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:1, abc.colSpan:1, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }] } ]);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:1, abc.colSpan:1, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }] } ]);
+                wrapper.checkFormSize(1000, 128);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 555, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 923, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 409, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:1, abc.colSpan:2, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] } ]);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:1, abc.colSpan:2, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }] } ]);
+                test_2Columns_4Items_AlignedLabels(wrapper);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:1, abc.colSpan:2, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }] } ]);
+                wrapper.checkFormSize(1000, 128);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 75, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 409, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:1, abc.colSpan:2, text,colSpan:2, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }] } ]);
+                wrapper.checkFormSize(1000, 128);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 75, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 924, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:2, abc.colSpan:1, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] } ]);
+                wrapper.checkFormSize(1000, 128);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 923, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 409, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:2, abc.colSpan:1, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }] } ]);
+                wrapper.checkFormSize(1000, 128);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 923, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 924, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:2, abc.colSpan:1, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }] } ]);
+                wrapper.checkFormSize(1000, 128);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 923, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 409, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 518, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 554, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 75, 409, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:2, abc.colSpan:2, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] } ]);
+                wrapper.checkFormSize(1000, 128);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 958, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 41, 958, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 100, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 93, 41, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 515, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 588, 409, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:2, abc.colSpan:2, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }] } ]);
+                wrapper.checkFormSize(1000, 128);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 958, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 41, 958, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 100, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 93, 41, 443, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 100, 515, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 93, 588, 409, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:2, abc.colSpan:2, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }] } ]);
+                wrapper.checkFormSize(1000, 174);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 93, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 146, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 139, 75, 409, 34);
+            });
+
+            QUnit.test('2 column-> group.colCount:2  [a.colSpan:2, abc.colSpan:2, text,colSpan:2, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 2, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }] } ]);
+                wrapper.checkFormSize(1000, 174);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 47, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 100, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 93, 75, 924, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 146, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 139, 75, 924, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a, abc, text, longText ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a' }, { dataField: 'abc' }, { dataField: 'text' }, { dataField: 'longText' }]);
+                if(alignItemLabels) {
+                    wrapper.checkFormSize(1000, 82);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+                } else {
+                    wrapper.checkFormSize(1000, 82);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+                }
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:1, abc.colSpan:1, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 }, { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:1, abc.colSpan:1, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 577, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:1, abc.colSpan:1, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:1, abc.colSpan:2, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 72, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 577, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:1, abc.colSpan:2, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }]);
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 72, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 577, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 577, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:1, abc.colSpan:2, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 612, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:1, abc.colSpan:2, text,colSpan:2, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 612, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:2, abc.colSpan:1, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:2, abc.colSpan:1, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 577, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:2, abc.colSpan:1, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:2, abc.colSpan:2, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }]);
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:2, abc.colSpan:2, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:2, abc.colSpan:2, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> form.colCount:3 [a.colSpan:2, abc.colSpan:2, text,colSpan:2, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(3, { alignItemLabels, alignItemLabelsInAllGroups }, [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }]);
+
+                wrapper.checkFormSize(1000, 82);
+
+                // NOTE: bug. If some item has colsPan, alignItemLabels option is ignored
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3.alignItemLabels:false [a, abc, text, longText ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{
+                    itemType: 'group', colCount: 3, alignItemLabels: false, items: [
+                        { dataField: 'a' }, { dataField: 'abc' }, { dataField: 'text' }, { dataField: 'longText' }]
+                }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3.alignItemLabels:true [a, abc, text, longText ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{
+                    itemType: 'group', colCount: 3, alignItemLabels: true, items: [
+                        { dataField: 'a' }, { dataField: 'abc' }, { dataField: 'text' }, { dataField: 'longText' }]
+                }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:1, abc.colSpan:1, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 }, { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:1, abc.colSpan:1, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 577, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:1, abc.colSpan:1, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:1, abc.colSpan:2, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 72, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 577, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:1, abc.colSpan:2, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 72, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 577, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 577, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:1, abc.colSpan:2, text,colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 612, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:1, abc.colSpan:2, text,colSpan:2, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 1 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 278, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 612, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:2, abc.colSpan:1, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:2, abc.colSpan:1, text.colSpan:1, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 2 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 577, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:2, abc.colSpan:1, text.colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 1 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:2, abc.colSpan:2, text.colSpan:1, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 1 }, { dataField: 'longText', colSpan: 1 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 279, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:2, abc.colSpan:2, text.colSpan:2, longText.colSpan:1 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 1 }] }]);
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [a.colSpan:2, abc.colSpan:2, text,colSpan:2, longText.colSpan:2 ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { dataField: 'a', colSpan: 2 }, { dataField: 'abc', colSpan: 2 },
+                    { dataField: 'text', colSpan: 2 }, { dataField: 'longText', colSpan: 2 }] }]);
+
+                wrapper.checkFormSize(1000, 82);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 244, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [group[a], group[abc], group[text], group[longText] ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{
+                    itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', items: ['a'] },
+                        { itemType: 'group', items: ['abc'] },
+                        { itemType: 'group', items: ['text'] },
+                        { itemType: 'group', items: ['longText'] }]
+                }]);
+                if(alignItemLabelsInAllGroups) {
+                    test_3Columns_4Items_AlignedLabels(wrapper);
+                } else {
+                    test_3Columns_4Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [group.colSpan:1[a], group.colSpan:1[abc], group.colSpan:1[text], group.colSpan:1[longText] ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { itemType: 'group', colSpan: 1, items: ['a'] },
+                    { itemType: 'group', colSpan: 1, items: ['abc'] },
+                    { itemType: 'group', colSpan: 1, items: ['text'] },
+                    { itemType: 'group', colSpan: 1, items: ['longText'] }] }]);
+
+                if(alignItemLabelsInAllGroups) {
+                    test_3Columns_4Items_AlignedLabels(wrapper);
+                } else {
+                    test_3Columns_4Items_NotAlignedLabels(wrapper);
+                }
+            });
+
+
+            QUnit.test('3 column -> group.colCount:3 [group.colSpan:1[a], group.colSpan:1[abc], group.colSpan:1[text], group.colSpan:2[longText] ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { itemType: 'group', colSpan: 1, items: ['a'] },
+                    { itemType: 'group', colSpan: 1, items: ['abc'] },
+                    { itemType: 'group', colSpan: 1, items: ['text'] },
+                    { itemType: 'group', colSpan: 2, items: ['longText'] }] } ]);
+                wrapper.checkFormSize(1000, 82);
+                if(alignItemLabelsInAllGroups) {
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 229, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 754, 244, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 577, 34);
+                } else {
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 577, 34);
+                }
+            });
+
+            QUnit.test('3 column -> group.colCount:3 [group.colSpan[a.colSpan:1, group.colSpan:1[abc], group.colSpan:2[text], group.colSpan:1[longText] ]', function(assert) {
+                const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                    { itemType: 'group', colSpan: 1, items: ['a'] },
+                    { itemType: 'group', colSpan: 1, items: ['abc'] },
+                    { itemType: 'group', colSpan: 2, items: ['text'] },
+                    { itemType: 'group', colSpan: 1, items: ['longText'] }] }]);
+
+                if(alignItemLabelsInAllGroups) {
+                    test_3Columns_4Items_AlignedLabels(wrapper);
+                } else {
+                    wrapper.checkFormSize(1000, 82);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 262, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 8, 681, 40, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 1, 720, 278, 34);
+                    wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 0, 74, 19);
+                    wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 75, 244, 34);
+                }
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:1[a], group.colSpan:2[abc], group.colSpan:1[text], group.colSpan:1[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 1, items: ['a'] },
+                        { itemType: 'group', colSpan: 2, items: ['abc'] },
+                        { itemType: 'group', colSpan: 1, items: ['text'] },
+                        { itemType: 'group', colSpan: 1, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 244, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 612, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 278, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+                    }
+                });
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:1[a], group.colSpan:2[abc], group.colSpan:1[text], group.colSpan:2[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 1, items: ['a'] },
+                        { itemType: 'group', colSpan: 2, items: ['abc'] },
+                        { itemType: 'group', colSpan: 1, items: ['text'] },
+                        { itemType: 'group', colSpan: 2, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 244, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 577, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 612, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 278, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 577, 34);
+                    }
+                });
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:1[a], group.colSpan:2[abc], group.colSpan:2[text], group.colSpan:1[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 1, items: ['a'] },
+                        { itemType: 'group', colSpan: 2, items: ['abc'] },
+                        { itemType: 'group', colSpan: 2, items: ['text'] },
+                        { itemType: 'group', colSpan: 1, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 612, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+                    }
+                });
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:1[a], group.colSpan:2[abc], group.colSpan:2[text], group.colSpan:2[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 1, items: ['a'] },
+                        { itemType: 'group', colSpan: 2, items: ['abc'] },
+                        { itemType: 'group', colSpan: 2, items: ['text'] },
+                        { itemType: 'group', colSpan: 2, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 244, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 421, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 293, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 348, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 386, 612, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 611, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 244, 34);
+                    }
+                });
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:2[a], group.colSpan:1[abc], group.colSpan:1[text], group.colSpan:1[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 2, items: ['a'] },
+                        { itemType: 'group', colSpan: 1, items: ['abc'] },
+                        { itemType: 'group', colSpan: 1, items: ['text'] },
+                        { itemType: 'group', colSpan: 1, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 242, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 242, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 627, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 279, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 229, 34);
+                    }
+                });
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:2[a], group.colSpan:1[abc], group.colSpan:1[text], group.colSpan:2[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 2, items: ['a'] },
+                        { itemType: 'group', colSpan: 1, items: ['abc'] },
+                        { itemType: 'group', colSpan: 1, items: ['text'] },
+                        { itemType: 'group', colSpan: 2, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 242, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 242, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 577, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 627, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 279, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 348, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 421, 577, 34);
+                    }
+                });
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:2[a], group.colSpan:1[abc], group.colSpan:2[text], group.colSpan:1[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 2, items: ['a'] },
+                        { itemType: 'group', colSpan: 1, items: ['abc'] },
+                        { itemType: 'group', colSpan: 2, items: ['text'] },
+                        { itemType: 'group', colSpan: 1, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 242, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 627, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 609, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
+                    }
+                });
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:2[a], group.colSpan:1[abc], group.colSpan:2[text], group.colSpan:2[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 2, items: ['a'] },
+                        { itemType: 'group', colSpan: 1, items: ['abc'] },
+                        { itemType: 'group', colSpan: 2, items: ['text'] },
+                        { itemType: 'group', colSpan: 2, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 242, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 627, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 609, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
+                    }
+                });
+
+                QUnit.test('3 column -> group.colCount:3 [group.colSpan:2[a], group.colSpan:2[abc], group.colSpan:2[text], group.colSpan:2[longText] ]', function(assert) {
+                    const wrapper = new FormLayoutTestWrapper(1, { alignItemLabels, alignItemLabelsInAllGroups }, [{ itemType: 'group', colCount: 3, items: [
+                        { itemType: 'group', colSpan: 2, items: ['a'] },
+                        { itemType: 'group', colSpan: 2, items: ['abc'] },
+                        { itemType: 'group', colSpan: 2, items: ['text'] },
+                        { itemType: 'group', colSpan: 2, items: ['longText'] }] }]);
+                    wrapper.checkFormSize(1000, 82);
+                    if(alignItemLabelsInAllGroups) {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 754, 242, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 75, 577, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
+                    } else {
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="a"]'), 8, 0, 25, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="a"]'), 1, 26, 627, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="abc"]'), 8, 681, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="abc"]'), 1, 720, 279, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="text"]'), 54, 0, 40, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="text"]'), 47, 41, 609, 34);
+                        wrapper.checkElementPosition(wrapper.$form.find('[for$="longText"]'), 54, 681, 74, 19);
+                        wrapper.checkElementPosition(wrapper.$form.find('[id$="longText"]'), 47, 754, 242, 34);
+                    }
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Labels are not aligned in the second column if the first column items has the specified colSpan property.

And multiple tests