### PR TITLE
Fix Deferred TS-declaration (T947959)

### DIFF
--- a/js/core/utils/deferred.d.ts
+++ b/js/core/utils/deferred.d.ts
@@ -26,17 +26,7 @@ export interface dxDeferred<T> {
     promise(target?: any): dxPromise<T>;
 }
 
-export class Deferred<T> implements dxDeferred<T> {
-    state(): string;
-    always(alwaysCallback?: dxPromiseCallback<T>): dxDeferred<T>;
-    done(doneCallback?: dxPromiseCallback<T>): dxDeferred<T>;
-    fail(failCallback?: dxPromiseCallback<T>): dxDeferred<T>;
-    progress(progressCallback?: dxPromiseCallback<T>): dxDeferred<T>;
-    notify(value?: any, ...args: any[]): dxDeferred<T>;
-    notifyWith(context: any, args?: any[]): dxDeferred<T>;
-    reject(value?: any, ...args: any[]): dxDeferred<T>;
-    rejectWith(context: any, args?: any[]): dxDeferred<T>;
-    resolve(value?: T, ...args: any[]): dxDeferred<T>;
-    resolveWith(context: any, args?: T[]): dxDeferred<T>;
-    promise(target?: any): dxPromise<T>;
-}
+/**
+ * @public
+ */
+export function Deferred<T>(): dxDeferred<T>;

--- a/js/core/utils/deferred.d.ts
+++ b/js/core/utils/deferred.d.ts
@@ -26,7 +26,4 @@ export interface dxDeferred<T> {
     promise(target?: any): dxPromise<T>;
 }
 
-/**
- * @public
- */
 export function Deferred<T>(): dxDeferred<T>;


### PR DESCRIPTION
* `Deferred` is declared as a class but implemented as a function (a factory).
* ~adding `@public` will remove the warning ([/core/utils/deferred.d.ts](https://unpkg.com/browse/devextreme@20.2.3/core/utils/deferred.d.ts), L43-45)~