### PR TITLE
DataGrid - Fixes the expand state changing of a group row when the Enter Key is pressed (T869799)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1008,7 +1008,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
             isOriginalHandlerRequired = true;
         } else {
             if(this._focusedCellPosition.rowIndex === undefined && $(eventTarget).hasClass(ROW_CLASS)) {
-                this._updateFocusedCellPosition($(eventTarget).children().not('.' + COMMAND_EXPAND_CLASS).first());
+                this._updateFocusedCellPosition($cell);
             }
 
             elementType = this._getElementType(eventTarget);
@@ -1150,7 +1150,14 @@ const KeyboardNavigationController = core.ViewController.inherit({
         this._isNeedFocus = true;
         this._isNeedScroll = true;
 
-        this._updateFocusedCellPosition(this._getCellElementFromTarget(originalEvent.target));
+        const eventTarget = originalEvent.target;
+        const elementType = this._getElementType(eventTarget);
+        if(elementType === 'cell' || (elementType === 'row' && !isDefined(this._focusedCellPosition?.columnIndex))) {
+            this._updateFocusedCellPosition(this._getCellElementFromTarget(originalEvent.target));
+        } else {
+            const $row = $(eventTarget);
+            this._focusedView && isGroupRow($row) && this.setFocusedRowIndex(this._getRowIndex($row));
+        }
 
         if(!isHandled) {
             switch(e.keyName) {
@@ -1432,7 +1439,9 @@ const KeyboardNavigationController = core.ViewController.inherit({
     },
 
     _getCellElementFromTarget: function(target) {
-        return $(target).closest('.' + ROW_CLASS + '> td');
+        const elementType = this._getElementType(target);
+        const $cell = elementType === 'cell' ? $(target).closest(`.${ROW_CLASS} > td`) : $(target).children().not('.' + COMMAND_EXPAND_CLASS).first();
+        return $cell;
     },
 
     init: function() {

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -355,6 +355,17 @@ const KeyboardNavigationController = core.ViewController.inherit({
         }
         return position;
     },
+
+    _updateFocusedCellPositionByTarget: function(target) {
+        const elementType = this._getElementType(target);
+        if(elementType === 'row' && isDefined(this._focusedCellPosition?.columnIndex)) {
+            const $row = $(target);
+            this._focusedView && isGroupRow($row) && this.setFocusedRowIndex(this._getRowIndex($row));
+        } else {
+            this._updateFocusedCellPosition(this._getCellElementFromTarget(target));
+        }
+    },
+
     _getCellPosition: function($cell, direction) {
         const that = this;
         let rowIndex;
@@ -1150,14 +1161,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
         this._isNeedFocus = true;
         this._isNeedScroll = true;
 
-        const eventTarget = originalEvent.target;
-        const elementType = this._getElementType(eventTarget);
-        if(elementType === 'cell' || (elementType === 'row' && !isDefined(this._focusedCellPosition?.columnIndex))) {
-            this._updateFocusedCellPosition(this._getCellElementFromTarget(originalEvent.target));
-        } else {
-            const $row = $(eventTarget);
-            this._focusedView && isGroupRow($row) && this.setFocusedRowIndex(this._getRowIndex($row));
-        }
+        this._updateFocusedCellPositionByTarget(originalEvent.target);
 
         if(!isHandled) {
             switch(e.keyName) {
@@ -1440,7 +1444,13 @@ const KeyboardNavigationController = core.ViewController.inherit({
 
     _getCellElementFromTarget: function(target) {
         const elementType = this._getElementType(target);
-        const $cell = elementType === 'cell' ? $(target).closest(`.${ROW_CLASS} > td`) : $(target).children().not('.' + COMMAND_EXPAND_CLASS).first();
+        const $targetElement = $(target);
+        let $cell;
+        if(elementType === 'cell') {
+            $cell = $targetElement.closest(`.${ROW_CLASS} > td`);
+        } else {
+            $cell = $targetElement.children().not('.' + COMMAND_EXPAND_CLASS).first();
+        }
         return $cell;
     },
 

--- a/testing/functional/model/dataGrid.ts
+++ b/testing/functional/model/dataGrid.ts
@@ -9,6 +9,7 @@ const CLASS = {
     dataRow: 'dx-data-row',
     groupRow: 'dx-group-row',
     commandEdit: 'dx-command-edit',
+    commandExpand: 'dx-command-expand',
     commandLink: 'dx-link',
     focused: 'dx-focused',
     focusedState: 'dx-state-focused',
@@ -24,7 +25,8 @@ const CLASS = {
     pagerPageSize: 'dx-page-size',
     pagerPrevNavButton: 'dx-prev-button',
     pagerNextNavButton: 'dx-next-button',
-    pagerPage: 'dx-page'
+    pagerPage: 'dx-page',
+    groupExpanded: 'dx-datagrid-group-opened'
 };
 
 class DxElement {
@@ -138,11 +140,17 @@ class DataRow extends DxElement {
 }
 
 class GroupRow extends DxElement {
+    widgetName: string;
     isFocusedRow: Promise<boolean>;
+    isFocused: Promise<boolean>;
+    isExpanded: Promise<boolean>;
 
-    constructor(element: Selector) {
+    constructor(element: Selector, widgetName: string) {
         super(element);
+        this.widgetName = widgetName;
         this.isFocusedRow = this.element.hasClass(CLASS.focusedRow);
+        this.isFocused = this.element.hasClass(CLASS.focused);
+        this.isExpanded = this.element.find(`.${CLASS.commandExpand} .${CLASS.groupExpanded}`).exists
     }
 
     getCell(index: number): DataCell {
@@ -218,7 +226,7 @@ export default class DataGrid extends Widget {
     }
 
     getGroupRow(index: number): GroupRow {
-        return new GroupRow(this.element.find(`.${CLASS.groupRow}`).nth(index));
+        return new GroupRow(this.element.find(`.${CLASS.groupRow}`).nth(index), this.name);
     }
 
     getFocusedRow(): Selector {

--- a/testing/functional/tests/dataGrid/keyboardNavigation.ts
+++ b/testing/functional/tests/dataGrid/keyboardNavigation.ts
@@ -557,3 +557,31 @@ test("Tab key on the focused group row should be handled by default behavior (T8
         }
     });
 });
+
+test('The first group row should be expanded when the Enter key is pressed (T869799)', async t => {
+    const dataGrid = new DataGrid('#container');
+    const firstGroupRow = dataGrid.getGroupRow(0);
+
+    await t
+        .pressKey('tab')
+        .pressKey('tab')
+
+        .expect(firstGroupRow.isFocused).ok()
+        .expect(firstGroupRow.isExpanded).notOk()
+
+        .pressKey('enter')
+
+        .expect(firstGroupRow.isExpanded).ok()
+
+}).before(() => createWidget('dxDataGrid', {
+    dataSource: [
+        { name: 'Alex', phone: '555555' }
+    ],
+    columns:[{
+        dataField: 'name',
+        groupIndex: 0
+    }, 'phone'],
+    grouping: {
+        autoExpandAll: false
+    }
+}));

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
@@ -4182,4 +4182,89 @@ QUnit.module('Keyboard keys', {
         assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { columnIndex: 0, rowIndex: 4 }, 'focused position');
     });
 
+    QUnit.testInActiveWindow('Focused cell position should be updated when the Enter key is pressed on the first focused group row (T869799)', function(assert) {
+        // arrange
+        this.columns = [
+            { visible: true, command: 'expand', cssClass: 'dx-command-expand' },
+            { caption: 'Column 1', visible: true, dataField: 'Column1' },
+            { caption: 'Column 2', visible: true, dataField: 'Column2' }
+        ];
+
+        this.dataControllerOptions = {
+            pageCount: 10,
+            pageIndex: 0,
+            pageSize: 10,
+            items: [
+                { values: ['group 1'], rowType: 'group', key: ['group 1'], groupIndex: 0 }
+            ]
+        };
+
+        setupModules(this);
+
+        // act
+        this.gridView.render($('#container'));
+
+        const $firstGroupRow = $(this.getRowElement(0));
+        $firstGroupRow.focus();
+        this.clock.tick();
+
+        // assert
+        assert.ok($firstGroupRow.hasClass('dx-focused'), 'the first group row is marked as focused');
+        assert.equal($(':focus').get(0), $firstGroupRow.get(0), 'the first group row is focused');
+        assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { });
+
+        // act
+        this.triggerKeyDown('enter', false, false, $firstGroupRow.get(0));
+
+        // assert
+        assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, {
+            rowIndex: 0,
+            columnIndex: 1
+        });
+    });
+
+    QUnit.testInActiveWindow('The second group row should be focused when the arrow down key is pressed on the first group row (T869799)', function(assert) {
+        // arrange
+        this.columns = [
+            { visible: true, command: 'expand', cssClass: 'dx-command-expand' },
+            { caption: 'Column 1', visible: true, dataField: 'Column1' },
+            { caption: 'Column 2', visible: true, dataField: 'Column2' }
+        ];
+
+        this.dataControllerOptions = {
+            pageCount: 10,
+            pageIndex: 0,
+            pageSize: 10,
+            items: [
+                { values: ['group 1'], rowType: 'group', key: ['group 1'], groupIndex: 0 },
+                { values: ['group 2'], rowType: 'group', key: ['group 2'], groupIndex: 0 }
+            ]
+        };
+
+        setupModules(this);
+
+        // act
+        this.gridView.render($('#container'));
+
+        const $firstGroupRow = $(this.getRowElement(0));
+        $firstGroupRow.focus();
+        this.clock.tick();
+
+        // assert
+        assert.ok($firstGroupRow.hasClass('dx-focused'), 'the first group row is marked as focused');
+        assert.equal($(':focus').get(0), $firstGroupRow.get(0), 'the first group row is focused');
+
+        // act
+        this.triggerKeyDown('downArrow', false, false, $firstGroupRow.get(0));
+        this.clock.tick();
+        const $secondGroupRow = $(this.getRowElement(1));
+
+        // assert
+        assert.ok($secondGroupRow.hasClass('dx-focused'), 'the second group row is marked as focused');
+        assert.equal($(':focus').get(0), $secondGroupRow.get(0), 'the second group row is focused');
+        assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, {
+            rowIndex: 1,
+            columnIndex: 1
+        });
+    });
 });


### PR DESCRIPTION
1. Fixed updating **_focusedCellPosition** when the Enter key is pressed on a grouped row.
2. Added unit tests.
3. Added a functional test.

