### PR TITLE
HtmlEditor - attach focus events only after the content was rendered (T934089)

### DIFF
--- a/js/ui/html_editor/ui.html_editor.js
+++ b/js/ui/html_editor/ui.html_editor.js
@@ -2,7 +2,7 @@ import $ from '../../core/renderer';
 import { extend } from '../../core/utils/extend';
 import { isDefined, isFunction } from '../../core/utils/type';
 import { getPublicElement } from '../../core/element';
-import { executeAsync, noop, ensureDefined } from '../../core/utils/common';
+import { executeAsync, noop, ensureDefined, deferRender } from '../../core/utils/common';
 import registerComponent from '../../core/component_registrator';
 import { EmptyTemplate } from '../../core/templates/empty_template';
 import Editor from '../editor/editor';
@@ -229,6 +229,10 @@ const HtmlEditor = Editor.inherit({
         this._addKeyPressHandler();
 
         return renderContentPromise;
+    },
+
+    _attachFocusEvents: function() {
+        deferRender(this.callBase.bind(this));
     },
 
     _addKeyPressHandler: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/events.tests.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 
 import 'ui/html_editor';
 import 'ui/html_editor/converters/markdown';
+import { deferUpdate } from 'core/utils/common';
 
 import keyboardMock from '../../../helpers/keyboardMock.js';
 
@@ -143,6 +144,19 @@ testModule('Events', createModuleConfig({ initialOptions: { value: '<p>Test 1</p
 
         assert.strictEqual(focusInStub.callCount, 1, 'Editor is focused one time');
         assert.strictEqual(focusOutStub.callCount, 1, 'Editor is blurred one time');
+    });
+
+    test('focus events listeners attached only after the content is rendered (T934089)', function(assert) {
+        const focusInStub = sinon.stub();
+        deferUpdate(() => {
+            this.createEditor({
+                onFocusIn: focusInStub,
+            });
+        });
+
+        this.instance.focus();
+
+        assert.strictEqual(focusInStub.callCount, 1, 'Focus event handler is attached');
     });
 
     ['html', 'markdown'].forEach((valueType) => {


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
