### PR TITLE
DataGrid: Fix loading data on scroll after a push to store when scrolling mode is 'infinite' and refreshMode is 'repaint' (T914296)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -488,7 +488,7 @@ module.exports = gridCore.Controller.inherit((function() {
                     dataSource.load();
                     isLoading = true;
                 }
-            } else {
+            } else if(!args || typeUtils.isDefined(args.changeType)) {
                 currentTotalCount = dataSource.pageIndex() * that.pageSize() + itemsCount;
                 that._currentTotalCount = Math.max(that._currentTotalCount, currentTotalCount);
                 if(itemsCount === 0 && dataSource.pageIndex() >= that.pageCount()) {


### PR DESCRIPTION
See https://devexpress.com/issue=T914296