### PR TITLE
Throw a warning message for toolbar.height and drawer.target options only once if widget was initialized with using these options

### DIFF
--- a/testing/tests/DevExpress.ui.widgets/drawer.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/drawer.tests.js
@@ -376,46 +376,6 @@ QUnit.module('Drawer behavior', () => {
         assert.ok($(instance._overlay.option('position').of).hasClass('dx-drawer-content'), 'target is ok');
     });
 
-    ['shrink', 'overlap', 'push'].forEach((openedStateMode) => {
-        QUnit.test(`warnings for deprecated 'target' option, ${openedStateMode}, target: notInitialized`, function(assert) {
-            sinon.spy(errors, 'log');
-
-            try {
-                $('#drawer').dxDrawer({
-                    openedStateMode: openedStateMode
-                });
-
-                assert.strictEqual(errors.log.callCount, 0, 'log.callCount');
-            } finally {
-                errors.log.restore();
-            }
-        });
-
-        [null, undefined, '#someID'].forEach((target) => {
-            QUnit.test(`warnings for deprecated 'target' option, openedStateMode: ${openedStateMode}, target: ${target}`, function(assert) {
-                sinon.spy(errors, 'log');
-
-                try {
-                    $('#drawer').dxDrawer({
-                        openedStateMode: openedStateMode,
-                        target: target
-                    });
-
-                    assert.strictEqual(errors.log.callCount, 1, 'log.callCount');
-                    assert.deepEqual(errors.log.firstCall.args, [
-                        'W0001',
-                        'dxDrawer',
-                        'target',
-                        '20.1',
-                        'Functionality associated with this option is not intended for the Drawer widget.'
-                    ], 'args of the log method');
-                } finally {
-                    errors.log.restore();
-                }
-            });
-        });
-    });
-
     QUnit.test('content() function', function(assert) {
         const $element = $('#drawer').dxDrawer({});
         const instance = $element.dxDrawer('instance');
@@ -2071,5 +2031,52 @@ QUnit.module('Modes changing', {
         const $panel = this.instance.$element().find('.' + DRAWER_PANEL_CONTENT_CLASS);
 
         assert.equal($panel.length, 1, 'one panel is rendered');
+    });
+});
+
+QUnit.module('Deprecated options', {
+    beforeEach: function() {
+        fx.off = true;
+    },
+    afterEach: function() {
+        fx.off = false;
+        this.stub.restore();
+    }
+}, () => {
+    ['shrink', 'overlap', 'push'].forEach((openedStateMode) => {
+        QUnit.test(`warnings for deprecated 'target' option, ${openedStateMode}, target: notInitialized`, function(assert) {
+            assert.expect(1);
+            this.stub = sinon.stub(errors, 'log', () => {
+                assert.strictEqual(true, false, 'error.log should not be called');
+            });
+
+            $('#drawer').dxDrawer({
+                openedStateMode: openedStateMode
+            });
+
+            assert.strictEqual(this.stub.callCount, 0, 'error.log.callCount');
+        });
+
+        [null, undefined, '#someID'].forEach((target) => {
+            QUnit.test(`warnings for deprecated 'target' option, openedStateMode: ${openedStateMode}, target: ${target}`, function(assert) {
+                assert.expect(2);
+                this.stub = sinon.stub(errors, 'log', () => {
+                    assert.deepEqual(errors.log.lastCall.args, [
+                        'W0001',
+                        'dxDrawer',
+                        'target',
+                        '20.1',
+                        'Functionality associated with this option is not intended for the Drawer widget.'
+                    ], 'args of the log method');
+                });
+
+                $('#drawer').dxDrawer({
+                    openedStateMode: openedStateMode,
+                    target: target
+                });
+
+                assert.strictEqual(this.stub.callCount, 1, 'error.log.callCount');
+            });
+        });
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -275,41 +275,44 @@ QUnit.module('render', {
         assert.ok(templateUsed);
         assert.equal(this.element.find('.custom-template').length, 1);
     });
+});
 
+QUnit.module('Deprecated options', {
+    afterEach: function() {
+        this.stub.restore();
+    }
+}, () => {
     QUnit.test('show warning if deprecated "height" option is used', function(assert) {
-        sinon.spy(errors, 'log');
-
-        try {
-            $('#toolbar').dxToolbar({
-                items: [ { location: 'before', text: 'text1' } ],
-                height: 50
-            });
-
-            assert.strictEqual(errors.log.callCount, 1, 'log.callCount');
-            assert.deepEqual(errors.log.firstCall.args, [
+        assert.expect(2);
+        this.stub = sinon.stub(errors, 'log', () => {
+            assert.deepEqual(errors.log.lastCall.args, [
                 'W0001',
-                'dxToolbar',
-                'height',
+                'dxDrawer',
+                'target',
                 '20.1',
-                'Functionality associated with this option is not intended for the Toolbar widget.'
+                'Functionality associated with this option is not intended for the Drawer widget.'
             ], 'args of the log method');
-        } finally {
-            errors.log.restore();
-        }
+        });
+
+        $('#toolbar').dxToolbar({
+            items: [ { location: 'before', text: 'text1' } ],
+            height: 50
+        });
+
+        assert.strictEqual(this.stub.callCount, 1, 'error.log.callCount');
     });
 
     QUnit.test('Warning messages not displaying if deprecated "height" option not used', function(assert) {
-        sinon.spy(errors, 'log');
+        assert.expect(1);
+        this.stub = sinon.stub(errors, 'log', () => {
+            assert.strictEqual(true, false, 'error.log should not be called');
+        });
 
-        try {
-            $('#toolbar').dxToolbar({
-                items: [ { location: 'before', text: 'text1' } ]
-            });
+        $('#toolbar').dxToolbar({
+            items: [ { location: 'before', text: 'text1' } ]
+        });
 
-            assert.strictEqual(errors.log.callCount, 0, 'log.callCount');
-        } finally {
-            errors.log.restore();
-        }
+        assert.strictEqual(this.stub.callCount, 0, 'error.log.callCount');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -287,10 +287,10 @@ QUnit.module('Deprecated options', {
         this.stub = sinon.stub(errors, 'log', () => {
             assert.deepEqual(errors.log.lastCall.args, [
                 'W0001',
-                'dxDrawer',
-                'target',
+                'dxToolbar',
+                'height',
                 '20.1',
-                'Functionality associated with this option is not intended for the Drawer widget.'
+                'Functionality associated with this option is not intended for the Toolbar widget.'
             ], 'args of the log method');
         });
 


### PR DESCRIPTION
refactor tests