### PR TITLE
DataGrid - Fixes loosing focus on master row expand (T892203)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -967,7 +967,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                     }
                     if($cell.is('td') || $cell.hasClass(that.addWidgetPrefix(EDIT_FORM_ITEM_CLASS))) {
                         const isCommandCell = $cell.is(COMMAND_CELL_SELECTOR);
-                        if(!isCommandCell && that.getController('editorFactory').focus()) {
+                        if((isRenderView || !isCommandCell) && that.getController('editorFactory').focus()) {
                             that._focus($cell);
                         } else if(that._isCellEditMode()) {
                             that._focus($cell, that._isHiddenFocus);

--- a/testing/functional/model/dataGrid.ts
+++ b/testing/functional/model/dataGrid.ts
@@ -203,6 +203,7 @@ class DataRow extends DxElement {
     isFocusedRow: Promise<boolean>;
     isSelected: Promise<boolean>;
     isEdited: Promise<boolean>;
+    isExpanded: Promise<boolean>;
 
     constructor(element: Selector, widgetName: string) {
         super(element);
@@ -211,6 +212,7 @@ class DataRow extends DxElement {
         this.isFocusedRow = this.element.hasClass(CLASS.focusedRow);
         this.isSelected = this.element.hasClass(CLASS.selection);
         this.isEdited = this.element.hasClass(CLASS.editedRow);
+        this.isExpanded = this.element.find(`.${CLASS.commandExpand} .${addWidgetPrefix(this.widgetName, CLASS.groupExpanded)}`).exists;
     }
 
     getDataCell(index: number): DataCell {
@@ -342,7 +344,7 @@ export default class DataGrid extends Widget {
     }
 
     getDataRow(index: number): DataRow {
-        return new DataRow(this.element.find(`.${CLASS.dataRow}:nth-child(${++index})`), this.name);
+        return new DataRow(this.element.find(`.${CLASS.dataRow}[aria-rowindex='${++index}']`), this.name);
     }
 
     getDataCell(rowIndex: number, columnIndex: number): DataCell {

--- a/testing/functional/tests/dataGrid/keyboardNavigation.ts
+++ b/testing/functional/tests/dataGrid/keyboardNavigation.ts
@@ -972,12 +972,15 @@ test('The first group row should be expanded when the Enter key is pressed (T869
         .pressKey('tab')
         .pressKey('tab')
 
+        .expect(firstGroupRow.element.focused).ok()
         .expect(firstGroupRow.isFocused).ok()
         .expect(firstGroupRow.isExpanded).notOk()
 
         .pressKey('enter')
 
-        .expect(firstGroupRow.isExpanded).ok()
+        .expect(firstGroupRow.element.focused).ok()
+        .expect(firstGroupRow.isFocused).ok()
+        .expect(firstGroupRow.isExpanded).ok();
 
 }).before(() => createWidget('dxDataGrid', {
     dataSource: [
@@ -992,3 +995,81 @@ test('The first group row should be expanded when the Enter key is pressed (T869
     }
 }));
 
+test('The expand cell should not lose focus on expanding a master row (T892203)', async t => {
+    const dataGrid = new DataGrid('#container');
+    const headerCell01 = dataGrid.getHeaders().getHeaderRow(0).getHeaderCell(1);
+    const dataRow0 = dataGrid.getDataRow(0);
+    const cell00 = dataRow0.getCommandCell(0);
+    const cell01 = dataRow0.getDataCell(1);
+    const dataRow1 = dataGrid.getDataRow(1);
+    const cell10 = dataRow1.getCommandCell(0);
+    const cell11 = dataRow1.getDataCell(1);
+
+    await t
+        .pressKey('tab')
+
+        .expect(headerCell01.element.focused).ok()
+
+        .pressKey('tab')
+
+        .expect(cell00.element.focused).ok()
+        .expect(cell00.isFocused).ok()
+
+        .pressKey('enter')
+
+        .expect(cell00.element.focused).ok()
+        .expect(cell00.isFocused).ok()
+        .expect(dataRow0.isExpanded).ok()
+
+        .pressKey('tab')
+
+        .expect(cell01.element.focused).ok()
+        .expect(cell01.isFocused).ok()
+
+        .pressKey('tab')
+
+        .expect(cell10.element.focused).ok()
+        .expect(cell10.isFocused).ok()
+
+        .pressKey('tab')
+
+        .expect(cell11.element.focused).ok()
+        .expect(cell11.isFocused).ok()
+
+        .pressKey('shift+tab')
+
+        .expect(cell10.element.focused).ok()
+        .expect(cell10.isFocused).ok()
+
+        .pressKey('shift+tab')
+
+        .expect(cell01.element.focused).ok()
+        .expect(cell01.isFocused).ok()
+
+        .pressKey('shift+tab')
+
+        .expect(cell00.element.focused).ok()
+        .expect(cell00.isFocused).ok()
+
+        .pressKey('enter')
+
+        .expect(cell00.element.focused).ok()
+        .expect(cell00.isFocused).ok()
+        .expect(dataRow0.isExpanded).notOk()
+
+        .pressKey('shift+tab')
+
+        .expect(headerCell01.element.focused).ok()
+
+        .pressKey('shift+tab')
+
+        .expect(Selector('BODY').focused).ok();
+
+}).before(() => createWidget('dxDataGrid', {
+    showBorders: true,
+    keyExpr: 'id',
+    dataSource: [{ id: 1 }, { id: 2 }],
+    masterDetail: {
+        enabled: true
+    }
+}));

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.realControllers.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.realControllers.tests.js
@@ -1482,4 +1482,39 @@ QUnit.module('Real DataController and ColumnsController', {
             });
         });
     });
+
+    QUnit.testInActiveWindow('The expand cell should restore focus on expanding a master row when the Enter key is pressed (T892203)', function(assert) {
+        // arrange
+        const $container = $('#container');
+        this.data = [{ id: 1 }];
+        this.columns = ['id'];
+        this.options = {
+            keyExpr: 'id',
+            masterDetail: {
+                enabled: true,
+                template: commonUtils.noop
+            }
+        };
+
+        this.setupModule();
+        this.gridView.render($container);
+        this.clock.tick();
+
+        let $commandCell = $(this.getCellElement(0, 0));
+        $commandCell.focus();
+        this.clock.tick();
+
+        // assert
+        assert.ok($commandCell.is(':focus'), 'command cell is focused');
+        assert.equal($commandCell.find('.dx-datagrid-group-closed').length, 1, 'cell is rendered as collapsed');
+
+        this.triggerKeyDown('enter', false, false, $commandCell);
+        this.clock.tick();
+
+        $commandCell = $(this.getCellElement(0, 0));
+
+        // assert
+        assert.ok($commandCell.is(':focus'), 'command cell is still focused afteк expanding');
+        assert.equal($commandCell.find('.dx-datagrid-group-opened').length, 1, 'cell is rendered as expanded');
+    });
 });


### PR DESCRIPTION
1. Restoring focus of a command cell after row re-rendering.
2. Adds a test.
