### PR TITLE
Drawer - The view content is out of bounds in 'push' mode if minSize is specified (T939579) (#14932)

### DIFF
--- a/js/ui/drawer/ui.drawer.rendering.strategy.js
+++ b/js/ui/drawer/ui.drawer.rendering.strategy.js
@@ -31,13 +31,14 @@ class DrawerStrategy {
         const config = this._getPositionRenderingConfig(isDrawerOpened);
 
         if(this._useDefaultAnimation()) {
+            // TODO: _defaultPositionRendering is not declared in OverlapStrategy, ShrinkStrategy
             this._defaultPositionRendering(config, isDrawerOpened, animate);
         } else {
             const revealMode = this.getDrawerInstance().option('revealMode');
             if(revealMode === 'slide') {
-                this._slidePositionRendering(config, isDrawerOpened, animate);
+                this._slidePositionRendering(config, isDrawerOpened, animate); // TODO: _slidePositionRendering is not declared in PushStrategy
             } else if(revealMode === 'expand') {
-                this._expandPositionRendering(config, isDrawerOpened, animate);
+                this._expandPositionRendering(config, isDrawerOpened, animate); // TODO: _expandPositionRendering is not declared in PushStrategy
             }
         }
     }

--- a/js/ui/drawer/ui.drawer.rendering.strategy.push.js
+++ b/js/ui/drawer/ui.drawer.rendering.strategy.push.js
@@ -13,6 +13,16 @@ class PushStrategy extends DrawerStrategy {
         const drawer = this.getDrawerInstance();
 
         $(drawer.content()).css(drawer.isHorizontalDirection() ? 'width' : 'height', config.maxSize);
+        if(drawer.getMinSize()) {
+            let paddingCssPropertyName = 'padding';
+            switch(drawer.calcTargetPosition()) {
+                case 'left': paddingCssPropertyName += 'Right'; break;
+                case 'right': paddingCssPropertyName += 'Left'; break;
+                case 'top': paddingCssPropertyName += 'Bottom'; break;
+                case 'bottom': paddingCssPropertyName += 'Top'; break;
+            }
+            $(drawer.viewContent()).css(paddingCssPropertyName, drawer.getMinSize());
+        }
 
         if(animate) {
             const animationConfig = {

--- a/testing/helpers/drawerHelpers.js
+++ b/testing/helpers/drawerHelpers.js
@@ -57,12 +57,12 @@ const LeftDrawerTester = {
 
     checkOpened: function(assert, drawer, drawerElement) {
         function checkPush(assert, env) {
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: 150, height: 100 }, 'template');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + 150, top: env.drawerRect.top, width: 200, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: leftTemplateSize, height: env.drawerRect.height }, 'template');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + leftTemplateSize, top: env.drawerRect.top, width: env.drawerRect.width - env.minSize, height: env.drawerRect.height }, 'view');
         }
         function checkShrink(assert, env) {
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: 150, height: 100 }, 'template');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + 150, top: env.drawerRect.top, width: 50, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: leftTemplateSize, height: env.drawerRect.height }, 'template');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + leftTemplateSize, top: env.drawerRect.top, width: env.drawerRect.width - leftTemplateSize, height: env.drawerRect.height }, 'view');
             checkMargin(assert, env.templateElement.parentElement, 0, 0, 0, 0, 'template should be visible by position');
         }
         function checkOverlap(assert, env) {
@@ -99,8 +99,8 @@ const LeftDrawerTester = {
 
     checkHidden: function(assert, drawer, drawerElement) {
         function checkPush(assert, env) {
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: 150, height: 100 }, 'template');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + env.minSize, top: env.drawerRect.top, width: 200, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: leftTemplateSize, height: env.drawerRect.height }, 'template');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + env.minSize, top: env.drawerRect.top, width: env.drawerRect.width - env.minSize, height: env.drawerRect.height }, 'view');
 
             assert.ok(
                 window.getComputedStyle(env.templateElement.parentElement).position === 'absolute' &&
@@ -109,34 +109,34 @@ const LeftDrawerTester = {
         }
         function checkShrink(assert, env) {
             if(env.revealMode === 'expand') {
-                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: leftTemplateSize, height: 100 }, 'template');
+                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: leftTemplateSize, height: env.drawerRect.height }, 'template');
                 checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.minSize, height: env.drawerRect.height }, 'template.parentElement');
             } else {
-                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left - 150 + env.minSize, top: env.drawerRect.top, width: 150, height: 100 }, 'template');
-                checkMargin(assert, env.templateElement.parentElement, 0, 0, 0, -150 + env.minSize, 'template should not be visible by position');
+                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left - leftTemplateSize + env.minSize, top: env.drawerRect.top, width: leftTemplateSize, height: env.drawerRect.height }, 'template');
+                checkMargin(assert, env.templateElement.parentElement, 0, 0, 0, -leftTemplateSize + env.minSize, 'template should not be visible by position');
             }
             assert.strictEqual(window.getComputedStyle(env.templateElement.parentElement).overflow, 'hidden', 'template should not be visible by parent.overflow');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + env.minSize, top: env.drawerRect.top, width: 200 - env.minSize, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + env.minSize, top: env.drawerRect.top, width: env.drawerRect.width - env.minSize, height: env.drawerRect.height }, 'view');
         }
         function checkOverlap(assert, env) {
             if(env.revealMode === 'expand') {
                 if(env.minSize) {
-                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: leftTemplateSize, height: 100 }, 'template');
-                    checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.minSize, height: 100 }, 'template.parentElement');
+                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: leftTemplateSize, height: env.drawerRect.height }, 'template');
+                    checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.minSize, height: env.drawerRect.height }, 'template.parentElement');
                 } else if(env.templateElement === null) {
                     assert.strictEqual(env.templateElement, null); // Scenarios (overlap, left, expand): opened: false, visible: false -> visible: true
                 } else {
-                    checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.minSize, height: 100 }, 'template.parentElement');
+                    checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.minSize, height: env.drawerRect.height }, 'template.parentElement');
                 }
             } else {
                 if(env.templateElement) {
-                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left - 150 + env.minSize, top: env.drawerRect.top, width: 150, height: 100 }, 'template');
+                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left - leftTemplateSize + env.minSize, top: env.drawerRect.top, width: leftTemplateSize, height: env.drawerRect.height }, 'template');
                     assert.strictEqual(window.getComputedStyle(env.drawerElement.firstElementChild).overflowX, 'hidden', 'template is shown out of bounds and not visible because of overflowX is hidden');
                 } else {
                     assert.notOk(env.templateElement, 'template should not be visible because it was not created');
                 }
             }
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + env.minSize, top: env.drawerRect.top, width: 200 - env.minSize, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left + env.minSize, top: env.drawerRect.top, width: env.drawerRect.width - env.minSize, height: env.drawerRect.height }, 'view');
         }
 
         checkBoundingClientRect(assert, drawerElement, { width: 200, height: 100 }, 'drawerElement');
