### PR TITLE
Fix some bugs in pager resize

### DIFF
--- a/js/renovation/ui/pager/__tests__/resizable_container.test.tsx
+++ b/js/renovation/ui/pager/__tests__/resizable_container.test.tsx
@@ -258,7 +258,7 @@ describe('resizable-container', () => {
         });
       });
 
-      it('update elementswidths if widths changed', () => {
+      it('update elementsWidth if widths changed', () => {
         const component = createComponent({
           width: 350, pageSizes: 100, pages: 100, info: 100,
         });

--- a/js/renovation/ui/pager/common/light_button.tsx
+++ b/js/renovation/ui/pager/common/light_button.tsx
@@ -5,7 +5,7 @@ import { registerKeyboardAction } from '../../../../ui/shared/accessibility';
 import { PAGER_CLASS } from './consts';
 import { closestClass } from '../utils/closest_class';
 import { subscribeToClickEvent } from '../../../utils/subscribe_to_event';
-import { EffectReturn } from '../../../utils/effect_return.d';
+import { DisposeEffectReturn } from '../../../utils/effect_return.d';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const viewFunction = ({
@@ -45,7 +45,7 @@ function createActionByOption(): () => void {
 export class LightButton extends JSXComponent(LightButtonProps) {
   @Ref() widgetRef!: HTMLDivElement;
 
-  @Effect() keyboardEffect(): EffectReturn {
+  @Effect() keyboardEffect(): DisposeEffectReturn {
     const fakePagerInstance = {
       option: (): boolean => false,
       element: (): HTMLElement | null => closestClass(this.widgetRef, PAGER_CLASS),
@@ -54,7 +54,7 @@ export class LightButton extends JSXComponent(LightButtonProps) {
     return registerKeyboardAction('pager', fakePagerInstance, this.widgetRef, undefined, this.props.onClick);
   }
 
-  @Effect() subscribeToClick(): EffectReturn {
+  @Effect() subscribeToClick(): DisposeEffectReturn {
     return subscribeToClickEvent(this.widgetRef, this.props.onClick);
   }
 }

--- a/js/renovation/utils/effect_return.d.ts
+++ b/js/renovation/utils/effect_return.d.ts
@@ -1,1 +1,2 @@
-export type EffectReturn = (() => void) | void;
+export type DisposeEffectReturn = (() => void) | undefined;
+export type EffectReturn = DisposeEffectReturn | void;

--- a/js/renovation/utils/subscribe_to_event.ts
+++ b/js/renovation/utils/subscribe_to_event.ts
@@ -1,9 +1,9 @@
 import eventsEngine from '../../events/core/events_engine';
 import * as clickEvent from '../../events/click';
+import { DisposeEffectReturn } from './effect_return.d';
 
-type EventSubscriptionDispose = (() => void) | undefined;
 export function subscribeToEvent(eventName: string) {
-  return (element: HTMLElement, handler): EventSubscriptionDispose => {
+  return (element: HTMLElement, handler): DisposeEffectReturn => {
     if (handler) {
       eventsEngine.on(element, eventName, handler);
       return (): void => eventsEngine.off(element, clickEvent.name, handler);


### PR DESCRIPTION
resize callback closure initial state of elementsWidths (with zero value) because @Effect({ run: 'once' })
If pager has the size to show only info for 0 page index changes pageIndex to 100 then grown info doesn't hide.
Simplify update logic
test refactoring to bugs reproduce and test changed code
Add DisposeEffectReturn for fix error in test
