### PR TITLE
Late binding DOM improves performance up to 88% for makeTable

### DIFF
--- a/js/ui/calendar/ui.calendar.base_view.js
+++ b/js/ui/calendar/ui.calendar.base_view.js
@@ -97,7 +97,6 @@ const BaseView = Widget.inherit({
             for(let colIndex = 0, colCount = this.option('colCount'); colIndex < colCount; colIndex++) {
                 this._renderCell(rowData, colIndex);
             }
-            this.$body.get(0).appendChild(rowData.row);
         }
     },
 
@@ -105,6 +104,7 @@ const BaseView = Widget.inherit({
         const row = domAdapter.createElement('tr');
 
         this.setAria('role', 'row', $(row));
+        this.$body.get(0).appendChild(row);
 
         return row;
     },

--- a/js/ui/calendar/ui.calendar.base_view.js
+++ b/js/ui/calendar/ui.calendar.base_view.js
@@ -97,6 +97,7 @@ const BaseView = Widget.inherit({
             for(let colIndex = 0, colCount = this.option('colCount'); colIndex < colCount; colIndex++) {
                 this._renderCell(rowData, colIndex);
             }
+            this.$body.get(0).appendChild(rowData.row);
         }
     },
 
@@ -104,7 +105,6 @@ const BaseView = Widget.inherit({
         const row = domAdapter.createElement('tr');
 
         this.setAria('role', 'row', $(row));
-        this.$body.get(0).appendChild(row);
 
         return row;
     },

--- a/js/ui/scheduler/ui.scheduler.table_creator.js
+++ b/js/ui/scheduler/ui.scheduler.table_creator.js
@@ -35,8 +35,6 @@ class SchedulerTableCreator {
         const groupIndex = options.groupIndex;
         const rowCount = options.rowCount;
 
-        $(options.container).append(tableBody);
-
         if(allDayElements) {
             this.insertAllDayRow(allDayElements, tableBody, 0);
             allDayElementIndex++;
@@ -44,7 +42,6 @@ class SchedulerTableCreator {
 
         for(let i = 0; i < rowCount; i++) {
             row = domAdapter.createElement(ROW_SELECTOR);
-            tableBody.appendChild(row);
 
             const isLastRowInGroup = (i + 1) % rowCountInGroup === 0;
 
@@ -54,7 +51,6 @@ class SchedulerTableCreator {
 
             for(let j = 0; j < options.cellCount; j++) {
                 const td = domAdapter.createElement('td');
-                row.appendChild(td);
 
                 if(options.cellClass) {
                     if(isFunction(options.cellClass)) {
@@ -63,7 +59,6 @@ class SchedulerTableCreator {
                         td.className = options.cellClass;
                     }
                 }
-
 
                 let cellDataObject;
                 let dataKey;
@@ -111,13 +106,19 @@ class SchedulerTableCreator {
                         td.innerHTML = '<div>' + options.getCellText(i, j) + '</div>';
                     }
                 }
+
+                row.appendChild(td);
             }
 
             if(allDayElements && isLastRowInGroup) {
                 this.insertAllDayRow(allDayElements, tableBody, allDayElementIndex);
                 allDayElementIndex++;
             }
+
+            tableBody.appendChild(row);
         }
+
+        $(options.container).append(tableBody);
 
         return templateCallbacks;
     }

--- a/js/ui/scheduler/ui.scheduler.table_creator.js
+++ b/js/ui/scheduler/ui.scheduler.table_creator.js
@@ -110,12 +110,12 @@ class SchedulerTableCreator {
                 row.appendChild(td);
             }
 
+            tableBody.appendChild(row);
+
             if(allDayElements && isLastRowInGroup) {
                 this.insertAllDayRow(allDayElements, tableBody, allDayElementIndex);
                 allDayElementIndex++;
             }
-
-            tableBody.appendChild(row);
         }
 
         $(options.container).append(tableBody);


### PR DESCRIPTION
Profiling for my company's usage of the scheduler, I found that several seconds can be spent within the makeTable call in ui.scheduler.table_creator.js. The issues occur with the schedules of 10-12 people for Week view especially. Using console.time measurements within this method, I found that a customer with 10 users' schedules, including hundreds of appointments over Week View could spend 3.5 seconds in this method. After these changes, that measurement dropped to around 400ms. 

The premise is that the later an element is bound to the DOM, the better. Making updates to an element that is within the DOM, like appending cells to a row and rows to a table will recalculate multiple elements each time it is done. The more elements in the DOM, the worse this becomes. The change is to simply move appendChild calls to as late as possible without changing much code.

We have a fork and are starting to use this for 19.2. We look forward to upgrading to 20.2, soon, hence the attempt to get this incorporated into your next release if possible.