### PR TITLE
Refactor dxmousewheel event (T850104)

### DIFF
--- a/js/events/core/wheel.js
+++ b/js/events/core/wheel.js
@@ -19,18 +19,18 @@ const wheel = {
         eventsEngine.off(element, `.${EVENT_NAMESPACE}`);
     },
 
-    _wheelHandler: function({ originalEvent }) {
-        const { deltaY, deltaMode } = originalEvent;
+    _wheelHandler: function(e) {
+        const { deltaY, deltaMode } = e.originalEvent;
 
         fireEvent({
             type: EVENT_NAME,
-            originalEvent,
+            originalEvent: e,
             delta: -deltaY,
             deltaMode,
             pointerType: 'mouse'
         });
 
-        originalEvent.stopPropagation();
+        e.stopPropagation();
     }
 };
 

--- a/js/events/core/wheel.js
+++ b/js/events/core/wheel.js
@@ -1,47 +1,37 @@
-const $ = require('../../core/renderer');
-const eventsEngine = require('../../events/core/events_engine');
-const domAdapter = require('../../core/dom_adapter');
-const callOnce = require('../../core/utils/call_once');
-const registerEvent = require('./event_registrator');
-const eventUtils = require('../utils');
+import $ from '../../core/renderer';
+import eventsEngine from '../../events/core/events_engine';
+import registerEvent from './event_registrator';
+import { addNamespace, fireEvent } from '../utils';
+
 
 const EVENT_NAME = 'dxmousewheel';
 const EVENT_NAMESPACE = 'dxWheel';
