### PR TITLE
Overlay should correctly restore affecting size css attributes after fullscreen option change (T937118) (#14852)

### DIFF
--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -1185,8 +1185,8 @@ const Overlay = Widget.inherit({
 
         const isWindow = this._isWindow($container);
 
-        wrapperWidth = isWindow ? null : $container.outerWidth(),
-        wrapperHeight = isWindow ? null : $container.outerHeight();
+        wrapperWidth = isWindow ? '' : $container.outerWidth(),
+        wrapperHeight = isWindow ? '' : $container.outerHeight();
 
         this._$wrapper.css({
             width: wrapperWidth,

--- a/js/ui/popup.js
+++ b/js/ui/popup.js
@@ -631,7 +631,11 @@ const Popup = Overlay.inherit({
         if(this.option('fullScreen')) {
             this._$content.css({
                 width: '100%',
-                height: '100%'
+                height: '100%',
+                minWidth: '',
+                maxWidth: '',
+                minHeight: '',
+                maxHeight: ''
             });
         } else {
             this.callBase(...arguments);

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -2160,6 +2160,42 @@ testModule('close on target scroll', moduleConfig, () => {
 
 
 testModule('container', moduleConfig, () => {
+    test('wrapper should have width and height css attributes equal to container width and height', function(assert) {
+        const $container = $('#customTargetContainer');
+        $container.css({
+            width: 100,
+            height: 100
+        });
+
+        const overlay = $('#overlay').dxOverlay({
+            container: $container,
+            visible: true
+        }).dxOverlay('instance');
+
+        const wrapperElement = overlay.$content().parent().get(0);
+
+        assert.strictEqual(wrapperElement.style.width, '100px', 'width is correct');
+        assert.strictEqual(wrapperElement.style.height, '100px', 'height is correct');
+    });
+
+    test('wrapper width and height should be restored after container option value changed to window (T937118)', function(assert) {
+        const $container = $('#customTargetContainer');
+        $container.css({
+            width: 100,
+            height: 100
+        });
+
+        const overlay = $('#overlay').dxOverlay({
+            container: $container,
+            visible: true
+        }).dxOverlay('instance');
+
+        const wrapperElement = overlay.$content().parent().get(0);
+        overlay.option('container', null);
+        assert.strictEqual(wrapperElement.style.width, '', 'width is restored after container option value changed to window');
+        assert.strictEqual(wrapperElement.style.height, '', 'height is restored after container option value changed to window');
+    });
+
     test('content should not be moved to container', function(assert) {
         const overlay = $('#overlay').dxOverlay({
             container: '#customTargetContainer'

--- a/testing/tests/DevExpress.ui.widgets/popup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/popup.tests.js
@@ -504,6 +504,31 @@ QUnit.module('dimensions', {
         assert.notEqual($overlayContent.height(), 100, 'auto height option');
     });
 
+    ['minWidth', 'maxWidth', 'minHeight', 'maxHeight'].forEach((option) => {
+        QUnit.test(`overlay content should have correct ${option} attr`, function(assert) {
+            const instance = $('#popup').dxPopup({
+                [option]: 100,
+                visible: true
+            }).dxPopup('instance');
+
+            const overlayContentElement = instance.$content().parent().get(0);
+
+            assert.strictEqual(overlayContentElement.style[option], '100px', 'css attr value is correct');
+        });
+
+        QUnit.test(`overlay content ${option} attr should be restored after fullScreen option set to true`, function(assert) {
+            const instance = $('#popup').dxPopup({
+                [option]: 100,
+                visible: true
+            }).dxPopup('instance');
+
+            const overlayContentElement = instance.$content().parent().get(0);
+
+            instance.option('fullScreen', true);
+            assert.strictEqual(overlayContentElement.style[option], '', 'css attr value is restored');
+        });
+    });
+
     QUnit.test('minHeight should affect popup content height correctly', function(assert) {
         const $popup = $('#popup').dxPopup({
             visible: true,


### PR DESCRIPTION
…

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
