### PR TITLE
Testing: Update to use qunit package

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "normalize-path": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "pre-commit": "^1.2.2",
-    "qunitjs": "^2.0.1",
+    "qunit": "^2.12.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-test-renderer": "^16.12.0",

--- a/testing/runner/Views/Main/RunSuite.cshtml
+++ b/testing/runner/Views/Main/RunSuite.cshtml
@@ -44,8 +44,8 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=@Model.IEMode">
     <title>@Model.Title - QUnit test page</title>
-    <link rel="stylesheet" href="@Url.ContentWithCacheBuster("~/node_modules/qunitjs/qunit/qunit.css")" />
-    <script src="@Url.ContentWithCacheBuster("~/node_modules/qunitjs/qunit/qunit.js")"></script>
+    <link rel="stylesheet" href="@Url.ContentWithCacheBuster("~/node_modules/qunit/qunit/qunit.css")" />
+    <script src="@Url.ContentWithCacheBuster("~/node_modules/qunit/qunit/qunit.js")"></script>
 
     <script>
         window.ROOT_URL = "@Url.Content("~/")";


### PR DESCRIPTION
The `qunitjs` package was deprecated since 2.4.1, in favour of the `qunit` package name. Apologies for the inconvenience!

Ref <https://qunitjs.com/intro/#package-name-prior-to-241>
Ref <https://github.com/qunitjs/qunit/blob/2.12.0/History.md>