### PR TITLE
Overlay should correctly restore affecting size css attributes after fullscreen option change (T937118)

### DIFF
--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -1181,8 +1181,8 @@ const Overlay = Widget.inherit({
 
         const isWindow = this._isWindow($container);
 
-        wrapperWidth = isWindow ? null : $container.outerWidth(),
-        wrapperHeight = isWindow ? null : $container.outerHeight();
+        wrapperWidth = isWindow ? '' : $container.outerWidth(),
+        wrapperHeight = isWindow ? '' : $container.outerHeight();
 
         this._$wrapper.css({
             width: wrapperWidth,

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -625,7 +625,11 @@ const Popup = Overlay.inherit({
         if(this.option('fullScreen')) {
             this._$content.css({
                 width: '100%',
-                height: '100%'
+                height: '100%',
+                minWidth: '',
+                maxWidth: '',
+                minHeight: '',
+                maxHeight: ''
             });
         } else {
             this.callBase.apply(this, arguments);

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -2161,6 +2161,24 @@ testModule('close on target scroll', moduleConfig, () => {
 
 
 testModule('container', moduleConfig, () => {
+    test('wrapper should have width and height css attributes equal to container width and height', function(assert) {
+        const $container = $('#customTargetContainer');
+        $container.css({
+            width: 100,
+            height: 100
+        });
+
+        const overlay = $('#overlay').dxOverlay({
+            container: $container,
+            visible: true
+        }).dxOverlay('instance');
+
+        const wrapperElement = overlay.$content().parent().get(0);
+
+        assert.strictEqual(wrapperElement.style.width, '100px', 'width is correct');
+        assert.strictEqual(wrapperElement.style.height, '100px', 'height is correct');
+    });
+
     test('wrapper width and height should be restored after container option value changed to window (T937118)', function(assert) {
         const $container = $('#customTargetContainer');
         $container.css({
@@ -2173,13 +2191,8 @@ testModule('container', moduleConfig, () => {
             visible: true
         }).dxOverlay('instance');
 
-        let wrapperElement = overlay.$content().parent().get(0);
-
-        assert.strictEqual(wrapperElement.style.width, '100px', 'width is correct');
-        assert.strictEqual(wrapperElement.style.height, '100px', 'height is correct');
-
+        const wrapperElement = overlay.$content().parent().get(0);
         overlay.option('container', null);
-        wrapperElement = overlay.$content().parent().get(0);
         assert.strictEqual(wrapperElement.style.width, '', 'width is restored after container option value changed to window');
         assert.strictEqual(wrapperElement.style.height, '', 'height is restored after container option value changed to window');
     });

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -2163,34 +2163,25 @@ testModule('close on target scroll', moduleConfig, () => {
 testModule('container', moduleConfig, () => {
     test('wrapper width and height should be restored after container option value changed to window (T937118)', function(assert) {
         const $container = $('#customTargetContainer');
-        const containerWidth = $container.css('width');
-        const containerHeight = $container.css('height');
         $container.css({
             width: 100,
             height: 100
         });
 
-        try {
-            const overlay = $('#overlay').dxOverlay({
-                container: $container
-            }).dxOverlay('instance');
+        const overlay = $('#overlay').dxOverlay({
+            container: $container,
+            visible: true
+        }).dxOverlay('instance');
 
-            overlay.show();
-            let wrapperElement = overlay.$content().parent().get(0);
+        let wrapperElement = overlay.$content().parent().get(0);
 
-            assert.strictEqual(wrapperElement.style.width, '100px', 'width is correct');
-            assert.strictEqual(wrapperElement.style.height, '100px', 'height is correct');
+        assert.strictEqual(wrapperElement.style.width, '100px', 'width is correct');
+        assert.strictEqual(wrapperElement.style.height, '100px', 'height is correct');
 
-            overlay.option('container', null);
-            wrapperElement = overlay.$content().parent().get(0);
-            assert.strictEqual(wrapperElement.style.width, '', 'width is restored after container option value changed to window');
-            assert.strictEqual(wrapperElement.style.height, '', 'height is restored after container option value changed to window');
-        } finally {
-            $container.css({
-                width: containerWidth,
-                height: containerHeight
-            });
-        }
+        overlay.option('container', null);
+        wrapperElement = overlay.$content().parent().get(0);
+        assert.strictEqual(wrapperElement.style.width, '', 'width is restored after container option value changed to window');
+        assert.strictEqual(wrapperElement.style.height, '', 'height is restored after container option value changed to window');
     });
 
     test('content should not be moved to container', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -2161,6 +2161,38 @@ testModule('close on target scroll', moduleConfig, () => {
 
 
 testModule('container', moduleConfig, () => {
+    test('wrapper width and height should be restored after container option value changed to window (T937118)', function(assert) {
+        const $container = $('#customTargetContainer');
+        const containerWidth = $container.css('width');
+        const containerHeight = $container.css('height');
+        $container.css({
+            width: 100,
+            height: 100
+        });
+
+        try {
+            const overlay = $('#overlay').dxOverlay({
+                container: $container
+            }).dxOverlay('instance');
+
+            overlay.show();
+            let wrapperElement = overlay.$content().parent().get(0);
+
+            assert.strictEqual(wrapperElement.style.width, '100px', 'width is correct');
+            assert.strictEqual(wrapperElement.style.height, '100px', 'height is correct');
+
+            overlay.option('container', null);
+            wrapperElement = overlay.$content().parent().get(0);
+            assert.strictEqual(wrapperElement.style.width, '', 'width is restored after container option value changed to window');
+            assert.strictEqual(wrapperElement.style.height, '', 'height is restored after container option value changed to window');
+        } finally {
+            $container.css({
+                width: containerWidth,
+                height: containerHeight
+            });
+        }
+    });
+
     test('content should not be moved to container', function(assert) {
         const overlay = $('#overlay').dxOverlay({
             container: '#customTargetContainer'

--- a/testing/tests/DevExpress.ui.widgets/popup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/popup.tests.js
@@ -503,6 +503,28 @@ QUnit.module('dimensions', {
         assert.notEqual($overlayContent.height(), 100, 'auto height option');
     });
 
+    QUnit.test('affecting size css atrrtibutes should be restored after fullScreen set to true', function(assert) {
+        const instance = $('#popup').dxPopup({
+            maxHeight: 100,
+            minHeight: 100,
+            minWidth: 100,
+            maxWidth: 100
+        }).dxPopup('instance');
+
+        instance.show();
+        const overlayContentElement = instance.$content().parent().get(0);
+        const affectingSizeOptions = ['minWidth', 'maxWidth', 'minHeight', 'maxHeight'];
+
+        affectingSizeOptions.forEach(attr => {
+            assert.strictEqual(overlayContentElement.style[attr], '100px', 'css attr value is correct');
+        });
+
+        instance.option('fullScreen', true);
+        affectingSizeOptions.forEach(attr => {
+            assert.strictEqual(overlayContentElement.style[attr], '', 'css attr is restored');
+        });
+    });
+
     QUnit.test('minHeight should affect popup content height correctly', function(assert) {
         const $popup = $('#popup').dxPopup({
             visible: true,

--- a/testing/tests/DevExpress.ui.widgets/popup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/popup.tests.js
@@ -503,25 +503,28 @@ QUnit.module('dimensions', {
         assert.notEqual($overlayContent.height(), 100, 'auto height option');
     });
 
-    QUnit.test('affecting size css atrrtibutes should be restored after fullScreen set to true', function(assert) {
-        const instance = $('#popup').dxPopup({
-            maxHeight: 100,
-            minHeight: 100,
-            minWidth: 100,
-            maxWidth: 100
-        }).dxPopup('instance');
+    ['minWidth', 'maxWidth', 'minHeight', 'maxHeight'].forEach((option) => {
+        QUnit.test(`overlay content should have correct ${option} attr`, function(assert) {
+            const instance = $('#popup').dxPopup({
+                [option]: 100,
+                visible: true
+            }).dxPopup('instance');
 
-        instance.show();
-        const overlayContentElement = instance.$content().parent().get(0);
-        const affectingSizeOptions = ['minWidth', 'maxWidth', 'minHeight', 'maxHeight'];
+            const overlayContentElement = instance.$content().parent().get(0);
 
-        affectingSizeOptions.forEach(attr => {
-            assert.strictEqual(overlayContentElement.style[attr], '100px', 'css attr value is correct');
+            assert.strictEqual(overlayContentElement.style[option], '100px', 'css attr value is correct');
         });
 
-        instance.option('fullScreen', true);
-        affectingSizeOptions.forEach(attr => {
-            assert.strictEqual(overlayContentElement.style[attr], '', 'css attr is restored');
+        QUnit.test(`overlay content ${option} attr should be restored after fullScreen option set to true`, function(assert) {
+            const instance = $('#popup').dxPopup({
+                [option]: 100,
+                visible: true
+            }).dxPopup('instance');
+
+            const overlayContentElement = instance.$content().parent().get(0);
+
+            instance.option('fullScreen', true);
+            assert.strictEqual(overlayContentElement.style[option], '', 'css attr value is restored');
         });
     });
 


### PR DESCRIPTION
…

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
