### PR TITLE
Fixes firing the Validator.onValidated event when an editor is in a read-only state(T873862)

### DIFF
--- a/js/ui/validator.js
+++ b/js/ui/validator.js
@@ -273,7 +273,9 @@ const Validator = DOMComponent.inherit({
     },
 
     _applyValidationResult: function(result, adapter) {
-        const validatedAction = this._createActionByOption('onValidated');
+        const validatedAction = this._createActionByOption('onValidated', {
+            excludeValidators: ['readOnly'],
+        });
         result.validator = this;
 
         adapter.applyValidationResults && adapter.applyValidationResults(result);

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.editors.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.editors.tests.js
@@ -221,5 +221,24 @@ QUnit.module('Editors Standard Adapter', {
         // assert
         assert.equal(spy.callCount, 2, 'The validationCallback is called after reset');
     });
+
+    QUnit.test('Editor(read-only) - Validator.validated event should be raised', function(assert) {
+        // arrange
+        this.fixture.createEditor({
+            value: 'test',
+            readOnly: true
+        });
+        const validatedHandler = sinon.stub();
+        const validator = this.fixture.createValidator({
+            adapter: null,
+            validationRules: [{ type: 'required' }]
+        });
+        validator.on('validated', validatedHandler);
+
+        validator.validate();
+
+        // assert
+        assert.ok(validatedHandler.calledOnce, 'validated was called');
+    });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.editors.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.editors.tests.js
@@ -222,7 +222,7 @@ QUnit.module('Editors Standard Adapter', {
         assert.equal(spy.callCount, 2, 'The validationCallback is called after reset');
     });
 
-    QUnit.test('Editor(read-only) - Validator.validated event should be raised', function(assert) {
+    QUnit.test('Editor(read-only) - Validator.validated event should be raised (T873862)', function(assert) {
         // arrange
         this.fixture.createEditor({
             value: 'test',


### PR DESCRIPTION
1. Fixed the issue by adding the excludeValidators parameter to the _createActionByOption method for creating the "onValidated" action.
2. Added a test.
