### PR TITLE
ESlint: Avoid using 'jquery', 'angular', 'knockout' and 'globalize' imports

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -14,10 +14,12 @@
             }
         ],
         "no-restricted-imports": [ "error", {
-            "paths": [{
-                "name": "jquery"
-            }],
-            "patterns": ["jquery/*"]
+            "paths": [
+                { "name": "jquery"},
+                { "name": "angular"},
+                { "name": "knockout"}
+            ],
+            "patterns": ["jquery/*", "angular/*", "knockout/*"]
         }]
     }
 }

--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -17,9 +17,10 @@
             "paths": [
                 { "name": "jquery"},
                 { "name": "angular"},
-                { "name": "knockout"}
+                { "name": "knockout"},
+                { "name": "globalize"}
             ],
-            "patterns": ["jquery/*", "angular/*", "knockout/*"]
+            "patterns": ["jquery/*", "angular/*", "knockout/*", "globalize/*"]
         }]
     }
 }

--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -6,12 +6,19 @@
     "parserOptions": {
         "sourceType": "module"
     },
+    "ignorePatterns": [ "integration/jquery/*.js" ],
     "rules": {
         "no-restricted-modules": [
             "error",
             {
                 "patterns": ["*.js"]
             }
-        ]
+        ],
+        "no-restricted-imports": [ "error", {
+            "paths": [{
+                "name": "jquery"
+            }],
+            "patterns": ["jquery/*"]
+        }]
     }
 }

--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -6,7 +6,6 @@
     "parserOptions": {
         "sourceType": "module"
     },
