### PR TITLE
TagBox: Fix UT with jQuery v1.x/v2.x on Chrome v83

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -2790,9 +2790,11 @@ QUnit.module('searchEnabled', moduleSetup, () => {
             acceptCustomValue: false
         });
 
-        const $input = $tagBox.find(`.${TEXTBOX_CLASS}`);
+        const input = $tagBox.find(`.${TEXTBOX_CLASS}`).get(0);
+        const inputWidth = input.getBoundingClientRect().width;
+
         // NOTE: width should be 0.1 because of T393423
-        assert.roughEqual($input.width(), 0.1, 0.101, 'input has correct width');
+        assert.roughEqual(inputWidth, 0.1, 0.101, 'input has correct width');
     });
 
     QUnit.test('no placeholder when textbox is not empty', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -2791,7 +2791,7 @@ QUnit.module('searchEnabled', moduleSetup, () => {
         });
 
         const input = $tagBox.find(`.${TEXTBOX_CLASS}`).get(0);
-        const inputWidth = input.getBoundingClientRect().width;
+        const { width: inputWidth } = input.getBoundingClientRect();
 
         // NOTE: width should be 0.1 because of T393423
         assert.roughEqual(inputWidth, 0.1, 0.101, 'input has correct width');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1420883/85839324-7644e400-b7a3-11ea-8973-7c51afd251e2.png)

NOTE: jQuery v1.x/v2.x uses [offsetWidth](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth). This property rounds the value to an integer.