### PR TITLE
Chart documentation. Rename 'model' to 'data'

### DIFF
--- a/js/viz/chart.d.ts
+++ b/js/viz/chart.d.ts
@@ -1556,13 +1556,13 @@ export interface dxChartCommonAxisSettingsLabel {
      * @docid dxChartOptions.commonAxisSettings.label.template
      * @type template|function
      * @default undefined
-     * @type_function_param1 model:any
+     * @type_function_param1 data:any
      * @type_function_param2 element:SVGGElement
      * @type_function_return string|SVGElement|jQuery
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    template?: template | ((model: any, element: SVGGElement) => string | SVGElement | JQuery);
+    template?: template | ((data: any, element: SVGGElement) => string | SVGElement | JQuery);
     /**
      * @docid dxChartOptions.commonAxisSettings.label.alignment
      * @type Enums.HorizontalAlignment

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -14860,7 +14860,7 @@ declare module DevExpress.viz {
         /**
          * [descr:dxChart.Options.commonAxisSettings.label.template]
          */
-        template?: DevExpress.core.template | ((model: any, element: SVGGElement) => string | SVGElement | JQuery);
+        template?: DevExpress.core.template | ((data: any, element: SVGGElement) => string | SVGElement | JQuery);
         /**
          * [descr:dxChart.Options.commonAxisSettings.label.textOverflow]
          */


### PR DESCRIPTION
'model' can be unclear name of argument.

CC @dxBeardedBear 