### PR TITLE
TextEditor - revert input container collapsing in ie11 (T879885)

### DIFF
--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -15,7 +15,6 @@ const ClearButton = require('./ui.text_editor.clear').default;
 const TextEditorButtonCollection = require('./texteditor_button_collection/index').default;
 const config = require('../../core/config');
 const errors = require('../widget/ui.errors');
-const browser = require('../../core/utils/browser');
 const Deferred = require('../../core/utils/deferred').Deferred;
 
 const TEXTEDITOR_CLASS = 'dx-texteditor';
@@ -32,7 +31,6 @@ const ALLOWED_STYLE_CLASSES = [
     TEXTEDITOR_STYLING_MODE_PREFIX + 'filled',
     TEXTEDITOR_STYLING_MODE_PREFIX + 'underlined'
 ];
-const TEXTEDITOR_COLLAPSED_CLASS = 'dx-texteditor-collapsed';
 
 const STATE_INVISIBLE_CLASS = 'dx-state-invisible';
 
@@ -408,7 +406,6 @@ const TextEditorBase = Editor.inherit({
         this._renderEnterKeyAction();
         this._renderEmptinessEvent();
         this.callBase();
-        this._collapseInputContainer();
     },
 
     _renderInput: function() {
@@ -470,14 +467,6 @@ const TextEditorBase = Editor.inherit({
                 buttonInstance.option && buttonInstance.option('stylingMode', editorStylingMode === 'underlined' ? 'text' : 'contained');
             }
         });
-    },
-
-    _collapseInputContainer: function() {
-        const $element = this.$element();
-        const isIE11 = browser.msie && browser.version <= 11;
-        if(isIE11 && $element.css('display') === 'block') {
-            $element.addClass(TEXTEDITOR_COLLAPSED_CLASS);
-        }
     },
 
     _renderValue: function() {

--- a/styles/widgets/common/textEditor.less
+++ b/styles/widgets/common/textEditor.less
@@ -62,10 +62,6 @@
 
 .dx-texteditor-input-container {
     .dx-editor-content-wrapper();
-
-    .dx-texteditor-collapsed & {
-        flex-basis: 0;
-    }
 }
 
 .dx-texteditor-input {

--- a/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
@@ -355,29 +355,6 @@ module('rendering', () => {
             textBox.option('readOnly', false);
             assert.ok(button.option('disabled'), 'button is disabled');
         });
-
-        test('editors content should not overlap the widgets bounds (T879885)', function(assert) {
-            const widgetWidth = 200;
-            const $textBox = $('<div>').appendTo('#qunit-fixture').dxTextBox({
-                width: widgetWidth,
-                buttons: [{
-                    name: 'custom',
-                    location: 'before',
-                    options: {
-                        text: 'custom'
-                    }
-                }, {
-                    name: 'custom 2',
-                    location: 'after',
-                    options: {
-                        text: 'custom'
-                    }
-                }]
-            });
-            const { $before, $after } = getTextEditorButtons($textBox);
-            const $input = $textBox.find('.dx-texteditor-input-container');
-            assert.ok($before.eq(0).outerWidth() + $input.outerWidth() + $after.eq(0).outerWidth() < widgetWidth);
-        });
     });
 
     module('numberBox', () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -7,7 +7,6 @@ import keyboardMock from '../../../helpers/keyboardMock.js';
 import caretWorkaround from './caretWorkaround.js';
 import themes from 'ui/themes';
 import config from 'core/config';
-import browser from 'core/utils/browser';
 
 import 'ui/text_box/ui.text_editor';
 
@@ -420,19 +419,6 @@ QUnit.module('general', {}, () => {
         assert.ok($textEditor.hasClass('dx-editor-underlined'));
 
         themes.isMaterial = realIsMaterial;
-    });
-
-    QUnit.test('editors has collapsed class in IE11 (T879885)', function(assert) {
-        const origBrowser = $.extend({}, browser);
-        browser.msie = true;
-        browser.version = '11.0';
-        try {
-            const $textEditor = $('#texteditor').dxTextEditor({});
-            assert.ok($textEditor.hasClass('dx-texteditor-collapsed'));
-        } finally {
-            browser.msie = origBrowser.msie;
-            browser.version = origBrowser.version;
-        }
     });
 });
 


### PR DESCRIPTION
This reverts commit dc72dc1eab3a316d8549945e3ba3eaad9e11863c.

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
