### PR TITLE
Add config for the Stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -23,6 +23,9 @@ markComment: >
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
 
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
 pulls:
   markComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -23,9 +23,6 @@ markComment: >
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
 
-# Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 30
-
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
 pulls:
   markComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,61 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 5
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+# type/discussion - our discussion pages. They can be inactive for a long time.
+# WIP - pull requests that have "work in progress" status
+  - type/discussion
+  - WIP
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,7 +15,7 @@ exemptLabels:
   - WIP
 
 # Label to use when marking as stale
-staleLabel: wontfix
+staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,9 +8,9 @@ daysUntilStale: 30
 daysUntilClose: 5
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels:
 # type/discussion - our discussion pages. They can be inactive for a long time.
 # WIP - pull requests that have "work in progress" status
+exemptLabels:
   - type/discussion
   - WIP
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,24 +7,12 @@ daysUntilStale: 30
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
 daysUntilClose: 5
 
-# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: []
-
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
 # type/discussion - our discussion pages. They can be inactive for a long time.
 # WIP - pull requests that have "work in progress" status
   - type/discussion
   - WIP
-
-# Set to true to ignore issues in a project (defaults to false)
-exemptProjects: false
-
-# Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: false
-
-# Set to true to ignore issues with an assignee (defaults to false)
-exemptAssignees: false
 
 # Label to use when marking as stale
 staleLabel: wontfix
@@ -35,19 +23,8 @@ markComment: >
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
 
-# Comment to post when removing the stale label.
-# unmarkComment: >
-#   Your comment here.
-
-# Comment to post when closing a stale Issue or Pull Request.
-# closeComment: >
-#   Your comment here.
-
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30
-
-# Limit to only `issues` or `pulls`
-# only: issues
 
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
 pulls:
@@ -55,7 +32,3 @@ pulls:
     This pull request has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
     for your contributions.
-
-# issues:
-#   exemptLabels:
-#     - confirmed

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,6 +13,7 @@ daysUntilClose: 5
 exemptLabels:
   - type/discussion
   - WIP
+  - roadmap
 
 # Label to use when marking as stale
 staleLabel: stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -25,7 +25,10 @@ markComment: >
   for your contributions.
 
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+issues:
+  closeComment: >
+     This issue was closed due to inactivity.
+     If you found a bug or have a question about our product, [create a new issue](https://github.com/DevExpress/DevExtreme/issues) on GitHub or submit a ticket in our [Support Center](https://www.devexpress.com/Support/Center/).
 
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
 pulls:


### PR DESCRIPTION
Considering [this](https://trello.com/c/LF0wqTHV) card we can use the [Stale bot](https://github.com/probot/stale) to close stale issues and pull requests in our repository.

[Github Marketplace page](https://github.com/marketplace/stale)