### PR TITLE
Fix value parsing in IE11 for DateBox with the "time" type and "native" pickerType options (T902036)

### DIFF
--- a/js/ui/date_box/ui.date_box.strategy.native.js
+++ b/js/ui/date_box/ui.date_box.strategy.native.js
@@ -11,7 +11,7 @@ const NativeStrategy = DateBoxStrategy.inherit({
 
     popupConfig: noop,
 
-    getParsedText: function(text) {
+    getParsedText: function(text, format) {
         if(!text) {
             return null;
         }
@@ -21,7 +21,16 @@ const NativeStrategy = DateBoxStrategy.inherit({
             return new Date(text.replace(/-/g, '/').replace('T', ' ').split('.')[0]);
         }
 
-        return dateUtils.fromStandardDateFormat(text);
+        if(this._isTextInput()) {
+            return this.callBase(text, format);
+        } else {
+            return dateUtils.fromStandardDateFormat(text);
+        }
+    },
+
+    // IE11 fallback (T902036)
+    _isTextInput: function() {
+        return this.dateBox._input().prop('type') === 'text';
     },
 
     renderPopupContent: noop,

--- a/testing/tests/DevExpress.knockout/datebox.tests.js
+++ b/testing/tests/DevExpress.knockout/datebox.tests.js
@@ -32,6 +32,9 @@ const FORMATS_MAP = uiDateUtils.FORMATS_MAP;
 const TEXTEDITOR_INPUT_CLASS = 'dx-texteditor-input';
 const widgetName = 'dxDateBox';
 
+const isTextEditor = function($input) {
+    return $input.prop('type') === 'text';
+};
 
 const getInstanceWidget = function(instance) {
     return instance._strategy._widget;
@@ -74,6 +77,15 @@ QUnit.test('several editors for same value', function(assert) {
 
     ko.applyBindings(vm, $('#several').get(0));
 
+    const getEditorTextByValue = function(value, type) {
+        this.instance.option({
+            type: type,
+            value: value
+        });
+
+        return this.instance.option('text');
+    }.bind(this);
+
     const $date = $('#dateboxWithDateFormat').find('.dx-texteditor-input');
     const $datetime = $('#dateboxWithDateTimeFormat').find('.dx-texteditor-input');
     const $time = $('#dateboxWithTimeFormat').find('.dx-texteditor-input');
@@ -86,8 +98,12 @@ QUnit.test('several editors for same value', function(assert) {
     assert.equal($time.val(), getExpectedResult(value, timeMode, toStandardDateFormat(value, timeMode)), '\'time\' format is displayed correctly');
 
     newValue = new Date(2013, 11, 22, 16, 40, 0);
+
+    let inputValue = isTextEditor($date) ?
+        getEditorTextByValue(newValue, 'date') :
+        toStandardDateFormat(newValue, dateMode);
     $date
-        .val(toStandardDateFormat(newValue, dateMode))
+        .val(inputValue)
         .trigger('change');
 
     assert.equal($date.val(), getExpectedResult(newValue, dateMode, toStandardDateFormat(newValue, dateMode)), '\'date\' format is displayed correctly');
@@ -95,8 +111,11 @@ QUnit.test('several editors for same value', function(assert) {
     assert.equal($time.val(), getExpectedResult(newValue, timeMode, toStandardDateFormat(newValue, timeMode)), '\'time\' format is displayed correctly');
 
     newValue = new Date(2008, 9, 26, 22, 30);
+    inputValue = isTextEditor($datetime) ?
+        getEditorTextByValue(newValue, 'datetime') :
+        toStandardDateFormat(newValue, datetimeMode);
     $datetime
-        .val(toStandardDateFormat(newValue, datetimeMode))
+        .val(inputValue)
         .trigger('change');
 
     assert.equal($date.val(), getExpectedResult(newValue, dateMode, toStandardDateFormat(newValue, dateMode)), '\'date\' format is displayed correctly');
@@ -104,8 +123,11 @@ QUnit.test('several editors for same value', function(assert) {
     assert.equal($time.val(), getExpectedResult(newValue, timeMode, toStandardDateFormat(newValue, timeMode)), '\'time\' format is displayed correctly');
 
     newValue = new Date(2008, 9, 26, 14, 29);
+    inputValue = isTextEditor($time) ?
+        getEditorTextByValue(newValue, 'time') :
+        toStandardDateFormat(newValue, timeMode);
     $time
-        .val(toStandardDateFormat(newValue, timeMode))
+        .val(inputValue)
         .trigger('change');
 
     assert.equal($date.val(), getExpectedResult(newValue, dateMode, toStandardDateFormat(newValue, dateMode)), '\'date\' format is displayed correctly');

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -5157,12 +5157,12 @@ testModule('native picker', function() {
                 value: new Date(2020, 10, 11, 13, 0, 0)
             });
             const instance = $editor.dxDateBox('instance');
-            const $newEditor = $('<div>').appendTo('#qunit-fixture').dxDateBox({
+            const newEditorInstance = $('<div>').appendTo('#qunit-fixture').dxDateBox({
                 pickerType: 'native',
                 type: editorType,
                 value: new Date(2020, 10, 12, 13, 1, 0)
-            });
-            const newValue = $newEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`).val();
+            }).dxDateBox('instance');
+            const newValue = newEditorInstance.option('text');
 
             $editor
                 .find(`.${TEXTEDITOR_INPUT_CLASS}`)

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -64,6 +64,7 @@ const DROP_DOWN_BUTTON_VISIBLE_CLASS = 'dx-dropdowneditor-button-visible';
 const CALENDAR_APPLY_BUTTON_SELECTOR = '.dx-popup-done.dx-button';
 
 const widgetName = 'dxDateBox';
+const { module: testModule, test } = QUnit;
 
 const getShortDate = date => {
     return dateSerialization.serializeDate(date, dateUtils.getShortDateFormat());
@@ -105,6 +106,8 @@ const getExpectedResult = (date, mode, stringDate) => {
     return support.inputType(mode) ? stringDate : localizedDate;
 };
 
+const prepareDateString = (type, year, month, day) => type === 'text' ? `${month}/${day}/${year}` : `${year}-${month}-${day}`;
+
 QUnit.module('datebox tests', moduleConfig, () => {
     QUnit.test('value is null after reset', function(assert) {
         const date = new Date(2012, 10, 26, 16, 40, 23);
@@ -120,8 +123,11 @@ QUnit.module('datebox tests', moduleConfig, () => {
             type: 'date'
         });
 
-        $(this.$input())
-            .val('2012-11-26')
+        const $input = $(this.$input());
+        const newValue = prepareDateString($input.prop('type'), 2012, 11, 26);
+
+        $input
+            .val(newValue)
             .trigger('change');
 
         const value = this.instance.option('value');
@@ -955,12 +961,13 @@ QUnit.module('merging dates', moduleConfig, () => {
 
         const instance = $element.dxDateBox('instance');
         const $input = $element.find('.' + TEXTEDITOR_INPUT_CLASS);
+        const inputType = $input.prop('type');
 
-        $input.val('2014-10-31');
+        $input.val(prepareDateString(inputType, 2014, 10, 31));
         $input.triggerHandler('change');
         assert.equal(instance.option('value').valueOf(), new Date(2014, 9, 31, 11, 22).valueOf(), 'date merged correctly');
 
-        $input.val('2014-11-01');
+        $input.val(prepareDateString(inputType, 2014, 11, '01'));
         $input.triggerHandler('change');
         assert.equal(instance.option('value').valueOf(), new Date(2014, 10, 1, 11, 22).valueOf(), 'date merged correctly');
     });
@@ -969,8 +976,11 @@ QUnit.module('merging dates', moduleConfig, () => {
         this.instance.option('type', 'date');
         this.instance.option('value', new Date(2000, 6, 31, 1, 1, 1));
 
-        $(this.$input())
-            .val('2000-09-10')
+        const $input = $(this.$input());
+        const inputType = $input.prop('type');
+
+        $input
+            .val(prepareDateString(inputType, 2000, '09', '10'))
             .trigger('change');
 
         assert.deepEqual(this.instance.option('value'), new Date(2000, 8, 10, 1, 1, 1));
@@ -979,14 +989,17 @@ QUnit.module('merging dates', moduleConfig, () => {
     QUnit.test('incorrect work of mergeDates function if previous value not valid (Q568689)', function(assert) {
         this.instance.option('type', 'time');
 
-        $(this.$input())
+        const $input = $(this.$input());
+        const inputType = $input.prop('type');
+
+        $input
             .val('')
             .trigger('change');
 
         assert.strictEqual(this.instance.option('value'), null);
 
-        $(this.$input())
-            .val('12:30')
+        $input
+            .val(inputType === 'text' ? '12:30 PM' : '12:30')
             .trigger('change');
 
         const date = new Date(null);
@@ -5129,4 +5142,46 @@ QUnit.module('DateBox number and string value support', {
         });
     });
 
+});
+
+testModule('native picker', function() {
+    [
+        { editorType: 'date', checkDate: true, checkTime: false },
+        { editorType: 'time', checkDate: false, checkTime: true },
+        { editorType: 'datetime', checkDate: true, checkTime: true }
+    ].forEach(({ editorType, checkDate, checkTime }) => {
+        test(`set new value for editor with ${editorType} type`, function(assert) {
+            const $editor = $('#dateBox').dxDateBox({
+                pickerType: 'native',
+                type: editorType,
+                value: new Date(2020, 10, 11, 13, 0, 0)
+            });
+            const instance = $editor.dxDateBox('instance');
+            const $newEditor = $('<div>').appendTo('#qunit-fixture').dxDateBox({
+                pickerType: 'native',
+                type: editorType,
+                value: new Date(2020, 10, 12, 13, 1, 0)
+            });
+            const newValue = $newEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`).val();
+
+            $editor
+                .find(`.${TEXTEDITOR_INPUT_CLASS}`)
+                .val(newValue)
+                .trigger('change');
+
+            assert.ok(instance.option('isValid'), 'New value is valid');
+
+            const currentDate = instance.option('value');
+            if(checkDate) {
+                assert.strictEqual(currentDate.getFullYear(), 2020);
+                assert.strictEqual(currentDate.getMonth(), 10);
+                assert.strictEqual(currentDate.getDate(), 12);
+            }
+
+            if(checkTime) {
+                assert.strictEqual(currentDate.getHours(), 13);
+                assert.strictEqual(currentDate.getMinutes(), 1);
+            }
+        });
+    });
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
