### PR TITLE
Fix unexpected data request by RadioGroup without initial value (T887090)

### DIFF
--- a/js/ui/radio_group/radio_group.js
+++ b/js/ui/radio_group/radio_group.js
@@ -270,8 +270,10 @@ class RadioGroup extends Editor {
             accessKey,
             focusStateEnabled,
             itemTemplate,
-            tabIndex
+            tabIndex,
+            valueExpr
         } = this.option();
+        const isNullSelectable = valueExpr !== 'this';
 
         this._radios = this._createComponent($radios, RadioCollection, {
             displayExpr,
@@ -286,7 +288,7 @@ class RadioGroup extends Editor {
             scrollingEnabled: false,
             selectionByClick: false,
             selectionMode: 'single',
-            selectedItemKeys: isDefined(value) ? [value] : [],
+            selectedItemKeys: isNullSelectable || isDefined(value) ? [value] : [],
             tabIndex
         });
         this._areRadiosCreated.resolve();

--- a/js/ui/radio_group/radio_group.js
+++ b/js/ui/radio_group/radio_group.js
@@ -2,6 +2,7 @@ import $ from '../../core/renderer';
 import { extend } from '../../core/utils/extend';
 import devices from '../../core/devices';
 import { deferRender } from '../../core/utils/common';
+import { isDefined } from '../../core/utils/type';
 import inkRipple from '../widget/utils.ink_ripple';
 import registerComponent from '../../core/component_registrator';
 import CollectionWidget from '../collection/ui.collection_widget.edit';
@@ -263,13 +264,21 @@ class RadioGroup extends Editor {
     _renderRadios() {
         this._areRadiosCreated = new Deferred();
         const $radios = $('<div>').appendTo(this.$element());
+        const {
+            value,
+            displayExpr,
+            accessKey,
+            focusStateEnabled,
+            itemTemplate,
+            tabIndex
+        } = this.option();
 
         this._radios = this._createComponent($radios, RadioCollection, {
-            displayExpr: this.option('displayExpr'),
-            accessKey: this.option('accessKey'),
+            displayExpr,
+            accessKey,
             dataSource: this._dataSource,
-            focusStateEnabled: this.option('focusStateEnabled'),
-            itemTemplate: this.option('itemTemplate'),
+            focusStateEnabled,
+            itemTemplate,
             keyExpr: this._getCollectionKeyExpr(),
             noDataText: '',
             onContentReady: () => this._fireContentReadyAction(true),
@@ -277,8 +286,8 @@ class RadioGroup extends Editor {
             scrollingEnabled: false,
             selectionByClick: false,
             selectionMode: 'single',
-            selectedItemKeys: [this.option('value')],
-            tabIndex: this.option('tabIndex')
+            selectedItemKeys: isDefined(value) ? [value] : [],
+            tabIndex
         });
         this._areRadiosCreated.resolve();
     }

--- a/testing/tests/DevExpress.ui.widgets.editors/radioGroup.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/radioGroup.markup.tests.js
@@ -74,6 +74,29 @@ QUnit.module('buttons group rendering', moduleConfig, () => {
 
         assert.ok(!$radioGroup.find('.dx-collection').hasClass('dx-state-disabled'), 'inner collection hasn\'t disabled-state class');
     });
+
+    test('widget should not try to load undefined initial value from the data source', function(assert) {
+        const loadStub = sinon.stub().returns([1, 2, 3]);
+        $('#radioGroup').dxRadioGroup({
+            dataSource: {
+                load: loadStub
+            }
+        });
+
+        assert.ok(loadStub.calledOnce, 'load callback called once');
+    });
+
+    test('widget should not try to extra load initial value from the data source', function(assert) {
+        const loadStub = sinon.stub().returns([1, 2, 3]);
+        $('#radioGroup').dxRadioGroup({
+            dataSource: {
+                load: loadStub
+            },
+            value: 2
+        });
+
+        assert.ok(loadStub.calledOnce, 'load callback called once');
+    });
 });
 
 QUnit.module('buttons rendering', moduleConfig, () => {


### PR DESCRIPTION
Related tickets: 
https://supportcenter.devexpress.com/ticket/details/T723263
https://supportcenter.devexpress.com/ticket/details/T823478

First data request -> retrieve items
Second data request -> get selected item (null) from dataSource