### PR TITLE
Drawer - Avoid content flicks on the first showing in React apps when openedStateMode is overlap (T848346)

### DIFF
--- a/js/ui/drawer/ui.drawer.js
+++ b/js/ui/drawer/ui.drawer.js
@@ -98,8 +98,11 @@ const Drawer = Widget.inherit({
         this._whenPanelContentRefreshed = undefined;
 
         this._$wrapper = $('<div>').addClass(DRAWER_WRAPPER_CLASS);
+
         this._$viewContentWrapper = $('<div>').addClass(DRAWER_VIEW_CONTENT_CLASS);
+        this._strategy.onViewContentWrapperCreated(this._$viewContentWrapper, this.calcTargetPosition());
         this._$wrapper.append(this._$viewContentWrapper);
+
         this.$element().append(this._$wrapper);
     },
 
@@ -180,7 +183,7 @@ const Drawer = Widget.inherit({
         this._whenPanelContentRendered.always(() => {
             ///#DEBUG
             if(this.option('__debugWhenPanelContentRendered')) {
-                this.option('__debugWhenPanelContentRendered')();
+                this.option('__debugWhenPanelContentRendered')({ drawer: this });
             }
             ///#ENDDEBUG
 
@@ -190,16 +193,16 @@ const Drawer = Widget.inherit({
             this._renderPosition(this.option('opened'), false);
             if(this._$panelContentWrapper.attr('manualposition')) {
                 this._$panelContentWrapper.removeAttr('manualPosition');
-                this._$panelContentWrapper.css({ position: '', top: '', left: '' });
+                this._$panelContentWrapper.css({ position: '', top: '', left: '', right: '', bottom: '' });
             }
         });
     },
 
     _renderPanelContentWrapper() {
         this._$panelContentWrapper = $('<div>').addClass(DRAWER_PANEL_CONTENT_CLASS);
-        if(this.option('openedStateMode') !== 'overlap' && !this.option('opened')) {
+        if(this.option('openedStateMode') !== 'overlap' && !this.option('opened') && !this.option('minSize')) {
             this._$panelContentWrapper.attr('manualposition', true);
-            this._$panelContentWrapper.css({ position: 'absolute', top: '-10000px', left: '-10000px' });
+            this._$panelContentWrapper.css({ position: 'absolute', top: '-10000px', left: '-10000px', right: 'auto', bottom: 'auto' });
         }
         this._$wrapper.append(this._$panelContentWrapper);
     },

--- a/js/ui/drawer/ui.drawer.rendering.strategy.js
+++ b/js/ui/drawer/ui.drawer.rendering.strategy.js
@@ -227,6 +227,8 @@ class DrawerStrategy {
     isViewContentFirst() {
         return false;
     }
+
+    onViewContentWrapperCreated() {}
 }
 
 module.exports = DrawerStrategy;

--- a/js/ui/drawer/ui.drawer.rendering.strategy.overlap.js
+++ b/js/ui/drawer/ui.drawer.rendering.strategy.overlap.js
@@ -99,6 +99,10 @@ class OverlapStrategy extends DrawerStrategy {
         }
     }
 
+    onViewContentWrapperCreated($viewContentWrapper, panelPosition) {
+        this._setupContent($viewContentWrapper, panelPosition);
+    }
+
     _setupContent($content, position) {
         $content.css('padding' + camelize(position, true), this.getDrawerInstance().option('minSize'));
         $content.css('transform', 'inherit');

--- a/testing/helpers/drawerHelpers.js
+++ b/testing/helpers/drawerHelpers.js
@@ -1,5 +1,3 @@
-import { extend } from 'core/utils/extend';
-
 function checkBoundingClientRect(assert, element, expectedRect, elementName) {
     assert.ok(!!element, elementName + ' is defined');
     if(element) {
@@ -306,11 +304,11 @@ const RightDrawerTester = {
     },
 
     checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
-        const drawerRect = drawerElement.getBoundingClientRect();
-        const expectedPanelRect = extend({}, drawerRect);
-        const expectedViewRect = extend({}, drawerRect);
+        const { top, left, width, height } = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = { top, left, width, height };
+        const expectedViewRect = { top, left, width, height };
         if(drawer.option('minSize')) {
-            expectedPanelRect.left += drawerRect.wight - drawer.option('minSize');
+            expectedPanelRect.left += expectedPanelRect.wight - drawer.option('minSize');
             expectedPanelRect.width = drawer.option('minSize');
             expectedViewRect.width -= drawer.option('minSize');
         }
@@ -437,9 +435,9 @@ const TopDrawerTester = {
     },
 
     checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
-        const drawerRect = drawerElement.getBoundingClientRect();
-        const expectedPanelRect = extend({}, drawerRect);
-        const expectedViewRect = extend({}, drawerRect);
+        const { top, left, width, height } = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = { top, left, width, height };
+        const expectedViewRect = { top, left, width, height };
         if(drawer.option('minSize')) {
             expectedPanelRect.height = drawer.option('minSize');
             expectedViewRect.top += drawer.option('minSize');

--- a/testing/helpers/drawerHelpers.js
+++ b/testing/helpers/drawerHelpers.js
@@ -25,45 +25,30 @@ function checkMargin(assert, element, top, right, bottom, left, message) {
 
 function checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect) {
     const drawerRect = drawerElement.getBoundingClientRect();
-    if(drawer.option('minSize')) {
-        if(drawer.option('openedStateMode') === 'overlap') {
-            const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
-            assert.strictEqual(
-                panelRect.left === expectedPanelRect.left
-                && panelRect.top === expectedPanelRect.top
-                && panelRect.width === expectedPanelRect.width
-                && panelRect.height === expectedPanelRect.height,
-                true,
-                'panelRect/expectedRect: ' +
-                `left:[${panelRect.left}/${expectedPanelRect.left}], top:[${panelRect.top}/${expectedPanelRect.top}], ` +
-                `width:[${panelRect.width}/${expectedPanelRect.width}], height:[${panelRect.height}/${expectedPanelRect.height}]`);
-        }
+
+    // Check Panel element rect
+
+    if(!drawer.option('minSize') && drawer.option('openedStateMode') !== 'overlap') {
+        const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
+        assert.strictEqual(
+            panelRect.right < drawerRect.left
+            || panelRect.left > drawerRect.right
+            || panelRect.bottom < drawerRect.top
+            || panelRect.top > drawerRect.bottom,
+            true,
+            'panel should be out of drawerRect, ' +
+            `left:[${panelRect.left}/${drawerRect.left}], top:[${panelRect.top}/${drawerRect.top}], ` +
+            `right:[${panelRect.right}/${drawerRect.right}], bottom:[${panelRect.bottom}/${drawerRect.bottom}], [panel/drawer]`);
     } else {
-        if(drawer.option('openedStateMode') !== 'overlap') {
-            const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
-            assert.strictEqual(
-                panelRect.right < drawerRect.left
-                || panelRect.left > drawerRect.right
-                || panelRect.bottom < drawerRect.top
-                || panelRect.top > drawerRect.bottom,
-                true,
-                'panel should be out of drawerRect, ' +
-                `left:[${panelRect.left}/${drawerRect.left}], top:[${panelRect.top}/${drawerRect.top}], ` +
-                `right:[${panelRect.right}/${drawerRect.right}], bottom:[${panelRect.bottom}/${drawerRect.bottom}], [panel/drawer]`);
+        if(drawer.option('minSize') && (drawer.option('openedStateMode') === 'overlap')) {
+            checkBoundingClientRect(assert, panelTemplateElement.parentElement, expectedPanelRect, 'panel');
         }
     }
 
+    // Check View element rect
+
     if(!drawer.option('minSize') || (drawer.option('openedStateMode') === 'overlap')) {
-        const viewRect = document.getElementById('view').getBoundingClientRect();
-        assert.strictEqual(
-            viewRect.left === expectedViewRect.left
-            && viewRect.top === expectedViewRect.top
-            && viewRect.width === expectedViewRect.width
-            && viewRect.height === expectedViewRect.height,
-            true,
-            'viewRect/expectedRect, ' +
-            `left:[${viewRect.left}/${expectedViewRect.left}], top:[${viewRect.top}/${expectedViewRect.top}], ` +
-            `width:[${viewRect.width}/${expectedViewRect.width}], height:[${viewRect.height}/${expectedViewRect.height}]`);
+        checkBoundingClientRect(assert, document.getElementById('view'), expectedViewRect, 'view');
     }
 }
 
@@ -183,13 +168,11 @@ const LeftDrawerTester = {
     },
 
     checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
-        const drawerRect = drawerElement.getBoundingClientRect();
-        const expectedPanelRect = extend({}, drawerRect);
+        const { top, left, width, height } = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = { top, left, width, height };
+        const expectedViewRect = { top, left, width, height };
         if(drawer.option('minSize')) {
             expectedPanelRect.width = drawer.option('minSize');
-        }
-        const expectedViewRect = extend({}, drawerRect);
-        if(drawer.option('minSize')) {
             expectedViewRect.left += drawer.option('minSize');
             expectedViewRect.width -= drawer.option('minSize');
         }
@@ -325,12 +308,10 @@ const RightDrawerTester = {
     checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
         const drawerRect = drawerElement.getBoundingClientRect();
         const expectedPanelRect = extend({}, drawerRect);
+        const expectedViewRect = extend({}, drawerRect);
         if(drawer.option('minSize')) {
             expectedPanelRect.left += drawerRect.wight - drawer.option('minSize');
             expectedPanelRect.width = drawer.option('minSize');
-        }
-        const expectedViewRect = extend({}, drawerRect);
-        if(drawer.option('minSize')) {
             expectedViewRect.width -= drawer.option('minSize');
         }
         checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect);
@@ -458,11 +439,9 @@ const TopDrawerTester = {
     checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
         const drawerRect = drawerElement.getBoundingClientRect();
         const expectedPanelRect = extend({}, drawerRect);
-        if(drawer.option('minSize')) {
-            expectedPanelRect.height = drawer.option('minSize');
-        }
         const expectedViewRect = extend({}, drawerRect);
         if(drawer.option('minSize')) {
+            expectedPanelRect.height = drawer.option('minSize');
             expectedViewRect.top += drawer.option('minSize');
             expectedViewRect.height -= drawer.option('minSize');
         }

--- a/testing/helpers/drawerHelpers.js
+++ b/testing/helpers/drawerHelpers.js
@@ -1,3 +1,5 @@
+import { extend } from 'core/utils/extend';
+
 function checkBoundingClientRect(assert, element, expectedRect, elementName) {
     assert.ok(!!element, elementName + ' is defined');
     if(element) {
@@ -19,6 +21,50 @@ function checkMargin(assert, element, top, right, bottom, left, message) {
     assert.strictEqual(window.getComputedStyle(element).marginTop, top + 'px', 'marginTop, ' + message);
     assert.strictEqual(window.getComputedStyle(element).marginRight, right + 'px', 'marginRight, ' + message);
     assert.strictEqual(window.getComputedStyle(element).marginBottom, bottom + 'px', 'marginBottom, ' + message);
+}
+
+function checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect) {
+    const drawerRect = drawerElement.getBoundingClientRect();
+    if(drawer.option('minSize')) {
+        if(drawer.option('openedStateMode') === 'overlap') {
+            const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
+            assert.strictEqual(
+                panelRect.left === expectedPanelRect.left
+                && panelRect.top === expectedPanelRect.top
+                && panelRect.width === expectedPanelRect.width
+                && panelRect.height === expectedPanelRect.height,
+                true,
+                'panelRect/expectedRect: ' +
+                `left:[${panelRect.left}/${expectedPanelRect.left}], top:[${panelRect.top}/${expectedPanelRect.top}], ` +
+                `width:[${panelRect.width}/${expectedPanelRect.width}], height:[${panelRect.height}/${expectedPanelRect.height}]`);
+        }
+    } else {
+        if(drawer.option('openedStateMode') !== 'overlap') {
+            const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
+            assert.strictEqual(
+                panelRect.right < drawerRect.left
+                || panelRect.left > drawerRect.right
+                || panelRect.bottom < drawerRect.top
+                || panelRect.top > drawerRect.bottom,
+                true,
+                'panel should be out of drawerRect, ' +
+                `left:[${panelRect.left}/${drawerRect.left}], top:[${panelRect.top}/${drawerRect.top}], ` +
+                `right:[${panelRect.right}/${drawerRect.right}], bottom:[${panelRect.bottom}/${drawerRect.bottom}], [panel/drawer]`);
+        }
+    }
+
+    if(!drawer.option('minSize') || (drawer.option('openedStateMode') === 'overlap')) {
+        const viewRect = document.getElementById('view').getBoundingClientRect();
+        assert.strictEqual(
+            viewRect.left === expectedViewRect.left
+            && viewRect.top === expectedViewRect.top
+            && viewRect.width === expectedViewRect.width
+            && viewRect.height === expectedViewRect.height,
+            true,
+            'viewRect/expectedRect, ' +
+            `left:[${viewRect.left}/${expectedViewRect.left}], top:[${viewRect.top}/${expectedViewRect.top}], ` +
+            `width:[${viewRect.width}/${expectedViewRect.width}], height:[${viewRect.height}/${expectedViewRect.height}]`);
+    }
 }
 
 const leftTemplateSize = 150;
@@ -134,6 +180,20 @@ const LeftDrawerTester = {
         } else {
             assert.notOk('configuration is not tested');
         }
+    },
+
+    checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
+        const drawerRect = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = extend({}, drawerRect);
+        if(drawer.option('minSize')) {
+            expectedPanelRect.width = drawer.option('minSize');
+        }
+        const expectedViewRect = extend({}, drawerRect);
+        if(drawer.option('minSize')) {
+            expectedViewRect.left += drawer.option('minSize');
+            expectedViewRect.width -= drawer.option('minSize');
+        }
+        checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect);
     }
 };
 
@@ -260,6 +320,20 @@ const RightDrawerTester = {
         } else {
             assert.notOk('configuration is not tested');
         }
+    },
+
+    checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
+        const drawerRect = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = extend({}, drawerRect);
+        if(drawer.option('minSize')) {
+            expectedPanelRect.left += drawerRect.wight - drawer.option('minSize');
+            expectedPanelRect.width = drawer.option('minSize');
+        }
+        const expectedViewRect = extend({}, drawerRect);
+        if(drawer.option('minSize')) {
+            expectedViewRect.width -= drawer.option('minSize');
+        }
+        checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect);
     }
 };
 
@@ -379,6 +453,20 @@ const TopDrawerTester = {
         } else {
             assert.notOk('configuration is not tested');
         }
+    },
+
+    checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
+        const drawerRect = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = extend({}, drawerRect);
+        if(drawer.option('minSize')) {
+            expectedPanelRect.height = drawer.option('minSize');
+        }
+        const expectedViewRect = extend({}, drawerRect);
+        if(drawer.option('minSize')) {
+            expectedViewRect.top += drawer.option('minSize');
+            expectedViewRect.height -= drawer.option('minSize');
+        }
+        checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect);
     }
 };
 

