### PR TITLE
Fix regression in cell text selection after PR #14106

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -236,7 +236,7 @@ const EditingController = modules.ViewController.inherit((function() {
                 // chrome 73+
                 let $pointerDownTarget;
                 let isResizing;
-                that._pointerUpEditorHandler = () => isResizing = that.getController('columnsResizer')?.isResizing();
+                that._pointerUpEditorHandler = () => { isResizing = that.getController('columnsResizer')?.isResizing(); };
                 that._pointerDownEditorHandler = e => $pointerDownTarget = $(e.target);
                 that._saveEditorHandler = that.createAction(function(e) {
                     const event = e.event;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -1962,10 +1962,6 @@ QUnit.module('Editing', {
 
     // T501010
     QUnit.test('Save changes on save button click when batch mode', function(assert) {
-        if(device.deviceType !== 'desktop') {
-            assert.ok(true, 'event emulation wrong');
-            return;
-        }
         // arrange
         const that = this;
         const headerPanel = this.headerPanel;


### PR DESCRIPTION

The following code
```
that._pointerUpEditorHandler = () => isResizing = that.getController('columnsResizer')?.isResizing();
```
transpiled to function that return isResizing and it's way to preventDefault of dxpointerup event.