### PR TITLE
Avoid Drawer panel DOM element flicks on the first load (T871628)  (#14599)

### DIFF
--- a/js/ui/drawer/ui.drawer.js
+++ b/js/ui/drawer/ui.drawer.js
@@ -180,15 +180,29 @@ const Drawer = Widget.inherit({
         this.callBase();
 
         this._whenPanelContentRendered.always(() => {
+            ///#DEBUG
+            if(this.option('__debugWhenPanelContentRendered')) {
+                this.option('__debugWhenPanelContentRendered')();
+            }
+            ///#ENDDEBUG
+
             this._initMinMaxSize();
             this._strategy.refreshPanelElementSize(this.option('revealMode') === 'slide' || !this.isHorizontalDirection());
 
             this._renderPosition(this.option('opened'), false);
+            if(this._$panelContentWrapper.attr('manualposition')) {
+                this._$panelContentWrapper.removeAttr('manualPosition');
+                this._$panelContentWrapper.css({ position: '', top: '', left: '' });
+            }
         });
     },
 
     _renderPanelContentWrapper() {
         this._$panelContentWrapper = $('<div>').addClass(DRAWER_PANEL_CONTENT_CLASS);
+        if(this.option('openedStateMode') !== 'overlap' && !this.option('opened')) {
+            this._$panelContentWrapper.attr('manualposition', true);
+            this._$panelContentWrapper.css({ position: 'absolute', top: '-10000px', left: '-10000px' });
+        }
         this._$wrapper.append(this._$panelContentWrapper);
     },
 

--- a/testing/helpers/drawerHelpers.js
+++ b/testing/helpers/drawerHelpers.js
@@ -2,9 +2,15 @@ function checkBoundingClientRect(assert, element, expectedRect, elementName) {
     assert.ok(!!element, elementName + ' is defined');
     if(element) {
         const rect = element.getBoundingClientRect();
+        let isCorrect = true;
+        let message = `${elementName} rect is incorrect`;
         for(const memberName in expectedRect) {
-            assert.strictEqual(rect[memberName], expectedRect[memberName], elementName + '.' + memberName);
+            message += `, ${memberName}:[${rect[memberName]}/${expectedRect[memberName]}]`;
+            if(rect[memberName] !== expectedRect[memberName]) {
+                isCorrect = false;
+            }
         }
+        assert.strictEqual(isCorrect, true, message + ', [actual/expected]');
     }
 }
 

--- a/testing/tests/DevExpress.ui.widgets/drawer.scenarios.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/drawer.scenarios.tests.js
@@ -212,11 +212,39 @@ configs.forEach(config => {
             return extend({ rtlEnabled: false, animationEnabled: false }, config, targetOptions);
         }
 
+        function checkPanelIsNotVisible(assert, drawerElement, panelTemplateElement) {
+            const drawerRect = drawerElement.getBoundingClientRect();
+            const panelTemplateRect = panelTemplateElement.getBoundingClientRect();
+            const panelTemplateParentRect = panelTemplateElement.parentElement.getBoundingClientRect();
+            if((panelTemplateRect.width > 0 || panelTemplateRect.height > 0) && (panelTemplateParentRect.width > 0 || panelTemplateParentRect.width > 0)) {
+                assert.strictEqual(
+                    panelTemplateRect.right < drawerRect.left
+                    || panelTemplateRect.left > drawerRect.right
+                    || panelTemplateRect.bottom < drawerRect.top
+                    || panelTemplateRect.top > drawerRect.bottom,
+                    true,
+                    `panel should not be visible, left:[${panelTemplateRect.left}/${drawerRect.left}], top:[${panelTemplateRect.top}/${drawerRect.top}], right:[${panelTemplateRect.right}/${drawerRect.right}], bottom:[${panelTemplateRect.bottom}/${drawerRect.bottom}], [panel/drawer]`);
+            }
+            const viewRect = document.getElementById('view').getBoundingClientRect();
+            assert.strictEqual(
+                viewRect.left === drawerRect.left
+                && viewRect.right === drawerRect.right
+                && viewRect.width === drawerRect.width
+                && viewRect.height === drawerRect.height,
+                true,
+                `view rect equals to drawer, left:[${viewRect.left}/${drawerRect.left}], top:[${viewRect.top}/${drawerRect.top}], right:[${viewRect.right}/${drawerRect.right}], bottom:[${viewRect.bottom}/${drawerRect.bottom}], [view/drawer]`);
+        }
+
         testOrSkip('opened: false', () => configIs('push', 'top') || configIs('overlap', 'right', 'expand') && config.minSize, function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: false,
                 template: drawerTesters[config.position].template,
+                __debugWhenPanelContentRendered: () => {
+                    if(!config.minSize) {
+                        checkPanelIsNotVisible(assert, drawerElement, document.getElementById('template'));
+                    }
+                }
             }));
 
             this.clock.tick(100);


### PR DESCRIPTION
* Make Drawer panel DOM element invisible via 'position:absolute' + 'out of parent bounds'

* Change several 'css' to single, replace 'expression' with explicit html attr

* Replace 'assert.ok' with 'assert.strictEqual(true)'

* Rename to actual html attribute name to avoid case sensitive issues

* Rename __whenPanelContentRendered to __debugWhenPanelContentRendered

(cherry picked from commit 5f4b918c3034525290e5f8c14b66430fcabdb3e0)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
