### PR TITLE
Update jQuery to version 3.5.1

### DIFF
--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -212,7 +212,6 @@ function start_runner_watchdog {
 }
 
 echo "node $(node -v), npm $(npm -v), dotnet $(dotnet --version)"
-npm ls jquery
 
 TARGET_FUNC="run_$TARGET"
 

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -212,6 +212,7 @@ function start_runner_watchdog {
 }
 
 echo "node $(node -v), npm $(npm -v), dotnet $(dotnet --version)"
+npm ls jquery
 
 TARGET_FUNC="run_$TARGET"
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "handlebars": "^4.7.3",
     "hogan.js": "3.0.2",
     "intl": "^1.2.5",
-    "jquery": "^3.5.0",
+    "jquery": "^3.5.1",
     "jquery.1": "^1.0.0",
     "jquery.2": "^1.0.0",
     "jquery.tmpl": "0.0.2",


### PR DESCRIPTION
- jQuery v3.5.0 has a regression issue:
https://github.com/jquery/jquery/issues/4665
- We have v3.5.0 in a node_modules cache:
https://devextreme-ci.devexpress.com/DevExpress/DevExtreme/31665/44
- This PR updates jQuery to v3.5.1 to be sure that all tests are passed.
