### PR TITLE
DataGrid: Fix loading data on scroll after a push to store when scrolling mode is 'infinite' and refreshMode is 'repaint' (T914296)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -486,7 +486,7 @@ module.exports = gridCore.Controller.inherit((function() {
                     dataSource.load();
                     isLoading = true;
                 }
-            } else {
+            } else if(!args || typeUtils.isDefined(args.changeType)) {
                 currentTotalCount = dataSource.pageIndex() * that.pageSize() + itemsCount;
                 that._currentTotalCount = Math.max(that._currentTotalCount, currentTotalCount);
                 if(itemsCount === 0 && dataSource.pageIndex() >= that.pageCount()) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -3461,6 +3461,49 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             assert.strictEqual(dataGrid.totalCount(), refreshMode === 'repaint' ? 152 : 151, 'totalCount'); // TODO: Fix duplicate added row when editing.refreshMode = 'repaint'
             assert.strictEqual(rows[rows.length - 2].key, 150, 'penultimate row key');
         });
+
+        QUnit.test(`loading data on scroll after a push to store if scrolling mode is infinite and refreshMode is ${refreshMode} (T914296)`, function(assert) {
+            // arrange
+            const array = [];
+
+            for(let i = 1; i <= 150; i++) {
+                array.push({ id: i });
+            }
+
+            const dataGrid = $('#dataGrid').dxDataGrid({
+                height: 400,
+                dataSource: array,
+                keyExpr: 'id',
+                editing: {
+                    mode: 'row',
+                    allowAdding: true,
+                    refreshMode: refreshMode
+                },
+                paging: {
+                    pageSize: 50
+                },
+                scrolling: {
+                    mode: 'infinite',
+                    useNative: false
+                },
+                columns: ['id'],
+                loadingTimeout: undefined
+            }).dxDataGrid('instance');
+
+            // act
+            dataGrid.getScrollable().scrollTo({ y: 10000 });
+            dataGrid.getScrollable().scrollTo({ y: 0 });
+            dataGrid.getDataSource().store().push([{ type: 'insert', data: { id: 987654321 }, index: 0 }]);
+            this.clock.tick();
+            dataGrid.getScrollable().scrollTo({ y: 10000 });
+            dataGrid.getScrollable().scrollTo({ y: 10000 });
+            dataGrid.getScrollable().scrollTo({ y: 10000 });
+
+            // assert
+            const rows = dataGrid.getVisibleRows();
+            assert.strictEqual(rows[rows.length - 2].key, 150, 'penultimate row key');
+            assert.strictEqual(dataGrid.totalCount(), 152, 'totalCount'); // TODO: Fix duplicate added row
+        });
     });
 
     QUnit.test('height from extern styles', function(assert) {


### PR DESCRIPTION
See https://devexpress.com/issue=T914296