### PR TITLE
TextEditor - Prevent custom buttons overlapping in ie11 (T879885)

### DIFF
--- a/styles/widgets/common/textEditor.less
+++ b/styles/widgets/common/textEditor.less
@@ -9,6 +9,7 @@
 .dx-editor-content-wrapper() {
     display: flex;
     flex-grow: 1;
+    width: 0;
     position: relative;
     align-items: baseline;
 }

--- a/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
@@ -355,6 +355,29 @@ module('rendering', () => {
             textBox.option('readOnly', false);
             assert.ok(button.option('disabled'), 'button is disabled');
         });
+
+        test('editors content should not overlap the widgets bounds', function(assert) {
+            const widgetWidth = 200;
+            const $textBox = $('<div>').appendTo('#qunit-fixture').dxTextBox({
+                width: widgetWidth,
+                buttons: [{
+                    name: 'custom',
+                    location: 'before',
+                    options: {
+                        text: 'custom'
+                    }
+                }, {
+                    name: 'custom 2',
+                    location: 'after',
+                    options: {
+                        text: 'custom'
+                    }
+                }]
+            });
+            const { $before, $after } = getTextEditorButtons($textBox);
+            const $input = $textBox.find('.dx-texteditor-input-container');
+            assert.ok($before.eq(0).outerWidth() + $input.outerWidth() + $after.eq(0).outerWidth() < widgetWidth);
+        });
     });
 
     module('numberBox', () => {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
