### PR TITLE
Drawer - The Panel and View contents overlap each other when 'opened:false' in some circumstances for "openedStateMode: push" mode (T949163) (#15305)

### DIFF
--- a/js/ui/drawer/ui.drawer.rendering.strategy.js
+++ b/js/ui/drawer/ui.drawer.rendering.strategy.js
@@ -143,7 +143,8 @@ class DrawerStrategy {
         return false;
     }
 
-    onViewContentWrapperCreated() {}
+    onViewContentWrapperCreated($viewContentWrapper, panelPosition) {
+    }
 }
 
 export default DrawerStrategy;

--- a/js/ui/drawer/ui.drawer.rendering.strategy.push.js
+++ b/js/ui/drawer/ui.drawer.rendering.strategy.push.js
@@ -51,6 +51,10 @@ class PushStrategy extends DrawerStrategy {
             maxSize: this._getPanelSize(true)
         });
     }
+
+    onViewContentWrapperCreated($viewContentWrapper, panelPosition) {
+        $viewContentWrapper.addClass('dx-theme-background-color');
+    }
 }
 
 export default PushStrategy;

--- a/testing/helpers/drawerHelpers.js
+++ b/testing/helpers/drawerHelpers.js
@@ -121,6 +121,7 @@ const LeftDrawerTester = {
                 window.getComputedStyle(getTemplateParent(env.templateElement)).position === 'absolute' &&
                 window.getComputedStyle(env.viewElement.parentElement).transform.indexOf('matrix') >= 0,
                 'template element should be hidden, view element should be visible');
+            assert.ok(env.viewElement.parentElement.classList.contains('dx-theme-background-color'), 'view element should override panel element');
         }
         function checkShrink(assert, env) {
             if(env.revealMode === 'expand') {


### PR DESCRIPTION
(cherry picked from commit 9fc84fdaf88a524b59013044dda8ef28f49baf15)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
