### PR TITLE
Remove luxon and es6-object-assign

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -23,8 +23,4 @@ rrule.js (Open Source - BSD License)
 Copyright 2010, Jakub Roztocil and Lars Schoning
 https://github.com/jakubroztocil/rrule/blob/master/LICENCE
 
-es6-object-assign (Open Source - MIT License)
-Copyright (c) 2015-2017 Rubén Norte
-https://github.com/rubennorte/es6-object-assign/blob/master/LICENSE
-
 The open source libraries included in this product are done so pursuant to each individual open source library license and subject to the disclaimers and limitations on liability set forth in each open source library license.

--- a/js/ui/diagram/diagram.items_option.js
+++ b/js/ui/diagram/diagram.items_option.js
@@ -11,7 +11,7 @@ class ItemsOption extends Component {
 
     _dataSourceChangedHandler(newItems, e) {
         this._resetCache();
-        this._items = newItems.map(item => Object.assign({}, item));
+        this._items = newItems.map(item => extend({}, item));
         this._dataSourceItems = newItems.slice();
 
         if(e && e.changes) {

--- a/js/ui/scheduler/recurrence.js
+++ b/js/ui/scheduler/recurrence.js
@@ -1,5 +1,3 @@
-// NOTE: https://github.com/jakubroztocil/rrule/issues/402 (IE11 support)
-import 'es6-object-assign/auto';
 import errors from '../../core/errors';
 import { each } from '../../core/utils/iterator';
 import { inArray } from '../../core/utils/array';

--- a/js/ui/scheduler/ui.scheduler.resource_manager.js
+++ b/js/ui/scheduler/ui.scheduler.resource_manager.js
@@ -493,7 +493,7 @@ export default class ResourceManager {
         const currentResourcesData = [];
 
         resourceData.forEach(
-            data => currentResourcesData.push(Object.assign({}, data))
+            data => currentResourcesData.push(extend({}, data))
         );
 
         each(groups, (_, value) => {

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
@@ -1223,7 +1223,7 @@ class SchedulerWorkSpace extends WidgetObserver {
 
         if(this.isVirtualScrolling()) {
             const virtualScrollingState = this.virtualScrollingDispatcher.getState();
-            Object.assign(options, {
+            extend(options, {
                 topVirtualRowHeight: virtualScrollingState.topVirtualRowHeight,
                 bottomVirtualRowHeight: virtualScrollingState.bottomVirtualRowHeight,
                 startRowIndex: virtualScrollingState.startIndex,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "jszip": "^2.0.0 || ^3.0.0",
     "devextreme-quill": "^0.9.5",
     "rrule": "2.6.6",
-    "es6-object-assign": "^1.1.0",
     "showdown": "^1.8.6",
     "turndown": "^6.0.0",
     "preact": "^10.4.5"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "devexpress-gantt": "1.1.17",
     "jszip": "^2.0.0 || ^3.0.0",
     "devextreme-quill": "^0.9.5",
-    "rrule": "2.6.4",
+    "rrule": "2.6.6",
     "es6-object-assign": "^1.1.0",
     "showdown": "^1.8.6",
     "turndown": "^6.0.0",

--- a/testing/runner/Views/Main/RunSuite.cshtml
+++ b/testing/runner/Views/Main/RunSuite.cshtml
@@ -196,7 +196,6 @@
                     'turndown': '@Url.Content("~/node_modules/turndown/lib/turndown.browser.umd.js")',
                     'showdown': '@Url.Content("~/node_modules/showdown/dist/showdown.js")',
                     'rrule': '@Url.Content("~/node_modules/rrule/dist/es5/rrule.js")',
-                    'luxon': '@Url.Content("~/node_modules/luxon/build/global/luxon.min.js")',
                     'es6-object-assign': '@Url.Content("~/node_modules/es6-object-assign")',
                     // Global CSS
 

--- a/testing/runner/Views/Main/RunSuite.cshtml
+++ b/testing/runner/Views/Main/RunSuite.cshtml
@@ -196,9 +196,8 @@
                     'turndown': '@Url.Content("~/node_modules/turndown/lib/turndown.browser.umd.js")',
                     'showdown': '@Url.Content("~/node_modules/showdown/dist/showdown.js")',
                     'rrule': '@Url.Content("~/node_modules/rrule/dist/es5/rrule.js")',
-                    'es6-object-assign': '@Url.Content("~/node_modules/es6-object-assign")',
-                    // Global CSS
 
+                    // Global CSS
                     'common.css': '@Url.Content("~/artifacts/css/dx.common.css")',
 
                     'generic_light.css': '@Url.Content("~/artifacts/css/dx.light.css")',
@@ -223,10 +222,6 @@
                     },
                     'cldr': {
                         main: '../cldr.js',
-                        defaultExtension: 'js'
-                    },
-                    'es6-object-assign': {
-                        main: './index.js',
                         defaultExtension: 'js'
                     }
                 },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = {
         'exceljs': 'window.ExcelJS',
         'jspdf': 'window.jspdf.jsPDF',
         'devexpress-diagram': 'window.DevExpress.diagram',
-        'devexpress-gantt': 'window.DevExpress.Gantt'
+        'devexpress-gantt': 'window.DevExpress.Gantt',
+        'luxon': 'window.luxon'
     }
 };


### PR DESCRIPTION
These libs were necessary for rrule v2.6.4 (see https://github.com/jakubroztocil/rrule/issues/344 and https://github.com/jakubroztocil/rrule/issues/402). But starting with v2.6.6 it is no need to include them (see https://github.com/jakubroztocil/rrule/releases/tag/v2.6.6 and https://github.com/jakubroztocil/rrule/pull/410).

This PR updates rrule to v2.6.6 and removes luxon and es6-object-assign libs from our dependencies as not necessary now.