### PR TITLE
Scss generator: fix regex and task name

### DIFF
--- a/build/gulp/scss/compiler.js
+++ b/build/gulp/scss/compiler.js
@@ -30,7 +30,7 @@ function compile() {
     ]);
 }
 
-gulp.task('compile', gulp.series(
+gulp.task('compile-scss', gulp.series(
     processDataUri,
     compile
 ));

--- a/build/gulp/scss/generator.js
+++ b/build/gulp/scss/generator.js
@@ -387,7 +387,7 @@ const fillWidgetColors = (theme) => {
     });
 };
 
-const makeVariableDefinitionDefault = (content) => content.replace(/(\$.*?)( !default)*;$/gm, '$1 !default;');
+const makeVariableDefinitionDefault = (content) => content.replace(/(\$.*?)( !default)*;/gm, '$1 !default;');
 
 const collectWidgetColorVariables = (content, schemeName) => {
     const widgetContentRegex = /\/\/\s?(?!TODO)(dx)?(\w.*)([\w\W]*?)(\n\/\/|$)/g;

--- a/build/gulp/scss/generator.js
+++ b/build/gulp/scss/generator.js
@@ -387,7 +387,7 @@ const fillWidgetColors = (theme) => {
     });
 };
 
-const makeVariableDefinitionDefault = (content) => content.replace(/(\$.*?)( !default)*;/gm, '$1 !default;');
+const makeVariableDefinitionDefault = (content) => content.replace(/(\$.*?)( !default)*;(\s)/gm, '$1 !default;$3');
 
 const collectWidgetColorVariables = (content, schemeName) => {
     const widgetContentRegex = /\/\/\s?(?!TODO)(dx)?(\w.*)([\w\W]*?)(\n\/\/|$)/g;

--- a/build/gulp/scss/tasks.js
+++ b/build/gulp/scss/tasks.js
@@ -13,6 +13,6 @@ gulp.task('generate-scss', gulp.series(
     'fix-mixins',
     'create-base-widget',
     'create-theme-index',
-    'compile',
+    'compile-scss',
     'scss-raw-scss-clean'
 ));


### PR DESCRIPTION
Fix for regular expression to allow processing such strings as
`$badge-bg: extColor.difference($base-accent, #171717); // #7ab8eb => #60a1d6`
to make default definition:
`$badge-bg: extColor.difference($base-accent, #171717) !default; // #7ab8eb => #60a1d6`