### PR TITLE
DataGrid: Fix error occurs on an attempt to set focusedRowKey to null in the customLoad callback when the focusedRowIndex value is specified (T957592)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -330,7 +330,7 @@ const FocusController = core.ViewController.inherit((function() {
                 that._clearPreviousFocusedRow($tableElement, focusedRowIndex);
 
                 that._prepareFocusedRow({
-                    changedItem: change.items[focusedRowIndex],
+                    changedItem: change?.items?.[focusedRowIndex],
                     $tableElement: $tableElement,
                     focusedRowIndex: focusedRowIndex,
                     isMainTable: isMainTable

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.integration.tests.js
@@ -412,4 +412,33 @@ QUnit.module('State storing', baseModuleConfig, () => {
         const rows = dataGrid.getVisibleRows();
         assert.equal(rows.length, 1, 'row was added');
     });
+
+    // T957592
+    QUnit.test('No exceptions on an attempt to set focusedRowKey to null in the customLoad callback when the focusedRowIndex value is specified', function(assert) {
+        // arrange, act
+        try {
+            const dataGrid = createDataGrid({
+                dataSource: [{ id: 1 }, { id: 2 }, { id: 3 }],
+                keyExpr: 'id',
+                focusedRowEnabled: true,
+                focusedRowIndex: 0,
+                stateStoring: {
+                    enabled: true,
+                    type: 'custom',
+                    customLoad: function() {
+                        return { focusedRowKey: null };
+                    },
+                    customSave: function() {
+                    }
+                },
+                loadingTimeout: null
+            });
+            this.clock.tick();
+
+            assert.strictEqual(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
+            assert.strictEqual(dataGrid.option('focusedRowKey'), null, 'focusedRowKey');
+        } catch(e) {
+            assert.ok(false, 'the error is thrown');
+        }
+    });
 });


### PR DESCRIPTION
See https://devexpress.com/issue=T957592