### PR TITLE
DataGrid - Fixes focusing row when a command button is clicked (T879627)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -742,12 +742,6 @@ const KeyboardNavigationController = core.ViewController.inherit({
         const $parent = $target.parent();
         const isEditingRow = $parent.hasClass(EDIT_ROW_CLASS);
         const isInteractiveElement = $(event.target).is(INTERACTIVE_ELEMENTS_SELECTOR);
-        const isCommandButtonTarget = $(event.target).hasClass('dx-link');
-
-        if(isCommandButtonTarget) {
-            this.setCellFocusType();
-            return;
-        }
 
         if(this._isEventInCurrentGrid(event) && this._isCellValid($target, !isInteractiveElement)) {
             $target = this._isInsideEditForm($target) ? $(event.target) : $target;
@@ -1532,6 +1526,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
             args.cancel = true;
             return args;
         }
+
         if(this.option('focusedRowEnabled')) {
             this.executeAction('onFocusedRowChanging', args);
             if(!args.cancel && args.newRowIndex !== newRowIndex) {


### PR DESCRIPTION
1. Removed the condition for preventing updating the focused row index when a command button is clicked.
2. Added functional tests.