### PR TITLE
Renovation: Widget sizes with numeric string

### DIFF
--- a/js/renovation/widget.tsx
+++ b/js/renovation/widget.tsx
@@ -50,6 +50,15 @@ const getCssClasses = (model: Partial<Widget> & Partial<WidgetProps>) => {
   return className.join(' ');
 };
 
+const isNumericString = (str: string): boolean => /^\d+$/.test(str);
+
+const tryParseInt = (size: string | number | undefined): string | number | undefined => {
+  if (typeof size === 'string' && isNumericString(size)) {
+    return parseInt(size, 10);
+  }
+  return size;
+};
+
 export const viewFunction = (viewModel: Widget) => (
   <div
     ref={viewModel.widgetRef as any}
@@ -287,8 +296,8 @@ export default class Widget extends JSXComponent(WidgetProps) {
     const { width, height } = this.props;
     const style = this.restAttributes.style || {};
 
-    const computedWidth = typeof width === 'function' ? width() : width;
-    const computedHeight = typeof height === 'function' ? height() : height;
+    const computedWidth = tryParseInt(typeof width === 'function' ? width() : width);
+    const computedHeight = tryParseInt(typeof height === 'function' ? height() : height);
 
     return {
       ...style,

--- a/js/renovation/widget.tsx
+++ b/js/renovation/widget.tsx
@@ -20,6 +20,7 @@ import {
 import { extend } from '../core/utils/extend';
 import { focusable } from '../ui/widget/selectors';
 import { isFakeClickEvent } from '../events/utils/index';
+import { normalizeStyleProp } from '../core/utils/style';
 import BaseWidgetProps from './utils/base-props';
 
 const getAria = (args): { [name: string]: string } => Object.keys(args).reduce((r, key) => {
@@ -48,15 +49,6 @@ const getCssClasses = (model: Partial<Widget> & Partial<WidgetProps>) => {
   model.onVisibilityChange && className.push('dx-visibility-change-handler');
 
   return className.join(' ');
-};
-
-const isNumericString = (str: string): boolean => /^\d+$/.test(str);
-
-const tryParseInt = (size: string | number | undefined): string | number | undefined => {
-  if (typeof size === 'string' && isNumericString(size)) {
-    return parseInt(size, 10);
-  }
-  return size;
 };
 
 export const viewFunction = (viewModel: Widget) => (
@@ -296,8 +288,8 @@ export default class Widget extends JSXComponent(WidgetProps) {
     const { width, height } = this.props;
     const style = this.restAttributes.style || {};
 
-    const computedWidth = tryParseInt(typeof width === 'function' ? width() : width);
-    const computedHeight = tryParseInt(typeof height === 'function' ? height() : height);
+    const computedWidth = normalizeStyleProp('width', typeof width === 'function' ? width() : width);
+    const computedHeight = normalizeStyleProp('height', typeof height === 'function' ? height() : height);
 
     return {
       ...style,

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "nconf": "^0.10.0",
     "npm-run-all": "^4.1.5",
     "pre-commit": "^1.2.2",
-    "preact": "^10.0.1",
+    "preact": "^10.4.5",
     "qunitjs": "^2.0.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/testing/jest/compatibility/widgets.json
+++ b/testing/jest/compatibility/widgets.json
@@ -183,6 +183,7 @@
         "pageCount",
         "pagesCountText",
         "visible",
+        "hasKnownLastPage",
         "pagesNavigatorVisible",
         "pageIndex",
         "pageSize",
@@ -202,6 +203,7 @@
         "pageCount",
         "pagesCountText",
         "visible",
+        "hasKnownLastPage",
         "pagesNavigatorVisible",
         "showPageSizes",
         "pageSizes",
@@ -243,7 +245,7 @@
         "onDelete",
         "onHide",
         "getTextAndFormatDate",
-        "singleAppointmentData",
+        "singleAppointment",
         "itemContentRender",
         "itemContentComponent"
       ],
@@ -252,7 +254,8 @@
         "item",
         "index",
         "showDeleteButton",
-        "singleAppointmentData",
+        "getTextAndFormatDate",
+        "singleAppointment",
         "itemContentRender",
         "itemContentComponent"
       ],
@@ -262,8 +265,7 @@
       ],
       "event": [
         "onDelete",
-        "onHide",
-        "getTextAndFormatDate"
+        "onHide"
       ],
       "ref": [],
       "slot": []

--- a/testing/jest/widget.tests.tsx
+++ b/testing/jest/widget.tests.tsx
@@ -575,6 +575,12 @@ describe('Widget', () => {
 
           expect(widget.styles).toEqual({});
         });
+
+        it('should convert string without unit into number', () => {
+          const widget = new Widget({ width: '50', height: '100' });
+
+          expect(widget.styles).toEqual({ width: 50, height: 100 });
+        });
       });
 
       describe('cssClasses', () => {

--- a/testing/jest/widget.tests.tsx
+++ b/testing/jest/widget.tests.tsx
@@ -555,7 +555,7 @@ describe('Widget', () => {
         it('should add width and height as functions', () => {
           const widget = new Widget({ width: () => 50, height: () => 'auto' });
 
-          expect(widget.styles).toEqual({ width: 50, height: 'auto' });
+          expect(widget.styles).toEqual({ width: '50px', height: 'auto' });
         });
 
         it('should add width and height as string values', () => {
@@ -567,7 +567,7 @@ describe('Widget', () => {
         it('should add width and height as number values', () => {
           const widget = new Widget({ width: 50, height: 70 });
 
-          expect(widget.styles).toEqual({ width: 50, height: 70 });
+          expect(widget.styles).toEqual({ width: '50px', height: '70px' });
         });
 
         it('should ignore width and height undefined values', () => {
@@ -579,7 +579,7 @@ describe('Widget', () => {
         it('should convert string without unit into number', () => {
           const widget = new Widget({ width: '50', height: '100' });
 
-          expect(widget.styles).toEqual({ width: 50, height: 100 });
+          expect(widget.styles).toEqual({ width: '50px', height: '100px' });
         });
       });
 


### PR DESCRIPTION
Make possible to use string value without unit as `width` or `height`