### PR TITLE
dxScheduler - Recurrence appointment date should be displayed equal to the targetedAppointmentData date in appointment popup from form(T882652)

### DIFF
--- a/js/ui/scheduler/tooltip_strategies/tooltipStrategyBase.js
+++ b/js/ui/scheduler/tooltip_strategies/tooltipStrategyBase.js
@@ -85,10 +85,7 @@ export class TooltipStrategyBase {
             dataSource: dataList,
             onContentReady: this._onListRender.bind(this),
             onItemClick: e => this._onListItemClick(e),
-            itemTemplate: (item, index) => {
-                const currentData = (item.settings && item.settings.targetedAppointmentData) || item.currentData || item.data;
-                return this._renderTemplate(item.data, currentData, index, item.color);
-            }
+            itemTemplate: (item, index) => this._renderTemplate(item.data, this._getCurrentAppointmentData(item), index, item.color)
         };
     }
 
@@ -140,10 +137,12 @@ export class TooltipStrategyBase {
 
     _onListItemClick(e) {
         this.hide();
-        if(this._extraOptions.clickEvent) {
-            this._extraOptions.clickEvent(e);
-        }
-        this._options.showAppointmentPopup(e.itemData.data, false, e.itemData.currentData);
+        this._extraOptions.clickEvent && this._extraOptions.clickEvent(e);
+        this._options.showAppointmentPopup(e.itemData.data, false, this._getCurrentAppointmentData(e.itemData));
+    }
+
+    _getCurrentAppointmentData(item) {
+        return (item.settings && item.settings.targetedAppointmentData) || item.currentData || item.data;
     }
 
     _createItemListContent(data, currentData, color) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentCollector.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentCollector.tests.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import translator from 'animation/translator';
 import fx from 'animation/fx';
-import { SchedulerTestWrapper } from './helpers.js';
+import { SchedulerTestWrapper, createWrapper } from './helpers.js';
 import themes from 'ui/themes';
 import { CompactAppointmentsHelper } from 'ui/scheduler/compactAppointmentsHelper';
 import Widget from 'ui/widget/ui.widget';
@@ -23,6 +23,55 @@ const ADAPTIVE_COLLECTOR_DEFAULT_SIZE = 28;
 const ADAPTIVE_COLLECTOR_BOTTOM_OFFSET = 40;
 const ADAPTIVE_COLLECTOR_RIGHT_OFFSET = 5;
 const COMPACT_THEME_ADAPTIVE_COLLECTOR_RIGHT_OFFSET = 1;
+
+const integrationCollectorConfig = {
+    beforeEach: function() {
+        fx.off = true;
+    },
+    afterEach: function() {
+        fx.off = false;
+    }
+};
+
+QUnit.module('Integration: collector', integrationCollectorConfig, () => {
+    QUnit.test('Start date should be equal targetedAppointmentData.startDate in appointment popup form in case recurrent appointment(T882652)', function(assert) {
+        var data = [{
+            text: '1',
+            startDate: new Date(2017, 4, 16, 9, 30),
+            endDate: new Date(2017, 4, 16, 11),
+
+        }, {
+            text: '2',
+            startDate: new Date(2017, 4, 16, 9, 30),
+            endDate: new Date(2017, 4, 16, 11),
+
+        }, {
+            text: 'Recurrence',
+            startDate: new Date(2017, 4, 1, 9, 30),
+            endDate: new Date(2017, 4, 1, 11),
+            recurrenceRule: 'FREQ=DAILY'
+        }];
+
+        const scheduler = createWrapper({
+            dataSource: data,
+            views: ['month'],
+            currentView: 'month',
+            currentDate: new Date(2017, 4, 25),
+            height: 600,
+            onAppointmentFormOpening: e => {
+                const startDate = e.form.getEditor('startDate').option('value');
+                assert.equal(startDate.getDate(), 16, 'Recurrence appointment date should be display equal targetedAppointmentData date in form');
+            }
+        });
+
+        scheduler.appointments.compact.click();
+        assert.equal(scheduler.tooltip.getDateText(),
+            'May 16 9:30 AM - 11:00 AM', 'Recurrence appointment date should be display equal targetedAppointmentData date in tooltip');
+
+        scheduler.tooltip.clickOnItem();
+        scheduler.appointmentPopup.dialog.clickEditAppointment();
+    });
+});
 
 QUnit.module('Integration: Appointments Collector Base Tests', {
     beforeEach: function() {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentCollector.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentCollector.tests.js
@@ -35,7 +35,7 @@ const integrationCollectorConfig = {
 
 QUnit.module('Integration: collector', integrationCollectorConfig, () => {
     QUnit.test('Start date should be equal targetedAppointmentData.startDate in appointment popup form in case recurrent appointment(T882652)', function(assert) {
-        var data = [{
+        const data = [{
             text: '1',
             startDate: new Date(2017, 4, 16, 9, 30),
             endDate: new Date(2017, 4, 16, 11),


### PR DESCRIPTION
…o the targetedAppointmentData date in appointment popup from form(T882652) (#12870)

* Fix

* create _getCurrentAppointmentData method

* Add test

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
