### PR TITLE
SelectBox: it should be possible to focus out editor when fieldTemplate is used and acceptCustomValue=true (T957627) (#15722)

### DIFF
--- a/js/ui/select_box.js
+++ b/js/ui/select_box.js
@@ -554,6 +554,7 @@ const SelectBox = DropDownList.inherit({
             }
         }
 
+        e.target = this._input().get(0);
         this.callBase(e);
     },
 

--- a/testing/testcafe/tests/editors/pages/selectBoxWithActionButton.html
+++ b/testing/testcafe/tests/editors/pages/selectBoxWithActionButton.html
@@ -16,14 +16,12 @@
             $(function(){
                 const editor = $('#editor').dxSelectBox({
                     items: ["item1", "item2"],
-                    fieldTemplate: (value) => $("<div>").dxTextBox({ value }),
                     buttons: [{
                         name: "test",
                         options: {
                             icon: "home",
                             onClick: () => {
                                 editor.option("value", "item2");
-                                editor.focus(); // NOTE: need because of editor input rerendering
                             }
                         }
                     }]

--- a/testing/testcafe/tests/editors/selectBox.ts
+++ b/testing/testcafe/tests/editors/selectBox.ts
@@ -66,3 +66,23 @@ test('SelectBox should correctly render his buttons when editor rendered as Tool
     .expect(actionButton.getText().innerText)
     .eql('test');
 });
+
+fixture`SelectBox with action button`
+  .page(url(__dirname, './pages/selectBoxWithActionButton.html'));
+
+test('editor can be focused out after click on action button', async (t) => {
+  const selectBox = new SelectBox('#editor');
+
+  await pureClick(t, selectBox);
+  await t
+    .expect(selectBox.isFocused).ok();
+
+  const actionButton = await selectBox.getButton(0);
+  await pureClick(t, actionButton);
+  await t
+    .expect(selectBox.isFocused).ok();
+
+  await purePressKey(t, 'tab');
+  await t
+    .expect(selectBox.isFocused).notOk();
+});

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -2000,6 +2000,21 @@ QUnit.module('editing', moduleSetup, () => {
         $selectBox.dxSelectBox('blur');
     });
 
+    QUnit.test('editor can be focused out when fieldTemplate is used and acceptCustomValue is true (T957627) ', function(assert) {
+        const $selectBox = $('#selectBox').dxSelectBox({
+            acceptCustomValue: true,
+            fieldTemplate: (data, elem) => {
+                $('<div>').appendTo(elem).dxTextBox();
+            },
+        });
+        const instance = $selectBox.dxSelectBox('instance');
+
+        instance.focus();
+        instance.blur();
+
+        assert.notOk($selectBox.hasClass(STATE_FOCUSED_CLASS), 'editor is focused out');
+    });
+
     QUnit.testInActiveWindow('input value should be restored on focusout if clearing is manually prevented', function(assert) {
         const $selectBox = $('#selectBox').dxSelectBox({
             searchEnabled: true,


### PR DESCRIPTION
…
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
