### PR TITLE
Fix T919206 DataGrid doesn't remove a green border from a boolean column in batch editing mode

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1556,6 +1556,7 @@ const EditingController = modules.ViewController.inherit((function() {
             const dataSource = dataController.dataSource();
             const editMode = getEditMode(this);
             const result = new Deferred();
+            const editData = this._editData.slice(0);
 
             const resetEditIndices = () => {
                 if(editMode !== EDIT_MODE_CELL) {
@@ -1563,14 +1564,24 @@ const EditingController = modules.ViewController.inherit((function() {
                     this._resetEditRowKey();
                 }
             };
-
+            const resetModifiedClassCells = () => {
+                if(editMode === EDIT_MODE_BATCH) {
+                    const columnsCount = this._columnsController.getVisibleColumns().length;
+                    editData.forEach(({ key }) => {
+                        const rowIndex = this._dataController.getRowIndexByKey(key);
+                        if(rowIndex !== -1) {
+                            for(let columnIndex = 0; columnIndex < columnsCount; columnIndex++) {
+                                this._rowsView._getCellElement(rowIndex, columnIndex).removeClass(CELL_MODIFIED);
+                            }
+                        }
+                    });
+                }
+            };
             const afterSaveEditData = (error) => {
                 when(this._afterSaveEditData()).done(function() {
                     result.resolve(error);
                 });
             };
-
-            const editData = this._editData.slice(0);
 
             if(!this._saveEditDataCore(deferreds, results, changes) && editMode === EDIT_MODE_CELL) {
                 this._focusEditingCell();
@@ -1583,6 +1594,7 @@ const EditingController = modules.ViewController.inherit((function() {
 
                 when.apply($, deferreds).done(() => {
                     if(this._processSaveEditDataResult(results)) {
+                        resetModifiedClassCells();
                         resetEditIndices();
 
                         if(editMode === EDIT_MODE_POPUP && this._editPopup) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -3048,6 +3048,29 @@ QUnit.module('Editing with real dataController', {
         assert.ok(!this.find(headerPanelElement, '.dx-datagrid-save-button').hasClass('dx-state-disabled'), 'save changes button enabled');
         assert.ok(!this.find(headerPanelElement, '.dx-datagrid-cancel-button').hasClass('dx-state-disabled'), 'cancel changes button enabled');
     });
+    // T919206
+    QUnit.test('Reset modified cell class (T919206)', function(assert) {
+    // arrange
+        const that = this;
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+        that.options.editing = {
+            allowUpdating: true,
+            mode: 'batch'
+        };
+        this.options.columns = [{ dataField: 'stateId', dataType: 'boolean' }];
+        this.options.repaintChangesOnly = true;
+        this.columnsController.init();
+        rowsView.render(testElement);
+
+        // act
+        $(this.getCellElement(0, 0)).find('.dx-checkbox').trigger('dxclick');
+        $(this.getCellElement(1, 0)).find('.dx-checkbox').trigger('dxclick');
+        assert.equal($('.dx-cell-modified').length, 2);
+        this.saveEditData();
+        // assert
+        assert.equal($('.dx-cell-modified').length, 0);
+    });
 
     // T181661
     QUnit.test('Close Editing Cell on hold', function(assert) {


### PR DESCRIPTION
Remove dx-modified-cell class for edited data rows cells after batch save.