### PR TITLE
Fix TextBox keyboard hotkeys operability in IE11 (T944726, T944493)

### DIFF
--- a/js/ui/text_box/text_box.js
+++ b/js/ui/text_box/text_box.js
@@ -124,7 +124,7 @@ const TextBox = TextEditor.inherit({
 
     _onKeyDownCutOffHandler: function(e) {
         const actualMaxLength = this._getMaxLength();
-        if(actualMaxLength) {
+        if(actualMaxLength && !e.ctrlKey) {
             const $input = $(e.target);
             const key = normalizeKeyName(e);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/textbox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textbox.tests.js
@@ -95,7 +95,7 @@ QUnit.module('common', {}, () => {
         }
     });
 
-    QUnit.test('"maxLength" option on IE should works correctly with the control commands', function(assert) {
+    QUnit.test('"maxLength" option on IE should works correctly with the hotkeys (T944726, T944493)', function(assert) {
         const originalIE = browser.msie;
 
         try {

--- a/testing/tests/DevExpress.ui.widgets.editors/textbox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textbox.tests.js
@@ -95,6 +95,26 @@ QUnit.module('common', {}, () => {
         }
     });
 
+    QUnit.test('"maxLength" option on IE should works correctly with the control commands', function(assert) {
+        const originalIE = browser.msie;
+
+        try {
+            browser.msie = true;
+            const $element = $('#textbox').dxTextBox({ maxLength: 1, value: 'b' });
+            const $input = $element.find('.' + INPUT_CLASS);
+            let event = $.Event('keydown', { key: 'a', ctrlKey: true });
+
+            $input.trigger(event);
+            assert.ok(!event.isDefaultPrevented(), 'default is not prevented');
+
+            event = $.Event('keydown', { key: 'z', ctrlKey: true });
+            $input.trigger(event);
+            assert.ok(!event.isDefaultPrevented(), 'default is not prevented');
+        } finally {
+            browser.msie = originalIE;
+        }
+    });
+
     QUnit.test('call focus() method', function(assert) {
         executeAsyncMock.setup();
         try {

--- a/testing/tests/DevExpress.ui.widgets.editors/textbox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textbox.tests.js
@@ -101,15 +101,15 @@ QUnit.module('common', {}, () => {
         try {
             browser.msie = true;
             const $element = $('#textbox').dxTextBox({ maxLength: 1, value: 'b' });
-            const $input = $element.find('.' + INPUT_CLASS);
+            const $input = $element.find(`.${INPUT_CLASS}`);
             let event = $.Event('keydown', { key: 'a', ctrlKey: true });
 
             $input.trigger(event);
-            assert.ok(!event.isDefaultPrevented(), 'default is not prevented');
+            assert.notOk(event.isDefaultPrevented(), 'default is not prevented');
 
             event = $.Event('keydown', { key: 'z', ctrlKey: true });
             $input.trigger(event);
-            assert.ok(!event.isDefaultPrevented(), 'default is not prevented');
+            assert.notOk(event.isDefaultPrevented(), 'default is not prevented');
         } finally {
             browser.msie = originalIE;
         }


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
