### PR TITLE
DataGrid - Fixes applying column options when other options are changed (T895552)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_controller.js
+++ b/js/ui/grid_core/ui.grid_core.data_controller.js
@@ -213,6 +213,7 @@ module.exports = {
                         case 'columns':
                             dataSource = that.dataSource();
                             if(dataSource && dataSource.isLoading() && args.name === args.fullName) {
+                                this._useSortingGroupingFromColumns = true;
                                 dataSource.load();
                             }
                             break;
@@ -288,7 +289,7 @@ module.exports = {
                         columnsController.updateColumnDataTypes(dataSource);
                     }
                     this._columnsUpdating = true;
-                    columnsController.updateSortingGrouping(dataSource, !this._isFirstLoading);
+                    columnsController.updateSortingGrouping(dataSource, !this._useSortingGroupingFromColumns);
                     this._columnsUpdating = false;
 
                     storeLoadOptions.sort = columnsController.getSortDataSourceParameters();
@@ -354,7 +355,7 @@ module.exports = {
                     const columnsController = that._columnsController;
                     let isAsyncDataSourceApplying = false;
 
-                    this._isFirstLoading = false;
+                    this._useSortingGroupingFromColumns = false;
 
                     if(dataSource && !that._isDataSourceApplying) {
                         that._isDataSourceApplying = true;
@@ -454,7 +455,7 @@ module.exports = {
 
                     that.callBase();
                     dataSource = that._dataSource;
-                    that._isFirstLoading = true;
+                    that._useSortingGroupingFromColumns = true;
                     if(dataSource) {
                         that._setPagingOptions(dataSource);
                         that.setDataSource(dataSource);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -10647,7 +10647,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
     // T708525
     QUnit.test('change columns with grouping after dataSource change', function(assert) {
-    // arrange, act
+        // arrange, act
         const dataGrid = createDataGrid({});
 
         // act
@@ -10657,7 +10657,39 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         this.clock.tick();
 
         // assert
-        assert.equal(dataGrid.getVisibleRows()[0].rowType, 'group', 'first row type is');
+        assert.equal(dataGrid.getVisibleRows()[0].rowType, 'group', 'first row type is group');
+        assert.equal(dataGrid.columnOption('b', 'groupIndex'), 0, 'column b is grouped');
+    });
+
+    QUnit.test('Column changes are applied while dataSource is loading (T895552)', function(assert) {
+        // arrange, act
+        const dataGrid = createDataGrid({
+            dataSource: {
+                store: {
+                    type: 'array',
+                    key: 'a',
+                    data: [{ a: 1, b: 2 }]
+                }
+            },
+            columns: ['a', 'b']
+        });
+        this.clock.tick();
+
+        // act
+        dataGrid.option('filterPanel.visible', true); // causes reloading a data source
+        const dataSource = dataGrid.getDataSource();
+
+        // assert
+        assert.ok(dataSource.isLoading(), 'dataSource is loading');
+
+        // act
+        dataGrid.option('columns', ['a', { dataField: 'b', groupIndex: 0 }]);
+        this.clock.tick();
+        const $filterPanelViewElement = $(dataGrid.getView('filterPanelView').element());
+
+        // assert
+        assert.ok($filterPanelViewElement.is(':visible'), 'filterPanel is visible');
+        assert.equal(dataGrid.getVisibleRows()[0].rowType, 'group', 'first row type is group');
         assert.equal(dataGrid.columnOption('b', 'groupIndex'), 0, 'column b is grouped');
     });
 


### PR DESCRIPTION
1. Renamed the **_isFirstLoading** option to **_useSortingGroupingFromColumns** in DataController and set it to **true** when columns are changed before reloading a data source.
2. Added a unit test.
