### PR TITLE
Fix T938656 20.1

### DIFF
--- a/js/ui/pager.js
+++ b/js/ui/pager.js
@@ -358,6 +358,9 @@ const Pager = Widget.inherit({
             max: pageCount,
             width: that._calculateLightPagesWidth($pageIndex, pageCount),
             onValueChanged: function(e) {
+                if(e.value === null) {
+                    return;
+                }
                 that.option('pageIndex', e.value);
             }
         });


### PR DESCRIPTION
NumberBox raise onValueChanged with e.value = null when text input is --0 or ++0.
Added checking value to null to prevent set pageIndex to null.
