### PR TITLE
Refactor current time indicator in Scheduler

### DIFF
--- a/js/ui/scheduler/workspaces/ui.scheduler.timeline.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.timeline.js
@@ -304,8 +304,8 @@ class SchedulerTimeline extends SchedulerWorkSpace {
         $indicator.css('left', left);
     }
 
-    _isIndicatorSimple(i) {
-        return this._isVerticalGroupedWorkSpace() && i > 0;
+    _isIndicatorSimple(index) {
+        return this._isVerticalGroupedWorkSpace() && index > 0;
     }
 
     _isVerticalShader() {

--- a/js/ui/scheduler/workspaces/ui.scheduler.timeline.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.timeline.js
@@ -289,23 +289,23 @@ class SchedulerTimeline extends SchedulerWorkSpace {
 
     }
 
-    _renderIndicator(height, rtlOffset, $container, groupCount) {
-        let $indicator;
-        const width = this.getIndicationWidth();
+    getIndicatorLeft(date, $cell) {
+        const cellWidth = this.getCellWidth();
+        const cellDate = this.getCellData($cell).startDate;
 
-        if(this.option('groupOrientation') === 'vertical') {
-            $indicator = this._createIndicator($container);
-            $indicator.height(getBoundingRect($container.get(0)).height);
-            $indicator.css('left', rtlOffset ? rtlOffset - width : width);
-        } else {
-            for(let i = 0; i < groupCount; i++) {
-                const offset = this.isGroupedByDate() ? i * this.getCellWidth() : this._getCellCount() * this.getCellWidth() * i;
-                $indicator = this._createIndicator($container);
-                $indicator.height(getBoundingRect($container.get(0)).height);
+        const duration = date.getTime() - cellDate.getTime();
+        const cellCount = duration / this.getCellDuration();
 
-                $indicator.css('left', rtlOffset ? rtlOffset - width - offset : width + offset);
-            }
-        }
+        return cellCount * cellWidth;
+    }
+
+    _shiftIndicator(date, $cell, $indicator) {
+        const left = this.getIndicatorLeft(date, $cell);
+        $indicator.css('left', left);
+    }
+
+    _isIndicatorSimple(i) {
+        return this._isVerticalGroupedWorkSpace() && i > 0;
     }
 
     _isVerticalShader() {

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.grouped.strategy.horizontal.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.grouped.strategy.horizontal.js
@@ -166,29 +166,6 @@ class HorizontalGroupedStrategy extends GroupedStrategy {
         };
     }
 
-    shiftIndicator($indicator, height, rtlOffset, groupIndex) {
-        const offset = this._getIndicatorOffset(groupIndex);
-
-        const horizontalOffset = rtlOffset ? rtlOffset - offset : offset;
-
-        $indicator.css('left', horizontalOffset);
-        $indicator.css('top', height);
-    }
-
-    _getIndicatorOffset(groupIndex) {
-        const groupByDay = this._workSpace.isGroupedByDate();
-
-        return groupByDay ? this._calculateGroupByDateOffset(groupIndex) : this._calculateOffset(groupIndex);
-    }
-
-    _calculateOffset(groupIndex) {
-        return this._workSpace._getCellCount() * this._workSpace.getRoundedCellWidth(groupIndex - 1, 0) * groupIndex + this._workSpace.getIndicatorOffset(groupIndex) + groupIndex;
-    }
-
-    _calculateGroupByDateOffset(groupIndex) {
-        return this._workSpace.getIndicatorOffset(0) * this._workSpace._getGroupCount() + this._workSpace.getRoundedCellWidth(groupIndex - 1, 0) * groupIndex;
-    }
-
     getShaderOffset(i, width) {
         const offset = this._workSpace._getCellCount() * this._workSpace.getRoundedCellWidth(i - 1) * i;
         return this._workSpace.option('rtlEnabled') ? getBoundingRect(this._workSpace._dateTableScrollable.$content().get(0)).width - offset - this._workSpace.getTimePanelWidth() - width : offset;

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.grouped.strategy.vertical.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.grouped.strategy.vertical.js
@@ -162,20 +162,6 @@ class VerticalGroupedStrategy extends GroupedStrategy {
         });
     }
 
-    shiftIndicator($indicator, height, rtlOffset, i) {
-        const offset = this._workSpace.getIndicatorOffset(0);
-        const tableOffset = this._workSpace.option('crossScrollingEnabled') ? 0 : this._workSpace.getGroupTableWidth();
-        const horizontalOffset = rtlOffset ? rtlOffset - offset : offset;
-        let verticalOffset = this._workSpace._getRowCount() * this._workSpace.getCellHeight() * i;
-
-        if(this._workSpace.supportAllDayRow() && this._workSpace.option('showAllDayPanel')) {
-            verticalOffset += this._workSpace.getAllDayHeight() * (i + 1);
-        }
-
-        $indicator.css('left', horizontalOffset + tableOffset);
-        $indicator.css('top', height + verticalOffset);
-    }
-
     getShaderOffset(i, width) {
         const offset = this._workSpace.option('crossScrollingEnabled') ? 0 : this._workSpace.getGroupTableWidth();
         return this._workSpace.option('rtlEnabled') ? getBoundingRect(this._$container.get(0)).width - offset - this._workSpace.getWorkSpaceLeftOffset() - width : offset;

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.indicator.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.indicator.js
@@ -64,8 +64,8 @@ class SchedulerWorkSpaceIndicator extends SchedulerWorkSpace {
         }
     }
 
-    _isIndicatorSimple(i) {
-        return this.isGroupedByDate() && i > 0;
+    _isIndicatorSimple(index) {
+        return this.isGroupedByDate() && index > 0;
     }
 
     _renderIndicator(date, groupCount) {

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
@@ -2586,6 +2586,14 @@ class SchedulerWorkSpace extends WidgetObserver {
         return this._groupedStrategy.getHorizontalMax(groupIndex);
     }
 
+    getCellByDate(date, groupIndex) {
+        const index = this.getCellIndexByDate(date);
+        const cellCoordinates = this._getCellCoordinatesByIndex(index);
+        const $cell = this._getCellByCoordinates(cellCoordinates, groupIndex, false);
+
+        return $cell;
+    }
+
     getCoordinatesByDate(date, groupIndex, inAllDayRow) {
         groupIndex = groupIndex || 0;
         let position;

--- a/scss/widgets/base/scheduler/_index.scss
+++ b/scss/widgets/base/scheduler/_index.scss
@@ -642,6 +642,8 @@ $scheduler-appointment-form-label-padding: 20px;
   .dx-scheduler-date-time-indicator {
     background-color: $scheduler-time-indicator-color;
     position: absolute;
+    z-index: 1000;
+    width: 100%;
     pointer-events: none;
     box-shadow: $scheduler-time-indicator-shadow;
 
@@ -649,7 +651,6 @@ $scheduler-appointment-form-label-padding: 20px;
       font-size: $scheduler-time-indicator-font-size;
       color: $scheduler-time-indicator-color;
       position: absolute;
-      z-index: 1000;
       margin-top: -$scheduler-time-indicator-top;
       margin-left: -$scheduler-time-indicator-left;
       text-shadow: $scheduler-time-indicator-text-shadow;
@@ -681,14 +682,9 @@ $scheduler-appointment-form-label-padding: 20px;
     }
 
     .dx-scheduler-date-time-indicator {
-      margin-left: $scheduler-left-column-width;
       height: $scheduler-time-indicator-size;
 
       @include dx-icon(spinright);
-
-      .dx-scheduler-small & {
-        margin-left: $scheduler-small-size-element-offset;
-      }
     }
 
     .dx-scheduler-date-time-shader,
@@ -757,6 +753,12 @@ $scheduler-appointment-form-label-padding: 20px;
         &::before {
           margin-right: -$scheduler-time-indicator-left;
         }
+
+        &.dx-scheduler-date-time-indicator-simple {
+          &::before {
+            content: "";
+          }
+        }
       }
 
       .dx-scheduler-date-time-shader-top,
@@ -810,6 +812,7 @@ $scheduler-appointment-form-label-padding: 20px;
   .dx-scheduler-timeline {
     .dx-scheduler-date-time-indicator {
       width: $scheduler-time-indicator-size;
+      height: 100%;
       top: 0;
 
       @include dx-icon(spindown);
@@ -893,6 +896,12 @@ $scheduler-appointment-form-label-padding: 20px;
         border-bottom: $scheduler-base-border;
       }
     }
+
+    .dx-scheduler-date-time-indicator-simple {
+      &::before {
+        content: "";
+      }
+    }
   }
 
 
@@ -902,6 +911,7 @@ $scheduler-appointment-form-label-padding: 20px;
   }
 
   .dx-scheduler-date-table-cell {
+    vertical-align: top;
     border-top: $scheduler-base-border;
     height: $scheduler-workspace-date-table-cell-height;
   }

--- a/scss/widgets/base/scheduler/_index.scss
+++ b/scss/widgets/base/scheduler/_index.scss
@@ -641,7 +641,7 @@ $scheduler-appointment-form-label-padding: 20px;
 
   .dx-scheduler-date-time-indicator {
     background-color: $scheduler-time-indicator-color;
-    position: absolute;
+    position: relative;
     z-index: 1000;
     width: 100%;
     pointer-events: none;

--- a/scss/widgets/base/scheduler/_index.scss
+++ b/scss/widgets/base/scheduler/_index.scss
@@ -641,7 +641,7 @@ $scheduler-appointment-form-label-padding: 20px;
 
   .dx-scheduler-date-time-indicator {
     background-color: $scheduler-time-indicator-color;
-    position: relative;
+    position: absolute;
     z-index: 1000;
     width: 100%;
     pointer-events: none;
@@ -1801,6 +1801,7 @@ $scheduler-appointment-form-label-padding: 20px;
     border-left: $scheduler-base-border;
     border-right: $scheduler-base-border;
     height: $scheduler-workspace-date-table-cell-height;
+    position: relative;
   }
 
   // stylelint-disable-next-line no-duplicate-selectors

--- a/testing/tests/DevExpress.ui.widgets.scheduler/currentTimeIndicator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/currentTimeIndicator.tests.js
@@ -7,6 +7,7 @@ const SCHEDULER_DATE_TIME_SHADER_ALL_DAY_CLASS = 'dx-scheduler-date-time-shader-
 const SCHEDULER_DATE_TIME_SHADER_TOP_CLASS = 'dx-scheduler-date-time-shader-top';
 const SCHEDULER_DATE_TIME_SHADER_BOTTOM_CLASS = 'dx-scheduler-date-time-shader-bottom';
 const SCHEDULER_DATE_TIME_INDICATOR_CLASS = 'dx-scheduler-date-time-indicator';
+const SCHEDULER_DATE_TABLE_CELL_CLASS = 'dx-scheduler-date-table-cell';
 
 import 'common.css!';
 import 'generic_light.css!';
@@ -33,6 +34,23 @@ const stubInvokeMethod = function(instance, options) {
             const resources = instance.resources || [{ field: 'one', dataSource: [{ id: 1 }, { id: 2 }] }];
             return new SchedulerResourcesManager(resources).getResourceTreeLeaves(arguments[1], arguments[2]);
         }
+    });
+};
+
+const testIndicators = function(testCases, $element, assert) {
+    const $indicators = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
+    assert.equal($indicators.length, testCases.length, 'Indicator count is correct');
+
+    testCases.forEach(({ cellIndex, offset, isSimple }, index) => {
+        const $cell = $element.find('.' + SCHEDULER_DATE_TABLE_CELL_CLASS).eq(cellIndex);
+        const $indicator = $indicators.eq(index);
+
+        assert.equal($indicators.eq(index).parent().get(0), $cell.get(0), 'Indicator was placed in the correct cell');
+        assert.equal($indicators.eq(index).css('top'), offset.top, 'Indicator has correct top offset');
+        assert.equal($indicators.eq(index).css('left'), offset.left, 'Indicator has correct left offset');
+
+        isSimple ? assert.ok($indicator.hasClass('dx-scheduler-date-time-indicator-simple'), 'Indicator is simple') :
+            assert.notOk($indicator.hasClass('dx-scheduler-date-time-indicator-simple'), 'Indicator is usual');
     });
 };
 
