### PR TITLE
DateBox list dropdown width should be equal to input width even when container is another (T938497) (#14903)

### DIFF
--- a/js/ui/date_box/ui.date_box.base.js
+++ b/js/ui/date_box/ui.date_box.base.js
@@ -63,6 +63,10 @@ const DateBox = DropDownEditor.inherit({
         return extend(this.callBase(), this._strategy.supportedKeys());
     },
 
+    getWidth: function() {
+        return this.$element().outerWidth();
+    },
+
     _renderButtonContainers: function() {
         this.callBase.apply(this, arguments);
         this._strategy.customizeButtons();

--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -44,8 +44,22 @@ const ListStrategy = DateBoxStrategy.inherit({
         return displayFormat || 'shorttime';
     },
 
+    _getPopupWidth: function() {
+        let popupWidth = this.dateBox.option('dropDownOptions.width');
+
+        if(popupWidth === null) {
+            popupWidth = undefined;
+        } else if(typeof popupWidth === 'function') {
+            popupWidth = popupWidth();
+        }
+
+        return popupWidth;
+    },
+
     popupConfig: function(popupConfig) {
-        return popupConfig;
+        return extend(popupConfig, {
+            width: this._getInputWidth.bind(this)
+        });
     },
 
     useCurrentDateByDefault: function() {
@@ -251,8 +265,18 @@ const ListStrategy = DateBoxStrategy.inherit({
 
     _dimensionChanged: function() {
         if(this._getPopup()) {
+            const popupWidth = this._getPopupWidth();
+
+            if(popupWidth === undefined) {
+                this.dateBox.setPopupOption('width', this._getInputWidth.bind(this));
+            }
+
             this._updatePopupHeight();
         }
+    },
+
+    _getInputWidth() {
+        return this.dateBox.getWidth();
     },
 
     _updatePopupHeight: function() {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -61,6 +61,7 @@ const GESTURE_COVER_CLASS = 'dx-gesture-cover';
 const DROP_DOWN_BUTTON_CLASS = 'dx-dropdowneditor-button';
 const DROP_DOWN_BUTTON_VISIBLE_CLASS = 'dx-dropdowneditor-button-visible';
 const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
+const OVERLAY_WRAPPER_CLASS = 'dx-overlay-wrapper';
 const POPUP_CLASS = 'dx-popup';
 
 const CALENDAR_APPLY_BUTTON_SELECTOR = '.dx-popup-done.dx-button';
@@ -2161,26 +2162,6 @@ QUnit.module('datebox w/ calendar', {
         assert.deepEqual(getInstanceWidget(this.fixture.dateBox).option('value'), date);
     });
 
-    QUnit.test('popup should have correct width after editor width runtime change', function(assert) {
-        this.fixture.dateBox.option('width', 300);
-        this.fixture.dateBox.option('dropDownOptions.width', '50%');
-        this.fixture.dateBox.option('opened', true);
-
-        this.fixture.dateBox.option('width', 700);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 350, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width when editor width is defined (T897820)', function(assert) {
-        const editorWidth = 200;
-        this.fixture.dateBox.option('width', editorWidth);
-        this.fixture.dateBox.option('opened', true);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.ok($overlayContent.outerWidth() > editorWidth, 'overlay content width is correct');
-    });
-
     QUnit.test('DateBox must update its value when a date is selected in the calendar when applyValueMode=\'instantly\'', function(assert) {
         const date = new Date(2011, 11, 11);
 
@@ -3496,76 +3477,6 @@ QUnit.module('datebox w/ time list', {
         assert.ok(getInstanceWidget(this.dateBox).$element().hasClass('dx-list'), 'list initialized');
     });
 
-    QUnit.test('popup width shoud be equal to the editor width when dropDownOptions.width in not defined', function(assert) {
-        this.dateBox.option('opened', true);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
-
-        this.dateBox.option('opened', false);
-        this.dateBox.option('width', '153');
-        this.dateBox.option('opened', true);
-        assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
-    });
-
-    QUnit.test('popup should have width equal to dropDownOptions.width if it\'s defined (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 500);
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 500);
-        this.dateBox.option('opened', true);
-
-        this.dateBox.option('width', 300);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have width auto if dropDownOptions.width is set to auto (T897820)', function(assert) {
-        this.dateBox.option('dropDownOptions.width', 'auto');
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), 'auto', 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), this.dateBox.$element().outerWidth(), 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width when dropDownOptions.width is percent (T897820)', function(assert) {
-        this.dateBox.option('width', 600);
-        this.dateBox.option('dropDownOptions.width', '50%');
-        this.dateBox.option('opened', true);
-
-        const popup = this.dateBox.$element().find(`.${POPUP_CLASS}`).dxPopup('instance');
-        assert.strictEqual(popup.option('width'), '50%', 'popup width option value is correct');
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 300, 'overlay content width is correct');
-    });
-
-    QUnit.test('popup should have correct width after editor width runtime change', function(assert) {
-        this.dateBox.option('width', 300);
-        this.dateBox.option('dropDownOptions.width', '50%');
-        this.dateBox.option('opened', true);
-
-        this.dateBox.option('width', 700);
-
-        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
-        assert.strictEqual($overlayContent.outerWidth(), 350, 'overlay content width is correct');
-    });
-
     QUnit.test('list should contain correct values if min/max does not specified', function(assert) {
         this.dateBox.option({
             min: null,
@@ -4007,6 +3918,360 @@ QUnit.module('datebox w/ time list', {
             .find('.dx-list-item')
             .first()
             .trigger('dxclick');
+    });
+});
+
+
+QUnit.module('width of datebox with list', {
+    beforeEach: function() {
+        fx.off = true;
+
+        this.$dateBox = $('#dateBox');
+    },
+    afterEach: function() {
+        fx.off = false;
+    }
+}, () => {
+    QUnit.module('overlay content real width', () => {
+        QUnit.test('should be equal to the editor width when dropDownOptions.width in not defined', function(assert) {
+            this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'list',
+                type: 'time'
+            }).dxDateBox('instance');
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
+        });
+
+        QUnit.test('should be equal to the editor width when dropDownOptions.width in not defined after editor width runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'list',
+                type: 'time'
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 153);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'popup width is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.width if it\'s defined (T897820)', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    width: 500
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    width: 500
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 300);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to auto (T897820)', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    width: 'auto'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth(), 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to 100%', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    width: '100%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth(), 'overlay content width is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper when dropDownOptions.width is percent (T897820)', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    width: '50%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth() / 2, 0.1, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper after editor width runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                width: 600,
+                dropDownOptions: {
+                    width: '50%'
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 700);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth() / 2, 0.1, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to editor input width even when dropDownOptions.container is defined (T938497)', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    container: '#containerWithWidth'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+
+            assert.strictEqual($overlayContent.outerWidth(), this.$dateBox.outerWidth(), 'width is correct');
+        });
+    });
+
+    QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {
+        this.$dateBox.dxDateBox({
+            type: 'time',
+            pickerType: 'list',
+            dropDownOptions: {
+                width: 500
+            },
+            opened: true
+        });
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
+    });
+
+    QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
+        const dateBox = this.$dateBox.dxDateBox({
+            type: 'time',
+            pickerType: 'list',
+            dropDownOptions: {
+                width: 500
+            },
+            opened: true
+        }).dxDateBox('instance');
+
+        dateBox.option('width', 300);
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
+    });
+});
+
+QUnit.module('width of datebox with calendar', {
+    beforeEach: function() {
+        fx.off = true;
+
+        this.$dateBox = $('#dateBox');
+    },
+    afterEach: function() {
+        fx.off = false;
+    }
+}, () => {
+    QUnit.module('overlay content width', () => {
+        QUnit.test('should be equal to the calendar width + margins when dropDownOptions.width in not defined', function(assert) {
+            this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'calendar'
+            }).dxDateBox('instance');
+
+            const $calendar = $(`.${CALENDAR_CLASS}`);
+            const paddingsWidth = parseInt($calendar.css('margin-left')) * 4;
+            const calendarWidth = $calendar.outerWidth() + paddingsWidth;
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.width(), calendarWidth, 'popup width is correct');
+        });
+
+        QUnit.test('should be equal to the calendar width + margins when dropDownOptions.width in not defined after editor width runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'calendar'
+            }).dxDateBox('instance');
+
+            const $calendar = $(`.${CALENDAR_CLASS}`);
+            const paddingsWidth = parseInt($calendar.css('margin-left')) * 4;
+            const calendarWidth = $calendar.outerWidth() + paddingsWidth;
+
+            dateBox.option('width', 153);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.width(), calendarWidth, 'popup width is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.width if it\'s defined', function(assert) {
+            this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
+                dropDownOptions: {
+                    width: 500
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.width even after editor input width change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
+                dropDownOptions: {
+                    width: 500
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 300);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), 500, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to calendar width + margins if dropDownOptions.width is set to auto', function(assert) {
+            this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
+                dropDownOptions: {
+                    width: 'auto'
+                },
+                opened: true
+            });
+
+            const $calendar = $(`.${CALENDAR_CLASS}`);
+            const paddingsWidth = parseInt($calendar.css('margin-left')) * 4;
+            const calendarWidth = $calendar.outerWidth() + paddingsWidth;
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.width(), calendarWidth, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to wrapper width if dropDownOptions.width is set to 100%', function(assert) {
+            this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
+                dropDownOptions: {
+                    width: '100%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth(), 'overlay content width is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper when dropDownOptions.width is percent', function(assert) {
+            this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
+                dropDownOptions: {
+                    width: '50%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth() / 2, 0.1, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper after editor width runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
+                width: 600,
+                dropDownOptions: {
+                    width: '50%'
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('width', 700);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerWidth(), $overlayWrapper.outerWidth() / 2, 0.1, 'overlay content width is correct');
+        });
+
+        QUnit.test('should be equal to calendar width + margins even when dropDownOptions.container is defined', function(assert) {
+            this.$dateBox.dxDateBox({
+                pickerType: 'calendar',
+                dropDownOptions: {
+                    container: '#containerWithWidth'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $calendar = $(`.${CALENDAR_CLASS}`);
+            const paddingsWidth = parseInt($calendar.css('margin-left')) * 4;
+            const calendarWidth = $calendar.outerWidth() + paddingsWidth;
+
+            assert.strictEqual($overlayContent.width(), calendarWidth, 'width is correct');
+        });
+    });
+
+    QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {
+        this.$dateBox.dxDateBox({
+            pickerType: 'calendar',
+            dropDownOptions: {
+                width: 500
+            },
+            opened: true
+        });
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
+    });
+
+    QUnit.test('popup should have width equal to dropDownOptions.width even after editor input width change (T897820)', function(assert) {
+        const dateBox = this.$dateBox.dxDateBox({
+            pickerType: 'calendar',
+            dropDownOptions: {
+                width: 500
+            },
+            opened: true
+        }).dxDateBox('instance');
+
+        dateBox.option('width', 300);
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
     });
 });
 


### PR DESCRIPTION
…

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
