### PR TITLE
Detect iOS 13 desktop mode as Tablet

### DIFF
--- a/js/core/devices.js
+++ b/js/core/devices.js
@@ -53,6 +53,10 @@ const DEFAULT_DEVICE = {
 
 const uaParsers = {
     generic(userAgent) {
+        if(isIOS13DesktopMode()) {
+            return;
+        }
+
         const isPhone = /windows phone/i.test(userAgent) || userAgent.match(/WPDesktop/);
         const isTablet = !isPhone && /Windows(.*)arm(.*)Tablet PC/i.test(userAgent);
         const isDesktop = !isPhone && !isTablet && /msapphost/i.test(userAgent);
@@ -72,7 +76,7 @@ const uaParsers = {
     },
 
     ios(userAgent) {
-        if(!/ip(hone|od|ad)/i.test(userAgent)) {
+        if(!/ip(hone|od|ad)/i.test(userAgent) && !isIOS13DesktopMode()) {
             return;
         }
 
@@ -109,6 +113,11 @@ const uaParsers = {
         };
     }
 };
+
+function isIOS13DesktopMode() {
+    // https://stackoverflow.com/a/58064481
+    return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+}
 
 class Devices {
     /**


### PR DESCRIPTION
[To discuss]

Starting with iOS 13, iPad uses Desktop mode by default:
- https://developer.apple.com/forums/thread/122189#613198022
- https://stackoverflow.com/q/58019463

Before patch: 
![Photo Dec 01, 10 10 44 AM](https://user-images.githubusercontent.com/4426185/100713347-3bd01a80-33c5-11eb-8bd2-62024e448667.png)

After patch:
![Photo Dec 01, 10 54 15 AM](https://user-images.githubusercontent.com/4426185/100713378-44285580-33c5-11eb-9429-58b5c571b903.png)
