### PR TITLE
DataGrid: Fix unstable unit tests

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
@@ -69,6 +69,7 @@ QUnit.module('AdaptiveColumns', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        this.dispose();
         this.clock.restore();
     }
 });
@@ -1869,6 +1870,7 @@ QUnit.module('API', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        this.dispose();
         this.clock.restore();
     }
 });
@@ -2113,6 +2115,7 @@ QUnit.module('Editing', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        this.dispose();
         this.clock.restore();
     }
 });
@@ -3762,6 +3765,7 @@ QUnit.module('Validation', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        this.dispose();
         this.clock.restore();
     }
 }, function() {
@@ -4277,6 +4281,9 @@ QUnit.module('Keyboard navigation', {
     },
 
     afterEach: function() {
+        if(this.dispose) {
+            this.dispose();
+        }
         this.clock.restore();
     }
 }, function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editorFactory.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editorFactory.tests.js
@@ -1123,6 +1123,7 @@ QUnit.module('Editor Factory - RTL', {
         executeAsyncMock.setup();
     },
     afterEach: function() {
+        this.dispose();
         executeAsyncMock.teardown();
     }
 });
@@ -1336,6 +1337,9 @@ QUnit.module('Focus', {
         };
     },
     afterEach: function() {
+        if(this.dispose) {
+            this.dispose();
+        }
         this.clock.restore();
     }
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
@@ -1421,6 +1421,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
         fx.off = true;
     },
     afterEach: function() {
+        this.dispose();
         this.clock.restore();
         fx.off = false;
     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.accessibility.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.accessibility.tests.js
@@ -86,6 +86,7 @@ QUnit.module('Keyboard navigation accessibility', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        this.dispose();
         this.clock.restore();
     }
 }, function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
@@ -70,6 +70,7 @@ QUnit.module('Customize keyboard navigation', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        this.dispose();
         this.clock.restore();
     }
 }, function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardController.tests.js
@@ -191,6 +191,9 @@ QUnit.module('Keyboard controller', {
         that.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        if(this.dispose) {
+            this.dispose();
+        }
         eventsEngine.on = this.originalEventsEngineOn;
         eventsEngine.off = this.originalEventsEngineOff;
         this.clock.restore();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
@@ -53,10 +53,7 @@ QUnit.module('Keyboard keys', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
-        if(this.dispose) {
-            this.dispose();
-        }
-
+        this.dispose();
         this.clock.restore();
     }
 }, function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.realControllers.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.realControllers.tests.js
@@ -72,6 +72,7 @@ QUnit.module('Real DataController and ColumnsController', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        this.dispose();
         this.clock.restore();
     }
 }, function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.rowsView.tests.js
@@ -82,6 +82,9 @@ QUnit.module('Rows view', {
         this.clock = sinon.useFakeTimers();
     },
     afterEach: function() {
+        if(this.dispose) {
+            this.dispose();
+        }
         this.clock.restore();
     }
 }, function() {


### PR DESCRIPTION
Fixes unstable tests with the update focus timeout.

For instance:
![image](https://user-images.githubusercontent.com/1420883/78057416-5ca42400-738f-11ea-9a59-30d4a2d0e591.png)
https://github.com/DevExpress/DevExtreme/runs/545426561?check_suite_focus=true#step:6:84