### PR TITLE
Implement pagesNavigatorVisible

### DIFF
--- a/js/renovation/pager/pager-content.tsx
+++ b/js/renovation/pager/pager-content.tsx
@@ -14,6 +14,8 @@ import PagerProps from './pager-props';
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const viewFunction = ({
   className,
+  pagesContainerVisible,
+  pagesContainerVisibility,
   isLargeDisplayMode,
   infoVisible,
   props: {
@@ -38,29 +40,35 @@ export const viewFunction = ({
       rtlEnabled={rtlEnabled}
     />
     )}
-    <div ref={pagesRef as any} className={PAGER_PAGES_CLASS}>
-      <PageIndexSelector
+    {pagesContainerVisible && (
+      <div
+        ref={pagesRef as any}
+        className={PAGER_PAGES_CLASS}
+        style={{ visibility: pagesContainerVisibility }}
+      >
+        <PageIndexSelector
                 // hasKnownLastPage={hasKnownLastPage}
-        isLargeDisplayMode={isLargeDisplayMode}
-        maxPagesCount={maxPagesCount}
-        pageCount={pageCount}
-        pageIndex={pageIndex}
-        pageIndexChange={pageIndexChange}
-        pagesCountText={pagesCountText}
-        rtlEnabled={rtlEnabled}
-        showNavigationButtons={showNavigationButtons}
-        totalCount={totalCount}
-      />
-      {infoVisible && (
-      <InfoText
-        ref={infoTextRef as any}
-        infoText={infoText}
-        pageCount={pageCount}
-        pageIndex={pageIndex}
-        totalCount={totalCount}
-      />
-      )}
-    </div>
+          isLargeDisplayMode={isLargeDisplayMode}
+          maxPagesCount={maxPagesCount}
+          pageCount={pageCount}
+          pageIndex={pageIndex}
+          pageIndexChange={pageIndexChange}
+          pagesCountText={pagesCountText}
+          rtlEnabled={rtlEnabled}
+          showNavigationButtons={showNavigationButtons}
+          totalCount={totalCount}
+        />
+        {infoVisible && (
+        <InfoText
+          ref={infoTextRef as any}
+          infoText={infoText}
+          pageCount={pageCount}
+          pageIndex={pageIndex}
+          totalCount={totalCount}
+        />
+        )}
+      </div>
+    )}
   </div>
 );
 
@@ -89,12 +97,22 @@ export class PagerContentProps extends PagerProps /* bug in generator  implement
   @OneWay() infoTextRef: any = null;
 }
 
-// tslint:disable-next-line: max-classes-per-file
 @Component({ defaultOptionRules: null, view: viewFunction })
 export default class PagerContentComponent extends JSXComponent(PagerContentProps) {
   get infoVisible(): boolean {
     const { showInfo, infoTextVisible } = this.props as Required<PagerContentProps>;
     return showInfo && infoTextVisible;
+  }
+
+  get pagesContainerVisible(): boolean {
+    return !!this.props.pagesNavigatorVisible;
+  }
+
+  get pagesContainerVisibility(): 'hidden' | undefined {
+    if (this.props.pagesNavigatorVisible === 'auto') {
+      return this.props.pageCount === 1 ? 'hidden' : undefined;
+    }
+    return undefined;
   }
 
   get isLargeDisplayMode(): boolean {

--- a/js/renovation/pager/pager-props.tsx
+++ b/js/renovation/pager/pager-props.tsx
@@ -16,7 +16,8 @@ export default class PagerProps {
   @OneWay() pagesCountText?: string = messageLocalization.getFormatter('dxPager-pagesCountText')();
 
   // visible: true,
-  // pagesNavigatorVisible: 'auto',
+  @OneWay() pagesNavigatorVisible?: boolean | 'auto' = 'auto';
+
   @TwoWay() pageIndex?: number = 0;
 
   @TwoWay() pageSize?: number = 5;

--- a/testing/jest/pager/pager-content.tests.tsx
+++ b/testing/jest/pager/pager-content.tests.tsx
@@ -15,6 +15,7 @@ describe('PagerContent', () => {
     it('render all children', () => {
       const props = {
         className: 'className',
+        pagesContainerVisible: true,
         isLargeDisplayMode: true,
         infoVisible: true,
         props: {
@@ -70,10 +71,36 @@ describe('PagerContent', () => {
         totalCount: 100,
       });
     });
+    it('pagesContainerVisibility = false', () => {
+      const parentRef = createRef();
+      const tree = mount(<PagerContentComponent
+        {...{
+          pagesContainerVisible: true,
+          pagesContainerVisibility: 'hidden',
+          props: {
+            parentRef,
+          },
+        } as Partial<PagerContent> as any}
+      /> as any).childAt(0);
+      expect((tree.find('.dx-pages').instance() as unknown as HTMLElement).style).toHaveProperty('visibility', 'hidden');
+    });
+    it('pagesContainerVisible = false', () => {
+      const parentRef = createRef();
+      const tree = mount(<PagerContentComponent
+        {...{
+          pagesContainerVisible: false,
+          props: {
+            parentRef,
+          },
+        } as any}
+      /> as any).childAt(0);
+      expect(tree.find('.dx-pages')).toHaveLength(0);
+    });
     it('infoVisible = false', () => {
       const parentRef = createRef();
       const tree = mount(<PagerContentComponent
         {...{
+          pagesContainerVisible: true,
           infoVisible: false,
           props: {
             parentRef,
@@ -104,6 +131,7 @@ describe('PagerContent', () => {
       const infoTextRef = createRef();
       const props = {
         className: 'className',
+        pagesContainerVisible: true,
         isLargeDisplayMode: true,
         infoVisible: true,
         props: {
@@ -123,7 +151,28 @@ describe('PagerContent', () => {
   });
 
   describe('Logic', () => {
-    it('Logic, className', () => {
+    it('pagesContainerVisible', () => {
+      const component = new PagerContent({
+        pageCount: 1,
+        pagesNavigatorVisible: 'auto',
+      } as PagerContentProps);
+      expect(component.pagesContainerVisible).toBe(true);
+      component.props.pagesNavigatorVisible = false;
+      expect(component.pagesContainerVisible).toBe(false);
+    });
+    it('pagesContainerVisibility', () => {
+      const component = new PagerContent({
+        pageCount: 1,
+        pagesNavigatorVisible: 'auto',
+      } as PagerContentProps);
+      expect(component.pagesContainerVisibility).toBe('hidden');
+      component.props.pageCount = 2;
+      expect(component.pagesContainerVisibility).toBeUndefined();
+      component.props.pageCount = 1;
+      component.props.pagesNavigatorVisible = true;
+      expect(component.pagesContainerVisibility).toBeUndefined();
+    });
+    it('className', () => {
       let component = new PagerContent({
         lightModeEnabled: false,
         isLargeDisplayMode: true,
@@ -138,7 +187,7 @@ describe('PagerContent', () => {
       expect(component.isLargeDisplayMode).toBe(false);
       expect(component.className.indexOf('dx-light-mode')).not.toBe(-1);
     });
-    it('Logic isLargeDisplayMode', () => {
+    it('isLargeDisplayMode', () => {
       let component = new PagerContent({
         lightModeEnabled: false,
         isLargeDisplayMode: true,
@@ -163,7 +212,7 @@ describe('PagerContent', () => {
       } as PagerContentProps);
       expect(component.isLargeDisplayMode).toBe(false);
     });
-    it('Logic infoVisible', () => {
+    it('infoVisible', () => {
       let component = new PagerContent({
         showInfo: true,
         infoTextVisible: true,

--- a/testing/jest/pager/pager.tests.tsx
+++ b/testing/jest/pager/pager.tests.tsx
@@ -12,6 +12,7 @@ describe('Pager', () => {
       const tree = shallow<PagerComponent>(<PagerComponent /> as any);
       expect(tree.props()).toEqual({
         children: [],
+        pagesNavigatorVisible: 'auto',
         contentTemplate: PagerContentComponent,
         pageIndexChange: tree.instance().pageIndexChange,
         pageSizeChange: tree.instance().pageSizeChange,


### PR DESCRIPTION
Reanimate the following qUnit tests:
PagesChooser is not visible if pages count equal one
PagesChooser is not visible if pageNavigatorVisible is false
PagesChooser is not visible when pageNavigatorVisible is false
Pages chooser visibility when page size is changed
