### PR TITLE
dxForm - Fix incorrectly validation message displaying for drop down editor if labels are located at the top in Material theme (T956436)

### DIFF
--- a/scss/widgets/material/form/_index.scss
+++ b/scss/widgets/material/form/_index.scss
@@ -67,7 +67,7 @@
     vertical-align: middle;
   }
 
-  .dx-label-v-align & {
+  &.dx-label-v-align {
     .dx-textarea {
       margin-top: 6px;
     }

--- a/testing/tests/DevExpress.ui.widgets.form/form.materialTheme.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/form.materialTheme.tests.js
@@ -522,3 +522,39 @@ QUnit.module('dx-invalid class on dx-field-item-content-wrapper (T949269)', {
         assert.ok(wrapper.hasClass(invalidClass));
     });
 });
+
+QUnit.module('check validation message location', {
+    beforeEach: function() {
+        this.clock = sinon.useFakeTimers();
+    },
+    afterEach: function() {
+        this.clock.restore();
+    }
+}, function() {
+    QUnit.testInActiveWindow('validation message fix at bottom of drop down editor if form labels have top location (T956436)', function(assert) {
+        $('#form').dxForm({
+            items: [{
+                dataField: 'Country',
+                editorType: 'dxSelectBox',
+                editorOptions: {
+                    dataSource: ['Afghanistan', 'Albania', 'Algeria']
+                },
+                validationRules: [{
+                    type: 'required',
+                    message: 'Country is required'
+                }]
+            }]
+        })
+            .dxForm('instance')
+            .validate();
+
+        const $editorElement = $('.dx-selectbox');
+        const invalidMessage = $editorElement.find('.dx-invalid-message')[0];
+
+        $editorElement.dxSelectBox('instance').focus();
+        this.clock.tick();
+
+        assert.equal($(invalidMessage).find('.dx-overlay-wrapper').css('transform'), 'matrix(1, 0, 0, 1, 0, 0)', 'change validation overlay wrapper style to fix message at bottom');
+        assert.equal($(invalidMessage).find('.dx-overlay-content').css('transform'), 'matrix(1, 0, 0, 1, 0, 0)', 'change validation overlay content style to fix message at bottom');
+    });
+});


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
