### PR TITLE
DataGrid - Fixes cell navigation when a left arrow key is pressed on an adaptive cell (T916621)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1332,13 +1332,13 @@ const KeyboardNavigationController = core.ViewController.inherit({
         const focusedCellPosition = cellPosition || this._focusedCellPosition;
         const isRowFocusType = this.isRowFocusType();
         const includeCommandCells = isRowFocusType || inArray(keyCode, ['next', 'previous']) > -1;
-        const isLastCellOnDirection = keyCode === 'previous' ? this._isFirstValidCell(focusedCellPosition) : this._isLastValidCell(focusedCellPosition);
         let $cell;
         let $row;
 
         if(this._focusedView && focusedCellPosition) {
             const newFocusedCellPosition = this._getNewPositionByCode(focusedCellPosition, elementType, keyCode);
             $cell = $(this._getCell(newFocusedCellPosition));
+            const isLastCellOnDirection = keyCode === 'previous' ? this._isFirstValidCell(newFocusedCellPosition) : this._isLastValidCell(newFocusedCellPosition);
 
             if(isElementDefined($cell) && !this._isCellValid($cell) && this._isCellInRow(newFocusedCellPosition, includeCommandCells) && !isLastCellOnDirection) {
                 if(isRowFocusType) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -728,4 +728,42 @@ QUnit.module('View\'s focus', {
         assert.notOk(onFocusedCellChanged.called, 'onFocusedCellChanged is not called');
         assert.notOk(onFocusedRowChanged.called, 'onFocusedRowChanged is not called');
     });
+
+    QUnit.test('Data cell should be focused correctly when a left arrow key is pressed on an adaptive cell in the last data row (T916621)', function(assert) {
+        // arrange
+        this.dataGrid.dispose();
+        const dataGrid = createDataGrid({
+            columnHidingEnabled: true,
+            dataSource: [
+                { id: 1, name: 'name1' }
+            ],
+            keyExpr: 'id',
+            columns: ['id', { dataField: 'name', width: 120 }],
+            width: 120
+        });
+
+        this.clock.tick();
+
+        const $cell0 = $(dataGrid.getCellElement(0, 0));
+        $cell0.trigger(CLICK_EVENT).trigger('dxclick');
+
+        let keyboard = keyboardMock($cell0);
+        keyboard.keyDown('right');
+        this.clock.tick();
+
+        const $cell1 = $(dataGrid.getCellElement(0, 2));
+
+        // assert
+        assert.notOk($cell0.hasClass('dx-focused'), 'cell is not focused');
+        assert.ok($cell1.hasClass('dx-command-adaptive'), 'adaptive cell');
+        assert.ok($cell1.hasClass('dx-focused'), 'cell is focused');
+
+
+        keyboard = keyboardMock($cell1);
+        keyboard.keyDown('left');
+        this.clock.tick();
+
+        // assert
+        assert.ok($cell0.hasClass('dx-focused'), 'cell is focused');
+    });
 });


### PR DESCRIPTION
1. Fixed the condition for determining if a cell is the last cell in a row in the **KeyboardNavigation._getNextCell** method.
2. Added a test.
