### PR TITLE
dxLookup - Fix dependence of usePopover and itemCenteringEnabled options

### DIFF
--- a/js/ui/lookup.js
+++ b/js/ui/lookup.js
@@ -641,7 +641,7 @@ const Lookup = DropDownList.inherit({
     },
 
     _getPopupHeight: function() {
-        if(this._list && this._list.itemElements() && this.option('itemCenteringEnabled')) {
+        if(this._list && this._list.itemElements()) {
             return this._calculateListHeight(this.option('grouped')) +
                 (this._$searchWrapper ? this._$searchWrapper.outerHeight() : 0) +
                 (this._popup._$bottom ? this._popup._$bottom.outerHeight() : 0) +
@@ -652,12 +652,12 @@ const Lookup = DropDownList.inherit({
     },
 
     _getPopupWidth: function() {
-        return this.option('itemCenteringEnabled') ? $(this.element()).outerWidth() : $(window).width() * 0.8;
+        return $(this.element()).outerWidth();
     },
 
     _renderPopup: function() {
         if(this.option('usePopover') && !this.option('dropDownOptions.fullScreen')) {
-            if(this.option('_scrollToSelectedItemEnabled') && this.option('itemCenteringEnabled')) {
+            if(this.option('_scrollToSelectedItemEnabled')) {
                 this.callBase();
             } else {
                 this._renderPopover();
@@ -736,10 +736,14 @@ const Lookup = DropDownList.inherit({
         delete result.animation;
         delete result.position;
 
-        if(this.option('_scrollToSelectedItemEnabled') && this.option('itemCenteringEnabled')) {
-            result.position = {
+        if(this.option('_scrollToSelectedItemEnabled')) {
+            result.position = this.option('itemCenteringEnabled') ? {
                 my: 'left top',
                 at: 'left top',
+                of: this.element()
+            } : {
+                my: 'left top',
+                at: 'left bottom',
                 of: this.element()
             };
         }
@@ -1126,8 +1130,9 @@ const Lookup = DropDownList.inherit({
             case '_scrollToSelectedItemEnabled':
                 break;
             case 'itemCenteringEnabled':
-                if(this.option('_scrollToSelectedItemEnabled') && value) {
-                    this.option('usePopover', false);
+                if(this.option('_scrollToSelectedItemEnabled')) {
+                    this.option('dropDownOptions.position', undefined);
+                    this._renderPopup();
                 }
                 break;
             default:

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -3325,7 +3325,7 @@ QUnit.module('default options', {
 
             $popup = $('.dx-popup-wrapper');
 
-            assert.roughEqual($popup.find('.dx-overlay-content').position().top, -2.5 - $('.dx-list-item').not('.dx-state-invisible').height(), 2, 'popup position if second visible item is selected');
+            assert.roughEqual($popup.find('.dx-overlay-content').position().top, -2.5 - $('.dx-list-item').not('.dx-state-invisible').height(), 3, 'popup position if second visible item is selected');
             lookup.close();
         } finally {
             $lookup.remove();

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -3277,6 +3277,60 @@ QUnit.module('default options', {
         }
     });
 
+    QUnit.test('Check popup position if there are invisible items in dataSource for Material theme', function(assert) {
+        const origIsMaterial = themes.isMaterial;
+        themes.isMaterial = function() { return true; };
+
+        const materialLookupPadding = 8;
+        const $lookup = $('<div>').prependTo('body');
+
+        try {
+            const lookup = $lookup.dxLookup({ dataSource: [{
+                'ID': 1,
+                'Color': 'black',
+                'visible': false
+            }, {
+                'ID': 2,
+                'Color': 'grey',
+                'visible': true
+            }, {
+                'ID': 3,
+                'Color': 'green',
+                'visible': true
+            }, {
+                'ID': 4,
+                'Color': 'white',
+                'visible': true
+            }, {
+                'ID': 5,
+                'Color': 'yellow',
+                'visible': true
+            }], valueExpr: 'ID', displayExpr: 'Color' }).dxLookup('instance');
+
+            $lookup.css('margin-top', 200);
+
+            $(lookup.field()).trigger('dxclick');
+
+            let $popup = $('.dx-popup-wrapper');
+
+            assert.roughEqual($popup.find('.dx-overlay-content').position().top, 0, 2, 'popup position if nothing is selected');
+            assert.equal(lookup.option('dropDownOptions.height')(), $('.dx-list-item').not('.dx-state-invisible').height() * 4 + materialLookupPadding * 2, 'popup height equal 4 items and 2 paddings (8px)');
+
+            lookup.close();
+            lookup.option('value', 3);
+
+            $(lookup.field()).trigger('dxclick');
+
+            $popup = $('.dx-popup-wrapper');
+
+            assert.roughEqual($popup.find('.dx-overlay-content').position().top, -2.5 - $('.dx-list-item').not('.dx-state-invisible').height(), 2, 'popup position if second visible item is selected');
+            lookup.close();
+        } finally {
+            $lookup.remove();
+            themes.isMaterial = origIsMaterial;
+        }
+    });
+
     QUnit.test('Check default popupHeight, position.of for Material theme if there are grouped items', function(assert) {
         const origIsMaterial = themes.isMaterial;
         themes.isMaterial = function() { return true; };
@@ -3400,7 +3454,7 @@ QUnit.module('default options', {
         }
     });
 
-    QUnit.test('Check when itemCenteringEnabled option is true for Material theme', function(assert) {
+    QUnit.test('Check when itemCenteringEnabled option for Material theme', function(assert) {
         const origIsMaterial = themes.isMaterial;
         themes.isMaterial = function() { return true; };
 
@@ -3482,6 +3536,14 @@ QUnit.module('default options', {
             assert.roughEqual($popup.find('.dx-overlay-content').position().top, -2.5 - materialLookupPadding, 1, 'popup position if last item is selected and there is not place');
 
             lookup.close();
+
+            lookup.option('itemCenteringEnabled', false);
+
+            $(lookup.field()).trigger('dxclick');
+
+            $popup = $('.dx-popup-wrapper');
+
+            assert.roughEqual($popup.find('.dx-overlay-content').position().top, $(lookup.field()).outerHeight(), 3, 'popup position if itemCenteringEnabled option is false');
         } finally {
             $lookup.remove();
             themes.isMaterial = origIsMaterial;
@@ -3489,35 +3551,42 @@ QUnit.module('default options', {
     });
 
 
-    QUnit.test('Check when itemCenteringEnabled option is false for Material theme', function(assert) {
+    QUnit.test('Check when itemCenteringEnabled option is false and change options for Material theme', function(assert) {
         const origIsMaterial = themes.isMaterial;
         themes.isMaterial = function() { return true; };
 
         const $lookup = $('<div>').prependTo('body');
 
+        const popupWidth = $(window).width() * 0.8;
+        const popupHeight = $(window).height() * 0.8;
+
         try {
 
-            const lookup = $lookup.dxLookup({ dataSource: ['blue', 'orange', 'lime', 'purple', 'green'], value: 'blue' }).dxLookup('instance');
-
-            lookup.option('usePopover', false);
-            lookup.option('itemCenteringEnabled', false);
+            const lookup = $lookup.dxLookup({
+                dataSource: ['blue', 'orange', 'lime', 'purple', 'green'],
+                value: 'blue',
+                itemCenteringEnabled: false,
+                dropDownOptions: {
+                    position: {
+                        at: 'center',
+                        my: 'center',
+                        of: $(window)
+                    },
+                    width: popupWidth,
+                    height: popupHeight
+                }
+            }).dxLookup('instance');
 
             $lookup.css('margin-top', 0);
 
             $(lookup.field()).trigger('dxclick');
 
-            const $popup = $('.dx-popup-wrapper');
+            let $popup = $('.dx-popup-wrapper');
 
-            assert.roughEqual($popup.find('.dx-overlay-content').outerWidth(), $(window).width() * 0.8, 3, 'default popup width like generic');
-            assert.roughEqual($popup.find('.dx-overlay-content').outerHeight(), $('.dx-list-item').height() * 5 + 2, 3, 'default popup height like generic');
+            assert.roughEqual($popup.find('.dx-overlay-content').outerWidth(), popupWidth, 3, 'popup width like generic');
+            assert.roughEqual($popup.find('.dx-overlay-content').outerHeight(), popupHeight, 3, 'popup height like generic');
 
-            assert.roughEqual($popup.find('.dx-overlay-content').position().top, ($(window).height() - $popup.find('.dx-overlay-content').outerHeight()) / 2, 1, 'default popup position of window');
-
-            lookup.option('dropDownOptions.position', 'top');
-
-            assert.roughEqual($popup.find('.dx-overlay-content').position().top, 0, 1, 'popup position of window after change position');
-
-            $(lookup.field()).trigger('dxclick');
+            assert.roughEqual($popup.find('.dx-overlay-content').position().top, ($(window).height() - $popup.find('.dx-overlay-content').outerHeight()) / 2, 1, 'popup position of window');
 
             lookup.close();
 
@@ -3525,14 +3594,20 @@ QUnit.module('default options', {
 
             $(lookup.field()).trigger('dxclick');
 
-            const $popover = $('.dx-popup-wrapper');
+            $popup = $('.dx-popup-wrapper');
+            assert.roughEqual($popup.find('.dx-overlay-content').outerWidth(), popupWidth, 3, 'popup width does not change when usePopover true');
+            assert.roughEqual($popup.find('.dx-overlay-content').outerHeight(), popupHeight, 3, 'popup height does not change when usePopover true');
 
-            assert.equal($popover.find('.dx-overlay-content').outerWidth(), $(lookup.field()).outerWidth() + 2, 'popup width match with lookup field width');
+            assert.roughEqual($popup.find('.dx-overlay-content').position().top, ($(window).height() - $popup.find('.dx-overlay-content').outerHeight()) / 2, 1, 'popup position does not change when usePopover true');
 
-            // android6 test fail
-            // assert.roughEqual($popover.find('.dx-overlay-content').outerHeight(), $('.dx-list-item').height() * 5 + 2, 3, 'popup height auto if usePopover true');
+            lookup.close();
 
-            assert.roughEqual($popover.find('.dx-overlay-content').eq(0).position().top, $(lookup.field()).outerHeight() + 8, 2, 'popover position of lookup field with body padding 8px');
+            lookup.option('dropDownOptions.position', 'top');
+
+            $(lookup.field()).trigger('dxclick');
+
+            $popup = $('.dx-popup-wrapper');
+            assert.roughEqual($popup.find('.dx-overlay-content').position().top, 0, 1, 'popup position of window after change position more');
 
             lookup.close();
         } finally {

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -3307,7 +3307,7 @@ QUnit.module('default options', {
                 'visible': true
             }], valueExpr: 'ID', displayExpr: 'Color' }).dxLookup('instance');
 
-            $lookup.css('margin-top', 200);
+            $lookup.css('margin-top', 0);
 
             $(lookup.field()).trigger('dxclick');
 
@@ -3317,6 +3317,8 @@ QUnit.module('default options', {
             assert.equal(lookup.option('dropDownOptions.height')(), $('.dx-list-item').not('.dx-state-invisible').height() * 4 + materialLookupPadding * 2, 'popup height equal 4 items and 2 paddings (8px)');
 
             lookup.close();
+
+            $lookup.css('margin-top', 200);
             lookup.option('value', 3);
 
             $(lookup.field()).trigger('dxclick');


### PR DESCRIPTION
Now, the usePopover option is always false for the Material theme. Popup position depends on the value of the itemCenteringEnabled option. 