### PR TITLE
Drawer - Update css rules to ignore deep child elements with '.dx-overlay-content' (T937452) #14890

### DIFF
--- a/scss/widgets/common/_drawer.scss
+++ b/scss/widgets/common/_drawer.scss
@@ -102,15 +102,11 @@
   }
 
 
-  &.dx-drawer-right.dx-drawer-expand {
-    .dx-overlay-content {
-      right: 0;
-    }
+  &.dx-drawer-right.dx-drawer-expand > .dx-drawer-wrapper > .dx-overlay > .dx-overlay-wrapper > .dx-overlay-content {
+    right: 0;
   }
 
-  &.dx-drawer-right.dx-drawer-slide {
-    .dx-overlay-content {
-      right: 0;
-    }
+  &.dx-drawer-right.dx-drawer-slide > .dx-drawer-wrapper > .dx-overlay > .dx-overlay-wrapper > .dx-overlay-content {
+    right: 0;
   }
 }


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
