### PR TITLE
Rollback the source mapping for tests (#11585)

### DIFF
--- a/build/gulp/transpile.js
+++ b/build/gulp/transpile.js
@@ -5,7 +5,6 @@ const replace = require('gulp-replace');
 const plumber = require('gulp-plumber');
 const path = require('path');
 const notify = require('gulp-notify');
-const sourceMaps = require('gulp-sourcemaps');
 
 const context = require('./context.js');
 
@@ -19,9 +18,7 @@ const VERSION_FILE_PATH = 'core/version.js';
 
 gulp.task('transpile', gulp.series('bundler-config', function() {
     return gulp.src(SRC)
-        .pipe(sourceMaps.init())
         .pipe(babel())
-        .pipe(sourceMaps.write())
         .pipe(gulp.dest(context.TRANSPILED_PATH));
 }));
 
@@ -33,13 +30,11 @@ gulp.task('version-replace', gulp.series('transpile', function() {
 
 gulp.task('transpile-watch', gulp.series('version-replace', function() {
     return watch(SRC)
-        .pipe(sourceMaps.init())
         .pipe(plumber({
             errorHandler: notify.onError('Error: <%= error.message %>')
                 .bind() // bind call is necessary to prevent firing 'end' event in notify.onError implementation
         }))
         .pipe(babel())
-        .pipe(sourceMaps.write())
         .pipe(gulp.dest(context.TRANSPILED_PATH));
 }));
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-replace-async": "0.0.1",
-    "gulp-sourcemaps": "^2.6.5",
     "gulp-tap": "^1.0.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^5.0.0",


### PR DESCRIPTION
The gulp-sourcemaps package adds a map as base64 content to a transpiled file. That leads to Increase file size and problems in the IE tasks on a testing farm.