### PR TITLE
Fix the detection of required numbers when formatting by LDML template (T907216)

### DIFF
--- a/js/localization/ldml/number.js
+++ b/js/localization/ldml/number.js
@@ -31,14 +31,20 @@ function isPercentFormat(format) {
     return format.indexOf('%') !== -1 && !format.match(/'[^']*%[^']*'/g);
 }
 
+function removeStubs(str) {
+    return str.replace(/'.+'/g, '');
+}
+
 function getNonRequiredDigitCount(floatFormat) {
     if(!floatFormat) return 0;
-    return floatFormat.length - floatFormat.replace(/[#]/g, '').length;
+    const format = removeStubs(floatFormat);
+    return format.length - format.replace(/[#]/g, '').length;
 }
 
 function getRequiredDigitCount(floatFormat) {
     if(!floatFormat) return 0;
-    return floatFormat.length - floatFormat.replace(/[0]/g, '').length;
+    const format = removeStubs(floatFormat);
+    return format.length - format.replace(/[0]/g, '').length;
 }
 
 function normalizeValueString(valuePart, minDigitCount, maxDigitCount) {

--- a/testing/tests/DevExpress.localization/ldml.tests.js
+++ b/testing/tests/DevExpress.localization/ldml.tests.js
@@ -346,6 +346,14 @@ QUnit.module('number formatter', () => {
         }, '#0.00');
     });
 
+    QUnit.test('escaped zero should not specify the formatter precision', function(assert) {
+        const zeroFormatter = getNumberFormatter('\'00\'0.0\'00\'');
+        const sharpFormatter = getNumberFormatter('\'#,##\'0.0\'##\'');
+
+        assert.strictEqual(zeroFormatter(1234.1234), '004.100', 'take into account non-escaped symbols only');
+        assert.strictEqual(sharpFormatter(1234.123), '#,##4.1##', 'take into account non-escaped symbols only');
+    });
+
     QUnit.module('getRegExpInfo method');
 
     QUnit.test('getRegExpInfo should return correct pattern set when stub is in the end', function(assert) {


### PR DESCRIPTION
Issue
--

The use of escaped characters "0" and "#" leads to incorrect determination of the number of required characters.

How to reproduce
--

`DevExpress.localization.formatNumber(1.123, "0.0'0'")`
Result -> "1.120"
Expected -> "1.10"
`DevExpress.localization.formatNumber(1.123, "0.0'#'")`
Result -> "1.12#"
Expected -> "1.1#"