### PR TITLE
DataGrid - Fix row gaps, pending indicator and saving invalid value when an async setCellValue callback is used

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1546,7 +1546,7 @@ const EditingController = modules.ViewController.inherit((function() {
                         return;
                     }
                     this._saveEditDataInner().done(deferred.resolve).fail(deferred.reject);
-                });
+                }).fail(deferred.reject);
             }).fail(deferred.reject);
             return deferred.promise();
         },
@@ -1848,7 +1848,6 @@ const EditingController = modules.ViewController.inherit((function() {
                 if(options.values) {
                     options.values[options.columnIndex] = value;
                 }
-
                 that.addDeferred(setCellValueResult);
             }
 
@@ -1856,18 +1855,24 @@ const EditingController = modules.ViewController.inherit((function() {
         },
 
         updateFieldValue: function(options, value, text, forceUpdateRow) {
-            const that = this;
             const rowKey = options.key;
+            const deferred = new Deferred();
 
             if(rowKey === undefined) {
-                that._dataController.fireError('E1043');
+                this._dataController.fireError('E1043');
             }
 
             if(options.column.setCellValue) {
                 this._prepareEditDataParams(options, value, text).done(params => {
-                    this._applyEditDataParams(options, params, forceUpdateRow);
+                    when(this._applyEditDataParams(options, params, forceUpdateRow)).always(() => {
+                        deferred.resolve();
+                    });
                 });
+            } else {
+                deferred.resolve();
             }
+
+            return deferred.promise();
         },
         _focusPreviousEditingCellIfNeed: function(options) {
             const that = this;

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1116,13 +1116,10 @@ const EditingController = modules.ViewController.inherit((function() {
         },
 
         executeOperation: function(deferred, func) {
-            if(this._lastOperation) {
-                this._lastOperation.reject();
-            }
-
+            this._lastOperation && this._lastOperation.reject();
             this._lastOperation = deferred;
 
-            when(...this._deferreds).always(() => {
+            this.waitForDeferredOperations().always(() => {
                 this._lastOperation = null;
             }).done(() => {
                 if(deferred.state() === 'rejected') {
@@ -1130,6 +1127,10 @@ const EditingController = modules.ViewController.inherit((function() {
                 }
                 func();
             }).fail(deferred.reject);
+        },
+
+        waitForDeferredOperations: function() {
+            return when(...this._deferreds);
         },
 
         editCell: function(rowIndex, columnIndex) {
@@ -1535,7 +1536,7 @@ const EditingController = modules.ViewController.inherit((function() {
                     deferred.resolve();
                 });
             };
-            when(...this._deferreds).done(() => {
+            this.waitForDeferredOperations().done(() => {
                 if(this._saving) {
                     afterSaveEditData();
                     return;
@@ -1848,7 +1849,7 @@ const EditingController = modules.ViewController.inherit((function() {
                 if(options.values) {
                     options.values[options.columnIndex] = value;
                 }
-                that.addDeferred(setCellValueResult);
+                that.addDeferred(deferred);
             }
 
             return deferred;

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1119,14 +1119,16 @@ const EditingController = modules.ViewController.inherit((function() {
             this._lastOperation && this._lastOperation.reject();
             this._lastOperation = deferred;
 
-            this.waitForDeferredOperations().always(() => {
-                this._lastOperation = null;
-            }).done(() => {
+            this.waitForDeferredOperations().done(() => {
                 if(deferred.state() === 'rejected') {
                     return;
                 }
                 func();
-            }).fail(deferred.reject);
+                this._lastOperation = null;
+            }).fail(() => {
+                deferred.reject();
+                this._lastOperation = null;
+            });
         },
 
         waitForDeferredOperations: function() {

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -1,7 +1,7 @@
 import $ from '../../core/renderer';
 import eventsEngine from '../../events/core/events_engine';
 import modules from './ui.grid_core.modules';
-import { createObjectWithChanges, getIndexByKey } from './ui.grid_core.utils';
+import { createObjectWithChanges, getIndexByKey, getWidgetInstance } from './ui.grid_core.utils';
 import { deferUpdate, equalByValue } from '../../core/utils/common';
 import { each } from '../../core/utils/iterator';
 import { isDefined, isEmptyObject } from '../../core/utils/type';
@@ -296,11 +296,20 @@ const ValidatingController = modules.Controller.inherit((function() {
                         eventsEngine.trigger($focus, pointerEvents.down);
                     }
                 }
+                const editor = !column.editCellTemplate && this.getController('editorFactory').getEditorInstance($container);
                 if(result.status === VALIDATION_STATUS.pending) {
                     this._editingController.showHighlighting($container, true);
-                    this.renderCellPendingIndicator($container);
+                    if(editor) {
+                        editor.option('validationStatus', VALIDATION_STATUS.pending);
+                    } else {
+                        this.renderCellPendingIndicator($container);
+                    }
                 } else {
-                    this.disposeCellPendingIndicator($container);
+                    if(editor) {
+                        editor.option('validationStatus', VALIDATION_STATUS.valid);
+                    } else {
+                        this.disposeCellPendingIndicator($container);
+                    }
                 }
                 $container.toggleClass(this.addWidgetPrefix(INVALIDATE_CLASS), result.status === VALIDATION_STATUS.invalid);
             }
@@ -1082,6 +1091,11 @@ module.exports = {
 
                         this.updateCellState($element, validationResult, hideBorder);
                         return this.callBase($element, hideBorder);
+                    },
+
+                    getEditorInstance: function($container) {
+                        const $editor = $container.find('.dx-texteditor').eq(0);
+                        return getWidgetInstance($editor);
                     }
                 };
             })()

--- a/js/ui/shared/ui.editor_factory_mixin.js
+++ b/js/ui/shared/ui.editor_factory_mixin.js
@@ -284,8 +284,8 @@ const EditorFactoryMixin = (function() {
                 options.editorName = options.editorType;
             }
 
-            if(options.parentType === 'dataRow' && !options.isOnForm && !typeUtils.isDefined(options.editorOptions.enableValidMark)) {
-                options.editorOptions.enableValidMark = false;
+            if(options.parentType === 'dataRow' && !options.isOnForm && !typeUtils.isDefined(options.editorOptions.showValidationMark)) {
+                options.editorOptions.showValidationMark = false;
             }
 
             createEditorCore(this, options);

--- a/js/ui/shared/ui.editor_factory_mixin.js
+++ b/js/ui/shared/ui.editor_factory_mixin.js
@@ -284,6 +284,10 @@ const EditorFactoryMixin = (function() {
                 options.editorName = options.editorType;
             }
 
+            if(options.parentType === 'dataRow' && !options.isOnForm && !typeUtils.isDefined(options.editorOptions.enableValidMark)) {
+                options.editorOptions.enableValidMark = false;
+            }
+
             createEditorCore(this, options);
 
             this.executeAction('onEditorPrepared', options);

--- a/styles/widgets/generic/gridBase.generic.less
+++ b/styles/widgets/generic/gridBase.generic.less
@@ -716,6 +716,12 @@
                     }
                 }
             }
+
+            td:not(.dx-cell-modified):not(.dx-validation-pending) {
+                .dx-highlight-outline {
+                    padding: 0;
+                }
+            }
         }
 
         .dx-row-removed > td {

--- a/styles/widgets/generic/gridBase.generic.less
+++ b/styles/widgets/generic/gridBase.generic.less
@@ -717,7 +717,7 @@
                 }
             }
 
-            td:not(.dx-cell-modified):not(.dx-validation-pending) {
+            td:not(.dx-cell-modified):not(.dx-validation-pending):not(.dx-@{widgetName}-invalid) {
                 .dx-highlight-outline {
                     padding: 0;
                 }

--- a/styles/widgets/material/gridBase.material.less
+++ b/styles/widgets/material/gridBase.material.less
@@ -915,7 +915,7 @@
         }
 
         .dx-data-row {
-            td:not(.dx-cell-modified):not(.dx-validation-pending) {
+            td:not(.dx-cell-modified):not(.dx-validation-pending):not(.dx-@{widgetName}-invalid) {
                 .dx-highlight-outline {
                     padding: 0;
                 }

--- a/styles/widgets/material/gridBase.material.less
+++ b/styles/widgets/material/gridBase.material.less
@@ -914,6 +914,14 @@
             }
         }
 
+        .dx-data-row {
+            td:not(.dx-cell-modified):not(.dx-validation-pending) {
+                .dx-highlight-outline {
+                    padding: 0;
+                }
+            }
+        }
+
         .dx-row-removed > td {
             background-color: @datagrid-row-removed-bg;
             border-top: 1px solid @datagrid-cell-modified-border-color;

--- a/testing/functional/tests/dataGrid/editing.ts
+++ b/testing/functional/tests/dataGrid/editing.ts
@@ -634,6 +634,8 @@ test("Async Validation(Batch) - Data is not saved when a cell with async setCell
         .pressKey('enter')
         .click(saveButton)
         .expect(cell0.isValidationPending).ok()
+        .expect(cell0.isValidationPending).notOk()
+        .expect(cell0.isInvalid).ok()
         .expect(cell0.isModified).ok()
         .expect(dataRow.isInserted).ok("row is in editing mode");
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -19588,6 +19588,82 @@ QUnit.test('Filter builder custom operations should update filterValue immediate
     assert.equal(filterBuilder.getItemValueTextParts().length, 2, 'IsAnyOf operation applyed');
 });
 
+QUnit.test('Row height should not be changed after validation', function(assert) {
+    // arrange
+    const done = assert.async();
+    const data = [
+        { a: 'a', b: 'b', c: 'c' }
+    ];
+
+    const grid = createDataGrid({
+        dataSource: {
+            asyncLoadEnabled: false,
+            store: data
+        },
+        editing: {
+            mode: 'cell',
+            allowUpdating: true
+        },
+        columns: [
+            {
+                dataField: 'a',
+                setCellValue: function(newData, value, currentData) {
+                    const d = $.Deferred();
+                    setTimeout(function() {
+                        d.resolve('');
+                    }, 20);
+                    return d.promise();
+                },
+                validationRules: [{
+                    type: 'async',
+                    validationCallback: function(params) {
+                        const d = $.Deferred();
+                        setTimeout(function() {
+                            d.reject();
+                        }, 10);
+                        return d.promise();
+                    }
+                }]
+            }, {
+                dataField: 'b',
+                validationRules: [{
+                    type: 'async',
+                    validationCallback: function(params) {
+                        const d = $.Deferred();
+                        setTimeout(function() {
+                            params.value ? d.resolve(true) : d.reject();
+                        }, 20);
+                        return d.promise();
+                    }
+                }]
+            }, {
+                dataField: 'c',
+                validationRules: [{
+                    type: 'async',
+                    validationCallback: function(params) {
+                        const d = $.Deferred();
+                        setTimeout(function() {
+                            params.value ? d.resolve(true) : d.reject();
+                        }, 20);
+                        return d.promise();
+                    }
+                }]
+            }
+        ]
+    });
+
+    this.clock.tick();
+    const rowHeight = $(grid.getRowElement(0)).height();
+    this.clock.restore();
+
+    grid.cellValue(0, 1, '');
+    grid.saveEditData().done(() => {
+        assert.strictEqual($(grid.getRowElement(0)).height(), rowHeight, 'row height is not changed');
+
+        done();
+    });
+});
+
 
 QUnit.module('Row dragging', baseModuleConfig);
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -11680,7 +11680,6 @@ QUnit.test('It\'s impossible to save new data when editing form is invalid', fun
     inputElement = getInputElements(testElement).first();
     inputElement.val('');
     inputElement.trigger('change');
-
     that.saveEditData();
     that.clock.tick();
 
@@ -12129,9 +12128,10 @@ QUnit.test('Prevent cell validation if template with editor is used', function(a
     this.editingController.init();
 
     // act
-    const cells = this.rowsView.element().find('td');
-    this.editorFactoryController.focus(cells.eq(1));
-    const validator = this.validatingController.getValidator();
+    const validator = this.validatingController.getCellValidator({
+        rowKey: this.getKeyByRowIndex(0),
+        columnIndex: 1
+    });
 
     // assert
     assert.ok(!validator, 'only internal editor validator');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -17174,4 +17174,35 @@ QUnit.module('Async validation', {
         assert.equal(this.editingController._editRowIndex, 0, 'first row is still editing');
         assert.equal($formRow.find('.dx-validation-pending').length, 1, 'There is one pending editor in first row');
     });
+
+    QUnit.test('Pending validator should be rendered in a cell editor', function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+
+        rowsView.render(testElement);
+
+        this.applyOptions({
+            loadingTimeout: undefined,
+            editing: {
+                mode: 'batch',
+                allowUpdating: true,
+            },
+            columns: [{
+                dataField: 'age',
+                validationRules: [{
+                    type: 'async',
+                    validationCallback: function(params) {
+                        return new Deferred().promise();
+                    }
+                }]
+            }]
+        });
+
+        // act
+        this.editCell(0, 0);
+        const $editor = $(this.getCellElement(0, 0)).find('.dx-texteditor');
+
+        assert.ok($editor.hasClass('dx-validation-pending'));
+    });
 });


### PR DESCRIPTION
1. A pending indicator is rendered in a cell editor when a cell has the editor.
2. Row gaps are removed in batch and cell editing modes.
3. DataGrid does not save an invalid value when an async setCellValue callback is used.