### PR TITLE
If pageCount = 0 pages selector shouldn't be visible

### DIFF
--- a/js/renovation/pager/pager-content.tsx
+++ b/js/renovation/pager/pager-content.tsx
@@ -107,7 +107,7 @@ export default class PagerContentComponent extends JSXComponent(PagerContentProp
   }
 
   get pagesContainerVisible(): boolean {
-    return !!this.props.pagesNavigatorVisible;
+    return !!this.props.pagesNavigatorVisible && (this.props.pageCount as number) > 0;
   }
 
   get pagesContainerVisibility(): 'hidden' | undefined {

--- a/testing/jest/pager/pager-content.tests.tsx
+++ b/testing/jest/pager/pager-content.tests.tsx
@@ -151,7 +151,7 @@ describe('PagerContent', () => {
   });
 
   describe('Logic', () => {
-    it('pagesContainerVisible', () => {
+    it('pagesContainerVisible, pagesNavigatorVisible', () => {
       const component = new PagerContent({
         pageCount: 1,
         pagesNavigatorVisible: 'auto',
@@ -159,6 +159,15 @@ describe('PagerContent', () => {
       expect(component.pagesContainerVisible).toBe(true);
       component.props.pagesNavigatorVisible = false;
       expect(component.pagesContainerVisible).toBe(false);
+    });
+    it('pagesContainerVisible, pageCount', () => {
+      const component = new PagerContent({
+        pageCount: 0,
+        pagesNavigatorVisible: 'auto',
+      } as PagerContentProps);
+      expect(component.pagesContainerVisible).toBe(false);
+      component.props.pageCount = 1;
+      expect(component.pagesContainerVisible).toBe(true);
     });
     it('pagesContainerVisibility', () => {
       const component = new PagerContent({


### PR DESCRIPTION
Reanimate QUnit test:
 * Pager is not rendered if pages count equal zero
 * render pager on changed event
