### PR TITLE
DataGrid - Fixes cell validation (T871515)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -325,7 +325,7 @@ const ValidatingController = modules.Controller.inherit((function() {
             };
             let showEditorAlways = column.showEditorAlways;
 
-            if(!column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length || isDefined(column.command)) return;
+            if(isDefined(column.command) || !column.allowEditing || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
 
             editIndex = editingController.getIndexByKey(parameters.key, editingController._editData);
 
@@ -336,7 +336,7 @@ const ValidatingController = modules.Controller.inherit((function() {
                     showEditorAlways = visibleColumns.some(function(column) { return column.showEditorAlways; });
                 }
 
-                if(showEditorAlways) {
+                if(showEditorAlways && editingController.isCellOrBatchEditMode() && editingController.allowUpdating({ row: parameters.row })) {
                     editIndex = editingController._addEditData({ key: parameters.key, oldData: parameters.data });
                 }
             }

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -325,7 +325,7 @@ const ValidatingController = modules.Controller.inherit((function() {
             };
             let showEditorAlways = column.showEditorAlways;
 
-            if(isDefined(column.command) || !column.allowEditing || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
+            if(isDefined(column.command) || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
 
             editIndex = editingController.getIndexByKey(parameters.key, editingController._editData);
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -13026,77 +13026,38 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
             assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
             assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
         });
-    });
 
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: false) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
-        // arrange
-        const rowsView = this.rowsView;
-        const testElement = $('#container');
+        QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: ${allowEditing}) - Cell with validation rules should have a validator(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
 
-        const gridConfig = {
-            dataSource: [
-                { a: true, b: null }
-            ],
-            editing: {
-                mode: mode.toLowerCase(),
-                allowUpdating: true
-            },
-            columns: [
-                'a',
-                {
-                    dataField: 'b',
-                    allowEditing: false,
-                    validationRules: [{ type: 'required' }]
-                }
-            ]
-        };
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: mode.toLowerCase(),
+                    allowUpdating: true
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
 
-        rowsView.render(testElement);
-        this.applyOptions(gridConfig);
-        let $secondCell = $(this.getCellElement(0, 1));
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            const $secondCell = $(this.getCellElement(0, 1));
 
-        // assert
-        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
-
-        this.focus($secondCell);
-        this.clock.tick();
-        $secondCell = $(this.getCellElement(0, 1));
-
-        // assert
-        assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
-        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
-    });
-
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should have a validator(T871515)`, function(assert) {
-        // arrange
-        const rowsView = this.rowsView;
-        const testElement = $('#container');
-
-        const gridConfig = {
-            dataSource: [
-                { a: true, b: null }
-            ],
-            editing: {
-                mode: mode.toLowerCase(),
-                allowUpdating: true
-            },
-            columns: [
-                'a',
-                {
-                    dataField: 'b',
-                    allowEditing: true,
-                    validationRules: [{ type: 'required' }]
-                }
-            ]
-        };
-
-        rowsView.render(testElement);
-        this.applyOptions(gridConfig);
-        const $secondCell = $(this.getCellElement(0, 1));
-
-        // assert
-        assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
-        assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+            // assert
+            assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
+            assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+        });
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8180,7 +8180,7 @@ QUnit.test('The current editable row should close when adding a new row in \'row
                 const rowsView = this.rowsView;
                 const $testElement = $('#container');
                 let dataSourceCallCount = 0;
-                let lookup2InitializedSpy = sinon.spy();
+                const lookup2InitializedSpy = sinon.spy();
 
                 this.options.repaintChangesOnly = repaintChangesOnly;
                 this.options.editing = {
@@ -12945,7 +12945,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
 
 [false, true].forEach((allowUpdating) => {
     [false, true].forEach((allowEditing) => {
-        QUnit.test(`row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
+        QUnit.test(`Row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
             // arrange
             const rowsView = this.rowsView;
             const testElement = $('#container');
@@ -13067,7 +13067,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
         assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
     });
 
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should have a validator(T871515)`, function(assert) {
         // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13092,7 +13092,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
 
         rowsView.render(testElement);
         this.applyOptions(gridConfig);
-        let $secondCell = $(this.getCellElement(0, 1));
+        const $secondCell = $(this.getCellElement(0, 1));
 
         // assert
         assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -12943,6 +12943,164 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
     });
 });
 
+[false, true].forEach((allowUpdating) => {
+    [false, true].forEach((allowEditing) => {
+        QUnit.test(`row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
+
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: 'row',
+                    allowUpdating: allowUpdating
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
+
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            let $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+            this.focus($secondCell);
+            this.clock.tick();
+            $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+        });
+    });
+});
+
+['Cell', 'Batch'].forEach((mode) => {
+    [true, false].forEach((allowEditing) => {
+        QUnit.test(`${mode}(allowUpdating: false, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
+
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: mode.toLowerCase(),
+                    allowUpdating: false
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
+
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            let $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+            this.focus($secondCell);
+            this.clock.tick();
+            $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+        });
+    });
+
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: false) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+
+        const gridConfig = {
+            dataSource: [
+                { a: true, b: null }
+            ],
+            editing: {
+                mode: mode.toLowerCase(),
+                allowUpdating: true
+            },
+            columns: [
+                'a',
+                {
+                    dataField: 'b',
+                    allowEditing: false,
+                    validationRules: [{ type: 'required' }]
+                }
+            ]
+        };
+
+        rowsView.render(testElement);
+        this.applyOptions(gridConfig);
+        let $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+        this.focus($secondCell);
+        this.clock.tick();
+        $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+    });
+
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+
+        const gridConfig = {
+            dataSource: [
+                { a: true, b: null }
+            ],
+            editing: {
+                mode: mode.toLowerCase(),
+                allowUpdating: true
+            },
+            columns: [
+                'a',
+                {
+                    dataField: 'b',
+                    allowEditing: true,
+                    validationRules: [{ type: 'required' }]
+                }
+            ]
+        };
+
+        rowsView.render(testElement);
+        this.applyOptions(gridConfig);
+        let $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
+        assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+    });
+});
+
+
 QUnit.module('Editing with real dataController with grouping, masterDetail', {
     beforeEach: function() {
         this.$element = () => $('#container');


### PR DESCRIPTION
1. Added an extra condition for preventing validator from creating. The validator should not be created if a cell is not editable.
2. Added the required tests.
