### PR TITLE
Fix localization gulp task after cldr-data@37 release

### DIFF
--- a/build/gulp/localization.js
+++ b/build/gulp/localization.js
@@ -66,8 +66,12 @@ const accountingFormats = function() {
     const result = {};
 
     locales.forEach(function(locale) {
-        const numbersData = require(path.join(`../../node_modules/cldr-numbers-full/main/${locale}/numbers.json`));
-        result[locale] = numbersData.main[locale].numbers['currencyFormats-numberSystem-latn'].accounting;
+        const dataFilePath = `../../node_modules/cldr-numbers-full/main/${locale}/numbers.json`;
+
+        if(fs.existsSync(path.join(__dirname, dataFilePath))) {
+            const numbersData = require(dataFilePath);
+            result[locale] = numbersData.main[locale].numbers['currencyFormats-numberSystem-latn'].accounting;
+        }
     });
 
     return result;


### PR DESCRIPTION
`ff-Adlm` locale was [appeared ](https://github.com/unicode-cldr/cldr-core/commit/2c2d91fa0c581b7f3a35fc748a1ce88e070ac550#diff-68538af80f50a6230e770ab68d99f0b6R610) in availableLocales in v37, but it does not exists in [full numbers data](https://github.com/unicode-cldr/cldr-numbers-full/tree/master/main).
