### PR TITLE
Lookup: Remove dxPopoverOptions type form dropDownOptions option

### DIFF
--- a/js/ui/lookup.d.ts
+++ b/js/ui/lookup.d.ts
@@ -395,12 +395,6 @@ export interface dxLookupOptions extends dxDropDownListOptions<dxLookup> {
      * @public
      */
     itemCenteringEnabled?: boolean;
-    /**
-     * @docid dxLookupOptions.dropDownOptions
-     * @type dxPopupOptions | dxPopoverOptions
-     */
-    dropDownOptions?: dxPopupOptions | dxPopoverOptions;
-
 }
 /**
  * @docid dxLookup

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -4512,8 +4512,6 @@ declare module DevExpress.ui {
         clearButtonText?: string;
         /** @name dxLookup.Options.closeOnOutsideClick */
         closeOnOutsideClick?: boolean | (() => boolean);
-        /** @name dxLookup.Options.dropDownOptions */
-        dropDownOptions?: dxPopupOptions | dxPopoverOptions;
         /** @name dxLookup.Options.fieldTemplate */
         fieldTemplate?: DevExpress.core.template | ((selectedItem: any, fieldElement: DevExpress.core.dxElement) => string | Element | JQuery);
         /** @name dxLookup.Options.focusStateEnabled */


### PR DESCRIPTION
To avoid the issue in Vue components:
![image](https://user-images.githubusercontent.com/1420883/77669834-706a1780-6f96-11ea-97cc-ceb4642e7ac2.png)
