### PR TITLE
Revert "DropDownList based editors: dropDownOptions.width should be passed to the popup correctly (T897820)" [Regression]

### DIFF
--- a/js/ui/autocomplete.js
+++ b/js/ui/autocomplete.js
@@ -117,7 +117,7 @@ const Autocomplete = DropDownList.inherit({
 
     _renderDimensions: function() {
         this.callBase();
-        this._dimensionChanged();
+        this._setPopupOption('width');
     },
 
     _popupWrapperClass: function() {

--- a/js/ui/date_box/ui.date_box.base.js
+++ b/js/ui/date_box/ui.date_box.base.js
@@ -259,7 +259,6 @@ const DateBox = DropDownEditor.inherit({
     _renderDimensions: function() {
         this.callBase();
         this.$element().toggleClass(DX_AUTO_WIDTH_CLASS, !this.option('width'));
-        this._strategy?._dimensionChanged();
     },
 
     _refreshFormatClass: function() {

--- a/js/ui/date_box/ui.date_box.strategy.js
+++ b/js/ui/date_box/ui.date_box.strategy.js
@@ -57,10 +57,6 @@ const DateBoxStrategy = Class.inherit({
 
     popupConfig: abstract,
 
-    _dimensionChanged: function() {
-        this._getPopup()?.repaint();
-    },
-
     renderPopupContent: function() {
         const popup = this._getPopup();
         this._renderWidget();

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -45,7 +45,9 @@ const ListStrategy = DateBoxStrategy.inherit({
     },
 
     popupConfig: function(popupConfig) {
-        return popupConfig;
+        return extend(popupConfig, {
+            width: this._getPopupWidth()
+        });
     },
 
     useCurrentDateByDefault: function() {
@@ -54,6 +56,10 @@ const ListStrategy = DateBoxStrategy.inherit({
 
     getDefaultDate: function() {
         return new Date(null);
+    },
+
+    _getPopupWidth: function() {
+        return this.dateBox.$element().outerWidth();
     },
 
     popupShowingHandler: function() {
@@ -250,9 +256,16 @@ const ListStrategy = DateBoxStrategy.inherit({
     },
 
     _dimensionChanged: function() {
-        if(this._getPopup()) {
-            this._updatePopupHeight();
-        }
+        this._getPopup() && this._updatePopupDimensions();
+    },
+
+    _updatePopupDimensions: function() {
+        this._updatePopupWidth();
+        this._updatePopupHeight();
+    },
+
+    _updatePopupWidth: function() {
+        this.dateBox._setPopupOption('width', this._getPopupWidth());
     },
 
     _updatePopupHeight: function() {

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -474,12 +474,7 @@ const DropDownEditor = TextBox.inherit({
     _renderPopupContent: noop,
 
     _renderPopup: function() {
-        const popupConfig = extend(this._popupConfig(), this._options.cache('dropDownOptions'));
-        if(popupConfig.width === 'auto') {
-            popupConfig.width = '100%';
-        }
-
-        this._popup = this._createComponent(this._$popup, Popup, popupConfig);
+        this._popup = this._createComponent(this._$popup, Popup, extend(this._popupConfig(), this._options.cache('dropDownOptions')));
 
         this._popup.on({
             'showing': this._popupShowingHandler.bind(this),

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -475,6 +475,9 @@ const DropDownEditor = TextBox.inherit({
 
     _renderPopup: function() {
         const popupConfig = extend(this._popupConfig(), this._options.cache('dropDownOptions'));
+        if(popupConfig.width === 'auto') {
+            popupConfig.width = '100%';
+        }
 
         this._popup = this._createComponent(this._$popup, Popup, popupConfig);
 

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -740,7 +740,6 @@ const DropDownList = DropDownEditor.inherit({
     },
 
     _popupShowingHandler: function() {
-        this._setPopupOption('minWidth', this.$element().outerWidth());
         this._dimensionChanged();
     },
 

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -430,6 +430,7 @@ const DropDownList = DropDownEditor.inherit({
     _popupConfig: function() {
         return extend(this.callBase(), {
             templatesRenderAsynchronously: false,
+            width: this.option('width'),
             height: 'auto',
             autoResizeEnabled: false,
             maxHeight: this._getMaxHeight.bind(this)
@@ -747,6 +748,15 @@ const DropDownList = DropDownEditor.inherit({
         this._popup && this._updatePopupDimensions();
     },
 
+    _updatePopupDimensions: function() {
+        this._updatePopupWidth();
+        this._updatePopupHeight();
+    },
+
+    _updatePopupWidth: function() {
+        this._setPopupOption('width', this.$element().outerWidth() + this.option('popupWidthExtension'));
+    },
+
     _needPopupRepaint: function() {
         if(!this._dataSource) {
             return false;
@@ -760,7 +770,7 @@ const DropDownList = DropDownEditor.inherit({
         return needRepaint;
     },
 
-    _updatePopupDimensions: function() {
+    _updatePopupHeight: function() {
         if(this._needPopupRepaint()) {
             this._popup.repaint();
         }

--- a/js/ui/lookup.js
+++ b/js/ui/lookup.js
@@ -722,7 +722,7 @@ const Lookup = DropDownList.inherit({
 
     _refreshPopupVisibility: function() {
         if(this.option('opened')) {
-            this._updatePopupDimensions();
+            this._updatePopupHeight();
         }
     },
 
@@ -732,6 +732,10 @@ const Lookup = DropDownList.inherit({
         }
 
         this.callBase();
+    },
+
+    _updatePopupDimensions: function() {
+        this._updatePopupHeight();
     },
 
     _input: function() {

--- a/js/ui/lookup.js
+++ b/js/ui/lookup.js
@@ -482,7 +482,7 @@ const Lookup = DropDownList.inherit({
     },
 
     _popupShowingHandler: function() {
-        this._dimensionChanged();
+        this.callBase(...arguments);
 
         if(this.option('cleanSearchOnOpening')) {
             if(this.option('searchEnabled') && this._searchBox.option('value')) {

--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -486,7 +486,7 @@ const SelectBox = DropDownList.inherit({
 
     _renderDimensions: function() {
         this.callBase();
-        this._dimensionChanged();
+        this._setPopupOption('width');
     },
 
     _isValueEqualInputText: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
@@ -110,41 +110,38 @@ QUnit.module('dxAutocomplete', {
     });
 
     QUnit.test('Resize by option', function(assert) {
-        const setUpWidth = 300;
-        const setUpHeight = 50;
+        const setUpWidth = 456;
+        const setUpHeight = 1000;
 
-        const $autocomplete = $('#autocomplete').dxAutocomplete({
+        const $autocomplete = $('#autocomplete2').dxAutocomplete({
             value: 'anotherText',
             dataSource: ['qwerty', 'item 2', 'item 3'],
             placeholder: 'type something',
             width: setUpWidth,
-            height: setUpHeight,
-            opened: true
+            height: setUpHeight
         });
 
         const autocomplete = $autocomplete.dxAutocomplete('instance');
         const popup = autocomplete._popup;
-        const $overlayContent = $('.dx-overlay-content');
-        const initialPopupWidth = $overlayContent.width();
+        const initialPopupWidth = popup.option('width');
         const initialWidth = $autocomplete.width();
         const initialHeight = $autocomplete.height();
         const increment = 123;
 
-        assert.strictEqual(initialWidth, setUpWidth, 'Width was set up successfully');
-        assert.strictEqual(initialHeight, setUpHeight, 'Height was set up successfully');
-        assert.strictEqual(popup.option('width'), '100%', 'Popup was set up successfully');
-        assert.strictEqual(initialPopupWidth, initialWidth, 'overlay content has correct width');
+        assert.equal(initialWidth, setUpWidth, 'Width was set up successfully');
+        assert.equal(initialHeight, setUpHeight, 'Height was set up successfully');
+        assert.equal(initialPopupWidth, initialWidth + autocomplete.option('popupWidthExtension'), 'Popup was set up successfully');
 
         autocomplete.option('height', initialHeight + increment);
         autocomplete.option('width', initialWidth + increment);
 
         const dHeight = $autocomplete.height() - initialHeight;
         const dWidth = $autocomplete.width() - initialWidth;
-        const dPopupWidth = $overlayContent.width() - initialPopupWidth;
+        const dPopupWidth = popup.option('width') - initialPopupWidth;
 
         assert.notEqual(dHeight, 0, 'Height could be changed');
         assert.notEqual(dWidth, 0, 'Width could be changed');
-        assert.equal(dWidth, dPopupWidth, 'Element and popup change width accordingly');
+        assert.equal(dWidth, dPopupWidth + autocomplete.option('popupWidthExtension'), 'Element and popup change width accordingly');
     });
 
     QUnit.test('check textbox sizes', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
@@ -132,7 +132,7 @@ QUnit.module('dxAutocomplete', {
 
         assert.strictEqual(initialWidth, setUpWidth, 'Width was set up successfully');
         assert.strictEqual(initialHeight, setUpHeight, 'Height was set up successfully');
-        assert.strictEqual(popup.option('width'), 'auto', 'Popup was set up successfully');
+        assert.strictEqual(popup.option('width'), '100%', 'Popup was set up successfully');
         assert.strictEqual(initialPopupWidth, initialWidth, 'overlay content has correct width');
 
         autocomplete.option('height', initialHeight + increment);

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -60,8 +60,6 @@ const TODAY_CELL_CLASS = 'dx-calendar-today';
 const GESTURE_COVER_CLASS = 'dx-gesture-cover';
 const DROP_DOWN_BUTTON_CLASS = 'dx-dropdowneditor-button';
 const DROP_DOWN_BUTTON_VISIBLE_CLASS = 'dx-dropdowneditor-button-visible';
-const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
-const POPUP_CLASS = 'dx-popup';
 
 const CALENDAR_APPLY_BUTTON_SELECTOR = '.dx-popup-done.dx-button';
 
@@ -2148,17 +2146,6 @@ QUnit.module('datebox w/ calendar', {
         assert.deepEqual(getInstanceWidget(this.fixture.dateBox).option('value'), date);
     });
 
-    QUnit.test('popup should have correct width after editor width runtime change (T897820)', function(assert) {
-        this.fixture.dateBox.option('width', 300);
-        this.fixture.dateBox.option('dropDownOptions.width', '50%');
-        this.fixture.dateBox.option('opened', true);
-
-        this.fixture.dateBox.option('width', 700);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 350, 'overlay content width is correct');
-    });
-
     QUnit.test('DateBox must update its value when a date is selected in the calendar when applyValueMode=\'instantly\'', function(assert) {
         const date = new Date(2011, 11, 11);
 
@@ -3408,74 +3395,19 @@ QUnit.module('datebox w/ time list', {
         assert.ok(getInstanceWidget(this.dateBox).$element().hasClass('dx-list'), 'list initialized');
     });
 
-    QUnit.test('popup width shoud be equal to the editor width when dropDownOptions.width in not defined', function(assert) {
+    QUnit.test('width option test', function(assert) {
+        this.dateBox.option('opened', false);
+        this.dateBox.option('width', 'auto');
         this.dateBox.option('opened', true);
 
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
+        const popup = this.$dateBox.find('.dx-popup').dxPopup('instance');
+
+        assert.equal(this.$dateBox.outerWidth(), popup.option('width'), 'timebox popup has equal width with timebox with option width \'auto\'');
 
         this.dateBox.option('opened', false);
-        this.dateBox.option('width', '153');
+        this.dateBox.option('width', '153px');
         this.dateBox.option('opened', true);
-        assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
-    });
-
-    QUnit.test('popup should have width equal to dropDownOptions.width if it\'s defined (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 500);
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 500);
-        this.dateBox.option('opened', true);
-
-        this.dateBox.option('width', 300);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width 100% if dropDownOptions.width is set to auto (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 'auto');
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), '100%', 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), this.dateBox.$element().outerWidth(), 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width when dropDownOptions.width is percent (T897820)', function(assert) {
-        this.dateBox.option('width', 600);
-        this.dateBox.option('dropDownOptions.width', '50%');
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), '50%', 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width after editor width runtime change', function(assert) {
-        this.dateBox.option('width', 300);
-        this.dateBox.option('dropDownOptions.width', '50%');
-        this.dateBox.option('opened', true);
-
-        this.dateBox.option('width', 700);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 350, 'overlay content width is correct');
+        assert.equal(this.$dateBox.outerWidth(), popup.option('width'), 'timebox popup has equal width with timebox with option width in pixels');
     });
 
     QUnit.test('list should contain correct values if min/max does not specified', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -2148,7 +2148,7 @@ QUnit.module('datebox w/ calendar', {
         assert.deepEqual(getInstanceWidget(this.fixture.dateBox).option('value'), date);
     });
 
-    QUnit.test('popup should have correct width after editor width runtime change', function(assert) {
+    QUnit.test('popup should have correct width after editor width runtime change (T897820)', function(assert) {
         this.fixture.dateBox.option('width', 300);
         this.fixture.dateBox.option('dropDownOptions.width', '50%');
         this.fixture.dateBox.option('opened', true);
@@ -2157,15 +2157,6 @@ QUnit.module('datebox w/ calendar', {
 
         const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
         assert.strictEqual($overlayContent.outerWidth(), 350, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width when editor width is defined (T897820)', function(assert) {
-        const editorWidth = 200;
-        this.fixture.dateBox.option('width', editorWidth);
-        this.fixture.dateBox.option('opened', true);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.ok($overlayContent.outerWidth() > editorWidth, 'overlay content width is correct');
     });
 
     QUnit.test('DateBox must update its value when a date is selected in the calendar when applyValueMode=\'instantly\'', function(assert) {
@@ -3453,12 +3444,12 @@ QUnit.module('datebox w/ time list', {
         assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
     });
 
-    QUnit.test('popup should have width auto if dropDownOptions.width is set to auto (T897820)', function(assert) {
+    QUnit.test('popup should have width 100% if dropDownOptions.width is set to auto (T897820)', function(assert) {
         this.dateBox.option('dropDownOptions.width', 'auto');
         this.dateBox.option('opened', true);
 
         const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 'auto', 'popup width option value is correct');
+        assert.strictEqual(popup.option('width'), '100%', 'popup width option value is correct');
 
         const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
         assert.strictEqual($overlayContent.outerWidth(), this.dateBox.$element().outerWidth(), 'overlay content width is correct');

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
@@ -394,23 +394,6 @@ QUnit.module('common', moduleConfig, () => {
 });
 
 QUnit.module('popup options', moduleConfig, () => {
-    QUnit.test('popup should have correct width after editor width runtime change', function(assert) {
-        const instance = $('#dropDownBox').dxDropDownBox({
-            width: 600,
-            dropDownOptions: {
-                width: '50%'
-            },
-            opened: true
-        }).dxDropDownBox('instance');
-
-        const $overlayContent = $('.dx-overlay-content');
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-
-        instance.option('width', 400);
-
-        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
-    });
-
     QUnit.test('customize width and height', function(assert) {
         const instance = new DropDownBox(this.$element, {
             width: 200,

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -1143,7 +1143,6 @@ QUnit.module('popup', moduleConfig, () => {
 
     QUnit.test('popup should have width equal to dropDownOptions.width if it\'s defined (T897820)', function(assert) {
         const instance = $('#dropDownList').dxDropDownList({
-            width: 100,
             dropDownOptions: {
                 width: 300
             },
@@ -1158,7 +1157,6 @@ QUnit.module('popup', moduleConfig, () => {
 
     QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
         const instance = $('#dropDownList').dxDropDownList({
-            width: 100,
             dropDownOptions: {
                 width: 500
             },
@@ -1198,22 +1196,22 @@ QUnit.module('popup', moduleConfig, () => {
         const instance = $('#dropDownList').dxDropDownList({
             width: 600,
             dropDownOptions: {
-                width: '150%'
+                width: '50%'
             },
             opened: true
         }).dxDropDownList('instance');
 
-        assert.strictEqual(getPopup(instance).option('width'), '150%', 'popup width option value is correct');
+        assert.strictEqual(getPopup(instance).option('width'), '50%', 'popup width option value is correct');
 
         const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 900, 'overlay content width is correct');
+        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
 
         instance.close();
         instance.option('width', 400);
         instance.open();
 
-        assert.strictEqual(getPopup(instance).option('width'), '150%', 'popup width option value is correct after editor width runtime change');
-        assert.strictEqual($overlayContent.outerWidth(), 600, 'overlay content width is correct after editor width runtime change');
+        assert.strictEqual(getPopup(instance).option('width'), '50%', 'popup width option value is correct after editor width runtime change');
+        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
     });
 
     QUnit.test('After load new page scrollTop should not be changed', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -30,11 +30,6 @@ const STATE_FOCUSED_CLASS = 'dx-state-focused';
 const TEXTEDITOR_INPUT_CLASS = 'dx-texteditor-input';
 const POPUP_CONTENT_CLASS = 'dx-popup-content';
 const LIST_CLASS = 'dx-list';
-const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
-
-const getPopup = (instance) => {
-    return instance._popup;
-};
 
 const moduleConfig = {
     beforeEach: function() {
@@ -86,7 +81,7 @@ QUnit.module('focus policy', {
         this.instance.option('opened', true);
 
         const mouseDownStub = sinon.stub();
-        const $popupContent = $(getPopup(this.instance).$content());
+        const $popupContent = $(this.instance._popup.$content());
 
         $popupContent
             .on('mousedown', mouseDownStub)
@@ -160,7 +155,7 @@ QUnit.module('keyboard navigation', {
         this.clock = sinon.useFakeTimers();
         this.instance = this.$element.dxDropDownList('instance');
         this.$input = this.$element.find('.' + TEXTEDITOR_INPUT_CLASS);
-        this.popup = getPopup(this.instance);
+        this.popup = this.instance._popup;
         this.$list = this.instance._$list;
         this.keyboard = keyboardMock(this.$input);
     },
@@ -1141,79 +1136,6 @@ QUnit.module('popup', moduleConfig, () => {
         assert.equal($dropDownList.hasClass(SKIP_GESTURE_EVENT_CLASS), false, 'skip gesture event class was removed after popup was closed');
     });
 
-    QUnit.test('popup should have width equal to dropDownOptions.width if it\'s defined (T897820)', function(assert) {
-        const instance = $('#dropDownList').dxDropDownList({
-            dropDownOptions: {
-                width: 300
-            },
-            opened: true
-        }).dxDropDownList('instance');
-
-        assert.strictEqual(getPopup(instance).option('width'), 300, 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
-        const instance = $('#dropDownList').dxDropDownList({
-            dropDownOptions: {
-                width: 500
-            },
-            opened: true
-        }).dxDropDownList('instance');
-
-        instance.option('width', 300);
-
-        assert.strictEqual(getPopup(instance).option('width'), 500, 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width 100% if dropDownOptions.width is set to auto (T897820)', function(assert) {
-        const instance = $('#dropDownList').dxDropDownList({
-            dropDownOptions: {
-                width: 'auto'
-            },
-            opened: true
-        }).dxDropDownList('instance');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), instance.$element().outerWidth(), 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width 100% if dropDownOptions.width is not defined (T897820)', function(assert) {
-        const instance = $('#dropDownList').dxDropDownList({
-            opened: true
-        }).dxDropDownList('instance');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), instance.$element().outerWidth(), 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width when dropDownOptions.width is percent (T897820)', function(assert) {
-        const instance = $('#dropDownList').dxDropDownList({
-            width: 600,
-            dropDownOptions: {
-                width: '50%'
-            },
-            opened: true
-        }).dxDropDownList('instance');
-
-        assert.strictEqual(getPopup(instance).option('width'), '50%', 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-
-        instance.close();
-        instance.option('width', 400);
-        instance.open();
-
-        assert.strictEqual(getPopup(instance).option('width'), '50%', 'popup width option value is correct after editor width runtime change');
-        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
-    });
-
     QUnit.test('After load new page scrollTop should not be changed', function(assert) {
         this.clock.restore();
 
@@ -1681,8 +1603,7 @@ QUnit.module(
 
             window
                 .waitFor(() => {
-                    const instance = $('#test-drop-down').dxDropDownList('instance');
-                    const popup = getPopup(instance).$content();
+                    const popup = $('#test-drop-down').dxDropDownList('instance')._popup.$content();
                     const items = popup.find('.dx-list-item');
 
                     return items.length === 1 && $(items[0]).text() === 'z';

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -94,10 +94,7 @@ QUnit.module('rendering with css', {}, () => {
 
         assert.ok($popup.hasClass(POPUP_CLASS));
 
-        assert.strictEqual(instance._popup.option('width'), '100%');
-
-        const $overlayContent = $('.dx-overlay-content');
-        assert.strictEqual($overlayContent.outerWidth(), 100, 'overlay content width is correct');
+        assert.equal(instance._popup.option('width'), 100 + instance.option('popupWidthExtension'));
     });
 });
 
@@ -939,41 +936,6 @@ QUnit.module('functionality', moduleSetup, () => {
 });
 
 QUnit.module('widget options', moduleSetup, () => {
-    QUnit.test('popup should have correct width when dropDownOptions.width is percent (T897820)', function(assert) {
-        const instance = $('#selectBox').dxSelectBox({
-            width: 600,
-            dropDownOptions: {
-                width: '50%'
-            },
-            opened: true
-        }).dxSelectBox('instance');
-
-        const $overlayContent = $('.dx-overlay-content');
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-
-        instance.close();
-        instance.option('width', 400);
-        instance.open();
-
-        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
-    });
-
-    QUnit.test('popup should have correct width after editor width runtime change (T897820)', function(assert) {
-        const instance = $('#selectBox').dxSelectBox({
-            width: 600,
-            dropDownOptions: {
-                width: '50%'
-            },
-            opened: true
-        }).dxSelectBox('instance');
-
-        const $overlayContent = $('.dx-overlay-content');
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-
-        instance.option('width', 400);
-
-        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
-    });
 
     QUnit.test('option onValueChanged', function(assert) {
         assert.expect(4);

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -87,18 +87,17 @@ const moduleSetup = {
 
 QUnit.module('rendering with css', {}, () => {
     QUnit.test('Right width of popup', function(assert) {
-        const editorWidth = 100;
-        const $element = $('#selectBox').dxSelectBox({ editorWidth: 100 });
+        const $element = $('#selectBox').dxSelectBox({ width: 100 });
         const instance = $element.dxSelectBox('instance');
         instance.open();
         const $popup = $(instance._popup.$element());
 
         assert.ok($popup.hasClass(POPUP_CLASS));
 
-        assert.strictEqual(instance._popup.option('width'), 'auto');
+        assert.strictEqual(instance._popup.option('width'), '100%');
 
         const $overlayContent = $('.dx-overlay-content');
-        assert.ok($overlayContent.outerWidth() > editorWidth, 'overlay content width is correct');
+        assert.strictEqual($overlayContent.outerWidth(), 100, 'overlay content width is correct');
     });
 });
 
@@ -944,36 +943,36 @@ QUnit.module('widget options', moduleSetup, () => {
         const instance = $('#selectBox').dxSelectBox({
             width: 600,
             dropDownOptions: {
-                width: '150%'
+                width: '50%'
             },
             opened: true
         }).dxSelectBox('instance');
 
         const $overlayContent = $('.dx-overlay-content');
-        assert.strictEqual($overlayContent.outerWidth(), 900, 'overlay content width is correct');
+        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
 
         instance.close();
         instance.option('width', 400);
         instance.open();
 
-        assert.strictEqual($overlayContent.outerWidth(), 600, 'overlay content width is correct after editor width runtime change');
+        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
     });
 
     QUnit.test('popup should have correct width after editor width runtime change (T897820)', function(assert) {
         const instance = $('#selectBox').dxSelectBox({
             width: 600,
             dropDownOptions: {
-                width: '150%'
+                width: '50%'
             },
             opened: true
         }).dxSelectBox('instance');
 
         const $overlayContent = $('.dx-overlay-content');
-        assert.strictEqual($overlayContent.outerWidth(), 900, 'overlay content width is correct');
+        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
 
         instance.option('width', 400);
 
-        assert.strictEqual($overlayContent.outerWidth(), 600, 'overlay content width is correct after editor width runtime change');
+        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
     });
 
     QUnit.test('option onValueChanged', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -3586,17 +3586,17 @@ QUnit.module('popup position and size', moduleSetup, () => {
         const instance = $('#tagBox').dxTagBox({
             width: 600,
             dropDownOptions: {
-                width: '150%'
+                width: '50%'
             },
             opened: true
         }).dxTagBox('instance');
 
         const $overlayContent = $('.dx-overlay-content');
-        assert.strictEqual($overlayContent.outerWidth(), 900, 'overlay content width is correct');
+        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
 
         instance.option('width', 400);
 
-        assert.strictEqual($overlayContent.outerWidth(), 600, 'overlay content width is correct after editor width runtime change');
+        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -3581,23 +3581,6 @@ QUnit.module('popup position and size', moduleSetup, () => {
 
         assert.ok(testPassed, 'There is no errors during test');
     });
-
-    QUnit.test('popup should have correct width after editor width runtime change', function(assert) {
-        const instance = $('#tagBox').dxTagBox({
-            width: 600,
-            dropDownOptions: {
-                width: '50%'
-            },
-            opened: true
-        }).dxTagBox('instance');
-
-        const $overlayContent = $('.dx-overlay-content');
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-
-        instance.option('width', 400);
-
-        assert.strictEqual($overlayContent.outerWidth(), 200, 'overlay content width is correct after editor width runtime change');
-    });
 });
 
 QUnit.module('the \'acceptCustomValue\' option', moduleSetup, () => {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
