### PR TITLE
Fix task crash on npm ls error

### DIFF
--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -18,7 +18,7 @@ function run_ts {
 
     npm i
     npm update devextreme-internal-tools
-    npm ls devextreme-internal-tools
+    npm ls devextreme-internal-tools || :
 
     npm run update-ts
 


### PR DESCRIPTION
We use `npm ls` for logging purposes. The npm fails to do smth, the whole process is shut down, thus I add this "catch" construction.

Here is the description of the situation I came across:

- `package.json` has `~1.2.0` version of a package (devextreme-internal-tools)
- `node_modules` (restored from the cache) contains `1.2.85`
- `npm ls` is OK
- `package.json` changed to use `stable` tag instead of version match
- `stable` tag points to the same `1.2.85`
- `npm i` and `npm update` doesn't modify the package in the `node_modules` - since the version is the same
- `npm ls` fails

The thing is that it matters not only WHAT version but also HOW is was installed.