@@ -68,13 +86,14 @@ const stubInvokeMethod = function(instance, options) {
         assert.equal($element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS).length, 0, 'Indicator wasn\'t rendered');
     });
 
-    QUnit.test('DateTimeIndicator should be wrapped by scrollable, Day view', function(assert) {
+    QUnit.test('DateTimeIndicator should be wrapped by appropriate cell, Day view', function(assert) {
         this.instance.option({
             indicatorTime: new Date(2017, 8, 5, 12, 45)
         });
         const $element = this.instance.$element();
+        const $cell = $element.find('.' + SCHEDULER_DATE_TABLE_CELL_CLASS).eq(9);
 
-        assert.ok($element.find('.' + SCHEDULER_DATE_TIME_SHADER_CLASS).parent().hasClass('dx-scrollable-content'), 'Scrollable contains time indicator');
+        assert.equal($element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS).eq(0).parent().get(0), $cell.get(0), 'Cell contains time indicator');
     });
 
     QUnit.test('Indication should be updated by some timer', function(assert) {
@@ -147,7 +166,7 @@ const stubInvokeMethod = function(instance, options) {
         assert.equal($element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS).length, 1, 'Indicator is rendered');
     });
 
-    QUnit.test('DateTimeIndicator should have correct positions, Day view with groups', function(assert) {
+    QUnit.test('DateTimeIndicator should have correct target cell and position, Day view with groups', function(assert) {
         this.instance.option({
             indicatorTime: new Date(2017, 8, 5, 12, 45)
         });
@@ -155,16 +174,26 @@ const stubInvokeMethod = function(instance, options) {
         this.instance.option('groups', [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]);
 
         const $element = this.instance.$element();
-        const $indicators = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
-        const cellHeight = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(0).get(0).getBoundingClientRect().height;
-        assert.equal($indicators.length, 2, 'Indicator count is correct');
-        assert.equal($indicators.eq(0).position().left, 0);
-        assert.equal($indicators.eq(0).position().top, 9.5 * cellHeight);
-        assert.equal($indicators.eq(1).position().left, this.instance.getRoundedCellWidth(1) + 1);
-        assert.equal($indicators.eq(1).position().top, 9.5 * cellHeight);
+
+        const testCases = [
+            {
+                cellIndex: 18,
+                offset: {
+                    top: '25px',
+                    left: '0px'
+                }
+            }, {
+                cellIndex: 19,
+                offset: {
+                    top: '25px',
+                    left: '0px'
+                }
+            }
+        ];
+        testIndicators(testCases, $element, assert);
     });
 
-    QUnit.test('DateTimeIndicator should have correct positions, Day view with groups without shader', function(assert) {
+    QUnit.skip('DateTimeIndicator should have correct positions, Day view with groups without shader', function(assert) {
         this.instance.option({
             indicatorTime: new Date(2017, 8, 5, 12, 45),
             shadeUntilCurrentTime: false
@@ -449,19 +478,30 @@ const stubInvokeMethod = function(instance, options) {
     QUnit.test('DateTimeIndicator should have correct positions, Day view with groups, verticalGrouping', function(assert) {
         this.instance.option({
             shadeUntilCurrentTime: false,
+            startDayHour: 11,
             indicatorTime: new Date(2017, 8, 5, 12, 45)
         });
 
         this.instance.option('groups', [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]);
 
         const $element = this.instance.$element();
-        const $indicators = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
-        const cellHeight = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(0).get(0).getBoundingClientRect().height;
-        assert.equal($indicators.length, 2, 'Indicator count is correct');
-        assert.equal($indicators.eq(0).position().left, 100);
-        assert.equal($indicators.eq(0).position().top, 10.5 * cellHeight);
-        assert.equal($indicators.eq(1).position().left, 100);
-        assert.equal($indicators.eq(1).position().top, 23.5 * cellHeight);
+
+        const testCases = [
+            {
+                cellIndex: 3,
+                offset: {
+                    top: '25px',
+                    left: '0px'
+                }
+            }, {
+                cellIndex: 9,
+                offset: {
+                    top: '25px',
+                    left: '0px'
+                }
+            }
+        ];
+        testIndicators(testCases, $element, assert);
     });
 
     QUnit.test('DateTimeIndicator should have correct positions, Day view with groups and allDay customization, verticalGrouping (T737095)', function(assert) {
@@ -472,18 +512,30 @@ const stubInvokeMethod = function(instance, options) {
 
             this.instance.option({
                 shadeUntilCurrentTime: false,
-                indicatorTime: new Date(2017, 8, 5, 12, 45)
+                indicatorTime: new Date(2017, 8, 5, 12, 42)
             });
 
             this.instance.option('groups', [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]);
 
             const $element = this.instance.$element();
-            const $indicators = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
-            const cellHeight = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(0).get(0).getBoundingClientRect().height;
 
-            assert.equal($indicators.eq(0).position().top, 9.5 * cellHeight + 150, 'Indicator top is 9.5 cells + allDay panel height');
+            const testCases = [
+                {
+                    cellIndex: 9,
+                    offset: {
+                        top: '20px',
+                        left: '0px'
+                    }
+                }, {
+                    cellIndex: 21,
+                    offset: {
+                        top: '20px',
+                        left: '0px'
+                    }
+                }
+            ];
 
-            assert.equal($indicators.eq(1).position().top, 21.5 * cellHeight + 2 * 150, 'Second indicator top is 21.5 cells + two allDay panel height');
+            testIndicators(testCases, $element, assert);
         } finally {
             $style.remove();
         }
@@ -493,37 +545,59 @@ const stubInvokeMethod = function(instance, options) {
         this.instance.option({
             showAllDayPanel: false,
             shadeUntilCurrentTime: false,
-            indicatorTime: new Date(2017, 8, 5, 12, 45)
+            indicatorTime: new Date(2017, 8, 5, 12, 42)
         });
 
         this.instance.option('groups', [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]);
 
         const $element = this.instance.$element();
-        const $indicators = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
-        const cellHeight = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(0).get(0).getBoundingClientRect().height;
-        assert.equal($indicators.length, 2, 'Indicator count is correct');
-        assert.equal($indicators.eq(0).position().left, 100);
-        assert.equal($indicators.eq(0).position().top, 9.5 * cellHeight);
-        assert.equal($indicators.eq(1).position().left, 100);
-        assert.equal($indicators.eq(1).position().top, 21.5 * cellHeight);
+
+        const testCases = [
+            {
+                cellIndex: 9,
+                offset: {
+                    top: '20px',
+                    left: '0px'
+                }
+            }, {
+                cellIndex: 21,
+                offset: {
+                    top: '20px',
+                    left: '0px'
+                }
+            }
+        ];
+
+        testIndicators(testCases, $element, assert);
     });
 
     QUnit.test('DateTimeIndicator should have correct positions, Day view with groups with shader', function(assert) {
         this.instance.option({
             shadeUntilCurrentTime: true,
-            indicatorTime: new Date(2017, 8, 5, 12, 45)
+            indicatorTime: new Date(2017, 8, 5, 12, 42)
         });
 
         this.instance.option('groups', [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]);
 
         const $element = this.instance.$element();
-        const $indicators = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
-        const cellHeight = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(0).get(0).getBoundingClientRect().height;
-        assert.equal($indicators.length, 2, 'Indicator count is correct');
-        assert.equal($indicators.eq(0).position().left, 100);
-        assert.equal($indicators.eq(0).position().top, 10.5 * cellHeight);
-        assert.equal($indicators.eq(1).position().left, 100);
-        assert.equal($indicators.eq(1).position().top, 23.5 * cellHeight);
+
+        const testCases = [
+            {
+                cellIndex: 9,
+                offset: {
+                    top: '20px',
+                    left: '0px'
+                }
+            }, {
+                cellIndex: 21,
+                offset: {
+                    top: '20px',
+                    left: '0px'
+                }
+            }
+        ];
+
+        testIndicators(testCases, $element, assert);
     });
 
     QUnit.test('AllDay Shader should be wrapped by allDay panel', function(assert) {
@@ -617,19 +691,6 @@ const stubInvokeMethod = function(instance, options) {
         this.instance.option('currentDate', new Date(2017, 8, 15));
 
         assert.equal($element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS).length, 0, 'Indicator wasn\'t rendered');
-    });
-
-    QUnit.test('Indicator should have correct positions after dimensionChanged', function(assert) {
-        this.instance.option({
-            indicatorTime: new Date(2017, 8, 5, 12, 45),
-            crossScrollingEnabled: true,
-            groups: [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]
-        });
-
-        resizeCallbacks.fire();
-
-        const $element = this.instance.$element();
-        assert.roughEqual($element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS).position().top, 475, 2, 'Indicator has correct position');
     });
 
     QUnit.test('Shader on allDayPanel should have correct height & width, Week view', function(assert) {
@@ -782,7 +843,40 @@ const stubInvokeMethod = function(instance, options) {
         assert.ok($cell.hasClass('dx-scheduler-header-panel-current-time-cell'), 'Cell has specific class');
     });
 
-    QUnit.test('DateTimeIndicator and shader should have correct positions, Week view with intervalCount, rtl mode', function(assert) {
+    [{
+        startDayHour: 8,
+        endDayHour: 14,
+        indicatorTime: new Date(2017, 8, 6, 10, 45),
+        isVisible: true,
+        caseName: 'indicator time is between startDayHour and endDayHour'
+    },
+    {
+        startDayHour: 8,
+        endDayHour: 14,
+        indicatorTime: new Date(2017, 8, 6, 15, 45),
+        isVisible: false,
+        caseName: 'indicator time is later than endDayHour'
+    },
+    {
+        startDayHour: 8,
+        endDayHour: 23,
+        indicatorTime: new Date(2017, 8, 6, 7, 45),
+        isVisible: false,
+        caseName: 'indicator time is earlier than startDayHour'
+    }].forEach(testCase => {
+        QUnit.test(`indicator visibility - ${testCase.caseName} `, function(assert) {
+            this.instance.option({
+                indicatorTime: testCase.indicatorTime,
+                startDayHour: testCase.startDayHour,
+                endDayHour: testCase.endDayHour
+            });
+
+            const $element = this.instance.$element();
+            assert.equal($element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS).length, testCase.isVisible ? 1 : 0, 'Indicator was rendered correctly');
+        });
+    });
+
+    QUnit.skip('DateTimeIndicator and shader should have correct positions, Week view with intervalCount, rtl mode', function(assert) {
         const workspace = $('#scheduler-work-space-rtl').dxSchedulerWorkSpaceWeek({
             showCurrentTimeIndicator: true,
             currentDate: new Date(2017, 8, 5),
@@ -875,16 +969,30 @@ QUnit.module('DateTime indicator on grouped Week View', moduleConfig, () => {
         this.instance.option({
             groups: [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }],
             groupByDate: true,
-            indicatorTime: new Date(2017, 8, 5, 12, 45)
+            indicatorTime: new Date(2017, 8, 5, 12, 0)
         });
 
         const $element = this.instance.$element();
-        const $indicator = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
-        const cellWidth = $element.find('.dx-scheduler-date-table-cell').eq(0).outerWidth();
+        const testCases = [
+            {
+                cellIndex: 116,
+                offset: {
+                    top: '0px',
+                    left: '0px'
+                },
+                isSimple: false
+            },
+            {
+                cellIndex: 117,
+                offset: {
+                    top: '0px',
+                    left: '0px'
+                },
+                isSimple: true
+            }
+        ];
 
-        assert.equal($indicator.length, 1, 'Indicator count is correct');
-        assert.roughEqual($indicator.eq(0).position().left, 256, 1.5, 'Indicator left is OK');
-        assert.roughEqual($indicator.outerWidth(), 2 * cellWidth, 1, 'Indicator has correct width');
+        testIndicators(testCases, $element, assert);
     });
 
     QUnit.test('Shader should have correct position and size, Week view with groupByDate = true', function(assert) {
@@ -995,6 +1103,53 @@ QUnit.module('DateTime indicator on grouped Week View', moduleConfig, () => {
 })('DateTime indicator on TimelineDay View');
 
 (function() {
+    QUnit.module('DateTime indicator on TimelineDay View, vertical grouping', {
+        beforeEach: function() {
+            this.instance = $('#scheduler-work-space').dxSchedulerTimelineDay({
+                showCurrentTimeIndicator: true,
+                currentDate: new Date(2017, 8, 5),
+                groupOrientation: 'vertical',
+                startDayHour: 10,
+                endDayHour: 18,
+                hoursInterval: 1,
+                height: 307
+            }).dxSchedulerTimelineDay('instance');
+            stubInvokeMethod(this.instance);
+        }
+    });
+
+    QUnit.test('DateTimeIndicator should be rendered correctly', function(assert) {
+        this.instance.option({
+            indicatorTime: new Date(2017, 8, 5, 12, 45)
+        });
+
+        this.instance.option('groups', [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]);
+
+        const $element = this.instance.$element();
+
+        const testCases = [
+            {
+                cellIndex: 2,
+                offset: {
+                    top: '0px',
+                    left: '150px'
+                },
+                isSimple: false
+            }, {
+                cellIndex: 10,
+                offset: {
+                    top: '0px',
+                    left: '150px'
+                },
+                isSimple: true
+            }
+        ];
+
+        testIndicators(testCases, $element, assert);
+    });
+})('DateTime indicator on TimelineDay View, vertical grouping');
+
+(function() {
     QUnit.module('DateTime indicator on TimelineDay View, horizontal grouping', {
         beforeEach: function() {
             this.instance = $('#scheduler-work-space').dxSchedulerTimelineDay({
@@ -1018,13 +1173,24 @@ QUnit.module('DateTime indicator on grouped Week View', moduleConfig, () => {
         this.instance.option('groups', [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]);
 
         const $element = this.instance.$element();
-        const $indicators = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
 
-        assert.equal($indicators.length, 2, 'Indicator count is correct');
-        assert.equal($indicators.eq(0).position().left, 950);
-        assert.equal($indicators.eq(0).position().top, 0);
-        assert.equal($indicators.eq(1).position().left, 2150);
-        assert.equal($indicators.eq(1).position().top, 0);
+        const testCases = [
+            {
+                cellIndex: 4,
+                offset: {
+                    top: '0px',
+                    left: '150px'
+                }
+            }, {
+                cellIndex: 10,
+                offset: {
+                    top: '0px',
+                    left: '150px'
+                }
+            }
+        ];
+
+        testIndicators(testCases, $element, assert);
     });
 
     [true, false].forEach(groupByDate => {
@@ -1057,15 +1223,24 @@ QUnit.module('DateTime indicator on grouped Week View', moduleConfig, () => {
         this.instance.option('groups', [{ name: 'a', items: [{ id: 1, text: 'a.1' }, { id: 2, text: 'a.2' }] }]);
 
         const $element = this.instance.$element();
-        const $indicators = $element.find('.' + SCHEDULER_DATE_TIME_INDICATOR_CLASS);
-        const cellWidth = $element.find('.dx-scheduler-date-table-cell').eq(0).outerWidth();
-        const indicationWidth = 50;
 
-        assert.equal($indicators.length, 2, 'Indicator count is correct');
-        assert.equal($indicators.eq(0).position().left, cellWidth * 2.5 + indicationWidth, 'First indicator left is Ok');
-        assert.equal($indicators.eq(0).position().top, 0);
-        assert.equal($indicators.eq(1).position().left, cellWidth * 3.5 + indicationWidth, 'Second indicator left is Ok');
-        assert.equal($indicators.eq(1).position().top, 0);
+        const testCases = [
+            {
+                cellIndex: 2,
+                offset: {
+                    top: '0px',
+                    left: '150px'
+                }
+            }, {
+                cellIndex: 3,
+                offset: {
+                    top: '0px',
+                    left: '150px'
+                }
+            }
+        ];
+
+        testIndicators(testCases, $element, assert);
     });
 
     QUnit.test('Shader should have correct height, width and position, groupByDate = true', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.workSpace.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.workSpace.tests.js
@@ -1475,7 +1475,7 @@ QUnit.test('Timepanel text should be calculated correctly if DST makes sense (T4
 });
 
 QUnit.test('DateTimeIndicator should show correct time in current time zone', function(assert) {
-    const currentDate = new Date(2018, 1, 4);
+    const currentDate = new Date(2021, 4, 26);
 
     this.createInstance({
         dataSource: [],
@@ -1485,15 +1485,17 @@ QUnit.test('DateTimeIndicator should show correct time in current time zone', fu
         startDayHour: 8,
         showCurrentTimeIndicator: true,
         currentDate: currentDate,
-        indicatorTime: new Date(2018, 1, 4, 9, 30),
+        timeZone: 'Europe/Moscow',
+        indicatorTime: new Date('2021-05-26T08:30:00.000Z'),
         height: 600
     });
-    const $initialIndicationCell = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(7);
+
+    const $initialIndicationCell = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(24);
     const indicatorPositionBefore = this.instance.$element().find('.dx-scheduler-date-time-indicator').position();
     assert.ok($initialIndicationCell.children().eq(0).hasClass('dx-scheduler-date-time-indicator'), 'Indicator was placed in a right cell');
 
     this.instance.option('timeZone', 'Asia/Yekaterinburg');
-    const $indicationCell = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(21);
+    const $indicationCell = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(38);
     const indicatorPositionAfter = this.instance.$element().find('.dx-scheduler-date-time-indicator').position();
 
     assert.equal(indicatorPositionAfter.top, indicatorPositionBefore.top, 'indicator has correct position');

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.workSpace.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.workSpace.tests.js
@@ -1482,21 +1482,22 @@ QUnit.test('DateTimeIndicator should show correct time in current time zone', fu
         views: ['week'],
         currentView: 'week',
         cellDuration: 60,
+        startDayHour: 8,
         showCurrentTimeIndicator: true,
         currentDate: currentDate,
         indicatorTime: new Date(2018, 1, 4, 9, 30),
         height: 600
     });
-
+    const $initialIndicationCell = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(7);
     const indicatorPositionBefore = this.instance.$element().find('.dx-scheduler-date-time-indicator').position();
-    const cellHeight = $(this.instance.$element()).find('.dx-scheduler-date-table td').eq(0).get(0).getBoundingClientRect().height;
+    assert.ok($initialIndicationCell.children().eq(0).hasClass('dx-scheduler-date-time-indicator'), 'Indicator was placed in a right cell');
 
     this.instance.option('timeZone', 'Asia/Yekaterinburg');
-
+    const $indicationCell = this.instance.$element().find('.dx-scheduler-date-table-cell').eq(21);
     const indicatorPositionAfter = this.instance.$element().find('.dx-scheduler-date-time-indicator').position();
-    const tzDiff = this.instance.fire('getClientTimezoneOffset', currentDate) / 3600000 + this.instance.fire('getTimezone');
 
-    assert.equal(indicatorPositionAfter.top, indicatorPositionBefore.top + cellHeight * tzDiff, 'indicator has correct position');
+    assert.equal(indicatorPositionAfter.top, indicatorPositionBefore.top, 'indicator has correct position');
+    assert.ok($indicationCell.children().eq(0).hasClass('dx-scheduler-date-time-indicator'), 'Indicator was placed in a right cell');
 });
 
 QUnit.test('Tables should take css class after width calculation(T491453)', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.scheduler/workSpace.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/workSpace.tests.js
@@ -1067,6 +1067,51 @@ QUnit.testStart(function() {
         assert.roughEqual($fourthGroupLastCell.position().top + $fourthGroupLastCell.get(0).getBoundingClientRect().height, this.instance.getVerticalMax(3), 1.1, 'Max top is OK');
     });
 
+    [{
+        date: new Date(2020, 11, 2, 12, 43),
+        groupIndex: 0,
+        cellStartDate: new Date(2020, 11, 2, 12, 30),
+        cellGroup: { one: 1 },
+        groupOrientation: 'vertical'
+    },
+    {
+        date: new Date(2020, 11, 2, 16, 25),
+        groupIndex: 1,
+        cellStartDate: new Date(2020, 11, 2, 16, 0),
+        cellGroup: { one: 2 },
+        groupOrientation: 'vertical'
+    },
+    {
+        date: new Date(2020, 11, 2, 10, 0),
+        groupIndex: 0,
+        cellStartDate: new Date(2020, 11, 2, 10, 0),
+        cellGroup: { one: 1 },
+        groupOrientation: 'horizontal'
+    },
+    {
+        date: new Date(2020, 11, 2, 16, 59),
+        groupIndex: 1,
+        cellStartDate: new Date(2020, 11, 2, 16, 30),
+        cellGroup: { one: 2 },
+        groupOrientation: 'horizontal'
+    }].forEach(testCase => {
+        QUnit.test(`the getCellByDate method should return correct cell from group -  ${testCase.groupIndex}, groupOrientation -  ${testCase.groupOrientation}`, function(assert) {
+            this.instance.option({
+                currentDate: new Date(2020, 11, 2),
+                groupOrientation: testCase.groupOrientation,
+                groups: [{
+                    name: 'one',
+                    items: [{ id: 1, text: 'a' }, { id: 2, text: 'b' }]
+                }]
+            });
+
+            const $cell = this.instance.getCellByDate(testCase.date, testCase.groupIndex);
+            const cellData = $cell.data('dxCellData');
+
+            assert.deepEqual(cellData.startDate, testCase.cellStartDate, 'returned cell has correct cellData.startDate');
+            assert.deepEqual(cellData.groups, testCase.cellGroup, 'returned cell has correct cellData.groups');
+        });
+    });
 })('Work Space Week');
 
 


### PR DESCRIPTION
place indicator into appropriate cell instead of calculating its table-relative position 

