### PR TITLE
Sortable: Only animate items around the current drop position (Fixes T905623)

### DIFF
--- a/js/ui/sortable.js
+++ b/js/ui/sortable.js
@@ -711,6 +711,9 @@ const Sortable = Draggable.inherit({
         const animationConfig = this.option('animation');
         const rtlEnabled = this.option('rtlEnabled');
 
+        const animationLowerLimit = ((toIndex || -1) >= 0 ? toIndex : (prevToIndex || 0)) - 10;
+        const animationUpperLimit = animationLowerLimit + 20;
+
         for(let i = 0; i < items.length; i++) {
             const $item = $(items[i]);
             const prevPosition = prevPositions[i];
@@ -720,10 +723,19 @@ const Sortable = Draggable.inherit({
                 fx.stop($item);
                 translator.resetPosition($item);
             } else if(prevPosition !== position) {
-                fx.stop($item);
-                fx.animate($item, extend({}, animationConfig, {
-                    to: { [positionPropName]: !isVerticalOrientation && rtlEnabled ? -position : position }
-                }));
+                if(i >= animationLowerLimit && i <= animationUpperLimit) {
+                    fx.stop($item);
+                    fx.animate($item, extend({}, animationConfig, {
+                        to: { [positionPropName]: !isVerticalOrientation && rtlEnabled ? -position : position }
+                    }));
+                } else {
+                    if(isVerticalOrientation) {
+                        translator.move($item, { top: position, left: 0 });
+                    } else {
+                        translator.move($item, { top: 0, left: rtlEnabled ? -position : position });
+                    }
+
+                }
             }
         }
     },


### PR DESCRIPTION
Animating hundreds or thousands of rows doesn't really make sense.

What this PR does:

- Only animate few items around the current drop position
- Instantly move all other items instead

Fixes T905623 (needs fix for t905423 as well to be fully resolved)

