### PR TITLE
Renovation: fix IE errors when using template wrapper

### DIFF
--- a/js/renovation/preact-wrapper/utils.js
+++ b/js/renovation/preact-wrapper/utils.js
@@ -1,15 +1,15 @@
+import { each } from '../../core/utils/iterator';
+
 // NOTE: function for jQuery templates
 export const wrapElement = ($element, $wrapper) => {
     const attributes = $wrapper.get(0).attributes;
-
-    for(let i = 0; i < attributes.length; i++) {
-        const { name, value } = attributes[i];
+    each(attributes, (_, { name, value }) => {
         if(name === 'class') {
             $element.addClass(value);
         } else {
             $element.attr(name, value);
         }
-    }
+    });
 
     const children = $wrapper.contents();
     $wrapper.replaceWith(children);

--- a/js/renovation/preact-wrapper/utils.js
+++ b/js/renovation/preact-wrapper/utils.js
@@ -1,13 +1,15 @@
 // NOTE: function for jQuery templates
 export const wrapElement = ($element, $wrapper) => {
-    const attributes = [...$wrapper.get(0).attributes];
-    attributes.forEach(({ name, value }) => {
+    const attributes = $wrapper.get(0).attributes;
+
+    for(let i = 0; i < attributes.length; i++) {
+        const { name, value } = attributes[i];
         if(name === 'class') {
             $element.addClass(value);
         } else {
             $element.attr(name, value);
         }
-    });
+    }
 
     const children = $wrapper.contents();
     $wrapper.replaceWith(children);


### PR DESCRIPTION
Use 'for' cycle for Element.attributes