### PR TITLE
Renovated validationMessage integrated to editors small improve

### DIFF
--- a/js/renovation/preact_wrapper/editor.ts
+++ b/js/renovation/preact_wrapper/editor.ts
@@ -29,14 +29,14 @@ export default class Editor extends Component {
       // it can change the editor's value
       if (isValidationMessageShownOnFocus) {
         // NOTE: Prevent the validation message from showing
-        const $validationMessage = $('.dx-invalid-message');
-        $validationMessage?.removeClass(INVALID_MESSAGE_AUTO);
+        const $validationMessageWrapper = $('.dx-invalid-message.dx-overlay-wrapper');
+        $validationMessageWrapper?.removeClass(INVALID_MESSAGE_AUTO);
 
         clearTimeout(this.showValidationMessageTimeout);
 
         // NOTE: Show the validation message after a click changes the value
         this.showValidationMessageTimeout = setTimeout(() => {
-          $validationMessage?.addClass(INVALID_MESSAGE_AUTO);
+          $validationMessageWrapper?.addClass(INVALID_MESSAGE_AUTO);
         }, 150);
       }
     };

--- a/js/renovation/ui/check_box.tsx
+++ b/js/renovation/ui/check_box.tsx
@@ -115,7 +115,7 @@ export class CheckBoxProps extends BaseWidgetProps {
 
   @OneWay() text?: string = '';
 
-  @OneWay() validationMessageMode?: string = 'auto';
+  @OneWay() validationMessageMode?: 'auto'|'always' = 'auto';
 
   @OneWay() validationStatus?: string = 'valid';
 

--- a/js/renovation/ui/validation_message.tsx
+++ b/js/renovation/ui/validation_message.tsx
@@ -21,7 +21,7 @@ export const viewFunction = ({
 
 @ComponentBindings()
 export class ValidationMessageProps extends WidgetProps {
-  @OneWay() mode?: string = 'auto';
+  @OneWay() mode?: 'auto'|'always' = 'auto';
 
   @OneWay() validationErrors?: object[] | null;
 


### PR DESCRIPTION
1. Specify type for validation message mode as `'auto'|'always'`
2. Fix VM appearing special case in `editor.js` according to [this bug fix](https://github.com/DevExpress/DevExtreme/pull/14987/files)