--- a/testing/tests/DevExpress.ui.widgets/drawer.scenarios.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/drawer.scenarios.tests.js
@@ -214,88 +214,6 @@ configs.forEach(config => {
             return extend({ rtlEnabled: false, animationEnabled: false }, config, targetOptions);
         }
 
-        function checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement) {
-            const drawerRect = drawerElement.getBoundingClientRect();
-            if(config.minSize) {
-                if(drawer.option('openedStateMode') === 'overlap') {
-                    const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
-                    const expectedPanelRect = extend({}, drawerRect);
-                    if(drawer.option('minSize')) {
-                        switch(drawer.option('position')) {
-                            case 'left':
-                                expectedPanelRect.width = drawer.option('minSize');
-                                break;
-                            case 'right':
-                                expectedPanelRect.left += drawerRect.wight - drawer.option('minSize');
-                                expectedPanelRect.width = drawer.option('minSize');
-                                break;
-                            case 'top':
-                                expectedPanelRect.height = drawer.option('minSize');
-                                break;
-                            case 'bottom':
-                                expectedPanelRect.top = drawerRect.bottom - drawer.option('minSize');
-                                expectedPanelRect.height = drawer.option('minSize');
-                                break;
-                        }
-                    }
-                    assert.strictEqual(
-                        panelRect.left === expectedPanelRect.left
-                        && panelRect.top === expectedPanelRect.top
-                        && panelRect.width === expectedPanelRect.width
-                        && panelRect.height === expectedPanelRect.height,
-                        true,
-                        'panelRect/expectedRect: ' +
-                        `left:[${panelRect.left}/${expectedPanelRect.left}], top:[${panelRect.top}/${expectedPanelRect.top}], ` +
-                        `width:[${panelRect.width}/${expectedPanelRect.width}], height:[${panelRect.height}/${expectedPanelRect.height}]`);
-                }
-            } else {
-                if(drawer.option('openedStateMode') !== 'overlap') {
-                    const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
-                    assert.strictEqual(
-                        panelRect.right < drawerRect.left
-                        || panelRect.left > drawerRect.right
-                        || panelRect.bottom < drawerRect.top
-                        || panelRect.top > drawerRect.bottom,
-                        true,
-                        'panel should be out of drawerRect, ' +
-                        `left:[${panelRect.left}/${drawerRect.left}], top:[${panelRect.top}/${drawerRect.top}], ` +
-                        `right:[${panelRect.right}/${drawerRect.right}], bottom:[${panelRect.bottom}/${drawerRect.bottom}], [panel/drawer]`);
-                }
-            }
-
-            if(!drawer.option('minSize') || (drawer.option('openedStateMode') === 'overlap')) {
-                const expectedViewRect = extend({}, drawerRect);
-                if(drawer.option('minSize')) {
-                    switch(drawer.option('position')) {
-                        case 'left':
-                            expectedViewRect.left += drawer.option('minSize');
-                            expectedViewRect.width -= drawer.option('minSize');
-                            break;
-                        case 'right':
-                            expectedViewRect.width -= drawer.option('minSize');
-                            break;
-                        case 'top':
-                            expectedViewRect.top += drawer.option('minSize');
-                            expectedViewRect.height -= drawer.option('minSize');
-                            break;
-                        case 'bottom':
-                            expectedViewRect.height -= drawer.option('minSize');
-                            break;
-                    }
-                }
-                const viewRect = document.getElementById('view').getBoundingClientRect();
-                assert.strictEqual(
-                    viewRect.left === expectedViewRect.left
-                    && viewRect.top === expectedViewRect.top
-                    && viewRect.width === expectedViewRect.width
-                    && viewRect.height === expectedViewRect.height,
-                    true,
-                    'viewRect/expectedRect, ' +
-                    `left:[${viewRect.left}/${expectedViewRect.left}], top:[${viewRect.top}/${expectedViewRect.top}], ` +
-                    `width:[${viewRect.width}/${expectedViewRect.width}], height:[${viewRect.height}/${expectedViewRect.height}]`);
-            }
-        }
-
         testOrSkip('opened: false', () => configIs('push', 'top') || configIs('overlap', ['right', 'top'], ['expand', 'slide']) && config.minSize, function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
 
@@ -303,7 +221,7 @@ configs.forEach(config => {
                 opened: false,
                 template: drawerTesters[config.position].template,
                 __debugWhenPanelContentRendered: (e) => {
-                    checkWhenPanelContentRendered(assert, e.drawer, drawerElement, document.getElementById('template'));
+                    drawerTesters[config.position].checkWhenPanelContentRendered(assert, e.drawer, drawerElement, document.getElementById('template'), config.minSize);
                 }
             }));
 

