### PR TITLE
SelectBox: search should be canceled after item selecting even if minSearchLength is specified (T943466)

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -2773,6 +2773,17 @@ QUnit.module('search', moduleSetup, () => {
                 assert.strictEqual(this.getListItems().length, this.items.length, 'search was canceled');
             });
 
+            QUnit.test(`item selecting when minSearchLength is specified and acceptCustomValue=${acceptCustomValue}(T943466)`, function(assert) {
+                this.reinit({ acceptCustomValue, items: [1, 11, 111], minSearchLength: 2 });
+
+                this.keyboard.type('11');
+                const $listItems = this.getListItems();
+                $listItems.eq(0).trigger('dxclick');
+
+                this.instance.open();
+                assert.strictEqual(this.getListItems().length, this.items.length, 'search was canceled');
+            });
+
             QUnit.test(`click outside of popup if acceptCustomValue=${acceptCustomValue}`, function(assert) {
                 this.reinit({ acceptCustomValue });
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
