### PR TITLE
Fix caret position utility for iOS browsers (T870784)

### DIFF
--- a/js/ui/text_box/utils.caret.js
+++ b/js/ui/text_box/utils.caret.js
@@ -1,9 +1,11 @@
 import $ from '../../core/renderer';
 import { isDefined } from '../../core/utils/type';
 import browser from '../../core/utils/browser';
+import devices from '../../core/devices';
 import domAdapter from '../../core/dom_adapter';
 
-const isFocusingOnCaretChange = browser.msie || browser.safari;
+const { ios, mac } = devices.real();
+const isFocusingOnCaretChange = browser.msie || ios || mac;
 
 const getCaret = function(input) {
     let range;
@@ -41,7 +43,7 @@ const caret = function(input, position) {
         return getCaret(input);
     }
 
-    // NOTE: IE focuses element input after caret position has changed
+    // NOTE: IE and AppleWebKit-based browsers focuses element input after caret position has changed
     if(isFocusingOnCaretChange && domAdapter.getActiveElement() !== input) {
         return;
     }

--- a/testing/tests/DevExpress.utils/utils.caret.tests.js
+++ b/testing/tests/DevExpress.utils/utils.caret.tests.js
@@ -1,6 +1,9 @@
 import $ from 'jquery';
 import caret from 'ui/text_box/utils.caret';
 import keyboardMock from '../../helpers/keyboardMock.js';
+import domAdapter from 'core/dom_adapter';
+import browser from 'core/utils/browser';
+import devices from 'core/devices';
 
 const { module: testModule, test } = QUnit;
 
@@ -81,5 +84,21 @@ testModule('caret', () => {
         }
 
         Object.defineProperty(HTMLInputElement.prototype, 'selectionStart', initialDescriptor);
+    });
+
+    test('setCaretPosition should be prevented for some browsers when they focus input after caret position has changed', function(assert) {
+        const { ios, mac } = devices.real();
+        const itShouldBePrevented = browser.msie || ios || mac;
+        const $input = $('<input>').val('12345').appendTo('#qunit-fixture');
+        const otherInput = $('<input>').appendTo('#qunit-fixture').get(0);
+        const getActiveElementStub = sinon.stub(domAdapter, 'getActiveElement', () => itShouldBePrevented ? otherInput : $input.get(0));
+
+        $input.focus();
+        const initialStartPosition = caret($input).start;
+        caret($input, { start: 2, end: 2 });
+        const isPositionChangePrevented = caret($input).start === initialStartPosition;
+
+        assert.strictEqual(isPositionChangePrevented, itShouldBePrevented, `Caret position change should ${itShouldBePrevented ? '' : 'not'} be prevented`);
+        getActiveElementStub.restore();
     });
 });


### PR DESCRIPTION
Apple forbids other web engines explicitly.
According [guidelines](https://developer.apple.com/app-store/review/guidelines/)
>Apps that browse the web must use the appropriate WebKit framework and WebKit Javascript.

So the Chrome for iOS (based on [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview)) has the same specific behavior as the Safari