### PR TITLE
Mark the "key" option of the Map widget as obsolete

### DIFF
--- a/js/ui/map.d.ts
+++ b/js/ui/map.d.ts
@@ -33,6 +33,14 @@ export interface MapLocation {
 
 export interface dxMapOptions extends WidgetOptions<dxMap> {
     /**
+     * @docid dxMapOptions.apiKey
+     * @type string|object
+     * @default { bing: '', google: '', googleStatic: '' }
+     * @prevFileNamespace DevExpress.ui
+     * @public
+     */
+    apiKey?: string | { bing?: string, google?: string, googleStatic?: string };
+    /**
      * @docid dxMapOptions.autoAdjust
      * @type boolean
      * @default true
@@ -75,9 +83,10 @@ export interface dxMapOptions extends WidgetOptions<dxMap> {
     /**
      * @docid dxMapOptions.key
      * @type string|object
-     * @default ""
+     * @default { bing: '', google: '', googleStatic: '' }
      * @prevFileNamespace DevExpress.ui
      * @public
+     * @deprecated dxMapOptions.apiKey
      */
     key?: string | { bing?: string, google?: string, googleStatic?: string };
     /**

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -197,6 +197,29 @@ const Map = Widget.inherit({
                 googleStatic: ''
             },
 
+            apiKey: {
+                /**
+                * @name dxMapOptions.apiKey.bing
+                * @type string
+                * @default ""
+                */
+                bing: '',
+
+                /**
+                * @name dxMapOptions.apiKey.google
+                * @type string
+                * @default ""
+                */
+                google: '',
+
+                /**
+                * @name dxMapOptions.apiKey.googleStatic
+                * @type string
+                * @default ""
+                */
+                googleStatic: ''
+            },
+
             controls: false,
 
             onReady: null,
@@ -226,6 +249,14 @@ const Map = Widget.inherit({
                 }
             }
         ]);
+    },
+
+    _setDeprecatedOptions: function() {
+        this.callBase();
+
+        extend(this._deprecatedOptions, {
+            'key': { since: '20.2', alias: 'apiKey' }
+        });
     },
 
     _init: function() {
@@ -340,6 +371,7 @@ const Map = Widget.inherit({
                 this._invalidate();
                 break;
             case 'key':
+            case 'apiKey':
                 errors.log('W1001');
                 break;
             case 'bounds':

--- a/js/ui/map/provider.js
+++ b/js/ui/map/provider.js
@@ -99,7 +99,7 @@ const Provider = Class.inherit({
     },
 
     _keyOption: function(providerName) {
-        const key = this._option('key');
+        const key = this._option('apiKey');
 
         return key[providerName] === undefined ? key : key[providerName];
     },

--- a/testing/tests/DevExpress.ui.widgets/mapParts/bingTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/bingTests.js
@@ -560,16 +560,16 @@ QUnit.test('controls', function(assert) {
     });
 });
 
-QUnit.test('key', function(assert) {
+QUnit.test('apiKey', function(assert) {
     const done = assert.async();
 
     $('#map').dxMap({
         provider: 'bing',
-        key: {
+        apiKey: {
             bing: '12345'
         },
         onReady: function() {
-            assert.equal(window.Microsoft.options.credentials, '12345', 'map key specified correctly');
+            assert.equal(window.Microsoft.options.credentials, '12345', 'map apiKey specified correctly');
 
             done();
         }

--- a/testing/tests/DevExpress.ui.widgets/mapParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/commonTests.js
@@ -3,6 +3,7 @@ import testing from './utils.js';
 import Map from 'ui/map';
 import GoogleStaticProvider from 'ui/map/provider.google_static';
 import ajaxMock from '../../../helpers/ajaxMock.js';
+import errors from 'core/errors';
 
 const MARKERS = testing.MARKERS;
 const ROUTES = testing.ROUTES;
@@ -35,6 +36,28 @@ QUnit.test('widget should be rendered', function(assert) {
     });
 
     assert.ok($map.hasClass(MAP_CLASS), 'widget class added');
+});
+
+QUnit.test('show warning when using outdated "key" option', function(assert) {
+    try {
+        sinon.stub(errors, 'log');
+
+        $('#map').dxMap({
+            provider: 'googleStatic',
+            key: 'testKey'
+        });
+
+        assert.equal(errors.log.callCount, 1, 'the log method is called once');
+        assert.deepEqual(errors.log.getCall(0).args, [
+            'W0001',
+            'dxMap',
+            'key',
+            '20.2',
+            'Use the \'apiKey\' option instead'
+        ], 'correct warning is shown');
+    } finally {
+        errors.log.restore();
+    }
 });
 
 QUnit.test('clicks inside map should be native (T349301)', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/mapParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/commonTests.js
@@ -47,7 +47,7 @@ QUnit.test('show warning when using outdated "key" option', function(assert) {
             key: 'testKey'
         });
 
-        assert.equal(errors.log.callCount, 1, 'the log method is called once');
+        assert.ok(errors.log.calledOnce, 'the log method is called once');
         assert.deepEqual(errors.log.getCall(0).args, [
             'W0001',
             'dxMap',

--- a/testing/tests/DevExpress.ui.widgets/mapParts/googleStaticTests.js
+++ b/testing/tests/DevExpress.ui.widgets/mapParts/googleStaticTests.js
@@ -208,11 +208,11 @@ QUnit.test('zoom', function(assert) {
     });
 });
 
-QUnit.test('key', function(assert) {
+QUnit.test('apiKey', function(assert) {
     return new Promise(function(resolve) {
         const map = new Map($('#map'), {
             provider: 'googleStatic',
-            key: 10153453,
+            apiKey: 10153453,
             onReady: function(e) {
                 assert.notEqual(mapUrl(map).indexOf('key=10153453'), -1, 'key set correctly');
 

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -8814,6 +8814,10 @@ declare module DevExpress.ui {
      */
     export interface dxMapOptions extends WidgetOptions<dxMap> {
         /**
+         * [descr:dxMap.Options.apiKey]
+         */
+        apiKey?: string | { bing?: string, google?: string, googleStatic?: string };
+        /**
          * [descr:dxMap.Options.autoAdjust]
          */
         autoAdjust?: boolean;
@@ -8835,6 +8839,7 @@ declare module DevExpress.ui {
         height?: number | string | (() => number | string);
         /**
          * [descr:dxMap.Options.key]
+         * @deprecated [depNote:dxMap.Options.key]
          */
         key?: string | { bing?: string, google?: string, googleStatic?: string };
         /**


### PR DESCRIPTION
Use the `apiKey` option instead of `key`.
E.g.
```js
new dxMap({
  apiKey: { google: 'YOUR_KEY' }
});
```
The `key` is reserved word in both React and Vue. 