### PR TITLE
DataGrid - Fixes the "Failed to execute 'removeChild' on 'Node'" error (T929219)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.column_fixing.js
+++ b/js/ui/grid_core/ui.grid_core.column_fixing.js
@@ -18,7 +18,6 @@ const LAST_CELL_CLASS = 'dx-last-cell';
 const HOVER_STATE_CLASS = 'dx-state-hover';
 const FIXED_COL_CLASS = 'dx-col-fixed';
 const FIXED_COLUMNS_CLASS = 'dx-fixed-columns';
-const POINTER_EVENTS_TARGET_CLASS = 'dx-pointer-events-target';
 const POINTER_EVENTS_NONE_CLASS = 'dx-pointer-events-none';
 const COMMAND_TRANSPARENT = 'transparent';
 const GROUP_ROW_CLASS = 'dx-group-row';
@@ -189,7 +188,7 @@ const baseFixedColumns = {
         const $scrollContainer = this.callBase.apply(this, arguments);
 
         if(this._isFixedTableRendering) {
-            $scrollContainer.addClass(this.addWidgetPrefix(CONTENT_FIXED_CLASS) + ' ' + POINTER_EVENTS_TARGET_CLASS);
+            $scrollContainer.addClass(this.addWidgetPrefix(CONTENT_FIXED_CLASS));
         }
 
         return $scrollContainer;
@@ -641,7 +640,7 @@ const RowsViewFixedColumnsExtender = extend({}, baseFixedColumns, {
         if(this._isFixedTableRendering) {
             return contentElement
                 .empty()
-                .addClass(this.addWidgetPrefix(CONTENT_CLASS) + ' ' + this.addWidgetPrefix(CONTENT_FIXED_CLASS) + ' ' + POINTER_EVENTS_TARGET_CLASS)
+                .addClass(this.addWidgetPrefix(CONTENT_CLASS) + ' ' + this.addWidgetPrefix(CONTENT_FIXED_CLASS))
                 .append(tableElement);
         }
 

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -69,8 +69,6 @@ const DATA_EDIT_DATA_INSERT_TYPE = 'insert';
 const DATA_EDIT_DATA_UPDATE_TYPE = 'update';
 const DATA_EDIT_DATA_REMOVE_TYPE = 'remove';
 
-const POINTER_EVENTS_TARGET_CLASS = 'dx-pointer-events-target';
-
 const DEFAULT_START_EDIT_ACTION = 'click';
 
 const EDIT_MODES = [EDIT_MODE_BATCH, EDIT_MODE_ROW, EDIT_MODE_CELL, EDIT_MODE_FORM, EDIT_MODE_POPUP];
@@ -2577,9 +2575,9 @@ const EditingController = modules.ViewController.inherit((function() {
 
         showHighlighting: function($cell) {
             const isHighlighted = $cell.hasClass(CELL_HIGHLIGHT_OUTLINE);
-            !isHighlighted && $cell.addClass(`${CELL_HIGHLIGHT_OUTLINE} ${POINTER_EVENTS_TARGET_CLASS}`);
+            !isHighlighted && $cell.addClass(CELL_HIGHLIGHT_OUTLINE);
             // if($cell.get(0).tagName === 'TD' && !$highlight.length) {
-            //     $cell.wrapInner($('<div>').addClass(CELL_HIGHLIGHT_OUTLINE + ' ' + POINTER_EVENTS_TARGET_CLASS));
+            //     $cell.wrapInner($('<div>').addClass(CELL_HIGHLIGHT_OUTLINE));
             // }
         },
 

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -50,7 +50,6 @@ const ROW_REMOVED = 'dx-row-removed';
 const ROW_INSERTED = 'dx-row-inserted';
 const ROW_MODIFIED = 'dx-row-modified';
 const CELL_MODIFIED = 'dx-cell-modified';
-const CELL_HIGHLIGHT_OUTLINE = 'dx-highlight-outline';
 const EDITING_NAMESPACE = 'dxDataGridEditing';
 const DATA_ROW_CLASS = 'dx-data-row';
 
@@ -2573,22 +2572,9 @@ const EditingController = modules.ViewController.inherit((function() {
             return buttonItems;
         },
 
-        showHighlighting: function($cell) {
-            const isHighlighted = $cell.hasClass(CELL_HIGHLIGHT_OUTLINE);
-            !isHighlighted && $cell.addClass(CELL_HIGHLIGHT_OUTLINE);
-            // if($cell.get(0).tagName === 'TD' && !$highlight.length) {
-            //     $cell.wrapInner($('<div>').addClass(CELL_HIGHLIGHT_OUTLINE));
-            // }
-        },
-
         highlightDataCell: function($cell, parameters) {
-            const isEditableCell = parameters.setValue;
             const cellModified = this.isCellModified(parameters);
-
-            if(cellModified && parameters.column.setCellValue || isEditableCell) {
-                this.showHighlighting($cell);
-                cellModified && parameters.column.setCellValue && $cell.addClass(CELL_MODIFIED);
-            }
+            cellModified && parameters.column.setCellValue && $cell.addClass(CELL_MODIFIED);
         },
 
         _afterInsertRow: function() { },

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -2576,21 +2576,20 @@ const EditingController = modules.ViewController.inherit((function() {
         },
 
         showHighlighting: function($cell) {
-            const $highlight = $cell.find('.' + CELL_HIGHLIGHT_OUTLINE);
-            if($cell.get(0).tagName === 'TD' && !$highlight.length) {
-                $cell.wrapInner($('<div>').addClass(CELL_HIGHLIGHT_OUTLINE + ' ' + POINTER_EVENTS_TARGET_CLASS));
-            }
+            const isHighlighted = $cell.hasClass(CELL_HIGHLIGHT_OUTLINE);
+            !isHighlighted && $cell.addClass(`${CELL_HIGHLIGHT_OUTLINE} ${POINTER_EVENTS_TARGET_CLASS}`);
+            // if($cell.get(0).tagName === 'TD' && !$highlight.length) {
+            //     $cell.wrapInner($('<div>').addClass(CELL_HIGHLIGHT_OUTLINE + ' ' + POINTER_EVENTS_TARGET_CLASS));
+            // }
         },
 
         highlightDataCell: function($cell, parameters) {
             const isEditableCell = parameters.setValue;
             const cellModified = this.isCellModified(parameters);
 
-            if(cellModified && parameters.column.setCellValue) {
+            if(cellModified && parameters.column.setCellValue || isEditableCell) {
                 this.showHighlighting($cell);
-                $cell.addClass(CELL_MODIFIED);
-            } else if(isEditableCell) {
-                this.showHighlighting($cell);
+                cellModified && parameters.column.setCellValue && $cell.addClass(CELL_MODIFIED);
             }
         },
 

--- a/js/ui/grid_core/ui.grid_core.editor_factory.js
+++ b/js/ui/grid_core/ui.grid_core.editor_factory.js
@@ -5,7 +5,7 @@ import modules from './ui.grid_core.modules';
 import { name as clickEventName } from '../../events/click';
 import pointerEvents from '../../events/pointer';
 import positionUtils from '../../animation/position';
-import { addNamespace, normalizeKeyName } from '../../events/utils';
+import { addNamespace, normalizeKeyName } from '../../events/utils/index';
 import browser from '../../core/utils/browser';
 import { extend } from '../../core/utils/extend';
 import { getBoundingRect } from '../../core/utils/position';

--- a/js/ui/grid_core/ui.grid_core.editor_factory.js
+++ b/js/ui/grid_core/ui.grid_core.editor_factory.js
@@ -5,7 +5,7 @@ import modules from './ui.grid_core.modules';
 import { name as clickEventName } from '../../events/click';
 import pointerEvents from '../../events/pointer';
 import positionUtils from '../../animation/position';
-import { addNamespace, fireEvent, normalizeKeyName } from '../../events/utils';
+import { addNamespace, normalizeKeyName } from '../../events/utils';
 import browser from '../../core/utils/browser';
 import { extend } from '../../core/utils/extend';
 import { getBoundingRect } from '../../core/utils/position';
@@ -20,8 +20,6 @@ const FOCUSED_ELEMENT_CLASS = 'dx-focused';
 const ROW_CLASS = 'dx-row';
 const MODULE_NAMESPACE = 'dxDataGridEditorFactory';
 const UPDATE_FOCUS_EVENTS = addNamespace([pointerEvents.down, 'focusin', clickEventName].join(' '), MODULE_NAMESPACE);
-const POINTER_EVENTS_TARGET_CLASS = 'dx-pointer-events-target';
-const POINTER_EVENTS_NONE_CLASS = 'dx-pointer-events-none';
 const DX_HIDDEN = 'dx-hidden';
 
 const EditorFactory = modules.ViewController.inherit({
@@ -139,7 +137,7 @@ const EditorFactory = modules.ViewController.inherit({
         }
 
         if(!that._$focusOverlay) {
-            that._$focusOverlay = $('<div>').addClass(that.addWidgetPrefix(FOCUS_OVERLAY_CLASS) + ' ' + POINTER_EVENTS_TARGET_CLASS);
+            that._$focusOverlay = $('<div>').addClass(that.addWidgetPrefix(FOCUS_OVERLAY_CLASS));
         }
 
         if(hideBorder) {
@@ -206,31 +204,6 @@ const EditorFactory = modules.ViewController.inherit({
                     that._updateFocusHandler(e);
                 }
             });
-        }
-    },
-
-    _focusOverlayEventProxy: function(e) {
-        const $target = $(e.target);
-        const $currentTarget = $(e.currentTarget);
-        const needProxy = $target.hasClass(POINTER_EVENTS_TARGET_CLASS) || $target.hasClass(POINTER_EVENTS_NONE_CLASS);
-
-        if(!needProxy || $currentTarget.hasClass(DX_HIDDEN)) return;
-
-        $currentTarget.addClass(DX_HIDDEN);
-
-        const element = $target.get(0).ownerDocument.elementFromPoint(e.clientX, e.clientY);
-
-        fireEvent({
-            originalEvent: e,
-            target: element
-        });
-
-        e.stopPropagation();
-
-        $currentTarget.removeClass(DX_HIDDEN);
-
-        if(e.type === clickEventName && element.tagName === 'INPUT') {
-            eventsEngine.trigger($(element), 'focus');
         }
     },
 

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -914,7 +914,7 @@ export default {
                     const isEditableCell = !!parameters.setValue;
                     const cellModified = this.isCellModified(parameters);
                     const isValidated = isDefined(parameters.validationStatus);
-                    const needValidation = (cellModified && parameters.column.setCellValue) || (isEditableCell && !cellModified && isValidated);
+                    const needValidation = (cellModified && parameters.column.setCellValue) || (isEditableCell && !cellModified && !(parameters.row.isNewRow || !isValidated));
                     if(needValidation) {
                         const validator = $cell.data('dxValidator');
                         if(validator) {

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -14,7 +14,7 @@ import ValidationEngine from '../validation_engine';
 import Validator from '../validator';
 import Tooltip from '../tooltip';
 import Overlay from '../overlay';
-import themes from '../themes';
+// import themes from '../themes';
 import errors from '../widget/ui.errors';
 import { Deferred, when } from '../../core/utils/deferred';
 import LoadIndicator from '../load_indicator';
@@ -1081,9 +1081,9 @@ export default {
                     },
 
                     _showValidationMessage: function($cell, messages, alignment, revertTooltip) {
-                        const $highlightContainer = $cell.find('.' + CELL_HIGHLIGHT_OUTLINE);
-                        const isMaterial = themes.isMaterial();
-                        const overlayTarget = $highlightContainer.length && !isMaterial ? $highlightContainer : $cell;
+                        // const $highlightContainer = $cell.find('.' + CELL_HIGHLIGHT_OUTLINE);
+                        // const isMaterial = themes.isMaterial();
+                        // const overlayTarget = $cell;// $highlightContainer.length && !isMaterial ? $highlightContainer : $cell;
                         const editorPopup = $cell.find('.dx-dropdowneditor-overlay').data('dxPopup');
                         const isOverlayVisible = editorPopup && editorPopup.option('visible');
                         const myPosition = isOverlayVisible ? 'top right' : 'top ' + alignment;
@@ -1102,7 +1102,7 @@ export default {
                             .appendTo($cell);
 
                         const overlayOptions = {
-                            target: overlayTarget,
+                            target: $cell,
                             container: $cell,
                             shading: false,
                             width: 'auto',

--- a/scss/widgets/base/_gridBase.scss
+++ b/scss/widgets/base/_gridBase.scss
@@ -446,7 +446,7 @@
         }
       }
 
-      .dx-editor-cell {
+      .dx-editor-cell:not(.dx-command-select) {
         overflow: visible;
         max-width: 0;
         padding: 0;
@@ -527,6 +527,7 @@
     }
   }
 
+  .dx-highlight-outline,
   .dx-cell-modified,
   .dx-#{$widget-name}-invalid {
     position: relative;
@@ -557,6 +558,7 @@
       margin: 0;
     }
 
+    .dx-highlight-outline,
     &.dx-cell-modified,
     &.dx-#{$widget-name}-invalid {
       padding: 0;
@@ -577,6 +579,7 @@
   }
 
   .dx-column-lines {
+    .dx-highlight-outline,
     .dx-cell-modified,
     .dx-#{$widget-name}-invalid {
       &::after {
@@ -711,6 +714,7 @@
     }
 
     .dx-focused {
+      .dx-highlight-outline,
       &.dx-cell-modified,
       &.dx-#{$widget-name}-invalid {
         &::after {

--- a/scss/widgets/base/_gridBase.scss
+++ b/scss/widgets/base/_gridBase.scss
@@ -439,7 +439,7 @@
 
       .dx-cell-modified,
       .dx-#{$widget-name}-invalid {
-        &:not(.dx-field-item-content) {
+        &:not(.dx-field-item-content):not(.dx-highlight-outline) {
           padding: 0;
         }
       }
@@ -562,11 +562,11 @@
       margin: 0;
     }
 
-    .dx-highlight-outline {
+    &.dx-highlight-outline {
       padding: 0;
     }
 
-    &.dx-editor-inline-block .dx-highlight-outline::before {
+    &.dx-editor-inline-block.dx-highlight-outline::before {
       display: inline-block;
       content: '\200b';
       vertical-align: middle;
@@ -915,7 +915,7 @@
     }
 
     .dx-data-row.dx-edit-row {
-      .dx-cell-modified .dx-highlight-outline:after {
+      .dx-cell-modified.dx-highlight-outline:after {
         border-color: transparent;
       }
     }

--- a/scss/widgets/base/_gridBase.scss
+++ b/scss/widgets/base/_gridBase.scss
@@ -147,7 +147,7 @@
           display: inline-block;
         }
 
-        &.dx-header-filter:after {
+        &.dx-header-filter::after {
           content: '';
           position: absolute;
           top: 0;
@@ -437,13 +437,6 @@
         overflow: hidden;
       }
 
-      .dx-cell-modified,
-      .dx-#{$widget-name}-invalid {
-        &:not(.dx-field-item-content):not(.dx-highlight-outline) {
-          padding: 0;
-        }
-      }
-
       .dx-#{$widget-name}-invalid .dx-invalid-message.dx-overlay {
         position: static;
 
@@ -454,6 +447,7 @@
       }
 
       .dx-editor-cell {
+        overflow: visible;
         max-width: 0;
         padding: 0;
         vertical-align: middle;
@@ -533,7 +527,8 @@
     }
   }
 
-  .dx-highlight-outline {
+  .dx-cell-modified,
+  .dx-#{$widget-name}-invalid {
     position: relative;
     padding: $grid-cell-padding;
 
@@ -562,22 +557,31 @@
       margin: 0;
     }
 
-    &.dx-highlight-outline {
+    &.dx-cell-modified,
+    &.dx-#{$widget-name}-invalid {
       padding: 0;
     }
 
-    &.dx-editor-inline-block.dx-highlight-outline::before {
-      display: inline-block;
-      content: '\200b';
-      vertical-align: middle;
-      padding-top: $grid-cell-padding;
-      padding-bottom: $grid-cell-padding;
+    &.dx-editor-inline-block {
+      &.dx-cell-modified,
+      &.dx-#{$widget-name}-invalid {
+        &::before {
+          display: inline-block;
+          content: '\200b';
+          vertical-align: middle;
+          padding-top: $grid-cell-padding;
+          padding-bottom: $grid-cell-padding;
+        }
+      }
     }
   }
 
   .dx-column-lines {
-    .dx-highlight-outline::after {
-      left: 0;
+    .dx-cell-modified,
+    .dx-#{$widget-name}-invalid {
+      &::after {
+        left: 0;
+      }
     }
   }
 
@@ -655,7 +659,7 @@
     .dx-editor-container .dx-texteditor {
       border-width: 0;
 
-      &.dx-state-focused:after {
+      &.dx-state-focused::after {
         content: " ";
         position: absolute;
         top: -1px;
@@ -671,8 +675,11 @@
       border-top: 1px solid transparent;
     }
 
-    .dx-editor-container.dx-highlight-outline {
-      padding: 0;
+    .dx-editor-container {
+      &.dx-cell-modified,
+      &.dx-#{$widget-name}-invalid {
+        padding: 0;
+      }
     }
   }
 
@@ -696,14 +703,16 @@
       }
     }
 
-    .dx-highlight-outline {
+    .dx-cell-modified,
+    .dx-#{$widget-name}-invalid {
       &::after {
         pointer-events: none;
       }
     }
 
     .dx-focused {
-      .dx-highlight-outline {
+      &.dx-cell-modified,
+      &.dx-#{$widget-name}-invalid {
         &::after {
           border-color: transparent;
         }
@@ -732,7 +741,7 @@
     }
 
     .dx-menu-item.dx-state-focused {
-      &:after {
+      &::after {
         position: absolute;
         left: 2px;
         top: 2px;
@@ -915,7 +924,7 @@
     }
 
     .dx-data-row.dx-edit-row {
-      .dx-cell-modified.dx-highlight-outline:after {
+      .dx-cell-modified::after {
         border-color: transparent;
       }
     }

--- a/scss/widgets/generic/gridBase/_index.scss
+++ b/scss/widgets/generic/gridBase/_index.scss
@@ -478,6 +478,7 @@ $generic-grid-base-checkbox-icon-size: 16px;
       }
     }
 
+    .dx-highlight-outline,
     .dx-cell-modified,
     .dx-#{$widget-name}-invalid {
       &::after {

--- a/scss/widgets/generic/gridBase/_index.scss
+++ b/scss/widgets/generic/gridBase/_index.scss
@@ -877,6 +877,24 @@ $generic-grid-base-checkbox-icon-size: 16px;
           background-color: $datagrid-base-background-color;
         }
       }
+
+      &.dx-editor-cell {
+        .dx-texteditor {
+          &.dx-validation-pending {
+            .dx-texteditor-input {
+              padding-right: $generic-texteditor-invalid-badge-size;
+            }
+
+            &.dx-rtl {
+              .dx-texteditor-input {
+                padding-right: $generic-grid-base-cell-padding;
+                padding-bottom: $generic-grid-base-cell-padding;
+                padding-left: $generic-texteditor-invalid-badge-size;
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/scss/widgets/generic/gridBase/_index.scss
+++ b/scss/widgets/generic/gridBase/_index.scss
@@ -658,11 +658,11 @@ $generic-grid-base-checkbox-icon-size: 16px;
 
     .dx-data-row {
       .dx-validator.dx-#{$widget-name}-invalid {
-        .dx-highlight-outline::after {
+        &.dx-highlight-outline::after {
           border: 1px solid $datagrid-row-invalid-faded-border-color;
         }
 
-        &.dx-focused > .dx-highlight-outline::after {
+        &.dx-focused.dx-highlight-outline::after {
           border: 1px solid $datagrid-row-invalid-border-color;
         }
       }
@@ -674,16 +674,10 @@ $generic-grid-base-checkbox-icon-size: 16px;
       }
 
       .dx-cell-modified {
-        .dx-highlight-outline {
+        &.dx-highlight-outline {
           &::after {
             border-color: $datagrid-cell-modified-border-color;
           }
-        }
-      }
-
-      td:not(.dx-cell-modified):not(.dx-validation-pending):not(.dx-#{$widget-name}-invalid) {
-        .dx-highlight-outline {
-          padding: 0;
         }
       }
     }
@@ -843,7 +837,8 @@ $generic-grid-base-checkbox-icon-size: 16px;
         position: relative;
         padding: 0;
 
-        .dx-highlight-outline {
+        &.dx-highlight-outline {
+          padding: $generic-grid-base-cell-padding;
           padding-right: $generic-texteditor-invalid-badge-size;
 
           @at-root #{selector-append(".dx-rtl", &)},

--- a/scss/widgets/generic/gridBase/_index.scss
+++ b/scss/widgets/generic/gridBase/_index.scss
@@ -257,9 +257,14 @@ $generic-grid-base-checkbox-icon-size: 16px;
       border-radius: 0;
     }
 
-    &.dx-editor-inline-block .dx-highlight-outline::before {
-      padding-top: $generic-grid-base-cell-padding;
-      padding-bottom: $generic-grid-base-cell-padding;
+    &.dx-editor-inline-block {
+      .dx-cell-modified,
+      .dx-#{$widget-name}-invalid {
+        &::before {
+          padding-top: $generic-grid-base-cell-padding;
+          padding-bottom: $generic-grid-base-cell-padding;
+        }
+      }
     }
   }
 
@@ -473,7 +478,8 @@ $generic-grid-base-checkbox-icon-size: 16px;
       }
     }
 
-    .dx-highlight-outline {
+    .dx-cell-modified,
+    .dx-#{$widget-name}-invalid {
       &::after {
         border-color: $datagrid-cell-modified-border-color;
       }
@@ -496,9 +502,14 @@ $generic-grid-base-checkbox-icon-size: 16px;
       overflow: inherit;
       box-shadow: 2px 2px 3px $datagrid-overlay-content-shadow-color;
 
-      .dx-editor-container.dx-highlight-outline::after {
-        border-color: $datagrid-cell-modified-border-color;
-        left: 0;
+      .dx-editor-container {
+        &.dx-cell-modified,
+        &.dx-#{$widget-name}-invalid {
+          &::after {
+            border-color: $datagrid-cell-modified-border-color;
+            left: 0;
+          }
+        }
       }
 
       .dx-texteditor {
@@ -545,7 +556,8 @@ $generic-grid-base-checkbox-icon-size: 16px;
     }
   }
 
-  .dx-highlight-outline {
+  .dx-cell-modified,
+  .dx-#{$widget-name}-invalid {
     padding: $generic-grid-base-cell-padding;
   }
 
@@ -658,12 +670,20 @@ $generic-grid-base-checkbox-icon-size: 16px;
 
     .dx-data-row {
       .dx-validator.dx-#{$widget-name}-invalid {
-        &.dx-highlight-outline::after {
-          border: 1px solid $datagrid-row-invalid-faded-border-color;
+        &.dx-cell-modified,
+        &.dx-#{$widget-name}-invalid {
+          &::after {
+            border: 1px solid $datagrid-row-invalid-faded-border-color;
+          }
         }
 
-        &.dx-focused.dx-highlight-outline::after {
-          border: 1px solid $datagrid-row-invalid-border-color;
+        &.dx-focused {
+          &.dx-cell-modified,
+          &.dx-#{$widget-name}-invalid {
+            &::after {
+              border: 1px solid $datagrid-row-invalid-border-color;
+            }
+          }
         }
       }
 
@@ -674,7 +694,8 @@ $generic-grid-base-checkbox-icon-size: 16px;
       }
 
       .dx-cell-modified {
-        &.dx-highlight-outline {
+        &.dx-cell-modified,
+        &.dx-#{$widget-name}-invalid {
           &::after {
             border-color: $datagrid-cell-modified-border-color;
           }
@@ -837,14 +858,15 @@ $generic-grid-base-checkbox-icon-size: 16px;
         position: relative;
         padding: 0;
 
-        &.dx-highlight-outline {
+        &.dx-cell-modified,
+        &.dx-#{$widget-name}-invalid {
           padding: $generic-grid-base-cell-padding;
           padding-right: $generic-texteditor-invalid-badge-size;
 
           @at-root #{selector-append(".dx-rtl", &)},
           .dx-rtl & {
             padding-left: $generic-texteditor-invalid-badge-size;
-            padding-right: 0;
+            padding-right: $generic-grid-base-cell-padding;
           }
         }
 

--- a/scss/widgets/material/gridBase/_index.scss
+++ b/scss/widgets/material/gridBase/_index.scss
@@ -869,14 +869,6 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
       }
     }
 
-    .dx-data-row {
-      td:not(.dx-cell-modified):not(.dx-validation-pending):not(.dx-#{$widget-name}-invalid) {
-        .dx-highlight-outline {
-          padding: 0;
-        }
-      }
-    }
-
     .dx-row-removed > td {
       background-color: $datagrid-row-removed-bg;
       border-top: 1px solid $datagrid-cell-modified-border-color;
@@ -1012,7 +1004,8 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
         position: relative;
         padding: 0;
 
-        .dx-highlight-outline {
+        &.dx-highlight-outline {
+          padding: $material-grid-base-cell-padding;
           padding-right: $material-texteditor-invalid-badge-size;
 
           @at-root #{selector-append(".dx-rtl", &)},

--- a/scss/widgets/material/gridBase/_index.scss
+++ b/scss/widgets/material/gridBase/_index.scss
@@ -7,6 +7,7 @@
 @use "../dropDownEditor" as *;
 @use "../textEditor" as *;
 @use "../common/mixins" as *;
+@use "../common/sizes" as *;
 @use "../popup/colors" as *;
 @use "../menu/colors" as *;
 @use "../toolbar/colors" as *;
@@ -239,9 +240,9 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
     }
 
     .dx-#{$widget-name}-content .dx-#{$widget-name}-table .dx-row {
-      > td,
-      > td.dx-cell-modified:not(.dx-field-item-content),
-      > td.dx-#{$widget-name}-invalid:not(.dx-field-item-content) {
+      > td:not(.dx-validation-pending),
+      > td.dx-cell-modified:not(.dx-field-item-content):not(.dx-validation-pending),
+      > td.dx-#{$widget-name}-invalid:not(.dx-field-item-content):not(.dx-validation-pending) {
         padding-right: $material-grid-base-cell-horizontal-padding;
         padding-left: $material-grid-base-cell-horizontal-padding;
         vertical-align: middle;
@@ -404,6 +405,15 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
         margin-top: 0;
       }
 
+      &.dx-validation-pending {
+        .dx-texteditor-input-container {
+          .dx-texteditor-input {
+            padding-top: 0;
+            padding-bottom: 0;
+          }
+        }
+      }
+
       .dx-tag-container {
         min-height: $material-grid-base-cell-height;
         padding: 0;
@@ -441,9 +451,14 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
       border-radius: 0;
     }
 
-    &.dx-editor-inline-block .dx-highlight-outline::before {
-      padding-top: $material-grid-base-cell-vertical-padding;
-      padding-bottom: $material-grid-base-cell-vertical-padding;
+    &.dx-editor-inline-block {
+      .dx-cell-modified,
+      .dx-#{$widget-name}-invalid {
+        &::before {
+          padding-top: $material-grid-base-cell-vertical-padding;
+          padding-bottom: $material-grid-base-cell-vertical-padding;
+        }
+      }
     }
   }
 
@@ -712,7 +727,8 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
     }
   }
 
-  .dx-highlight-outline {
+  .dx-cell-modified,
+  .dx-#{$widget-name}-invalid {
     padding: $material-grid-base-cell-vertical-padding 0 $material-grid-base-cell-vertical-padding 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1004,22 +1020,29 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
         position: relative;
         padding: 0;
 
-        &.dx-highlight-outline {
+        &.dx-cell-modified,
+        .dx-#{$widget-name}-invalid {
           padding: $material-grid-base-cell-padding;
           padding-right: $material-texteditor-invalid-badge-size;
 
           @at-root #{selector-append(".dx-rtl", &)},
           .dx-rtl & {
             padding-left: $material-texteditor-invalid-badge-size;
-            padding-right: 0;
+            padding-right: $material-grid-base-cell-horizontal-padding;
           }
         }
 
-        .dx-pending-indicator {
+        > .dx-pending-indicator {
           @include dx-pending-indicator-material();
           @include texteditor-validation-icon-offset();
 
-          background-color: $datagrid-base-background-color;
+          right: $material-invalid-badge-size;
+          background-color: transparent;
+
+          @at-root #{selector-append(".dx-rtl", &)},
+          .dx-rtl & {
+            left: $material-invalid-badge-size;
+          }
         }
       }
     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
@@ -2897,8 +2897,7 @@ QUnit.module('Editing', {
 
         // assert
         assert.equal($('.dx-texteditor').length, 1, 'editor\'s count');
-        assert.equal($('.dx-editor-cell').length, 0, 'the editor cell class is not applied'); // dx-highlight-outline
-        assert.equal($('.dx-highlight-outline').length, 0, 'the highlight outline class is not applied');
+        assert.equal($('.dx-editor-cell').length, 0, 'the editor cell class is not applied');
     });
 
     QUnit.test('Edit batch. Editor is rendered only one when click on text', function(assert) {
@@ -3405,7 +3404,7 @@ QUnit.module('Editing', {
         this.resizingController.resize();
         this.clock.tick();
 
-        assert.equal($('.dx-cell-modified .dx-highlight-outline').text(), '102', 'text of modified cell');
+        assert.equal($('.dx-cell-modified').text(), '102', 'text of modified cell');
     });
 
     QUnit.test('Edit batch. Repaint form with unsaved data', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -3784,7 +3784,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // assert
         overlayTarget = dataGrid.$element().find('.dx-invalid-message').data('dxOverlay').option('target');
-        assert.ok(overlayTarget.hasClass('dx-highlight-outline'), 'target in generic theme');
+        assert.ok(overlayTarget.hasClass('dx-editor-cell'), 'target in generic theme');
 
         // act
         dataGrid.closeEditCell();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -12061,9 +12061,9 @@ QUnit.module('Editing with validation', {
         const that = this;
         let $cellWithRevertButton;
 
-        this.editorFactoryController._showRevertButton = function($cell, $targetElement) {
+        this.editorFactoryController._showRevertButton = function($cell) {
             $cellWithRevertButton = $cell;
-            $.proxy(showRevertButton, that.editorFactoryController)($cell, $targetElement);
+            $.proxy(showRevertButton, that.editorFactoryController)($cell);
         };
 
         this.editCell(0, 2);
@@ -12110,9 +12110,9 @@ QUnit.module('Editing with validation', {
         const that = this;
         let $cellWithRevertButton;
 
-        this.editorFactoryController._showRevertButton = function($cell, $targetElement) {
+        this.editorFactoryController._showRevertButton = function($cell) {
             $cellWithRevertButton = $cell;
-            $.proxy(showRevertButton, that.editorFactoryController)($cell, $targetElement);
+            $.proxy(showRevertButton, that.editorFactoryController)($cell);
         };
 
         this.editCell(0, 2);
@@ -12349,9 +12349,9 @@ QUnit.module('Editing with validation', {
         const that = this;
         let $cellWithRevertButton;
 
-        this.editorFactoryController._showRevertButton = function($cell, $targetElement) {
+        this.editorFactoryController._showRevertButton = function($cell) {
             $cellWithRevertButton = $cell;
-            $.proxy(showRevertButton, that.editorFactoryController)($cell, $targetElement);
+            $.proxy(showRevertButton, that.editorFactoryController)($cell);
         };
         this.editCell(0, 1);
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -4305,13 +4305,15 @@ QUnit.module('Editing with real dataController', {
         // assert
         assert.equal(testElement.find('input').length, 0, 'count input');
         assert.strictEqual(testElement.find('tbody > tr').first().find('td').first().text(), 'Test1', 'text first cell');
-        assert.equal(testElement.find('.dx-highlight-outline').length, 1, 'has element with class name dx-highlight-outline');
+        assert.equal(testElement.find('.dx-editor-cell').length, 0, 'has element with class name dx-editor-cell');
+        assert.equal(testElement.find('.dx-cell-modified').length, 1, 'no element with class name dx-cell-modified');
 
         // act
         that.saveEditData();
 
         // assert
-        assert.equal(testElement.find('.dx-highlight-outline').length, 0, 'not has element with class name dx-highlight-outline');
+        assert.equal(testElement.find('.dx-editor-cell').length, 0, 'no element with class name dx-editor-cell');
+        assert.equal(testElement.find('.dx-cell-modified').length, 0, 'no element with class name dx-cell-modified');
 
         // arrange
         that.dataController.store().update = originalUpdate;
@@ -4338,13 +4340,15 @@ QUnit.module('Editing with real dataController', {
         // assert
         assert.equal(testElement.find('input').length, 0, 'count input');
         assert.strictEqual(testElement.find('tbody > tr').first().find('td').first().text(), 'Test2', 'text first cell');
-        assert.equal(testElement.find('.dx-highlight-outline').length, 1, 'has element with class name dx-highlight-outline');
+        assert.equal(testElement.find('.dx-editor-cell').length, 0, 'no element with class name dx-editor-cell');
+        assert.equal(testElement.find('.dx-cell-modified').length, 1, 'has element with class name dx-cell-modified');
 
         // act
         that.saveEditData();
 
         // assert
-        assert.equal(testElement.find('.dx-highlight-outline').length, 1, 'has element with class name dx-highlight-outline');
+        assert.equal(testElement.find('.dx-editor-cell').length, 0, 'no element with class name dx-editor-cell');
+        assert.equal(testElement.find('.dx-cell-modified').length, 1, 'has element with class name dx-cell-modified');
     });
 
     QUnit.test('Update cell when edit mode batch and cancel in onRowUpdating is deferred and resolved', function(assert) {
@@ -4630,13 +4634,15 @@ QUnit.module('Editing with real dataController', {
         // assert
         assert.equal(testElement.find('input').length, 0, 'count input');
         assert.strictEqual(testElement.find('tbody > tr').first().find('td').first().text(), 'Test', 'text first cell');
-        assert.equal(testElement.find('.dx-highlight-outline').length, 1, 'has element with class name dx-highlight-outline');
+        assert.equal(testElement.find('.dx-editor-cell').length, 0, 'no element with class name dx-editor-cell');
+        assert.equal(testElement.find('.dx-cell-modified').length, 1, 'has element with class name dx-cell-modified');
 
         // act
         that.saveEditData();
 
         // assert
-        assert.equal(testElement.find('.dx-highlight-outline').length, 0, 'not has element with class name dx-highlight-outline');
+        assert.equal(testElement.find('.dx-editor-cell').length, 0, 'no element with class name dx-editor-cell');
+        assert.equal(testElement.find('.dx-cell-modified').length, 0, 'no element with class name dx-cell-modified');
     });
 
     QUnit.test('Highlight modified boolean editor', function(assert) {
@@ -4677,10 +4683,9 @@ QUnit.module('Editing with real dataController', {
 
         // assert
         $checkbox = testElement.find('.dx-row').first().find('.dx-checkbox');
-        assert.ok($checkbox.parent().hasClass('dx-highlight-outline'), 'checkbox parent is dx-highlight-outline');
-        assert.ok($checkbox.parent().parent().hasClass('dx-editor-cell'), 'cell has dx-editor-cell class');
-        assert.ok($checkbox.parent().parent().hasClass('dx-editor-inline-block'), 'cell has dx-editor-inline-block class');
-        assert.ok($checkbox.parent().parent().hasClass('dx-cell-modified'), 'cell has dx-cell-modified class');
+        assert.ok($checkbox.parent().hasClass('dx-editor-cell'), 'cell has dx-editor-cell class');
+        assert.ok($checkbox.parent().hasClass('dx-editor-inline-block'), 'cell has dx-editor-inline-block class');
+        assert.ok($checkbox.parent().hasClass('dx-cell-modified'), 'cell has dx-cell-modified class');
     });
 
     // T389185
@@ -4810,7 +4815,6 @@ QUnit.module('Editing with real dataController', {
         // assert
         const cell = rowsView.element().find('td').first();
         assert.ok(cell.find('.dx-texteditor').length, 'has editor');
-        assert.ok(cell.children().hasClass('dx-highlight-outline'), 'has element with class dx-highlight-outline');
         assert.ok(!cell.hasClass('dx-cell-modified'), 'not has class dx-cell-modified');
 
         // act
@@ -5360,7 +5364,7 @@ QUnit.module('Editing with real dataController', {
         assert.equal(testElement.find('td').first().next().text(), '$123.000', 'cell text after editing');
     });
 
-    QUnit.test('Add highlight outline by batch edit mode_T118843', function(assert) {
+    QUnit.test('Add cell modified by batch edit mode_T118843', function(assert) {
     // arrange
         const that = this;
         const testElement = $('#container');
@@ -5374,13 +5378,13 @@ QUnit.module('Editing with real dataController', {
         testElement.find('td').eq(1).trigger('dxclick');
 
         // act
-        testElement.find('input').first().val('11');
-        testElement.find('input').first().trigger('change');
+        testElement.find('.dx-texteditor-input').first().val('11');
+        testElement.find('.dx-texteditor-input').first().trigger('change');
 
         testElement.find('td').eq(0).trigger('dxclick');
 
         // assert
-        assert.ok(testElement.find('.dx-highlight-outline').length > 0, 'highlight outline');
+        assert.ok(testElement.find('.dx-cell-modified').length > 0, 'cell modified');
 
     });
 
@@ -5403,14 +5407,14 @@ QUnit.module('Editing with real dataController', {
 
         testElement.find('td').eq(0).trigger('dxclick');
 
-        const $outlineElement = testElement.find('.dx-highlight-outline');
+        const $modifiedCell = testElement.find('.dx-cell-modified');
 
         // assert
-        assert.strictEqual($outlineElement.text(), $('<div>&nbsp;</div>').text(), 'empty text');
+        assert.strictEqual($modifiedCell.text(), $('<div>&nbsp;</div>').text(), 'empty text');
     });
 
     // T136710
-    QUnit.test('Add highlight outline by batch edit mode when delayed template used (KO)', function(assert) {
+    QUnit.test('Add modified cell by batch edit mode when delayed template used (KO)', function(assert) {
     // arrange
         const that = this;
         const testElement = $('#container');
@@ -5436,16 +5440,16 @@ QUnit.module('Editing with real dataController', {
         testElement.find('td').eq(0).trigger('dxclick');
 
         // act
-        testElement.find('input').first().val('Test11');
-        testElement.find('input').first().trigger('change');
+        testElement.find('.dx-texteditor-input').first().val('Test11');
+        testElement.find('.dx-texteditor-input').first().trigger('change');
 
         that.editingController.closeEditCell();
         that.clock.tick();
 
         // assert
-        const $elementWithOutline = testElement.find('td').first().find('.dx-highlight-outline');
-        assert.strictEqual($elementWithOutline.length, 1, 'highlight outline');
-        assert.strictEqual($elementWithOutline.text(), 'test_Test11', 'text in outline element');
+        const $modifiedCell = testElement.find('td.dx-cell-modified');
+        assert.strictEqual($modifiedCell.length, 1, 'modified cell');
+        assert.strictEqual($modifiedCell.text(), 'test_Test11', 'text in modified cell');
     });
 
 
@@ -8300,7 +8304,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     // T858174
-    QUnit.test('The highlight outline should be correctly rendered after editing cell when cellTemplate is specified (React)', function(assert) {
+    QUnit.test('The modified cell should be correctly rendered after editing when cellTemplate is specified (React)', function(assert) {
     // arrange
         const that = this;
         const $testElement = $('#container');
@@ -8330,8 +8334,8 @@ QUnit.module('Editing with real dataController', {
         $testElement.find('td').eq(0).trigger('dxclick');
 
         // act
-        $testElement.find('input').first().val('Test11');
-        $testElement.find('input').first().trigger('change');
+        $testElement.find('.dx-texteditor-input').first().val('Test11');
+        $testElement.find('.dx-texteditor-input').first().trigger('change');
 
         template.reset();
         that.editingController.closeEditCell();
@@ -8340,9 +8344,9 @@ QUnit.module('Editing with real dataController', {
         // assert
         assert.strictEqual(template.callCount, 1, 'template is called');
         assert.ok(template.getCall(0).args[0].onRendered, 'template args - there is onRendered');
-        const $elementWithOutline = $testElement.find('td').first().find('.dx-highlight-outline');
-        assert.strictEqual($elementWithOutline.length, 1, 'highlight outline');
-        assert.strictEqual($elementWithOutline.text(), 'test_Test11', 'text in outline element');
+        const $modifiedCell = $testElement.find('td.dx-cell-modified');
+        assert.strictEqual($modifiedCell.length, 1, 'modified cell');
+        assert.strictEqual($modifiedCell.text(), 'test_Test11', 'text in modified cell');
     });
 
     ['row', 'form', 'popup'].forEach(editingMode => {
@@ -10337,7 +10341,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.ok(!getInputElements(testElement).length, 'not has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         that.editCell(0, 1);
@@ -10354,7 +10357,7 @@ QUnit.module('Editing with validation', {
         // assert
         assert.ok(!getInputElements(testElement).length, 'not has input');
         assert.ok(!cells.eq(1).hasClass('dx-datagrid-invalid'), 'success validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
+        assert.ok(cells.eq(1).hasClass('dx-cell-modified'), 'cell modified');
     });
 
     QUnit.test('Save edit data when edit mode batch and set validate in column', function(assert) {
@@ -10399,7 +10402,7 @@ QUnit.module('Editing with validation', {
         assert.equal(saveEditDataResult.state(), 'resolved');
         assert.ok(!getInputElements(testElement).length, 'not has input');
         assert.ok(cells.eq(4).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(4).children().first().hasClass('dx-highlight-outline'), 'has highlight');
+        assert.ok(cells.eq(4).hasClass('dx-cell-modified'), 'cell modified');
 
         // act
         that.editCell(1, 1);
@@ -10416,7 +10419,7 @@ QUnit.module('Editing with validation', {
         assert.equal(saveEditDataResult.state(), 'resolved');
         assert.ok(!getInputElements(testElement).length, 'not has input');
         assert.ok(!cells.eq(4).hasClass('dx-datagrid-invalid'), 'success validation');
-        assert.ok(!cells.eq(4).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
+        assert.ok(!cells.eq(4).hasClass('dx-cell-modified'), 'cell is not modified');
     });
 
     // T620368
@@ -10523,7 +10526,7 @@ QUnit.module('Editing with validation', {
 
         // assert
         assert.ok(cells.eq(2).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(2).children().first().hasClass('dx-highlight-outline'), 'has highlight');
+        assert.ok(cells.eq(2).hasClass('dx-cell-modified'), 'cell modified');
         assert.equal(testElement.find('tbody > tr').length, 5, 'count rows');
 
         // act
@@ -10533,8 +10536,8 @@ QUnit.module('Editing with validation', {
         assert.equal(getInputElements(testElement).length, 1, 'has input');
 
         // act
-        testElement.find('input').first().val('Test');
-        testElement.find('input').first().trigger('change');
+        testElement.find('.dx-texteditor-input').first().val('Test');
+        testElement.find('.dx-texteditor-input').first().trigger('change');
 
         that.closeEditCell();
         that.clock.tick();
@@ -10547,7 +10550,7 @@ QUnit.module('Editing with validation', {
         assert.equal(testElement.find('tbody > tr').length, 5, 'count rows');
         assert.strictEqual(cells.eq(11).text(), 'Test', 'text cell 12');
         assert.ok(!cells.eq(11).hasClass('dx-datagrid-invalid'), 'success validation');
-        assert.ok(!cells.eq(11).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
+        assert.ok(!cells.eq(11).hasClass('dx-cell-modified'), 'cell is not modified');
     });
 
     // T823583
@@ -10616,7 +10619,6 @@ QUnit.module('Editing with validation', {
 
         // assert
         assert.ok(cells.eq(2).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(2).children().first().hasClass('dx-highlight-outline'), 'has highlight');
     });
 
     // T186431
@@ -10894,14 +10896,13 @@ QUnit.module('Editing with validation', {
         // assert
         cells = rowsView.element().find('tbody > tr').first().find('td');
         assert.ok(!cells.eq(0).hasClass('dx-datagrid-invalid'), 'not have validate');
-        assert.ok(!cells.eq(0).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
+        assert.ok(!cells.eq(0).hasClass('dx-cell-modified'), 'not modified');
 
         assert.ok(!cells.eq(1).hasClass('dx-datagrid-invalid'), 'success validate');
         assert.ok(cells.eq(1).hasClass('dx-cell-modified'), 'modified cell');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         assert.ok(!cells.eq(2).hasClass('dx-datagrid-invalid'), 'not have validate');
-        assert.ok(!cells.eq(2).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
+        assert.ok(!cells.eq(2).hasClass('dx-cell-modified'), 'not modified');
     });
 
     // T183295
@@ -10929,7 +10930,6 @@ QUnit.module('Editing with validation', {
         const callBackFunc = function() {
         // assert
             assert.ok(testElement.find('td').eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-            assert.ok(testElement.find('td').eq(1).children().hasClass('dx-highlight-outline'), 'has highlight');
             // assert.ok(testElement.find("td").eq(1).children().hasClass("dx-focused"), "has class dx-focused");
 
             that.editorFactoryController.focused.remove(callBackFunc);
@@ -10939,8 +10939,8 @@ QUnit.module('Editing with validation', {
         // act
         that.editCell(0, 1); // edit cell
 
-        testElement.find('input').val(101); // change value
-        testElement.find('input').trigger('change');
+        testElement.find('.dx-texteditor-input').val(101); // change value
+        testElement.find('.dx-texteditor-input').trigger('change');
 
         that.closeEditCell(); // close edit cell
         that.clock.tick();
@@ -11034,7 +11034,6 @@ QUnit.module('Editing with validation', {
         cells = rowsView.element().find('tbody > tr').first().find('td');
         assert.equal(getInputElements(testElement).length, 3, 'has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
         assert.equal(testElement.find('tbody > tr').length, 4, 'count rows');
         assert.equal(saveEditDataResult.state(), 'resolved');
 
@@ -11050,7 +11049,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(getInputElements(testElement).length, 0, 'not has input');
         assert.ok(!cells.eq(1).hasClass('dx-datagrid-invalid'), 'success validation');
-        assert.ok(!cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
         assert.equal(testElement.find('tbody > tr').length, 4, 'count rows');
         assert.equal(saveEditDataResult.state(), 'resolved');
     });
@@ -11092,7 +11090,6 @@ QUnit.module('Editing with validation', {
 
         // assert
         assert.ok(cells.eq(2).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(2).children().first().hasClass('dx-highlight-outline'), 'has highlight');
         assert.equal(testElement.find('tbody > tr').length, 5, 'count rows');
 
         // act
@@ -11108,7 +11105,6 @@ QUnit.module('Editing with validation', {
         assert.equal(getInputElements(testElement).length, 0, 'not has input');
         assert.strictEqual(cells.eq(14).text(), 'Test', 'text cell 12');
         assert.ok(!cells.eq(14).hasClass('dx-datagrid-invalid'), 'success validation');
-        assert.ok(!cells.eq(14).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
         assert.equal(testElement.find('tbody > tr').length, 5, 'count rows');
     });
 
@@ -11210,7 +11206,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.ok(!getInputElements($testElement).length, 'not has input');
         assert.ok($cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok($cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         $($cells.eq(1)).trigger('dxclick');
@@ -11227,7 +11222,7 @@ QUnit.module('Editing with validation', {
         // T335660
         const overlayInstance = $overlayElement.dxOverlay('instance');
         assert.ok(overlayInstance, 'has overlay instance');
-        assert.ok(overlayInstance.option('target').hasClass('dx-highlight-outline'), 'target of the overlay');
+        assert.ok(overlayInstance.option('target').hasClass('dx-editor-cell'), 'target of the overlay');
 
         // act
         $inputElement = getInputElements($testElement).first();
@@ -11350,7 +11345,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.ok(!getInputElements(testElement).length, 'not has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         cells.eq(1).trigger('dxclick');
@@ -11366,8 +11360,8 @@ QUnit.module('Editing with validation', {
         assert.ok(rowsView.element().find('.dx-freespace-row').height() > 0, 'freespace row has height ');
 
         // T526383
-        const $highlightContainer = cells.eq(1).find('.dx-highlight-outline').first();
-        assert.ok($overlayContent.offset().top >= ($highlightContainer.offset().top + $highlightContainer.height()), 'tooltip is under the cell');
+        const $modifiedCell = cells.eq(1);
+        assert.ok($overlayContent.offset().top >= ($modifiedCell.offset().top + $modifiedCell.height()), 'tooltip is under the cell');
     });
 
     // T200857
@@ -11422,7 +11416,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.ok(!getInputElements(testElement).length, 'not has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         cells.eq(1).trigger('dxclick');
@@ -11686,11 +11679,8 @@ QUnit.module('Editing with validation', {
 
         // assert
         assert.ok(cells.eq(2).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(2).children().first().hasClass('dx-highlight-outline'), 'has highlight');
         assert.ok(cells.eq(6).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(6).children().first().hasClass('dx-highlight-outline'), 'has highlight');
         assert.ok(cells.eq(10).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(10).children().first().hasClass('dx-highlight-outline'), 'has highlight');
         assert.equal(testElement.find('tbody > tr').length, 10, 'count rows');
         assert.ok(testElement.find('tbody > tr').eq(1).hasClass('dx-error-row'), 'has error row 1');
         assert.ok(testElement.find('tbody > tr').eq(3).hasClass('dx-error-row'), 'has error row 2');
@@ -11833,8 +11823,6 @@ QUnit.module('Editing with validation', {
         $input = $(rowsView.element().find('.dx-data-row').first().find('td').eq(2).find('.dx-texteditor-input'));
 
         // assert
-        const $highlight = $input.closest('.dx-highlight-outline');
-        assert.ok($highlight.length, 'has highlight');
         assert.ok(!$input.closest('td').hasClass('dx-datagrid-invalid'), 'not has class dx-datagrid-invalid on cell');
     });
 
@@ -12021,7 +12009,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(getInputElements(testElement).length, 1, 'has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         that.editCell(0, 2);
@@ -12031,7 +12018,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(getInputElements(testElement).length, 1, 'has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
     });
 
     QUnit.testInActiveWindow('Show the revert button when an edit cell to invalid value when the edit mode cell is enabled', function(assert) {
@@ -12276,7 +12262,7 @@ QUnit.module('Editing with validation', {
         assert.equal(testElement.find('.dx-data-row td').eq(0).text(), 'Alex', 'old value');
     });
 
-    QUnit.test('Revert button is not shown when the height light css class is not applied', function(assert) {
+    QUnit.test('Revert button is not shown when a cell is not defined', function(assert) {
     // arrange
         const testElement = $('#container');
 
@@ -12295,8 +12281,7 @@ QUnit.module('Editing with validation', {
         // act
         this.editCell(0, 1);
 
-        const $cells = $(this.rowsView.element().find('tbody > tr').first().find('td'));
-        this.editorFactoryController._showRevertButton($cells.eq(0));
+        this.editorFactoryController._showRevertButton();
 
         // assert
         assert.equal($('.dx-datagrid-revert-tooltip').length, 0);
@@ -12453,7 +12438,6 @@ QUnit.module('Editing with validation', {
         // assert
         // equal(getInputElements(testElement).length, 1, "has input");
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
         assert.equal(testElement.find('tbody > tr').length, 5, 'count rows');
 
         // act
@@ -12465,7 +12449,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.ok(getInputElements(testElement).length, 'not has input');
         assert.ok(!cells.find('.dx-datagrid-invalid').length, 'not validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
         assert.equal(testElement.find('tbody > tr').length, 5, 'count rows');
     });
 
@@ -12550,7 +12533,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(getInputElements(testElement).length, 0, 'has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         that.dataController.pageIndex(1);
@@ -12569,7 +12551,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(testElement.find('tbody > tr').length, 3, 'count rows');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
     });
 
     // T836508
@@ -12756,7 +12737,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(getInputElements(testElement).length, 0, 'has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         that.dataController.pageIndex(1);
@@ -12776,7 +12756,6 @@ QUnit.module('Editing with validation', {
         assert.ok(that.hasEditData(), 'data is not saved');
         assert.equal(testElement.find('tbody > tr').length, 3, 'count rows');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
     });
 
     // T495625
@@ -12883,7 +12862,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(getInputElements(testElement).length, 0, 'has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         that.columnsController.changeSortOrder(1, 'desc');
@@ -12903,7 +12881,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(testElement.find('tbody > tr').length, 4, 'count rows');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
     });
 
     QUnit.test('Edit cell with edit mode batch and filtering', function(assert) {
@@ -12950,7 +12927,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(getInputElements(testElement).length, 0, 'has input');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
 
         // act
         that.columnsController.columnOption(1, 'filterValue', 17);
@@ -12959,7 +12935,7 @@ QUnit.module('Editing with validation', {
 
         // assert
         assert.ok(!cells.eq(1).hasClass('dx-datagrid-invalid'), 'not failed validation');
-        assert.ok(!cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
+        assert.ok(!cells.eq(1).hasClass('dx-cell-modified'), 'cell is not modified');
         assert.equal(testElement.find('tbody > tr').length, 2, 'count rows');
 
         // act
@@ -12970,7 +12946,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(testElement.find('tbody > tr').length, 3, 'count rows');
         assert.ok(cells.eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
-        assert.ok(cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'has highlight');
     });
 
     // T186431
@@ -15742,7 +15717,6 @@ QUnit.module('Editing with scrolling', {
         // assert
         const $cell = testElement.find('tbody > tr').eq(3).children().first();
         assert.strictEqual($cell.text(), 'test', 'value of the cell');
-        assert.ok($cell.find('.dx-highlight-outline').length, 'has highlight');
     });
 
     QUnit.test('Save inserted data with set onRowValidating and infinite scrolling', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -10741,7 +10741,6 @@ QUnit.module('Editing with validation', {
         // assert
         assert.equal(getInputElements(testElement).length, 0, 'not has input');
         assert.ok(!cells.eq(1).hasClass('dx-datagrid-invalid'), 'success validation');
-        assert.ok(!cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
 
         // act
         that.saveEditData();
@@ -12870,7 +12869,6 @@ QUnit.module('Editing with validation', {
 
         // assert
         assert.ok(!cells.eq(1).hasClass('dx-datagrid-invalid'), 'not failed validation');
-        assert.ok(!cells.eq(1).children().first().hasClass('dx-highlight-outline'), 'not has highlight');
         assert.equal(testElement.find('tbody > tr').length, 3, 'count rows');
 
         // act


### PR DESCRIPTION
Removed a DIV element with the 'dx-highlight-outline' CSS rule from data cells.
