### PR TITLE
Add the 'getModule' method to the HtmlEditor

### DIFF
--- a/js/ui/html_editor.d.ts
+++ b/js/ui/html_editor.d.ts
@@ -227,7 +227,7 @@ export default class dxHtmlEditor extends Editor {
     getLength(): number;
     /**
      * @docid dxHtmlEditorMethods.getModule
-     * @publicName getModule()
+     * @publicName getModule(moduleName)
      * @param1 moduleName:string
      * @return Object
      * @prevFileNamespace DevExpress.ui

--- a/js/ui/html_editor.d.ts
+++ b/js/ui/html_editor.d.ts
@@ -226,6 +226,15 @@ export default class dxHtmlEditor extends Editor {
      */
     getLength(): number;
     /**
+     * @docid dxHtmlEditorMethods.getModule
+     * @publicName getModule()
+     * @param1 moduleName:string
+     * @return Object
+     * @prevFileNamespace DevExpress.ui
+     * @public
+     */
+    getModule(moduleName: string): any;
+    /**
      * @docid dxHtmlEditorMethods.getQuillInstance
      * @publicName getQuillInstance()
      * @return Object

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -543,6 +543,10 @@ const HtmlEditor = Editor.inherit({
         return this._getRegistrator().getQuill().import(modulePath);
     },
 
+    getModule: function(moduleName) {
+        return this._applyQuillMethod('getModule', arguments);
+    },
+
     getQuillInstance: function() {
         return this._quillInstance;
     },

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/api.tests.js
@@ -53,6 +53,15 @@ QUnit.module('API', moduleConfig, () => {
         assert.ok(quillInstance.format, 'specific method isn\'t undefined');
     });
 
+    test('get module instance', function(assert) {
+        this.createEditor();
+        const Clipboard = this.instance.get('modules/clipboard');
+        const clipboardInstance = this.instance.getModule('clipboard');
+
+        assert.ok(clipboardInstance, 'module instance is not undefined');
+        assert.ok(clipboardInstance instanceof Clipboard, 'module is instance of the Clipboard class');
+    });
+
     test('get/set selection', function(assert) {
         this.createEditor();
         this.instance.setSelection(1, 2);

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -7941,6 +7941,10 @@ declare module DevExpress.ui {
          */
         getLength(): number;
         /**
+         * <-dxHtmlEditor.getModule(moduleName)->
+         */
+        getModule(moduleName: string): any;
+        /**
          * <-dxHtmlEditor.getQuillInstance()->
          */
         getQuillInstance(): any;


### PR DESCRIPTION
Add the common way to get the module instance.

```js
editor.getModule('table').insertRowAbove();
editor.getModule('clipboard').addMatcher(/* args */);
``` 