@@ -185,12 +185,12 @@ const RightDrawerTester = {
 
     checkOpened: function(assert, drawer, drawerElement) {
         function checkPush(assert, env) {
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left + 50, top: env.drawerRect.top, width: rightTemplateSize, height: 100 }, 'template');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left - rightTemplateSize, top: env.drawerRect.top, width: 200, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.right - rightTemplateSize, top: env.drawerRect.top, width: rightTemplateSize, height: env.drawerRect.height }, 'template');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left - rightTemplateSize + env.minSize, top: env.drawerRect.top, width: env.drawerRect.width - env.minSize, height: env.drawerRect.height }, 'view');
         }
         function checkShrink(assert, env) {
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left + 50, top: env.drawerRect.top, width: rightTemplateSize, height: 100 }, 'template');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: 50, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.right - rightTemplateSize, top: env.drawerRect.top, width: rightTemplateSize, height: env.drawerRect.height }, 'template');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.drawerRect.width - rightTemplateSize, height: env.drawerRect.height }, 'view');
             checkMargin(assert, env.templateElement.parentElement, 0, 0, 0, 0, 'template should be visible by position');
         }
         function checkOverlap(assert, env) {
@@ -230,31 +230,32 @@ const RightDrawerTester = {
         function checkPush(assert, env) {
             if(env.revealMode === 'expand') {
                 if(env.minSize) {
-                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.right - rightTemplateSize, top: env.drawerRect.top, width: rightTemplateSize, height: 100 }, 'template');
+                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.right - rightTemplateSize, top: env.drawerRect.top, width: rightTemplateSize, height: env.drawerRect.height }, 'template');
                 }
                 assert.ok( // Scenarios (push, right, expand): opened: false
                     window.getComputedStyle(env.templateElement.parentElement).position === 'absolute' &&
                     window.getComputedStyle(env.viewElement.parentElement).transform.indexOf('matrix') >= 0,
                     'template element should be hidden, view element should be visible');
             } else {
-                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.right - rightTemplateSize, top: env.drawerRect.top, width: rightTemplateSize, height: 100 }, 'template');
+                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.right - rightTemplateSize, top: env.drawerRect.top, width: rightTemplateSize, height: env.drawerRect.height }, 'template');
                 assert.ok(
                     window.getComputedStyle(env.templateElement.parentElement).position === 'absolute' &&
                     window.getComputedStyle(env.viewElement.parentElement).transform.indexOf('matrix') >= 0,
                     'template element should be hidden, view element should be visible');
             }
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left - env.minSize, top: env.drawerRect.top, width: 200, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.drawerRect.width - env.minSize, height: env.drawerRect.height }, 'view');
         }
         function checkShrink(assert, env) {
             if(env.revealMode === 'expand') {
                 checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.right - env.minSize, top: env.drawerRect.top, width: rightTemplateSize, height: env.drawerRect.height }, 'template');
                 checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.right - env.minSize, top: env.drawerRect.top, width: env.minSize, height: env.drawerRect.height }, 'template.parentElement');
             } else {
-                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left + 200 - env.minSize, top: env.drawerRect.top, width: rightTemplateSize, height: 100 }, 'template');
+                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.right - env.minSize, top: env.drawerRect.top, width: rightTemplateSize, height: env.drawerRect.height }, 'template');
+                checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.right - env.minSize, top: env.drawerRect.top, width: rightTemplateSize, height: env.drawerRect.height }, 'template.parentElement');
                 checkMargin(assert, env.templateElement.parentElement, 0, -rightTemplateSize + env.minSize, 0, 0, 'template should not be visible by position');
             }
             assert.strictEqual(window.getComputedStyle(env.templateElement.parentElement).overflow, 'hidden', 'template should not be visible by parent.overflow');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: 200 - env.minSize, height: 100 }, 'view');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.drawerRect.width - env.minSize, height: env.drawerRect.height }, 'view');
         }
         function checkOverlap(assert, env) {
             if(env.revealMode === 'expand') {
@@ -327,8 +328,8 @@ const TopDrawerTester = {
             checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top + topTemplateSize, width: env.drawerRect.width, height: env.drawerRect.height - env.minSize }, 'view');
         }
         function checkShrink(assert, env) {
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: 200, height: topTemplateSize }, 'template');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top + topTemplateSize, width: 200, height: env.drawerRect.height - topTemplateSize }, 'view');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.drawerRect.width, height: topTemplateSize }, 'template');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top + topTemplateSize, width: env.drawerRect.width, height: env.drawerRect.height - topTemplateSize }, 'view');
             checkMargin(assert, env.templateElement.parentElement, 0, 0, 0, 0, 'template should be visible by position');
         }
         function checkOverlap(assert, env) {
@@ -379,11 +380,11 @@ const TopDrawerTester = {
                 checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.drawerRect.width, height: topTemplateSize }, 'template');
                 checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.drawerRect.width, height: env.minSize }, 'template.parentElement');
             } else {
-                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top - topTemplateSize + env.minSize, width: 200, height: topTemplateSize }, 'template');
+                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top - topTemplateSize + env.minSize, width: env.drawerRect.width, height: topTemplateSize }, 'template');
                 checkMargin(assert, env.templateElement.parentElement, -topTemplateSize + env.minSize, 0, 0, 0, 'template should not be visible by position');
             }
             assert.strictEqual(window.getComputedStyle(env.templateElement.parentElement).overflow, 'hidden', 'template should not be visible by parent.overflow');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.minSize, width: 200, height: 100 - env.minSize }, 'view');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.minSize, width: env.drawerRect.width, height: env.drawerRect.height - env.minSize }, 'view');
         }
         function checkOverlap(assert, env) {
             if(env.revealMode === 'expand') {
@@ -454,11 +455,11 @@ const BottomDrawerTester = {
 
     checkOpened: function(assert, drawer, drawerElement) {
         function checkPush(assert, env) {
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - bottomTemplateSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
-            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top - bottomTemplateSize, width: env.drawerRect.width, height: env.drawerRect.height }, 'view');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - bottomTemplateSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
+            checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top - bottomTemplateSize + env.minSize, width: env.drawerRect.width, height: env.drawerRect.height - env.minSize }, 'view');
         }
         function checkShrink(assert, env) {
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - bottomTemplateSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - bottomTemplateSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
             checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.drawerRect.width, height: env.drawerRect.height - bottomTemplateSize }, 'view');
             checkMargin(assert, env.templateElement.parentElement, 0, 0, 0, 0, 'template should be visible by position');
         }
