### PR TITLE
Scroll Event: Clean up the dxscroll test

### DIFF
--- a/testing/tests/DevExpress.ui.events/scroll.tests.js
+++ b/testing/tests/DevExpress.ui.events/scroll.tests.js
@@ -180,13 +180,9 @@ QUnit.module('scroll move');
 QUnit.test('dxscroll fired on pointer move', function(assert) {
     let fired = 0;
     let args;
-    let initEventData; // eslint-disable-line no-unused-vars
     let moveEventData;
 
     const $scrollable = $('#scrollable')
-        .on(scrollEvents.init, function(e) {
-            initEventData = eventUtils.eventData(e.originalEvent);
-        })
         .on(scrollEvents.move, function(e) {
             args = e;
             fired++;


### PR DESCRIPTION
We have an ESLint error after its update to v7.2.0:
https://devextreme-ci.devexpress.com/DevExpress/DevExtreme/32742/43

Possible causes:
https://github.com/eslint/eslint/issues/13181


