### PR TITLE
Update babel-loader to version 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "angular": "^1.6.10",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.3",
-    "babel-loader": "^7.1.2",
+    "babel-loader": "^8.1.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
>This is the first stable release of babel-loader for Babel 7.x.

From:
https://github.com/babel/babel-loader/releases/tag/v8.0.0