### PR TITLE
DateBox with rollers should have popup width 100% on mobile ios (#15061)

### DIFF
--- a/js/ui/date_box/ui.date_box.strategy.date_view.js
+++ b/js/ui/date_box/ui.date_box.strategy.date_view.js
@@ -29,7 +29,6 @@ const DateViewStrategy = DateBoxStrategy.inherit({
         return {
             toolbarItems: this.dateBox._popupToolbarItemsConfig(),
             onInitialized: config.onInitialized,
-            width: 'auto',
 
             defaultOptionsRules: [
                 {

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -1109,6 +1109,15 @@ QUnit.module('dateView integration', {
         assert.equal(this.popup().$content().find('.dx-dateview').length, 1);
     });
 
+    QUnit.test('dateView popup width should be equal to 100% on mobile ios', function(assert) {
+        if(devices.real().deviceType !== 'phone' || devices.real().platform !== 'ios') {
+            assert.ok(true, 'is actual only for mobile ios');
+            return;
+        }
+
+        assert.strictEqual(this.popup().option('width'), '100%', 'popup width is equal to 100%');
+    });
+
     QUnit.test('readOnly input prop should be always true to prevent keyboard open if simulated dateView is using', function(assert) {
         this.instance.option('readOnly', false);
         assert.ok(this.$element.find('.' + TEXTEDITOR_INPUT_CLASS).prop('readOnly'), 'readonly prop specified correctly');


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
