### PR TITLE
dxScheduler - move call focus of dxList after changing tooltip visibility(T917777)

### DIFF
--- a/js/ui/scheduler/tooltip_strategies/desktopTooltipStrategy.js
+++ b/js/ui/scheduler/tooltip_strategies/desktopTooltipStrategy.js
@@ -6,13 +6,7 @@ const APPOINTMENT_TOOLTIP_WRAPPER_CLASS = 'dx-scheduler-appointment-tooltip-wrap
 const MAX_TOOLTIP_HEIGHT = 200;
 
 export class DesktopTooltipStrategy extends TooltipStrategyBase {
-    constructor(options) {
-        super(options);
-        this._skipHidingOnScroll = false;
-    }
-
-    _showCore(target, dataList) {
-        super._showCore(target, dataList);
+    _prepareBeforeVisibleChanged(dataList) {
         this._tooltip.option('position', {
             my: 'bottom',
             at: 'top',
@@ -47,8 +41,6 @@ export class DesktopTooltipStrategy extends TooltipStrategyBase {
 
         return this._options.createComponent(tooltip, Tooltip, {
             target: target,
-            onShowing: this._onTooltipShowing.bind(this),
-            closeOnTargetScroll: () => this._skipHidingOnScroll,
             maxHeight: MAX_TOOLTIP_HEIGHT,
             rtlEnabled: this._extraOptions.rtlEnabled,
             onShown: this._onShown.bind(this),
@@ -58,19 +50,5 @@ export class DesktopTooltipStrategy extends TooltipStrategyBase {
 
     _onListRender(e) {
         return this._extraOptions.dragBehavior && this._extraOptions.dragBehavior(e);
-    }
-
-    dispose() {
-        clearTimeout(this._skipHidingOnScrollTimeId);
-    }
-
-    _onTooltipShowing() {
-        clearTimeout(this._skipHidingOnScrollTimeId);
-
-        this._skipHidingOnScroll = true;
-        this._skipHidingOnScrollTimeId = setTimeout(() => {
-            this._skipHidingOnScroll = false;
-            clearTimeout(this._skipHidingOnScrollTimeId);
-        }, 0);
     }
 }

--- a/js/ui/scheduler/tooltip_strategies/tooltipStrategyBase.js
+++ b/js/ui/scheduler/tooltip_strategies/tooltipStrategyBase.js
@@ -36,7 +36,12 @@ export class TooltipStrategyBase {
             this._list.option('dataSource', dataList);
         }
 
+        this._prepareBeforeVisibleChanged(dataList);
         this._tooltip.option('visible', true);
+    }
+
+    _prepareBeforeVisibleChanged(dataList) {
+
     }
 
     _getContentTemplate(dataList) {

--- a/testing/testcafe/tests/scheduler/hotkeysBehaviour/init/widget.setup.ts
+++ b/testing/testcafe/tests/scheduler/hotkeysBehaviour/init/widget.setup.ts
@@ -11,4 +11,4 @@ export default (options = {}) => createWidget('dxScheduler', extend({
   maxAppointmentsPerCell: 5,
   currentView: 'month',
   currentDate: new Date(2019, 3, 1),
-}, options));
+}, options), true);

--- a/testing/testcafe/tests/scheduler/tooltipBehaviour/tooltipBehavior.ts
+++ b/testing/testcafe/tests/scheduler/tooltipBehaviour/tooltipBehavior.ts
@@ -6,14 +6,61 @@ import Scheduler from '../../../model/scheduler';
 fixture`Appointment tooltip behavior during scrolling in the Scheduler (T755449)`
   .page(url(__dirname, '../../container.html'));
 
-test('The tooltip shouldn\'t hide after automatic scrolling during an appointment click', async (t) => {
+test('The tooltip of collector should not scroll page and immediately hide', async (t) => {
+  const scheduler = new Scheduler('#container');
+
+  await t
+    .resizeWindow(600, 450)
+    .click(scheduler.getAppointmentCollector('7').element, { speed: 0.2 })
+    .expect(scheduler.appointmentTooltip.isVisible())
+    .ok();
+}).before(() => createScheduler({
+  views: [{
+    type: 'week',
+    name: 'week',
+    maxAppointmentsPerCell: '0',
+  }],
+  currentDate: new Date(2017, 4, 25),
+  startDayHour: 9,
+  currentView: 'week',
+  dataSource: [{
+    text: 'A',
+    startDate: new Date(2017, 4, 22, 9, 30),
+    endDate: new Date(2017, 4, 22, 11, 30),
+  }, {
+    text: 'B',
+    startDate: new Date(2017, 4, 22, 9, 30),
+    endDate: new Date(2017, 4, 22, 11, 30),
+  }, {
+    text: 'C',
+    startDate: new Date(2017, 4, 22, 9, 30),
+    endDate: new Date(2017, 4, 22, 11, 30),
+  }, {
+    text: 'D',
+    startDate: new Date(2017, 4, 22, 9, 30),
+    endDate: new Date(2017, 4, 22, 11, 30),
+  }, {
+    text: 'E',
+    startDate: new Date(2017, 4, 22, 9, 30),
+    endDate: new Date(2017, 4, 22, 11, 30),
+  }, {
+    text: 'F',
+    startDate: new Date(2017, 4, 22, 9, 30),
+    endDate: new Date(2017, 4, 22, 11, 30),
+  }, {
+    text: 'G',
+    startDate: new Date(2017, 4, 22, 9, 30),
+    endDate: new Date(2017, 4, 22, 11, 30),
+  }],
+}));
+
+test('The tooltip should not hide after automatic scrolling during an appointment click', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('Brochure Design Review');
 
   await t
     .resizeWindow(600, 400)
-    .click(appointment.element)
-    .wait(500)
+    .click(appointment.element, { speed: 0.2 })
     .expect(scheduler.appointmentTooltip.isVisible())
     .ok();
 }).before(() => createScheduler({
@@ -28,8 +75,7 @@ test('The tooltip should hide after manually scrolling in the browser', async (t
 
   await t
     .resizeWindow(600, 400)
-    .click(appointment.element)
-    .wait(500)
+    .click(appointment.element, { speed: 0.2 })
     .expect(scheduler.appointmentTooltip.isVisible())
     .ok();
   await scroll(0, 100);

--- a/testing/tests/DevExpress.ui.widgets.scheduler/desktopTooltip.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/desktopTooltip.tests.js
@@ -64,14 +64,14 @@ QUnit.test('Show tooltip', function(assert) {
     assert.ok(tooltip, 'tooltip is created');
 
     assert.equal(stubComponent.option.callCount, 2);
-    assert.deepEqual(stubComponent.option.getCall(0).args, ['visible', true], 'tooltip is visible');
-    assert.deepEqual(stubComponent.option.getCall(1).args, ['position', {
+    assert.deepEqual(stubComponent.option.getCall(0).args, ['position', {
         'at': 'top',
         'collision': 'fit flipfit',
         'my': 'bottom',
         boundary: '<div>',
         offset: 'offset',
     }], 'tooltip has correct position');
+    assert.deepEqual(stubComponent.option.getCall(1).args, ['visible', true], 'tooltip is visible');
 
     assert.ok(stubCreateComponent.calledOnce);
 });
@@ -93,32 +93,13 @@ QUnit.test('createComponent should be called with correct options', function(ass
 
     assert.equal(stubCreateComponent.getCall(0).args[0][0].className, 'dx-scheduler-appointment-tooltip-wrapper');
     assert.deepEqual(stubCreateComponent.getCall(0).args[1], Tooltip);
-    assert.equal(Object.keys(stubCreateComponent.getCall(0).args[2]).length, 7);
+    assert.equal(Object.keys(stubCreateComponent.getCall(0).args[2]).length, 5);
     assert.equal(stubCreateComponent.getCall(0).args[2].target, 'target');
     assert.equal(stubCreateComponent.getCall(0).args[2].maxHeight, 200);
     assert.equal(stubCreateComponent.getCall(0).args[2].rtlEnabled, true);
 
-    assert.ok(stubCreateComponent.getCall(0).args[2].onShowing);
     assert.ok(stubCreateComponent.getCall(0).args[2].onShown);
     assert.ok(stubCreateComponent.getCall(0).args[2].contentTemplate);
-    assert.ok(stubCreateComponent.getCall(0).args[2].closeOnTargetScroll);
-});
-
-QUnit.test('onShowing and closeOnTargetScroll options passed to createComponent should work correct', function(assert) {
-    const tooltip = this.createSimpleTooltip(this.tooltipOptions);
-    const dataList = ['data1', 'data2'];
-
-    tooltip.show('target', dataList, this.extraOptions);
-
-    const done = assert.async();
-
-    stubCreateComponent.getCall(0).args[2].onShowing();
-    assert.equal(stubCreateComponent.getCall(0).args[2].closeOnTargetScroll(), true);
-    assert.timeout(1000);
-    setTimeout(function() {
-        assert.equal(stubCreateComponent.getCall(0).args[2].closeOnTargetScroll(), false);
-        done();
-    });
 });
 
 QUnit.test('contentTemplate passed to createComponent should work correct', function(assert) {
@@ -160,14 +141,14 @@ QUnit.test('Tooltip should update the content after call method "show" several t
     assert.deepEqual(stubComponent.option.getCall(0).args, ['visible', false]);
     assert.deepEqual(stubComponent.option.getCall(1).args, ['target', 'target']);
     assert.deepEqual(stubComponent.option.getCall(2).args, ['dataSource', ['updatedData1', 'updatedData2']]);
-    assert.deepEqual(stubComponent.option.getCall(3).args, ['visible', true]);
-    assert.deepEqual(stubComponent.option.getCall(4).args, ['position', {
+    assert.deepEqual(stubComponent.option.getCall(3).args, ['position', {
         'at': 'top',
         'collision': 'fit flipfit',
         'my': 'bottom',
         boundary: '<div>',
         offset: 'offset'
     }]);
+    assert.deepEqual(stubComponent.option.getCall(4).args, ['visible', true]);
 });
 
 QUnit.test('onShown passed to createComponent should work correct, one element in tooltip', function(assert) {


### PR DESCRIPTION
dxScheduler - move call focus of dxList after changing tooltip visibility(T917777)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
