### PR TITLE
DropDownBox - call displayValueFormatter only once on init (T883129)

### DIFF
--- a/js/ui/drop_down_box.js
+++ b/js/ui/drop_down_box.js
@@ -148,8 +148,7 @@ const DropDownBox = DropDownEditor.inherit({
             .always((function() {
                 this.option('displayValue', values);
                 callBase(values.length && values);
-            }).bind(this))
-            .fail(callBase);
+            }).bind(this));
     },
 
     _loadItem: function(value) {

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
@@ -381,6 +381,16 @@ QUnit.module('common', moduleConfig, () => {
 
         assert.equal(instance.option('displayValue'), '12', 'displayValue option has been changed');
     });
+
+    QUnit.test('displayValueFormatter should be called once (T883129)', function(assert) {
+        const spy = sinon.spy();
+        new DropDownBox(this.$element, {
+            value: 1,
+            displayValueFormatter: spy
+        });
+
+        assert.strictEqual(spy.callCount, 1, 'value has been applied');
+    });
 });
 
 QUnit.module('popup options', moduleConfig, () => {


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
