### PR TITLE
DataGrid - Prevents the content from scrolling on refresh (T884308)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -782,7 +782,7 @@ module.exports = {
                                     const $rowElement = rowElement && rowElement[0] && $(rowElement[0]);
                                     let top = $rowElement && $rowElement.position().top;
 
-                                    const allowedTopOffset = browser.mozilla ? 1 : 0; // T884308
+                                    const allowedTopOffset = browser.mozilla || browser.msie ? 1 : 0; // T884308
                                     if(top > allowedTopOffset) {
                                         top = Math.round(top + $rowElement.outerHeight() * (itemIndex % 1));
                                         scrollable.scrollTo({ y: top });

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -7,6 +7,7 @@ import { each } from '../../core/utils/iterator';
 import { Deferred } from '../../core/utils/deferred';
 import translator from '../../animation/translator';
 import LoadIndicator from '../load_indicator';
+import browser from '../../core/utils/browser';
 
 const TABLE_CLASS = 'table';
 const BOTTOM_LOAD_PANEL_CLASS = 'bottom-load-panel';
@@ -781,7 +782,8 @@ module.exports = {
                                     const $rowElement = rowElement && rowElement[0] && $(rowElement[0]);
                                     let top = $rowElement && $rowElement.position().top;
 
-                                    if(top > 0) {
+                                    const allowedTopOffset = browser.mozilla ? 1 : 0; // T884308
+                                    if(top > allowedTopOffset) {
                                         top = Math.round(top + $rowElement.outerHeight() * (itemIndex % 1));
                                         scrollable.scrollTo({ y: top });
                                     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -9818,6 +9818,36 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.deepEqual(selectedKeys, [1]);
         assert.notOk(onSelectionChangedHandler.called, 'onSelectionChanged is not called');
     });
+
+    QUnit.test('Data rows shouuld not be scrolled on refresh (T884308)', function(assert) {
+        // arrange
+        const onScrollHandler = sinon.spy();
+        const generateData = function() {
+            const data = [];
+            for(let i = 0; i < 100; i++) {
+                data.push({
+                    id: i + 1
+                });
+            }
+            return data;
+        };
+        const gridOptions = {
+            dataSource: generateData(),
+            height: 400,
+            keyExpr: 'id',
+            scrolling: {
+                mode: 'virtual'
+            }
+        };
+        const dataGrid = createDataGrid(gridOptions);
+        this.clock.tick();
+        dataGrid.getScrollable().on('scroll', onScrollHandler);
+        dataGrid.refresh();
+        this.clock.tick();
+
+        // assert
+        assert.notOk(onScrollHandler.called, 'onScroll handler is not called');
+    });
 });
 
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -9819,7 +9819,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.notOk(onSelectionChangedHandler.called, 'onSelectionChanged is not called');
     });
 
-    QUnit.test('Data rows shouuld not be scrolled on refresh (T884308)', function(assert) {
+    QUnit.test('Data rows should not be scrolled on refresh (T884308)', function(assert) {
         // arrange
         const onScrollHandler = sinon.spy();
         const generateData = function() {


### PR DESCRIPTION
1. Fixed the issue by comparing the **top** position option with 1 for IE and Firefox.
2. Added a test.