### PR TITLE
Themebuilder scss: integration tests

### DIFF
--- a/themebuilder-scss/jest.config.js
+++ b/themebuilder-scss/jest.config.js
@@ -13,7 +13,8 @@ module.exports = {
     },
     testEnvironment: 'node',
     testMatch: [
-        '**/tests/**/*.test.ts'
+        //'**/tests/**/*.test.ts'
+        '**/tests/**/builder.test.ts'
     ],
     coverageThreshold: {
         global: {

--- a/themebuilder-scss/jest.config.js
+++ b/themebuilder-scss/jest.config.js
@@ -13,8 +13,7 @@ module.exports = {
     },
     testEnvironment: 'node',
     testMatch: [
-        //'**/tests/**/*.test.ts'
-        '**/tests/**/builder.test.ts'
+        '**/tests/**/*.test.ts'
     ],
     coverageThreshold: {
         global: {

--- a/themebuilder-scss/package.json
+++ b/themebuilder-scss/package.json
@@ -13,9 +13,11 @@
   "repository": "https://github.com/DevExpress/DevExtreme",
   "license": "SEE LICENSE IN README.md",
   "dependencies": {
+    "autoprefixer": "^9.8.0",
     "bootstrap": "^4.3.1",
-    "clean-css": "^4.2.1",
+    "clean-css": "^4.2.3",
     "less": "^3.9.0",
+    "postcss": "^7.0.31",
     "sass": "^1.26.3",
     "semver": "^5.6.0"
   },
@@ -29,6 +31,7 @@
     "build": "npm run generate-metadata && npm run build-ts"
   },
   "devDependencies": {
+    "@types/autoprefixer": "^9.7.2",
     "@types/clean-css": "^4.2.1",
     "@types/jest": "^25.2.1",
     "@types/less": "^3.0.1",

--- a/themebuilder-scss/package.json
+++ b/themebuilder-scss/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@types/autoprefixer": "^9.7.2",
-    "@types/clean-css": "^4.2.1",
     "@types/jest": "^25.2.1",
     "@types/less": "^3.0.1",
     "@types/node-sass": "^4.11.0",

--- a/themebuilder-scss/src/metadata/collector.ts
+++ b/themebuilder-scss/src/metadata/collector.ts
@@ -40,14 +40,22 @@ export default class MetadataCollector {
     });
   }
 
-  async saveMetadata(filePath: string, version: string): Promise<void> {
+  async saveMetadata(
+    filePath: string,
+    version: string,
+    browsersList: Array<string>,
+  ): Promise<void> {
     const absolutePath = resolve(filePath);
     const metadata = this.generator.getMetadata();
     const metaString = JSON.stringify(metadata)
       .replace(/"/g, '\'')
       .replace(/'(ON|OFF)'/g, '"$1"');
+    const browsersListString = JSON.stringify(browsersList)
+      .replace(/"/g, '\'');
+
     let metaContent = `export const metadata: Array<MetaItem> = ${metaString};\n`;
     metaContent += `export const version: string = '${version}';\n`;
+    metaContent += `export const browsersList: Array<string> = ${browsersListString};\n`;
     await fs.mkdir(dirname(absolutePath), { recursive: true });
     await fs.writeFile(absolutePath, metaContent);
   }

--- a/themebuilder-scss/src/metadata/generate.ts
+++ b/themebuilder-scss/src/metadata/generate.ts
@@ -2,6 +2,7 @@
 import MetadataCollector from './collector';
 import { version } from '../../../build/gulp/context';
 import { resolveDataUri } from '../../../build/gulp/gulp-data-uri';
+import { browserslist } from '../../../package.json';
 
 const stylesDirectory = '../scss';
 const stylesDestinationDirectory = './src/data/scss';
@@ -15,7 +16,7 @@ const generate = async (): Promise<void> => {
     const collector = new MetadataCollector();
     const sourceFiles = collector.readFiles(stylesDirectory, sourceHandler);
     await MetadataCollector.saveScssFiles(sourceFiles, stylesDestinationDirectory);
-    await collector.saveMetadata(metadataDestinationFile, version.package);
+    await collector.saveMetadata(metadataDestinationFile, version.package, browserslist);
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/themebuilder-scss/src/modules/builder.ts
+++ b/themebuilder-scss/src/modules/builder.ts
@@ -1,15 +1,12 @@
 
 import normalize from './config-normalizer';
+import CompileManager from './compile-manager';
 
-export default class Builder {
-  static buildTheme(config: ConfigSettings): void {
-    normalize(config);
-    // TODO return promise with
-    // compiledmetadata - compiler (+)
-    // css - compiler (+),
-    // swatchSelector - compiler (+),
-    // version - metadata (+),
-    // widgets - ?
-    // unusedWidgets - ?
-  }
-}
+export const buildTheme = (config: ConfigSettings): Promise<PackageResult> => {
+  normalize(config);
+  const compileManager = new CompileManager();
+  return compileManager.compile(config);
+};
+
+// compatibility default export
+export default { buildTheme };

--- a/themebuilder-scss/src/modules/clean-css-options.ts
+++ b/themebuilder-scss/src/modules/clean-css-options.ts
@@ -1,6 +1,8 @@
 // TODO we need to share this option with scss compiler (in gulp task)
 
-export default {
+import CleanCSS from 'clean-css';
+
+const config: CleanCSS.Options = {
   rebase: false,
   format: {
     breaks: {
@@ -23,14 +25,9 @@ export default {
       beforeValue: true,
     },
     wrapAt: false,
+    semicolonAfterLastProperty: true,
   },
-  level: {
-    1: {
-      all: false,
-      semicolonAfterLastProperty: true,
-    },
-    2: {
-      all: true,
-    },
-  },
+  level: 2,
 };
+
+export default config;

--- a/themebuilder-scss/src/modules/compile-manager.ts
+++ b/themebuilder-scss/src/modules/compile-manager.ts
@@ -46,6 +46,12 @@ export default class CompileManager {
         css = PostCompiler.addBasePath(css, config.assetsBasePath);
       }
 
+      css = await PostCompiler.autoPrefix(css);
+
+      if (!config.noClean) {
+        css = await PostCompiler.cleanCss(css);
+      }
+
       css = PostCompiler.addInfoHeader(css, version);
 
       return {

--- a/themebuilder-scss/src/modules/post-compiler.ts
+++ b/themebuilder-scss/src/modules/post-compiler.ts
@@ -1,3 +1,9 @@
+import CleanCSS, { Options } from 'clean-css';
+import AutoPrefix from 'autoprefixer';
+import PostCss from 'postcss';
+import commonOptions from './clean-css-options';
+import { browsersList } from '../data/metadata/dx-theme-builder-metadata';
+
 export default class PostCompiler {
   static addBasePath(css: string | Buffer, basePath: string): string {
     const normalizedPath = `${basePath.replace(/[/\\]$/, '')}/`;
@@ -10,5 +16,20 @@ export default class PostCompiler {
     const link = '* http://js.devexpress.com/ThemeBuilder/';
 
     return `/*${generatedBy}\n${versionString}\n${link}\n*/\n\n${css}`;
+  }
+
+  static async cleanCss(css: string): Promise<string> {
+    const promiseOptions: Options = { returnPromise: true };
+    const options: Options = { ...commonOptions, ...promiseOptions };
+    const cleaner = new CleanCSS(options);
+    return (await cleaner.minify(css)).styles;
+  }
+
+  static async autoPrefix(css: string): Promise<string> {
+    return (await PostCss(AutoPrefix({
+      overrideBrowserslist: browsersList,
+    })).process(css, {
+      from: undefined,
+    })).css;
   }
 }

--- a/themebuilder-scss/src/modules/pre-compiler.ts
+++ b/themebuilder-scss/src/modules/pre-compiler.ts
@@ -3,8 +3,9 @@ const SWATCH_SELECTOR_PREFIX = '.dx-swatch-';
 export default class PreCompiler {
   static createSassForSwatch(outColorScheme: string, sass: string | Buffer): SwatchSass {
     const selector: string = SWATCH_SELECTOR_PREFIX + outColorScheme;
+    const cleanSass: string = sass.toString().replace('@charset "UTF-8";', '');
     return {
-      sass: `${selector} { ${sass} };`,
+      sass: `${selector} { ${cleanSass} };`,
       selector,
     };
   }

--- a/themebuilder-scss/src/modules/widgets-handler.ts
+++ b/themebuilder-scss/src/modules/widgets-handler.ts
@@ -11,8 +11,9 @@ export default class WidgetsHandler {
   baseIndexContent: string;
 
   constructor(widgets: Array<string>, bundlePath: string) {
+    const theme = /material/.test(bundlePath) ? 'material' : 'generic';
     this.widgets = widgets || [];
-    this.indexPath = join(dirname(bundlePath), '..', 'widgets', 'generic', '_index.scss');
+    this.indexPath = join(dirname(bundlePath), '..', 'widgets', theme, '_index.scss');
   }
 
   getIndexWidgetItems(indexContent: string): Array<WidgetItem> {

--- a/themebuilder-scss/src/types/clean-css.d.ts
+++ b/themebuilder-scss/src/types/clean-css.d.ts
@@ -1,0 +1,318 @@
+/* eslint-disable */
+// NOTE devextreme-themebuilder need this file because
+// original @types/clean-css package has an error
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45111
+
+// Type definitions for clean-css 4.2
+// Project: https://github.com/jakubpawlowicz/clean-css
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+//                 Andrew Potter <https://github.com/GolaWaya>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// / <reference types="node" />
+
+import { RequestOptions as HttpsRequestOptions } from 'https';
+import { RequestOptions as HttpRequestOptions } from 'http';
+
+declare interface OptionsBase {
+
+  compatibility?: '*' | 'ie9' | 'ie8' | 'ie7' | CleanCSS.CompatibilityOptions;
+
+  fetch?: (
+    uri: string,
+    inlineRequest: HttpRequestOptions | HttpsRequestOptions,
+    inlineTimeout: number,
+    done: (message: string | number, body: string) => void,
+  ) => void;
+
+  format?: 'beautify' | 'keep-breaks' | CleanCSS.FormatOptions | false;
+
+  inline?: ReadonlyArray<string> | false;
+
+  inlineRequest?: HttpRequestOptions | HttpsRequestOptions;
+
+  inlineTimeout?: number;
+
+  level?: 0 | 1 | 2 | CleanCSS.OptimizationsOptions;
+
+  rebase?: boolean;
+
+  rebaseTo?: string;
+
+  sourceMap?: boolean;
+
+  sourceMapInlineSources?: boolean;
+}
+
+declare namespace CleanCSS {
+
+  interface Output {
+
+    styles: string;
+
+    sourceMap: string;
+
+    errors: string[];
+
+    warnings: string[];
+
+    stats: {
+
+      originalSize: number;
+
+      minifiedSize: number;
+
+      timeSpent: number;
+
+      efficiency: number;
+    };
+  }
+
+  interface CompatibilityOptions {
+
+    colors?: {
+
+      opacity?: boolean;
+    };
+
+    properties?: {
+
+      backgroundClipMerging?: boolean;
+
+      backgroundOriginMerging?: boolean;
+
+      backgroundSizeMerging?: boolean;
+
+      colors?: boolean;
+
+      ieBangHack?: boolean;
+
+      ieFilters?: boolean;
+
+      iePrefixHack?: boolean;
+
+      ieSuffixHack?: boolean;
+
+      merging?: boolean;
+
+      shorterLengthUnits?: false;
+
+      spaceAfterClosingBrace?: true;
+
+      urlQuotes?: boolean;
+
+      zeroUnits?: boolean;
+    };
+
+    selectors?: {
+
+      adjacentSpace?: boolean;
+
+      ie7Hack?: boolean;
+
+      mergeablePseudoClasses?: ReadonlyArray<string>;
+
+      mergeablePseudoElements: ReadonlyArray<string>;
+
+      mergeLimit: number;
+
+      multiplePseudoMerging: boolean;
+    };
+
+    units?: {
+
+      ch?: boolean;
+
+      in?: boolean;
+
+      pc?: boolean;
+
+      pt?: boolean;
+
+      rem?: boolean;
+
+      vh?: boolean;
+
+      vm?: boolean;
+
+      vmax?: boolean;
+
+      vmin?: boolean;
+    };
+  }
+
+  interface FormatOptions {
+
+    breaks?: {
+
+      afterAtRule?: boolean;
+
+      afterBlockBegins?: boolean;
+
+      afterBlockEnds?: boolean;
+
+      afterComment?: boolean;
+
+      afterProperty?: boolean;
+
+      afterRuleBegins?: boolean;
+
+      afterRuleEnds?: boolean;
+
+      beforeBlockEnds?: boolean;
+
+      betweenSelectors?: boolean;
+    };
+
+    breakWith?: string;
+
+    indentBy?: number;
+
+    indentWith?: 'space' | 'tab';
+
+    spaces?: {
+
+      aroundSelectorRelation?: boolean;
+
+      beforeBlockBegins?: boolean;
+
+      beforeValue?: boolean;
+    };
+
+    wrapAt?: false | number;
+
+    semicolonAfterLastProperty?: boolean;
+  }
+
+  interface OptimizationsOptions {
+    1?: {
+
+      all?: boolean;
+
+      cleanupCharsets?: boolean;
+
+      normalizeUrls?: boolean;
+
+      optimizeBackground?: boolean;
+
+      optimizeBorderRadius?: boolean;
+
+      optimizeFilter?: boolean;
+
+      optimizeFont?: boolean;
+
+      optimizeFontWeight?: boolean;
+
+      optimizeOutline?: boolean;
+
+      removeEmpty?: boolean;
+
+      removeNegativePaddings?: boolean;
+
+      removeQuotes?: boolean;
+
+      removeWhitespace?: boolean;
+
+      replaceMultipleZeros?: boolean;
+
+      replaceTimeUnits?: boolean;
+
+      replaceZeroUnits?: boolean;
+
+      roundingPrecision?: boolean;
+
+      selectorsSortingMethod?: 'standard' | 'natural' | 'none';
+
+      specialComments?: string;
+
+      tidyAtRules?: boolean;
+
+      tidyBlockScopes?: boolean;
+
+      tidySelectors?: boolean;
+
+      transform?: (propertyName: string, propertyValue: string, selector?: string) => string;
+    };
+    2?: {
+
+      all?: boolean;
+
+      mergeAdjacentRules?: boolean;
+
+      mergeIntoShorthands?: boolean;
+
+      mergeMedia?: boolean;
+
+      mergeNonAdjacentRules?: boolean;
+
+      mergeSemantically?: boolean;
+
+      overrideProperties?: boolean;
+
+      removeEmpty?: boolean;
+
+      reduceNonAdjacentRules?: boolean;
+
+      removeDuplicateFontRules?: boolean;
+
+      removeDuplicateMediaBlocks?: boolean;
+
+      removeDuplicateRules?: boolean;
+
+      removeUnusedAtRules?: boolean;
+
+      restructureRules?: boolean;
+
+      skipProperties?: ReadonlyArray<string>;
+    };
+  }
+
+  interface Source {
+
+    [path: string]: {
+
+      styles: string;
+
+      sourceMap?: string;
+    };
+  }
+
+    type FetchCallback = (message: string | number, body: string) => void;
+
+    type Sources = string | ReadonlyArray<string> | Source | ReadonlyArray<Source> | Buffer;
+
+    type Minifier = MinifierOutput | MinifierPromise;
+
+    interface MinifierOutput {
+      minify(sources: Sources, callback?: (error: any, output: Output) => void): Output;
+      minify(
+        sources: Sources,
+        sourceMap: string,
+        callback?: (error: any, output: Output) => void
+      ): Output;
+    }
+
+    interface MinifierPromise {
+      minify(sources: Sources, sourceMap?: string): Promise<Output>;
+    }
+
+    type OptionsPromise = OptionsBase & {
+
+      returnPromise: true;
+    };
+
+    type OptionsOutput = OptionsBase & {
+
+      returnPromise?: false;
+    };
+
+    type Options = OptionsPromise | OptionsOutput;
+
+    interface Constructor {
+      new(options: OptionsPromise): MinifierPromise;
+      new(options?: OptionsOutput): MinifierOutput;
+    }
+}
+
+declare const CleanCSS: CleanCSS.Constructor;
+
+export = CleanCSS;

--- a/themebuilder-scss/src/types/types.ts
+++ b/themebuilder-scss/src/types/types.ts
@@ -27,6 +27,7 @@ interface ConfigSettings {
   items?: Array<ConfigMetaItem>;
   data?: string;
   widgets?: Array<string>;
+  noClean?: boolean;
 
   fileFormat?: string;
   baseTheme?: string;
@@ -43,10 +44,7 @@ interface ConfigSettings {
   inputFile?: string;
   lessPath?: string;
   scssPath?: string;
-  out?: string; // TODO need?
-
-  reader?: Function; // TODO need?
-  lessCompiler?: LessCompilerInterface; // TODO need?
+  out?: string;
 }
 
 interface CompilerResult {

--- a/themebuilder-scss/tests/data/compilation-results/no-changes-css.ts
+++ b/themebuilder-scss/tests/data/compilation-results/no-changes-css.ts
@@ -1,7 +1,7 @@
 export default `.dx-accordion {
-  background-color: "Helvetica Neue", "Segoe UI", Helvetica, Verdana, sans-serif;
+  background-color: "Helvetica Neue","Segoe UI",Helvetica,Verdana,sans-serif;
   color: #337ab7;
-  font: url("icons/icons.woff2");
+  background-image: url(icons/icons.woff2);
 }
 .dx-accordion .from-base {
   background-color: transparent;

--- a/themebuilder-scss/tests/data/scss/widgets/generic/_colors.scss
+++ b/themebuilder-scss/tests/data/scss/widgets/generic/_colors.scss
@@ -9,7 +9,7 @@ $base-accent: null !default;
 
 
 @if $color == "light" {
-    $base-font-family: 'Helvetica Neue', 'Segoe UI', Helvetica, Verdana, sans-serif !default;
+    $base-font-family: 'Helvetica Neue','Segoe UI',Helvetica,Verdana,sans-serif !default;
     $base-accent: #337ab7 !default;
 }
 

--- a/themebuilder-scss/tests/data/scss/widgets/generic/accordion/_index.scss
+++ b/themebuilder-scss/tests/data/scss/widgets/generic/accordion/_index.scss
@@ -10,12 +10,10 @@ $font-file: "icons";
 .dx-accordion {
     background-color: $base-font-family;
     color: $accordion-title-color;
-    font: url("icons/#{$font-file}.woff2");
+    background-image: url(icons/#{$font-file}.woff2);
 
     .from-base {
         background-color: $accordion-item-title-opened-bg;
         color: $base-accent;
     }
 }
-
-

--- a/themebuilder-scss/tests/metadata/collector.test.ts
+++ b/themebuilder-scss/tests/metadata/collector.test.ts
@@ -87,8 +87,9 @@ describe('MetadataCollector', () => {
 
     let metaContent = 'export const metadata: Array<MetaItem> = [{\'Key\':\'$var\',\'Value\':\'"ON"\'}];\n';
     metaContent += `export const version: string = '${version}';\n`;
+    metaContent += 'export const browsersList: Array<string> = [];\n';
 
-    await collector.saveMetadata(fileName, version);
+    await collector.saveMetadata(fileName, version, []);
 
     expect(promises.mkdir).toHaveBeenCalledTimes(1);
     expect(promises.mkdir).toHaveBeenCalledWith(expectedDirName, { recursive: true });

--- a/themebuilder-scss/tests/modules/builder.test.ts
+++ b/themebuilder-scss/tests/modules/builder.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { buildTheme } from '../../src/modules/builder';
+import commands from '../../src/modules/commands';
+
+const buildTimeout = 150000;
+
+const normalizeCss = (css: string): string => css
+  .toLowerCase()
+  .replace(/\s*\/\*[\s\S]*?\*\//g, '')
+  .trim();
+
+describe('Builder integration tests', () => {
+  test('Build base theme with swatch', () => {
+    const config: ConfigSettings = {
+      command: commands.BUILD_THEME,
+      makeSwatch: true,
+      outputColorScheme: 'custom-scheme',
+    };
+
+    return buildTheme(config).then((result) => {
+      expect(result.css).not.toBe('');
+      expect(result.swatchSelector).toBe('.dx-swatch-custom-scheme');
+    });
+  }, buildTimeout);
+
+  test('Build theme according to bootstrap', () => {
+    const config: ConfigSettings = {
+      command: commands.BUILD_THEME,
+      inputFile: 'some.less',
+      data: '',
+      outputColorScheme: 'custom-scheme',
+    };
+
+    return buildTheme(config).then((result) => {
+      expect(result.css).not.toBe('');
+    });
+  }, buildTimeout);
+
+  test('Build theme with changed color constants (generic)', () => {
+    const config: ConfigSettings = {
+      command: commands.BUILD_THEME,
+      outputColorScheme: 'custom-scheme',
+      items: [{ key: '@base-bg', value: '#abcdef' }],
+    };
+
+    return buildTheme(config).then((result) => {
+      expect(result.css).not.toBe('');
+      expect(/#abcdef/.test(result.css)).toBe(true);
+    });
+  }, buildTimeout);
+
+  test('Build theme with changed color constants (material)', () => {
+    const config: ConfigSettings = {
+      command: commands.BUILD_THEME,
+      outputColorScheme: 'custom-scheme',
+      baseTheme: 'material.blue.light',
+      items: [{ key: '@base-bg', value: '#abcdef' }],
+    };
+
+    return buildTheme(config).then((result) => {
+      expect(result.css).not.toBe('');
+      expect(/#abcdef/.test(result.css)).toBe(true);
+    });
+  }, buildTimeout);
+
+  test('Theme built without parameters is the same that in distribution (generic)', () => {
+    const config: ConfigSettings = {
+      command: commands.BUILD_THEME,
+      outputColorScheme: 'custom-scheme',
+      items: [],
+    };
+
+    return buildTheme(config).then((result) => {
+      const themeBuilderCss = normalizeCss(result.css);
+      // TODO this path should be changed after less->scss migration
+      const distributionCss = normalizeCss(readFileSync(join(__dirname, '../../../artifacts/scss-css/dx.light.css'), 'utf8'));
+      expect(themeBuilderCss).toBe(distributionCss);
+    });
+  }, buildTimeout);
+});

--- a/themebuilder-scss/tests/modules/compile-manager.test.ts
+++ b/themebuilder-scss/tests/modules/compile-manager.test.ts
@@ -40,9 +40,9 @@ describe('Compile manager - integration test on test sass', () => {
       outColorScheme: 'test-theme',
     }).then((result) => {
       expect(result.css).toBe(`.dx-swatch-test-theme .dx-accordion {
-  background-color: "Helvetica Neue", "Segoe UI", Helvetica, Verdana, sans-serif;
+  background-color: "Helvetica Neue","Segoe UI",Helvetica,Verdana,sans-serif;
   color: #337ab7;
-  font: url("icons/icons.woff2");
+  background-image: url(icons/icons.woff2);
 }
 .dx-swatch-test-theme .dx-accordion .from-base {
   background-color: transparent;
@@ -58,9 +58,9 @@ describe('Compile manager - integration test on test sass', () => {
       assetsBasePath: 'base-path',
     }).then((result) => {
       expect(result.css).toBe(`.dx-accordion {
-  background-color: "Helvetica Neue", "Segoe UI", Helvetica, Verdana, sans-serif;
+  background-color: "Helvetica Neue","Segoe UI",Helvetica,Verdana,sans-serif;
   color: #337ab7;
-  font: url("base-path/icons/icons.woff2");
+  background-image: url(base-path/icons/icons.woff2);
 }
 .dx-accordion .from-base {
   background-color: transparent;
@@ -96,9 +96,9 @@ describe('Compile manager - integration test on test sass', () => {
       data: '@brand-primary: red;',
     }).then((result) => {
       expect(result.css).toBe(`.dx-accordion {
-  background-color: "Helvetica Neue", "Segoe UI", Helvetica, Verdana, sans-serif;
+  background-color: "Helvetica Neue","Segoe UI",Helvetica,Verdana,sans-serif;
   color: red;
-  font: url("icons/icons.woff2");
+  background-image: url(icons/icons.woff2);
 }
 .dx-accordion .from-base {
   background-color: transparent;
@@ -133,9 +133,9 @@ describe('Compile manager - integration test on test sass', () => {
       data: '$primary: red;',
     }).then((result) => {
       expect(result.css).toBe(`.dx-accordion {
-  background-color: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  background-color: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
   color: red;
-  font: url("icons/icons.woff2");
+  background-image: url(icons/icons.woff2);
 }
 .dx-accordion .from-base {
   background-color: transparent;
@@ -159,6 +159,24 @@ describe('Compile manager - integration test on test sass', () => {
         Path: 'tb/widgets/generic/accordion/colors',
         Value: 'rgba(0,0,0,0)',
       }]);
+    });
+  });
+
+  test('compile test bundle with noClean option', () => {
+    const manager = new CompileManager();
+    return manager.compile({
+      noClean: true,
+    }).then((result) => {
+      expect(result.css).toBe(`.dx-accordion {
+  background-color: "Helvetica Neue", "Segoe UI", Helvetica, Verdana, sans-serif;
+  color: #337ab7;
+  background-image: url(icons/icons.woff2);
+}
+.dx-accordion .from-base {
+  background-color: transparent;
+  color: #337ab7;
+}`);
+      expect(result.compiledMetadata).toEqual(noModificationsMeta);
     });
   });
 

--- a/themebuilder-scss/tests/modules/compiler.test.ts
+++ b/themebuilder-scss/tests/modules/compiler.test.ts
@@ -2,7 +2,6 @@
 import path from 'path';
 import fs from 'fs';
 import { metadata } from '../data/metadata';
-import noModificationsResult from '../data/compilation-results/no-changes-css';
 import noModificationsMeta from '../data/compilation-results/no-changes-meta';
 
 import Compiler, { ImportType } from '../../src/modules/compiler';
@@ -28,7 +27,15 @@ describe('compile', () => {
       includePaths,
     }).then((data) => {
       // compiled css
-      expect(data.result.css.toString()).toBe(noModificationsResult);
+      expect(data.result.css.toString()).toBe(`.dx-accordion {
+  background-color: "Helvetica Neue", "Segoe UI", Helvetica, Verdana, sans-serif;
+  color: #337ab7;
+  background-image: url(icons/icons.woff2);
+}
+.dx-accordion .from-base {
+  background-color: transparent;
+  color: #337ab7;
+}`);
       // collected variables
       expect(data.changedVariables).toEqual(noModificationsMeta);
     });
@@ -48,7 +55,7 @@ describe('compile', () => {
       expect(data.result.css.toString()).toBe(`.dx-accordion {
   background-color: "Helvetica Neue", "Segoe UI", Helvetica, Verdana, sans-serif;
   color: red;
-  font: url("icons/icons.woff2");
+  background-image: url(icons/icons.woff2);
 }
 .dx-accordion .from-base {
   background-color: green;
@@ -106,7 +113,7 @@ describe('compile', () => {
       expect(data.result.css.toString()).toBe(
         '.dx-accordion{background-color:'
         + '"Helvetica Neue","Segoe UI",Helvetica,Verdana,sans-serif;'
-        + 'color:#337ab7;font:url("icons/icons.woff2")}.dx-accordion '
+        + 'color:#337ab7;background-image:url(icons/icons.woff2)}.dx-accordion '
         + '.from-base{background-color:transparent;color:#337ab7}.extra-class{color:red}',
       );
     });

--- a/themebuilder-scss/tests/modules/config-normalizer.test.ts
+++ b/themebuilder-scss/tests/modules/config-normalizer.test.ts
@@ -1,11 +1,6 @@
 import normalizeConfig from '../../src/modules/config-normalizer';
 import commands from '../../src/modules/commands';
 
-const reader = (): void => {};
-const lessCompiler: LessCompilerInterface = {
-  render: (): void => {},
-};
-
 describe('Cli arguments normalizer', () => {
   test('Commands stay unchanged', () => {
     let config: ConfigSettings = { command: 'build-theme' };
@@ -378,15 +373,13 @@ describe('Cli arguments normalizer', () => {
     });
   });
 
-  test('build-theme \'data\', \'items\', \'reader\', \'lessCompiler\' stay unchanged', () => {
+  test('build-theme \'data\', \'items\' stay unchanged', () => {
     const config: ConfigSettings = {
       command: 'build-theme',
       baseTheme: 'material.blue.light',
       inputFile: 'file.json',
       data: 'somedata',
       items: [{ key: '1', value: '2' }],
-      reader,
-      lessCompiler,
     };
     normalizeConfig(config);
 
@@ -399,11 +392,9 @@ describe('Cli arguments normalizer', () => {
       fileFormat: 'css',
       isBootstrap: false,
       items: [{ key: '1', value: '2' }],
-      lessCompiler,
       makeSwatch: false,
       out: 'dx.material.custom-scheme.css',
       outColorScheme: 'custom-scheme',
-      reader,
       themeName: 'material',
     });
   });
@@ -414,8 +405,6 @@ describe('Cli arguments normalizer', () => {
       baseTheme: 'material.blue.light',
       data: '',
       items: [{ key: '', value: '' }],
-      reader,
-      lessCompiler,
     };
 
     normalizeConfig(config);
@@ -429,11 +418,9 @@ describe('Cli arguments normalizer', () => {
       fileFormat: 'css',
       isBootstrap: false,
       items: [{ key: '', value: '' }],
-      lessCompiler,
       makeSwatch: false,
       out: 'dx.material.custom-scheme.css',
       outColorScheme: 'custom-scheme',
-      reader,
       themeName: 'material',
     });
   });
@@ -572,8 +559,6 @@ describe('Cli arguments normalizer', () => {
       inputFile: 'file.json',
       data: 'somedata',
       items: [{ key: '1', value: '2' }, { key: '@treelist-bg-color', value: '2' }, { key: '@treelist-border-color', value: '3' }],
-      reader,
-      lessCompiler,
     };
     normalizeConfig(config);
 
@@ -586,11 +571,9 @@ describe('Cli arguments normalizer', () => {
       fileFormat: 'css',
       isBootstrap: false,
       items: [{ key: '1', value: '2' }, { key: '$datagrid-bg-color', value: '2' }, { key: '$datagrid-border-color', value: '3' }],
-      lessCompiler,
       makeSwatch: false,
       out: 'dx.material.custom-scheme.css',
       outColorScheme: 'custom-scheme',
-      reader,
       themeName: 'material',
     });
   });
@@ -602,8 +585,6 @@ describe('Cli arguments normalizer', () => {
       inputFile: 'file.json',
       data: 'somedata',
       items: [{ key: '@datagrid-bg-color', value: '2' }, { key: '@datagrid-border-color', value: '3' }],
-      reader,
-      lessCompiler,
     };
     normalizeConfig(config);
 
@@ -616,11 +597,9 @@ describe('Cli arguments normalizer', () => {
       fileFormat: 'css',
       isBootstrap: false,
       items: [{ key: '$datagrid-bg-color', value: '2' }, { key: '$datagrid-border-color', value: '3' }],
-      lessCompiler,
       makeSwatch: false,
       out: 'dx.material.custom-scheme.css',
       outColorScheme: 'custom-scheme',
-      reader,
       themeName: 'material',
     });
   });

--- a/themebuilder-scss/tests/modules/post-compiler.test.ts
+++ b/themebuilder-scss/tests/modules/post-compiler.test.ts
@@ -25,4 +25,14 @@ describe('PostCompiler', () => {
       + '*/\n\n'
       + 'css');
   });
+
+  test('cleanCss', async () => {
+    expect(await PostCompiler.cleanCss('.c1 { color: #F00; } .c2 { color: #F00; }'))
+      .toBe('.c1,\n.c2 {\n  color: red;\n}');
+  });
+
+  test('autoPrefixer', async () => {
+    expect(await PostCompiler.autoPrefix('.c1 { box-shadow: none; }'))
+      .toBe('.c1 { -webkit-box-shadow: none; box-shadow: none; }');
+  });
 });

--- a/themebuilder-scss/tests/modules/pre-compiler.test.ts
+++ b/themebuilder-scss/tests/modules/pre-compiler.test.ts
@@ -7,4 +7,10 @@ describe('PreCompiler class tests', () => {
     expect(swatchSass.sass).toBe('.dx-swatch-test-theme-name { sass };');
     expect(swatchSass.selector).toBe('.dx-swatch-test-theme-name');
   });
+
+  test('createSassForSwatch clean sass from encoding', () => {
+    const swatchSass = PreCompiler.createSassForSwatch('test-theme-name', '@charset "UTF-8";\nsass');
+    expect(swatchSass.sass).toBe('.dx-swatch-test-theme-name { \nsass };');
+    expect(swatchSass.selector).toBe('.dx-swatch-test-theme-name');
+  });
 });

--- a/themebuilder-scss/tests/modules/widgets-handler.test.ts
+++ b/themebuilder-scss/tests/modules/widgets-handler.test.ts
@@ -71,11 +71,21 @@ describe('Widgets handler tests', () => {
   });
 
   test('getIndexContent', async () => {
-    const widgetsHandler = new WidgetsHandler([], '/path/dx.bundle.scss');
+    const widgetsHandler = new WidgetsHandler([], '/path/dx.light.scss');
     await widgetsHandler.getIndexContent();
 
     expect(fs.promises.readFile).toBeCalledTimes(1);
     expect(fs.promises.readFile).toBeCalledWith(join('/', 'widgets', 'generic', '_index.scss'));
+    (fs.promises.readFile as jest.Mock).mockClear();
+  });
+
+  test('getIndexContent (material)', async () => {
+    const widgetsHandler = new WidgetsHandler([], '/path/dx.material.blue.light.scss');
+    await widgetsHandler.getIndexContent();
+
+    expect(fs.promises.readFile).toBeCalledTimes(1);
+    expect(fs.promises.readFile).toBeCalledWith(join('/', 'widgets', 'material', '_index.scss'));
+    (fs.promises.readFile as jest.Mock).mockClear();
   });
 
   test('getIndexContent if bundle does not exists', async () => {

--- a/themebuilder-scss/tests/tsconfig.json
+++ b/themebuilder-scss/tests/tsconfig.json
@@ -5,6 +5,9 @@
         "paths": {
             "sass": [
                 "../node_modules/@types/node-sass"
+            ],
+            "clean-css": [
+                "../src/types/clean-css.d.ts"
             ]
         }
     },

--- a/themebuilder-scss/tsconfig.json
+++ b/themebuilder-scss/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "es6",
         "noImplicitAny": true,
         "allowJs": true,
+        "resolveJsonModule": true,
         "moduleResolution": "node",
         "outDir": "dist",
         "baseUrl": ".",


### PR DESCRIPTION
Also, `autoprefixer` and `clean-css` were added to get in the themebuilder the same css as compiler does.