### PR TITLE
Fix date formatting in appointment details tooltip in Scheduler (T860979)

### DIFF
--- a/js/localization/date.js
+++ b/js/localization/date.js
@@ -27,7 +27,6 @@ const FORMATS_TO_PATTERN_MAP = {
     'day': 'd',
     'year': 'y',
     'shortdateshorttime': 'M/d/y, h:mm a',
-    'mediumdatemediumtime': 'MMMM d, h:mm a',
     'longdatelongtime': 'EEEE, MMMM d, y, h:mm:ss a',
     'month': 'LLLL',
     'shortyear': 'yy',

--- a/js/localization/globalize/date.js
+++ b/js/localization/globalize/date.js
@@ -613,10 +613,6 @@ if(Globalize && Globalize.formatDate) {
             path: 'dateTimeFormats/short',
             parts: ['shorttime', 'shortdate']
         },
-        'mediumdatemediumtime': {
-            path: 'dateTimeFormats/medium',
-            parts: ['shorttime', 'monthandday']
-        },
         'longdatelongtime': {
             path: 'dateTimeFormats/medium',
             parts: ['longtime', 'longdate']

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -269,33 +269,37 @@ const subscribes = {
 
     _formatDates(startDate, endDate, isAllDay, format) {
         const formatType = format || this.fire('_getTypeFormat', startDate, endDate, isAllDay);
+        const dateFormat = 'monthandday';
+        const timeFormat = 'shorttime';
 
         const formatTypes = {
             'DATETIME': function() {
-                const dateFormat = 'monthandday';
-                const timeFormat = 'shorttime';
+                const isSameDate = startDate.getDate() === endDate.getDate();
 
-                const startDateString = dateLocalization.format(startDate, dateFormat) + ' ' + dateLocalization.format(startDate, timeFormat) + ' - ';
-
-                const endDateString = (startDate.getDate() === endDate.getDate()) ?
-                    dateLocalization.format(endDate, timeFormat) :
-                    dateLocalization.format(endDate, dateFormat) + ' ' + dateLocalization.format(endDate, timeFormat);
-
-                return startDateString + endDateString;
+                return [
+                    dateLocalization.format(startDate, dateFormat),
+                    ' ',
+                    dateLocalization.format(startDate, timeFormat),
+                    ' - ',
+                    isSameDate ? '' : dateLocalization.format(endDate, dateFormat) + ' ',
+                    dateLocalization.format(endDate, timeFormat)
+                ].join('');
             },
             'TIME': function() {
-                return dateLocalization.format(startDate, 'shorttime') + ' - ' + dateLocalization.format(endDate, 'shorttime');
+                return [
+                    dateLocalization.format(startDate, timeFormat),
+                    ' - ',
+                    dateLocalization.format(endDate, timeFormat),
+                ].join('');
             },
             'DATE': function() {
-                const dateTimeFormat = 'monthAndDay';
-                const startDateString = dateLocalization.format(startDate, dateTimeFormat);
                 const isDurationMoreThanDay = (endDate.getTime() - startDate.getTime()) > toMs('day');
+                const isDifferentDays = endDate.getDate() !== startDate.getDate();
 
-                const endDateString = (isDurationMoreThanDay || endDate.getDate() !== startDate.getDate()) ?
-                    ' - ' + dateLocalization.format(endDate, dateTimeFormat) :
-                    '';
-
-                return startDateString + endDateString;
+                return [
+                    dateLocalization.format(startDate, dateFormat),
+                    isDurationMoreThanDay || isDifferentDays ? ' - ' + dateLocalization.format(endDate, dateFormat) : '',
+                ].join('');
             }
         };
 

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -272,12 +272,14 @@ const subscribes = {
 
         const formatTypes = {
             'DATETIME': function() {
-                const dateTimeFormat = 'mediumdatemediumtime';
-                const startDateString = dateLocalization.format(startDate, dateTimeFormat) + ' - ';
+                const dateFormat = 'monthandday';
+                const timeFormat = 'shorttime';
+
+                const startDateString = dateLocalization.format(startDate, dateFormat) + ', ' + dateLocalization.format(startDate, timeFormat) + ' - ';
 
                 const endDateString = (startDate.getDate() === endDate.getDate()) ?
-                    dateLocalization.format(endDate, 'shorttime') :
-                    dateLocalization.format(endDate, dateTimeFormat);
+                    dateLocalization.format(endDate, timeFormat) :
+                    dateLocalization.format(endDate, dateFormat) + ', ' + dateLocalization.format(endDate, timeFormat);
 
                 return startDateString + endDateString;
             },

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -286,11 +286,7 @@ const subscribes = {
                 ].join('');
             },
             'TIME': function() {
-                return [
-                    dateLocalization.format(startDate, timeFormat),
-                    ' - ',
-                    dateLocalization.format(endDate, timeFormat),
-                ].join('');
+                return `${dateLocalization.format(startDate, timeFormat)} - ${dateLocalization.format(endDate, timeFormat)}`;
             },
             'DATE': function() {
                 const isDurationMoreThanDay = (endDate.getTime() - startDate.getTime()) > toMs('day');

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -275,11 +275,11 @@ const subscribes = {
                 const dateFormat = 'monthandday';
                 const timeFormat = 'shorttime';
 
-                const startDateString = dateLocalization.format(startDate, dateFormat) + ', ' + dateLocalization.format(startDate, timeFormat) + ' - ';
+                const startDateString = dateLocalization.format(startDate, dateFormat) + ' ' + dateLocalization.format(startDate, timeFormat) + ' - ';
 
                 const endDateString = (startDate.getDate() === endDate.getDate()) ?
                     dateLocalization.format(endDate, timeFormat) :
-                    dateLocalization.format(endDate, dateFormat) + ', ' + dateLocalization.format(endDate, timeFormat);
+                    dateLocalization.format(endDate, dateFormat) + ' ' + dateLocalization.format(endDate, timeFormat);
 
                 return startDateString + endDateString;
             },

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -283,7 +283,7 @@ const subscribes = {
         const dateFormat = 'monthandday';
         const timeFormat = 'shorttime';
         const isSameDate = startDate.getDate() === endDate.getDate();
-        const isDurationMoreThanDay = (endDate.getTime() - startDate.getTime()) > toMs('day');
+        const isDurationLessThanDay = (endDate.getTime() - startDate.getTime()) <= toMs('day');
 
         switch(formatType) {
             case 'DATETIME':
@@ -298,7 +298,7 @@ const subscribes = {
             case 'TIME':
                 return `${dateLocalization.format(startDate, timeFormat)} - ${dateLocalization.format(endDate, timeFormat)}`;
             case 'DATE':
-                return `${dateLocalization.format(startDate, dateFormat)}${isDurationMoreThanDay || !isSameDate ? ' - ' + dateLocalization.format(endDate, dateFormat) : ''}`;
+                return `${dateLocalization.format(startDate, dateFormat)}${isDurationLessThanDay || isSameDate ? '' : ' - ' + dateLocalization.format(endDate, dateFormat)}`;
         }
     },
 

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -246,18 +246,12 @@ const subscribes = {
             endDate = this.fire('convertDateByTimezone', appointmentFields.endDate, appointmentFields.endDateTimeZone);
         }
 
+        const formatType = format || this.fire('_getTypeFormat', startDate, endDate, appointmentFields.allDay);
+
         return {
-            text: this.fire('createAppointmentTitle', appointmentFields),
-            formatDate: this.fire('_formatDates', startDate, endDate, appointmentFields.allDay, format)
+            text: this.fire('_createAppointmentTitle', appointmentFields),
+            formatDate: this.fire('_formatDates', startDate, endDate, formatType)
         };
-    },
-
-    createAppointmentTitle: function(data) {
-        if(typeUtils.isPlainObject(data)) {
-            return data.text;
-        }
-
-        return String(data);
     },
 
     _getAppointmentFields(data, arrayOfFields) {
@@ -267,8 +261,25 @@ const subscribes = {
         }, {});
     },
 
-    _formatDates(startDate, endDate, isAllDay, format) {
-        const formatType = format || this.fire('_getTypeFormat', startDate, endDate, isAllDay);
+    _getTypeFormat(startDate, endDate, isAllDay) {
+        if(isAllDay) {
+            return 'DATE';
+        }
+        if(this.option('currentView') !== 'month' && dateUtils.sameDate(startDate, endDate)) {
+            return 'TIME';
+        }
+        return 'DATETIME';
+    },
+
+    _createAppointmentTitle(data) {
+        if(typeUtils.isPlainObject(data)) {
+            return data.text;
+        }
+
+        return String(data);
+    },
+
+    _formatDates(startDate, endDate, formatType) {
         const dateFormat = 'monthandday';
         const timeFormat = 'shorttime';
 
@@ -300,16 +311,6 @@ const subscribes = {
         };
 
         return formatTypes[formatType]();
-    },
-
-    _getTypeFormat(startDate, endDate, isAllDay) {
-        if(isAllDay) {
-            return 'DATE';
-        }
-        if(this.option('currentView') !== 'month' && dateUtils.sameDate(startDate, endDate)) {
-            return 'TIME';
-        }
-        return 'DATETIME';
     },
 
     getResizableAppointmentArea: function(options) {

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -298,10 +298,7 @@ const subscribes = {
             case 'TIME':
                 return `${dateLocalization.format(startDate, timeFormat)} - ${dateLocalization.format(endDate, timeFormat)}`;
             case 'DATE':
-                return [
-                    dateLocalization.format(startDate, dateFormat),
-                    isDurationMoreThanDay || !isSameDate ? ' - ' + dateLocalization.format(endDate, dateFormat) : '',
-                ].join('');
+                return `${dateLocalization.format(startDate, dateFormat)}${isDurationMoreThanDay || !isSameDate ? ' - ' + dateLocalization.format(endDate, dateFormat) : ''}`;
         }
     },
 

--- a/js/ui/scheduler/ui.scheduler.subscribes.js
+++ b/js/ui/scheduler/ui.scheduler.subscribes.js
@@ -282,11 +282,11 @@ const subscribes = {
     _formatDates(startDate, endDate, formatType) {
         const dateFormat = 'monthandday';
         const timeFormat = 'shorttime';
+        const isSameDate = startDate.getDate() === endDate.getDate();
+        const isDurationMoreThanDay = (endDate.getTime() - startDate.getTime()) > toMs('day');
 
-        const formatTypes = {
-            'DATETIME': function() {
-                const isSameDate = startDate.getDate() === endDate.getDate();
-
+        switch(formatType) {
+            case 'DATETIME':
                 return [
                     dateLocalization.format(startDate, dateFormat),
                     ' ',
@@ -295,22 +295,14 @@ const subscribes = {
                     isSameDate ? '' : dateLocalization.format(endDate, dateFormat) + ' ',
                     dateLocalization.format(endDate, timeFormat)
                 ].join('');
-            },
-            'TIME': function() {
+            case 'TIME':
                 return `${dateLocalization.format(startDate, timeFormat)} - ${dateLocalization.format(endDate, timeFormat)}`;
-            },
-            'DATE': function() {
-                const isDurationMoreThanDay = (endDate.getTime() - startDate.getTime()) > toMs('day');
-                const isDifferentDays = endDate.getDate() !== startDate.getDate();
-
+            case 'DATE':
                 return [
                     dateLocalization.format(startDate, dateFormat),
-                    isDurationMoreThanDay || isDifferentDays ? ' - ' + dateLocalization.format(endDate, dateFormat) : '',
+                    isDurationMoreThanDay || !isSameDate ? ' - ' + dateLocalization.format(endDate, dateFormat) : '',
                 ].join('');
-            }
-        };
-
-        return formatTypes[formatType]();
+        }
     },
 
     getResizableAppointmentArea: function(options) {

--- a/testing/tests/DevExpress.localization/sharedParts/localization.shared.js
+++ b/testing/tests/DevExpress.localization/sharedParts/localization.shared.js
@@ -403,26 +403,7 @@ module.exports = function() {
             'yyyy MMMM d': {
                 text: '2015 March 2',
                 expected: new Date(2015, 2, 2)
-            },
-
-            'mediumdatemediumtime': [
-                {
-                    text: 'March 2, 3:12 AM',
-                    expectedConfig: { month: 2, day: 2, hours: 3, minutes: 12, seconds: 0 }
-                },
-                {
-                    text: 'March 2, 3:12 PM',
-                    expectedConfig: { month: 2, day: 2, hours: 15, minutes: 12, seconds: 0 }
-                },
-                {
-                    text: 'March 2, 12:12 AM',
-                    expectedConfig: { month: 2, day: 2, hours: 0, minutes: 12, seconds: 0 }
-                },
-                {
-                    text: 'March 2, 12:12 PM',
-                    expectedConfig: { month: 2, day: 2, hours: 12, minutes: 12, seconds: 0 }
-                }
-            ]
+            }
         };
 
         try {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
@@ -17,6 +17,9 @@ import 'common.css!';
 import 'generic_light.css!';
 import 'ui/scheduler/ui.scheduler';
 
+const dateFormat = 'monthandday';
+const timeFormat = 'shorttime';
+
 const { testStart, module, test } = QUnit;
 
 testStart(() => initTestMarkup());
@@ -402,7 +405,7 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
 
         scheduler.appointments.click();
 
-        assert.equal(scheduler.tooltip.getDateText(), 'October 5, 11:30 PM - October 6, 1:00 AM', 'dates and time were displayed correctly');
+        assert.equal(scheduler.tooltip.getDateText(), 'October 5 11:30 PM - October 6 1:00 AM', 'dates and time were displayed correctly');
     });
 
     test('Scheduler appointment tooltip dates should be correct, when custom timeZone is set', function(assert) {
@@ -506,7 +509,7 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
 
         scheduler.appointments.click(1);
 
-        assert.equal(scheduler.tooltip.getDateText(), 'February 9, 11:00 AM - 12:00 PM', 'dates and time were displayed correctly');
+        assert.equal(scheduler.tooltip.getDateText(), 'February 9 11:00 AM - 12:00 PM', 'dates and time were displayed correctly');
     });
 
     test('Click on tooltip-remove button should call scheduler.deleteAppointment and hide tooltip', function(assert) {
@@ -673,7 +676,10 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
 
         scheduler.appointments.click(0);
 
-        assert.equal(scheduler.tooltip.getDateText(), dateLocalization.format(startDate, 'mediumdatemediumtime') + ' - ' + dateLocalization.format(endDate, 'mediumdatemediumtime'), 'dates were displayed correctly');
+        const startDateString = dateLocalization.format(startDate, dateFormat) + ' ' + dateLocalization.format(startDate, timeFormat);
+        const endDateString = dateLocalization.format(endDate, dateFormat) + ' ' + dateLocalization.format(endDate, timeFormat);
+
+        assert.equal(scheduler.tooltip.getDateText(), startDateString + ' - ' + endDateString, 'dates were displayed correctly');
     });
 
     test('Tooltip of multiday appointment should display date & time for month view', function(assert) {
@@ -692,7 +698,10 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
 
         scheduler.appointments.click(0);
 
-        assert.equal(scheduler.tooltip.getDateText(), dateLocalization.format(startDate, 'mediumdatemediumtime') + ' - ' + dateLocalization.format(endDate, 'mediumdatemediumtime'), 'dates were displayed correctly');
+        const startDateString = dateLocalization.format(startDate, dateFormat) + ' ' + dateLocalization.format(startDate, timeFormat);
+        const endDateString = dateLocalization.format(endDate, dateFormat) + ' ' + dateLocalization.format(endDate, timeFormat);
+
+        assert.equal(scheduler.tooltip.getDateText(), startDateString + ' - ' + endDateString, 'dates were displayed correctly');
     });
 
     test('Tooltip of appointment part after midnight should display right date & time', function(assert) {
@@ -711,7 +720,10 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
 
         scheduler.appointments.click(1);
 
-        assert.equal(scheduler.tooltip.getDateText(), dateLocalization.format(startDate, 'mediumdatemediumtime') + ' - ' + dateLocalization.format(endDate, 'mediumdatemediumtime'), 'dates were displayed correctly');
+        const startDateString = dateLocalization.format(startDate, dateFormat) + ' ' + dateLocalization.format(startDate, timeFormat);
+        const endDateString = dateLocalization.format(endDate, dateFormat) + ' ' + dateLocalization.format(endDate, timeFormat);
+
+        assert.equal(scheduler.tooltip.getDateText(), startDateString + ' - ' + endDateString, 'dates were displayed correctly');
     });
 
     test('Tooltip of recurrence appointment part after midnight should display right date & time', function(assert) {
@@ -731,7 +743,7 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
 
         scheduler.appointments.click(2);
 
-        assert.equal(scheduler.tooltip.getDateText(), 'May 30, 11:00 PM - May 31, 1:15 AM', 'dates were displayed correctly');
+        assert.equal(scheduler.tooltip.getDateText(), 'May 30 11:00 PM - May 31 1:15 AM', 'dates were displayed correctly');
     });
 
     test('Tooltip for recurrence appointment should display right dates(T384181)', function(assert) {
@@ -752,7 +764,7 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
 
         scheduler.appointments.click(1);
 
-        assert.equal(scheduler.tooltip.getDateText(), 'February 6, 11:00 AM - 12:00 PM', 'dates and time were displayed correctly');
+        assert.equal(scheduler.tooltip.getDateText(), 'February 6 11:00 AM - 12:00 PM', 'dates and time were displayed correctly');
     });
 
     test('Tooltip should hide when window was resized', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentsWithTimezone.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentsWithTimezone.tests.js
@@ -1329,7 +1329,7 @@ QUnit.test('DropDown appointment should be rendered correctly when timezone is s
         });
 
         scheduler.appointments.compact.click();
-        assert.equal(scheduler.tooltip.getDateText(), 'September 16 10:00 PM - 11:00 PM', 'Dates is correct');
+        assert.equal(scheduler.tooltip.getDateText(), 'September 16 10:00 PM - 11:00 PM', 'Dates are correct');
     } finally {
         tzOffsetStub.restore();
     }

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentsWithTimezone.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentsWithTimezone.tests.js
@@ -1329,7 +1329,7 @@ QUnit.test('DropDown appointment should be rendered correctly when timezone is s
         });
 
         scheduler.appointments.compact.click();
-        assert.equal(scheduler.tooltip.getDateText(), 'September 16, 10:00 PM - 11:00 PM', 'Dates is correct');
+        assert.equal(scheduler.tooltip.getDateText(), 'September 16 10:00 PM - 11:00 PM', 'Dates is correct');
     } finally {
         tzOffsetStub.restore();
     }

--- a/testing/tests/DevExpress.ui.widgets.scheduler/subscribes.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/subscribes.tests.js
@@ -1142,7 +1142,7 @@ QUnit.test('getTextAndFormatDate, simple appointment, month view, without format
     });
 
     assert.deepEqual(this.instance.fire('getTextAndFormatDate', data, data), {
-        formatDate: 'March 1, 10:00 AM - 11:00 AM',
+        formatDate: 'March 1 10:00 AM - 11:00 AM',
         text: 'Appointment test text'
     });
 });
@@ -1163,7 +1163,7 @@ QUnit.test('getTextAndFormatData, recurrance appointment with different data', f
         currentView: 'month'
     });
     assert.deepEqual(this.instance.fire('getTextAndFormatDate', initialData, dataRecur), {
-        formatDate: 'March 2, 10:00 AM - 11:00 AM',
+        formatDate: 'March 2 10:00 AM - 11:00 AM',
         text: 'Appointment test text'
     });
 });


### PR DESCRIPTION
- 'mediumdatemediumtime' was replaced by 'monthandday' and 'shorttime'
- 'mediumdatemediumtime' was removed from localization