### PR TITLE
DroneCI - Set 'ui.widgets' constellation for "DevExpress.ui.widgets"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,6 +33,7 @@ matrix:
     - { TARGET: test, CONSTEL: misc, TZ: 'Japan' }
     - { TARGET: test, CONSTEL: misc, TZ: 'Australia/ACT' }
     - { TARGET: test, CONSTEL: ui }
+    - { TARGET: test, CONSTEL: ui.widgets }
     - { TARGET: test, CONSTEL: ui.editors }
     - { TARGET: test, CONSTEL: ui.editors, TZ: 'PST8PDT' }
     - { TARGET: test, CONSTEL: ui.editors, TZ: 'Japan' }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        CONSTEL: [ export, misc, ui, ui.editors, ui.grid, ui.scheduler, viz, renovation ]
+        CONSTEL: [ export, misc, ui, ui.widgets, ui.editors, ui.grid, ui.scheduler, viz, renovation ]
         JQUERY: [ jquery=3, nojquery=true ]
 
     runs-on: windows-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - TARGET=test CONSTEL=misc TZ='Japan'
     - TARGET=test CONSTEL=misc TZ='Australia/ACT'
     - TARGET=test CONSTEL=ui
+    - TARGET=test CONSTEL=ui.widgets
     - TARGET=test CONSTEL=ui.editors
     - TARGET=test CONSTEL=ui.editors TZ='PST8PDT'
     - TARGET=test CONSTEL=ui.editors TZ='Japan'

--- a/shippable.yml
+++ b/shippable.yml
@@ -10,6 +10,7 @@ env:
     - TARGET=test CONSTEL=misc TZ='Japan'
     - TARGET=test CONSTEL=misc TZ='Australia/ACT'
     - TARGET=test CONSTEL=ui
+    - TARGET=test CONSTEL=ui.widgets
     - TARGET=test CONSTEL=ui.editors
     - TARGET=test CONSTEL=ui.editors TZ='PST8PDT'
     - TARGET=test CONSTEL=ui.editors TZ='Japan'

--- a/testing/runner/Tools/UIModelHelper.cs
+++ b/testing/runner/Tools/UIModelHelper.cs
@@ -14,7 +14,7 @@ namespace Runner.Tools
     public class UIModelHelper
     {
         // constellation is a set of categories, they are defined in __meta.json files inside category directories
-        static readonly ICollection<string> KnownConstellations = new HashSet<string> { "export", "misc", "ui", "ui.editors", "ui.grid", "ui.scheduler", "viz", "perf", "renovation" };
+        static readonly ICollection<string> KnownConstellations = new HashSet<string> { "export", "misc", "ui", "ui.widgets", "ui.editors", "ui.grid", "ui.scheduler", "viz", "perf", "renovation" };
 
         UrlHelper UrlHelper;
         string TestsRootPath;

--- a/testing/tests/DevExpress.ui.widgets/__meta.json
+++ b/testing/tests/DevExpress.ui.widgets/__meta.json
@@ -1,5 +1,5 @@
 { 
-    "constellation": "ui",
+    "constellation": "ui.widgets",
     "explicit": false,
     "runOnDevices": true
 }


### PR DESCRIPTION
Testing 'ui' constellation spend a lot of time. Sometimes more than testing timeout (1 hour).
As a solution - extract 'DevExpress.ui.widgets' to a separate constellation.