### PR TITLE
Change export of ODataContext (T886254)

### DIFF
--- a/js/bundles/modules/data.odata.js
+++ b/js/bundles/modules/data.odata.js
@@ -2,8 +2,8 @@
 
 require('./data');
 
-DevExpress.data.ODataStore = require('../../data/odata/store');
-DevExpress.data.ODataContext = require('../../data/odata/context');
+DevExpress.data.ODataStore = require('../../data/odata/store').default;
+DevExpress.data.ODataContext = require('../../data/odata/context').default;
 
 DevExpress.data.utils = DevExpress.data.utils || {};
 DevExpress.data.utils.odata = {};

--- a/js/data/odata/context.js
+++ b/js/data/odata/context.js
@@ -85,4 +85,6 @@ const ODataContext = Class.inherit({
     },
 });
 
-export default ODataContext;
+// TODO: replace by "export default" after "js/bundles/modules/data.odata" refactor
+//       (should replace all "require" by "import")
+module.exports = ODataContext;

--- a/js/data/odata/context.js
+++ b/js/data/odata/context.js
@@ -85,6 +85,4 @@ const ODataContext = Class.inherit({
     },
 });
 
-// TODO: replace by "export default" after "js/bundles/modules/data.odata" refactor
-//       (should replace all "require" by "import")
-module.exports = ODataContext;
+export default ODataContext;

--- a/js/data/odata/store.js
+++ b/js/data/odata/store.js
@@ -203,5 +203,6 @@ const ODataStore = Store.inherit({
 
 }, 'odata');
 
-// TODO: replace by "export default" after "odata/context" refactor
+// TODO: replace by "export default" after "js/bundles/modules/data.odata" refactor
+//       (should replace all "require" by "import")
 module.exports = ODataStore;

--- a/js/data/odata/store.js
+++ b/js/data/odata/store.js
@@ -203,6 +203,4 @@ const ODataStore = Store.inherit({
 
 }, 'odata');
 
-// TODO: replace by "export default" after "js/bundles/modules/data.odata" refactor
-//       (should replace all "require" by "import")
-module.exports = ODataStore;
+export default ODataStore;

--- a/testing/tests/DevExpress.data/dataSourceCreating.tests.js
+++ b/testing/tests/DevExpress.data/dataSourceCreating.tests.js
@@ -1,9 +1,9 @@
-const DataSource = require('data/data_source/data_source').DataSource;
-const ArrayStore = require('data/array_store');
-const CustomStore = require('data/custom_store');
-const LocalStore = require('data/local_store');
-const ODataStore = require('data/odata/store');
-const ajaxMock = require('../../helpers/ajaxMock.js');
+import { DataSource } from 'data/data_source/data_source';
+import ArrayStore from 'data/array_store';
+import CustomStore from 'data/custom_store';
+import LocalStore from 'data/local_store';
+import ODataStore from 'data/odata/store';
+import ajaxMock from '../../helpers/ajaxMock.js';
 
 QUnit.test('no options', function(assert) {
     const ds = new DataSource();


### PR DESCRIPTION
In future we should replace all `require` by `import` to use `export default` for the ODataStore and the ODataContext