### PR TITLE
Add flag option to use deferUpdate in templates

### DIFF
--- a/js/core/template_manager.js
+++ b/js/core/template_manager.js
@@ -54,6 +54,7 @@ export class TemplateManager {
                     return noop;
                 },
                 templates: { 'dx-polymorph-widget': DX_POLYMORPH_WIDGET_TEMPLATE },
+                useDeferUpdateForTemplates: false
             }
         };
     }

--- a/testing/tests/DevExpress.core/domComponent.tests.js
+++ b/testing/tests/DevExpress.core/domComponent.tests.js
@@ -511,6 +511,15 @@ QUnit.module('default', {
         assert.strictEqual(template.render(), 'Default content markup', 'name1 is not found in integrationOptions. Use the default');
     });
 
+    QUnit.test('component does not use deferUpdate strategy for template rendering', function(assert) {
+        const $element = $('#component').TestComponent();
+        const instance = $element.TestComponent('instance');
+
+        const useDeferUpdate = instance.option('integrationOptions.useDeferUpdateForTemplates');
+
+        assert.strictEqual(useDeferUpdate, false);
+    });
+
     QUnit.test('option \'rtl\'', function(assert) {
         const $element = $('#component').TestComponent();
         const instance = $element.TestComponent('instance');

--- a/testing/tests/DevExpress.core/template_manager.tests.js
+++ b/testing/tests/DevExpress.core/template_manager.tests.js
@@ -37,6 +37,7 @@ QUnit.test('#defaultOptions', function(assert) {
     assert.ok(defaultOptions.integrationOptions.watchMethod, 'watchMethod is defined');
     assert.ok(defaultOptions.integrationOptions.templates, 'templates are defined');
     assert.ok(defaultOptions.integrationOptions.templates['dx-polymorph-widget'], 'default polymorph widget template is defined');
+    assert.strictEqual(defaultOptions.integrationOptions.useDeferUpdateForTemplates, false, 'do not use deferUpdate for template rendering');
 });
 
 QUnit.module('TemplateManager methods');


### PR DESCRIPTION
Check `integrationOptions.useDeferUpdateForTemplates` option value after widget creation to set appropriate strategy for templates rendering.
