### PR TITLE
Skips unstable test

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -17516,7 +17516,7 @@ QUnit.module('Async validation', {
         });
     });
 
-    QUnit.test('Cell - Only the last cell should be switched to edit mode', function(assert) {
+    QUnit.skip('Cell - Only the last cell should be switched to edit mode', function(assert) {
         // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');


### PR DESCRIPTION
Skips the "Cell - Only the last cell should be switched to edit mode" test in the editing module.