### PR TITLE
Fix dropDownEditors height and dropDownOptions.height issues

### DIFF
--- a/js/ui/date_box/ui.date_box.strategy.list.js
+++ b/js/ui/date_box/ui.date_box.strategy.list.js
@@ -9,6 +9,7 @@ const extend = require('../../core/utils/extend').extend;
 const dateUtils = require('./ui.date_utils');
 const dateLocalization = require('../../localization/date');
 const dateSerialization = require('../../core/utils/date_serialization');
+const getSizeValue = require('../drop_down_editor/utils').getSizeValue;
 
 const DATE_FORMAT = 'date';
 
@@ -250,11 +251,14 @@ const ListStrategy = DateBoxStrategy.inherit({
     },
 
     _updatePopupHeight: function() {
-        this.dateBox._setPopupOption('height', 'auto');
+        const dropDownOptionsHeight = getSizeValue(this.dateBox.option('dropDownOptions.height'));
+        if(dropDownOptionsHeight === undefined || dropDownOptionsHeight === 'auto') {
+            this.dateBox._setPopupOption('height', 'auto');
+            const popupHeight = this._widget.$element().outerHeight();
+            const maxHeight = $(window).height() * 0.45;
+            this.dateBox._setPopupOption('height', Math.min(popupHeight, maxHeight));
+        }
 
-        const popupHeight = this._widget.$element().outerHeight();
-        const maxHeight = $(window).height() * 0.45;
-        this.dateBox._setPopupOption('height', Math.min(popupHeight, maxHeight));
         this.dateBox._timeList && this.dateBox._timeList.updateDimensions();
     },
 

--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -17,7 +17,7 @@ import { isPlainObject, isDefined } from '../core/utils/type';
 import { ensureDefined } from '../core/utils/common';
 import Guid from '../core/guid';
 import { format as formatMessage } from '../localization/message';
-import { getElementWidth, getPopupWidth } from './drop_down_editor/utils';
+import { getElementWidth, getSizeValue } from './drop_down_editor/utils';
 
 const DROP_DOWN_BUTTON_CLASS = 'dx-dropdownbutton';
 const DROP_DOWN_BUTTON_CONTENT = 'dx-dropdownbutton-content';
@@ -420,7 +420,7 @@ const DropDownButton = Widget.inherit({
     },
 
     _dimensionChanged: function() {
-        const popupWidth = getPopupWidth(this.option('dropDownOptions.width'));
+        const popupWidth = getSizeValue(this.option('dropDownOptions.width'));
 
         if(popupWidth === undefined) {
             this._setPopupOption('width', () => getElementWidth(this.$element()));

--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -632,7 +632,7 @@ const DropDownButton = Widget.inherit({
             case 'width':
             case 'height':
                 this.callBase(args);
-                this._popup && this._popup.repaint();
+                this._popup?.repaint();
                 break;
             case 'stylingMode':
                 this._buttonGroup.option(name, value);

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -760,6 +760,7 @@ const DropDownEditor = TextBox.inherit({
     _optionChanged: function(args) {
         switch(args.name) {
             case 'width':
+            case 'height':
                 this.callBase(args);
                 this._popup?.repaint();
                 break;

--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -21,7 +21,7 @@ import devices from '../../core/devices';
 import { FunctionTemplate } from '../../core/templates/function_template';
 import Popup from '../popup';
 import { hasWindow } from '../../core/utils/window';
-import { getElementWidth, getPopupWidth } from './utils';
+import { getElementWidth, getSizeValue } from './utils';
 
 const DROP_DOWN_EDITOR_CLASS = 'dx-dropdowneditor';
 const DROP_DOWN_EDITOR_INPUT_WRAPPER = 'dx-dropdowneditor-input-wrapper';
@@ -550,7 +550,7 @@ const DropDownEditor = TextBox.inherit({
     },
 
     _dimensionChanged: function() {
-        const popupWidth = getPopupWidth(this.option('dropDownOptions.width'));
+        const popupWidth = getSizeValue(this.option('dropDownOptions.width'));
 
         if(popupWidth === undefined) {
             this._setPopupOption('width', () => getElementWidth(this.$element()));

--- a/js/ui/drop_down_editor/utils.js
+++ b/js/ui/drop_down_editor/utils.js
@@ -6,15 +6,15 @@ const getElementWidth = function($element) {
     }
 };
 
-const getPopupWidth = function(width) {
-    if(width === null) {
-        width = undefined;
+const getSizeValue = function(size) {
+    if(size === null) {
+        size = undefined;
     }
-    if(typeof width === 'function') {
-        width = width();
+    if(typeof size === 'function') {
+        size = size();
     }
 
-    return width;
+    return size;
 };
 
-export { getElementWidth, getPopupWidth };
+export { getElementWidth, getSizeValue };

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -63,6 +63,7 @@ const DROP_DOWN_BUTTON_VISIBLE_CLASS = 'dx-dropdowneditor-button-visible';
 const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
 const OVERLAY_WRAPPER_CLASS = 'dx-overlay-wrapper';
 const POPUP_CLASS = 'dx-popup';
+const LIST_CLASS = 'dx-list';
 
 const CALENDAR_APPLY_BUTTON_SELECTOR = '.dx-popup-done.dx-button';
 
@@ -3474,7 +3475,7 @@ QUnit.module('datebox w/ time list', {
         this.dateBox.option('opened', true);
 
         assert.ok(getInstanceWidget(this.dateBox), 'list exist');
-        assert.ok(getInstanceWidget(this.dateBox).$element().hasClass('dx-list'), 'list initialized');
+        assert.ok(getInstanceWidget(this.dateBox).$element().hasClass(LIST_CLASS), 'list initialized');
     });
 
     QUnit.test('list should contain correct values if min/max does not specified', function(assert) {
@@ -3485,7 +3486,7 @@ QUnit.module('datebox w/ time list', {
 
         this.dateBox.option('opened', true);
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const $listItems = $timeList.find('.dx-list-item-content');
 
         assert.equal($listItems.first().text(), '12:00 AM', 'min value is right');
@@ -3501,7 +3502,7 @@ QUnit.module('datebox w/ time list', {
 
         this.dateBox.option('opened', true);
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const $listItems = $timeList.find('.dx-list-item-content');
 
         assert.strictEqual($listItems.first().text(), '5:45 AM', 'min value is right');
@@ -3517,7 +3518,7 @@ QUnit.module('datebox w/ time list', {
 
         this.dateBox.option('opened', true);
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const $listItems = $timeList.find('.dx-list-item-content');
 
         assert.equal($listItems.first().text(), '4:00 AM', 'min value is right');
@@ -3532,7 +3533,7 @@ QUnit.module('datebox w/ time list', {
 
         this.dateBox.option('opened', true);
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const $listItems = $timeList.find('.dx-list-item-content');
 
         assert.strictEqual($listItems.first().text(), '4:00 AM', 'min value is right');
@@ -3549,7 +3550,7 @@ QUnit.module('datebox w/ time list', {
 
         this.dateBox.option('opened', true);
 
-        let $timeList = $('.dx-list');
+        let $timeList = $(`.${LIST_CLASS}`);
         let items = $timeList.find(LIST_ITEM_SELECTOR);
 
         assert.strictEqual(items.length, 3, 'interval option works');
@@ -3557,7 +3558,7 @@ QUnit.module('datebox w/ time list', {
         this.dateBox.option('interval', 120);
         this.dateBox.option('opened', true);
 
-        $timeList = $('.dx-list');
+        $timeList = $(`.${LIST_CLASS}`);
         items = $timeList.find(LIST_ITEM_SELECTOR);
 
         assert.strictEqual(items.length, 2, 'interval option works');
@@ -3624,7 +3625,7 @@ QUnit.module('datebox w/ time list', {
             opened: true
         });
 
-        const list = $('.dx-list').dxList('instance');
+        const list = $(`.${LIST_CLASS}`).dxList('instance');
         assert.ok(list.option('items').length > 0, 'list is not empty');
     });
 
@@ -3692,7 +3693,7 @@ QUnit.module('datebox w/ time list', {
             opened: true
         });
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         let items = $timeList.find(LIST_ITEM_SELECTOR);
 
         assert.equal(items.length, 24, '24 items should be find');
@@ -3714,7 +3715,7 @@ QUnit.module('datebox w/ time list', {
                 opened: true
             });
 
-            const $timeList = $('.dx-list');
+            const $timeList = $(`.${LIST_CLASS}`);
             let items = $timeList.find(LIST_ITEM_SELECTOR);
 
             assert.equal(items.length, 11, 'interval option works');
@@ -3739,7 +3740,7 @@ QUnit.module('datebox w/ time list', {
             opened: true
         });
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const items = $timeList.find(LIST_ITEM_SELECTOR);
 
         assert.strictEqual(items.length, 16, 'list should be contain right count of items');
@@ -3754,7 +3755,7 @@ QUnit.module('datebox w/ time list', {
             opened: true
         });
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const items = $timeList.find(LIST_ITEM_SELECTOR);
 
         assert.equal(items.length, 19, 'list should be contain right count of items');
@@ -3770,7 +3771,7 @@ QUnit.module('datebox w/ time list', {
             opened: true
         });
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const items = $timeList.find(LIST_ITEM_SELECTOR);
 
         assert.equal(items.eq(0).text(), '12:02 AM', 'first item in list is correct');
@@ -3801,7 +3802,7 @@ QUnit.module('datebox w/ time list', {
 
         this.dateBox.option('opened', true);
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const $listItems = $timeList.find('.dx-list-item-content');
 
         assert.strictEqual($listItems.first().text(), '8:00 AM', 'min value is right');
@@ -3817,7 +3818,7 @@ QUnit.module('datebox w/ time list', {
 
         this.dateBox.option('opened', true);
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
         const $listItems = $timeList.find('.dx-list-item-content');
 
         assert.strictEqual($listItems.first().text(), '8:00 AM', 'min value is right');
@@ -4097,6 +4098,200 @@ QUnit.module('width of datebox with list', {
     });
 });
 
+QUnit.module('height of datebox with list', {
+    beforeEach: function() {
+        fx.off = true;
+
+        this.$dateBox = $('#dateBox');
+    },
+    afterEach: function() {
+        fx.off = false;
+    }
+}, () => {
+    QUnit.module('overlay content height', () => {
+        QUnit.test('should be equal to 0.45 * window height when dropDownOptions.height in not defined and list hight is bigger than 0.45 of window height', function(assert) {
+            this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'list',
+                type: 'time'
+            }).dxDateBox('instance');
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), 0.45 * $(window).outerHeight(), 0.1, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to 0.45 * window height when dropDownOptions.height in set to auto and list hight is bigger than 0.45 of window height', function(assert) {
+            this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'list',
+                type: 'time',
+                dropDownOptions: {
+                    height: 'auto'
+                }
+            }).dxDateBox('instance');
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), 0.45 * $(window).outerHeight(), 0.1, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to 0.45 * window height when dropDownOptions.height in not defined after editor height runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'list',
+                type: 'time'
+            }).dxDateBox('instance');
+
+            dateBox.option('height', 153);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), 0.45 * $(window).outerHeight(), 0.1, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to list height when dropDownOptions.height in not defined and content list is smaller than 0.45 of window height', function(assert) {
+            this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'list',
+                type: 'time',
+                min: Date.now(),
+                max: Date.now(),
+            }).dxDateBox('instance');
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $list = $(`.${LIST_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), $list.outerHeight(), 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to list height when dropDownOptions.height in set to auto and content list is smaller than 0.45 of window height', function(assert) {
+            this.$dateBox.dxDateBox({
+                opened: true,
+                pickerType: 'list',
+                type: 'time',
+                min: Date.now(),
+                max: Date.now(),
+                dropDownOptions: {
+                    height: 'auto'
+                }
+            }).dxDateBox('instance');
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $list = $(`.${LIST_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), $list.outerHeight(), 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.height if it is defined', function(assert) {
+            const dropDownOptionsHeight = 200;
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    height: dropDownOptionsHeight
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), dropDownOptionsHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.height even after editor input height change', function(assert) {
+            const dropDownOptionsHeight = 500;
+            const dateBox = this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    height: dropDownOptionsHeight
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('height', 300);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), dropDownOptionsHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to wrapper height if dropDownOptions.height is set to 100%', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    height: '100%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight(), 'overlay content height is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper when dropDownOptions.height is percent', function(assert) {
+            this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                dropDownOptions: {
+                    height: '50%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight() / 2, 0.1, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper after editor height runtime change', function(assert) {
+            const dateBox = this.$dateBox.dxDateBox({
+                type: 'time',
+                pickerType: 'list',
+                height: 600,
+                dropDownOptions: {
+                    height: '50%'
+                },
+                opened: true
+            }).dxDateBox('instance');
+
+            dateBox.option('height', 700);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight() / 2, 0.1, 'overlay content height is correct');
+        });
+    });
+
+    QUnit.test('dropDownOptions.height should be passed to popup', function(assert) {
+        const dropDownOptionsHeight = 500;
+        this.$dateBox.dxDateBox({
+            type: 'time',
+            pickerType: 'list',
+            dropDownOptions: {
+                height: dropDownOptionsHeight
+            },
+            opened: true
+        });
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('height'), dropDownOptionsHeight, 'popup height option value is correct');
+    });
+
+    QUnit.test('popup should have height equal to dropDownOptions.height even after editor input height change', function(assert) {
+        const dropDownOptionsHeight = 500;
+        const dateBox = this.$dateBox.dxDateBox({
+            type: 'time',
+            pickerType: 'list',
+            dropDownOptions: {
+                height: dropDownOptionsHeight
+            },
+            opened: true
+        }).dxDateBox('instance');
+
+        dateBox.option('height', 300);
+
+        const popup = this.$dateBox.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('height'), dropDownOptionsHeight, 'popup height option value is correct');
+    });
+});
+
 QUnit.module('width of datebox with calendar', {
     beforeEach: function() {
         fx.off = true;
@@ -4318,7 +4513,7 @@ QUnit.module('keyboard navigation', {
 
         this.$input.focusin();
         this.dateBox.option('opened', true);
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
 
         this.keyboard.keyDown('down');
         this.keyboard.keyDown('end');
@@ -4337,7 +4532,7 @@ QUnit.module('keyboard navigation', {
         this.dateBox.option('opened', true);
         this.keyboard.keyDown('down');
 
-        const $timeList = $('.dx-list');
+        const $timeList = $(`.${LIST_CLASS}`);
 
         assert.ok($timeList.find(LIST_ITEM_SELECTOR).eq(2).hasClass(STATE_FOCUSED_CLASS), 'correct item is focused');
 

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -32,6 +32,7 @@ const POPUP_CONTENT = 'dx-popup-content';
 const TAB_KEY_CODE = 'Tab';
 const ESC_KEY_CODE = 'Escape';
 const POPUP_CLASS = 'dx-popup';
+const POPUP_CONTENT_CLASS = 'dx-popup-content';
 const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
 const OVERLAY_WRAPPER_CLASS = 'dx-overlay-wrapper';
 
@@ -1279,6 +1280,25 @@ QUnit.module('popup integration', () => {
             assert.strictEqual($overlayContent.outerWidth(), $dropDownEditor.outerWidth(), 'overlay content width is correct');
         });
 
+        QUnit.test('should be equal to content width if dropDownOptions.width is set to auto', function(assert) {
+            const contentWidth = 500;
+            const dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+                dropDownOptions: {
+                    width: 'auto'
+                }
+            }).dxDropDownEditor('instance');
+
+            dropDownEditor._renderPopupContent = function() {
+                return $('<div>')
+                    .css({ width: contentWidth })
+                    .appendTo(dropDownEditor._popup.$content());
+            };
+            dropDownEditor.open();
+
+            const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
+            assert.strictEqual($popupContent.width(), contentWidth, 'overlay content width is correct');
+        });
+
         QUnit.test('should be equal to dropDownOptions.width if it\'s defined', function(assert) {
             const overlayContentWidth = 500;
             $('#dropDownEditorLazy').dxDropDownEditor({
@@ -1369,6 +1389,135 @@ QUnit.module('popup integration', () => {
         });
     });
 
+    QUnit.module('overlay content height', () => {
+        QUnit.test('should be equal to content height if dropDownOptions.height is not specified', function(assert) {
+            const contentHeight = 500;
+            const dropDownEditor = $('#dropDownEditorLazy')
+                .dxDropDownEditor()
+                .dxDropDownEditor('instance');
+
+            dropDownEditor._renderPopupContent = function() {
+                return $('<div>')
+                    .css({ height: contentHeight })
+                    .appendTo(dropDownEditor._popup.$content());
+            };
+            dropDownEditor.open();
+
+            const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
+            assert.strictEqual($popupContent.height(), contentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to content height if dropDownOptions.height is not specified even after editor height change', function(assert) {
+            const contentHeight = 500;
+            const dropDownEditor = $('#dropDownEditorLazy')
+                .dxDropDownEditor()
+                .dxDropDownEditor('instance');
+
+            dropDownEditor._renderPopupContent = function() {
+                return $('<div>')
+                    .css({ height: contentHeight })
+                    .appendTo(dropDownEditor._popup.$content());
+            };
+            dropDownEditor.open();
+
+            dropDownEditor.option('height', 300);
+
+            const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
+            assert.strictEqual($popupContent.height(), contentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to content height if dropDownOptions.height is set to auto', function(assert) {
+            const contentHeight = 500;
+            const dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+                dropDownOptions: {
+                    height: 'auto'
+                }
+            }).dxDropDownEditor('instance');
+
+            dropDownEditor._renderPopupContent = function() {
+                return $('<div>')
+                    .css({ height: contentHeight })
+                    .appendTo(dropDownEditor._popup.$content());
+            };
+            dropDownEditor.open();
+
+            const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
+            assert.strictEqual($popupContent.height(), contentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.height if it is specified', function(assert) {
+            const overlayContentHeight = 500;
+            $('#dropDownEditorLazy').dxDropDownEditor({
+                dropDownOptions: {
+                    height: overlayContentHeight
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), overlayContentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.height even after editor height change', function(assert) {
+            const overlayContentHeight = 500;
+            const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+                dropDownOptions: {
+                    height: overlayContentHeight
+                },
+                opened: true
+            });
+            const instance = $dropDownEditor.dxDropDownEditor('instance');
+
+            instance.option('height', 300);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), overlayContentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to wrapper height if dropDownOptions.height is set to 100%', function(assert) {
+            $('#dropDownEditorLazy').dxDropDownEditor({
+                dropDownOptions: {
+                    height: '100%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight(), 'overlay content height is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper when dropDownOptions.height is percent', function(assert) {
+            $('#dropDownEditorLazy').dxDropDownEditor({
+                dropDownOptions: {
+                    height: '50%'
+                },
+                opened: true
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight() / 2, 0.1, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper after editor height runtime change', function(assert) {
+            const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+                height: 600,
+                dropDownOptions: {
+                    height: '50%'
+                },
+                opened: true
+            });
+            const instance = $dropDownEditor.dxDropDownEditor('instance');
+
+            instance.option('height', 700);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight() / 2, 0.1, 'overlay content height is correct');
+        });
+    });
+
     QUnit.test('popup should be repositioned after height option runtime change', function(assert) {
         const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
             opened: true
@@ -1410,6 +1559,33 @@ QUnit.module('popup integration', () => {
 
         const popup = $dropDownEditor.find(`.${POPUP_CLASS}`).dxPopup('instance');
         assert.strictEqual(popup.option('width'), 500, 'popup width option value is correct');
+    });
+
+    QUnit.test('dropDownOptions.height should be passed to popup', function(assert) {
+        const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+            dropDownOptions: {
+                height: 500
+            },
+            opened: true
+        });
+
+        const popup = $dropDownEditor.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('height'), 500, 'popup height option value is correct');
+    });
+
+    QUnit.test('popup should have height equal to dropDownOptions.height even after editor height change', function(assert) {
+        const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+            dropDownOptions: {
+                height: 500
+            },
+            opened: true
+        });
+        const dropDownEditor = $dropDownEditor.dxDropDownEditor('instance');
+
+        dropDownEditor.option('height', 300);
+
+        const popup = $dropDownEditor.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('height'), 500, 'popup height option value is correct');
     });
 
     QUnit.test('onPopupInitialized', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -1369,6 +1369,22 @@ QUnit.module('popup integration', () => {
         });
     });
 
+    QUnit.test('popup should be repositioned after height option runtime change', function(assert) {
+        const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
+            opened: true
+        });
+        const instance = $dropDownEditor.dxDropDownEditor('instance');
+
+        instance.option('height', 300);
+
+        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+        const overlayContentRect = $overlayContent.get(0).getBoundingClientRect();
+        const editorRect = $dropDownEditor.get(0).getBoundingClientRect();
+
+        assert.strictEqual(overlayContentRect.top, editorRect.bottom, 'top position is correct');
+        assert.strictEqual(overlayContentRect.left, editorRect.left, 'left position is correct');
+    });
+
     QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {
         const $dropDownEditor = $('#dropDownEditorLazy').dxDropDownEditor({
             dropDownOptions: {

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -1530,8 +1530,8 @@ QUnit.module('popup integration', () => {
         const overlayContentRect = $overlayContent.get(0).getBoundingClientRect();
         const editorRect = $dropDownEditor.get(0).getBoundingClientRect();
 
-        assert.roughEqual(overlayContentRect.top, editorRect.bottom, 1, 'top position is correct');
-        assert.roughEqual(overlayContentRect.left, editorRect.left, 1, 'left position is correct');
+        assert.roughEqual(overlayContentRect.top, editorRect.bottom, 1.01, 'top position is correct');
+        assert.roughEqual(overlayContentRect.left, editorRect.left, 1.01, 'left position is correct');
     });
 
     QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -1530,8 +1530,8 @@ QUnit.module('popup integration', () => {
         const overlayContentRect = $overlayContent.get(0).getBoundingClientRect();
         const editorRect = $dropDownEditor.get(0).getBoundingClientRect();
 
-        assert.strictEqual(overlayContentRect.top, editorRect.bottom, 'top position is correct');
-        assert.strictEqual(overlayContentRect.left, editorRect.left, 'left position is correct');
+        assert.roughEqual(overlayContentRect.top, editorRect.bottom, 1, 'top position is correct');
+        assert.roughEqual(overlayContentRect.left, editorRect.left, 1, 'left position is correct');
     });
 
     QUnit.test('dropDownOptions.width should be passed to popup', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
@@ -673,8 +673,8 @@ QUnit.module('popup integration', {
         const overlayContentRect = $overlayContent.get(0).getBoundingClientRect();
         const dropDownButtonRect = $('#dropDownButton').get(0).getBoundingClientRect();
 
-        assert.strictEqual(overlayContentRect.top, dropDownButtonRect.bottom, 'top position is correct');
-        assert.strictEqual(overlayContentRect.left, dropDownButtonRect.left, 'left position is correct');
+        assert.roughEqual(overlayContentRect.top, dropDownButtonRect.bottom, 1, 'top position is correct');
+        assert.roughEqual(overlayContentRect.left, dropDownButtonRect.left, 1, 'left position is correct');
     });
 
     QUnit.test('dropDownOptions can be restored after repaint', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
@@ -21,6 +21,7 @@ const DROP_DOWN_BUTTON_HAS_ARROW_CLASS = 'dx-dropdownbutton-has-arrow';
 const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
 const OVERLAY_WRAPPER_CLASS = 'dx-overlay-wrapper';
 const POPUP_CONTENT_CLASS = 'dx-popup-content';
+const POPUP_CLASS = 'dx-popup';
 
 QUnit.testStart(() => {
     const markup =
@@ -79,6 +80,169 @@ QUnit.module('popup integration', {
         this.popup = getPopup(this.instance);
     }
 }, () => {
+    QUnit.module('overlay content height', () => {
+        QUnit.test('should be equal to content height when dropDownOptions.height in not defined', function(assert) {
+            const contentHeight = 300;
+            $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownContentTemplate: () => {
+                    return $('<div>').css({ height: contentHeight });
+                },
+            });
+
+            const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
+            assert.strictEqual($popupContent.height(), contentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to content height when dropDownOptions.height is set to auto', function(assert) {
+            const contentHeight = 300;
+            $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownContentTemplate: () => {
+                    return $('<div>').css({ height: contentHeight });
+                },
+                dropDownOptions: {
+                    height: 'auto'
+                }
+            });
+
+            const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
+            assert.strictEqual($popupContent.height(), contentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to content height when dropDownOptions.height in not defined after editor height runtime change', function(assert) {
+            const contentHeight = 300;
+            const dropDownButton = $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownContentTemplate: () => {
+                    return $('<div>').css({ height: contentHeight });
+                },
+            }).dxDropDownButton('instance');
+
+            dropDownButton.option('height', 200);
+
+            const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
+            assert.strictEqual($popupContent.height(), contentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to content height when dropDownOptions.height is set to auto after editor height runtime change', function(assert) {
+            const contentHeight = 300;
+            const dropDownButton = $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownContentTemplate: () => {
+                    return $('<div>').css({ height: contentHeight });
+                },
+                dropDownOptions: {
+                    height: 'auto'
+                }
+            }).dxDropDownButton('instance');
+
+            dropDownButton.option('height', 200);
+
+            const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
+            assert.strictEqual($popupContent.height(), contentHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.height if it is defined', function(assert) {
+            const dropDownOptionsHeight = 300;
+            $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownOptions: {
+                    height: dropDownOptionsHeight
+                }
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), dropDownOptionsHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to dropDownOptions.height if it is defined even after editor height runtime change', function(assert) {
+            const dropDownOptionsHeight = 300;
+            const dropDownButton = $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownOptions: {
+                    height: dropDownOptionsHeight
+                }
+            }).dxDropDownButton('instance');
+
+            dropDownButton.option('height', 200);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), dropDownOptionsHeight, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be equal to wrapper height if dropDownOptions.height is set to 100%', function(assert) {
+            $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownOptions: {
+                    height: '100%'
+                }
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.strictEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight(), 'overlay content height is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper when dropDownOptions.height is percent', function(assert) {
+            $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownOptions: {
+                    height: '50%'
+                }
+            });
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight() / 2, 0.1, 'overlay content height is correct');
+        });
+
+        QUnit.test('should be calculated relative to wrapper after editor height runtime change', function(assert) {
+            const dropDownButton = $('#dropDownButton').dxDropDownButton({
+                opened: true,
+                dropDownOptions: {
+                    height: '50%'
+                },
+                height: 600,
+            }).dxDropDownButton('instance');
+
+            dropDownButton.option('height', 200);
+
+            const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+            const $overlayWrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
+            assert.roughEqual($overlayContent.outerHeight(), $overlayWrapper.outerHeight() / 2, 0.1, 'overlay content height is correct');
+        });
+    });
+
+    QUnit.test('dropDownOptions.height should be passed to popup', function(assert) {
+        const dropDownOptionsHeight = 500;
+        const $dropDownButton = $('#dropDownButton').dxDropDownButton({
+            dropDownOptions: {
+                height: dropDownOptionsHeight
+            },
+            opened: true
+        });
+
+        const popup = $dropDownButton.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('height'), dropDownOptionsHeight, 'popup height option value is correct');
+    });
+
+    QUnit.test('popup should have height equal to dropDownOptions.height even after editor input height change', function(assert) {
+        const dropDownOptionsHeight = 500;
+        const $dropDownButton = $('#dropDownButton').dxDropDownButton({
+            dropDownOptions: {
+                height: dropDownOptionsHeight
+            },
+            opened: true
+        });
+        const dropDownButton = $dropDownButton.dxDropDownButton('instance');
+
+        dropDownButton.option('height', 300);
+
+        const popup = $dropDownButton.find(`.${POPUP_CLASS}`).dxPopup('instance');
+        assert.strictEqual(popup.option('height'), dropDownOptionsHeight, 'popup height option value is correct');
+    });
+
     QUnit.module('overlay content width', () => {
         QUnit.test('should be equal to editor width if dropDownOptions.width is not defined and content width is smaller than editor width', function(assert) {
             const $container = $('<div>')

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
@@ -673,8 +673,8 @@ QUnit.module('popup integration', {
         const overlayContentRect = $overlayContent.get(0).getBoundingClientRect();
         const dropDownButtonRect = $('#dropDownButton').get(0).getBoundingClientRect();
 
-        assert.roughEqual(overlayContentRect.top, dropDownButtonRect.bottom, 1, 'top position is correct');
-        assert.roughEqual(overlayContentRect.left, dropDownButtonRect.left, 1, 'left position is correct');
+        assert.roughEqual(overlayContentRect.top, dropDownButtonRect.bottom, 1.01, 'top position is correct');
+        assert.roughEqual(overlayContentRect.left, dropDownButtonRect.left, 1.01, 'left position is correct');
     });
 
     QUnit.test('dropDownOptions can be restored after repaint', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
@@ -495,6 +495,24 @@ QUnit.module('popup integration', {
         assert.strictEqual(repaintMock.callCount, 3, 'popup has been repainted 3 times');
     });
 
+    QUnit.test('popup should be repositioned after height option runtime change', function(assert) {
+        const instance = new DropDownButton('#dropDownButton', {
+            opened: true,
+            dropDownOptions: {
+                'position.collision': 'none'
+            },
+        });
+
+        instance.option('height', 300);
+
+        const $overlayContent = $(`.${OVERLAY_CONTENT_CLASS}`);
+        const overlayContentRect = $overlayContent.get(0).getBoundingClientRect();
+        const dropDownButtonRect = $('#dropDownButton').get(0).getBoundingClientRect();
+
+        assert.strictEqual(overlayContentRect.top, dropDownButtonRect.bottom, 'top position is correct');
+        assert.strictEqual(overlayContentRect.left, dropDownButtonRect.left, 'left position is correct');
+    });
+
     QUnit.test('dropDownOptions can be restored after repaint', function(assert) {
         const instance = new DropDownButton('#dropDownButton', {
             deferRendering: false,


### PR DESCRIPTION
1. Added dropDownEditor popup repaint after `height` option runtime change for popup position recalculating
2. Made possible to customize dateBox (with list) popup height using dropDownOptions
3. Added tests for all widgets