### PR TITLE
Use babel-eslint for js files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ testing/helpers/sinon/*
 *.j.js
 *.p.d.ts
 *.j.d.ts
-playground/react/*
+playground/*
 themebuilder/data/metadata/*
 themebuilder-scss/**/*
+js/bundles/dx.custom.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -90,5 +90,9 @@
             }
         ],
         "quotes": ["error", "single"]
-    }
+    },
+    "overrides": [{
+        "files": ["*.js"],
+        "parser": "babel-eslint"
+    }]
 }


### PR DESCRIPTION
`@typescript-eslint/parser` has some performance problems (https://github.com/typescript-eslint/typescript-eslint/issues/389)

We use `babel-eslint` for `*.js` files using overrides (https://stackoverflow.com/questions/58727078/eslint-allow-multiple-parsers-based-on-glob-patterns)