### PR TITLE
Form - Fix changing item editorType via itemOption(id, options) (T903774)

### DIFF
--- a/js/ui/form/ui.form.js
+++ b/js/ui/form/ui.form.js
@@ -962,6 +962,11 @@ const Form = Widget.inherit({
 
             if(layoutManager) {
                 const fullOptionName = getFullOptionName(nameParts[endPartIndex], optionName);
+                if(optionName === 'editorType') { // T903774
+                    if(layoutManager.option(fullOptionName) !== value) {
+                        return false;
+                    }
+                }
                 if(optionName === 'visible') { // T874843
                     const formItems = this.option(getFullOptionName(itemPath, 'items'));
                     if(formItems && formItems.length) {

--- a/testing/tests/DevExpress.ui.widgets.form/form.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.tests.js
@@ -3,6 +3,7 @@ import resizeCallbacks from 'core/utils/resize_callbacks';
 import responsiveBoxScreenMock from '../../helpers/responsiveBoxScreenMock.js';
 import typeUtils from 'core/utils/type';
 import browser from 'core/utils/browser';
+import { extend } from 'core/utils/extend';
 import domUtils from 'core/utils/dom';
 import { __internals as internals } from 'ui/form/ui.form';
 import themes from 'ui/themes';
@@ -412,6 +413,75 @@ QUnit.test('From renders the right types of editors according to stylingMode opt
     assert.ok($testContainer.find('.dx-field-item .dx-textbox').hasClass('dx-editor-underlined'), 'right class rendered');
 });
 
+[
+    { editorType: 'dxTextBox' },
+    { label: { text: 'label text' } },
+    { editorOptions: { width: 400 } },
+].forEach(testConfig => {
+    [true, false].forEach(useRepaint => {
+        const clone = (item) => JSON.parse(JSON.stringify(item));
+        QUnit.test(`Form.itemOption('group.item1', newItem2), testConfig = ${JSON.stringify(testConfig)}. useRepaint = ${useRepaint} (T903774)`, function(assert) {
+            const item1 = {
+                editorType: 'dxDropDownBox',
+                dataField: 'item1',
+                label: { text: 'item1' },
+                editorOptions: { placeholder: 'test_placeHolder' }
+            };
+            const newItem1 = extend({
+                dataField: 'newItem1',
+                label: { text: 'new item1' },
+                editorOptions: { width: 300 }
+            }, testConfig);
+
+            const form = $('#form').dxForm({
+                items: [{
+                    itemType: 'group',
+                    caption: 'group1',
+                    items: [ clone(item1) ]
+                }]
+            }).dxForm('instance');
+
+            form.itemOption('group1.item1', clone(newItem1));
+            if(useRepaint) {
+                form.repaint();
+            }
+
+            if('editorType' in testConfig) {
+                assert.deepEqual(form.itemOption('group1.item1'), undefined, 'item1');
+                assert.deepEqual(form.itemOption('group1.newItem1'), extend(true, {}, newItem1, { editorType: testConfig.editorType || item1.editorType }), 'newItem1');
+            } else {
+                assert.deepEqual(form.itemOption('group1.item1'), extend(true, {}, item1, newItem1, { editorType: item1.editorType, dataField: item1.dataField }), 'item1');
+                assert.deepEqual(form.itemOption('group1.newItem1'), undefined, 'newItem1');
+            }
+        });
+
+        QUnit.test(`Form.itemOption('item1', newItem2), testConfig = ${JSON.stringify(testConfig)}. useRepaint = ${useRepaint} (T903774)`, function(assert) {
+            const item1 = {
+                editorType: 'dxDropDownBox',
+                dataField: 'item1',
+                label: { text: 'item1' },
+                editorOptions: { placeholder: 'test_placeHolder' }
+            };
+            const newItem1 = extend({
+                dataField: 'newItem1',
+                label: { text: 'new item1' },
+                editorOptions: { width: 300 }
+            }, testConfig);
+
+            const form = $('#form').dxForm({
+                items: [ clone(item1) ]
+            }).dxForm('instance');
+
+            form.itemOption('item1', clone(newItem1));
+            if(useRepaint) {
+                form.repaint();
+            }
+
+            assert.deepEqual(form.itemOption('item1'), undefined, 'item1');
+            assert.deepEqual(form.itemOption('newItem1'), extend(true, {}, newItem1, { editorType: testConfig.editorType || item1.editorType }), 'newItem1');
+        });
+    });
+});
 
 QUnit.module('Tabs', {
     beforeEach: function() {


### PR DESCRIPTION
…774) (#14006)

* Adding repaintChangesOnly option
Allows the user to disable the partial update of the form (T903774)

* Rename option

* Tests for new option

* Simplified test

* PR feedback

* Use deepEquals

* More test cases

* New logic of changing editorType option

* Fix changing option via itemOption(id, options) method

* Correct fix

* If editor type is changed - rerender full form

* Remove form rerendering on editorType option change

* Remove unnecessary function

* Fix changing editorType via itemOption (T903774)