### PR TITLE
TextEditor - collapse input container in ie11 only if the container has enough width

### DIFF
--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -16,6 +16,7 @@ const TextEditorButtonCollection = require('./texteditor_button_collection/index
 const config = require('../../core/config');
 const errors = require('../widget/ui.errors');
 const browser = require('../../core/utils/browser');
+const getWindow = require('../../core/utils/window').getWindow;
 const Deferred = require('../../core/utils/deferred').Deferred;
 
 const TEXTEDITOR_CLASS = 'dx-texteditor';
@@ -473,11 +474,28 @@ const TextEditorBase = Editor.inherit({
     },
 
     _collapseInputContainer: function() {
-        const $element = this.$element();
         const isIE11 = browser.msie && browser.version <= 11;
-        if(isIE11 && $element.css('display') === 'block') {
+        const $element = this.$element();
+        const $parentElement = $element.parent();
+
+        if(isIE11 && $element.css('display') === 'block' && this._hasParentEnoughWidth($parentElement)) {
             $element.addClass(TEXTEDITOR_COLLAPSED_CLASS);
         }
+    },
+
+    _hasParentEnoughWidth: function($parent) {
+        const window = getWindow();
+        return !window.getComputedStyle($parent.get(0)) || $parent.width() > this._calculateEditorMinWidth();
+    },
+
+    _calculateEditorMinWidth: function() {
+        const $input = this._input();
+        const beforeButtonsWidth = $(this._$beforeButtonsContainer).width() || 0;
+        const afterButtonsWidth = $(this._$afterButtonsContainer).width() || 0;
+        const inputLeftPadding = parseFloat($input.css('paddingLeft'));
+        const inputRightPadding = parseFloat($input.css('paddingRight'));
+
+        return beforeButtonsWidth + afterButtonsWidth + inputLeftPadding + inputRightPadding;
     },
 
     _renderValue: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -422,13 +422,39 @@ QUnit.module('general', {}, () => {
         themes.isMaterial = realIsMaterial;
     });
 
-    QUnit.test('editors has collapsed class in IE11 (T879885)', function(assert) {
+    QUnit.test('editor has collapsed class in IE11 (T879885)', function(assert) {
         const origBrowser = $.extend({}, browser);
-        browser.msie = true;
-        browser.version = '11.0';
+        $.extend(browser, { msie: true, version: '11.0' });
         try {
             const $textEditor = $('#texteditor').dxTextEditor({});
             assert.ok($textEditor.hasClass('dx-texteditor-collapsed'));
+        } finally {
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
+        }
+    });
+
+    QUnit.test('editor has no collapsed class in IE11 if the editor has custom display style', function(assert) {
+        const origBrowser = $.extend({}, browser);
+        $.extend(browser, { msie: true, version: '11.0' });
+        const $element = $('#texteditor');
+        try {
+            $element.css('display', 'inline-block');
+            const $textEditor = $element.dxTextEditor({});
+            assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
+        } finally {
+            browser.msie = origBrowser.msie;
+            browser.version = origBrowser.version;
+        }
+    });
+
+    QUnit.test('editor has no collapsed class in IE11 if the editor has auto width container', function(assert) {
+        const origBrowser = $.extend({}, browser);
+        $.extend(browser, { msie: true, version: '11.0' });
+        const $container = $('<div></div>').css('width', 0);
+        try {
+            const $textEditor = $('#texteditor').wrap($container).dxTextEditor({});
+            assert.notOk($textEditor.hasClass('dx-texteditor-collapsed'));
         } finally {
             browser.msie = origBrowser.msie;
             browser.version = origBrowser.version;


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
