### PR TITLE
Renovation: Fix validation message

### DIFF
--- a/js/renovation/ui/__tests__/overlay.test.tsx
+++ b/js/renovation/ui/__tests__/overlay.test.tsx
@@ -13,7 +13,8 @@ describe('Overlay', () => {
       const rootElementRef = { } as HTMLDivElement;
       const componentProps = new OverlayProps();
       const props = {
-        props: { ...componentProps, rootElementRef },
+        props: { rootElementRef },
+        componentProps,
         restAttributes: { 'rest-attributes': 'true' },
       } as Partial<Overlay>;
       const tree = shallow(<OverlayView {...props as any} /> as any);
@@ -24,6 +25,18 @@ describe('Overlay', () => {
         componentType: LegacyOverlay,
         'rest-attributes': 'true',
       });
+    });
+  });
+
+  describe('Logic', () => {
+    it('componentProps', () => {
+      const props = new OverlayProps();
+      const validationMessage = new Overlay({
+        ...props,
+        rootElementRef: {} as unknown as HTMLDivElement,
+      });
+
+      expect(validationMessage.componentProps).toMatchObject(props);
     });
   });
 });

--- a/js/renovation/ui/__tests__/validation_message.test.tsx
+++ b/js/renovation/ui/__tests__/validation_message.test.tsx
@@ -8,20 +8,35 @@ import { DomComponentWrapper } from '../common/dom_component_wrapper';
 jest.mock('../../../ui/validation_message', () => jest.fn());
 
 describe('ValidationMessage', () => {
-  it('View render', () => {
-    const rootElementRef = { } as HTMLDivElement;
-    const componentProps = new ValidationMessageProps();
-    const props = {
-      props: { ...componentProps, rootElementRef },
-      restAttributes: { 'rest-attributes': 'true' },
-    } as Partial<ValidationMessage>;
-    const tree = shallow(<ValidationMessageView {...props as any} />);
+  describe('View', () => {
+    it('View render', () => {
+      const rootElementRef = { } as HTMLDivElement;
+      const componentProps = new ValidationMessageProps();
+      const props = {
+        props: { rootElementRef },
+        componentProps,
+        restAttributes: { 'rest-attributes': 'true' },
+      } as Partial<ValidationMessage>;
+      const tree = shallow(<ValidationMessageView {...props as any} />);
 
-    expect(tree.find(DomComponentWrapper).props()).toMatchObject({
-      rootElementRef: {},
-      componentProps,
-      componentType: LegacyValidationMessage,
-      'rest-attributes': 'true',
+      expect(tree.find(DomComponentWrapper).props()).toMatchObject({
+        rootElementRef: {},
+        componentProps,
+        componentType: LegacyValidationMessage,
+        'rest-attributes': 'true',
+      });
+    });
+  });
+
+  describe('Logic', () => {
+    it('componentProps', () => {
+      const props = new ValidationMessageProps();
+      const validationMessage = new ValidationMessage({
+        ...props,
+        rootElementRef: {} as unknown as HTMLDivElement,
+      });
+
+      expect(validationMessage.componentProps).toMatchObject(props);
     });
   });
 });

--- a/js/renovation/ui/check_box.tsx
+++ b/js/renovation/ui/check_box.tsx
@@ -8,6 +8,7 @@ import {
   Ref,
   Effect,
   Event,
+  ForwardRef,
 } from 'devextreme-generator/component_declaration/common';
 import { createDefaultOptionRules } from '../../core/options/utils';
 import devices from '../../core/devices';
@@ -162,7 +163,7 @@ export class CheckBox extends JSXComponent(CheckBoxProps) {
 
   @Ref() widgetRef!: Widget;
 
-  @Ref() target!: HTMLDivElement;
+  @ForwardRef() target!: HTMLDivElement;
 
   @Effect({ run: 'once' })
   afterInitEffect(): EffectReturn {

--- a/js/renovation/ui/common/dom_component_wrapper.tsx
+++ b/js/renovation/ui/common/dom_component_wrapper.tsx
@@ -80,7 +80,12 @@ export class DomComponentWrapper extends JSXComponent<DomComponentWrapperProps, 
   config?: ConfigContextValue;
 
   get properties(): Record<string, unknown> {
-    const { itemTemplate, valueChange, ...restProps } = this.props.componentProps;
+    const {
+      itemTemplate,
+      valueChange,
+      ...restProps
+    } = this.props.componentProps;
+
     const properties = ({
       rtlEnabled: this.config?.rtlEnabled || false, // widget expects boolean
       ...restProps,

--- a/js/renovation/ui/overlay.tsx
+++ b/js/renovation/ui/overlay.tsx
@@ -12,7 +12,8 @@ import { animationConfig } from '../../animation/fx';
 import { DomComponentWrapper } from './common/dom_component_wrapper';
 
 export const viewFunction = ({
-  props: { rootElementRef, ...componentProps },
+  props: { rootElementRef },
+  componentProps,
   restAttributes,
 }: Overlay): JSX.Element => (
   <DomComponentWrapper
@@ -62,4 +63,13 @@ export class OverlayProps extends WidgetProps {
   defaultOptionRules: null,
   view: viewFunction,
 })
-export class Overlay extends JSXComponent(OverlayProps) { }
+export class Overlay extends JSXComponent(OverlayProps) {
+  get componentProps(): WidgetProps {
+    const {
+      rootElementRef,
+      ...restProps
+    } = this.props;
+
+    return restProps;
+  }
+}

--- a/js/renovation/ui/validation_message.tsx
+++ b/js/renovation/ui/validation_message.tsx
@@ -1,12 +1,13 @@
 import {
-  Component, ComponentBindings, JSXComponent, OneWay,
+  Component, ComponentBindings, ForwardRef, JSXComponent, OneWay,
 } from 'devextreme-generator/component_declaration/common';
 import { WidgetProps } from './common/widget';
 import LegacyValidationMessage from '../../ui/validation_message';
 import { DomComponentWrapper } from './common/dom_component_wrapper';
 
 export const viewFunction = ({
-  props: { rootElementRef, ...componentProps },
+  props: { rootElementRef },
+  componentProps,
   restAttributes,
 }: ValidationMessage): JSX.Element => (
   <DomComponentWrapper
@@ -26,11 +27,11 @@ export class ValidationMessageProps extends WidgetProps {
 
   @OneWay() positionRequest?: string;
 
-  @OneWay() boundary?: string | Element;
+  @ForwardRef() boundary?: string | Element;
 
-  @OneWay() container?: string | Element;
+  @ForwardRef() container?: string | Element;
 
-  @OneWay() target?: string | Element;
+  @ForwardRef() target?: string | Element;
 
   @OneWay() offset?: object = { h: 0, v: 0 };
 }
@@ -38,4 +39,13 @@ export class ValidationMessageProps extends WidgetProps {
   defaultOptionRules: null,
   view: viewFunction,
 })
-export class ValidationMessage extends JSXComponent(ValidationMessageProps) { }
+export class ValidationMessage extends JSXComponent(ValidationMessageProps) {
+  get componentProps(): WidgetProps {
+    const {
+      rootElementRef,
+      ...restProps
+    } = this.props;
+
+    return restProps;
+  }
+}

--- a/js/renovation/viz/core/renderers/svg_text.tsx
+++ b/js/renovation/viz/core/renderers/svg_text.tsx
@@ -131,7 +131,7 @@ export class TextSvgElement extends JSXComponent(TextSvgElementProps) {
       const items = this.parseTspanElements(texts);
 
       this.alignTextNodes(items);
-      applyGraphicProps(this.textRef, this.props, this.props.x, this.props.y);
+      applyGraphicProps(this.textRef, this.props as SvgGraphicsProps, this.props.x, this.props.y);
       if (this.props.x !== undefined || this.props.y !== undefined) {
         this.locateTextNodes(items);
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "cssom": "^0.4.4",
     "del": "^2.2.2",
     "devextreme-cldr-data": "^1.0.2",
-    "devextreme-generator": "1.0.130",
+    "devextreme-generator": "1.0.131",
     "devextreme-internal-tools": "stable",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",


### PR DESCRIPTION
https://github.com/DevExpress/devextreme-renovation/issues/518

componentProps in Overlay and ValidationMessage is moved in getter because we need to get a native element from reference.

This notation props: { rootElementRef, ...restProps } leaves ref objects