### PR TITLE
Apply dataSource changes only after the widget's radios collection is ready (T861468)

### DIFF
--- a/js/ui/radio_group/radio_group.js
+++ b/js/ui/radio_group/radio_group.js
@@ -7,6 +7,7 @@ import registerComponent from '../../core/component_registrator';
 import CollectionWidget from '../collection/ui.collection_widget.edit';
 import DataExpressionMixin from '../editor/ui.data_expression';
 import Editor from '../editor/editor';
+import { Deferred } from '../../core/utils/deferred';
 
 const RADIO_BUTTON_CHECKED_CLASS = 'dx-radiobutton-checked';
 const RADIO_BUTTON_CLASS = 'dx-radiobutton';
@@ -293,6 +294,7 @@ class RadioGroup extends Editor {
     }
 
     _renderRadios() {
+        this._areRadiosCreated = new Deferred();
         const $radios = $('<div>').appendTo(this.$element());
 
         this._radios = this._createComponent($radios, RadioCollection, {
@@ -311,6 +313,7 @@ class RadioGroup extends Editor {
             selectedItemKeys: [this.option('value')],
             tabIndex: this.option('tabIndex')
         });
+        this._areRadiosCreated.resolve();
     }
 
     _renderSubmitElement() {
@@ -335,7 +338,7 @@ class RadioGroup extends Editor {
     }
 
     _setCollectionWidgetOption() {
-        this._setWidgetOption('_radios', arguments);
+        this._areRadiosCreated.done(this._setWidgetOption.bind(this, '_radios', arguments));
     }
 
     _toggleActiveState($element, value, e) {

--- a/testing/tests/DevExpress.ui.widgets.editors/radioGroup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/radioGroup.tests.js
@@ -135,6 +135,60 @@ module('buttons group rendering', () => {
         instance.option('dataSource', [1, 2, 3]);
         assert.strictEqual(onContentReadyHandler.callCount, 2);
     });
+
+    test('should render new items if them were setted in onContentReady handler (T861468)', function(assert) {
+        const onContentReadyHandler = sinon.spy((e) => {
+            if(!isReady) {
+                isReady = true;
+                e.component.option('items', [1, 2, 3]);
+            }
+        });
+        let isReady;
+        const instance = getInstance(
+            createRadioGroup({
+                items: ['str1', 'str2'],
+                onContentReady: onContentReadyHandler
+            })
+        );
+
+        assert.strictEqual(onContentReadyHandler.callCount, 2);
+        assert.strictEqual($(instance.element()).find(`.${RADIO_BUTTON_CLASS}`).length, 3);
+    });
+
+    test('should render new items if async dataSource was setted in onContentReady handler (T861468)', function(assert) {
+        const clock = sinon.useFakeTimers();
+        const asyncDataSource = new DataSource({
+            load: () => {
+                const d = $.Deferred();
+
+                setTimeout(function() {
+                    d.resolve([1, 2, 3]);
+                }, 200);
+
+                return d.promise();
+            }
+        });
+
+        const onContentReadyHandler = sinon.spy((e) => {
+            if(!isReady) {
+                isReady = true;
+                e.component.option('dataSource', asyncDataSource);
+            }
+        });
+        let isReady;
+        const instance = getInstance(
+            createRadioGroup({
+                dataSource: ['str1', 'str2'],
+                onContentReady: onContentReadyHandler
+            })
+        );
+
+        clock.tick(300);
+
+        assert.strictEqual(onContentReadyHandler.callCount, 2);
+        assert.strictEqual($(instance.element()).find(`.${RADIO_BUTTON_CLASS}`).length, 3);
+        clock.restore();
+    });
 });
 
 module('layout', moduleConfig, () => {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
