### PR TITLE
DataGrid - Fixes duplicated characters in Firefox (T882996)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1401,7 +1401,8 @@ const KeyboardNavigationController = core.ViewController.inherit({
         if(!keyDownEvent.isDefaultPrevented()) {
             eventsEngine.trigger($input, keyPressEvent);
             if(!keyPressEvent.isDefaultPrevented()) {
-                setTimeout(function() {
+                const timeout = browser.mozilla ? 25 : 0; // T882996
+                setTimeout(() => {
                     $input.val(editorValue);
 
                     const $widgetContainer = $input.closest(`.${WIDGET_CLASS}`);
@@ -1410,7 +1411,8 @@ const KeyboardNavigationController = core.ViewController.inherit({
                         eventsEngine.trigger($input, 'change');
                     });
                     eventsEngine.trigger($input, inputEvent);
-                });
+                }, timeout);
+
             }
         }
     },

--- a/testing/functional/tests/dataGrid/keyboardNavigation.ts
+++ b/testing/functional/tests/dataGrid/keyboardNavigation.ts
@@ -592,11 +592,11 @@ test('Cell should be highlighted after editing another cell when startEditAction
         .expect(cell0.isFocused).notOk()
         .expect(cell1.isFocused).notOk()
 
-        .doubleClick(cell0.element, { speed: 0.8 })
+        .doubleClick(cell0.element)
         .expect(cell0.isFocused).ok()
         .expect(cell0.isEditCell).ok()
 
-        .click(cell1.element, { speed: 0.8 })
+        .click(cell1.element)
         .expect(cell1.isFocused).ok()
         .expect(cell0.isFocused).notOk()
         .expect(cell0.isEditCell).notOk();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
@@ -2806,18 +2806,25 @@ QUnit.module('Customize keyboard navigation', {
             // act
             this.focusCell(0, 0);
             this.triggerKeyDown('a');
-
-            // NOTE:
-            // This is ahack to fix the issue, because Firefox triggers keypress, keyup and input events
-            // even if an input is focused with a delay using a zero timeout.
-            // That is why it is necessary to increase a timeout to 25 for Firefox
-            const timeout = browser.mozilla ? 25 : 0;
-
-            this.clock.tick(timeout);
+            this.clock.tick();
             const $input = $('.dx-texteditor-input');
 
             // assert
             assert.equal($input.length, 1, 'Editor is rendered');
+
+            // NOTE:
+            // This is a hack to fix the issue, because Firefox triggers keypress, keyup and input events
+            // even if an input is focused with a delay using a zero timeout.
+            // That is why it is necessary to increase a timeout to 25 for Firefox
+            if(browser.mozilla) {
+                assert.notEqual($input.val(), 'a', 'entered value is not modified');
+
+                this.clock.tick(25);
+
+                assert.strictEqual($input.val(), 'a', 'entered value is correct');
+                return;
+            }
+
             assert.strictEqual($input.val(), 'a', 'entered value is correct');
         });
     });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
@@ -2820,9 +2820,6 @@ QUnit.module('Customize keyboard navigation', {
                 assert.notEqual($input.val(), 'a', 'entered value is not modified');
 
                 this.clock.tick(25);
-
-                assert.strictEqual($input.val(), 'a', 'entered value is correct');
-                return;
             }
 
             assert.strictEqual($input.val(), 'a', 'entered value is correct');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
@@ -13,6 +13,7 @@ import 'generic_light.css!';
 import 'ui/data_grid/ui.data_grid';
 
 import $ from 'jquery';
+import browser from 'core/utils/browser';
 import { setupDataGridModules } from '../../helpers/dataGridMocks.js';
 import keyboardMock from '../../helpers/keyboardMock.js';
 import {
@@ -117,7 +118,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('2');
-        this.clock.tick(500);
+        this.clock.tick(525);
         keyboardMock($(':focus')[0]).keyDown('downArrow');
         this.clock.tick();
         // assert
@@ -137,7 +138,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('1');
-        this.clock.tick(500);
+        this.clock.tick(525);
         keyboardMock($(':focus')[0]).keyDown('downArrow');
         this.clock.tick();
         keyboardMock($(':focus')[0]).keyDown('enter');
@@ -844,7 +845,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Delete');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -896,7 +897,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Delete');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -948,7 +949,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Backspace');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -1000,7 +1001,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Backspace');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -1052,7 +1053,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -1103,7 +1104,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -1155,7 +1156,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -1206,7 +1207,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -1258,7 +1259,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
         $editor = $('.dx-texteditor').eq(0);
 
         // assert
