### PR TITLE
DataGrid - Prevents onSelectionChanged from firing when deferred selection and state storing are enabled (T885777)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.state_storing.js
+++ b/js/ui/grid_core/ui.grid_core.state_storing.js
@@ -287,6 +287,16 @@ module.exports = {
                     clearTimeout(this._restoreStateTimeoutID);
                     this.callBase();
                 }
+            },
+            selection: {
+                _fireSelectionChanged: function(options) {
+                    const stateStoringController = this.getController('stateStoring');
+                    const isDeferredSelection = this.option('selection.deferred');
+                    if(stateStoringController.isLoading() && isDeferredSelection) {
+                        return;
+                    }
+                    this.callBase.apply(this, arguments);
+                }
             }
         }
     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -9797,6 +9797,38 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.ok(freeSpaceRowHeightStatuses.length);
         freeSpaceRowHeightStatuses.forEach(heightStatus => assert.ok(heightStatus));
     });
+
+    QUnit.test('Deferred selection - The onSelectionChanged event should not fire on initial loading if a restored state contains selecitonFilter (T885777)', function(assert) {
+        // arrange
+        const onSelectionChangedHandler = sinon.spy();
+        const gridOptions = {
+            keyExpr: 'id',
+            dataSource: [{ id: 1 }],
+            columns: ['id'],
+            stateStoring: {
+                enabled: true,
+                type: 'custom',
+                customLoad: function() {
+                    return { selectionFilter: ['id', '=', 1] };
+                }
+            },
+            selection: {
+                mode: 'multiple',
+                deferred: true
+            },
+            onSelectionChanged: onSelectionChangedHandler
+        };
+        const dataGrid = createDataGrid(gridOptions);
+        this.clock.tick();
+
+        let selectedKeys;
+        dataGrid.getSelectedRowKeys().done(keys => selectedKeys = keys);
+        this.clock.tick();
+
+        // assert
+        assert.deepEqual(selectedKeys, [1]);
+        assert.notOk(onSelectionChangedHandler.called, 'onSelectionChanged is not called');
+    });
 });
 
 


### PR DESCRIPTION
1. Overrided the  **SelectionController._fireSelectionChanged** method for preventing **onSelectionChanged** from firing on initial load when state storing and deferred selection are used.
2. Added tests.