### PR TITLE
Prepare tests for build image update

### DIFF
--- a/testing/tests/DevExpress.exporter/exceljsParts/ExcelJSTestHelper.js
+++ b/testing/tests/DevExpress.exporter/exceljsParts/ExcelJSTestHelper.js
@@ -58,9 +58,17 @@ class ExcelJSTestHelper {
         });
     }
 
-    checkColumnWidths(expectedWidths, startColumnIndex) {
+    checkColumnWidths(expectedWidths, startColumnIndex, tolerance) {
         for(let i = 0; i < expectedWidths.length; i++) {
-            assert.equal(this.worksheet.getColumn(startColumnIndex + i).width, expectedWidths[i], `worksheet.getColumns(${i}).width`);
+            const actual = this.worksheet.getColumn(startColumnIndex + i).width;
+            const expected = expectedWidths[i];
+            const message = `worksheet.getColumns(${i}).width`;
+
+            if(tolerance && isFinite(expected)) {
+                assert.roughEqual(actual, expected, tolerance, message);
+            } else {
+                assert.equal(actual, expected, message);
+            }
         }
     }
 

--- a/testing/tests/DevExpress.exporter/exceljsParts/exceljs.tests.js
+++ b/testing/tests/DevExpress.exporter/exceljsParts/exceljs.tests.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import browser from 'core/utils/browser';
-import devices from 'core/devices';
 import localization from 'localization';
 import ja from 'localization/messages/ja.json!';
 import messageLocalization from 'localization/message';
@@ -442,8 +441,6 @@ const moduleConfig = {
         });
 
         QUnit.test('Header - 2 column, column.width: auto', function(assert) {
-            const currentDevice = devices.current();
-            const isWinPhone = currentDevice.deviceType === 'phone' && currentDevice.platform === 'generic';
             const done = assert.async();
 
             const dataGrid = $('#dataGrid').dxDataGrid({
@@ -452,13 +449,7 @@ const moduleConfig = {
             }).dxDataGrid('instance');
 
             exportDataGrid(getOptions(this, dataGrid, null, true)).then(() => {
-                let expectedWidths = [3.71, 67.71, undefined];
-                if(browser.mozilla) {
-                    expectedWidths = [3.85, 67.57, undefined];
-                } else if(browser.msie && !isWinPhone) {
-                    expectedWidths = [3.77, 67.65, undefined];
-                }
-                helper.checkColumnWidths(expectedWidths, topLeft.column);
+                helper.checkColumnWidths([3.8, 67.6, undefined], topLeft.column, 0.2);
                 done();
             });
         });

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -1162,7 +1162,12 @@ QUnit.module('popup', moduleConfig, () => {
 
     QUnit.testInActiveWindow('After search and load new page scrollTop should not be changed', function(assert) {
         if(browser.msie) {
-            assert.ok(true, 'test does not actual for IE');
+            assert.ok(true, 'not applicable in IE');
+            return;
+        }
+
+        if(browser.chrome && !window.INTRANET) {
+            assert.ok(true, 'TODO https://trello.com/c/l50V8hPU/');
             return;
         }
 


### PR DESCRIPTION
We're going to upgrade Drone CI build image. Browser updates exposed a couple of flaws in existing tests:
- `exceljs`:  browser-dependent fractional pixels replaced with `roughEqual`
- `dropDownList` scrollbar test case: @San4es suggested to temporary disable and 'нырять' soon but later