### PR TITLE
GitHub Actions: Update the 'cache' action to v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Restore npm cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: .\node_modules
         key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}


### PR DESCRIPTION
See https://github.com/actions/cache/releases for details.