--- a/testing/tests/DevExpress.ui.widgets/drawer.scenarios.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/drawer.scenarios.tests.js
@@ -218,35 +218,35 @@ configs.forEach(config => {
             const drawerRect = drawerElement.getBoundingClientRect();
             if(config.minSize) {
                 if(drawer.option('openedStateMode') === 'overlap') {
-                    const panelParentRect = panelTemplateElement.parentElement.getBoundingClientRect();
-                    const expectedPanelParentRect = extend({}, drawerRect);
+                    const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
+                    const expectedPanelRect = extend({}, drawerRect);
                     if(drawer.option('minSize')) {
                         switch(drawer.option('position')) {
                             case 'left':
-                                expectedPanelParentRect.width = drawer.option('minSize');
+                                expectedPanelRect.width = drawer.option('minSize');
                                 break;
                             case 'right':
-                                expectedPanelParentRect.left += drawerRect.wight - drawer.option('minSize');
-                                expectedPanelParentRect.width = drawer.option('minSize');
+                                expectedPanelRect.left += drawerRect.wight - drawer.option('minSize');
+                                expectedPanelRect.width = drawer.option('minSize');
                                 break;
                             case 'top':
-                                expectedPanelParentRect.height = drawer.option('minSize');
+                                expectedPanelRect.height = drawer.option('minSize');
                                 break;
                             case 'bottom':
-                                expectedPanelParentRect.top = drawerRect.bottom - drawer.option('minSize');
-                                expectedPanelParentRect.height = drawer.option('minSize');
+                                expectedPanelRect.top = drawerRect.bottom - drawer.option('minSize');
+                                expectedPanelRect.height = drawer.option('minSize');
                                 break;
                         }
                     }
                     assert.strictEqual(
-                        panelParentRect.left === expectedPanelParentRect.left
-                        && panelParentRect.top === expectedPanelParentRect.top
-                        && panelParentRect.width === expectedPanelParentRect.width
-                        && panelParentRect.height === expectedPanelParentRect.height,
+                        panelRect.left === expectedPanelRect.left
+                        && panelRect.top === expectedPanelRect.top
+                        && panelRect.width === expectedPanelRect.width
+                        && panelRect.height === expectedPanelRect.height,
                         true,
-                        'panelTemplateRect/expectedRect: ' +
-                        `left:[${panelParentRect.left}/${expectedPanelParentRect.left}], top:[${panelParentRect.top}/${expectedPanelParentRect.top}], ` +
-                        `width:[${panelParentRect.width}/${expectedPanelParentRect.width}], height:[${panelParentRect.height}/${expectedPanelParentRect.height}]`);
+                        'panelRect/expectedRect: ' +
+                        `left:[${panelRect.left}/${expectedPanelRect.left}], top:[${panelRect.top}/${expectedPanelRect.top}], ` +
+                        `width:[${panelRect.width}/${expectedPanelRect.width}], height:[${panelRect.height}/${expectedPanelRect.height}]`);
                 }
             } else {
                 if(drawer.option('openedStateMode') !== 'overlap') {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
