### PR TITLE
DateBox: Use 'beforeInput' event for mask on Android devices (T838638) (#12355)

### DIFF
--- a/js/ui/date_box/ui.date_box.mask.js
+++ b/js/ui/date_box/ui.date_box.mask.js
@@ -13,6 +13,7 @@ import { isString } from '../../core/utils/type';
 import { sign } from '../../core/utils/math';
 import DateBoxBase from './ui.date_box.base';
 import numberLocalization from '../../localization/number';
+import devices from '../../core/devices';
 
 const MASK_EVENT_NAMESPACE = 'dateBoxMask';
 const FORWARD = 1;
@@ -125,8 +126,13 @@ const DateBoxMask = DateBoxBase.inherit({
     },
 
     _isSingleCharKey(e) {
-        const key = e.originalEvent.key;
+        const key = e.originalEvent.data || e.originalEvent.key;
         return typeof key === 'string' && key.length === 1 && !e.ctrl && !e.alt;
+    },
+
+    _useBeforeInputEvent: function() {
+        const device = devices.real();
+        return device.android && device.version[0] > 4;
     },
 
     _keyboardHandler(e) {
@@ -134,21 +140,68 @@ const DateBoxMask = DateBoxBase.inherit({
 
         const result = this.callBase(e);
 
-        if(!this._useMaskBehavior() || !this._isSingleCharKey(e)) {
+        if(!this._useMaskBehavior() || this._useBeforeInputEvent() || !this._isSingleCharKey(e)) {
             return result;
         }
 
-        if(this._isAllSelected()) {
-            this._activePartIndex = 0;
-        }
-
-        this._setNewDateIfEmpty();
-
-        isNaN(parseInt(key)) ? this._searchString(key) : this._searchNumber(key);
+        this._processInputKey(key);
 
         e.originalEvent.preventDefault();
 
         return result;
+    },
+
+    _maskBeforeInputHandler(e) {
+        this._maskInputHandler = null;
+
+        const { inputType } = e.originalEvent;
+
+        if(inputType === 'insertCompositionText') {
+            this._maskInputHandler = () => {
+                this._renderDisplayText(this._getDisplayedText(this._maskValue));
+                this._selectNextPart();
+            };
+        }
+
+        const isBackwardDeletion = inputType === 'deleteContentBackward';
+        const isForwardDeletion = inputType === 'deleteContentForward';
+        if(isBackwardDeletion || isForwardDeletion) {
+            const direction = isBackwardDeletion ? BACKWARD : FORWARD;
+            this._maskInputHandler = () => {
+                this._revertPart();
+                this._selectNextPart(direction);
+            };
+        }
+
+        if(!this._useMaskBehavior() || !this._isSingleCharKey(e)) {
+            return;
+        }
+
+        const key = e.originalEvent.data;
+        this._processInputKey(key);
+        e.preventDefault();
+        return true;
+    },
+
+    _keyPressHandler(e) {
+        this.callBase(e);
+
+        if(this._maskInputHandler) {
+            this._maskInputHandler();
+            this._maskInputHandler = null;
+        }
+    },
+
+    _processInputKey(key) {
+        if(this._isAllSelected()) {
+            this._activePartIndex = 0;
+        }
+        this._setNewDateIfEmpty();
+        if(isNaN(parseInt(key))) {
+            this._searchString(key);
+        } else {
+            this._searchNumber(key);
+        }
     },
 
     _isAllSelected() {
@@ -304,6 +357,10 @@ const DateBoxMask = DateBoxBase.inherit({
             this._renderDisplayText(this._getDisplayedText(this._maskValue));
             this._selectNextPart();
         });
+
+        if(this._useBeforeInputEvent()) {
+            eventsEngine.on(this._input(), addNamespace('beforeinput', MASK_EVENT_NAMESPACE), this._maskBeforeInputHandler.bind(this));
+        }
     },
 
     _selectLastPart() {

--- a/testing/helpers/keyboardMock.js
+++ b/testing/helpers/keyboardMock.js
@@ -407,8 +407,10 @@ var focused;
 
                     if(!this.event.isDefaultPrevented()) {
                         this.beforeInput(char);
-                        typeChar(char);
-                        this.input(char);
+                        if(!this.event.isDefaultPrevented()) {
+                            typeChar(char);
+                            this.input(char);
+                        }
                     }
 
                     this.keyUp(char);

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
@@ -6,6 +6,7 @@ import { noop } from 'core/utils/common';
 import pointerMock from '../../helpers/pointerMock.js';
 import 'ui/date_box';
 import keyboardMock from '../../helpers/keyboardMock.js';
+import devices from 'core/devices';
 
 const { test, module } = QUnit;
 
@@ -1202,5 +1203,67 @@ module('Advanced caret', setupModule, () => {
 
         this.keyboard.type('01');
         assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, 'caret was moved to month');
+    });
+});
+
+module('Using beforeInput event', {
+    beforeEach: function() {
+        try {
+            this.originalDevice = $.extend({ }, devices.real());
+            devices.real({
+                android: true,
+                version: [ '5', '0' ]
+            });
+
+            return setupModule.beforeEach.apply(this, arguments);
+        } finally {
+            this.instance.option({
+                value: new Date(2020, 0, 2, 3, 45),
+                displayFormat: 'dd/MM/yyyy HH:mm',
+            });
+        }
+    },
+    afterEach: function() {
+        try {
+            return setupModule.afterEach.apply(this, arguments);
+        } finally {
+            devices.real(this.originalDevice);
+        }
+    }
+
+}, () => {
+
+    test('typing valid symbols changes value correctly', function(assert) {
+        const input = this.$input.get(0);
+        this.keyboard.type('030420210455');
+        assert.strictEqual(input.value, '03/04/2021 04:55');
+    });
+
+    test('typing invalid symbols does not changes value', function(assert) {
+        const input = this.$input.get(0);
+        this.keyboard.type('abcde');
+        assert.strictEqual(input.value, '02/01/2020 03:45');
+    });
+
+    test('typing invalid symbols does not changes value on Android devices (T838638)', function(assert) {
+        const $input = this.$input;
+
+        $input.val('A');
+
+        this.keyboard
+            .keyDown('Unidentified')
+            .beforeInput('A', 'insertCompositionText')
+            .input('A', 'insertCompositionText');
+
+        assert.strictEqual($input.get(0).value, '02/01/2020 03:45');
+    });
+
+    test('unable to delete mask chars on Android devices (T838638)', function(assert) {
+        this.keyboard
+            .caret(3)
+            .beforeInput(null, 'deleteContentBackward')
+            .input(null, 'deleteContentBackward');
+
+        assert.strictEqual(this.$input.get(0).value, '01/01/2020 03:45');
     });
 });


### PR DESCRIPTION
Cherry-pick #12355.