### PR TITLE
HtmlEditor - attach focus events only after the content was rendered (T934089)

### DIFF
--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -8,7 +8,7 @@ import { EmptyTemplate } from '../../core/templates/empty_template';
 import Editor from '../editor/editor';
 import Errors from '../widget/ui.errors';
 import Callbacks from '../../core/utils/callbacks';
-import { Deferred } from '../../core/utils/deferred';
+import { Deferred, when } from '../../core/utils/deferred';
 import eventsEngine from '../../events/core/events_engine';
 import { addNamespace } from '../../events/utils';
 import scrollEvents from '../scroll_view/ui.events.emitter.gesture.scroll';
@@ -200,9 +200,7 @@ const HtmlEditor = Editor.inherit({
     _attachFocusEvents: function() {
         const callBase = this.callBase.bind(this);
 
-        this._isContentRendered.done(() => {
-            callBase();
-        });
+        when(this._isContentRendered).done(callBase);
     },
 
     _prepareQuillRegistrator: function() {

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -509,13 +509,6 @@ const HtmlEditor = Editor.inherit({
         this._abortUpdateContentTask();
         this._cleanCallback.empty();
         this._contentInitializedCallback.empty();
-        this._isContentRendered = undefined;
-        this.callBase();
-    },
-
-    _detachFocusEvents: function() {
-        this._isContentRendered && this._isContentRendered.reject();
-
         this.callBase();
     },
 

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -8,7 +8,7 @@ import { EmptyTemplate } from '../../core/templates/empty_template';
 import Editor from '../editor/editor';
 import Errors from '../widget/ui.errors';
 import Callbacks from '../../core/utils/callbacks';
-import { Deferred, when } from '../../core/utils/deferred';
+import { Deferred } from '../../core/utils/deferred';
 import eventsEngine from '../../events/core/events_engine';
 import { addNamespace } from '../../events/utils';
 import scrollEvents from '../scroll_view/ui.events.emitter.gesture.scroll';
@@ -200,7 +200,9 @@ const HtmlEditor = Editor.inherit({
     _attachFocusEvents: function() {
         const callBase = this.callBase.bind(this);
 
-        when(this._isContentRendered).done(callBase);
+        this._isContentRendered.done(() => {
+            callBase();
+        });
     },
 
     _prepareQuillRegistrator: function() {

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -509,6 +509,13 @@ const HtmlEditor = Editor.inherit({
         this._abortUpdateContentTask();
         this._cleanCallback.empty();
         this._contentInitializedCallback.empty();
+        this._isContentRendered = undefined;
+        this.callBase();
+    },
+
+    _detachFocusEvents: function() {
+        this._isContentRendered && this._isContentRendered.reject();
+
         this.callBase();
     },
 

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -191,9 +191,18 @@ const HtmlEditor = Editor.inherit({
     },
 
     _render: function() {
+        this._isContentRendered = new Deferred();
         this._prepareConverters();
 
         this.callBase();
+    },
+
+    _attachFocusEvents: function() {
+        const callBase = this.callBase.bind(this);
+
+        this._isContentRendered.done(() => {
+            callBase();
+        });
     },
 
     _prepareQuillRegistrator: function() {
@@ -230,6 +239,7 @@ const HtmlEditor = Editor.inherit({
         this._renderHtmlEditor();
         this._renderFormDialog();
         this._addKeyPressHandler();
+        this._isContentRendered.resolve();
 
         return renderContentPromise;
     },

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -2,7 +2,7 @@ import $ from '../../core/renderer';
 import { extend } from '../../core/utils/extend';
 import { isDefined, isFunction } from '../../core/utils/type';
 import { getPublicElement } from '../../core/utils/dom';
-import { executeAsync, noop, ensureDefined } from '../../core/utils/common';
+import { executeAsync, noop, ensureDefined, deferRender } from '../../core/utils/common';
 import registerComponent from '../../core/component_registrator';
 import { EmptyTemplate } from '../../core/templates/empty_template';
 import Editor from '../editor/editor';
@@ -232,6 +232,10 @@ const HtmlEditor = Editor.inherit({
         this._addKeyPressHandler();
 
         return renderContentPromise;
+    },
+
+    _attachFocusEvents: function() {
+        deferRender(this.callBase.bind(this));
     },
 
     _addKeyPressHandler: function() {

--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -191,18 +191,9 @@ const HtmlEditor = Editor.inherit({
     },
 
     _render: function() {
-        this._isContentRendered = new Deferred();
         this._prepareConverters();
 
         this.callBase();
-    },
-
-    _attachFocusEvents: function() {
-        const callBase = this.callBase.bind(this);
-
-        this._isContentRendered.done(() => {
-            callBase();
-        });
     },
 
     _prepareQuillRegistrator: function() {
@@ -239,7 +230,6 @@ const HtmlEditor = Editor.inherit({
         this._renderHtmlEditor();
         this._renderFormDialog();
         this._addKeyPressHandler();
-        this._isContentRendered.resolve();
 
         return renderContentPromise;
     },

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 
 import 'ui/html_editor';
 import 'ui/html_editor/converters/markdown';
+import { deferUpdate } from 'core/utils/common';
 
 import keyboardMock from '../../../helpers/keyboardMock.js';
 
@@ -134,6 +135,19 @@ testModule('Events', createModuleConfig({ value: '<p>Test 1</p><p>Test 2</p><p>T
 
         assert.strictEqual(focusInStub.callCount, 1, 'Editor is focused one time');
         assert.strictEqual(focusOutStub.callCount, 1, 'Editor is blurred one time');
+    });
+
+    test('focus events listeners attached only after the content is rendered (T934089)', function(assert) {
+        const focusInStub = sinon.stub();
+        deferUpdate(() => {
+            this.createEditor({
+                onFocusIn: focusInStub,
+            });
+        });
+
+        this.instance.focus();
+
+        assert.strictEqual(focusInStub.callCount, 1, 'Focus event handler is attached');
     });
 
     ['html', 'markdown'].forEach((valueType) => {

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
@@ -136,6 +136,27 @@ testModule('Events', createModuleConfig({ value: '<p>Test 1</p><p>Test 2</p><p>T
         assert.strictEqual(focusOutStub.callCount, 1, 'Editor is blurred one time');
     });
 
+    test('focus events listeners attached only after the content is rendered (T934089)', function(assert) {
+        const focusInStub = sinon.stub();
+        this.createEditor({
+            onFocusIn: focusInStub,
+        });
+        const renderContentImplOrig = this.instance._renderContentImpl;
+        this.instance._renderContentImpl = () => {
+            setTimeout(() => {
+                renderContentImplOrig.call(this.instance);
+            }, 0);
+        };
+        this.instance.repaint();
+
+        this.clock.tick(TIME_TO_WAIT);
+
+        this.instance.focus();
+        this.clock.tick(TIME_TO_WAIT);
+
+        assert.strictEqual(focusInStub.callCount, 1, 'Focus event handler is attached');
+    });
+
     ['html', 'markdown'].forEach((valueType) => {
         test(`change value to "null" should raise only one ValueChanged event (valueType is "${valueType}")`, function(assert) {
             const valueChangedStub = sinon.stub();

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
@@ -136,27 +136,6 @@ testModule('Events', createModuleConfig({ value: '<p>Test 1</p><p>Test 2</p><p>T
         assert.strictEqual(focusOutStub.callCount, 1, 'Editor is blurred one time');
     });
 
-    test('focus events listeners attached only after the content is rendered (T934089)', function(assert) {
-        const focusInStub = sinon.stub();
-        this.createEditor({
-            onFocusIn: focusInStub,
-        });
-        const renderContentImplOrig = this.instance._renderContentImpl;
-        this.instance._renderContentImpl = () => {
-            setTimeout(() => {
-                renderContentImplOrig.call(this.instance);
-            }, 0);
-        };
-        this.instance.repaint();
-
-        this.clock.tick(TIME_TO_WAIT);
-
-        this.instance.focus();
-        this.clock.tick(TIME_TO_WAIT);
-
-        assert.strictEqual(focusInStub.callCount, 1, 'Focus event handler is attached');
-    });
-
     ['html', 'markdown'].forEach((valueType) => {
         test(`change value to "null" should raise only one ValueChanged event (valueType is "${valueType}")`, function(assert) {
             const valueChangedStub = sinon.stub();


### PR DESCRIPTION


<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
