### PR TITLE
Rollback 'export default' for ODataContext and ODataStore

### DIFF
--- a/js/bundles/modules/data.odata.js
+++ b/js/bundles/modules/data.odata.js
@@ -2,8 +2,8 @@
 
 require('./data');
 
-DevExpress.data.ODataStore = require('../../data/odata/store').default;
-DevExpress.data.ODataContext = require('../../data/odata/context').default;
+DevExpress.data.ODataStore = require('../../data/odata/store');
+DevExpress.data.ODataContext = require('../../data/odata/context');
 
 DevExpress.data.utils = DevExpress.data.utils || {};
 DevExpress.data.utils.odata = {};

--- a/js/data/odata/context.js
+++ b/js/data/odata/context.js
@@ -85,4 +85,4 @@ const ODataContext = Class.inherit({
     },
 });
 
-export default ODataContext;
+module.exports = ODataContext;

--- a/js/data/odata/store.js
+++ b/js/data/odata/store.js
@@ -203,4 +203,4 @@ const ODataStore = Store.inherit({
 
 }, 'odata');
 
-export default ODataStore;
+module.exports = ODataStore;


### PR DESCRIPTION
Fix farm's screenshot tests.