@@ -497,8 +498,7 @@ const BottomDrawerTester = {
 
     checkHidden: function(assert, drawer, drawerElement) {
         function checkPush(assert, env) {
-            // checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - env.minSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
-            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - bottomTemplateSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
+            checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - bottomTemplateSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
             checkBoundingClientRect(assert, env.viewElement, { left: env.drawerRect.left, top: env.drawerRect.top, width: env.drawerRect.width, height: env.drawerRect.height - env.minSize }, 'view');
 
             assert.ok(
@@ -508,10 +508,11 @@ const BottomDrawerTester = {
         }
         function checkShrink(assert, env) {
             if(env.revealMode === 'expand') {
-                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - env.minSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
-                checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - env.minSize, width: env.drawerRect.width, height: env.minSize }, 'template.parentElement');
+                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - env.minSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
+                checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - env.minSize, width: env.drawerRect.width, height: env.minSize }, 'template.parentElement');
             } else {
-                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - env.minSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
+                checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - env.minSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
+                checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - env.minSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template.parentElement');
                 checkMargin(assert, env.templateElement.parentElement, 0, 0, -bottomTemplateSize + env.minSize, 0, 'template should not be visible by position');
             }
             assert.strictEqual(window.getComputedStyle(env.templateElement.parentElement).overflow, 'hidden', 'template should not be visible by parent.overflow');
@@ -520,8 +521,8 @@ const BottomDrawerTester = {
         function checkOverlap(assert, env) {
             if(env.revealMode === 'expand') {
                 if(env.minSize) {
-                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - env.minSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
-                    checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - env.minSize, width: env.drawerRect.width, height: env.minSize }, 'template.parentElement should cut template to minSize');
+                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - env.minSize, width: env.drawerRect.width, height: bottomTemplateSize }, 'template');
+                    checkBoundingClientRect(assert, env.templateElement.parentElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - env.minSize, width: env.drawerRect.width, height: env.minSize }, 'template.parentElement should cut template to minSize');
                 } else {
                     if(env.templateElement === null) {
                         assert.ok(true); // Scenarios (overlap, top, expand): opened: false, visible: false -> visible: true
@@ -531,7 +532,7 @@ const BottomDrawerTester = {
                 }
             } else {
                 if(env.templateElement) {
-                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.top + env.drawerRect.height - env.minSize, width: env.drawerRect.width, height: env.minSize }, 'template');
+                    checkBoundingClientRect(assert, env.templateElement, { left: env.drawerRect.left, top: env.drawerRect.bottom - env.minSize, width: env.drawerRect.width, height: env.minSize }, 'template');
                     assert.strictEqual(window.getComputedStyle(env.drawerElement.firstElementChild).overflowY, 'hidden', 'template is shown out of bounds and not visible because of overflowY is hidden');
                 } else {
                     assert.notOk(env.templateElement, 'template should not be visible because it was not created');

--- a/testing/tests/DevExpress.ui.widgets/drawer.scenarios.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/drawer.scenarios.tests.js
@@ -19,7 +19,7 @@ import dxDrawer from 'ui/drawer';
 
 QUnit.testStart(() => {
     $('#qunit-fixture').html(drawerTesters.markup);
-    // $("#qunit-tests").prepend(drawerTesters.markup);
+    // $('#qunit-tests').prepend(drawerTesters.markup);
 });
 
 // TODO: templateSize, maxSize, scrolling, rtlEnabled, animationEnabled, onRendered, _viewPortChangeHandler, target, template overflow and/or view overflow
@@ -214,7 +214,7 @@ configs.forEach(config => {
             return extend({ rtlEnabled: false, animationEnabled: false }, config, targetOptions);
         }
 
-        testOrSkip('opened: false', () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', ['right', 'top', 'bottom', ], ['expand', 'slide']) && config.minSize || configIs('overlap', 'bottom', 'slide'), function(assert) {
+        testOrSkip('opened: false', () => configIs('overlap', ['right', 'top', 'bottom', ], ['expand', 'slide']) && config.minSize || configIs('overlap', 'bottom', 'slide'), function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
 
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
@@ -230,7 +230,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkHidden(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: false -> opened: true', () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', 'right') || configIs('overlap', 'bottom') && config.minSize, function(assert) {
+        testOrSkip('opened: false -> opened: true', () => configIs('overlap', 'right') || configIs('overlap', 'bottom') && config.minSize, function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: false,
@@ -244,7 +244,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkOpened(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: false, visible: false -> visible: true', () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap') && config.minSize, function(assert) {
+        testOrSkip('opened: false, visible: false -> visible: true', () => configIs('overlap') && config.minSize, function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: false,
@@ -259,7 +259,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkHidden(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: false, visible: false -> visible: true -> opened: true', () => configIs('overlap') || configIs('push', ['top', 'bottom']) && config.minSize, function(assert) {
+        testOrSkip('opened: false, visible: false -> visible: true -> opened: true', () => configIs('overlap'), function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: false,
@@ -276,7 +276,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkOpened(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: true', () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', 'bottom') && config.minSize, function(assert) {
+        testOrSkip('opened: true', () => configIs('overlap', 'bottom') && config.minSize, function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: true,
@@ -304,7 +304,7 @@ configs.forEach(config => {
         });
 
         [true, false].forEach((closeOnOutsideClick) => {
-            testOrSkip(`opened: true -> click by viewContent, closeOnOutsideClick: ${closeOnOutsideClick}`, () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', 'bottom'), function(assert) {
+            testOrSkip(`opened: true -> click by viewContent, closeOnOutsideClick: ${closeOnOutsideClick}`, () => configIs('overlap', 'bottom'), function(assert) {
                 const drawerElement = document.getElementById(drawerTesters.drawerElementId);
                 const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                     opened: true,
@@ -324,7 +324,7 @@ configs.forEach(config => {
             });
         });
 
-        testOrSkip('opened: true -> visible: false -> visible: true', () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', 'bottom') && config.minSize, function(assert) {
+        testOrSkip('opened: true -> visible: false -> visible: true', () => configIs('overlap', 'bottom') && config.minSize, function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: true,
@@ -340,7 +340,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkOpened(assert, drawer, drawerElement);
         });
 
-        testOrSkip(`opened: true, shading: ${config.shading} -> shading: ${!config.shading}`, () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', 'bottom') && config.minSize, function(assert) {
+        testOrSkip(`opened: true, shading: ${config.shading} -> shading: ${!config.shading}`, () => configIs('overlap', 'bottom') && config.minSize, function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: true,
@@ -355,7 +355,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkOpened(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: true -> repaint', () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', 'bottom') && config.minSize, function(assert) {
+        testOrSkip('opened: true -> repaint', () => configIs('overlap', 'bottom') && config.minSize, function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: true,
@@ -369,7 +369,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkOpened(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: false -> resize -> opened: true, update position config after resize', () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', 'bottom'), function(assert) {
+        testOrSkip('opened: false -> resize -> opened: true, update position config after resize', () => configIs('overlap', 'bottom'), function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: false,
@@ -393,7 +393,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkOpened(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: true (template + onRendered)', () => configIs('push', ['top', 'bottom']) && config.minSize || configIs('overlap', 'right', 'expand') || configIs('overlap', 'bottom'), function(assert) {
+        testOrSkip('opened: true (template + onRendered)', () => configIs('overlap', 'right', 'expand') || configIs('overlap', 'bottom'), function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 width: 200,
@@ -445,7 +445,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkOpened(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: true, visible: false -> visible: true', () => configIs('overlap') || configIs('push') && config.minSize, function(assert) {
+        testOrSkip('opened: true, visible: false -> visible: true', () => configIs('overlap'), function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: true,
@@ -460,7 +460,7 @@ configs.forEach(config => {
             drawerTesters[config.position].checkOpened(assert, drawer, drawerElement);
         });
 
-        testOrSkip('opened: true, visible: false -> repaint -> visible: true', () => configIs('shrink') && config.minSize || configIs('overlap') || configIs('push') && config.minSize, function(assert) {
+        testOrSkip('opened: true, visible: false -> repaint -> visible: true', () => configIs('overlap'), function(assert) {
             const drawerElement = document.getElementById(drawerTesters.drawerElementId);
             const drawer = new dxDrawer(drawerElement, getFullDrawerOptions({
                 opened: true,


### PR DESCRIPTION
* Drawer - The view content is out of bounds in 'push' mode if minSize is specified (T939579)

* Typo

* Remove 'skip' from some configs

(cherry picked from commit 300686513bbc7fe161f92863a62d541d6d60b242)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
