### PR TITLE
 Add logic for handling empty (undefined) data that is passed to the showAppointmentPopup in Scheduler

### DIFF
--- a/js/ui/scheduler/appointmentPopup.js
+++ b/js/ui/scheduler/appointmentPopup.js
@@ -9,6 +9,7 @@ import { isDefined } from '../../core/utils/type';
 import { getWindow, hasWindow } from '../../core/utils/window';
 import { triggerResizeEvent } from '../../events/visibility_change';
 import messageLocalization from '../../localization/message';
+import { isEmptyObject } from '../../core/utils/type';
 import Popup from '../popup';
 import { APPOINTMENT_FORM_GROUP_NAMES, AppointmentForm } from './ui.scheduler.appointment_form';
 import loading from './ui.loading';
@@ -48,6 +49,12 @@ export default class AppointmentPopup {
     }
 
     show(data = {}, isDoneButtonVisible, processTimeZone) {
+        if(isEmptyObject(data)) {
+            const startDate = this.scheduler.option('currentDate');
+            const endDate = new Date(startDate.getTime() + this.scheduler.option('cellDuration') * toMs('minute'));
+            this.scheduler.fire('setField', 'startDate', data, startDate);
+            this.scheduler.fire('setField', 'endDate', data, endDate);
+        }
         this.state.appointment.data = data;
         this.state.appointment.processTimeZone = processTimeZone;
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointmentPopup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointmentPopup.tests.js
@@ -11,6 +11,7 @@ import { DataSource } from 'data/data_source/data_source';
 import resizeCallbacks from 'core/utils/resize_callbacks';
 import messageLocalization from 'localization/message';
 import { APPOINTMENT_FORM_GROUP_NAMES } from 'ui/scheduler/ui.scheduler.appointment_form';
+import { dateToMilliseconds as toMs } from 'core/utils/date';
 import 'ui/scheduler/ui.scheduler';
 import 'ui/switch';
 
@@ -1539,40 +1540,51 @@ QUnit.test('Multiple showing appointment popup for recurrence appointments shoul
 
 QUnit.test('Appointment popup will render even if no appointmentData is provided (T734413)', function(assert) {
     const scheduler = createInstance();
+    const currentDate = new Date(2020, 2, 4);
+    const cellDuration = 60;
+    scheduler.option('currentDate', currentDate);
+    scheduler.option('cellDuration', cellDuration);
+
     scheduler.instance.showAppointmentPopup({}, true);
     scheduler.instance.hideAppointmentPopup(true);
     scheduler.instance.showAppointmentPopup({}, true);
     const { startDate, endDate } = scheduler.appointmentForm.getFormInstance().option('formData');
     const appointmentPopup = scheduler.appointmentPopup;
 
-    assert.equal(startDate, null, 'startDate has null in the dxForm');
-    assert.equal(endDate, null, 'endDate has null in the dxForm');
+    assert.equal(startDate.getTime(), currentDate.getTime(), 'startDate is currentDate in Appointment Form');
+    assert.equal(endDate.getTime(), new Date(currentDate.getTime() + cellDuration * toMs('minute')).getTime(), 'endDate is currentDate + cellDuration in Appointment Form');
     assert.ok(appointmentPopup.isVisible(), 'Popup is rendered');
 
     const $popup = appointmentPopup.getPopup();
     const $startDate = $popup.find('input[name=\'startDate\']')[0];
     const $endDate = $popup.find('input[name=\'endDate\']')[0];
 
-    assert.equal($startDate.value, '', 'startDate is rendered empty');
-    assert.equal($endDate.value, '', 'endDate is rendered empty');
+    assert.equal($startDate.value, '2020-03-04T00:00:00', 'startDate is specified');
+    assert.equal($endDate.value, '2020-03-04T01:00:00', 'endDate is specified');
 });
 
-QUnit.test('Appointment popup will render on showAppointmentPopup with no arguments', function(assert) {
+QUnit.test('Appointment popup will render with currentDate on showAppointmentPopup with no arguments', function(assert) {
     const scheduler = createInstance();
+    const currentDate = new Date(2020, 2, 4);
+    const cellDuration = 60;
+    scheduler.option('currentDate', currentDate);
+    scheduler.option('cellDuration', cellDuration);
+
     scheduler.instance.showAppointmentPopup();
+
     const { startDate, endDate } = scheduler.appointmentForm.getFormInstance().option('formData');
     const appointmentPopup = scheduler.appointmentPopup;
 
-    assert.equal(startDate, null, 'startDate has null in the dxForm');
-    assert.equal(endDate, null, 'endDate has null in the dxForm');
+    assert.equal(startDate.getTime(), currentDate.getTime(), 'startDate is currentDate in Appointment Form');
+    assert.equal(endDate.getTime(), new Date(currentDate.getTime() + cellDuration * toMs('minute')).getTime(), 'endDate is currentDate + cellDuration in Appointment Form');
     assert.ok(appointmentPopup.isVisible(), 'Popup is rendered');
 
     const $popup = appointmentPopup.getPopup();
     const $startDate = $popup.find('input[name=\'startDate\']')[0];
     const $endDate = $popup.find('input[name=\'endDate\']')[0];
 
-    assert.equal($startDate.value, '', 'startDate is rendered empty');
-    assert.equal($endDate.value, '', 'endDate is rendered empty');
+    assert.equal($startDate.value, '2020-03-04T00:00:00', 'startDate is specified');
+    assert.equal($endDate.value, '2020-03-04T01:00:00', 'endDate is specified');
 });
 
 QUnit.test('Appointment form will have right dates on multiple openings (T727713)', function(assert) {


### PR DESCRIPTION
When appointmentData is undefined or empty object, dates will be replaced as follows:

startDate = scheduler.option('currentDate')
endDate = startDate + cellDuration
