### PR TITLE
DataGrid - Fixes applying pager options when repaintChangesOnly is enabled (T886628)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.pager.js
+++ b/js/ui/grid_core/ui.grid_core.pager.js
@@ -19,6 +19,8 @@ const PagerView = modules.View.inherit({
                 const pager = that._getPager();
                 if(pager) {
                     pager.option({
+                        pageIndex: that._getPageIndex(dataController),
+                        pageSize: dataController.pageSize(),
                         pageCount: dataController.pageCount(),
                         totalCount: dataController.totalCount(),
                         hasKnownLastPage: dataController.hasKnownLastPage()
@@ -45,7 +47,7 @@ const PagerView = modules.View.inherit({
         const keyboardController = that.getController('keyboardNavigation');
         const options = {
             maxPagesCount: MAX_PAGES_COUNT,
-            pageIndex: 1 + (parseInt(dataController.pageIndex()) || 0),
+            pageIndex: that._getPageIndex(dataController),
             pageCount: dataController.pageCount(),
             pageSize: dataController.pageSize(),
             showPageSizes: pagerOptions.showPageSizeSelector,
@@ -77,6 +79,10 @@ const PagerView = modules.View.inherit({
         }
 
         that._createComponent($element, Pager, options);
+    },
+
+    _getPageIndex: function(dataController) {
+        return 1 + (parseInt(dataController.pageIndex()) || 0);
     },
 
     getPageSizes: function() {

--- a/js/ui/grid_core/ui.grid_core.pager.js
+++ b/js/ui/grid_core/ui.grid_core.pager.js
@@ -7,6 +7,10 @@ import { hasWindow } from '../../core/utils/window';
 const PAGER_CLASS = 'pager';
 const MAX_PAGES_COUNT = 10;
 
+const getPageIndex = function(dataController) {
+    return 1 + (parseInt(dataController.pageIndex()) || 0);
+};
+
 const PagerView = modules.View.inherit({
     init: function() {
         const that = this;
@@ -19,7 +23,7 @@ const PagerView = modules.View.inherit({
                 const pager = that._getPager();
                 if(pager) {
                     pager.option({
-                        pageIndex: that._getPageIndex(dataController),
+                        pageIndex: getPageIndex(dataController),
                         pageSize: dataController.pageSize(),
                         pageCount: dataController.pageCount(),
                         totalCount: dataController.totalCount(),
@@ -47,7 +51,7 @@ const PagerView = modules.View.inherit({
         const keyboardController = that.getController('keyboardNavigation');
         const options = {
             maxPagesCount: MAX_PAGES_COUNT,
-            pageIndex: that._getPageIndex(dataController),
+            pageIndex: getPageIndex(dataController),
             pageCount: dataController.pageCount(),
             pageSize: dataController.pageSize(),
             showPageSizes: pagerOptions.showPageSizeSelector,
@@ -79,10 +83,6 @@ const PagerView = modules.View.inherit({
         }
 
         that._createComponent($element, Pager, options);
-    },
-
-    _getPageIndex: function(dataController) {
-        return 1 + (parseInt(dataController.pageIndex()) || 0);
     },
 
     getPageSizes: function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
@@ -254,7 +254,7 @@ QUnit.module('Pager', {
         assert.equal(pagerView._createComponent.callCount, 1, '_createComponent call count after partial update');
     });
 
-    QUnit.test('pageCount is updated on partial update with repaintChangesOnly', function(assert) {
+    QUnit.test('pageCount, pageIndex, pageSize are updated on partial update with repaintChangesOnly', function(assert) {
     // arrange
         const testElement = $('#container');
         const pagerView = this.pagerView;
@@ -276,7 +276,9 @@ QUnit.module('Pager', {
         assert.deepEqual(pagerView._getPager().option.getCall(0).args, [{
             hasKnownLastPage: true, // T697587
             totalCount: 143, // #7259
-            pageCount: 20
+            pageCount: 20,
+            pageIndex: 2, // T886628
+            pageSize: 7 // T886628
         }], 'pager option args');
     });
 


### PR DESCRIPTION
1. Fixed applying options in the **DataController.changed** event handler when **repaintChangesOnly** is enabled.
2. Refactored tests.
