### PR TITLE
DateBox list dropdown width should be equal to input width even when container is another (T938497)

### DIFF
--- a/js/ui/date_box/ui.date_box.base.js
+++ b/js/ui/date_box/ui.date_box.base.js
@@ -66,6 +66,10 @@ const DateBox = DropDownEditor.inherit({
         });
     },
 
+    getWidth: function() {
+        return this.$element().outerWidth();
+    },
+
     _renderButtonContainers: function() {
         this.callBase.apply(this, arguments);
         this._strategy.customizeButtons();

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -9,7 +9,6 @@ const extend = require('../../core/utils/extend').extend;
 const dateUtils = require('./ui.date_utils');
 const dateLocalization = require('../../localization/date');
 const dateSerialization = require('../../core/utils/date_serialization');
-const typeUtils = require('../../core/utils/type');
 
 const DATE_FORMAT = 'date';
 
@@ -43,15 +42,6 @@ const ListStrategy = DateBoxStrategy.inherit({
 
     getDisplayFormat: function(displayFormat) {
         return displayFormat || 'shorttime';
-    },
-
-    _updatePopupMinWidth(popupWidth) {
-        if(window && this._getPopup()) {
-            if(popupWidth === undefined) {
-                popupWidth = this._getInputWidth();
-            }
-            this._getPopup().overlayContent().css('minWidth', popupWidth);
-        }
     },
 
     _getPopupWidth() {
@@ -277,13 +267,9 @@ const ListStrategy = DateBoxStrategy.inherit({
     _dimensionChanged: function() {
         if(this._getPopup()) {
             const popupWidth = this._getPopupWidth();
-            const popupMinWidth = this.dateBox.option('dropDownOptions.minWidth');
 
             if(popupWidth === undefined) {
                 this.dateBox.setPopupOption('width', (this._getInputWidth.bind(this)));
-            }
-            if(!typeUtils.isDefined(popupMinWidth)) {
-                this._updatePopupMinWidth(popupWidth);
             }
 
             this._updatePopupHeight();

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -9,6 +9,7 @@ const extend = require('../../core/utils/extend').extend;
 const dateUtils = require('./ui.date_utils');
 const dateLocalization = require('../../localization/date');
 const dateSerialization = require('../../core/utils/date_serialization');
+const typeUtils = require('../../core/utils/type');
 
 const DATE_FORMAT = 'date';
 
@@ -44,8 +45,32 @@ const ListStrategy = DateBoxStrategy.inherit({
         return displayFormat || 'shorttime';
     },
 
+    _updatePopupMinWidth(popupWidth) {
+        if(window && this._getPopup()) {
+            if(popupWidth === undefined) {
+                popupWidth = this._getInputWidth();
+            }
+            this._getPopup().overlayContent().css('minWidth', popupWidth);
+        }
+    },
+
+    _getPopupWidth() {
+        const popupWidth = this.dateBox.option('dropDownOptions.width');
+
+        if(popupWidth === null) {
+            return undefined;
+        }
+        if(typeof popupWidth === 'function') {
+            return popupWidth();
+        }
+
+        return popupWidth;
+    },
+
     popupConfig: function(popupConfig) {
-        return popupConfig;
+        return extend(popupConfig, {
+            width: this._getInputWidth.bind(this)
+        });
     },
 
     useCurrentDateByDefault: function() {
@@ -251,8 +276,22 @@ const ListStrategy = DateBoxStrategy.inherit({
 
     _dimensionChanged: function() {
         if(this._getPopup()) {
+            const popupWidth = this._getPopupWidth();
+            const popupMinWidth = this.dateBox.option('dropDownOptions.minWidth');
+
+            if(popupWidth === undefined) {
+                this.dateBox.setPopupOption('width', (this._getInputWidth.bind(this)));
+            }
+            if(!typeUtils.isDefined(popupMinWidth)) {
+                this._updatePopupMinWidth(popupWidth);
+            }
+
             this._updatePopupHeight();
         }
+    },
+
+    _getInputWidth() {
+        return this.dateBox.$element().outerWidth();
     },
 
     _updatePopupHeight: function() {

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -277,7 +277,7 @@ const ListStrategy = DateBoxStrategy.inherit({
     },
 
     _getInputWidth() {
-        return this.dateBox.$element().outerWidth();
+        return this.dateBox.getWidth();
     },
 
     _updatePopupHeight: function() {

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -45,13 +45,12 @@ const ListStrategy = DateBoxStrategy.inherit({
     },
 
     _getPopupWidth: function() {
-        const popupWidth = this.dateBox.option('dropDownOptions.width');
+        let popupWidth = this.dateBox.option('dropDownOptions.width');
 
         if(popupWidth === null) {
-            return undefined;
-        }
-        if(typeof popupWidth === 'function') {
-            return popupWidth();
+            popupWidth = undefined;
+        } else if(typeof popupWidth === 'function') {
+            popupWidth = popupWidth();
         }
 
         return popupWidth;

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -44,7 +44,7 @@ const ListStrategy = DateBoxStrategy.inherit({
         return displayFormat || 'shorttime';
     },
 
-    _getPopupWidth() {
+    _getPopupWidth: function() {
         const popupWidth = this.dateBox.option('dropDownOptions.width');
 
         if(popupWidth === null) {

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -269,7 +269,7 @@ const ListStrategy = DateBoxStrategy.inherit({
             const popupWidth = this._getPopupWidth();
 
             if(popupWidth === undefined) {
-                this.dateBox.setPopupOption('width', (this._getInputWidth.bind(this)));
+                this.dateBox.setPopupOption('width', this._getInputWidth.bind(this));
             }
 
             this._updatePopupHeight();

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -61,6 +61,7 @@ const GESTURE_COVER_CLASS = 'dx-gesture-cover';
 const DROP_DOWN_BUTTON_CLASS = 'dx-dropdowneditor-button';
 const DROP_DOWN_BUTTON_VISIBLE_CLASS = 'dx-dropdowneditor-button-visible';
 const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
+const OVERLAY_WRAPPER_CLASS = 'dx-overlay-wrapper';
 const POPUP_CLASS = 'dx-popup';
 
 const CALENDAR_APPLY_BUTTON_SELECTOR = '.dx-popup-done.dx-button';
@@ -2161,26 +2162,6 @@ QUnit.module('datebox w/ calendar', {
         assert.deepEqual(getInstanceWidget(this.fixture.dateBox).option('value'), date);
     });
 
-    QUnit.test('popup should have correct width after editor width runtime change', function(assert) {
-        this.fixture.dateBox.option('width', 300);
-        this.fixture.dateBox.option('dropDownOptions.width', '50%');
-        this.fixture.dateBox.option('opened', true);
-
-        this.fixture.dateBox.option('width', 700);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 350, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width when editor width is defined (T897820)', function(assert) {
-        const editorWidth = 200;
-        this.fixture.dateBox.option('width', editorWidth);
-        this.fixture.dateBox.option('opened', true);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.ok($overlayContent.outerWidth() > editorWidth, 'overlay content width is correct');
-    });
-
     QUnit.test('DateBox must update its value when a date is selected in the calendar when applyValueMode=\'instantly\'', function(assert) {
         const date = new Date(2011, 11, 11);
 
@@ -3496,87 +3477,6 @@ QUnit.module('datebox w/ time list', {
         assert.ok(getInstanceWidget(this.dateBox).$element().hasClass('dx-list'), 'list initialized');
     });
 
-    QUnit.test('popup width shoud be equal to the editor width when dropDownOptions.width in not defined', function(assert) {
-        this.dateBox.option('opened', true);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
-
-        this.dateBox.option('opened', false);
-        this.dateBox.option('width', '153');
-        this.dateBox.option('opened', true);
-        assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
-    });
-
-    QUnit.test('popup should have width equal to dropDownOptions.width if it\'s defined (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 500);
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 500);
-        this.dateBox.option('opened', true);
-
-        this.dateBox.option('width', 300);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width auto if dropDownOptions.width is set to auto (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 'auto');
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 'auto', 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), this.dateBox.$element().outerWidth(), 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width when dropDownOptions.width is percent (T897820)', function(assert) {
-        this.dateBox.option('width', 600);
-        this.dateBox.option('dropDownOptions.width', '50%');
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), '50%', 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width after editor width runtime change', function(assert) {
-        this.dateBox.option('width', 300);
-        this.dateBox.option('dropDownOptions.width', '50%');
-        this.dateBox.option('opened', true);
-
-        this.dateBox.option('width', 700);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 350, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width when dropDownOptions.container is defined (T938497)', function(assert) {
-        this.dateBox.option({
-            'dropDownOptions.container': '#containerWithWidth',
-            opened: true
-        });
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-
-        assert.strictEqual($overlayContent.outerWidth(), 1000, 'width is correct');
-    });
-
     QUnit.test('list should contain correct values if min/max does not specified', function(assert) {
         this.dateBox.option({
             min: null,
@@ -4018,6 +3918,317 @@ QUnit.module('datebox w/ time list', {
             .find('.dx-list-item')
             .first()
             .trigger('dxclick');
+    });
+});
+
+
+QUnit.module('width of datebox with list', {
+    beforeEach: function() {
+        fx.off = true;
+
+        this.$dateBox = $('#dateBox');
+    },
+    afterEach: function() {
+        fx.off = false;
+    }
+}, () => {
+    QUnit.module('overlay content real width', () => {
+        QUnit.test('should be equal to the editor width when dropDownOptions.width in not defined', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                opened: true,
+                type: 'time'
+            }).dxDateBox('instance');
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
+
+            dateBox.option('width', 153);
+            assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.width if it\'s defined (T897820)', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                dropDownOptions: {
+                    width: 500
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                type: 'time',
+                dropDownOptions: {
+                    width: 500
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 300);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to auto (T897820)', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                dropDownOptions: {
+                    width: 'auto'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth(), 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to 100%', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                dropDownOptions: {
+                    width: '100%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth(), 'overlay content width is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper when dropDownOptions.width is percent (T897820)', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                dropDownOptions: {
+                    width: '50%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth() / 2, 0.1, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper after editor width runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                type: 'time',
+                width: 600,
+                dropDownOptions: {
+                    width: '50%'
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 700);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth() / 2, 0.1, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to editor input width even when dropDownOptions.container is defined (T938497)', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                dropDownOptions: {
+                    container: '#containerWithWidth'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+
+            assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'width is correct');
+        });
+    });
+
+    QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {
+        this.$dateBox.dxDateBox({
+            type: 'time',
+            dropDownOptions: {
+                width: 500
+            },
+            opened: true
+        });
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
+    });
+
+    QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
+        const dateBox = this.$dateBox.dxDateBox({
+            type: 'time',
+            dropDownOptions: {
+                width: 500
+            },
+            opened: true
+        }).dxDateBox('instance');
+
+        dateBox.option('width', 300);
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
+    });
+});
+
+QUnit.module('width of datebox with calendar', {
+    beforeEach: function() {
+        fx.off = true;
+
+        this.$dateBox = $('#dateBox');
+    },
+    afterEach: function() {
+        fx.off = false;
+    }
+}, () => {
+    QUnit.module('overlay content width', () => {
+        QUnit.test('should be equal to the calendar width + margins when dropDownOptions.width in not defined', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                opened: true,
+            }).dxDateBox('instance');
+
+            const $calendar = $(`.${CALENDAR_CLASS}`);
+            const paddingsWidth = parseInt($calendar.css('margin-left')) * 4;
+            const calendarWidth = $calendar.outerWidth() + paddingsWidth;
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.width(), calendarWidth, 'popup width is correct');
+
+            dateBox.option('width', 153);
+            assert.strictEqual($overlayContent.width(), calendarWidth, 'popup width is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.width if it\'s defined', function(assert) {
+            this.$dateBox.dxDateBox({
+                dropDownOptions: {
+                    width: 500
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.width even after editor input width change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                dropDownOptions: {
+                    width: 500
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 300);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to calendar width + margins if dropDownOptions.width is set to auto', function(assert) {
+            this.$dateBox.dxDateBox({
+                dropDownOptions: {
+                    width: 'auto'
+                },
+                opened: true
+            });
+
+            const $calendar = $(`.${CALENDAR_CLASS}`);
+            const paddingsWidth = parseInt($calendar.css('margin-left')) * 4;
+            const calendarWidth = $calendar.outerWidth() + paddingsWidth;
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.width(), calendarWidth, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to 100%', function(assert) {
+            this.$dateBox.dxDateBox({
+                dropDownOptions: {
+                    width: '100%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth(), 'overlay content width is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper when dropDownOptions.width is percent', function(assert) {
+            this.$dateBox.dxDateBox({
+                dropDownOptions: {
+                    width: '50%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth() / 2, 0.1, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper after editor width runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                width: 600,
+                dropDownOptions: {
+                    width: '50%'
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 700);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth() / 2, 0.1, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to calendar width + margins even when dropDownOptions.container is defined', function(assert) {
+            this.$dateBox.dxDateBox({
+                dropDownOptions: {
+                    container: '#containerWithWidth'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $calendar = $(`.${CALENDAR_CLASS}`);
+            const paddingsWidth = parseInt($calendar.css('margin-left')) * 4;
+            const calendarWidth = $calendar.outerWidth() + paddingsWidth;
+
+            assert.strictEqual($overlayContent.width(), calendarWidth, 'width is correct');
+        });
+    });
+
+    QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {
+        this.$dateBox.dxDateBox({
+            dropDownOptions: {
+                width: 500
+            },
+            opened: true
+        });
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
+    });
+
+    QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
+        const dateBox = this.$dateBox.dxDateBox({
+            dropDownOptions: {
+                width: 500
+            },
+            opened: true
+        }).dxDateBox('instance');
+
+        dateBox.option('width', 300);
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -3566,6 +3566,17 @@ QUnit.module('datebox w/ time list', {
         assert.strictEqual($overlayContent.outerWidth(), 350, 'overlay content width is correct');
     });
 
+    QUnit.test('popup should have correct width when dropDownOptions.container is defined (T938497)', function(assert) {
+        this.dateBox.option({
+            'dropDownOptions.container': '#containerWithWidth',
+            opened: true
+        });
+
+        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+
+        assert.strictEqual($overlayContent.outerWidth(), 1000, 'width is correct');
+    });
+
     QUnit.test('list should contain correct values if min/max does not specified', function(assert) {
         this.dateBox.option({
             min: null,

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -3934,7 +3934,7 @@ QUnit.module('width of datebox with list', {
 }, () => {
     QUnit.module('overlay content real width', () => {
         QUnit.test('should be equal to the editor width when dropDownOptions.width in not defined', function(assert) {
-            const dateBox = this.$dateBox.dxDateBox({
+            this.$dateBox.dxDateBox({
                 opened: true,
                 pickerType: 'list',
                 type: 'time'
@@ -3942,8 +3942,18 @@ QUnit.module('width of datebox with list', {
 
             const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
             assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
+        });
+
+        QUnit.test('should be equal to the editor width when dropDownOptions.width in not defined after editor width runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'list',
+                type: 'time'
+            }).dxDateBox('instance');
 
             dateBox.option('width', 153);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
             assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
         });
 
@@ -4099,7 +4109,7 @@ QUnit.module('width of datebox with calendar', {
 }, () => {
     QUnit.module('overlay content width', () => {
         QUnit.test('should be equal to the calendar width + margins when dropDownOptions.width in not defined', function(assert) {
-            const dateBox = this.$dateBox.dxDateBox({
+            this.$dateBox.dxDateBox({
                 opened: true,
                 pickerType: 'calendar'
             }).dxDateBox('instance');
@@ -4110,8 +4120,21 @@ QUnit.module('width of datebox with calendar', {
 
             const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
             assert.strictEqual($overlayContent.width(), calendarWidth, 'popup width is correct');
+        });
+
+        QUnit.test('should be equal to the calendar width + margins when dropDownOptions.width in not defined after editor width runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'calendar'
+            }).dxDateBox('instance');
+
+            const $calendar = $(`.${CALENDAR_CLASS}`);
+            const paddingsWidth = parseInt($calendar.css('margin-left')) * 4;
+            const calendarWidth = $calendar.outerWidth() + paddingsWidth;
 
             dateBox.option('width', 153);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
             assert.strictEqual($overlayContent.width(), calendarWidth, 'popup width is correct');
         });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -3936,6 +3936,7 @@ QUnit.module('width of datebox with list', {
         QUnit.test('should be equal to the editor width when dropDownOptions.width in not defined', function(assert) {
             const dateBox = this.$dateBox.dxDateBox({
                 opened: true,
+                pickerType: 'list',
                 type: 'time'
             }).dxDateBox('instance');
 
@@ -3949,6 +3950,7 @@ QUnit.module('width of datebox with list', {
         QUnit.test('should be equal to dropDownOptions.width if it\'s defined (T897820)', function(assert) {
             this.$dateBox.dxDateBox({
                 type: 'time',
+                pickerType: 'list',
                 dropDownOptions: {
                     width: 500
                 },
@@ -3962,6 +3964,7 @@ QUnit.module('width of datebox with list', {
         QUnit.test('should be equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
             const dateBox = this.$dateBox.dxDateBox({
                 type: 'time',
+                pickerType: 'list',
                 dropDownOptions: {
                     width: 500
                 },
@@ -3977,6 +3980,7 @@ QUnit.module('width of datebox with list', {
         QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to auto (T897820)', function(assert) {
             this.$dateBox.dxDateBox({
                 type: 'time',
+                pickerType: 'list',
                 dropDownOptions: {
                     width: 'auto'
                 },
@@ -3991,6 +3995,7 @@ QUnit.module('width of datebox with list', {
         QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to 100%', function(assert) {
             this.$dateBox.dxDateBox({
                 type: 'time',
+                pickerType: 'list',
                 dropDownOptions: {
                     width: '100%'
                 },
@@ -4005,6 +4010,7 @@ QUnit.module('width of datebox with list', {
         QUnit.test('should be calculated relative to wrapper when dropDownOptions.width is percent (T897820)', function(assert) {
             this.$dateBox.dxDateBox({
                 type: 'time',
+                pickerType: 'list',
                 dropDownOptions: {
                     width: '50%'
                 },
@@ -4019,6 +4025,7 @@ QUnit.module('width of datebox with list', {
         QUnit.test('should be calculated relative to wrapper after editor width runtime change', function(assert) {
             const dateBox = this.$dateBox.dxDateBox({
                 type: 'time',
+                pickerType: 'list',
                 width: 600,
                 dropDownOptions: {
                     width: '50%'
@@ -4036,6 +4043,7 @@ QUnit.module('width of datebox with list', {
         QUnit.test('should be equal to editor input width even when dropDownOptions.container is defined (T938497)', function(assert) {
             this.$dateBox.dxDateBox({
                 type: 'time',
+                pickerType: 'list',
                 dropDownOptions: {
                     container: '#containerWithWidth'
                 },
@@ -4051,6 +4059,7 @@ QUnit.module('width of datebox with list', {
     QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {
         this.$dateBox.dxDateBox({
             type: 'time',
+            pickerType: 'list',
             dropDownOptions: {
                 width: 500
             },
@@ -4064,6 +4073,7 @@ QUnit.module('width of datebox with list', {
     QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
         const dateBox = this.$dateBox.dxDateBox({
             type: 'time',
+            pickerType: 'list',
             dropDownOptions: {
                 width: 500
             },
@@ -4091,6 +4101,7 @@ QUnit.module('width of datebox with calendar', {
         QUnit.test('should be equal to the calendar width + margins when dropDownOptions.width in not defined', function(assert) {
             const dateBox = this.$dateBox.dxDateBox({
                 opened: true,
+                pickerType: 'calendar'
             }).dxDateBox('instance');
 
             const $calendar = $(`.${CALENDAR_CLASS}`);
@@ -4106,6 +4117,7 @@ QUnit.module('width of datebox with calendar', {
 
         QUnit.test('should be equal to dropDownOptions.width if it\'s defined', function(assert) {
             this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
                 dropDownOptions: {
                     width: 500
                 },
@@ -4118,6 +4130,7 @@ QUnit.module('width of datebox with calendar', {
 
         QUnit.test('should be equal to dropDownOptions.width even after editor input width change', function(assert) {
             const dateBox = this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
                 dropDownOptions: {
                     width: 500
                 },
@@ -4132,6 +4145,7 @@ QUnit.module('width of datebox with calendar', {
 
         QUnit.test('should be equal to calendar width + margins if dropDownOptions.width is set to auto', function(assert) {
             this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
                 dropDownOptions: {
                     width: 'auto'
                 },
@@ -4148,6 +4162,7 @@ QUnit.module('width of datebox with calendar', {
 
         QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to 100%', function(assert) {
             this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
                 dropDownOptions: {
                     width: '100%'
                 },
@@ -4161,6 +4176,7 @@ QUnit.module('width of datebox with calendar', {
 
         QUnit.test('should be calculated relative to wrapper when dropDownOptions.width is percent', function(assert) {
             this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
                 dropDownOptions: {
                     width: '50%'
                 },
@@ -4174,6 +4190,7 @@ QUnit.module('width of datebox with calendar', {
 
         QUnit.test('should be calculated relative to wrapper after editor width runtime change', function(assert) {
             const dateBox = this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
                 width: 600,
                 dropDownOptions: {
                     width: '50%'
@@ -4190,6 +4207,7 @@ QUnit.module('width of datebox with calendar', {
 
         QUnit.test('should be equal to calendar width + margins even when dropDownOptions.container is defined', function(assert) {
             this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
                 dropDownOptions: {
                     container: '#containerWithWidth'
                 },
@@ -4207,6 +4225,7 @@ QUnit.module('width of datebox with calendar', {
 
     QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {
         this.$dateBox.dxDateBox({
+            pickerType: 'calendar',
             dropDownOptions: {
                 width: 500
             },
@@ -4219,6 +4238,7 @@ QUnit.module('width of datebox with calendar', {
 
     QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
         const dateBox = this.$dateBox.dxDateBox({
+            pickerType: 'calendar',
             dropDownOptions: {
                 width: 500
             },


### PR DESCRIPTION
…
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
