### PR TITLE
DataGrid - Fixes checkbox overflow in a cell (T953436) (#15466)

### DIFF
--- a/scss/widgets/base/_gridBase.scss
+++ b/scss/widgets/base/_gridBase.scss
@@ -451,10 +451,6 @@
       }
 
       .dx-editor-cell {
-        &:not(.dx-command-select) {
-          overflow: visible;
-        }
-
         max-width: 0;
         padding: 0;
         vertical-align: middle;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -1378,6 +1378,31 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         // assert
         assert.strictEqual($($(dataGrid.$element()).find('.dx-error-row')).length, 0, 'no errors');
     });
+
+    QUnit.test('Edit cell content should not overflow a cell (T953436)', function(assert) {
+        // act
+        const dataGrid = createDataGrid({
+            dataSource: [{ id: 1, checked: true, name: 'name', description: 'description' }],
+            keyExpr: 'id',
+            selection: {
+                mode: 'multiple'
+            },
+            columns: ['checked', {
+                dataField: 'name',
+                showEditorAlways: true
+            }, 'description']
+        });
+
+        this.clock.tick();
+
+        const $dataCells = $(dataGrid.getRowElement(0)).find('td');
+
+        // assert
+        assert.equal($dataCells.length, 4, 'cells count');
+        $dataCells.each((_, cell) => {
+            assert.strictEqual($(cell).css('overflow'), 'hidden', 'overflow hidden');
+        });
+    });
 });
 
 QUnit.module('Editing', baseModuleConfig, () => {


### PR DESCRIPTION
Removed the overflow CSS property of an editable cell that is set to 'visible'.
