### PR TITLE
Fix: DataGrid - Resize icon showing then resize isn't possible in Cell and Batch edit modes (T916159)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_resizing_reordering.js
+++ b/js/ui/grid_core/ui.grid_core.columns_resizing_reordering.js
@@ -650,8 +650,7 @@ const ColumnsResizerViewController = modules.ViewController.inherit({
                 that._targetPoint = that._getTargetPoint(that.pointsByColumns(), eventData.x, columnsSeparatorWidth);
                 that._previousParentOffset = parentOffset;
                 that._isReadyResizing = false;
-
-                if(that._targetPoint) {
+                if(that._targetPoint && that._canResize()) {
                     that._columnsSeparatorView.changeCursor('col-resize');
                     that._columnsSeparatorView.moveByX(that._targetPoint.x - deltaX);
                     that._tablePositionController.update(that._targetPoint.y);
@@ -667,7 +666,12 @@ const ColumnsResizerViewController = modules.ViewController.inherit({
             }
         }
     },
-
+    _canResize: function() {
+        const editingController = this.getController('editing');
+        const editingMode = this.option('editing.mode');
+        const isCellEditing = editingController.isEditing() && (editingMode === 'batch' || editingMode === 'cell');
+        return !isCellEditing;
+    },
     _endResizing: function(args) {
         const e = args.event;
         const that = e.data;
@@ -710,9 +714,6 @@ const ColumnsResizerViewController = modules.ViewController.inherit({
         const e = args.event;
         const that = e.data;
         const eventData = getEventData(e);
-        const editingController = that.getController('editing');
-        const editingMode = that.option('editing.mode');
-        const isCellEditing = editingController.isEditing() && (editingMode === 'batch' || editingMode === 'cell');
 
         if(isTouchEvent(e)) {
             if(that._isHeadersRowArea(eventData.y)) {
@@ -726,7 +727,7 @@ const ColumnsResizerViewController = modules.ViewController.inherit({
             }
         }
 
-        if(that._isReadyResizing && !isCellEditing) {
+        if(that._isReadyResizing && that._canResize()) {
             ///#DEBUG
             if(that._targetPoint) {
                 that._testColumnIndex = that._targetPoint.columnIndex;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsResizingReorderingModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsResizingReorderingModule.tests.js
@@ -1735,6 +1735,38 @@ QUnit.module('Columns resizing', {
         assert.ok(resizeController._isResizing, 'columnsResizer is resizing');
     });
 
+    ['cell', 'batch'].forEach((mode) => {
+        QUnit.test(`Dont show resize cursor during editing in ${mode} mode. T915568`, function(assert) {
+            // arrange
+            const resizeController = this.createColumnsResizerViewController();
+            this.options['editing.mode'] = mode;
+            this.component._controllers.editing._isEditing = true;
+
+            this.renderViews($('#container'));
+            resizeController._pointsByColumns = [
+                { x: -9875, columnIndex: 0, index: 1, y: -9995 },
+                { x: -9750, columnIndex: 1, index: 2, y: -9995 },
+            ];
+
+            // assert
+            resizeController._columnsSeparatorView.changeCursor = function(cursorName) {
+                assert.notEqual(cursorName, 'col-resize', 'we cannot resize column while editing is active');
+            };
+            // act
+            resizeController._columnsSeparatorView.height(100);
+            const options = {
+                data: resizeController,
+                type: 'mousedown',
+                pageX: -9750,
+                pageY: -9995
+            };
+            resizeController._moveSeparator(getEvent(options));
+
+            // assert
+            assert.expect(1);
+        });
+    });
+
     QUnit.test('No start resizing while cell is opened for editing in "cell" mode. T450598', function(assert) {
         // arrange
         const callPositionChanged = sinon.stub();


### PR DESCRIPTION
Extract canResize method from _startResizing and call it during icon updating to resize.