### PR TITLE
Fix incorrect max boundary of the DateBox hour editor (T948979) (#15825)

### DIFF
--- a/js/ui/date_box/ui.time_view.js
+++ b/js/ui/date_box/ui.time_view.js
@@ -155,7 +155,7 @@ const TimeView = Editor.inherit({
     _renderField: function() {
         const is12HourFormat = !this.option('use24HourFormat');
 
-        this._createHourBox();
+        this._createHourBox(is12HourFormat);
         this._createMinuteBox();
 
         if(is12HourFormat) {
@@ -170,10 +170,10 @@ const TimeView = Editor.inherit({
         }).$element();
     },
 
-    _createHourBox: function() {
+    _createHourBox: function(is12HourFormat) {
         const editor = this._hourBox = this._createComponent($('<div>'), NumberBox, extend({
             min: -1,
-            max: 24,
+            max: is12HourFormat ? 12 : 24,
             value: this._getValue().getHours(),
             onValueChanged: this._onHourBoxValueChanged.bind(this),
             onKeyboardHandled: opts => this._keyboardHandler(opts)

--- a/testing/tests/DevExpress.ui.widgets.editors/timeView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/timeView.tests.js
@@ -440,18 +440,67 @@ QUnit.module('12 hours format', () => {
 });
 
 QUnit.module('format rendering', () => {
-    QUnit.test('minute numberbox should have min/max constraints', function(assert) {
-        const $element = $('#timeView').dxTimeView(); const minuteNumberBox = $element.find('.' + NUMBERBOX_CLASS).eq(1).dxNumberBox('instance');
+    [false, true].forEach((use24HourFormat) => {
+        QUnit.test(`minute numberbox should have min/max constraints, use24HourFormat=${use24HourFormat}`, function(assert) {
+            const $element = $('#timeView').dxTimeView({ use24HourFormat });
+            const minuteNumberBox = $element.find(`.${NUMBERBOX_CLASS}`).eq(1).dxNumberBox('instance');
 
-        assert.equal(minuteNumberBox.option('min'), -1, 'min constraint set');
-        assert.equal(minuteNumberBox.option('max'), 60, 'max constraint set');
-    });
+            assert.equal(minuteNumberBox.option('min'), -1, 'min constraint set');
+            assert.equal(minuteNumberBox.option('max'), 60, 'max constraint set');
+        });
 
-    QUnit.test('hour numberbox should have min/max constraints', function(assert) {
-        const $element = $('#timeView').dxTimeView(); const hourNumberBox = $element.find('.' + NUMBERBOX_CLASS).eq(0).dxNumberBox('instance');
+        QUnit.test(`minute numberbox should have min/max constraints, use24HourFormat changed from ${use24HourFormat} to ${!use24HourFormat}`, function(assert) {
+            const $element = $('#timeView').dxTimeView({ use24HourFormat });
+            const timeView = $element.dxTimeView('instance');
+            const newUse24HourFormatValue = !use24HourFormat;
 
-        assert.equal(hourNumberBox.option('min'), -1, 'min constraint set');
-        assert.equal(hourNumberBox.option('max'), 24, 'max constraint set');
+            timeView.option('use24HourFormat', newUse24HourFormatValue);
+            const minuteNumberBox = $element.find(`.${NUMBERBOX_CLASS}`).eq(1).dxNumberBox('instance');
+
+            assert.equal(minuteNumberBox.option('min'), -1, 'min constraint set');
+            assert.equal(minuteNumberBox.option('max'), 60, 'max constraint set');
+        });
+
+        QUnit.test(`hour numberbox should have min/max constraints, use24HourFormat=${use24HourFormat}`, function(assert) {
+            const $element = $('#timeView').dxTimeView({ use24HourFormat });
+            const hourNumberBox = $element.find(`.${NUMBERBOX_CLASS}`).eq(0).dxNumberBox('instance');
+            const expectedMaxValue = use24HourFormat ? 24 : 12;
+
+            assert.equal(hourNumberBox.option('min'), -1, 'min constraint set');
+            assert.equal(hourNumberBox.option('max'), expectedMaxValue, 'max constraint set');
+        });
+
+        QUnit.test(`hour numberbox should have min/max constraints, use24HourFormat changed from ${use24HourFormat} to ${!use24HourFormat}`, function(assert) {
+            const $element = $('#timeView').dxTimeView({ use24HourFormat });
+            const timeView = $element.dxTimeView('instance');
+            const newUse24HourFormatValue = !use24HourFormat;
+            const expectedMaxValue = newUse24HourFormatValue ? 24 : 12;
+
+            timeView.option('use24HourFormat', newUse24HourFormatValue);
+            const hourNumberBox = $element.find(`.${NUMBERBOX_CLASS}`).eq(0).dxNumberBox('instance');
+
+            assert.equal(hourNumberBox.option('min'), -1, 'min constraint set');
+            assert.equal(hourNumberBox.option('max'), expectedMaxValue, 'max constraint set');
+        });
+
+        [
+            new Date(2000, 1, 1, 5, 15),
+            new Date(2000, 1, 1, 15, 15),
+            new Date(2000, 1, 1, 0, 15)
+        ].forEach((value) => {
+            QUnit.test(`hour numberbox should have correct initial value, use24HourFormat=${use24HourFormat}, initial hour value=${value.getHours()}`, function(assert) {
+                const $element = $('#timeView').dxTimeView({ use24HourFormat, value });
+                const hourNumberBox = $element.find(`.${NUMBERBOX_CLASS}`).eq(0).dxNumberBox('instance');
+                const maxHourValue = use24HourFormat ? 24 : 12;
+                let expectedValue = value.getHours() % maxHourValue;
+
+                if(!use24HourFormat && expectedValue === 0) {
+                    expectedValue = 12; // 12AM
+                }
+
+                assert.equal(hourNumberBox.option('value'), expectedValue, 'correct value');
+            });
+        });
     });
 });
 


### PR DESCRIPTION
(cherry picked from commit f2a2125b861e3b6caeb4b5103c789a8239b55a79)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
