### PR TITLE
File Manager: Fix displaying files if its extension contains capitalized letters (T868274 and T854231)

### DIFF
--- a/js/ui/file_manager/file_items_controller.js
+++ b/js/ui/file_manager/file_items_controller.js
@@ -555,7 +555,7 @@ class FileSecurityController {
 
         this._extensionsMap = {};
         this._allowedFileExtensions.forEach(extension => {
-            this._extensionsMap[extension] = true;
+            this._extensionsMap[extension.toUpperCase()] = true;
         });
     }
 
@@ -582,8 +582,7 @@ class FileSecurityController {
         if(this._allowedFileExtensions.length === 0) {
             return true;
         }
-
-        const extension = getFileExtension(name).toLowerCase();
+        const extension = getFileExtension(name).toUpperCase();
         return this._extensionsMap[extension];
     }
 

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/fileItemsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/fileItemsController.tests.js
@@ -505,4 +505,25 @@ QUnit.module('FileItemsController tests', moduleConfig, () => {
         assert.ok(rootItem.isRoot(), 'root has root flag');
     });
 
+    test('files can have extensions of any letter case', function(assert) {
+        const extendedData = this.data.concat({ name: 'File2.JPEG' }, { name: 'File3.Doc' });
+        this.controller = new FileItemsController({
+            fileProvider: extendedData,
+            allowedFileExtensions: [ '.jpeg', '.doC' ]
+        });
+        const selectedDir = this.controller.getCurrentDirectory();
+        const done1 = assert.async();
+        this.controller
+            .getDirectoryContents(selectedDir)
+            .done(items => {
+                assert.equal(items.length, 4);
+                assert.equal(items[0].fileItem.name, 'F1');
+                assert.equal(items[1].fileItem.name, 'F2');
+                assert.equal(items[2].fileItem.name, 'File2.JPEG');
+                assert.equal(items[3].fileItem.name, 'File3.Doc');
+                done1();
+            });
+        this.clock.tick(100);
+    });
+
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
