### PR TITLE
Fix lost aspnet.createComponent calls, part II (fixes T886572)

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -143,17 +143,29 @@
     function createComponent(name, options, id, validatorOptions) {
         var selector = '#' + String(id).replace(/[^\w-]/g, '\\$&');
         pendingCreateComponentRoutines.push(function() {
-            var $component = $(selector)[name](options);
-            if($.isPlainObject(validatorOptions)) {
-                $component.dxValidator(validatorOptions);
+            var $element = $(selector);
+            if($element.length) {
+                var $component = $(selector)[name](options);
+                if($.isPlainObject(validatorOptions)) {
+                    $component.dxValidator(validatorOptions);
+                }
+                return true;
             }
+            return false;
         });
     }
 
     templateRendered.add(function() {
         var snapshot = pendingCreateComponentRoutines.slice();
+        var leftover = [ ];
+
         pendingCreateComponentRoutines = [ ];
-        snapshot.forEach(function(func) { func(); });
+        snapshot.forEach(function(func) {
+            if(!func()) {
+                leftover.push(func);
+            }
+        });
+        pendingCreateComponentRoutines = pendingCreateComponentRoutines.concat(leftover);
     });
 
     return {

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -3,10 +3,13 @@
         define(function(require, exports, module) {
             require('integration/jquery'),
             require('ui/button');
+            require('ui/check_box');
+            require('ui/drop_down_button');
             require('ui/form');
             require('ui/popup');
             require('ui/select_box');
             require('ui/text_box');
+            require('ui/toolbar');
             require('ui/validator');
             require('ui/validation_summary');
 
@@ -521,6 +524,40 @@
             assert.ok($('#' + NUMERIC_ID).dxTextBox('instance'));
         } finally {
             setTemplateEngine('default');
+        }
+    });
+
+    QUnit.test('T886572', function(assert) {
+        aspnet.setTemplateEngine();
+        window.__createCheckBox = function(id) {
+            DevExpress.aspnet.createComponent('dxCheckBox', { text: id }, id);
+        };
+
+        try {
+            $('#qunit-fixture').html(
+                '<div id=toolbar1></div>' +
+                '<script id=template1 type=text/html>' +
+                '  <div id=checkBox1></div><% __createCheckBox("checkBox1") %>' +
+                '</script>'
+            );
+            $('#toolbar1').dxToolbar({
+                items: [
+                    {
+                        widget: 'dxDropDownButton',
+                        options: {
+                            deferRendering: false,
+                            items: [
+                                { template: $('#template1') }
+                            ]
+                        }
+                    }
+                ]
+            });
+
+            assert.ok($('#checkBox1').dxCheckBox('instance'));
+        } finally {
+            setTemplateEngine('default');
+            delete window.__createCheckBox;
         }
     });
 


### PR DESCRIPTION
I considered this back in September. Check 'Keep the handler in queue until the element is found' in #9540.

Now, thanks to ticket https://devexpress.com/issue=T886572, we have a test case that confirms the actual need.

