### PR TITLE
Fix default value of the MediaResizing.allowedTargets option (T935691) (#14762)

### DIFF
--- a/js/ui/html_editor.d.ts
+++ b/js/ui/html_editor.d.ts
@@ -307,7 +307,7 @@ export interface dxHtmlEditorMediaResizing {
     /**
      * @docid dxHtmlEditorMediaResizing.allowedTargets
      * @type Array<string>
-     * @default ["images"]
+     * @default ["image"]
      * @prevFileNamespace DevExpress.ui
      * @public
      */


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
