### PR TITLE
DataGrid - Fixes sorting after ungrouping  with single sorting mode (T933738)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -754,7 +754,7 @@ export default {
                 }
             };
 
-            const updateSortOrderWhenGrouping = function(column, groupIndex, prevGroupIndex) {
+            const updateSortOrderWhenGrouping = function(that, column, groupIndex, prevGroupIndex) {
                 const columnWasGrouped = prevGroupIndex >= 0;
 
                 if(groupIndex >= 0) {
@@ -762,7 +762,17 @@ export default {
                         column.lastSortOrder = column.sortOrder;
                     }
                 } else {
-                    column.sortOrder = column.lastSortOrder;
+                    const sortMode = that.option('sorting.mode');
+                    let sortOrder = column.lastSortOrder;
+
+                    if(sortMode === 'single') {
+                        const sortedByAnotherColumn = that._columns.some(col => col !== column && isDefined(col.sortIndex));
+                        if(sortedByAnotherColumn) {
+                            sortOrder = undefined;
+                        }
+                    }
+
+                    column.sortOrder = sortOrder;
                 }
             };
 
@@ -795,7 +805,7 @@ export default {
                 if(prevValue !== value) {
                     if(optionName === 'groupIndex' || optionName === 'calculateGroupValue') {
                         changeType = 'grouping';
-                        updateSortOrderWhenGrouping(column, value, prevValue);
+                        updateSortOrderWhenGrouping(that, column, value, prevValue);
                     } else if(optionName === 'sortIndex' || optionName === 'sortOrder' || optionName === 'calculateSortValue') {
                         changeType = 'sorting';
                     } else {
@@ -1770,8 +1780,10 @@ export default {
                     if(allowSorting && column && column.allowSorting) {
                         if(needResetSorting && !isDefined(column.groupIndex)) {
                             iteratorUtils.each(that._columns, function(index) {
-                                if(index !== columnIndex && this.sortOrder && !isDefined(this.groupIndex)) {
-                                    delete this.sortOrder;
+                                if(index !== columnIndex && this.sortOrder) {
+                                    if(!isDefined(this.groupIndex)) {
+                                        delete this.sortOrder;
+                                    }
                                     delete this.sortIndex;
                                 }
                             });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
@@ -1,0 +1,73 @@
+import { createDataGrid, baseModuleConfig } from '../../helpers/dataGridHelper.js';
+import $ from 'jquery';
+
+QUnit.testStart(function() {
+    const markup = `
+        <div id="container">
+            <div id="dataGrid"></div>
+        </div>
+    `;
+
+    $('#qunit-fixture').html(markup);
+});
+
+
+QUnit.module('Initialization', baseModuleConfig, () => {
+    QUnit.test('Only one column should be sorted after ungrouping when sorting.mode is \'single\' (T933738)', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            dataSource: [{ id: 1, name: 'test' }],
+            columns: ['id', 'name'],
+            loadingTimeout: undefined,
+            sorting: {
+                mode: 'single'
+            }
+        });
+
+        // act
+        const $idHeaderElement = $(dataGrid.element()).find('.dx-header-row td').eq(0);
+        $idHeaderElement.trigger('dxclick');
+        this.clock.tick();
+
+        let sortedColumns = dataGrid.getVisibleColumns().filter(col => col.sortIndex >= 0);
+
+        // assert
+        assert.equal(sortedColumns.length, 1, 'only one sorted column before grouping');
+        assert.strictEqual(sortedColumns[0].dataField, 'id', '\'id\' column is sorted before grouping');
+        assert.strictEqual(sortedColumns[0].sortOrder, 'asc', 'sortOrder before grouping');
+
+        // act
+        dataGrid.columnOption('id', 'groupIndex', 0);
+        this.clock.tick();
+
+        sortedColumns = dataGrid.getVisibleColumns().filter(col => col.sortIndex >= 0);
+
+        // assert
+        assert.equal(sortedColumns.length, 1, 'only one sorted column after grouping');
+        assert.strictEqual(sortedColumns[0].dataField, 'id', '\'id\' column is sorted after grouping');
+        assert.strictEqual(sortedColumns[0].sortOrder, 'asc', 'sortOrder after grouping');
+
+        // act
+        const $nameHeaderElement = $(dataGrid.element()).find('.dx-header-row td').eq(1);
+        $nameHeaderElement.trigger('dxclick');
+        this.clock.tick();
+
+        sortedColumns = dataGrid.getVisibleColumns().filter(col => col.sortIndex >= 0);
+
+        // assert
+        assert.equal(sortedColumns.length, 1, 'only one sorted column after clicking the \'name\' column header');
+        assert.strictEqual(sortedColumns[0].dataField, 'name', '\'name\' column is sorted after clicking the \'name\' column header');
+        assert.strictEqual(sortedColumns[0].sortOrder, 'asc', 'sortOrder after clicking the \'name\' column header');
+
+        // act
+        dataGrid.columnOption('id', 'groupIndex', undefined);
+        this.clock.tick();
+
+        sortedColumns = dataGrid.getVisibleColumns().filter(col => col.sortIndex >= 0);
+
+        // assert
+        assert.equal(sortedColumns.length, 1, 'only one sorted column after ungrouping');
+        assert.strictEqual(sortedColumns[0].dataField, 'name', '\'name\' column is sorted after ungrouping');
+        assert.strictEqual(sortedColumns[0].sortOrder, 'asc', 'sortOrder after ungrouping');
+    });
+});


### PR DESCRIPTION
Resets the sortOrder/sortIndex column option of a grouped column when an ungrouped column is sorted.
