### PR TITLE
DataGrid - Fixes virtual row rendering on changing data source (T966221) (#16133)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -837,7 +837,8 @@ export default {
                             return;
                         }
 
-                        that._rowPageIndex = Math.ceil(that.pageIndex() * that.pageSize() / that.getRowPageSize());
+                        const pageIndex = that.pageIndex() >= that.pageCount() ? that.pageCount() - 1 : that.pageIndex();
+                        that._rowPageIndex = Math.ceil(pageIndex * that.pageSize() / that.getRowPageSize());
 
                         that._visibleItems = [];
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -3045,6 +3045,42 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             });
         });
     });
+
+    QUnit.test('DataGrid should not display virtual rows on data source changing when rowRenderingMode is set to \'virtual\' (T966221)', function(assert) {
+        // arrange
+        const generateDataSource = function(count) {
+            const result = [];
+            for(let i = 0; i < count; ++i) {
+                result.push({ id: i + 1, name: `Name ${i + 1}` });
+            }
+            return result;
+        };
+        const dataSource1 = generateDataSource(40);
+        const dataGrid = createDataGrid({
+            height: 500,
+            dataSource: dataSource1,
+            keyExpr: 'id',
+            scrolling: {
+                rowRenderingMode: 'virtual'
+            },
+        });
+
+        this.clock.tick();
+
+        // act
+        dataGrid.pageIndex(1);
+        this.clock.tick();
+        const dataSource2 = generateDataSource(18);
+        dataGrid.option('dataSource', dataSource2);
+        this.clock.tick(300);
+        const $gridElement = $(dataGrid.element());
+        const $virtualRows = $gridElement.find('.dx-datagrid-rowsview .dx-row.dx-virtual-row');
+        const $renderedRows = $gridElement.find('.dx-datagrid-rowsview .dx-row.dx-data-row');
+
+        // assert
+        assert.equal($renderedRows.length, 18, 'rendered data rows');
+        assert.equal($virtualRows.length, 0, 'no virtual rows');
+    });
 });
 
 


### PR DESCRIPTION
Resets the DataController._rowPageIndex option when data source is changed.