### PR TITLE
Fixes firing the Validator.onValidated event when an editor is in a read-only state(T873862)

### DIFF
--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -265,7 +265,9 @@ const Validator = DOMComponent.inherit({
     },
 
     _applyValidationResult(result, adapter) {
-        const validatedAction = this._createActionByOption('onValidated');
+        const validatedAction = this._createActionByOption('onValidated', {
+            excludeValidators: ['readOnly'],
+        });
         result.validator = this;
         this._updateValidationResult(result);
         adapter.applyValidationResults && adapter.applyValidationResults(this._validationInfo.result);

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.editors.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.editors.tests.js
@@ -385,5 +385,38 @@ QUnit.module('Editors Standard Adapter', {
         editor.option('validationErrors', null);
         assert.notOk(editor.option('validationError'), 'validationError === null');
     });
+
+    QUnit.test('Editor(read-only) - validating and validated events of a validator should be raised', function(assert) {
+        // arrange
+        this.fixture.createTextEditor({
+            value: 'test',
+            readOnly: true
+        });
+        const validatingHandler = sinon.stub();
+        const validatedHandler = sinon.stub();
+        const validator = this.fixture.createValidator({
+            adapter: null,
+            validationRules: [
+                {
+                    type: 'async',
+                    validationCallback: function() {
+                        return new Deferred().resolve().promise();
+                    }
+                }
+            ]
+        });
+        validator.on('validating', validatingHandler);
+        validator.on('validated', validatedHandler);
+        const done = assert.async();
+
+        const result = validator.validate();
+        result.complete.then(() => {
+            // assert
+            assert.ok(validatingHandler.calledOnce, 'validating was called');
+            assert.ok(validatedHandler.calledOnce, 'validated was called');
+
+            done();
+        });
+    });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.editors.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.editors.tests.js
@@ -386,7 +386,7 @@ QUnit.module('Editors Standard Adapter', {
         assert.notOk(editor.option('validationError'), 'validationError === null');
     });
 
-    QUnit.test('Editor(read-only) - validating and validated events of a validator should be raised', function(assert) {
+    QUnit.test('Editor(read-only) - validating and validated events of a validator should be raised (T873862)', function(assert) {
         // arrange
         this.fixture.createTextEditor({
             value: 'test',


### PR DESCRIPTION
1. Fixed the issue by adding the excludeValidators parameter to the _createActionByOption method for creating the "onValidated" action.
2. Added a test.
