### PR TITLE
DataGrid - Row alternation color is not applied under certain conditions when grouping, virtual scrolling, and rendering are enabled (T907168) (#14021)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_controller.js
+++ b/js/ui/grid_core/ui.grid_core.data_controller.js
@@ -491,7 +491,7 @@ module.exports = {
                     const visibleColumns = that._columnsController.getVisibleColumns(null, changeType === 'loadingAll');
                     const visibleItems = that._items;
                     const lastVisibleItem = changeType === 'append' && visibleItems.length > 0 ? visibleItems[visibleItems.length - 1] : null;
-                    const dataIndex = isDefined(lastVisibleItem?.dataIndex) ? lastVisibleItem.dataIndex + 1 : 0;
+                    const dataIndex = typeUtils.isDefined(lastVisibleItem?.dataIndex) ? lastVisibleItem.dataIndex + 1 : 0;
                     const options = {
                         visibleColumns: visibleColumns,
                         dataIndex: dataIndex

--- a/js/ui/grid_core/ui.grid_core.data_controller.js
+++ b/js/ui/grid_core/ui.grid_core.data_controller.js
@@ -490,7 +490,8 @@ module.exports = {
                     const changeType = change.changeType;
                     const visibleColumns = that._columnsController.getVisibleColumns(null, changeType === 'loadingAll');
                     const visibleItems = that._items;
-                    const dataIndex = changeType === 'append' && visibleItems.length > 0 ? visibleItems[visibleItems.length - 1].dataIndex + 1 : 0;
+                    const lastVisibleItem = changeType === 'append' && visibleItems.length > 0 ? visibleItems[visibleItems.length - 1] : null;
+                    const dataIndex = isDefined(lastVisibleItem?.dataIndex) ? lastVisibleItem.dataIndex + 1 : 0;
                     const options = {
                         visibleColumns: visibleColumns,
                         dataIndex: dataIndex

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -4475,6 +4475,65 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
         assert.deepEqual(changedArgs.changeType, 'append');
         assert.deepEqual(changedArgs.removeCount, 40, 'removeCount is correct');
     });
+
+    // T907168
+    QUnit.test('Check dataIndex for grouped items in the next page if group row is in the prev page', function(assert) {
+        const array = [];
+        const pageSize = 5;
+        const groupRowCountInFirstPage = 2;
+        const firstGroupItemsCount = pageSize - groupRowCountInFirstPage;
+        for(let group = 1; group <= 10; group++) {
+            const rowCount = group === 1 ? firstGroupItemsCount : 4;
+            for(let row = 1; row <= rowCount; row++) {
+                array.push({ id: group * row, group: group, name: `text ${group},${row}` });
+            }
+        }
+        this.applyOptions({
+            remoteOperations: {},
+            columns: [
+                'id', { dataField: 'group', groupIndex: 0 }, 'name'
+            ] });
+        this.setupDataSource({
+            data: array,
+            pageSize
+        });
+        this.dataController.viewportSize(pageSize);
+        const items = this.dataController.items();
+        assert.equal(items[pageSize - 1].rowType, 'group');
+        assert.equal(items[pageSize].data.name, 'text 2,1');
+        assert.equal(items[pageSize].dataIndex, 0);
+    });
+
+    // T907168
+    QUnit.test('Check dataIndex for the first and the second row in group', function(assert) {
+        const array = [];
+        const pageSize = 5;
+        const groupRowCountInFirstPage = 2;
+        const firstGroupItemsCount = pageSize - groupRowCountInFirstPage - 1;
+        for(let group = 1; group <= 10; group++) {
+            const rowCount = group === 1 ? firstGroupItemsCount : 4;
+            for(let row = 1; row <= rowCount; row++) {
+                array.push({ id: group * row, group: group, name: `text ${group},${row}` });
+            }
+        }
+        this.applyOptions({
+            remoteOperations: {},
+            columns: [
+                'id', { dataField: 'group', groupIndex: 0 }, 'name'
+            ] });
+        this.setupDataSource({
+            data: array,
+            pageSize
+        });
+        this.dataController.viewportSize(pageSize);
+        const items = this.dataController.items();
+        assert.equal(items[pageSize - 2].rowType, 'group');
+        assert.equal(items[pageSize - 1].data.name, 'text 2,1');
+        assert.equal(items[pageSize - 1].dataIndex, 0);
+        assert.equal(items[pageSize].data.name, 'text 2,2');
+        assert.equal(items[pageSize].dataIndex, 1);
+    });
+
 });
 
 QUnit.module('Infinite scrolling', {


### PR DESCRIPTION
dataIndex setup to NAN if the last item in visibleItems is group item because groupItem doesnt have dataIndex field.
