### PR TITLE
Some ResizableContainer improvements

### DIFF
--- a/js/renovation/ui/pager/common/light_button.tsx
+++ b/js/renovation/ui/pager/common/light_button.tsx
@@ -5,6 +5,7 @@ import { registerKeyboardAction } from '../../../../ui/shared/accessibility';
 import { PAGER_CLASS } from './consts';
 import { closestClass } from '../utils/closest_class';
 import { subscribeToClickEvent } from '../../../utils/subscribe_to_event';
+import { EffectReturn } from '../../../utils/effect_return.d';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const viewFunction = ({
@@ -44,7 +45,7 @@ function createActionByOption(): () => void {
 export class LightButton extends JSXComponent(LightButtonProps) {
   @Ref() widgetRef!: HTMLDivElement;
 
-  @Effect() keyboardEffect(): (() => void) {
+  @Effect() keyboardEffect(): EffectReturn {
     const fakePagerInstance = {
       option: (): boolean => false,
       element: (): HTMLElement | null => closestClass(this.widgetRef, PAGER_CLASS),
@@ -53,7 +54,7 @@ export class LightButton extends JSXComponent(LightButtonProps) {
     return registerKeyboardAction('pager', fakePagerInstance, this.widgetRef, undefined, this.props.onClick);
   }
 
-  @Effect() subscribeToClick(): (() => void) | undefined {
+  @Effect() subscribeToClick(): EffectReturn {
     return subscribeToClickEvent(this.widgetRef, this.props.onClick);
   }
 }

--- a/js/renovation/ui/pager/content.tsx
+++ b/js/renovation/ui/pager/content.tsx
@@ -73,14 +73,8 @@ export const viewFunction = ({
   </div>
 );
 
-/* Vitik bug in generator try to use in resizable-container
-export type TwoWayProps = {
-  pageIndexChange?: (pageIndex: number) => void;
-  pageSizeChange?: (pageSize: number) => void;
-}; */
-
 @ComponentBindings()
-export class PagerContentProps extends PagerProps /* bug in generator  implements TwoWayProps */ {
+export class PagerContentProps extends PagerProps {
   @OneWay() infoTextVisible = true;
 
   @OneWay() isLargeDisplayMode = true;


### PR DESCRIPTION
use common EffectReturn
remove unused parentWidth
add typing for contentTemplate
