### PR TITLE
Show deprecated warnings for SlideOut, SlideOutView and NavBar widgets to console when they are initialized

### DIFF
--- a/js/core/component.js
+++ b/js/core/component.js
@@ -95,7 +95,7 @@ const Component = Class.inherit({
             this._options.onChanging(
                 (name, previousValue, value) => this._initialized && this._optionChanging(name, previousValue, value));
             this._options.onDeprecated(
-                (option, info) => this._logDeprecatedWarning(option, info));
+                (optionName, info) => this._logDeprecatedWarning('W0001', { ...info, optionName }));
             this._options.onChanged(
                 (name, value, previousValue) => this._notifyOptionChanged(name, value, previousValue));
             this._options.onStartChange(() => this.beginUpdate());
@@ -125,9 +125,15 @@ const Component = Class.inherit({
         });
     },
 
-    _logDeprecatedWarning(option, info) {
-        const message = info.message || (`Use the '${info.alias}' option instead`);
-        errors.log('W0001', this.NAME, option, info.since, message);
+    _logDeprecatedWarning(error, options) {
+        const { since, alias } = options;
+        if(error === 'W0000') {
+            errors.log(error, this.NAME, since, `Use the '${alias}' widget instead`);
+        } else if(error === 'W0001') {
+            const { optionName } = options;
+            const message = options.message || (`Use the '${alias}' option instead`);
+            errors.log(error, this.NAME, optionName, since, message);
+        }
     },
 
     _createOptionChangedAction() {

--- a/js/core/component.js
+++ b/js/core/component.js
@@ -95,7 +95,7 @@ const Component = Class.inherit({
             this._options.onChanging(
                 (name, previousValue, value) => this._initialized && this._optionChanging(name, previousValue, value));
             this._options.onDeprecated(
-                (optionName, info) => this._logDeprecatedWarning('W0001', { ...info, optionName }));
+                (option, info) => this._logDeprecatedOptionWarning(option, info));
             this._options.onChanged(
                 (name, value, previousValue) => this._notifyOptionChanged(name, value, previousValue));
             this._options.onStartChange(() => this.beginUpdate());
@@ -125,15 +125,13 @@ const Component = Class.inherit({
         });
     },
 
-    _logDeprecatedWarning(error, options) {
-        const { since, alias } = options;
-        if(error === 'W0000') {
-            errors.log(error, this.NAME, since, `Use the '${alias}' widget instead`);
-        } else if(error === 'W0001') {
-            const { optionName } = options;
-            const message = options.message || (`Use the '${alias}' option instead`);
-            errors.log(error, this.NAME, optionName, since, message);
-        }
+    _logDeprecatedOptionWarning(option, info) {
+        const message = info.message || (`Use the '${info.alias}' option instead`);
+        errors.log('W0001', this.NAME, option, info.since, message);
+    },
+
+    _logDeprecatedComponentWarning(since, alias) {
+        errors.log('W0000', this.NAME, since, `Use the '${alias}' widget instead`);
     },
 
     _createOptionChangedAction() {

--- a/js/ui/nav_bar.js
+++ b/js/ui/nav_bar.js
@@ -9,6 +9,11 @@ const NAVBAR_ITEM_CLASS = 'dx-nav-item';
 const NAVBAR_ITEM_CONTENT_CLASS = 'dx-nav-item-content';
 
 const NavBar = Tabs.inherit({
+    _init: function() {
+        this.callBase();
+        this._logDeprecatedWarning('W0000', { since: '20.1', alias: 'dxTabs' });
+    },
+
     _getDefaultOptions: function() {
         return extend(this.callBase(), {
             /**

--- a/js/ui/nav_bar.js
+++ b/js/ui/nav_bar.js
@@ -9,9 +9,9 @@ const NAVBAR_ITEM_CLASS = 'dx-nav-item';
 const NAVBAR_ITEM_CONTENT_CLASS = 'dx-nav-item-content';
 
 const NavBar = Tabs.inherit({
-    _init: function() {
-        this.callBase();
-        this._logDeprecatedWarning('W0000', { since: '20.1', alias: 'dxTabs' });
+    ctor: function(element, options) {
+        this.callBase(element, options);
+        this._logDeprecatedComponentWarning('20.1', 'dxTabs');
     },
 
     _getDefaultOptions: function() {

--- a/js/ui/slide_out.js
+++ b/js/ui/slide_out.js
@@ -107,6 +107,7 @@ const SlideOut = CollectionWidget.inherit({
         this.callBase();
         this.$element().addClass(SLIDEOUT_CLASS);
         this._initSlideOutView();
+        this._logDeprecatedWarning('W0000', { since: '20.1', alias: 'dxDrawer' });
     },
 
     _initTemplates: function() {

--- a/js/ui/slide_out.js
+++ b/js/ui/slide_out.js
@@ -20,6 +20,10 @@ const SLIDEOUT_ITEM_CLASS = 'dx-slideout-item';
 const SLIDEOUT_ITEM_DATA_KEY = 'dxSlideoutItemData';
 
 const SlideOut = CollectionWidget.inherit({
+    ctor: function(element, options) {
+        this.callBase(element, options);
+        this._logDeprecatedComponentWarning('20.1', 'dxDrawer');
+    },
 
     _getDefaultOptions: function() {
         /**
@@ -107,7 +111,6 @@ const SlideOut = CollectionWidget.inherit({
         this.callBase();
         this.$element().addClass(SLIDEOUT_CLASS);
         this._initSlideOutView();
-        this._logDeprecatedWarning('W0000', { since: '20.1', alias: 'dxDrawer' });
     },
 
     _initTemplates: function() {

--- a/js/ui/slide_out_view.js
+++ b/js/ui/slide_out_view.js
@@ -42,6 +42,10 @@ const animation = {
 };
 
 const SlideOutView = Widget.inherit({
+    ctor: function(element, options) {
+        this.callBase(element, options);
+        this._logDeprecatedComponentWarning('20.1', 'dxDrawer');
+    },
 
     _getDefaultOptions: function() {
         return extend(this.callBase(), {
@@ -122,7 +126,6 @@ const SlideOutView = Widget.inherit({
         this._whenAnimationComplete = undefined;
         this._whenMenuRendered = undefined;
         this._initHideTopOverlayHandler();
-        this._logDeprecatedWarning('W0000', { since: '20.1', alias: 'dxDrawer' });
     },
 
     _initHideTopOverlayHandler: function() {

--- a/js/ui/slide_out_view.js
+++ b/js/ui/slide_out_view.js
@@ -122,6 +122,7 @@ const SlideOutView = Widget.inherit({
         this._whenAnimationComplete = undefined;
         this._whenMenuRendered = undefined;
         this._initHideTopOverlayHandler();
+        this._logDeprecatedWarning('W0000', { since: '20.1', alias: 'dxDrawer' });
     },
 
     _initHideTopOverlayHandler: function() {

--- a/testing/tests/DevExpress.core/component.tests.js
+++ b/testing/tests/DevExpress.core/component.tests.js
@@ -127,10 +127,10 @@ const TestComponent = Component.inherit({
 });
 
 class TestDeprecatedComponent extends Component {
-    _init() {
-        super._init();
+    constructor(options) {
+        super(options);
         this.NAME = 'TestDeprecatedComponent';
-        this._logDeprecatedWarning('W0000', { since: '20.1', alias: 'TestComponent' });
+        this._logDeprecatedComponentWarning('20.1', 'TestComponent');
     }
 }
 
@@ -489,7 +489,7 @@ QUnit.module('default', {}, () => {
             ++warningCount;
         };
 
-        instance._logDeprecatedWarning = _logDeprecatedWarningMock;
+        instance._logDeprecatedOptionWarning = _logDeprecatedWarningMock;
 
         instance._options.silent({
             deprecatedOption: true,
@@ -499,15 +499,14 @@ QUnit.module('default', {}, () => {
         assert.equal(warningCount, 0);
     });
 
-    QUnit.test('reading & writing a deprecated option must invoke the _logDeprecatedWarning method and pass the option name as a parameter', function(assert) {
+    QUnit.test('reading & writing a deprecated option must invoke the _logDeprecatedOptionWarning method and pass the option name as a parameter', function(assert) {
         const instance = new TestComponent();
         const deprecatedOption = 'deprecatedOption';
-        const _logDeprecatedWarningMock = (error, options) => {
-            const { optionName } = options;
-            assert.strictEqual(optionName, deprecatedOption);
+        const _logDeprecatedWarningMock = option => {
+            assert.strictEqual(option, deprecatedOption);
         };
 
-        instance._logDeprecatedWarning = _logDeprecatedWarningMock;
+        instance._logDeprecatedOptionWarning = _logDeprecatedWarningMock;
         assert.expect(3);
         instance.option(deprecatedOption);
         instance.option(deprecatedOption, true);
@@ -549,14 +548,14 @@ QUnit.module('default', {}, () => {
         assert.deepEqual(instance.option('deprecatedOptionAliasWithSugarSyntax'), 'new test');
     });
 
-    QUnit.test('reading all options should not invoke the _logDeprecatedWarning method', function(assert) {
+    QUnit.test('reading all options should not invoke the _logDeprecatedOptionWarning method', function(assert) {
         const instance = new TestComponent();
         let warningCount = 0;
         const _logDeprecatedWarningMock = option => {
             ++warningCount;
         };
 
-        instance._logDeprecatedWarning = _logDeprecatedWarningMock;
+        instance._logDeprecatedOptionWarning = _logDeprecatedWarningMock;
         instance.option();
         assert.strictEqual(warningCount, 0);
     });
@@ -569,7 +568,7 @@ QUnit.module('default', {}, () => {
             ++warningCount;
         };
 
-        instance._logDeprecatedWarning = _logDeprecatedWarningMock;
+        instance._logDeprecatedOptionWarning = _logDeprecatedWarningMock;
 
         assert.strictEqual(warningCount, 0);
         instance.option(deprecatedOption);
@@ -937,7 +936,7 @@ QUnit.module('default', {}, () => {
 
     QUnit.test('\'hasActionSubscription\' should not raise deprecation warning for event option', function(assert) {
         const instance = new TestComponent();
-        const logDeprecatedWarningSpy = sinon.spy(instance, '_logDeprecatedWarning');
+        const logDeprecatedWarningSpy = sinon.spy(instance, '_logDeprecatedOptionWarning');
 
         try {
             instance.hasActionSubscription('onDeprecatedEvent');
@@ -1523,7 +1522,7 @@ QUnit.module('action API', {}, () => {
             ++warningCount;
         };
 
-        instance._logDeprecatedWarning = _logDeprecatedWarningMock;
+        instance._logDeprecatedOptionWarning = _logDeprecatedWarningMock;
         instance._createActionByOption(deprecatedOption, {});
         assert.strictEqual(warningCount, 0);
         instance.option(deprecatedOption);

--- a/testing/tests/DevExpress.ui.widgets/navBar.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/navBar.markup.tests.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import errors from 'core/errors';
 
 import 'ui/nav_bar';
 
@@ -46,6 +47,26 @@ QUnit.module('rendering', () => {
         const $item = $navBar.find(toSelector(NAVBAR_ITEM_CLASS)).eq(0);
 
         assert.ok($item.hasClass(TAB_SELECTED_CLASS), 'selection present');
+    });
+
+    QUnit.test('show deprecated warning by the initialization', function(assert) {
+        const originalLog = errors.log;
+        try {
+            const stub = sinon.stub();
+            errors.log = stub;
+
+            $('#navbar').dxNavBar();
+
+            assert.equal(stub.callCount, 1, 'the log method is called once');
+            assert.deepEqual(stub.getCall(0).args, [
+                'W0000',
+                'dxNavBar',
+                '20.1',
+                'Use the \'dxTabs\' widget instead'
+            ], 'args of the log method');
+        } finally {
+            errors.log = originalLog;
+        }
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/slideOut.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/slideOut.markup.tests.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import errors from 'core/errors';
 
 import 'ui/slide_out';
 import 'common.css!';
@@ -98,6 +99,32 @@ QUnit.module('render widget', {
         });
 
         assert.equal($.trim(slideOut.find('.' + SLIDEOUT_ITEM_CONTAINER_CLASS).text()), 'itemText', 'item was rendered only once');
+    });
+
+    QUnit.test('show deprecated warning by the initialization', function(assert) {
+        const originalLog = errors.log;
+        try {
+            const stub = sinon.stub();
+            errors.log = stub;
+
+            this.$element.dxSlideOut();
+
+            assert.equal(stub.callCount, 2, 'the log method is called twice');
+            assert.deepEqual(stub.getCall(0).args, [
+                'W0000',
+                'dxSlideOutView',
+                '20.1',
+                'Use the \'dxDrawer\' widget instead'
+            ], 'first call - args of the log method');
+            assert.deepEqual(stub.getCall(1).args, [
+                'W0000',
+                'dxSlideOut',
+                '20.1',
+                'Use the \'dxDrawer\' widget instead'
+            ], 'second call - args of the log method');
+        } finally {
+            errors.log = originalLog;
+        }
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/slideOutView.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/slideOutView.markup.tests.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import config from 'core/config';
 import typeUtils from 'core/utils/type';
 import windowUtils from 'core/utils/window';
+import errors from 'core/errors';
 
 import 'common.css!';
 import 'ui/slide_out_view';
@@ -120,6 +121,26 @@ QUnit.module('rendering', () => {
         });
 
         assert.equal($element.find('.' + SLIDEOUTVIEW_SHIELD_CLASS).length, 1, 'slideoutview has shield');
+    });
+
+    QUnit.test('show deprecated warning by the initialization', function(assert) {
+        const originalLog = errors.log;
+        try {
+            const stub = sinon.stub();
+            errors.log = stub;
+
+            $('#slideOutView').dxSlideOutView();
+
+            assert.equal(stub.callCount, 1, 'the log method is called once');
+            assert.deepEqual(stub.getCall(0).args, [
+                'W0000',
+                'dxSlideOutView',
+                '20.1',
+                'Use the \'dxDrawer\' widget instead'
+            ], 'args of the log method');
+        } finally {
+            errors.log = originalLog;
+        }
     });
 });
 


### PR DESCRIPTION
Deprecate the `dxSlideOut`, `dxSlideOutView `and `dxNavBar`
Warnings:
1. W0000 - 'dxSlideOut' is deprecated in 20.1. Use the 'dxDrawer' widget instead. See:
http://js.devexpress.com/error/20_1/W0000
2. W0000 - 'dxSlideOutView' is deprecated in 20.1. Use the 'dxDrawer' widget instead. See:
http://js.devexpress.com/error/20_1/W0000
3. W0000 - 'dxNavBar' is deprecated in 20.1. Use the 'dxTabs' widget instead. See:
http://js.devexpress.com/error/20_1/W0000

**NOTE:** The `dxSlideOut` thrown two warnings to the console: own and from the `dxSlideOutView`