### PR TITLE
Diagram for Vue - The "Cannot read property 'length' of undefined" script error occurs when a set of custom shapes is defined in the toolbox (T889726)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "types": "./bundles/dx.all.d.ts",
   "license": "SEE LICENSE IN README.md",
   "dependencies": {
-    "devexpress-diagram": "1.0.3",
+    "devexpress-diagram": "1.0.4",
     "devexpress-gantt": "1.0.1",
     "jszip": "^2.0.0 || ^3.0.0",
     "quill": "^1.3.7",


### PR DESCRIPTION
…ript error occurs when a set of custom shapes is defined in the toolbox (T889726)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
