### PR TITLE
DataGrid - Hides the 'between' operation for a lookup column (T889066)

### DIFF
--- a/js/ui/filter_builder/between.js
+++ b/js/ui/filter_builder/between.js
@@ -50,7 +50,8 @@ function getConfig(caption) {
         icon: 'range',
         valueSeparator: SEPARATOR,
         dataTypes: ['number', 'date', 'datetime'],
-        editorTemplate: editorTemplate
+        editorTemplate: editorTemplate,
+        notForLookup: true
     };
 }
 

--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -30,7 +30,6 @@ const DEFAULT_FORMAT = {
     'datetime': 'shortDateShortTime'
 };
 const LOOKUP_OPERATIONS = ['=', '<>', 'isblank', 'isnotblank'];
-const FORBIDDEN_LOOKUP_OPERATIONS = ['between'];
 const AVAILABLE_FIELD_PROPERTIES = [
     'caption',
     'customizeText',
@@ -195,13 +194,12 @@ function getCustomOperation(customOperations, name) {
 
 function getAvailableOperations(field, filterOperationDescriptions, customOperations) {
     const filterOperations = getFilterOperations(field);
-
+    const isLookupField = !!field.lookup;
     customOperations.forEach(function(customOperation) {
-        const isLookupField = !!field.lookup;
-        const isOperationForbidden = isLookupField ? FORBIDDEN_LOOKUP_OPERATIONS.indexOf(customOperation.name) >= 0 : false;
-        if(!field.filterOperations && !isOperationForbidden && filterOperations.indexOf(customOperation.name) === -1) {
+        if(!field.filterOperations && filterOperations.indexOf(customOperation.name) === -1) {
             const dataTypes = customOperation && customOperation.dataTypes;
-            if(dataTypes && dataTypes.indexOf(field.dataType || DEFAULT_DATA_TYPE) >= 0) {
+            const isOperationForbidden = isLookupField ? !!customOperation.notForLookup : false;
+            if(!isOperationForbidden && dataTypes && dataTypes.indexOf(field.dataType || DEFAULT_DATA_TYPE) >= 0) {
                 filterOperations.push(customOperation.name);
             }
         }

--- a/js/ui/filter_builder/utils.js
+++ b/js/ui/filter_builder/utils.js
@@ -30,6 +30,7 @@ const DEFAULT_FORMAT = {
     'datetime': 'shortDateShortTime'
 };
 const LOOKUP_OPERATIONS = ['=', '<>', 'isblank', 'isnotblank'];
+const FORBIDDEN_LOOKUP_OPERATIONS = ['between'];
 const AVAILABLE_FIELD_PROPERTIES = [
     'caption',
     'customizeText',
@@ -196,7 +197,9 @@ function getAvailableOperations(field, filterOperationDescriptions, customOperat
     const filterOperations = getFilterOperations(field);
 
     customOperations.forEach(function(customOperation) {
-        if(!field.filterOperations && filterOperations.indexOf(customOperation.name) === -1) {
+        const isLookupField = !!field.lookup;
+        const isOperationForbidden = isLookupField ? FORBIDDEN_LOOKUP_OPERATIONS.indexOf(customOperation.name) >= 0 : false;
+        if(!field.filterOperations && !isOperationForbidden && filterOperations.indexOf(customOperation.name) === -1) {
             const dataTypes = customOperation && customOperation.dataTypes;
             if(dataTypes && dataTypes.indexOf(field.dataType || DEFAULT_DATA_TYPE) >= 0) {
                 filterOperations.push(customOperation.name);

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -23,18 +23,19 @@ const groupOperations = [{
     value: '!or'
 }];
 const filterOperationsDescriptions = {
+    between: 'Is between',
+    contains: 'Contains',
+    endsWith: 'Ends with',
     equal: 'Equals',
-    notEqual: 'Does not equal',
-    lessThan: 'Is less than',
-    lessThanOrEqual: 'Is less than or equal to',
     greaterThan: 'Is greater than',
     greaterThanOrEqual: 'Is greater than or equal to',
-    startsWith: 'Starts with',
-    contains: 'Contains',
-    notContains: 'Does not contain',
-    endsWith: 'Ends with',
     isBlank: 'Is blank',
-    isNotBlank: 'Is not blank'
+    isNotBlank: 'Is not blank',
+    lessThan: 'Is less than',
+    lessThanOrEqual: 'Is less than or equal to',
+    notContains: 'Does not contain',
+    notEqual: 'Does not equal',
+    startsWith: 'Starts with'
 };
 
 QUnit.module('Errors', function() {
@@ -1120,6 +1121,32 @@ QUnit.module('getAvailableOperations', {
 
         // assert
         assert.strictEqual(operations[0].text, 'Last Days');
+    });
+
+    // T889066
+    QUnit.test('the \'between\' operation should not be listed for a lookup field (dataType === number)', function(assert) {
+        // arrange, act
+        const customOperations = [
+            {
+                name: 'between',
+                dataTypes: ['number']
+            },
+            {
+                name: 'anyof',
+                dataTypes: ['number']
+            }
+        ];
+        const field = {
+            dataField: 'test',
+            dataType: 'number',
+            lookup: {}
+        };
+
+        const operations = utils.getAvailableOperations(field, filterOperationsDescriptions, customOperations);
+        const betweenOperation = operations.filter(operation => operation.value === 'between');
+
+        // assert
+        assert.equal(betweenOperation.length, 0, 'the \'between\' operation should not be found');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
+++ b/testing/tests/DevExpress.ui.widgets/filterBuilderParts/utilsTests.js
@@ -1124,29 +1124,51 @@ QUnit.module('getAvailableOperations', {
     });
 
     // T889066
-    QUnit.test('the \'between\' operation should not be listed for a lookup field (dataType === number)', function(assert) {
+    QUnit.test('a custom operation with enabled notForLookup option should not be listed for a lookup column', function(assert) {
         // arrange, act
         const customOperations = [
             {
-                name: 'between',
+                name: 'test1',
+                notForLookup: true,
                 dataTypes: ['number']
             },
             {
-                name: 'anyof',
+                name: 'test2',
+                notForLookup: false,
+                dataTypes: ['number']
+            },
+            {
+                name: 'test3',
                 dataTypes: ['number']
             }
         ];
-        const field = {
+        const field1 = {
+            dataField: 'test',
+            dataType: 'number'
+        };
+        const field2 = {
             dataField: 'test',
             dataType: 'number',
             lookup: {}
         };
 
-        const operations = utils.getAvailableOperations(field, filterOperationsDescriptions, customOperations);
-        const betweenOperation = operations.filter(operation => operation.value === 'between');
+        // act
+        let operations = utils.getAvailableOperations(field1, filterOperationsDescriptions, customOperations);
+        let operationValues = operations.map(operation => operation.value);
 
         // assert
-        assert.equal(betweenOperation.length, 0, 'the \'between\' operation should not be found');
+        assert.ok(operationValues.indexOf('test1') >= 0, 'test1 is in the list');
+        assert.ok(operationValues.indexOf('test2') >= 0, 'test2 is in the list');
+        assert.ok(operationValues.indexOf('test3') >= 0, 'test3 is in the list');
+
+        // act
+        operations = utils.getAvailableOperations(field2, filterOperationsDescriptions, customOperations);
+        operationValues = operations.map(operation => operation.value);
+
+        // assert
+        assert.equal(operationValues.indexOf('test1'), -1, 'test1 is not listed');
+        assert.ok(operationValues.indexOf('test2') >= 0, 'test2 is in the list');
+        assert.ok(operationValues.indexOf('test3') >= 0, 'test3 is in the list');
     });
 });
 


### PR DESCRIPTION
1. The 'between' operation is hidden for a lookup column.
2. Added a test.