### PR TITLE
TextEditor input should be focused even after focus from inner button move (T963822) (#16001)

### DIFF
--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -583,6 +583,10 @@ const TextEditorBase = Editor.inherit({
         return this.element();
     },
 
+    _isInput: function(element) {
+        return element === this._input().get(0);
+    },
+
     _preventNestedFocusEvent: function(event) {
         if(event.isDefaultPrevented()) {
             return true;
@@ -591,7 +595,7 @@ const TextEditorBase = Editor.inherit({
         let result = this._isNestedTarget(event.relatedTarget);
 
         if(event.type === 'focusin') {
-            result = result && this._isNestedTarget(event.target);
+            result = result && this._isNestedTarget(event.target) && !this._isInput(event.target);
         }
 
         result && event.preventDefault();

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/common.tests.js
@@ -341,6 +341,25 @@ QUnit.module('general', {}, () => {
         assert.strictEqual(blurStub.callCount, 0, 'FocusOut event has not been triggered');
     });
 
+    QUnit.testInActiveWindow('input should be focused even after focus from inner button move (T963822)', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            buttons: [{
+                name: 'test',
+                options: {
+                    icon: 'home'
+                }
+            }]
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+        const actionButton = textEditor.getButton('test');
+
+        actionButton.focus();
+        assert.notOk($textEditor.hasClass(STATE_FOCUSED_CLASS), 'input is not focused');
+
+        textEditor.focus();
+        assert.ok($textEditor.hasClass(STATE_FOCUSED_CLASS), 'input is focused');
+    });
+
     QUnit.test('TextEditor should pass integration options to the nested buttons (T894344)', function(assert) {
         const text = 'my template';
         const editor = $('#texteditor').dxTextEditor({


### PR DESCRIPTION
… 

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
