### PR TITLE
TS: Skip default library compilation checks

### DIFF
--- a/build/gulp/ts.js
+++ b/build/gulp/ts.js
@@ -16,6 +16,11 @@ const TS_BUNDLE_FILE = './ts/dx.all.d.ts';
 const TS_BUNDLE_SOURCES = [TS_BUNDLE_FILE, './ts/aliases.d.ts'];
 const TS_MODULES_GLOB = './js/**/*.d.ts';
 
+const COMMON_TS_COMPILER_OPTIONS = {
+    noEmitOnError: true,
+    skipLibCheck: true
+};
+
 gulp.task('ts-vendor', function() {
     return gulp.src('./ts/vendor/*')
         .pipe(gulp.dest(OUTPUT_ARTIFACTS_DIR));
@@ -65,16 +70,12 @@ gulp.task('ts-jquery-check', gulp.series('ts-bundle', function checkJQueryAugmen
         }).join('\n');
 
     return file('artifacts/globals.ts', content, { src: true })
-        .pipe(ts({
-            noEmitOnError: true
-        }, ts.reporter.fullReporter()));
+        .pipe(ts(COMMON_TS_COMPILER_OPTIONS, ts.reporter.fullReporter()));
 }));
 
 gulp.task('ts-compilation-check', function() {
     return gulp.src(TS_BUNDLE_FILE)
-        .pipe(ts({
-            noEmitOnError: true
-        }, ts.reporter.fullReporter()));
+        .pipe(ts(COMMON_TS_COMPILER_OPTIONS, ts.reporter.fullReporter()));
 });
 
 gulp.task('ts-modules', function generateModules() {
@@ -130,10 +131,11 @@ gulp.task('ts-modules-check', gulp.series('ts-modules', function checkModules() 
     }).join('\n');
 
     return file('artifacts/modules.ts', content, { src: true })
-        .pipe(ts({
-            allowSyntheticDefaultImports: true,
-            noEmitOnError: true
-        }, ts.reporter.fullReporter()));
+        .pipe(ts(
+            Object.assign({}, COMMON_TS_COMPILER_OPTIONS, {
+                allowSyntheticDefaultImports: true
+            })
+        ), ts.reporter.fullReporter());
 }));
 
 gulp.task('ts', gulp.series(


### PR DESCRIPTION
We get the following error:

```
TypeScript error: 
.../node_modules/@types/node/globals.d.ts(318,65): error TS2339: Property 'toPrimitive' does not exist on type 'SymbolConstructor'.
```

after this change in @types/node@10.17.15:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42111/files#diff-ad3552bc3f967859ad249ffc9b9cf5c1R358

This PR enables `skipLibCheck` option for TS compiler to avoid default library compilation in our Gulp tasks (see https://www.typescriptlang.org/docs/handbook/compiler-options.html).