### PR TITLE
DataGrid/TreeList - Fixes wrapping command buttons by the edit command column

### DIFF
--- a/styles/widgets/common/gridBase.less
+++ b/styles/widgets/common/gridBase.less
@@ -498,6 +498,7 @@
                 text-overflow: clip;
                 width: @GRID_COMMAND_EDIT_COLUMN_WIDTH;
                 min-width: @GRID_COMMAND_EDIT_COLUMN_WIDTH;
+                white-space: nowrap;
 
                 &.dx-command-edit-with-icons {
                     width: @GRID_COMMAND_EDIT_COLUMN_WITH_ICONS_WIDTH;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -542,11 +542,12 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         });
     });
 
+
     [false, true].forEach((useIcons) => {
         QUnit.test(`Command buttons should be rendered with RTL when useIcons=${useIcons} (T915926)`, function(assert) {
             // arrange
             const columnsWrapper = dataGridWrapper.columns;
-            createDataGrid({
+            const dataGrid = createDataGrid({
                 rtlEnabled: true,
                 dataSource: [{ id: 0, c0: 'c0' }],
                 editing: {
@@ -558,14 +559,42 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
             this.clock.tick();
 
-            // assert
             const $buttons = columnsWrapper.getCommandButtons();
+            const $commandCell = $(dataGrid.getCellElement(0, 0));
 
+            // assert
+            assert.ok($commandCell.length, 'command cell is rendered');
+            assert.equal($commandCell.css('white-space'), 'nowrap', 'white-space style');
             assert.equal($buttons.length, 2, 'command buttons are rendered');
             $buttons.each((_, button) => {
                 assert.equal($(button).css('display'), 'inline-block', 'display style');
                 assert.equal($(button).css('direction'), 'rtl', 'direction style');
             });
+        });
+
+        QUnit.test(`Edit command column should not wrap command buttons when useIcons=${useIcons}`, function(assert) {
+            // arrange
+            const dataGrid = createDataGrid({
+                dataSource: [{}],
+                editing: {
+                    allowUpdating: true,
+                    allowDeleting: true,
+                    useIcons
+                },
+                columns: [
+                    {
+                        type: 'buttons'
+                    }
+                ]
+            });
+
+            this.clock.tick();
+
+            // assert
+            const $commandCell = $(dataGrid.getCellElement(0, 0));
+
+            assert.ok($commandCell.length, 'command cell is rendered');
+            assert.equal($commandCell.css('white-space'), 'nowrap', 'white-space style');
         });
     });
 


### PR DESCRIPTION
Added the **white-space** style that equals **nowrap** to the **dx-command-edit** CSS rule.
