### PR TITLE
Renovation: Rename `style` property

### DIFF
--- a/js/renovation/widget.tsx
+++ b/js/renovation/widget.tsx
@@ -22,14 +22,14 @@ import { focusable } from '../ui/widget/selectors';
 import { isFakeClickEvent } from '../events/utils';
 import { BaseWidgetProps } from './utils/base-props';
 
-const getStyles = ({ width, height, style }) => {
+const getStyles = ({ width, height, styles }) => {
   const computedWidth = typeof width === 'function' ? width() : width;
   const computedHeight = typeof height === 'function' ? height() : height;
 
   return {
     height: computedHeight ?? undefined,
     width: computedWidth ?? undefined,
-    ...style,
+    ...styles,
   };
 };
 
@@ -90,7 +90,7 @@ export const viewFunction = (viewModel: Widget) => (
     title={viewModel.props.hint}
     hidden={!viewModel.props.visible}
     className={viewModel.cssClasses}
-    style={viewModel.styles}
+    style={viewModel.computedStyles}
     {...viewModel.restAttributes} // eslint-disable-line react/jsx-props-no-spreading
   >
     {viewModel.props.children}
@@ -125,7 +125,7 @@ export class WidgetProps extends BaseWidgetProps {
 
   @Event() onVisibilityChange?: (args: boolean) => undefined;
 
-  @OneWay() style?: { [name: string]: any };
+  @OneWay() styles?: { [name: string]: any };
 }
 
 @Component({
@@ -322,10 +322,10 @@ export default class Widget extends JSXComponent(WidgetProps) {
     return { ...attrsWithoutClass, ...arias };
   }
 
-  get styles() {
-    const { width, height, style } = this.props;
+  get computedStyles() {
+    const { width, height, styles } = this.props;
 
-    return getStyles({ width, height, style });
+    return getStyles({ width, height, styles });
   }
 
   get cssClasses() {

--- a/testing/jest/widget.tests.tsx
+++ b/testing/jest/widget.tests.tsx
@@ -86,28 +86,28 @@ describe('Widget', () => {
     describe('width/height', () => {
       it('should have the ability to be a function', () => {
         const widget = render({ width: () => 50, height: () => 'auto' });
-        const props = widget.props() as WidgetProps;
+        const props = widget.props() as any;
 
         expect(props.style).toEqual({ width: 50, height: 'auto' });
       });
 
       it('should process string values', () => {
         const widget = render({ width: '50px', height: () => '100%' });
-        const props = widget.props() as WidgetProps;
+        const props = widget.props() as any;
 
         expect(props.style).toEqual({ width: '50px', height: '100%' });
       });
 
       it('should process number values', () => {
         const widget = render({ width: 50, height: 70 });
-        const props = widget.props() as WidgetProps;
+        const props = widget.props() as any;
 
         expect(props.style).toEqual({ width: 50, height: 70 });
       });
 
       it('should ignore null/undefined values', () => {
         const widget = render({ width: null, height: undefined });
-        const props = widget.props() as WidgetProps;
+        const props = widget.props() as any;
 
         expect(props.style).toEqual({});
       });
@@ -240,8 +240,8 @@ describe('Widget', () => {
         expect(widget.is('.custom-class.dx-widget')).toBe(true);
       });
 
-      it('should add merge `style` property', () => {
-        const widget = render({ style: { fontSize: '20px', height: 10 } });
+      it('should add merge `styles` property', () => {
+        const widget = render({ styles: { fontSize: '20px', height: 10 } });
 
         expect(widget.prop('style')).toMatchObject({
           fontSize: '20px',


### PR DESCRIPTION
The `style` property cannot be used in Vue (reserved name).
The `style` property have replaced with `styles`.