### PR TITLE
Drawer - Avoid content flicks on the first showing in React apps when openedStateMode is overlap (T848346) (#14657)

### DIFF
--- a/js/ui/drawer/ui.drawer.js
+++ b/js/ui/drawer/ui.drawer.js
@@ -105,8 +105,11 @@ const Drawer = Widget.inherit({
         this._whenPanelContentRefreshed = undefined;
 
         this._$wrapper = $('<div>').addClass(DRAWER_WRAPPER_CLASS);
+
         this._$viewContentWrapper = $('<div>').addClass(DRAWER_VIEW_CONTENT_CLASS);
+        this._strategy.onViewContentWrapperCreated(this._$viewContentWrapper, this.calcTargetPosition());
         this._$wrapper.append(this._$viewContentWrapper);
+
         this.$element().append(this._$wrapper);
     },
 
@@ -181,7 +184,7 @@ const Drawer = Widget.inherit({
         this._whenPanelContentRendered.always(() => {
             ///#DEBUG
             if(this.option('__debugWhenPanelContentRendered')) {
-                this.option('__debugWhenPanelContentRendered')();
+                this.option('__debugWhenPanelContentRendered')({ drawer: this });
             }
             ///#ENDDEBUG
 
@@ -191,16 +194,16 @@ const Drawer = Widget.inherit({
             this._renderPosition(this.option('opened'), false);
             if(this._$panelContentWrapper.attr('manualposition')) {
                 this._$panelContentWrapper.removeAttr('manualPosition');
-                this._$panelContentWrapper.css({ position: '', top: '', left: '' });
+                this._$panelContentWrapper.css({ position: '', top: '', left: '', right: '', bottom: '' });
             }
         });
     },
 
     _renderPanelContentWrapper() {
         this._$panelContentWrapper = $('<div>').addClass(DRAWER_PANEL_CONTENT_CLASS);
-        if(this.option('openedStateMode') !== 'overlap' && !this.option('opened')) {
+        if(this.option('openedStateMode') !== 'overlap' && !this.option('opened') && !this.option('minSize')) {
             this._$panelContentWrapper.attr('manualposition', true);
-            this._$panelContentWrapper.css({ position: 'absolute', top: '-10000px', left: '-10000px' });
+            this._$panelContentWrapper.css({ position: 'absolute', top: '-10000px', left: '-10000px', right: 'auto', bottom: 'auto' });
         }
         this._$wrapper.append(this._$panelContentWrapper);
     },

--- a/js/ui/drawer/ui.drawer.rendering.strategy.js
+++ b/js/ui/drawer/ui.drawer.rendering.strategy.js
@@ -227,6 +227,8 @@ class DrawerStrategy {
     isViewContentFirst() {
         return false;
     }
+
+    onViewContentWrapperCreated() {}
 }
 
 module.exports = DrawerStrategy;

--- a/js/ui/drawer/ui.drawer.rendering.strategy.overlap.js
+++ b/js/ui/drawer/ui.drawer.rendering.strategy.overlap.js
@@ -100,6 +100,10 @@ class OverlapStrategy extends DrawerStrategy {
         }
     }
 
+    onViewContentWrapperCreated($viewContentWrapper, panelPosition) {
+        this._setupContent($viewContentWrapper, panelPosition);
+    }
+
     _setupContent($content, position) {
         $content.css('padding' + camelize(position, true), this.getDrawerInstance().option('minSize'));
         $content.css('transform', 'inherit');

--- a/testing/helpers/drawerHelpers.js
+++ b/testing/helpers/drawerHelpers.js
@@ -21,6 +21,35 @@ function checkMargin(assert, element, top, right, bottom, left, message) {
     assert.strictEqual(window.getComputedStyle(element).marginBottom, bottom + 'px', 'marginBottom, ' + message);
 }
 
+function checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect) {
+    const drawerRect = drawerElement.getBoundingClientRect();
+
+    // Check Panel element rect
+
+    if(!drawer.option('minSize') && drawer.option('openedStateMode') !== 'overlap') {
+        const panelRect = panelTemplateElement.parentElement.getBoundingClientRect();
+        assert.strictEqual(
+            panelRect.right < drawerRect.left
+            || panelRect.left > drawerRect.right
+            || panelRect.bottom < drawerRect.top
+            || panelRect.top > drawerRect.bottom,
+            true,
+            'panel should be out of drawerRect, ' +
+            `left:[${panelRect.left}/${drawerRect.left}], top:[${panelRect.top}/${drawerRect.top}], ` +
+            `right:[${panelRect.right}/${drawerRect.right}], bottom:[${panelRect.bottom}/${drawerRect.bottom}], [panel/drawer]`);
+    } else {
+        if(drawer.option('minSize') && (drawer.option('openedStateMode') === 'overlap')) {
+            checkBoundingClientRect(assert, panelTemplateElement.parentElement, expectedPanelRect, 'panel');
+        }
+    }
+
+    // Check View element rect
+
+    if(!drawer.option('minSize') || (drawer.option('openedStateMode') === 'overlap')) {
+        checkBoundingClientRect(assert, document.getElementById('view'), expectedViewRect, 'view');
+    }
+}
+
 const leftTemplateSize = 150;
 const LeftDrawerTester = { // TODO: convert to class with abstract methods
     templateSize: leftTemplateSize,
@@ -126,6 +155,18 @@ const LeftDrawerTester = { // TODO: convert to class with abstract methods
         } else {
             assert.notOk('configuration is not tested');
         }
+    },
+
+    checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
+        const { top, left, width, height } = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = { top, left, width, height };
+        const expectedViewRect = { top, left, width, height };
+        if(drawer.option('minSize')) {
+            expectedPanelRect.width = drawer.option('minSize');
+            expectedViewRect.left += drawer.option('minSize');
+            expectedViewRect.width -= drawer.option('minSize');
+        }
+        checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect);
     }
 };
 
@@ -241,6 +282,18 @@ const RightDrawerTester = { // TODO: convert to class with abstract methods
         } else {
             assert.notOk('configuration is not tested');
         }
+    },
+
+    checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
+        const { top, left, width, height } = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = { top, left, width, height };
+        const expectedViewRect = { top, left, width, height };
+        if(drawer.option('minSize')) {
+            expectedPanelRect.left += expectedPanelRect.wight - drawer.option('minSize');
+            expectedPanelRect.width = drawer.option('minSize');
+            expectedViewRect.width -= drawer.option('minSize');
+        }
+        checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect);
     }
 };
 
@@ -349,6 +402,18 @@ const TopDrawerTester = { // TODO: convert to class with abstract methods
         } else {
             assert.notOk('configuration is not tested');
         }
+    },
+
+    checkWhenPanelContentRendered: function(assert, drawer, drawerElement, panelTemplateElement) {
+        const { top, left, width, height } = drawerElement.getBoundingClientRect();
+        const expectedPanelRect = { top, left, width, height };
+        const expectedViewRect = { top, left, width, height };
+        if(drawer.option('minSize')) {
+            expectedPanelRect.height = drawer.option('minSize');
+            expectedViewRect.top += drawer.option('minSize');
+            expectedViewRect.height -= drawer.option('minSize');
+        }
+        checkWhenPanelContentRendered(assert, drawer, drawerElement, panelTemplateElement, expectedPanelRect, expectedViewRect);
     }
 };
 


### PR DESCRIPTION
* Avoid content flicks on the first showing (T848346)

* Fix typos

* Move asserts to helpers

* Use checkBoundingClientRect in tests

* Reduce getBoundingClientRect result

(cherry picked from commit 1aa0e725782908c9cae82ffd006ade91df35b71e)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
