### PR TITLE
TileView - correct content size reduce after the widget resize (T934021)

### DIFF
--- a/js/ui/tile_view.js
+++ b/js/ui/tile_view.js
@@ -222,14 +222,12 @@ const TileView = CollectionWidget.inherit({
         this._renderContentSize(config, itemMargin);
     },
 
-    _renderContentSize: function(config, itemMargin) {
+    _renderContentSize: function({ mainDimension, baseItemMainDimension }, itemMargin) {
         if(hasWindow()) {
-            const actualContentSize = this._cells.length * this.option(config.baseItemMainDimension) + (this._cells.length + 1) * itemMargin;
-            const containerSize = this._$container[config.mainDimension]();
+            const actualContentSize = this._cells.length * this.option(baseItemMainDimension) + (this._cells.length + 1) * itemMargin;
+            const elementSize = this.$element()[mainDimension]();
 
-            if(actualContentSize > containerSize) {
-                this._$container[config.mainDimension](actualContentSize);
-            }
+            this._$container[mainDimension](Math.max(actualContentSize, elementSize));
         }
     },
 

--- a/testing/tests/DevExpress.ui.widgets/tileView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tileView.tests.js
@@ -361,6 +361,35 @@ QUnit.module('widget sizing render', () => {
 
         assert.roughEqual($element.find(`.${SCROLLVIEW_CONTENT_CLASS}`).width(), customWidth, 1);
     });
+
+    QUnit.test('scrollable content height is recalculated if the element was resized and the widget has vertical direction (T934021)', function(assert) {
+        const $element = $('#widget').dxTileView({
+            direction: 'vertical',
+            items: prepareItems(items, configs.vertical),
+            height: 300,
+            width: 240
+        });
+        const instance = $element.dxTileView('instance');
+        const startContentHeight = $element.find(`.${SCROLLVIEW_CONTENT_CLASS}`).height();
+
+        instance.option('width', 900);
+
+        assert.ok($element.find(`.${SCROLLVIEW_CONTENT_CLASS}`).height() < startContentHeight / 2);
+    });
+
+    QUnit.test('scrollable content height is recalculated if the element was resized and the widget has horizontal direction (T934021)', function(assert) {
+        const $element = $('#widget').dxTileView({
+            items: prepareItems(items, configs.horizontal),
+            height: 240,
+            width: 300
+        });
+        const instance = $element.dxTileView('instance');
+        const startContentWidth = $element.find(`.${SCROLLVIEW_CONTENT_CLASS}`).width();
+
+        instance.option('height', 900);
+
+        assert.ok($element.find(`.${SCROLLVIEW_CONTENT_CLASS}`).width() < startContentWidth / 2);
+    });
 });
 
 QUnit.module('integration with dataSource', {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
