### PR TITLE
DataGrid - Fixes cell validation (T871515)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -161,8 +161,8 @@ const ValidatingController = modules.Controller.inherit((function() {
 
         createValidator: function(parameters, $container) {
             const that = this;
-            const editingController = that._editingController;
             const column = parameters.column;
+            const editingController = that._editingController;
             let editData;
             let editIndex;
             const defaultValidationResult = function(options) {
@@ -191,7 +191,7 @@ const ValidatingController = modules.Controller.inherit((function() {
             let columnsController;
             let showEditorAlways = column.showEditorAlways;
 
-            if(!column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length || isDefined(column.command)) return;
+            if(isDefined(column.command) || !column.allowEditing || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
 
             editIndex = editingController.getIndexByKey(parameters.key, editingController._editData);
 
@@ -202,7 +202,7 @@ const ValidatingController = modules.Controller.inherit((function() {
                     showEditorAlways = visibleColumns.some(function(column) { return column.showEditorAlways; });
                 }
 
-                if(showEditorAlways) {
+                if(showEditorAlways && editingController.isCellOrBatchEditMode() && editingController.allowUpdating({ row: parameters.row })) {
                     editIndex = editingController._addEditData({ key: parameters.key, oldData: parameters.data });
                 }
             }

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -191,7 +191,7 @@ const ValidatingController = modules.Controller.inherit((function() {
             let columnsController;
             let showEditorAlways = column.showEditorAlways;
 
-            if(isDefined(column.command) || !column.allowEditing || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
+            if(isDefined(column.command) || !column.validationRules || !Array.isArray(column.validationRules) || !column.validationRules.length) return;
 
             editIndex = editingController.getIndexByKey(parameters.key, editingController._editData);
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8345,8 +8345,13 @@ QUnit.module('Editing with validation', {
             return renderer('.dx-datagrid');
         };
 
-        setupDataGridModules(this, ['data', 'columns', 'columnHeaders', 'columnFixing', 'rows', 'editing', 'masterDetail', 'gridView', 'grouping', 'editorFactory', 'errorHandling', 'validating', 'filterRow', 'adaptivity'], {
-            initViews: true
+        setupDataGridModules(this, ['data', 'columns', 'columnHeaders', 'columnFixing', 'rows', 'editing', 'masterDetail', 'gridView', 'grouping', 'editorFactory', 'errorHandling', 'validating', 'filterRow', 'adaptivity', 'summary', 'keyboardNavigation'], {
+            initViews: true,
+            options: {
+                keyboardNavigation: {
+                    enabled: true
+                }
+            }
         });
 
         this.applyOptions = function(options) {
@@ -8355,11 +8360,17 @@ QUnit.module('Editing with validation', {
             this.columnsController.init();
             this.editingController.init();
             this.validatingController.init();
+            this.keyboardNavigationController.init();
         };
 
         this.columnHeadersView.getColumnCount = function() {
             return 3;
         };
+
+        this.focus = function($element) {
+            this.keyboardNavigationController.focus($element);
+        };
+
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
@@ -11848,6 +11859,164 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
     // assert
     assert.notOk($secondCell.hasClass('dx-focused'), 'cell is not focused');
     assert.notOk($secondCell.hasClass('dx-datagrid-invalid'), 'cell is not marked as invalid');
+});
+
+
+[false, true].forEach((allowUpdating) => {
+    [false, true].forEach((allowEditing) => {
+        QUnit.test(`row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
+
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: 'row',
+                    allowUpdating: allowUpdating
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
+
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            let $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+            this.focus($secondCell);
+            this.clock.tick();
+            $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+        });
+    });
+});
+
+['Cell', 'Batch'].forEach((mode) => {
+    [true, false].forEach((allowEditing) => {
+        QUnit.test(`${mode}(allowUpdating: false, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
+
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: mode.toLowerCase(),
+                    allowUpdating: false
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
+
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            let $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+            this.focus($secondCell);
+            this.clock.tick();
+            $secondCell = $(this.getCellElement(0, 1));
+
+            // assert
+            assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+            assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+        });
+    });
+
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: false) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+
+        const gridConfig = {
+            dataSource: [
+                { a: true, b: null }
+            ],
+            editing: {
+                mode: mode.toLowerCase(),
+                allowUpdating: true
+            },
+            columns: [
+                'a',
+                {
+                    dataField: 'b',
+                    allowEditing: false,
+                    validationRules: [{ type: 'required' }]
+                }
+            ]
+        };
+
+        rowsView.render(testElement);
+        this.applyOptions(gridConfig);
+        let $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+
+        this.focus($secondCell);
+        this.clock.tick();
+        $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
+        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
+    });
+
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+
+        const gridConfig = {
+            dataSource: [
+                { a: true, b: null }
+            ],
+            editing: {
+                mode: mode.toLowerCase(),
+                allowUpdating: true
+            },
+            columns: [
+                'a',
+                {
+                    dataField: 'b',
+                    allowEditing: true,
+                    validationRules: [{ type: 'required' }]
+                }
+            ]
+        };
+
+        rowsView.render(testElement);
+        this.applyOptions(gridConfig);
+        let $secondCell = $(this.getCellElement(0, 1));
+
+        // assert
+        assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
+        assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+    });
 });
 
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8350,7 +8350,8 @@ QUnit.module('Editing with validation', {
             options: {
                 keyboardNavigation: {
                     enabled: true
-                }
+                },
+                useKeyboard: true
             }
         });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -11946,77 +11946,38 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
             assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
             assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
         });
-    });
 
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: false) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
-        // arrange
-        const rowsView = this.rowsView;
-        const testElement = $('#container');
+        QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: ${allowEditing}) - Cell with validation rules should have a validator(T871515)`, function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
 
-        const gridConfig = {
-            dataSource: [
-                { a: true, b: null }
-            ],
-            editing: {
-                mode: mode.toLowerCase(),
-                allowUpdating: true
-            },
-            columns: [
-                'a',
-                {
-                    dataField: 'b',
-                    allowEditing: false,
-                    validationRules: [{ type: 'required' }]
-                }
-            ]
-        };
+            const gridConfig = {
+                dataSource: [
+                    { a: true, b: null }
+                ],
+                editing: {
+                    mode: mode.toLowerCase(),
+                    allowUpdating: true
+                },
+                columns: [
+                    'a',
+                    {
+                        dataField: 'b',
+                        allowEditing: allowEditing,
+                        validationRules: [{ type: 'required' }]
+                    }
+                ]
+            };
 
-        rowsView.render(testElement);
-        this.applyOptions(gridConfig);
-        let $secondCell = $(this.getCellElement(0, 1));
+            rowsView.render(testElement);
+            this.applyOptions(gridConfig);
+            const $secondCell = $(this.getCellElement(0, 1));
 
-        // assert
-        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
-
-        this.focus($secondCell);
-        this.clock.tick();
-        $secondCell = $(this.getCellElement(0, 1));
-
-        // assert
-        assert.ok($secondCell.hasClass('dx-focused'), 'cell is focused');
-        assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
-    });
-
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should have a validator(T871515)`, function(assert) {
-        // arrange
-        const rowsView = this.rowsView;
-        const testElement = $('#container');
-
-        const gridConfig = {
-            dataSource: [
-                { a: true, b: null }
-            ],
-            editing: {
-                mode: mode.toLowerCase(),
-                allowUpdating: true
-            },
-            columns: [
-                'a',
-                {
-                    dataField: 'b',
-                    allowEditing: true,
-                    validationRules: [{ type: 'required' }]
-                }
-            ]
-        };
-
-        rowsView.render(testElement);
-        this.applyOptions(gridConfig);
-        const $secondCell = $(this.getCellElement(0, 1));
-
-        // assert
-        assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
-        assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+            // assert
+            assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');
+            assert.notOk($secondCell.hasClass('dx-datagrid-invalid'));
+        });
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -11987,7 +11987,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
         assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
     });
 
-    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
+    QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: true) - Cell with validation rules should have a validator(T871515)`, function(assert) {
         // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -11865,7 +11865,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
 
 [false, true].forEach((allowUpdating) => {
     [false, true].forEach((allowEditing) => {
-        QUnit.test(`row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
+        QUnit.test(`Row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
             // arrange
             const rowsView = this.rowsView;
             const testElement = $('#container');
@@ -12012,7 +12012,7 @@ QUnit.test('Row - An untouched cell should not be validated (T872003)', function
 
         rowsView.render(testElement);
         this.applyOptions(gridConfig);
-        let $secondCell = $(this.getCellElement(0, 1));
+        const $secondCell = $(this.getCellElement(0, 1));
 
         // assert
         assert.ok($secondCell.hasClass('dx-validator'), 'cell should have validator');


### PR DESCRIPTION
1. Added an extra condition for preventing validator from creating. The validator should not be created if a cell is not editable.
2. Added the required tests.
