### PR TITLE
DataGrid - Fixes the searchPanel.text value when state storing is enabled (T887758)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.state_storing.js
+++ b/js/ui/grid_core/ui.grid_core.state_storing.js
@@ -221,7 +221,7 @@ module.exports = {
 
                     that.component.endUpdate();
 
-                    that.option('searchPanel.text', searchText || '');
+                    searchText && that.option('searchPanel.text', searchText);
 
                     that.option('filterValue', getFilterValue(that, state));
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
@@ -1724,16 +1724,13 @@ QUnit.module('State Storing with real controllers', {
             },
         });
 
-        this.clock.tick();
-
-        // act
-        this.refresh();
         this.clock.tick(2000);
 
         // assert
         assert.ok(customSave.calledOnce, 'customSave is called once');
         assert.strictEqual(customSave.getCall(0).args[0].searchText, '1', 'customSave is called with the searchPanel.text initial value');
         assert.strictEqual(this.option('searchPanel.text'), '1', 'searchPanel.text equals its initial value');
+        assert.equal(this.dataController.items().length, 1);
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
@@ -1703,6 +1703,38 @@ QUnit.module('State Storing with real controllers', {
         // assert
         assert.strictEqual(customSaveCallCount, 0, 'customSave is not fired');
     });
+
+    QUnit.test('searchPanel.text should not be ignored (T887758)', function(assert) {
+        // arrange
+        const customSave = sinon.spy();
+
+        this.setupDataGridModules({
+            dataSource: [{ id: 1 }, { id: 2 }],
+            searchPanel: {
+                visible: true,
+                text: '1'
+            },
+            stateStoring: {
+                enabled: true,
+                type: 'custom',
+                customLoad: function() {
+                    return null;
+                },
+                customSave
+            },
+        });
+
+        this.clock.tick();
+
+        // act
+        this.refresh();
+        this.clock.tick(2000);
+
+        // assert
+        assert.ok(customSave.calledOnce, 'customSave is called once');
+        assert.strictEqual(customSave.getCall(0).args[0].searchText, '1', 'customSave is called with the searchPanel.text initial value');
+        assert.strictEqual(this.option('searchPanel.text'), '1', 'searchPanel.text equals its initial value');
+    });
 });
 
 QUnit.module('State Storing for filterPanel', {


### PR DESCRIPTION
1. Fixed the issue by preventing **searchPanel.text** from updating when the loaded state is null.
2. Added a test.
