### PR TITLE
ESlint: Use "qunit/recommended" and "qunit/two" presets (#12772)

### DIFF
--- a/testing/.eslintrc
+++ b/testing/.eslintrc
@@ -13,15 +13,16 @@
     "plugins": [
         "qunit"
     ],
+    "extends": [
+        "plugin:qunit/recommended",
+        "plugin:qunit/two"
+    ],
     "rules": {
-        "qunit/assert-args": "error",
-        "qunit/literal-compare-order": "error",
         "qunit/no-arrow-tests": "error",
-        "qunit/no-async-in-loops": "error",
         "qunit/no-commented-tests": "warn",
         "qunit/no-identical-names": "warn",
-        "qunit/no-ok-equality": "error",
-        "qunit/no-only": "error",
-        "qunit/no-setup-teardown": "error"
+        "qunit/no-global-module-test": "off",
+        "qunit/require-expect": "off",
+        "qunit/resolve-async": "off"
     }
 }

--- a/testing/tests/DevExpress.viz.core/utils.tests.js
+++ b/testing/tests/DevExpress.viz.core/utils.tests.js
@@ -114,14 +114,14 @@ QUnit.test('convertXYToPolar', function(assert) {
 });
 
 QUnit.test('map', function(assert) {
-    function test(array, callback, expected, messages) {
+    function check(array, callback, expected, messages) {
         assert.deepEqual(utils.map(array, callback), expected, messages);
     }
 
-    test([], function(el, i) { return el * i + 2; }, [], 'empty array');
-    test([1, 2, 3], function(el, i) { return el * i + 2; }, [2, 4, 8], 'non-empty array');
-    test([1, 2, 3, 4, 5, 6], function(el) { return el % 2 ? el : null; }, [1, 3, 5], 'callback w/ null');
-    test([1, 2, 3, 4, 5, 6], function(el) { return el % 2 ? el : undefined; }, [1, undefined, 3, undefined, 5, undefined], 'callback w/ undefined');
+    check([], function(el, i) { return el * i + 2; }, [], 'empty array');
+    check([1, 2, 3], function(el, i) { return el * i + 2; }, [2, 4, 8], 'non-empty array');
+    check([1, 2, 3, 4, 5, 6], function(el) { return el % 2 ? el : null; }, [1, 3, 5], 'callback w/ null');
+    check([1, 2, 3, 4, 5, 6], function(el) { return el % 2 ? el : undefined; }, [1, undefined, 3, undefined, 5, undefined], 'callback w/ undefined');
 });
 
 QUnit.test('unique', function(assert) {


### PR DESCRIPTION
Cherry-pick #12772.
