### PR TITLE
DataGrid - Fixes SelectAll state when all items in the header filter are deselected (T875471)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.header_filter_core.js
+++ b/js/ui/grid_core/ui.grid_core.header_filter_core.js
@@ -271,14 +271,21 @@ exports.HeaderFilterView = modules.View.inherit({
                         const items = e.component.option('items');
                         const selectedItems = e.component.option('selectedItems');
 
+                        const filterValuesOnAnotherPage = !!items.length && !!options.filterValues && options.filterValues.some(filterValue => {
+                            return gridCoreUtils.getIndexByKey(filterValue, items, 'value') < 0;
+                        });
+
                         if(!e.component._selectedItemsUpdating && !e.component.option('searchValue') && !options.isFilterBuilder) {
-                            if(selectedItems.length === 0 && items.length && (!options.filterValues || options.filterValues.length <= 1)) {
+                            if(selectedItems.length === 0 && items.length && (!options.filterValues || options.filterValues.length <= 1 || !filterValuesOnAnotherPage)) {
                                 options.filterType = 'include';
                                 options.filterValues = [];
                             } else if(selectedItems.length === items.length) {
                                 options.filterType = 'exclude';
                                 options.filterValues = [];
                             }
+                        } else if(options.filterValues && selectedItems.length === items.length && !filterValuesOnAnotherPage) {
+                            options.filterType = 'exclude';
+                            options.filterValues = [];
                         }
 
                         each(items, function(index, item) {

--- a/js/ui/grid_core/ui.grid_core.header_filter_core.js
+++ b/js/ui/grid_core/ui.grid_core.header_filter_core.js
@@ -271,21 +271,16 @@ exports.HeaderFilterView = modules.View.inherit({
                         const items = e.component.option('items');
                         const selectedItems = e.component.option('selectedItems');
 
-                        const filterValuesOnAnotherPage = !!items.length && !!options.filterValues && options.filterValues.some(filterValue => {
-                            return gridCoreUtils.getIndexByKey(filterValue, items, 'value') < 0;
-                        });
-
                         if(!e.component._selectedItemsUpdating && !e.component.option('searchValue') && !options.isFilterBuilder) {
-                            if(selectedItems.length === 0 && items.length && (!options.filterValues || options.filterValues.length <= 1 || !filterValuesOnAnotherPage)) {
+                            const filterValues = options.filterValues || [];
+                            const isExclude = options.filterType === 'exclude';
+                            if(selectedItems.length === 0 && items.length && (filterValues.length <= 1 || isExclude && filterValues.length === items.length - 1)) {
                                 options.filterType = 'include';
                                 options.filterValues = [];
                             } else if(selectedItems.length === items.length) {
                                 options.filterType = 'exclude';
                                 options.filterValues = [];
                             }
-                        } else if(options.filterValues && selectedItems.length === items.length && !filterValuesOnAnotherPage) {
-                            options.filterType = 'exclude';
-                            options.filterValues = [];
                         }
 
                         each(items, function(index, item) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -2151,7 +2151,8 @@ QUnit.test('Checks whether the SelectAll checkbox is deselected when all filter 
     const $testElement = $('#container');
 
     this.generateItems(3);
-    this.columns[0].filterValues = ['test01', 'test02', 'test03'];
+    this.columns[0].filterValues = [];
+    this.columns[0].filterType = 'exclude';
     this.setupDataGrid();
     this.columnHeadersView.render($testElement);
     this.headerFilterView.render($testElement);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -2146,6 +2146,46 @@ QUnit.testInActiveWindow('No scroll on opening the header filter when the popup 
     }
 });
 
+QUnit.test('Checks whether the SelectAll checkbox is deselected when all filter items are deselected (T875471)', function(assert) {
+    // arrange
+    const $testElement = $('#container');
+
+    this.generateItems(3);
+    this.columns[0].filterValues = ['test01', 'test02', 'test03'];
+    this.setupDataGrid();
+    this.columnHeadersView.render($testElement);
+    this.headerFilterView.render($testElement);
+
+    this.headerFilterController.showHeaderFilterMenu(0);
+
+    const $popupContent = this.headerFilterView.getPopupContainer().$content();
+    const $selectAll = $popupContent.find('.dx-list-select-all-checkbox');
+    const $items = $popupContent.find('.dx-list-item');
+
+    // assert
+    assert.ok($selectAll.hasClass('dx-checkbox-checked'), 'selectAll is checked');
+    assert.equal($items.length, 3);
+
+    $($items.eq(0)).trigger('dxclick');
+
+    // assert
+    assert.ok($selectAll.hasClass('dx-checkbox-indeterminate'), 'selectAll is in the indeterminate state');
+
+    $($items.eq(1)).trigger('dxclick');
+    $($items.eq(2)).trigger('dxclick');
+
+    // assert
+    assert.notOk($selectAll.hasClass('dx-checkbox-indeterminate'), 'selectAll is not in the indeterminate state');
+    assert.notOk($selectAll.hasClass('dx-checkbox-checked'), 'selectAll is not checked');
+
+    $($popupContent.parent().find('.dx-button').eq(0)).trigger('dxclick'); // apply filter
+    this.clock.tick(500);
+
+    // assert
+    assert.notOk(this.columns[0].filterValues, 'filterValues not defined');
+});
+
+
 QUnit.module('Header Filter with real columnsController', {
     beforeEach: function() {
         this.items = [{ Test1: 'value1', Test2: 'value2' }, { Test1: 'value3', Test2: 'value4' }];


### PR DESCRIPTION
1. Added the required condition to reset the **filterValues** array to make the **updateSelectAllState** method not to set the SelectAll checkbox value to undefined. 
2. Added a test.

