### PR TITLE
ThemeBuilder: Change export for base-parameters module

### DIFF
--- a/themebuilder-scss/src/modules/base-parameters.ts
+++ b/themebuilder-scss/src/modules/base-parameters.ts
@@ -1,1 +1,1 @@
-export default ['@base-accent', '@base-text-color', '@base-bg', '@base-border-color', '@base-border-radius'];
+export = ['@base-accent', '@base-text-color', '@base-bg', '@base-border-color', '@base-border-radius'];


### PR DESCRIPTION
`require('base-parameters')` should return array of items `[....]` (after transpile in commonjs module). Now it returns `{ default: [....]}`
