### PR TITLE
Diagram - Items collection doesn't have a dataItem field for child shapes in the onSelectionChanged event handler when the diagram is bound to a hierarchical array (T903152)

### DIFF
--- a/js/ui/diagram/diagram.nodes_option.js
+++ b/js/ui/diagram/diagram.nodes_option.js
@@ -4,6 +4,12 @@ class NodesOption extends ItemsOption {
     _getKeyExpr() {
         return this._diagramWidget._createOptionGetter('nodes.keyExpr');
     }
+    _getItemsExpr() {
+        return this._diagramWidget._createOptionGetter('nodes.itemsExpr');
+    }
+    _getContainerChildrenExpr() {
+        return this._diagramWidget._createOptionGetter('nodes.containerChildrenExpr');
+    }
 }
 
 module.exports = NodesOption;

--- a/testing/tests/DevExpress.ui.widgets/diagramParts/options.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/diagramParts/options.tests.js
@@ -563,4 +563,61 @@ QUnit.module('Options (initially set)', {}, () => {
         assert.equal(instance._nodesOption._getIndexByKey('3'), 2);
     });
 
+    test('items_option keys cache must be updated on data source changes (hierarchical data)', function(assert) {
+        const store = new ArrayStore({
+            key: 'id',
+            data: [
+                {
+                    id: '1',
+                    text: 'text1',
+                    items: [
+                        {
+                            id: '3',
+                            text: 'text3'
+                        }
+                    ],
+                    children: [
+                        {
+                            id: '4',
+                            text: 'text4'
+                        }
+                    ]
+                },
+                {
+                    id: '2',
+                    text: 'text2'
+                }
+            ],
+        });
+        const dataSource = new DataSource({
+            store
+        });
+        const $element = $('#diagram').dxDiagram({
+            nodes: {
+                dataSource,
+                itemsExpr: 'items'
+            }
+        });
+        const instance = $element.dxDiagram('instance');
+
+        assert.equal(instance._nodesOption._items.length, 2);
+        assert.equal(instance._nodesOption._items[0].items.length, 1);
+        assert.equal(instance._nodesOption._getIndexByKey('1'), 0);
+        assert.equal(instance._nodesOption._getIndexByKey('2'), 1);
+        assert.equal(instance._nodesOption._getIndexByKey('3'), 2);
+        assert.equal(instance._nodesOption._getIndexByKey('4'), 3);
+
+        store.insert({
+            id: '5',
+            text: 'text5'
+        });
+        dataSource.reload();
+        assert.equal(instance._nodesOption._items.length, 3);
+        assert.equal(instance._nodesOption._getIndexByKey('1'), 0);
+        assert.equal(instance._nodesOption._getIndexByKey('2'), 1);
+        assert.equal(instance._nodesOption._getIndexByKey('3'), 3);
+        assert.equal(instance._nodesOption._getIndexByKey('4'), 4);
+        assert.equal(instance._nodesOption._getIndexByKey('5'), 2);
+    });
+
 });


### PR DESCRIPTION
…apes in the onSelectionChanged event handler when the diagram is bound to a hierarchical array (T903152)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
