### PR TITLE
T873507 - Diagram - The picture field of a shape item which contains …

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "types": "./bundles/dx.all.d.ts",
   "license": "SEE LICENSE IN README.md",
   "dependencies": {
-    "devexpress-diagram": "0.2.30",
+    "devexpress-diagram": "0.2.31",
     "devexpress-gantt": "0.1.12",
     "jszip": "^2.0.0 || ^3.0.0",
     "quill": "^1.3.7",


### PR DESCRIPTION
…a base64 value becomes empty in ArrayStore once the diagram is shown

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