@@ -1334,7 +1335,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1384,7 +1385,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('2');
-        this.clock.tick();
+        this.clock.tick(25);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1434,7 +1435,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1484,7 +1485,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1535,7 +1536,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(25);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1549,7 +1550,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('downArrow');
         this.clock.tick();
         this.triggerKeyDown('A');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // arrange, assert
         $editor = $('.dx-texteditor').eq(0);
@@ -1589,7 +1590,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('2');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // arrange, assert
         let $input = $('.dx-row .dx-texteditor-input').eq(0);
@@ -1604,7 +1605,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('downArrow');
         this.clock.tick();
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // // arrange, assert
         $input = $('.dx-row .dx-texteditor-input').eq(0);
@@ -1675,7 +1676,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('2');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // arrange, assert
         let $input = $('.dx-row .dx-texteditor-container input').eq(0);
@@ -1688,7 +1689,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('rightArrow');
         this.clock.tick();
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // // arrange, assert
         $input = $('.dx-row .dx-texteditor-container input').eq(0);
@@ -1725,7 +1726,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('2');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // arrange, assert
         let $input = $('.dx-texteditor-input').eq(0);
@@ -1738,7 +1739,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('downArrow');
         this.clock.tick();
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // arrange, assert
         $input = $('.dx-texteditor-input').eq(0);
@@ -1776,7 +1777,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('2');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // arrange, assert
         let $input = $('.dx-row .dx-texteditor-input').eq(0);
@@ -1789,7 +1790,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('rightArrow');
         this.clock.tick();
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // // arrange, assert
         $input = $('.dx-row .dx-texteditor-input').eq(0);
@@ -1970,7 +1971,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('2');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // arrange, assert
         let $input = $('.dx-row .dx-texteditor-container input').eq(0);
@@ -1983,7 +1984,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('downArrow');
         this.clock.tick();
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // // arrange, assert
         $input = $('.dx-row .dx-texteditor-container input').eq(0);
@@ -1997,7 +1998,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('upArrow');
         this.clock.tick();
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(25);
 
         // // arrange, assert
         $input = $('.dx-row .dx-texteditor-container input').eq(0);
@@ -2048,7 +2049,7 @@ QUnit.module('Customize keyboard navigation', {
         const $input = editor.getInputElement();
         assert.equal($input.val(), 'Alex', 'input value has not changed');
 
-        this.clock.tick();
+        this.clock.tick(25);
 
         assert.equal($input.val(), '1', 'input value has changed after timeout');
     });
@@ -2782,5 +2783,42 @@ QUnit.module('Customize keyboard navigation', {
         // assert
         assert.ok(input, 'Editor input');
         assert.equal(getTextSelection(input), input.value, 'Selection');
+    });
+
+    ['Batch', 'Cell'].forEach(mode => {
+        testInDesktop(`${mode} - A cell should display only a single typed character (T882996)`, function(assert) {
+            // arrange
+            this.options = {
+                keyboardNavigation: {
+                    editOnKeyPress: true
+                },
+                editing: {
+                    mode: mode.toLowerCase(),
+                    allowUpdating: true,
+                    startEditAction: 'dblClick'
+                }
+            };
+            this.columns = ['name'];
+
+            this.setupModule();
+            this.renderGridView();
+
+            // act
+            this.focusCell(0, 0);
+            this.triggerKeyDown('a');
+
+            // NOTE:
+            // This is ahack to fix the issue, because Firefox triggers keypress, keyup and input events
+            // even if an input is focused with a delay using a zero timeout.
+            // That is why it is necessary to increase a timeout to 25 for Firefox
+            const timeout = browser.mozilla ? 25 : 0;
+
+            this.clock.tick(timeout);
+            const $input = $('.dx-texteditor-input');
+
+            // assert
+            assert.equal($input.length, 1, 'Editor is rendered');
+            assert.strictEqual($input.val(), 'a', 'entered value is correct');
+        });
     });
 });


### PR DESCRIPTION
1. Fixed the issue by increasing a timeout to 25 ms for Firefox where the **input.val** method is called.
2. Refactored tests by passing 25 to **clock.tick** where it is necessary.
3. Added new tests.
4. Modified the "Cell should be highlighted after editing another cell when startEditAction is 'dblClick' and 'batch' edit mode if isHighlighted is set to true in onFocusedCellChanging (T836391)" functional test by removing the **speed** parameter because the test was not stable on Firefox.