-
-const getWheelEventName = callOnce(function() {
-    return domAdapter.hasDocumentProperty('onwheel') ? 'wheel' : 'mousewheel';
-});
+const NATIVE_EVENT_NAME = 'wheel';
 
 const wheel = {
 
     setup: function(element) {
         const $element = $(element);
-        eventsEngine.on($element, eventUtils.addNamespace(getWheelEventName(), EVENT_NAMESPACE), wheel._wheelHandler.bind(wheel));
+        eventsEngine.on($element, addNamespace(NATIVE_EVENT_NAME, EVENT_NAMESPACE), wheel._wheelHandler.bind(wheel));
     },
 
     teardown: function(element) {
-        eventsEngine.off(element, '.' + EVENT_NAMESPACE);
+        eventsEngine.off(element, `.${EVENT_NAMESPACE}`);
     },
 
-    _wheelHandler: function(e) {
-        const delta = this._getWheelDelta(e.originalEvent);
+    _wheelHandler: function({ originalEvent }) {
+        const { deltaY, deltaMode } = originalEvent;
 
-        eventUtils.fireEvent({
+        fireEvent({
             type: EVENT_NAME,
-            originalEvent: e,
-            delta: delta,
+            originalEvent,
+            deltaY: -deltaY,
+            deltaMode,
             pointerType: 'mouse'
         });
 
-        e.stopPropagation();
-    },
-
-    _getWheelDelta: function(event) {
-        return event.wheelDelta
-            ? event.wheelDelta
-            : -event.deltaY * 30;
+        originalEvent.stopPropagation();
     }
-
 };
 
 registerEvent(EVENT_NAME, wheel);

--- a/js/events/core/wheel.js
+++ b/js/events/core/wheel.js
@@ -38,7 +38,7 @@ const wheel = {
         e.stopPropagation();
     },
 
-    _normalizeDelta(delta, deltaMode) {
+    _normalizeDelta(delta, deltaMode = PIXEL_MODE) {
         if(deltaMode === PIXEL_MODE) {
             return -delta;
         } else {

--- a/js/events/core/wheel.js
+++ b/js/events/core/wheel.js
@@ -8,8 +8,10 @@ const EVENT_NAME = 'dxmousewheel';
 const EVENT_NAMESPACE = 'dxWheel';
 const NATIVE_EVENT_NAME = 'wheel';
 
-const wheel = {
+const PIXEL_MODE = 0;
+const DELTA_MUTLIPLIER = 30;
 
+const wheel = {
     setup: function(element) {
         const $element = $(element);
         eventsEngine.on($element, addNamespace(NATIVE_EVENT_NAME, EVENT_NAMESPACE), wheel._wheelHandler.bind(wheel));
@@ -20,17 +22,30 @@ const wheel = {
     },
 
     _wheelHandler: function(e) {
-        const { deltaY, deltaMode } = e.originalEvent;
+        const { deltaMode, deltaY, deltaX, deltaZ } = e.originalEvent;
 
         fireEvent({
             type: EVENT_NAME,
             originalEvent: e,
-            delta: -deltaY,
+            delta: this._normalizeDelta(deltaY, deltaMode),
+            deltaX,
+            deltaY,
+            deltaZ,
             deltaMode,
             pointerType: 'mouse'
         });
 
         e.stopPropagation();
+    },
+
+    _normalizeDelta(delta, deltaMode) {
+        if(deltaMode === PIXEL_MODE) {
+            return -delta;
+        } else {
+            // Use multiplier to get rough delta value in px for the LINE or PAGE mode
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1392460
+            return -DELTA_MUTLIPLIER * delta;
+        }
     }
 };
 

--- a/js/events/core/wheel.js
+++ b/js/events/core/wheel.js
@@ -25,7 +25,7 @@ const wheel = {
         fireEvent({
             type: EVENT_NAME,
             originalEvent,
-            deltaY: -deltaY,
+            delta: -deltaY,
             deltaMode,
             pointerType: 'mouse'
         });

--- a/testing/helpers/nativePointerMock.js
+++ b/testing/helpers/nativePointerMock.js
@@ -960,9 +960,10 @@
                 return this;
             },
 
-            wheel: function(d, shiftKey) {
+            wheel: function(d, shiftKey, deltaMode) {
                 triggerEvent('wheel', {
                     deltaY: -d,
+                    deltaMode: deltaMode || 0,
                     shiftKey: shiftKey
                 });
 

--- a/testing/helpers/nativePointerMock.js
+++ b/testing/helpers/nativePointerMock.js
@@ -961,17 +961,10 @@
             },
 
             wheel: function(d, shiftKey) {
-                if(document['onwheel'] !== undefined) {
-                    triggerEvent('wheel', {
-                        deltaY: -d,
-                        shiftKey: shiftKey
-                    });
-                } else {
-                    triggerEvent('mousewheel', {
-                        wheelDelta: d,
-                        shiftKey: shiftKey
-                    });
-                }
+                triggerEvent('wheel', {
+                    deltaY: -d,
+                    shiftKey: shiftKey
+                });
 
                 triggerEvent('scroll');
                 return this;

--- a/testing/helpers/nativePointerMock.js
+++ b/testing/helpers/nativePointerMock.js
@@ -963,7 +963,7 @@
             wheel: function(d, shiftKey) {
                 if(document['onwheel'] !== undefined) {
                     triggerEvent('wheel', {
-                        deltaY: -d / 30,
+                        deltaY: -d,
                         shiftKey: shiftKey
                     });
                 } else {

--- a/testing/tests/DevExpress.ui.events/wheel.tests.js
+++ b/testing/tests/DevExpress.ui.events/wheel.tests.js
@@ -60,3 +60,20 @@ QUnit.test('provide delta and pointerType in event args', function(assert) {
     assert.equal(args.delta, 10, 'wheel delta provided');
     assert.equal(args.pointerType, 'mouse', 'wheel pointerType provided');
 });
+
+QUnit.test('normalize delta for deltaMode LINE and PAGE', function(assert) {
+    const wheelHandler = sinon.stub();
+    const LINE_MODE = 1;
+    const PAGE_MODE = 2;
+    const $element = $('#test');
+    const mouse = nativePointerMock($element).start();
+
+    $element.on(wheelEvent.name, wheelHandler);
+
+    mouse.wheel(3, false, LINE_MODE);
+    mouse.wheel(3, false, PAGE_MODE);
+
+    assert.strictEqual(wheelHandler.callCount, 2);
+    assert.strictEqual(wheelHandler.firstCall.args[0].delta, 30);
+    assert.strictEqual(wheelHandler.lastCall.args[0].delta, 30);
+});

--- a/testing/tests/DevExpress.ui.events/wheel.tests.js
+++ b/testing/tests/DevExpress.ui.events/wheel.tests.js
@@ -62,18 +62,20 @@ QUnit.test('provide delta and pointerType in event args', function(assert) {
 });
 
 QUnit.test('normalize delta for deltaMode LINE and PAGE', function(assert) {
-    const wheelHandler = sinon.stub();
     const LINE_MODE = 1;
     const PAGE_MODE = 2;
+    const DELTA_MULTIPLIER = 30;
+    const DELTA = 3;
+    const wheelHandler = sinon.stub();
     const $element = $('#test');
     const mouse = nativePointerMock($element).start();
 
     $element.on(wheelEvent.name, wheelHandler);
 
-    mouse.wheel(3, false, LINE_MODE);
-    mouse.wheel(3, false, PAGE_MODE);
+    mouse.wheel(DELTA, false, LINE_MODE);
+    mouse.wheel(DELTA, false, PAGE_MODE);
 
     assert.strictEqual(wheelHandler.callCount, 2);
-    assert.strictEqual(wheelHandler.firstCall.args[0].delta, 30);
-    assert.strictEqual(wheelHandler.lastCall.args[0].delta, 30);
+    assert.strictEqual(wheelHandler.firstCall.args[0].delta, DELTA * DELTA_MULTIPLIER);
+    assert.strictEqual(wheelHandler.lastCall.args[0].delta, DELTA * DELTA_MULTIPLIER);
 });

--- a/testing/tests/DevExpress.viz.vectorMap/tracker.tests.js
+++ b/testing/tests/DevExpress.viz.vectorMap/tracker.tests.js
@@ -37,7 +37,7 @@ const EVENTS = {
         'pointer': 'pointerup'
     },
     'wheel': {
-        'mouse': document['onwheel'] !== undefined ? 'wheel' : 'mousewheel'
+        'mouse': 'wheel'
     }
 };
 
@@ -339,33 +339,33 @@ QUnit.module('zoom / mouse', $.extend({}, environment, {
 }));
 
 QUnit.test('raised on wheel', function(assert) {
-    this.trigger('wheel', { x: 10, y: 20 }, { wheelDelta: 120 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -120 });
 
     assert.deepEqual(this.onZoom.lastCall.args, [{ delta: 1, x: 10, y: 20 }]);
 });
 
 // T107589
 QUnit.test('raised on small deltas', function(assert) {
-    this.trigger('wheel', { x: 10, y: 20 }, { wheelDelta: -20 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: 20 });
 
     assert.deepEqual(this.onZoom.lastCall.args, [{ delta: -1, x: 10, y: 20 }]);
 });
 
 QUnit.test('too big deltas are truncated', function(assert) {
-    this.trigger('wheel', { x: 10, y: 20 }, { wheelDelta: 800 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -800 });
 
     assert.deepEqual(this.onZoom.lastCall.args, [{ delta: 4, x: 10, y: 20 }]);
 });
 
 QUnit.test('consequent deltas are ignored', function(assert) {
-    this.trigger('wheel', { x: 10, y: 20 }, { wheelDelta: 200 }).trigger('wheel', { x: 11, y: 22 }, { wheelDelta: 120 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -200 }).trigger('wheel', { x: 11, y: 22 }, { deltaY: -120 });
 
     assert.deepEqual(this.onZoom.lastCall.args, [{ delta: 2, x: 10, y: 20 }]);
 });
 
 QUnit.test('not raised when disabled', function(assert) {
     this.tracker.setOptions({ wheelEnabled: false });
-    this.trigger('wheel', { x: 10, y: 20 }, { wheelDelta: 120 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -120 });
 
     assert.strictEqual(this.onZoom.lastCall, null);
 });

--- a/testing/tests/DevExpress.viz.vectorMap/tracker.tests.js
+++ b/testing/tests/DevExpress.viz.vectorMap/tracker.tests.js
@@ -339,33 +339,33 @@ QUnit.module('zoom / mouse', $.extend({}, environment, {
 }));
 
 QUnit.test('raised on wheel', function(assert) {
-    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -120 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -120, deltaMode: 0 });
 
     assert.deepEqual(this.onZoom.lastCall.args, [{ delta: 1, x: 10, y: 20 }]);
 });
 
 // T107589
 QUnit.test('raised on small deltas', function(assert) {
-    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: 20 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: 20, deltaMode: 0 });
 
     assert.deepEqual(this.onZoom.lastCall.args, [{ delta: -1, x: 10, y: 20 }]);
 });
 
 QUnit.test('too big deltas are truncated', function(assert) {
-    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -800 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -800, deltaMode: 0 });
 
     assert.deepEqual(this.onZoom.lastCall.args, [{ delta: 4, x: 10, y: 20 }]);
 });
 
 QUnit.test('consequent deltas are ignored', function(assert) {
-    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -200 }).trigger('wheel', { x: 11, y: 22 }, { deltaY: -120 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -200, deltaMode: 0 }).trigger('wheel', { x: 11, y: 22 }, { deltaY: -120, deltaMode: 0 });
 
     assert.deepEqual(this.onZoom.lastCall.args, [{ delta: 2, x: 10, y: 20 }]);
 });
 
 QUnit.test('not raised when disabled', function(assert) {
     this.tracker.setOptions({ wheelEnabled: false });
-    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -120 });
+    this.trigger('wheel', { x: 10, y: 20 }, { deltaY: -120, deltaMode: 0 });
 
     assert.strictEqual(this.onZoom.lastCall, null);
 });


### PR DESCRIPTION
- Removed [deprecated](https://developer.mozilla.org/ru/docs/Web/API/MouseWheelEvent) non-standard `mousewheel` event fallback
- Removed rough normalization for `wheel` event `deltaY` value when `deltaMode` === DOM_DELTA_PIXEL
- Rough normalization of `deltaY` value for DOM_DELTA_LINE and DOM_DELTA_PAGE modes was not changed.