### PR TITLE
Freeze @types/node package due TS compilation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.7.5",
     "@babel/preset-env": "^7.7.7",
     "@types/jquery": "^2.0.34",
+    "@types/node": "10.17.14",
     "angular": "^1.6.10",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
We get the following error:

```
TypeScript error: 
.../node_modules/@types/node/globals.d.ts(318,65): error TS2339: Property 'toPrimitive' does not exist on type 'SymbolConstructor'.
```

after this change in @types/node@10.17.15:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42111/files#diff-ad3552bc3f967859ad249ffc9b9cf5c1R358

/cc @viterobk @OlegKipchatov 