-    "ignorePatterns": [ "integration/jquery/*.js" ],
     "rules": {
         "no-restricted-modules": [
             "error",

--- a/js/integration/angular/action_executors.js
+++ b/js/integration/angular/action_executors.js
@@ -1,4 +1,5 @@
 import Action from '../../core/action';
+// eslint-disable-next-line no-restricted-imports
 import angular from 'angular';
 
 if(angular) {

--- a/js/integration/angular/component_registrator.js
+++ b/js/integration/angular/component_registrator.js
@@ -1,4 +1,5 @@
 import $ from '../../core/renderer';
+// eslint-disable-next-line no-restricted-imports
 import angular from 'angular';
 import eventsEngine from '../../events/core/events_engine';
 import Config from '../../core/config';

--- a/js/integration/angular/components.js
+++ b/js/integration/angular/components.js
@@ -1,5 +1,6 @@
 import Callbacks from '../../core/utils/callbacks';
 import ngModule from './module';
+// eslint-disable-next-line no-restricted-imports
 import angular from 'angular';
 
 if(angular) {

--- a/js/integration/angular/event_registrator.js
+++ b/js/integration/angular/event_registrator.js
@@ -1,6 +1,7 @@
 import eventRegistratorCallbacks from '../../events/core/event_registrator_callbacks';
 import eventsEngine from '../../events/core/events_engine';
 import ngModule from './module';
+// eslint-disable-next-line no-restricted-imports
 import angular from 'angular';
 
 if(angular) {

--- a/js/integration/angular/module.js
+++ b/js/integration/angular/module.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import angular from 'angular';
 let ngModule;
 if(angular) {

--- a/js/integration/jquery.js
+++ b/js/integration/jquery.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import { compare as compareVersions } from '../core/utils/version';
 import errors from '../core/utils/error';

--- a/js/integration/jquery/ajax.js
+++ b/js/integration/jquery/ajax.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import ajax from '../../core/utils/ajax';
 import useJQueryFn from './use_jquery';

--- a/js/integration/jquery/component_registrator.js
+++ b/js/integration/jquery/component_registrator.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import componentRegistratorCallbacks from '../../core/component_registrator_callbacks';
 import errors from '../../core/errors';

--- a/js/integration/jquery/deferred.js
+++ b/js/integration/jquery/deferred.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import { setStrategy } from '../../core/utils/deferred';
 import { compare as compareVersion } from '../../core/utils/version';

--- a/js/integration/jquery/easing.js
+++ b/js/integration/jquery/easing.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import easing from '../../animation/easing';
 

--- a/js/integration/jquery/element_data.js
+++ b/js/integration/jquery/element_data.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import { setDataStrategy } from '../../core/element_data';
 import useJQueryFn from './use_jquery';

--- a/js/integration/jquery/events.js
+++ b/js/integration/jquery/events.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import eventsEngine from '../../events/core/events_engine';
 import useJQueryFn from './use_jquery';

--- a/js/integration/jquery/hold_ready.js
+++ b/js/integration/jquery/hold_ready.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import themes_callback from '../../ui/themes_callback';
 import { add as ready } from '../../core/utils/ready_callbacks';

--- a/js/integration/jquery/hooks.js
+++ b/js/integration/jquery/hooks.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import useJQueryFn from './use_jquery';
 const useJQuery = useJQueryFn();

--- a/js/integration/jquery/renderer.js
+++ b/js/integration/jquery/renderer.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import rendererBase from '../../core/renderer_base';
 import useJQueryFn from './use_jquery';

--- a/js/integration/jquery/use_jquery.js
+++ b/js/integration/jquery/use_jquery.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import jQuery from 'jquery';
 import config from '../../core/config';
 const useJQuery = config().useJQuery;

--- a/js/integration/knockout.js
+++ b/js/integration/knockout.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import errors from '../core/errors';
 import { compare as compareVersion } from '../core/utils/version';

--- a/js/integration/knockout/clean_node.js
+++ b/js/integration/knockout/clean_node.js
@@ -1,4 +1,5 @@
 import { afterCleanData, strategyChanging, cleanData } from '../../core/element_data';
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import { compare as compareVersion } from '../../core/utils/version';
 

--- a/js/integration/knockout/clean_node_old.js
+++ b/js/integration/knockout/clean_node_old.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import { compare as compareVersion } from '../../core/utils/version';
 import { strategyChanging } from '../../core/element_data';

--- a/js/integration/knockout/component_registrator.js
+++ b/js/integration/knockout/component_registrator.js
@@ -1,4 +1,5 @@
 import $ from '../../core/renderer';
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import Callbacks from '../../core/utils/callbacks';
 import { isPlainObject } from '../../core/utils/type';

--- a/js/integration/knockout/components.js
+++ b/js/integration/knockout/components.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import iconUtils from '../../core/utils/icon';
 

--- a/js/integration/knockout/event_registrator.js
+++ b/js/integration/knockout/event_registrator.js
@@ -1,5 +1,6 @@
 import $ from '../../core/renderer';
 import eventsEngine from '../../events/core/events_engine';
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import { isPlainObject } from '../../core/utils/type';
 import eventRegistratorCallbacks from '../../events/core/event_registrator_callbacks';

--- a/js/integration/knockout/template.js
+++ b/js/integration/knockout/template.js
@@ -1,5 +1,6 @@
 import $ from '../../core/renderer';
 import domAdapter from '../../core/dom_adapter';
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import { isDefined } from '../../core/utils/type';
 import { TemplateBase } from '../../core/templates/template_base';

--- a/js/integration/knockout/utils.js
+++ b/js/integration/knockout/utils.js
@@ -1,4 +1,5 @@
 
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 
 export const getClosestNodeWithContext = (node) => {

--- a/js/integration/knockout/validation.js
+++ b/js/integration/knockout/validation.js
@@ -5,6 +5,7 @@ import { EventsStrategy } from '../../core/events_strategy';
 import ValidationEngine from '../../ui/validation_engine';
 import { Deferred } from '../../core/utils/deferred';
 import Guid from '../../core/guid';
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 
 if(ko) {

--- a/js/integration/knockout/variable_wrapper_utils.js
+++ b/js/integration/knockout/variable_wrapper_utils.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import variableWrapper from '../../core/utils/variable_wrapper';
 

--- a/js/localization/globalize/core.js
+++ b/js/localization/globalize/core.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import Globalize from 'globalize';
 import coreLocalization from '../core';
 

--- a/js/localization/globalize/currency.js
+++ b/js/localization/globalize/currency.js
@@ -2,6 +2,7 @@ import openXmlCurrencyFormat from '../open_xml_currency_format';
 import './core';
 import './number';
 import '../currency';
+// eslint-disable-next-line no-restricted-imports
 import 'globalize/currency';
 
 const enCurrencyUSD = {
@@ -47,6 +48,7 @@ const currencyData = {
     }
 };
 
+// eslint-disable-next-line no-restricted-imports
 import Globalize from 'globalize';
 import config from '../../core/config';
 import numberLocalization from '../number';

--- a/js/localization/globalize/date.js
+++ b/js/localization/globalize/date.js
@@ -1,5 +1,6 @@
 import './core';
 import './number';
+// eslint-disable-next-line no-restricted-imports
 import 'globalize/date';
 
 const timeData = {
@@ -562,6 +563,7 @@ const weekData = {
 const ACCEPTABLE_JSON_FORMAT_PROPERTIES = ['skeleton', 'date', 'time', 'datetime', 'raw'];
 const RTL_MARKS_REGEX = /[\u200E\u200F]/g;
 
+// eslint-disable-next-line no-restricted-imports
 import Globalize from 'globalize';
 import dateLocalization from '../date';
 import { isObject } from '../../core/utils/type';

--- a/js/localization/globalize/message.js
+++ b/js/localization/globalize/message.js
@@ -1,9 +1,11 @@
 import './core';
 
+// eslint-disable-next-line no-restricted-imports
 import Globalize from 'globalize';
 import messageLocalization from '../message';
 import coreLocalization from '../core';
 
+// eslint-disable-next-line no-restricted-imports
 import 'globalize/message';
 
 if(Globalize && Globalize.formatMessage) {

--- a/js/localization/globalize/number.js
+++ b/js/localization/globalize/number.js
@@ -1,7 +1,9 @@
 import './core';
+// eslint-disable-next-line no-restricted-imports
 import Globalize from 'globalize';
 import numberLocalization from '../number';
 import errors from '../../core/errors';
+// eslint-disable-next-line no-restricted-imports
 import 'globalize/number';
 
 if(Globalize && Globalize.formatNumber) {


### PR DESCRIPTION
We can avoid issue with jQuery imports that will lead to new relabel how it happened in 20.1.5
` import { isFunction } from 'jquery';`