### PR TITLE
Renovation: fix template wrapper with text node child

### DIFF
--- a/js/renovation/dist/button.j.jsx
+++ b/js/renovation/dist/button.j.jsx
@@ -1,4 +1,3 @@
-
 import $ from '../../core/renderer';
 import * as Preact from 'preact';
 import registerComponent from '../../core/component_registrator';
@@ -27,10 +26,10 @@ class Button extends Widget {
             props.contentRender = ({ parentRef, ...restProps }) => {
                 useLayoutEffect(() => {
                     const $parent = $(parentRef.current);
-                    let $template = template.render({
+                    let $template = $(template.render({
                         container: getPublicElement($parent),
                         ...restProps,
-                    });
+                    }));
 
                     if($template.hasClass(TEMPLATE_WRAPPER_CLASS)) {
                         $template = wrapElement($parent, $template);

--- a/js/renovation/preact-wrapper/utils.js
+++ b/js/renovation/preact-wrapper/utils.js
@@ -1,7 +1,11 @@
+import { each } from '../../core/utils/iterator';
+
 // NOTE: function for jQuery templates
 export const wrapElement = ($element, $wrapper) => {
-    const attributes = [...$wrapper.get(0).attributes];
-    attributes.forEach(({ name, value }) => {
+    const attributes = $wrapper.get(0).attributes;
+    const children = $wrapper.contents();
+
+    each(attributes, (_, { name, value }) => {
         if(name === 'class') {
             $element.addClass(value);
         } else {
@@ -9,8 +13,10 @@ export const wrapElement = ($element, $wrapper) => {
         }
     });
 
-    const children = $wrapper.contents();
-    $wrapper.replaceWith(children);
+    $wrapper.remove();
+    each(children, (_, child) => {
+        $element.append(child);
+    });
 
     return children;
 };

--- a/testing/tests/Renovation/button.markup.tests.js
+++ b/testing/tests/Renovation/button.markup.tests.js
@@ -190,19 +190,20 @@ QUnit.module('Button markup', () => {
         });
     });
 
-    // TODO
-    QUnit.skip('Button should render custom template with render function that returns dom node', function(assert) {
+    QUnit.test('Button should render custom template with render function that returns dom node', function(assert) {
         const $element = $('#button').Button({
-            integrationOptions: {
-                templates: {
-                    'content': {
-                        render: function(args) {
-                            const $element = $('<span>')
-                                .addClass('dx-template-wrapper')
-                                .text('button text');
+            template: 'test',
+        });
 
-                            return $element.get(0);
-                        }
+        $element.Button('instance').option('integrationOptions', {
+            templates: {
+                'test': {
+                    render: function(args) {
+                        const $element = $('<span>')
+                            .addClass('dx-template-wrapper')
+                            .text('button text');
+
+                        return $element.get(0);
                     }
                 }
             }

--- a/testing/tests/Renovation/button.tests.js
+++ b/testing/tests/Renovation/button.tests.js
@@ -708,8 +708,8 @@ QUnit.module('templates', () => {
                 assert.strictEqual(checkStyleHelper.getWhiteSpace($template[0].parentNode), 'nowrap', 'whiteSpace');
 
                 done();
-            }, 10);
-        }, 10);
+            }, 100);
+        }, 100);
     });
 
     checkStyleHelper.testInChromeOnDesktopActiveWindow('parent styles when button is focused, text is empty', function(assert) {
@@ -732,8 +732,8 @@ QUnit.module('templates', () => {
                 assert.strictEqual(checkStyleHelper.getWhiteSpace($template[0].parentNode), 'normal', 'whiteSpace');
 
                 done();
-            }, 10);
-        }, 10);
+            }, 100);
+        }, 100);
     });
 });
 


### PR DESCRIPTION
Fix a bug when template wrapper has only one child - the text node.
Correct legacy test