### PR TITLE
Accordion - fix layout rendering if option with long path is used (T869114)

### DIFF
--- a/js/ui/accordion.js
+++ b/js/ui/accordion.js
@@ -388,6 +388,10 @@ const Accordion = CollectionWidget.inherit({
             case 'multiple':
                 this.option('selectionMode', args.value ? 'multiple' : 'single');
                 break;
+            case 'items':
+                this.callBase(args);
+                this._updateItemHeightsWrapper(true);
+                break;
             default:
                 this.callBase(args);
         }

--- a/js/ui/accordion.js
+++ b/js/ui/accordion.js
@@ -371,6 +371,13 @@ const Accordion = CollectionWidget.inherit({
         this.callBase();
     },
 
+    _itemOptionChanged: function(item, property, value, oldValue) {
+        this.callBase(item, property, value, oldValue);
+        if(property === 'visible') {
+            this._updateItemHeightsWrapper(true);
+        }
+    },
+
     _optionChanged: function(args) {
         switch(args.name) {
             case 'animationDuration':
@@ -387,10 +394,6 @@ const Accordion = CollectionWidget.inherit({
                 break;
             case 'multiple':
                 this.option('selectionMode', args.value ? 'multiple' : 'single');
-                break;
-            case 'items':
-                this.callBase(args);
-                this._updateItemHeightsWrapper(true);
                 break;
             default:
                 this.callBase(args);

--- a/testing/tests/DevExpress.ui.widgets/accordion.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.tests.js
@@ -169,6 +169,25 @@ QUnit.module('widget rendering', moduleSetup, () => {
         assert.equal($element.find('.' + ACCORDION_ITEM_BODY_CLASS).length, 1, 'body is rendered');
     });
 
+    QUnit.test('item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)', function(assert) {
+        const $element = this.$element.dxAccordion({
+            items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
+            collapsible: true,
+            multiple: true,
+        });
+        const instance = $element.dxAccordion('instance');
+        const item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+        assert.ok(item1.is(':hidden'), 'item1 is hidden');
+
+        instance.option('items[1].visible', true);
+        assert.ok(item1.is(':visible'), 'item1 is visible');
+        assert.ok(item1.height() > 0, 'item1 has valid height');
+
+        instance.option('items[1].visible', false);
+        assert.ok(item1.is(':hidden'), 'item1 is hodden');
+        assert.strictEqual(item1.height(), 0, 'item1 has zero height');
+    });
+
     QUnit.test('Item body should be rendered on item changing and selectionChanging when the \'deferRendering\' option is true (T586536)', function(assert) {
         const $element = this.$element.dxAccordion({
             items: this.items,

--- a/testing/tests/DevExpress.ui.widgets/accordion.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.tests.js
@@ -173,24 +173,29 @@ QUnit.module('widget rendering', moduleSetup, () => {
     [true, false].forEach(collapsible => {
         [true, false].forEach(multiple => {
             [true, false].forEach(deferRendering => {
-                QUnit.test(`collapsible: ${collapsible}, multiple: ${multiple}, deferRendering: ${deferRendering} item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)`, function(assert) {
-                    const $element = this.$element.dxAccordion({
-                        items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
-                        deferRendering,
-                        collapsible,
-                        multiple
+                [true, false].forEach(repaintChangesOnly => {
+                    QUnit.test(`collapsible: ${collapsible}, multiple: ${multiple}, deferRendering: ${deferRendering}, repaintChangesOnly: ${repaintChangesOnly}, item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)`, function(assert) {
+                        const $element = this.$element.dxAccordion({
+                            items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
+                            repaintChangesOnly,
+                            deferRendering,
+                            collapsible,
+                            multiple
+                        });
+                        const instance = $element.dxAccordion('instance');
+                        let item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
+
+                        instance.option('items[1].visible', true);
+                        item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), false, 'item1 is visible');
+                        assert.roughEqual(item1.height(), 21, 0.5, 'item1 has valid height');
+
+                        instance.option('items[1].visible', false);
+                        item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
+                        assert.strictEqual(item1.height(), 0, 'item1 has zero height');
                     });
-                    const instance = $element.dxAccordion('instance');
-                    const item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
-                    assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
-
-                    instance.option('items[1].visible', true);
-                    assert.strictEqual(item1.hasClass(HIDDEN_CLASS), false, 'item1 is visible');
-                    assert.roughEqual(item1.height(), 21, 0.5, 'item1 has valid height');
-
-                    instance.option('items[1].visible', false);
-                    assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
-                    assert.strictEqual(item1.height(), 0, 'item1 has zero height');
                 });
             });
         });

--- a/testing/tests/DevExpress.ui.widgets/accordion.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.tests.js
@@ -170,36 +170,46 @@ QUnit.module('widget rendering', moduleSetup, () => {
         assert.equal($element.find('.' + ACCORDION_ITEM_BODY_CLASS).length, 1, 'body is rendered');
     });
 
+    const configs = [];
     [true, false].forEach(collapsible => {
         [true, false].forEach(multiple => {
             [true, false].forEach(deferRendering => {
                 [true, false].forEach(repaintChangesOnly => {
-                    QUnit.test(`collapsible: ${collapsible}, multiple: ${multiple}, deferRendering: ${deferRendering}, repaintChangesOnly: ${repaintChangesOnly}, item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)`, function(assert) {
-                        const $element = this.$element.dxAccordion({
-                            items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
-                            repaintChangesOnly,
-                            deferRendering,
-                            collapsible,
-                            multiple
-                        });
-                        const instance = $element.dxAccordion('instance');
-                        const item1GetterFunc = () => $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
-
-                        let item1 = item1GetterFunc();
-                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
-
-                        instance.option('items[1].visible', true);
-                        item1 = item1GetterFunc();
-                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), false, 'item1 is visible');
-                        assert.roughEqual(item1.height(), 21, 0.5, 'item1 has valid height');
-
-                        instance.option('items[1].visible', false);
-                        item1 = item1GetterFunc();
-                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
-                        assert.strictEqual(item1.height(), 0, 'item1 has zero height');
+                    [
+                        (accordion, value) => { accordion.option('items[1].visible', value); },
+                        (accordion, value) => { accordion.option('items')[1].visible = value; accordion.repaint(); }
+                    ].forEach(changeVisibleFunc => {
+                        configs.push({ collapsible, multiple, deferRendering, repaintChangesOnly, changeVisibleFunc });
                     });
                 });
             });
+        });
+    });
+
+    configs.forEach(config => {
+        QUnit.test(`collapsible: ${config.collapsible}, multiple: ${config.multiple}, deferRendering: ${config.deferRendering}, repaintChangesOnly: ${config.repaintChangesOnly}, item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)`, function(assert) {
+            const $element = this.$element.dxAccordion({
+                items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
+                repaintChangesOnly: config.repaintChangesOnly,
+                deferRendering: config.deferRendering,
+                collapsible: config.collapsible,
+                multiple: config.multiple
+            });
+            const instance = $element.dxAccordion('instance');
+            const item1GetterFunc = () => $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+
+            let item1 = item1GetterFunc();
+            assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
+
+            config.changeVisibleFunc(instance, true);
+            item1 = item1GetterFunc();
+            assert.strictEqual(item1.hasClass(HIDDEN_CLASS), false, 'item1 is visible');
+            assert.roughEqual(item1.height(), 21, 0.5, 'item1 has valid height');
+
+            config.changeVisibleFunc(instance, false);
+            item1 = item1GetterFunc();
+            assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
+            assert.strictEqual(item1.height(), 0, 'item1 has zero height');
         });
     });
 

--- a/testing/tests/DevExpress.ui.widgets/accordion.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.tests.js
@@ -170,22 +170,6 @@ QUnit.module('widget rendering', moduleSetup, () => {
         assert.equal($element.find('.' + ACCORDION_ITEM_BODY_CLASS).length, 1, 'body is rendered');
     });
 
-    const configs = [];
-    [true, false].forEach(collapsible => {
-        [true, false].forEach(multiple => {
-            [true, false].forEach(deferRendering => {
-                [true, false].forEach(repaintChangesOnly => {
-                    [
-                        (accordion, value) => { accordion.option('items[1].visible', value); },
-                        (accordion, value) => { accordion.option('items')[1].visible = value; accordion.repaint(); }
-                    ].forEach(changeVisibleFunc => {
-                        configs.push({ collapsible, multiple, deferRendering, repaintChangesOnly, changeVisibleFunc });
-                    });
-                });
-            });
-        });
-    });
-
     [true, false].forEach(collapsible => {
         [true, false].forEach(multiple => {
             [true, false].forEach(deferRendering => {

--- a/testing/tests/DevExpress.ui.widgets/accordion.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.tests.js
@@ -169,23 +169,30 @@ QUnit.module('widget rendering', moduleSetup, () => {
         assert.equal($element.find('.' + ACCORDION_ITEM_BODY_CLASS).length, 1, 'body is rendered');
     });
 
-    QUnit.test('item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)', function(assert) {
-        const $element = this.$element.dxAccordion({
-            items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
-            collapsible: true,
-            multiple: true,
+    [true, false].forEach(collapsible => {
+        [true, false].forEach(multiple => {
+            [true, false].forEach(deferRendering => {
+                QUnit.test(`collapsible: ${collapsible}, multiple: ${multiple}, deferRendering: ${deferRendering} item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)`, function(assert) {
+                    const $element = this.$element.dxAccordion({
+                        items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
+                        deferRendering,
+                        collapsible,
+                        multiple
+                    });
+                    const instance = $element.dxAccordion('instance');
+                    const item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+                    assert.ok(item1.is(':hidden'), 'item1 is hidden');
+
+                    instance.option('items[1].visible', true);
+                    assert.ok(item1.is(':visible'), 'item1 is visible');
+                    assert.ok(item1.height() > 0, 'item1 has valid height');
+
+                    instance.option('items[1].visible', false);
+                    assert.ok(item1.is(':hidden'), 'item1 is hodden');
+                    assert.strictEqual(item1.height(), 0, 'item1 has zero height');
+                });
+            });
         });
-        const instance = $element.dxAccordion('instance');
-        const item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
-        assert.ok(item1.is(':hidden'), 'item1 is hidden');
-
-        instance.option('items[1].visible', true);
-        assert.ok(item1.is(':visible'), 'item1 is visible');
-        assert.ok(item1.height() > 0, 'item1 has valid height');
-
-        instance.option('items[1].visible', false);
-        assert.ok(item1.is(':hidden'), 'item1 is hodden');
-        assert.strictEqual(item1.height(), 0, 'item1 has zero height');
     });
 
     QUnit.test('Item body should be rendered on item changing and selectionChanging when the \'deferRendering\' option is true (T586536)', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/accordion.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.tests.js
@@ -40,6 +40,7 @@ const ACCORDION_ITEM_TITLE_CLASS = 'dx-accordion-item-title';
 const ACCORDION_ITEM_BODY_CLASS = 'dx-accordion-item-body';
 const ACCORDION_ITEM_OPENED_CLASS = 'dx-accordion-item-opened';
 const ACCORDION_ITEM_CLOSED_CLASS = 'dx-accordion-item-closed';
+const HIDDEN_CLASS = 'dx-state-invisible';
 
 const moduleSetup = {
     beforeEach: function() {
@@ -181,14 +182,14 @@ QUnit.module('widget rendering', moduleSetup, () => {
                     });
                     const instance = $element.dxAccordion('instance');
                     const item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
-                    assert.ok(item1.is(':hidden'), 'item1 is hidden');
+                    assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
 
                     instance.option('items[1].visible', true);
-                    assert.ok(item1.is(':visible'), 'item1 is visible');
-                    assert.ok(item1.height() > 0, 'item1 has valid height');
+                    assert.strictEqual(item1.hasClass(HIDDEN_CLASS), false, 'item1 is visible');
+                    assert.roughEqual(item1.height(), 21, 0.5, 'item1 has valid height');
 
                     instance.option('items[1].visible', false);
-                    assert.ok(item1.is(':hidden'), 'item1 is hodden');
+                    assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
                     assert.strictEqual(item1.height(), 0, 'item1 has zero height');
                 });
             });

--- a/testing/tests/DevExpress.ui.widgets/accordion.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.tests.js
@@ -186,30 +186,36 @@ QUnit.module('widget rendering', moduleSetup, () => {
         });
     });
 
-    configs.forEach(config => {
-        QUnit.test(`collapsible: ${config.collapsible}, multiple: ${config.multiple}, deferRendering: ${config.deferRendering}, repaintChangesOnly: ${config.repaintChangesOnly}, item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)`, function(assert) {
-            const $element = this.$element.dxAccordion({
-                items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
-                repaintChangesOnly: config.repaintChangesOnly,
-                deferRendering: config.deferRendering,
-                collapsible: config.collapsible,
-                multiple: config.multiple
+    [true, false].forEach(collapsible => {
+        [true, false].forEach(multiple => {
+            [true, false].forEach(deferRendering => {
+                [true, false].forEach(repaintChangesOnly => {
+                    QUnit.test(`collapsible: ${collapsible}, multiple: ${multiple}, deferRendering: ${deferRendering}, repaintChangesOnly: ${repaintChangesOnly}, item1.display: false -> accordion.option(items[1].visible, true) -> accordion.option(items[1].visible, false) (T869114)`, function(assert) {
+                        const $element = this.$element.dxAccordion({
+                            items: [ { id: 0, title: 'item0' }, { id: 1, title: 'item1', visible: false } ],
+                            repaintChangesOnly: repaintChangesOnly,
+                            deferRendering: deferRendering,
+                            collapsible: collapsible,
+                            multiple: multiple
+                        });
+                        const instance = $element.dxAccordion('instance');
+                        const item1GetterFunc = () => $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+
+                        let item1 = item1GetterFunc();
+                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
+
+                        instance.option('items[1].visible', true);
+                        item1 = item1GetterFunc();
+                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), false, 'item1 is visible');
+                        assert.roughEqual(item1.height(), 21, 0.5, 'item1 has valid height');
+
+                        instance.option('items[1].visible', false);
+                        item1 = item1GetterFunc();
+                        assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
+                        assert.strictEqual(item1.height(), 0, 'item1 has zero height');
+                    });
+                });
             });
-            const instance = $element.dxAccordion('instance');
-            const item1GetterFunc = () => $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
-
-            let item1 = item1GetterFunc();
-            assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
-
-            config.changeVisibleFunc(instance, true);
-            item1 = item1GetterFunc();
-            assert.strictEqual(item1.hasClass(HIDDEN_CLASS), false, 'item1 is visible');
-            assert.roughEqual(item1.height(), 21, 0.5, 'item1 has valid height');
-
-            config.changeVisibleFunc(instance, false);
-            item1 = item1GetterFunc();
-            assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
-            assert.strictEqual(item1.height(), 0, 'item1 has zero height');
         });
     });
 

--- a/testing/tests/DevExpress.ui.widgets/accordion.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/accordion.tests.js
@@ -183,16 +183,18 @@ QUnit.module('widget rendering', moduleSetup, () => {
                             multiple
                         });
                         const instance = $element.dxAccordion('instance');
-                        let item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+                        const item1GetterFunc = () => $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+
+                        let item1 = item1GetterFunc();
                         assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
 
                         instance.option('items[1].visible', true);
-                        item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+                        item1 = item1GetterFunc();
                         assert.strictEqual(item1.hasClass(HIDDEN_CLASS), false, 'item1 is visible');
                         assert.roughEqual(item1.height(), 21, 0.5, 'item1 has valid height');
 
                         instance.option('items[1].visible', false);
-                        item1 = $element.find(`.${ACCORDION_ITEM_CLASS}`).eq(1);
+                        item1 = item1GetterFunc();
                         assert.strictEqual(item1.hasClass(HIDDEN_CLASS), true, 'item1 is hidden');
                         assert.strictEqual(item1.height(), 0, 'item1 has zero height');
                     });


### PR DESCRIPTION
Bugfix T869114
Accordion - The option method doesn't update layout if a long path is used