### PR TITLE
TextEditor - collapse input container in ie11 only if the container has enough width

### DIFF
--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -354,10 +354,12 @@ const TextEditorBase = Editor.inherit({
 
     _editorMinWidth: function() {
         const $input = this._input();
-        return ($(this._$beforeButtonsContainer).width() || 0) +
-            ($(this._$afterButtonsContainer).width() || 0) +
-            parseFloat($input.css('paddingRight')) +
-            parseFloat($input.css('paddingLeft'));
+        const buttonsWidth = ($(this._$beforeButtonsContainer).width() || 0) +
+            ($(this._$afterButtonsContainer).width() || 0);
+        const inputPaddings = $input
+            ? (parseFloat($input.css('paddingRight')) + parseFloat($input.css('paddingLeft')))
+            : 0;
+        return buttonsWidth + inputPaddings;
     },
 
     _renderValue: function() {

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -348,13 +348,17 @@ const TextEditorBase = Editor.inherit({
     },
 
     _collapseInputContainer: function() {
-        const $element = this.$element();
         const isIE11 = browser.msie && browser.version <= 11;
+        const $element = this.$element();
         const parentElement = $element.parent();
 
-        if(isIE11 && $element.css('display') === 'block' && (!window.getComputedStyle(parentElement.get(0)) || parentElement.innerWidth() > this._editorMinWidth())) {
+        if(isIE11 && $element.css('display') === 'block' && this._parentHasEnoughWidth(parentElement)) {
             $element.addClass(TEXTEDITOR_COLLAPSED_CLASS);
         }
+    },
+
+    _parentHasEnoughWidth: function($parent) {
+        return !window.getComputedStyle($parent.get(0)) || $parent.width() > this._editorMinWidth();
     },
 
     _editorMinWidth: function() {

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -347,9 +347,17 @@ const TextEditorBase = Editor.inherit({
     _collapseInputContainer: function() {
         const $element = this.$element();
         const isIE11 = browser.msie && browser.version <= 11;
-        if(isIE11 && $element.css('display') === 'block') {
+        if(isIE11 && $element.css('display') === 'block' && $element.parent().width() > this._editorMinWidth()) {
             $element.addClass(TEXTEDITOR_COLLAPSED_CLASS);
         }
+    },
+
+    _editorMinWidth: function() {
+        const $input = this._input();
+        return ($(this._$beforeButtonsContainer).width() || 0) +
+            ($(this._$afterButtonsContainer).width() || 0) +
+            parseFloat($input.css('paddingRight')) +
+            parseFloat($input.css('paddingLeft'));
     },
 
     _renderValue: function() {

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -350,24 +350,24 @@ const TextEditorBase = Editor.inherit({
         const $element = this.$element();
         const $parentElement = $element.parent();
 
-        if(isIE11 && $element.css('display') === 'block' && this._parentHasEnoughWidth($parentElement)) {
+        if(isIE11 && $element.css('display') === 'block' && this._hasParentEnoughWidth($parentElement)) {
             $element.addClass(TEXTEDITOR_COLLAPSED_CLASS);
         }
     },
 
-    _parentHasEnoughWidth: function($parent) {
+    _hasParentEnoughWidth: function($parent) {
         const window = getWindow();
-        return !window.getComputedStyle($parent.get(0)) || $parent.width() > this._editorMinWidth();
+        return !window.getComputedStyle($parent.get(0)) || $parent.width() > this._calculateEditorMinWidth();
     },
 
-    _editorMinWidth: function() {
+    _calculateEditorMinWidth: function() {
         const $input = this._input();
         const beforeButtonsWidth = $(this._$beforeButtonsContainer).width() || 0;
         const afterButtonsWidth = $(this._$afterButtonsContainer).width() || 0;
-        const paddingLeft = parseFloat($input.css('paddingLeft'));
-        const paddingRight = parseFloat($input.css('paddingRight'));
+        const inputLeftPadding = parseFloat($input.css('paddingLeft'));
+        const inputRightPadding = parseFloat($input.css('paddingRight'));
 
-        return beforeButtonsWidth + afterButtonsWidth + paddingLeft + paddingRight;
+        return beforeButtonsWidth + afterButtonsWidth + inputLeftPadding + inputRightPadding;
     },
 
     _renderValue: function() {

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -352,7 +352,7 @@ const TextEditorBase = Editor.inherit({
         const isIE11 = browser.msie && browser.version <= 11;
         const parentElement = $element.parent();
 
-        if(isIE11 && $element.css('display') === 'block' && (!domUtils.contains(window.document, parentElement) || parentElement.innerWidth() > this._editorMinWidth())) {
+        if(isIE11 && $element.css('display') === 'block' && (!window.getComputedStyle(parentElement.get(0)) || parentElement.innerWidth() > this._editorMinWidth())) {
             $element.addClass(TEXTEDITOR_COLLAPSED_CLASS);
         }
     },

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -350,7 +350,9 @@ const TextEditorBase = Editor.inherit({
     _collapseInputContainer: function() {
         const $element = this.$element();
         const isIE11 = browser.msie && browser.version <= 11;
-        if(isIE11 && $element.css('display') === 'block' && $element.parent().width() > this._editorMinWidth()) {
+        const parentElement = $element.parent();
+
+        if(isIE11 && $element.css('display') === 'block' && (!domUtils.contains(window.document, parentElement) || parentElement.innerWidth() > this._editorMinWidth())) {
             $element.addClass(TEXTEDITOR_COLLAPSED_CLASS);
         }
     },
@@ -359,9 +361,8 @@ const TextEditorBase = Editor.inherit({
         const $input = this._input();
         const buttonsWidth = ($(this._$beforeButtonsContainer).width() || 0) +
             ($(this._$afterButtonsContainer).width() || 0);
-        const styles = window.getComputedStyle($input.get(0));
-        const inputPaddings = ($input && styles)
-            ? (parseFloat(styles.paddingRight) + parseFloat(styles.paddingLeft))
+        const inputPaddings = $input
+            ? (parseFloat($input.css('paddingRight')) + parseFloat($input.css('paddingLeft')))
             : 0;
         return buttonsWidth + inputPaddings;
     },

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -16,8 +16,11 @@ import TextEditorButtonCollection from './texteditor_button_collection/index';
 import config from '../../core/config';
 import errors from '../widget/ui.errors';
 import browser from '../../core/utils/browser';
+import { getWindow } from '../../core/utils/window';
 import { Deferred } from '../../core/utils/deferred';
 import LoadIndicator from '../load_indicator';
+
+const window = getWindow();
 
 const TEXTEDITOR_CLASS = 'dx-texteditor';
 const TEXTEDITOR_INPUT_CONTAINER_CLASS = 'dx-texteditor-input-container';
@@ -356,8 +359,9 @@ const TextEditorBase = Editor.inherit({
         const $input = this._input();
         const buttonsWidth = ($(this._$beforeButtonsContainer).width() || 0) +
             ($(this._$afterButtonsContainer).width() || 0);
-        const inputPaddings = $input
-            ? (parseFloat($input.css('paddingRight')) + parseFloat($input.css('paddingLeft')))
+        const styles = window.getComputedStyle($input.get(0));
+        const inputPaddings = ($input && styles)
+            ? (parseFloat(styles.paddingRight) + parseFloat(styles.paddingLeft))
             : 0;
         return buttonsWidth + inputPaddings;
     },

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -348,9 +348,9 @@ const TextEditorBase = Editor.inherit({
     _collapseInputContainer: function() {
         const isIE11 = browser.msie && browser.version <= 11;
         const $element = this.$element();
-        const parentElement = $element.parent();
+        const $parentElement = $element.parent();
 
-        if(isIE11 && $element.css('display') === 'block' && this._parentHasEnoughWidth(parentElement)) {
+        if(isIE11 && $element.css('display') === 'block' && this._parentHasEnoughWidth($parentElement)) {
             $element.addClass(TEXTEDITOR_COLLAPSED_CLASS);
         }
     },

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -20,8 +20,6 @@ import { getWindow } from '../../core/utils/window';
 import { Deferred } from '../../core/utils/deferred';
 import LoadIndicator from '../load_indicator';
 
-const window = getWindow();
-
 const TEXTEDITOR_CLASS = 'dx-texteditor';
 const TEXTEDITOR_INPUT_CONTAINER_CLASS = 'dx-texteditor-input-container';
 const TEXTEDITOR_INPUT_CLASS = 'dx-texteditor-input';
@@ -358,6 +356,7 @@ const TextEditorBase = Editor.inherit({
     },
 
     _parentHasEnoughWidth: function($parent) {
+        const window = getWindow();
         return !window.getComputedStyle($parent.get(0)) || $parent.width() > this._editorMinWidth();
     },
 

--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -362,12 +362,12 @@ const TextEditorBase = Editor.inherit({
 
     _editorMinWidth: function() {
         const $input = this._input();
-        const buttonsWidth = ($(this._$beforeButtonsContainer).width() || 0) +
-            ($(this._$afterButtonsContainer).width() || 0);
-        const inputPaddings = $input
-            ? (parseFloat($input.css('paddingRight')) + parseFloat($input.css('paddingLeft')))
-            : 0;
-        return buttonsWidth + inputPaddings;
+        const beforeButtonsWidth = $(this._$beforeButtonsContainer).width() || 0;
+        const afterButtonsWidth = $(this._$afterButtonsContainer).width() || 0;
+        const paddingLeft = parseFloat($input.css('paddingLeft'));
+        const paddingRight = parseFloat($input.css('paddingRight'));
+
+        return beforeButtonsWidth + afterButtonsWidth + paddingLeft + paddingRight;
     },
 
     _renderValue: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -432,34 +432,28 @@ QUnit.module('general', {}, () => {
         }
     });
 
-    QUnit.test('editors has no collapsed class in IE11 if the editor has custom display style', function(assert) {
+    QUnit.test('editor has no collapsed class in IE11 if the editor has custom display style', function(assert) {
         const origBrowser = $.extend({}, browser);
-        browser.msie = true;
-        browser.version = '11.0';
+        $.extend(browser, { msie: true, version: '11.0' });
         const $element = $('#texteditor');
         try {
             $element.css('display', 'inline-block');
             const $textEditor = $element.dxTextEditor({});
             assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            browser.msie = origBrowser.msie;
-            browser.version = origBrowser.version;
-            $element.css('display', 'block');
+            $.extend(browser, { msie: origBrowser.msie, version: origBrowser.version });
         }
     });
 
-    QUnit.test('editors has no collapsed class in IE11 if the editor has auto width container', function(assert) {
+    QUnit.test('editor has no collapsed class in IE11 if the editor has auto width container', function(assert) {
         const origBrowser = $.extend({}, browser);
-        browser.msie = true;
-        browser.version = '11.0';
-        const $container = $('<div><div id=\'inner-texteditor\'></div></div>').css('width', 0).appendTo('#qunit-fixture');
+        $.extend(browser, { msie: true, version: '11.0' });
+        const $container = $('<div></div>').css('width', 0);
         try {
-            const $textEditor = $('#inner-texteditor').dxTextEditor({});
+            const $textEditor = $('#texteditor').wrap($container).dxTextEditor({});
             assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            browser.msie = origBrowser.msie;
-            browser.version = origBrowser.version;
-            $container.remove();
+            $.extend(browser, { msie: origBrowser.msie, version: origBrowser.version });
         }
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -421,8 +421,7 @@ QUnit.module('general', {}, () => {
 
     QUnit.test('editors has collapsed class in IE11 (T879885)', function(assert) {
         const origBrowser = $.extend({}, browser);
-        browser.msie = true;
-        browser.version = '11.0';
+        $.extend(browser, { msie: true, version: '11.0' });
         try {
             const $textEditor = $('#texteditor').dxTextEditor({});
             assert.ok($textEditor.hasClass('dx-texteditor-collapsed'));
@@ -441,7 +440,8 @@ QUnit.module('general', {}, () => {
             const $textEditor = $element.dxTextEditor({});
             assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            $.extend(browser, { msie: origBrowser.msie, version: origBrowser.version });
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
         }
     });
 
@@ -453,7 +453,8 @@ QUnit.module('general', {}, () => {
             const $textEditor = $('#texteditor').wrap($container).dxTextEditor({});
             assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            $.extend(browser, { msie: origBrowser.msie, version: origBrowser.version });
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
         }
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -426,7 +426,8 @@ QUnit.module('general', {}, () => {
             const $textEditor = $('#texteditor').dxTextEditor({});
             assert.ok($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            browser = origBrowser;
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
         }
     });
 
@@ -439,7 +440,8 @@ QUnit.module('general', {}, () => {
             const $textEditor = $element.dxTextEditor({});
             assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            browser = origBrowser;
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
         }
     });
 
@@ -451,7 +453,8 @@ QUnit.module('general', {}, () => {
             const $textEditor = $('#texteditor').wrap($container).dxTextEditor({});
             assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            browser = origBrowser;
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
         }
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -426,8 +426,7 @@ QUnit.module('general', {}, () => {
             const $textEditor = $('#texteditor').dxTextEditor({});
             assert.ok($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            browser.msie = origBrowser.msie;
-            browser.version = origBrowser.version;
+            browser = origBrowser;
         }
     });
 
@@ -440,8 +439,7 @@ QUnit.module('general', {}, () => {
             const $textEditor = $element.dxTextEditor({});
             assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            browser.msie = origBrowser.msie;
-            browser.version = origBrowser.version;
+            browser = origBrowser;
         }
     });
 
@@ -453,8 +451,7 @@ QUnit.module('general', {}, () => {
             const $textEditor = $('#texteditor').wrap($container).dxTextEditor({});
             assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
-            browser.msie = origBrowser.msie;
-            browser.version = origBrowser.version;
+            browser = origBrowser;
         }
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -431,6 +431,37 @@ QUnit.module('general', {}, () => {
             browser.version = origBrowser.version;
         }
     });
+
+    QUnit.test('editors has no collapsed class in IE11 if the editor has custom display style', function(assert) {
+        const origBrowser = $.extend({}, browser);
+        browser.msie = true;
+        browser.version = '11.0';
+        const $element = $('#texteditor');
+        try {
+            $element.css('display', 'inline-block');
+            const $textEditor = $element.dxTextEditor({});
+            assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
+        } finally {
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
+            $element.css('display', 'block');
+        }
+    });
+
+    QUnit.test('editors has no collapsed class in IE11 if the editor has auto width container', function(assert) {
+        const origBrowser = $.extend({}, browser);
+        browser.msie = true;
+        browser.version = '11.0';
+        const $container = $('<div><div id=\'inner-texteditor\'></div></div>').css('width', 0).appendTo('#qunit-fixture');
+        try {
+            const $textEditor = $('#inner-texteditor').dxTextEditor({});
+            assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
+        } finally {
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
+            $container.remove();
+        }
+    });
 });
 
 QUnit.module('text option', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -419,7 +419,7 @@ QUnit.module('general', {}, () => {
         themes.isMaterial = realIsMaterial;
     });
 
-    QUnit.test('editors has collapsed class in IE11 (T879885)', function(assert) {
+    QUnit.test('editor has collapsed class in IE11 (T879885)', function(assert) {
         const origBrowser = $.extend({}, browser);
         $.extend(browser, { msie: true, version: '11.0' });
         try {


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
