### PR TITLE
Renovation: Prevent call 'onOptionChanged' for inner options

### DIFF
--- a/js/core/component.js
+++ b/js/core/component.js
@@ -17,7 +17,7 @@ const getEventName = (actionName) => {
 };
 
 const isInnerOption = (optionName) => {
-    return optionName.startsWith('__');
+    return optionName.indexOf('__', 0) === 0;
 };
 
 const Component = Class.inherit({

--- a/js/core/component.js
+++ b/js/core/component.js
@@ -16,6 +16,10 @@ const getEventName = (actionName) => {
     return actionName.charAt(2).toLowerCase() + actionName.substr(3);
 };
 
+const isInnerOption = (optionName) => {
+    return optionName.startsWith('__');
+};
+
 const Component = Class.inherit({
     _setDeprecatedOptions() {
         this._deprecatedOptions = {};
@@ -228,8 +232,10 @@ const Component = Class.inherit({
                     previousValue: previousValue
                 };
 
-                this._optionChangedCallbacks.fireWith(this, [extend(this._defaultActionArgs(), args)]);
-                this._optionChangedAction(extend({}, args));
+                if(!isInnerOption(name)) {
+                    this._optionChangedCallbacks.fireWith(this, [extend(this._defaultActionArgs(), args)]);
+                    this._optionChangedAction(extend({}, args));
+                }
 
                 if(!this._disposed && this._cancelOptionChange !== args.name) {
                     this._optionChanged(args);

--- a/js/core/component.js
+++ b/js/core/component.js
@@ -17,7 +17,7 @@ const getEventName = (actionName) => {
 };
 
 const isInnerOption = (optionName) => {
-    return optionName.indexOf('__', 0) === 0;
+    return optionName.indexOf('_', 0) === 0;
 };
 
 const Component = Class.inherit({

--- a/testing/tests/DevExpress.core/component.tests.js
+++ b/testing/tests/DevExpress.core/component.tests.js
@@ -201,6 +201,38 @@ QUnit.module('default', {}, () => {
         assert.deepEqual(eventChangeLog, expectedLog);
     });
 
+
+    QUnit.test('options api - changing inner options', function(assert) {
+        let callCount = 0;
+        const instance = new TestComponent({
+            onOptionChanged: () => callCount++
+        });
+        instance._resetTraceLog();
+
+        instance.option({
+            'publicOption': 'a'
+        });
+        assert.equal(callCount, 1, 'Public option calls "onOptionChanged"');
+
+        instance.option({
+            '__privateOption': 'a'
+        });
+        assert.equal(callCount, 1, 'Inner option doesn\'t calls "onOptionChanged"');
+
+        const methodCallStack = $.map(instance._traceLog, i => {
+            return i.method;
+        });
+
+        assert.deepEqual(methodCallStack, [
+            'beginUpdate',
+            '_optionChanged',
+            'endUpdate',
+            'beginUpdate',
+            '_optionChanged',
+            'endUpdate'
+        ]);
+    });
+
     QUnit.test('options api - \'onOptionChanged\' changing', function(assert) {
         let called = null;
 

--- a/testing/tests/DevExpress.core/component.tests.js
+++ b/testing/tests/DevExpress.core/component.tests.js
@@ -215,7 +215,7 @@ QUnit.module('default', {}, () => {
         assert.equal(callCount, 1, 'Public option calls "onOptionChanged"');
 
         instance.option({
-            '__privateOption': 'a'
+            '_privateOption': 'a'
         });
         assert.equal(callCount, 1, 'Inner option doesn\'t calls "onOptionChanged"');
 


### PR DESCRIPTION
Now, all options with prefix `_` is inner options and don't trigger `onOptionChanged`