### PR TITLE
PivotGrid - ExcelJs Export. Implement KeepColumnWidths property

### DIFF
--- a/js/exporter/exceljs/export.js
+++ b/js/exporter/exceljs/export.js
@@ -70,12 +70,12 @@ const Export = {
         excelCell.alignment.vertical = 'top';
     },
 
-    setColumnsWidth: function(worksheet, columns, startColumnIndex) {
-        if(!isDefined(columns)) {
+    setColumnsWidth: function(worksheet, widths, startColumnIndex) {
+        if(!isDefined(widths)) {
             return;
         }
-        for(let i = 0; i < columns.length; i++) {
-            const columnWidth = columns[i].width;
+        for(let i = 0; i < widths.length; i++) {
+            const columnWidth = widths[i];
             if((typeof columnWidth === 'number') && isFinite(columnWidth)) {
                 worksheet.getColumn(startColumnIndex + i).width =
                     Math.min(MAX_EXCEL_COLUMN_WIDTH, Math.floor(columnWidth / MAX_DIGIT_WIDTH_IN_PIXELS * 100) / 100);
@@ -148,7 +148,7 @@ const Export = {
                 const dataRowsCount = dataProvider.getRowsCount();
 
                 if(keepColumnWidths) {
-                    this.setColumnsWidth(worksheet, columns, cellRange.from.column);
+                    this.setColumnsWidth(worksheet, dataProvider.getColumnsWidths(), cellRange.from.column);
                 }
 
                 const mergedCells = [];
@@ -242,7 +242,7 @@ const Export = {
 };
 
 //#DEBUG
-Export.__internals = { MAX_EXCEL_COLUMN_WIDTH };
+Export.__internals = { MAX_EXCEL_COLUMN_WIDTH, MAX_DIGIT_WIDTH_IN_PIXELS };
 //#ENDDEBUG
 
 export { Export };

--- a/js/ui/data_grid/ui.data_grid.export.js
+++ b/js/ui/data_grid/ui.data_grid.export.js
@@ -139,6 +139,13 @@ exports.DataProvider = Class.inherit({
         return getColumnsByAllRows ? columns : columns[columns.length - 1];
     },
 
+    getColumnsWidths: function() {
+        const columns = this.getColumns();
+        return isDefined(columns)
+            ? columns.map(c => c.width)
+            : undefined;
+    },
+
     getRowsCount: function() {
         return this._options.items.length + this.getHeaderRowCount();
     },

--- a/js/ui/pivot_grid/ui.pivot_grid.export.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.export.js
@@ -2,6 +2,7 @@ import Class from '../../core/class';
 import { isDefined } from '../../core/utils/type';
 import { extend } from '../../core/utils/extend';
 import { each } from '../../core/utils/iterator';
+import { hasWindow } from '../../core/utils/window';
 import { format } from '../../format_helper';
 import { parse } from '../../localization/number';
 import clientExporter, { excel as excelExporter } from '../../exporter';
@@ -115,6 +116,8 @@ exports.ExportMixin = extend({}, exportMixin, {
             rtlEnabled: this.option('rtlEnabled'),
             dataFields: this.getDataSource().getAreaFields('data'),
             customizeExcelCell: this.option('export.customizeExcelCell'),
+            rowsArea: this._rowsArea,
+            columnsArea: this._columnsArea
         });
     }
 });
@@ -185,6 +188,13 @@ exports.DataProvider = Class.inherit({
         return this._options.columns;
     },
 
+    getColumnsWidths: function() {
+        const useDefaultWidth = !hasWindow() || this._options.columnsArea.option('scrolling.mode') === 'virtual';
+        return useDefaultWidth
+            ? this._options.columns.map(_ => DEFAUL_COLUMN_WIDTH)
+            : this._options.rowsArea.getColumnsWidth().concat(this._options.columnsArea.getColumnsWidth());
+    },
+
     getRowsCount: function() {
         return this._options.items.length;
     },
@@ -234,6 +244,11 @@ exports.DataProvider = Class.inherit({
         } else {
             result.value = item.value;
         }
+
+        if(result.cellSourceData && result.cellSourceData.isWhiteSpace) {
+            result.value = '';
+        }
+
         return result;
     },
 
@@ -281,3 +296,9 @@ exports.DataProvider = Class.inherit({
         }
     },
 });
+
+//#DEBUG
+export const PivotGridExport = {
+    DEFAUL_COLUMN_WIDTH
+};
+//#ENDDEBUG

--- a/testing/tests/DevExpress.exporter/exceljsParts/exceljs.pivotGrid.tests.js
+++ b/testing/tests/DevExpress.exporter/exceljsParts/exceljs.pivotGrid.tests.js
@@ -10,6 +10,7 @@ import { initializeDxObjectAssign, clearDxObjectAssign } from './objectAssignHel
 import { initializeDxArrayFind, clearDxArrayFind } from './arrayFindHelper.js';
 import ExcelJSLocalizationFormatTests from './exceljs.format.tests.js';
 import { ExcelJSOptionTests } from './exceljs.option.tests.js';
+import browser from 'core/utils/browser';
 
 import typeUtils from 'core/utils/type';
 import 'ui/pivot_grid/ui.pivot_grid';
@@ -18,16 +19,10 @@ import 'common.css!';
 import 'generic_light.css!';
 
 import { DataController } from 'ui/pivot_grid/ui.pivot_grid.data_controller.js';
+import { PivotGridExport } from 'ui/pivot_grid/ui.pivot_grid.export.js';
+import { Export } from 'exporter/exceljs/export';
 
 let helper;
-
-// TODO: Support the WYSIWYG column width. We are supporting the default column value width equal 100px for each column.
-const excelColumnWidthFromColumn100Pixels = 14.28;
-// const excelColumnWidthFromGrid500Pixels = 71.42;
-// const excelColumnWidthFromColumn150Pixels = 21.42;
-// const excelColumnWidthFromColumn200Pixels = 28.57;
-// const excelColumnWidthFromColumn250Pixels = 35.71;
-// const excelColumnWidthFromColumn300Pixels = 42.85;
 
 const alignLeftTopWrap = { horizontal: 'left', vertical: 'top', wrapText: true };
 const alignLeftTopNoWrap = { horizontal: 'left', vertical: 'top', wrapText: false };
@@ -70,6 +65,12 @@ const moduleConfig = {
 
 QUnit.module('Scenarios', moduleConfig, () => {
     const topLeft = { row: 2, column: 3 };
+    const epsilon = browser.chrome ? 1.15 : 4;
+
+    const toExcelWidth = (width) => {
+        const excelWidth = parseFloat(width) / Export.__internals.MAX_DIGIT_WIDTH_IN_PIXELS;
+        return Math.floor(excelWidth * 100) / 100;
+    };
 
     const getOptions = (context, pivotGrid, expectedCustomizeCellArgs, options) => {
         const { keepColumnWidths = true, selectedRowsOnly = false, topLeftCell = topLeft } = options || {};
@@ -92,7 +93,9 @@ QUnit.module('Scenarios', moduleConfig, () => {
     QUnit.test('Empty pivot', function(assert) {
         const done = assert.async();
 
-        const pivotGrid = $('#pivotGrid').dxPivotGrid({}).dxPivotGrid('instance');
+        const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000
+        }).dxPivotGrid('instance');
 
         const expectedCells = [[
             { excelCell: { value: '', alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 1, text: '', width: 100 } },
@@ -106,7 +109,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -132,6 +135,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -149,7 +153,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -176,6 +180,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataFieldArea: 'column',
@@ -200,7 +205,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(345), toExcelWidth(584)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -227,6 +232,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataFieldArea: 'row',
@@ -251,7 +257,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -278,6 +284,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -301,7 +308,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(457), toExcelWidth(472)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -330,6 +337,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -353,7 +361,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(457), toExcelWidth(472)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -380,6 +388,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -403,7 +412,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -432,6 +441,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -455,7 +465,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -483,6 +493,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -514,7 +525,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(422), toExcelWidth(436)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -544,6 +555,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -575,7 +587,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(422), toExcelWidth(436)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -599,6 +611,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -619,7 +632,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 1 }, { row: 3, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -646,6 +659,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -666,7 +680,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 1 }, { row: 3, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -691,6 +705,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -711,7 +726,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 2 }, { row: 3, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -739,6 +754,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -759,7 +775,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 2 }, { row: 3, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -784,6 +800,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -807,7 +824,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(448), toExcelWidth(481)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -835,6 +852,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -858,7 +876,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(448), toExcelWidth(481)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -886,6 +904,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -913,7 +932,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 4, column: 3 }, { row: 4, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(457), toExcelWidth(472)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -942,6 +961,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -969,7 +989,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 4, column: 3 }, { row: 4, column: 3 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(457), toExcelWidth(472)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -997,6 +1017,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: true,
             showRowGrandTotals: true,
             dataSource: ds
@@ -1066,6 +1087,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: true,
             showRowGrandTotals: true,
             rtlEnabled: true,
@@ -1108,7 +1130,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 5, column: 5 }, { row: 5, column: 5 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(71), toExcelWidth(70), toExcelWidth(169), toExcelWidth(277), toExcelWidth(412)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -1134,6 +1156,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -1151,7 +1174,6 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -1259,7 +1281,6 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1344,7 +1365,6 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
                 exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                     helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-                    helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
                     helper.checkFont(expectedCells);
                     helper.checkAlignment(expectedCells);
                     helper.checkValues(expectedCells);
@@ -1373,6 +1393,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             wordWrapEnabled: false,
@@ -1391,7 +1412,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -1418,6 +1439,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
         };
 
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -1435,7 +1457,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -1467,6 +1489,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             }
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
                 dataSource: ds,
@@ -1501,7 +1524,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(296), toExcelWidth(292), toExcelWidth(341)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1527,6 +1550,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             ]
         };
         const pivotGrid = $('#pivotGrid').dxPivotGrid({
+            width: 1000,
             showColumnGrandTotals: false,
             showRowGrandTotals: false,
             dataSource: ds
@@ -1544,7 +1568,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
         exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
             helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-            helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+            helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
             helper.checkFont(expectedCells);
             helper.checkAlignment(expectedCells);
             helper.checkValues(expectedCells);
@@ -1558,7 +1582,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, newTopLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells, { topLeftCell: newTopLeft })).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 2, column: 2 }, newTopLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], newTopLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1587,6 +1611,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 rowHeaderLayout: 'standard',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
@@ -1594,7 +1619,6 @@ QUnit.module('Scenarios', moduleConfig, () => {
                 showRowTotals: false,
                 dataSource: ds
             }).dxPivotGrid('instance');
-
             const expectedCells = [[
                 { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 2, rowspan: 1, text: '', width: 100 } },
                 { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 1, text: '', width: 100 } },
@@ -1609,7 +1633,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 2, column: 3 }, { row: 2, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1636,6 +1660,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 rowHeaderLayout: 'tree',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
@@ -1653,7 +1678,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
                 { excelCell: { value: 'r1 Total', master: [2, 1], alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, isLast: true, path: ['r1'], text: '', type: 'T', dataSourceIndex: 1, expanded: true } },
                 { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, rowspan: 1, columnPath: ['c1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['r1'], rowType: 'T', text: '1' } },
             ], [
-                { excelCell: { value: 'r1', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, path: ['r1'], text: 'r1', type: 'D', dataSourceIndex: 1, isWhiteSpace: true, width: null } },
+                { excelCell: { value: '', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, path: ['r1'], text: 'r1', type: 'D', dataSourceIndex: 1, isWhiteSpace: true, width: null } },
                 { excelCell: { value: 'r2', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, isLast: true, path: ['r1', 'r2'], text: 'r2', type: 'D', dataSourceIndex: 2 } },
                 { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, rowspan: 1, columnPath: ['c1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['r1', 'r2'], rowType: 'D', text: '1' } },
             ]];
@@ -1662,7 +1687,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(19), toExcelWidth(71), toExcelWidth(909)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1689,6 +1714,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 rowHeaderLayout: 'standard',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
@@ -1715,7 +1741,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1742,6 +1768,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 rowHeaderLayout: 'tree',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
@@ -1759,7 +1786,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
                 { excelCell: { value: 'r1 Total', master: [2, 1], alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, isLast: true, path: ['r1'], text: '', type: 'T', dataSourceIndex: 1, expanded: true } },
                 { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, rowspan: 1, columnPath: ['c1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['r1'], rowType: 'T', text: '1' } },
             ], [
-                { excelCell: { value: 'r1', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, path: ['r1'], text: 'r1', type: 'D', dataSourceIndex: 1, isWhiteSpace: true, width: null } },
+                { excelCell: { value: '', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, path: ['r1'], text: 'r1', type: 'D', dataSourceIndex: 1, isWhiteSpace: true, width: null } },
                 { excelCell: { value: 'r2', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, isLast: true, path: ['r1', 'r2'], text: 'r2', type: 'D', dataSourceIndex: 2 } },
                 { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, rowspan: 1, columnPath: ['c1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['r1', 'r2'], rowType: 'D', text: '1' } },
             ]];
@@ -1768,7 +1795,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(19), toExcelWidth(71), toExcelWidth(909)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1795,6 +1822,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 rowHeaderLayout: 'standard',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: true,
@@ -1825,7 +1853,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 3 }, { row: 4, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1852,6 +1880,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 rowHeaderLayout: 'tree',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: true,
@@ -1869,7 +1898,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
                 { excelCell: { value: 'r1 Total', master: [2, 1], alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, isLast: true, path: ['r1'], text: '', type: 'T', dataSourceIndex: 1, expanded: true } },
                 { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, rowspan: 1, columnPath: ['c1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['r1'], rowType: 'T', text: '1' } },
             ], [
-                { excelCell: { value: 'r1', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, path: ['r1'], text: 'r1', type: 'D', dataSourceIndex: 1, isWhiteSpace: true, width: null } },
+                { excelCell: { value: '', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, path: ['r1'], text: 'r1', type: 'D', dataSourceIndex: 1, isWhiteSpace: true, width: null } },
                 { excelCell: { value: 'r2', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, isLast: true, path: ['r1', 'r2'], text: 'r2', type: 'D', dataSourceIndex: 2 } },
                 { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, rowspan: 1, columnPath: ['c1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['r1', 'r2'], rowType: 'D', text: '1' } },
             ], [
@@ -1882,7 +1911,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 3 }, { row: 4, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(19), toExcelWidth(71), toExcelWidth(909)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1909,6 +1938,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 rowHeaderLayout: 'standard',
                 showTotalsPrior: 'rows',
                 showColumnGrandTotals: false,
@@ -1941,7 +1971,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 3 }, { row: 4, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -1968,6 +1998,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 rowHeaderLayout: 'tree',
                 showTotalsPrior: 'rows',
                 showColumnGrandTotals: false,
@@ -1990,7 +2021,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
                 { excelCell: { value: 'r1 Total', master: [3, 1], alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, isLast: true, path: ['r1'], text: '', type: 'T', dataSourceIndex: 1, expanded: true } },
                 { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, rowspan: 1, columnPath: ['c1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['r1'], rowType: 'T', text: '1' } },
             ], [
-                { excelCell: { value: 'r1', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, path: ['r1'], text: 'r1', type: 'D', dataSourceIndex: 1, isWhiteSpace: true, width: null } },
+                { excelCell: { value: '', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, path: ['r1'], text: 'r1', type: 'D', dataSourceIndex: 1, isWhiteSpace: true, width: null } },
                 { excelCell: { value: 'r2', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, rowspan: 1, isLast: true, path: ['r1', 'r2'], text: 'r2', type: 'D', dataSourceIndex: 2 } },
                 { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, rowspan: 1, columnPath: ['c1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['r1', 'r2'], rowType: 'D', text: '1' } },
             ]];
@@ -1999,7 +2030,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 3 }, { row: 4, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(19), toExcelWidth(71), toExcelWidth(909)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2007,6 +2038,72 @@ QUnit.module('Scenarios', moduleConfig, () => {
                 helper.checkOutlineLevel([0, 0, 0], topLeft.row);
                 helper.checkAutoFilter(false, { from: topLeft, to: topLeft }, { state: 'frozen', ySplit: topLeft.row, xSplit: topLeft.column + 1 });
                 helper.checkCellRange(cellRange, { row: 4, column: 3 }, topLeft);
+                done();
+            });
+        });
+
+        QUnit.test('Export [row1,row2,row3 x col1 x data] & rowHeaderLayout = tree & showRowTotals & showRowGrandTotals', function(assert) {
+            const done = assert.async();
+            const ds = {
+                fields: [
+                    { area: 'row', dataField: 'row1', dataType: 'string', expanded: true },
+                    { area: 'row', dataField: 'row2', dataType: 'string', expanded: true },
+                    { area: 'row', dataField: 'row3', dataType: 'string', expanded: true },
+                    { area: 'column', dataField: 'col1', dataType: 'string', expanded: true },
+                    { area: 'data', summaryType: 'count', dataType: 'number' }
+                ],
+                store: [
+                    { row1: 'r1', row2: 'r2', row3: 'r3', col1: 'c1', col2: 'c2' },
+                ]
+            };
+
+            const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
+                rowHeaderLayout: 'tree',
+                showColumnGrandTotals: false,
+                showRowGrandTotals: true,
+                showColumnTotals: false,
+                showRowTotals: true,
+                dataSource: ds
+            }).dxPivotGrid('instance');
+            const expectedCells = [[
+                { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 3, rowspan: 1, text: '', width: 100 } },
+                { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 1, text: '', width: 100 } },
+                { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 1, text: '', width: 100 } },
+                { excelCell: { value: 'c1', alignment: alignCenterTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: 'c1', width: 100, path: ['c1'], type: 'D', isLast: true, dataSourceIndex: 1, area: 'column' } },
+            ], [
+                { excelCell: { value: 'r1 Total', master: [2, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 3, rowspan: 1, text: 'r1 Total', path: ['r1'], type: 'T', isLast: true, dataSourceIndex: 1, area: 'row', expanded: true } },
+                { excelCell: { value: 'r1 Total', master: [2, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '', path: ['r1'], type: 'T', isLast: true, dataSourceIndex: 1, area: 'row', expanded: true } },
+                { excelCell: { value: 'r1 Total', master: [2, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '', path: ['r1'], type: 'T', isLast: true, dataSourceIndex: 1, area: 'row', expanded: true } },
+                { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '1', rowPath: ['r1'], columnPath: ['c1'], dataIndex: 0, area: 'data', dataType: 'number', rowType: 'T', columnType: 'D' } },
+            ], [
+                { excelCell: { value: '', master: [3, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 2, text: 'r1', width: null, path: ['r1'], type: 'D', dataSourceIndex: 1, area: 'row', isWhiteSpace: true } },
+                { excelCell: { value: 'r2 Total', master: [3, 2], alignment: alignLeftTopWrap }, pivotCell: { colspan: 2, rowspan: 1, text: 'r2 Total', path: ['r1', 'r2'], type: 'T', isLast: true, dataSourceIndex: 2, area: 'row', expanded: true } },
+                { excelCell: { value: 'r2 Total', master: [3, 2], alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '', path: ['r1', 'r2'], type: 'T', isLast: true, dataSourceIndex: 2, area: 'row', expanded: true } },
+                { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '1', rowPath: ['r1', 'r2'], columnPath: ['c1'], dataIndex: 0, area: 'data', dataType: 'number', rowType: 'T', columnType: 'D' } },
+            ], [
+                { excelCell: { value: '', master: [3, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '', width: null, path: ['r1'], type: 'D', dataSourceIndex: 1, area: 'row', isWhiteSpace: true } },
+                { excelCell: { value: '', alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: 'r2', width: null, path: ['r1', 'r2'], type: 'D', dataSourceIndex: 2, area: 'row', isWhiteSpace: true } },
+                { excelCell: { value: 'r3', alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: 'r3', path: ['r1', 'r2', 'r3'], type: 'D', isLast: true, dataSourceIndex: 3, area: 'row' } },
+                { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '1', rowPath: ['r1', 'r2', 'r3'], columnPath: ['c1'], dataIndex: 0, area: 'data', dataType: 'number', rowType: 'D', columnType: 'D' } },
+            ], [
+                { excelCell: { value: 'Grand Total', master: [5, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 3, rowspan: 1, text: 'Grand Total', type: 'GT', isLast: true, area: 'row' } },
+                { excelCell: { value: 'Grand Total', master: [5, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '', type: 'GT', isLast: true, area: 'row' } },
+                { excelCell: { value: 'Grand Total', master: [5, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '', type: 'GT', isLast: true, area: 'row' } },
+                { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '1', rowPath: [], columnPath: ['c1'], dataIndex: 0, area: 'data', dataType: 'number', rowType: 'GT', columnType: 'D' } },
+            ]];
+
+            helper.extendExpectedCells(expectedCells, topLeft);
+            exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
+                helper.checkRowAndColumnCount({ row: 5, column: 4 }, { row: 5, column: 4 }, topLeft);
+                helper.checkColumnWidths([toExcelWidth(19), toExcelWidth(20), toExcelWidth(71), toExcelWidth(889)], topLeft.column, epsilon);
+                helper.checkFont(expectedCells);
+                helper.checkAlignment(expectedCells);
+                helper.checkValues(expectedCells);
+                helper.checkMergeCells(expectedCells, topLeft);
+                helper.checkOutlineLevel([0, 0, 0], topLeft.row);
+                helper.checkAutoFilter(false, { from: topLeft, to: topLeft }, { state: 'frozen', ySplit: topLeft.row, xSplit: topLeft.column + 2 });
+                helper.checkCellRange(cellRange, { row: 5, column: 4 }, topLeft);
                 done();
             });
         });
@@ -2029,6 +2126,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
                 showColumnTotals: false,
@@ -2050,7 +2148,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 2, column: 3 }, { row: 2, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2077,6 +2175,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
                 showColumnTotals: false,
@@ -2102,7 +2201,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2129,6 +2228,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: true,
                 showColumnTotals: false,
@@ -2158,7 +2258,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 3 }, { row: 4, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2185,6 +2285,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: false,
@@ -2218,7 +2319,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(234), toExcelWidth(624)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2245,6 +2346,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: false,
@@ -2264,7 +2366,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2291,6 +2393,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: false,
@@ -2316,7 +2419,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
 
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2343,6 +2446,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
                 showColumnTotals: false,
@@ -2364,7 +2468,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 2 }, { row: 3, column: 2 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2391,6 +2495,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
                 showColumnTotals: true,
@@ -2415,7 +2520,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(361), toExcelWidth(568)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2442,6 +2547,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -2470,7 +2576,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 3 }, { row: 4, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(361), toExcelWidth(568)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2497,6 +2603,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -2529,7 +2636,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(198), toExcelWidth(311), toExcelWidth(420)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2556,6 +2663,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -2580,7 +2688,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(361), toExcelWidth(568)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2607,6 +2715,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -2625,7 +2734,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2653,6 +2762,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
                 showColumnTotals: false,
@@ -2677,7 +2787,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(858)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2705,6 +2815,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
                 showColumnTotals: true,
@@ -2732,7 +2843,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 4 }, { row: 3, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(334), toExcelWidth(524)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2760,6 +2871,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: false,
                 showColumnTotals: true,
@@ -2790,7 +2902,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 5 }, { row: 3, column: 5 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(183), toExcelWidth(287), toExcelWidth(388)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2818,6 +2930,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -2854,7 +2967,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 5 }, { row: 4, column: 5 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(183), toExcelWidth(287), toExcelWidth(388)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2882,6 +2995,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -2909,7 +3023,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 3, column: 4 }, { row: 3, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(334), toExcelWidth(524)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2937,6 +3051,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -2955,7 +3070,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -2983,6 +3098,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
                 showColumnTotals: true,
@@ -3015,7 +3131,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(334), toExcelWidth(524)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -3043,6 +3159,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: false,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -3080,7 +3197,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 5, column: 4 }, { row: 5, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(334), toExcelWidth(524)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -3108,6 +3225,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -3150,7 +3268,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 5, column: 5 }, { row: 5, column: 5 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(183), toExcelWidth(287), toExcelWidth(388)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -3178,6 +3296,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -3210,7 +3329,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(334), toExcelWidth(524)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -3238,6 +3357,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showColumnGrandTotals: true,
                 showRowGrandTotals: true,
                 showColumnTotals: true,
@@ -3256,7 +3376,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(929)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -3284,6 +3404,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showTotalsPrior: 'columns',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
@@ -3317,7 +3438,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(584), toExcelWidth(274)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -3345,6 +3466,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showTotalsPrior: 'rows',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
@@ -3378,7 +3500,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(334), toExcelWidth(524)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -3406,6 +3528,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             };
 
             const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
                 showTotalsPrior: 'both',
                 showColumnGrandTotals: false,
                 showRowGrandTotals: false,
@@ -3439,7 +3562,7 @@ QUnit.module('Scenarios', moduleConfig, () => {
             helper.extendExpectedCells(expectedCells, topLeft);
             exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
                 helper.checkRowAndColumnCount({ row: 4, column: 4 }, { row: 4, column: 4 }, topLeft);
-                helper.checkColumnWidths([excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels, excelColumnWidthFromColumn100Pixels], topLeft.column);
+                helper.checkColumnWidths([toExcelWidth(70), toExcelWidth(71), toExcelWidth(584), toExcelWidth(274)], topLeft.column, epsilon);
                 helper.checkFont(expectedCells);
                 helper.checkAlignment(expectedCells);
                 helper.checkValues(expectedCells);
@@ -3447,6 +3570,211 @@ QUnit.module('Scenarios', moduleConfig, () => {
                 helper.checkOutlineLevel([0, 0, 0, 0], topLeft.row);
                 helper.checkAutoFilter(false, { from: topLeft, to: topLeft }, { state: 'frozen', ySplit: topLeft.row + 1, xSplit: topLeft.column + 1 });
                 helper.checkCellRange(cellRange, { row: 4, column: 4 }, topLeft);
+                done();
+            });
+        });
+    });
+
+    QUnit.module('fields[].width', moduleConfig, () => {
+        const PADDING_WIDTH = 10;
+        const BORDER_WIDTH = 1;
+        const CHAR_WIDTH = 7;
+
+        [1000, 600, 300, 50].forEach(pivotWidth => {
+            [200, 100, undefined].forEach(columnWidth => {
+                QUnit.test(`Export [row1.width=100,column1.width=${columnWidth}], grid.width=${pivotWidth}`, function(assert) {
+                    const done = assert.async();
+                    const ds = {
+                        fields: [
+                            { area: 'row', dataField: 'row1', dataType: 'string', width: 100 },
+                            { area: 'column', dataField: 'col1', dataType: 'string', width: columnWidth },
+                            { area: 'data', summaryType: 'count', dataType: 'number' }
+                        ],
+                        store: [
+                            { row1: 'A', row2: 'B', col1: 'a' },
+                        ]
+                    };
+
+                    const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                        width: pivotWidth,
+                        showColumnGrandTotals: false,
+                        showRowGrandTotals: false,
+                        dataSource: ds
+                    }).dxPivotGrid('instance');
+
+                    const expectedCells = [[
+                        { excelCell: { value: '', alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 1, text: '', width: 100 } },
+                        { excelCell: { value: 'a', alignment: alignCenterTopWrap }, pivotCell: { area: 'column', colspan: 1, dataSourceIndex: 1, isLast: true, path: ['a'], rowspan: 1, text: 'a', type: 'D', width: 100 } }
+                    ], [
+                        { excelCell: { value: 'A', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, dataSourceIndex: 1, isLast: true, path: ['A'], rowspan: 1, text: 'A', type: 'D', width: 100 } },
+                        { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, columnPath: ['a'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['A'], rowType: 'D', rowspan: 1, text: '1' } }
+                    ]];
+
+                    helper.extendExpectedCells(expectedCells, topLeft);
+                    exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then(() => {
+                        const rowWidth = 100 + 2 * PADDING_WIDTH;
+                        const minColumnWidth = (columnWidth || CHAR_WIDTH) + 2 * PADDING_WIDTH + BORDER_WIDTH;
+                        let expectedColumnWidth = pivotWidth - rowWidth - BORDER_WIDTH;
+                        if(expectedColumnWidth < minColumnWidth) {
+                            expectedColumnWidth = minColumnWidth;
+                        }
+                        helper.checkColumnWidths([toExcelWidth(rowWidth), toExcelWidth(expectedColumnWidth)], topLeft.column, epsilon);
+                        helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
+                        done();
+                    });
+                });
+
+                QUnit.test(`Export [row1.width=100,row2=150,column1.width=${columnWidth}], grid.width=${pivotWidth}`, function(assert) {
+                    const done = assert.async();
+                    const ds = {
+                        fields: [
+                            { area: 'row', dataField: 'row1', dataType: 'string', width: 100, expanded: true },
+                            { area: 'row', dataField: 'row2', dataType: 'string', width: 150 },
+                            { area: 'column', dataField: 'col1', dataType: 'string', width: columnWidth },
+                            { area: 'data', summaryType: 'count', dataType: 'number' }
+                        ],
+                        store: [
+                            { row1: 'A', row2: 'B', col1: 'a' },
+                        ]
+                    };
+
+                    const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                        width: pivotWidth,
+                        showColumnGrandTotals: false,
+                        showRowGrandTotals: false,
+                        dataSource: ds
+                    }).dxPivotGrid('instance');
+
+                    const expectedCells = [[
+                        { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 2, rowspan: 1, text: '', width: 100 } },
+                        { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 1, text: '', width: 100 } },
+                        { excelCell: { value: 'a', alignment: alignCenterTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: 'a', width: 100, path: ['a'], type: 'D', isLast: true, dataSourceIndex: 1, area: 'column' } },
+                    ], [
+                        { excelCell: { value: 'A', alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: 'A', width: 100, path: ['A'], type: 'D', dataSourceIndex: 1, area: 'row', expanded: true } },
+                        { excelCell: { value: 'B', alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: 'B', width: 150, path: ['A', 'B'], type: 'D', isLast: true, dataSourceIndex: 2, area: 'row' } },
+                        { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '1', rowPath: ['A', 'B'], columnPath: ['a'], area: 'data', dataIndex: 0, dataType: 'number', rowType: 'D', columnType: 'D' } },
+                    ], [
+                        { excelCell: { value: 'A Total', master: [3, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 2, rowspan: 1, text: 'A Total', path: ['A'], type: 'T', isLast: true, dataSourceIndex: 1, area: 'row' } },
+                        { excelCell: { value: 'A Total', master: [3, 1], alignment: alignLeftTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '', path: ['A'], type: 'T', isLast: true, dataSourceIndex: 1, area: 'row' } },
+                        { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { colspan: 1, rowspan: 1, text: '1', rowPath: ['A'], columnPath: ['a'], area: 'data', dataIndex: 0, dataType: 'number', rowType: 'T', columnType: 'D' } },
+                    ]];
+
+                    helper.extendExpectedCells(expectedCells, topLeft);
+                    exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then(() => {
+                        const row1Width = 100 + 2 * PADDING_WIDTH;
+                        const row2Width = 150 + 2 * PADDING_WIDTH + BORDER_WIDTH;
+                        const minColumnWidth = (columnWidth || CHAR_WIDTH) + 2 * PADDING_WIDTH + BORDER_WIDTH;
+                        let expectedColumnWidth = pivotWidth - row1Width - row2Width - BORDER_WIDTH;
+                        if(expectedColumnWidth < minColumnWidth) {
+                            expectedColumnWidth = minColumnWidth;
+                        }
+                        helper.checkColumnWidths([toExcelWidth(row1Width), toExcelWidth(row2Width), toExcelWidth(expectedColumnWidth)], topLeft.column, epsilon);
+                        helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    QUnit.module('ScrollingMode = virtual', moduleConfig, () => {
+        QUnit.test('Export [string x string x number]', function(assert) {
+            const done = assert.async();
+            const ds = {
+                fields: [
+                    { area: 'row', dataField: 'row1', dataType: 'string' },
+                    { area: 'column', dataField: 'col1', dataType: 'string' },
+                    { area: 'data', summaryType: 'count', dataType: 'number' }
+                ],
+                store: [
+                    { row1: 'A', col1: 'a' },
+                ]
+            };
+
+            const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
+                showColumnGrandTotals: false,
+                showRowGrandTotals: false,
+                dataSource: ds,
+                scrolling: {
+                    mode: 'virtual'
+                }
+            }).dxPivotGrid('instance');
+
+            const expectedCells = [[
+                { excelCell: { value: '', alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 1, text: '', width: 100 } },
+                { excelCell: { value: 'a', alignment: alignCenterTopWrap }, pivotCell: { area: 'column', colspan: 1, dataSourceIndex: 1, isLast: true, path: ['a'], rowspan: 1, text: 'a', type: 'D', width: 100 } }
+            ], [
+                { excelCell: { value: 'A', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, dataSourceIndex: 1, isLast: true, path: ['A'], rowspan: 1, text: 'A', type: 'D' } },
+                { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, columnPath: ['a'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['A'], rowType: 'D', rowspan: 1, text: '1' } }
+            ]];
+
+            helper.extendExpectedCells(expectedCells, topLeft);
+            exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
+                helper.checkRowAndColumnCount({ row: 2, column: 2 }, { row: 2, column: 2 }, topLeft);
+                helper.checkColumnWidths([toExcelWidth(PivotGridExport.DEFAUL_COLUMN_WIDTH), toExcelWidth(PivotGridExport.DEFAUL_COLUMN_WIDTH)], topLeft.column, epsilon);
+                helper.checkFont(expectedCells);
+                helper.checkAlignment(expectedCells);
+                helper.checkValues(expectedCells);
+                helper.checkMergeCells(expectedCells, topLeft);
+                helper.checkOutlineLevel([0, 0], topLeft.row);
+                helper.checkAutoFilter(false, { from: topLeft, to: topLeft }, { state: 'frozen', ySplit: topLeft.row, xSplit: topLeft.column });
+                helper.checkCellRange(cellRange, { row: 2, column: 2 }, topLeft);
+                done();
+            });
+        });
+
+        QUnit.test('Export [string x string/string(a1,a2) x number]', function(assert) {
+            const done = assert.async();
+            const ds = {
+                fields: [
+                    { area: 'row', dataField: 'row1', dataType: 'string' },
+                    { area: 'column', dataField: 'col1', dataType: 'string', expanded: true, showTotals: false },
+                    { area: 'column', dataField: 'col2', dataType: 'string' },
+                    { area: 'data', summaryType: 'count', dataType: 'number' }
+                ],
+                store: [
+                    { row1: 'A', col1: 'a', col2: 'a1' },
+                    { row1: 'A', col1: 'a', col2: 'a2' },
+                    { row1: 'A', col1: 'a', col2: 'a2' },
+                ]
+            };
+
+            const pivotGrid = $('#pivotGrid').dxPivotGrid({
+                width: 1000,
+                showColumnGrandTotals: false,
+                showRowGrandTotals: false,
+                dataSource: ds,
+                scrolling: {
+                    mode: 'virtual'
+                }
+            }).dxPivotGrid('instance');
+
+            const expectedCells = [[
+                { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 2, text: '' } },
+                { excelCell: { value: 'a', master: [1, 2], alignment: alignCenterTopWrap }, pivotCell: { area: 'column', colspan: 2, dataSourceIndex: 1, expanded: true, path: ['a'], rowspan: 1, text: 'a', type: 'D' } },
+                { excelCell: { value: 'a', master: [1, 2], alignment: alignCenterTopWrap }, pivotCell: { area: 'column', colspan: 1, dataSourceIndex: 1, expanded: true, path: ['a'], rowspan: 1, text: '', type: 'D' } }
+            ], [
+                { excelCell: { value: '', master: [1, 1], alignment: alignCenterTopWrap }, pivotCell: { alignment: 'left', colspan: 1, rowspan: 1, text: '', width: 100 } },
+                { excelCell: { value: 'a1', alignment: alignCenterTopWrap }, pivotCell: { area: 'column', colspan: 1, dataSourceIndex: 2, isLast: true, path: ['a', 'a1'], rowspan: 1, text: 'a1', type: 'D', width: 100 } },
+                { excelCell: { value: 'a2', alignment: alignCenterTopWrap }, pivotCell: { area: 'column', colspan: 1, dataSourceIndex: 3, isLast: true, path: ['a', 'a2'], rowspan: 1, text: 'a2', type: 'D', width: 100 } }
+            ], [
+                { excelCell: { value: 'A', alignment: alignLeftTopWrap }, pivotCell: { area: 'row', colspan: 1, dataSourceIndex: 1, isLast: true, path: ['A'], rowspan: 1, text: 'A', type: 'D' } },
+                { excelCell: { value: 1, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, columnPath: ['a', 'a1'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['A'], rowType: 'D', rowspan: 1, text: '1' } },
+                { excelCell: { value: 2, alignment: alignRightTopWrap }, pivotCell: { area: 'data', colspan: 1, columnPath: ['a', 'a2'], columnType: 'D', dataIndex: 0, dataType: 'number', format: undefined, rowPath: ['A'], rowType: 'D', rowspan: 1, text: '2' } }
+            ]];
+
+            helper.extendExpectedCells(expectedCells, topLeft);
+            exportPivotGrid(getOptions(this, pivotGrid, expectedCells)).then((cellRange) => {
+                helper.checkRowAndColumnCount({ row: 3, column: 3 }, { row: 3, column: 3 }, topLeft);
+                helper.checkColumnWidths([toExcelWidth(PivotGridExport.DEFAUL_COLUMN_WIDTH), toExcelWidth(PivotGridExport.DEFAUL_COLUMN_WIDTH), toExcelWidth(PivotGridExport.DEFAUL_COLUMN_WIDTH)], topLeft.column, epsilon);
+                helper.checkFont(expectedCells);
+                helper.checkAlignment(expectedCells);
+                helper.checkValues(expectedCells);
+                helper.checkMergeCells(expectedCells, topLeft);
+                helper.checkOutlineLevel([0, 0, 0], topLeft.row);
+                helper.checkAutoFilter(false, { from: topLeft, to: topLeft }, { state: 'frozen', ySplit: topLeft.row + 1, xSplit: topLeft.column });
+                helper.checkCellRange(cellRange, { row: 3, column: 3 }, topLeft);
                 done();
             });
         });


### PR DESCRIPTION
* Initial realization of keepColumnsWidth for pivotGrid

* Updated tests for a keepColumnWidths option

* Small refactoring

* Fix implementation for datagrid

* Fix test in FF

* Fix terst in FF

* Fix export with server side rendering

* Fix tests for FF

* Tests for field width option

* virtual scrolling support

* Fix rowHeaderLayout for tree value

* Bugfix of undefined value

* Use only static data for tests

* Check multiple grid width

* Fix test for different font rendering engine

* Fix tests for ci environment

* Small fix

* Even more test cases

* Small renaming

