### PR TITLE
DataGrid - Fixes cell validation (T871515)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -206,7 +206,7 @@ const ValidatingController = modules.Controller.inherit((function() {
             const that = this;
             const column = parameters.column;
 
-            if(isDefined(column.command) || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
+            if(isDefined(column.command) || !column.allowEditing || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
 
             const editingController = that._editingController;
             let editData;
@@ -246,7 +246,7 @@ const ValidatingController = modules.Controller.inherit((function() {
                     showEditorAlways = visibleColumns.some(function(column) { return column.showEditorAlways; });
                 }
 
-                if(showEditorAlways) {
+                if(showEditorAlways && editingController.isCellOrBatchEditMode() && editingController.allowUpdating({ row: parameters.row })) {
                     editIndex = editingController._addEditData({ key: parameters.key, oldData: parameters.data });
                 }
             }

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -204,8 +204,11 @@ const ValidatingController = modules.Controller.inherit((function() {
 
         createValidator: function(parameters, $container) {
             const that = this;
-            const editingController = that._editingController;
             const column = parameters.column;
+
+            if(isDefined(column.command) || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
+
+            const editingController = that._editingController;
             let editData;
             let editIndex;
             const defaultValidationResult = function(options) {
@@ -233,8 +236,6 @@ const ValidatingController = modules.Controller.inherit((function() {
             let visibleColumns;
             let columnsController;
             let showEditorAlways = column.showEditorAlways;
-
-            if(!column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length || isDefined(column.command)) return;
 
             editIndex = editingController.getIndexByKey(parameters.key, editingController._editData);
 

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -205,9 +205,6 @@ const ValidatingController = modules.Controller.inherit((function() {
         createValidator: function(parameters, $container) {
             const that = this;
             const column = parameters.column;
-
-            if(isDefined(column.command) || !column.allowEditing || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
-
             const editingController = that._editingController;
             let editData;
             let editIndex;
@@ -236,6 +233,8 @@ const ValidatingController = modules.Controller.inherit((function() {
             let visibleColumns;
             let columnsController;
             let showEditorAlways = column.showEditorAlways;
+
+            if(isDefined(column.command) || !column.allowEditing || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
 
             editIndex = editingController.getIndexByKey(parameters.key, editingController._editData);
 

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -234,7 +234,7 @@ const ValidatingController = modules.Controller.inherit((function() {
             let columnsController;
             let showEditorAlways = column.showEditorAlways;
 
-            if(isDefined(column.command) || !column.allowEditing || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
+            if(isDefined(column.command) || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
 
             editIndex = editingController.getIndexByKey(parameters.key, editingController._editData);
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -12782,7 +12782,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
 
 [false, true].forEach((allowUpdating) => {
     [false, true].forEach((allowEditing) => {
-        QUnit.test(`row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
+        QUnit.test(`Row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
             // arrange
             const rowsView = this.rowsView;
             const testElement = $('#container');
@@ -12904,7 +12904,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
         assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
     });
 
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should have a validator(T871515)`, function(assert) {
         // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8657,8 +8657,13 @@ QUnit.module('Editing with validation', {
             return renderer('.dx-datagrid');
         };
 
-        setupDataGridModules(this, ['data', 'columns', 'columnHeaders', 'columnFixing', 'rows', 'editing', 'masterDetail', 'gridView', 'grouping', 'editorFactory', 'errorHandling', 'validating', 'filterRow', 'adaptivity', 'summary'], {
-            initViews: true
+        setupDataGridModules(this, ['data', 'columns', 'columnHeaders', 'columnFixing', 'rows', 'editing', 'masterDetail', 'gridView', 'grouping', 'editorFactory', 'errorHandling', 'validating', 'filterRow', 'adaptivity', 'summary', 'keyboardNavigation'], {
+            initViews: true,
+            options: {
+                keyboardNavigation: {
+                    enabled: true
+                }
+            }
         });
 
         this.applyOptions = function(options) {
@@ -8667,10 +8672,15 @@ QUnit.module('Editing with validation', {
             this.columnsController.init();
             this.editingController.init();
             this.validatingController.init();
+            this.keyboardNavigationController.init();
         };
 
         this.columnHeadersView.getColumnCount = function() {
             return 3;
+        };
+
+        this.focus = function($element) {
+            this.keyboardNavigationController.focus($element);
         };
 
         this.clock = sinon.useFakeTimers();
@@ -12769,6 +12779,164 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
         assert.equal(visibleRows.length, 4, 'rows count');
     });
 });
+
+[false, true].forEach((allowUpdating) => {
+    [false, true].forEach((allowEditing) => {
+        QUnit.test(`row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
+
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: 'row',
+                    allowUpdating: allowUpdating
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
+
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            let $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+            this.focus($secondCell);
+            this.clock.tick();
+            $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+        });
+    });
+});
+
+['Cell', 'Batch'].forEach((mode) => {
+    [true, false].forEach((allowEditing) => {
+        QUnit.test(`${mode}(allowUpdating: false, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
+
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: mode.toLowerCase(),
+                    allowUpdating: false
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
+
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            let $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+            this.focus($secondCell);
+            this.clock.tick();
+            $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+        });
+    });
+
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: false) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+
+        const gridConfig = {
+            dataSource: [
+                { a: true, b: null }
+            ],
+            editing: {
+                mode: mode.toLowerCase(),
+                allowUpdating: true
+            },
+            columns: [
+                'a',
+                {
+                    dataField: 'b',
+                    allowEditing: false,
+                    validationRules: [{ type: 'required' }]
+                }
+            ]
+        };
+
+        rowsView.render(testElement);
+        this.applyOptions(gridConfig);
+        let $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+        this.focus($secondCell);
+        this.clock.tick();
+        $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+    });
+
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+
+        const gridConfig = {
+            dataSource: [
+                { a: true, b: null }
+            ],
+            editing: {
+                mode: mode.toLowerCase(),
+                allowUpdating: true
+            },
+            columns: [
+                'a',
+                {
+                    dataField: 'b',
+                    allowEditing: true,
+                    validationRules: [{ type: 'required' }]
+                }
+            ]
+        };
+
+        rowsView.render(testElement);
+        this.applyOptions(gridConfig);
+        let $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
+        assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+    });
+});
+
 
 QUnit.module('Editing with real dataController with grouping, masterDetail', {
     beforeEach: function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -12863,77 +12863,38 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
             assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
             assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
         });
-    });
 
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: false) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
-        // arrange
-        const rowsView = this.rowsView;
-        const testElement = $('#container');
+        QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: ${allowEditing}) - Cell with validation rules should have a validator(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
 
-        const gridConfig = {
-            dataSource: [
-                { a: true, b: null }
-            ],
-            editing: {
-                mode: mode.toLowerCase(),
-                allowUpdating: true
-            },
-            columns: [
-                'a',
-                {
-                    dataField: 'b',
-                    allowEditing: false,
-                    validationRules: [{ type: 'required' }]
-                }
-            ]
-        };
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: mode.toLowerCase(),
+                    allowUpdating: true
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
 
-        rowsView.render(testElement);
-        this.applyOptions(gridConfig);
-        let $secondCell = $(this.getCellElement(0, 1));
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            const $secondCell = $(this.getCellElement(0, 1));
 
-        // assert
-        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
-
-        this.focus($secondCell);
-        this.clock.tick();
-        $secondCell = $(this.getCellElement(0, 1));
-
-        // assert
-        assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
-        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
-    });
-
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should have a validator(T871515)`, function(assert) {
-        // arrange
-        const rowsView = this.rowsView;
-        const testElement = $('#container');
-
-        const gridConfig = {
-            dataSource: [
-                { a: true, b: null }
-            ],
-            editing: {
-                mode: mode.toLowerCase(),
-                allowUpdating: true
-            },
-            columns: [
-                'a',
-                {
-                    dataField: 'b',
-                    allowEditing: true,
-                    validationRules: [{ type: 'required' }]
-                }
-            ]
-        };
-
-        rowsView.render(testElement);
-        this.applyOptions(gridConfig);
-        const $secondCell = $(this.getCellElement(0, 1));
-
-        // assert
-        assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
-        assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+            // assert
+            assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
+            assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+        });
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -12929,7 +12929,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
 
         rowsView.render(testElement);
         this.applyOptions(gridConfig);
-        let $secondCell = $(this.getCellElement(0, 1));
+        const $secondCell = $(this.getCellElement(0, 1));
 
         // assert
         assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');


### PR DESCRIPTION
1. Added an extra condition for preventing validator from creating. The validator should not be created if a cell is not editable.
2. Added the required tests.
