### PR TITLE
SelectBox: Fix null ref errors during search

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -665,12 +665,12 @@ const DropDownList = DropDownEditor.inherit({
         this._clearSearchTimer();
 
         const dataSource = this._dataSource;
-
-        dataSource.searchExpr(this.option('searchExpr') || this._displayGetterExpr());
-        dataSource.searchOperation(this.option('searchMode'));
-        dataSource.searchValue(searchValue);
-
-        return dataSource.load().done(this._dataSourceFiltered.bind(this, searchValue));
+        if(dataSource) {
+            dataSource.searchExpr(this.option('searchExpr') || this._displayGetterExpr());
+            dataSource.searchOperation(this.option('searchMode'));
+            dataSource.searchValue(searchValue);
+            dataSource.load().done(this._dataSourceFiltered.bind(this, searchValue));
+        }
     },
 
     _clearFilter: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -473,6 +473,31 @@ QUnit.module('functionality', moduleSetup, () => {
         assert.deepEqual(selectBox._list.option('items'), []);
     });
 
+    QUnit.test('no exceptions after dataSource reset during typing', function(assert) {
+        try {
+            const $element = $('#selectBox');
+            const selectBox = $element.dxSelectBox({
+                dataSource: ['one', 'two'],
+                searchTimeout: 0,
+                searchEnabled: true
+            }).dxSelectBox('instance');
+
+            const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            const keyboard = keyboardMock($input);
+
+            keyboard
+                .focus()
+                .type('o');
+
+            selectBox.option('dataSource', null);
+
+            keyboard.type('n');
+            assert.ok(true, 'no errors');
+        } catch(e) {
+            assert.ok(false, `The '${e.message}' is raised`);
+        }
+    });
+
     QUnit.test('list item obtained focus only after press on control key', function(assert) {
         if(devices.real().deviceType !== 'desktop') {
             assert.ok(true, 'test does not actual for mobile devices');


### PR DESCRIPTION
- Fixes null reference errors with dataSource during a search (for instance, set dataSource to null while typing).
- Fixes [this](https://trello.com/c/BWr4rsWb/) unstable test in MS Edge:
![image](https://user-images.githubusercontent.com/1420883/78194149-0d401f80-7485-11ea-8f8d-a88c2e0b3303.png)

