### PR TITLE
Update HtmlEditor table operations interaction policy

### DIFF
--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -685,10 +685,10 @@ if(Quill) {
             const selection = this.quill.getSelection();
             const isTableOperationsEnabled = selection && Boolean(this.quill.getFormat(selection)?.table);
             TABLE_OPERATIONS.forEach((operationName) => {
-                if(operationName !== 'insertTable') {
-                    const widget = this._toolbarWidgets.getByName(operationName);
-                    this._updateManipulationWidget(widget, isTableOperationsEnabled);
-                }
+                const isInsertTable = operationName === 'insertTable';
+
+                const widget = this._toolbarWidgets.getByName(operationName);
+                this._updateManipulationWidget(widget, isInsertTable ? !isTableOperationsEnabled : isTableOperationsEnabled);
             });
         }
 

--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -686,8 +686,8 @@ if(Quill) {
             const isTableOperationsEnabled = selection && Boolean(this.quill.getFormat(selection)?.table);
             TABLE_OPERATIONS.forEach((operationName) => {
                 const isInsertTable = operationName === 'insertTable';
-
                 const widget = this._toolbarWidgets.getByName(operationName);
+
                 this._updateManipulationWidget(widget, isInsertTable ? !isTableOperationsEnabled : isTableOperationsEnabled);
             });
         }

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -1278,7 +1278,7 @@ testModule('tables', simpleModuleConfig, function() {
             assert.strictEqual(
                 $(element).hasClass(DISABLED_STATE_CLASS),
                 expectedDisabledState,
-                `${operationName} item should be disabled in case the table is not focused`
+                `${operationName} item should ${expectedDisabledState ? '' : 'not'} be disabled in case the table is not focused`
             );
         });
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -1272,7 +1272,14 @@ testModule('tables', simpleModuleConfig, function() {
         $formatWidgets.each((index, element) => {
             const operationName = TABLE_OPERATIONS[index];
             const isElementExist = Boolean($(element).find(`.dx-icon-${operationName.toLowerCase()}`).length);
+            const expectedDisabledState = operationName === 'insertTable' ? false : true;
+
             assert.ok(isElementExist, `${operationName} item has an related icon`);
+            assert.strictEqual(
+                $(element).hasClass(DISABLED_STATE_CLASS),
+                expectedDisabledState,
+                `${operationName} item should be disabled in case the table is not focused`
+            );
         });
     });
 
@@ -1288,9 +1295,11 @@ testModule('tables', simpleModuleConfig, function() {
         toolbar.updateTableWidgets();
 
         const $disabledFormatWidgets = this.$element.find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}.${DISABLED_STATE_CLASS}`);
-        const toolbarHasDisabledItems = Boolean($disabledFormatWidgets.length);
+        const disabledItemsCount = $disabledFormatWidgets.length;
+        const isInsertTableOperationDisabled = $disabledFormatWidgets.first().hasClass('dx-inserttable-format');
 
-        assert.notOk(toolbarHasDisabledItems, 'table focused -> all table operation buttons are enabled');
+        assert.strictEqual(disabledItemsCount, 1, 'table focused -> all table operation buttons are enabled (except "insertTable")');
+        assert.ok(isInsertTableOperationDisabled);
     });
 
     test('buttons interaction', function(assert) {


### PR DESCRIPTION
Table isn't focused -> `insertTable` operation active, other operations disabled:
![image](https://user-images.githubusercontent.com/1554153/94121388-ef62de80-fe59-11ea-8715-bd789a7fbf51.png)

Table focused -> `insertTable` operation disabled, other operations active:
![image](https://user-images.githubusercontent.com/1554153/94121529-18836f00-fe5a-11ea-972c-6bc72d301f03.png)

