### PR TITLE
DataGrid - Fixes resetting modified value on keyboard navigation (T916159)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1113,7 +1113,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
             case 'nextInRow':
             case 'next':
                 visibleColumnsCount = this._getVisibleColumnCount();
-                if(columnIndex < visibleColumnsCount - 1 && !this._isLastValidCell({ columnIndex: columnIndex, rowIndex: rowIndex }) && elementType !== 'row') {
+                if(columnIndex < visibleColumnsCount - 1 && elementType !== 'row' && this._hasValidCellAfterPosition({ columnIndex: columnIndex, rowIndex: rowIndex })) {
                     columnIndex++;
                 } else if(!this._isLastRow(rowIndex) && code === 'next') {
                     columnIndex = 0;
@@ -1122,7 +1122,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                 break;
             case 'previousInRow':
             case 'previous':
-                if(columnIndex > 0 && !this._isFirstValidCell({ columnIndex: columnIndex, rowIndex: rowIndex }) && elementType !== 'row') {
+                if(columnIndex > 0 && elementType !== 'row' && this._hasValidCellBeforePosition({ columnIndex: columnIndex, rowIndex: rowIndex })) {
                     columnIndex--;
                 } else if(rowIndex > 0 && code === 'previous') {
                     rowIndex--;
@@ -1209,18 +1209,31 @@ const KeyboardNavigationController = core.ViewController.inherit({
         let isFirstValidCell = false;
 
         if(cellPosition.rowIndex === 0 && cellPosition.columnIndex >= 0) {
-            isFirstValidCell = isFirstValidCell || !this._haveValidCellBeforePosition(cellPosition);
+            isFirstValidCell = isFirstValidCell || !this._hasValidCellBeforePosition(cellPosition);
         }
 
         return isFirstValidCell;
     },
 
-    _haveValidCellBeforePosition: function(cellPosition) {
+    _hasValidCellBeforePosition: function(cellPosition) {
         let columnIndex = cellPosition.columnIndex;
         let hasValidCells = false;
 
         while(columnIndex > 0 && !hasValidCells) {
             const checkingPosition = { columnIndex: --columnIndex, rowIndex: cellPosition.rowIndex };
+
+            hasValidCells = this._isCellByPositionValid(checkingPosition);
+        }
+        return hasValidCells;
+    },
+
+    _hasValidCellAfterPosition: function(cellPosition) {
+        let columnIndex = cellPosition.columnIndex;
+        let hasValidCells = false;
+        const visibleColumnCount = this._getVisibleColumnCount();
+
+        while(columnIndex < visibleColumnCount - 1 && !hasValidCells) {
+            const checkingPosition = { columnIndex: ++columnIndex, rowIndex: cellPosition.rowIndex };
 
             hasValidCells = this._isCellByPositionValid(checkingPosition);
         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -811,7 +811,7 @@ QUnit.module('View\'s focus', {
                     this.clock.tick();
                     let keyboard = keyboardMock($cell);
                     keyboard.keyDown('a');
-                    this.clock.tick(25);
+                    this.clock.tick(25); // 25 because of T882996
                     $cell = $(dataGrid.getCellElement(rowIndex, 1));
 
                     // assert

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -811,7 +811,7 @@ QUnit.module('View\'s focus', {
                     this.clock.tick();
                     let keyboard = keyboardMock($cell);
                     keyboard.keyDown('a');
-                    this.clock.tick();
+                    this.clock.tick(25);
                     $cell = $(dataGrid.getCellElement(rowIndex, 1));
 
                     // assert

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.rowsView.tests.js
@@ -182,7 +182,7 @@ QUnit.module('Rows view', {
 
         navigationController._isCellValid = function($cell) {
             const cell = $cell[0];
-            return cell.cellIndex > 0 && cell.cellIndex < 2;
+            return cell.cellIndex === 3;
         };
         navigationController._focusedView = rowsView;
         navigationController._focusedCellPosition = { rowIndex: 0, columnIndex: 1 };


### PR DESCRIPTION
1. Replaced the **_isFirstValidCell** and **_isLastValidCell** method with **_hasValidCellBeforePosition** and **_hasValidCellAfterPosition** correspondingly forchecking if there are valid cell foracertain direction in the KeyboardNavigationController.

2. Added tests.