### PR TITLE
Fix HtmlEditor separator item height for Material theme (multiline Toolbar)

### DIFF
--- a/styles/widgets/material/htmlEditor.material.less
+++ b/styles/widgets/material/htmlEditor.material.less
@@ -64,10 +64,6 @@
             background-color: @htmleditor-danger-format-active-bg;
         }
     }
-
-    .dx-htmleditor-toolbar-separator {
-        height: @MATERIAL_TOOLBAR_HEIGHT;
-    }
 }
 
 .dx-htmleditor-toolbar-format {
@@ -86,6 +82,10 @@
 .dx-htmleditor-toolbar-separator {
     height: 50%;
     border-left-color: @htmleditor-toolbar-border-color;
+
+    .dx-toolbar-multiline & {
+        height: @MATERIAL_TOOLBAR_HEIGHT / 2;
+    }
 }
 
 .dx-htmleditor-toolbar-menu-separator {


### PR DESCRIPTION
Actual result (20.1, multiline toolbar):
![image](https://user-images.githubusercontent.com/1554153/77329380-fa17ac00-6d2e-11ea-9eb0-354780bb176c.png)
With this fix:
![image](https://user-images.githubusercontent.com/1554153/77329456-0ef43f80-6d2f-11ea-8ab3-d5b39e2e38cb.png)

Current appearance (19.2, adaptive toolbar):
![image](https://user-images.githubusercontent.com/1554153/77329671-58448f00-6d2f-11ea-8d4f-2434424fa66e.png)

