### PR TITLE
Makes DataGrid load several pages at once on virtual scrolling

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -643,7 +643,7 @@ export default gridCore.Controller.inherit((function() {
                             d.resolve(data, loadResult.extra);
                         }).fail(d.reject);
                     }).fail(d.reject);
-                }, that.option('loadingTimeout'));
+                }, options.sync ? undefined : that.option('loadingTimeout'));
 
                 return d.fail(function() {
                     that._eventsStrategy.fireEvent('loadError', arguments);

--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -643,7 +643,7 @@ export default gridCore.Controller.inherit((function() {
                             d.resolve(data, loadResult.extra);
                         }).fail(d.reject);
                     }).fail(d.reject);
-                }, options.sync ? undefined : that.option('loadingTimeout'));
+                }, that.option('loadingTimeout'));
 
                 return d.fail(function() {
                     that._eventsStrategy.fireEvent('loadError', arguments);

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -145,7 +145,7 @@ const VirtualScrollingDataSourceAdapterExtender = (function() {
             });
         },
         _handleLoadingChanged: function(isLoading) {
-            if(!isVirtualMode(this) || this._isLoadingAll/* || this.option(NEW_SCROLLING_MODE)*/) {
+            if(!isVirtualMode(this) || this._isLoadingAll) {
                 this._isLoading = isLoading;
                 this.callBase.apply(this, arguments);
             }

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -1,11 +1,9 @@
 import $ from '../../core/renderer';
 import { getWindow } from '../../core/utils/window';
-import { deferUpdate, deferRender } from '../../core/utils/common';
 import { VirtualScrollController, subscribeToExternalScrollers } from './ui.grid_core.virtual_scrolling_core';
 import gridCoreUtils from './ui.grid_core.utils';
 import { each } from '../../core/utils/iterator';
 import { Deferred } from '../../core/utils/deferred';
-import { move } from '../../animation/translator';
 import LoadIndicator from '../load_indicator';
 import browser from '../../core/utils/browser';
 import { getBoundingRect } from '../../core/utils/position';
@@ -502,48 +500,6 @@ const VirtualScrollingRowsViewExtender = (function() {
                     this._addVirtualRow($(element), isFixed, 'top', top);
                     this._addVirtualRow($(element), isFixed, 'bottom', bottom);
                     this._isFixedTableRendering = false;
-                });
-            } else {
-                deferUpdate(() => {
-                    this._updateContentPositionCore();
-                });
-            }
-        },
-
-        _updateContentPositionCore: function() {
-            const that = this;
-            let contentHeight;
-            let $tables;
-            let $contentTable;
-            const rowHeight = that._rowHeight || 20;
-            const virtualItemsCount = that._dataController.virtualItemsCount();
-
-            if(virtualItemsCount) {
-                const contentElement = that._findContentElement();
-                $tables = contentElement.children();
-                $contentTable = $tables.eq(0);
-                const virtualTable = $tables.eq(1);
-
-                that._contentTableHeight = $contentTable[0].offsetHeight;
-
-                that._dataController.viewportItemSize(rowHeight);
-                that._dataController.setContentSize(that._contentTableHeight);
-
-                contentHeight = that._dataController.getVirtualContentSize();
-                const top = that._dataController.getContentOffset();
-
-                deferRender(function() {
-                    move($contentTable, { left: 0, top: top });
-
-                    // TODO jsdmitry: Separate this functionality on render and resize
-                    const isRenderVirtualTableContentRequired = that._contentHeight !== contentHeight || contentHeight === 0 ||
-                        !that._isTableLinesDisplaysCorrect(virtualTable) ||
-                        !that._isColumnElementsEqual($contentTable.find('col'), virtualTable.find('col'));
-
-                    if(isRenderVirtualTableContentRequired) {
-                        that._contentHeight = contentHeight;
-                        that._renderVirtualTableContent(virtualTable, contentHeight);
-                    }
                 });
             }
         },

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -262,7 +262,7 @@ const VirtualScrollingDataSourceAdapterExtender = (function() {
         'virtualItemsCount',
         'getContentOffset',
         'getVirtualContentSize',
-        'setContentSize', 'setViewportPosition',
+        'setContentItemSizes', 'setViewportPosition',
         'getViewportItemIndex', 'setViewportItemIndex', 'getItemIndexByPosition',
         'viewportSize', 'viewportItemSize', 'getItemSize', 'getItemSizes',
         'pageIndex', 'beginPageIndex', 'endPageIndex',
@@ -485,7 +485,7 @@ const VirtualScrollingRowsViewExtender = (function() {
                 if(!isRender) {
                     const rowHeights = this._getRowHeights();
                     const correctedRowHeights = this._correctRowHeights(rowHeights);
-                    dataController.setContentSize(correctedRowHeights);
+                    dataController.setContentItemSizes(correctedRowHeights);
                 }
                 const top = dataController.getContentOffset('begin');
                 const bottom = dataController.getContentOffset('end');
@@ -1009,14 +1009,14 @@ export default {
                             dataSource?.setViewportPosition.apply(dataSource, arguments);
                         }
                     },
-                    setContentSize: function(sizes) {
+                    setContentItemSizes: function(sizes) {
                         const rowsScrollController = this._rowsScrollController;
 
 
-                        rowsScrollController && rowsScrollController.setContentSize(sizes);
+                        rowsScrollController && rowsScrollController.setContentItemSizes(sizes);
 
                         const dataSource = this._dataSource;
-                        return dataSource && dataSource.setContentSize(sizes);
+                        return dataSource && dataSource.setContentItemSizes(sizes);
                     },
                     loadIfNeed: function() {
                         const rowsScrollController = this._rowsScrollController;

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling_core.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling_core.js
@@ -304,7 +304,8 @@ export const VirtualScrollController = Class.inherit((function() {
 
             this._viewportSize = 0;
             this._viewportItemSize = 20;
-            this._viewportItemIndex = -1;
+            this._viewportItemIndex = 0;
+            this._contentSize = 0;
             this._itemSizes = {};
             this._sizeRatio = 1;
             this._items = [];
@@ -407,22 +408,16 @@ export const VirtualScrollController = Class.inherit((function() {
             return result;
         },
 
-        setContentSize: function(size) {
-            const sizes = Array.isArray(size) && size;
+        setContentItemSizes: function(sizes) {
             const virtualItemsCount = this.virtualItemsCount();
 
-            if(sizes) {
-                size = sizes.reduce((a, b) => a + b, 0);
-            }
-
-            this._contentSize = size;
+            this._contentSize = sizes.reduce((a, b) => a + b, 0);
 
             if(virtualItemsCount) {
-                if(sizes) {
-                    sizes.forEach((size, index) => {
-                        this._itemSizes[virtualItemsCount.begin + index] = size;
-                    });
-                }
+                sizes.forEach((size, index) => {
+                    this._itemSizes[virtualItemsCount.begin + index] = size;
+                });
+
                 const virtualContentSize = (virtualItemsCount.begin + virtualItemsCount.end + this.itemsCount()) * this._viewportItemSize;
                 const contentHeightLimit = getContentHeightLimit(browser);
                 if(virtualContentSize > contentHeightLimit) {

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling_core.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling_core.js
@@ -327,10 +327,10 @@ export const VirtualScrollController = Class.inherit((function() {
             if(isVirtualMode(this)) {
                 const totalItemsCount = this._dataSource.totalItemsCount();
                 if(this.option(NEW_SCROLLING_MODE) && totalItemsCount !== -1) {
-                    const loadParams = this.getVisibleItemParams();
-                    const endItemsCount = totalItemsCount - (loadParams.skip + loadParams.take);
+                    const viewportParams = this.getViewportParams();
+                    const endItemsCount = totalItemsCount - (viewportParams.skip + viewportParams.take);
                     return {
-                        begin: loadParams.skip,
+                        begin: viewportParams.skip,
                         end: endItemsCount
                     };
                 }
@@ -513,7 +513,7 @@ export const VirtualScrollController = Class.inherit((function() {
             return this._viewportSize;
         },
         pageIndex: function(pageIndex) {
-            if(isVirtualMode(this) || isAppendMode(this)) {
+            if(!this.option(NEW_SCROLLING_MODE) && (isVirtualMode(this) || isAppendMode(this))) {
                 if(pageIndex !== undefined) {
                     this._pageIndex = pageIndex;
                 }
@@ -679,7 +679,7 @@ export const VirtualScrollController = Class.inherit((function() {
         },
 
         // new mode
-        getVisibleItemParams: function() {
+        getViewportParams: function() {
             const skip = Math.floor(this._viewportItemIndex);
             let take = this._viewportSize + 1;
             if(isVirtualMode(this)) {
@@ -691,6 +691,6 @@ export const VirtualScrollController = Class.inherit((function() {
                 skip,
                 take
             };
-        },
+        }
     };
 })());

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling_core.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling_core.js
@@ -540,7 +540,7 @@ export const VirtualScrollController = Class.inherit((function() {
             const dataSource = this._dataSource;
             let result;
 
-            if(isVirtualMode(this) || isAppendMode(this)) {
+            if(!this.option(NEW_SCROLLING_MODE) && (isVirtualMode(this) || isAppendMode(this))) {
                 const pageIndexForLoad = getPageIndexForLoad(this);
 
                 if(pageIndexForLoad >= 0) {
@@ -588,7 +588,7 @@ export const VirtualScrollController = Class.inherit((function() {
 
             if(e && e.changes) {
                 fireChanged(this, callBase, e);
-            } else if(isVirtualMode(this) || isAppendMode(this)) {
+            } else if(!this.option(NEW_SCROLLING_MODE) && (isVirtualMode(this) || isAppendMode(this))) {
                 const beginPageIndex = getBeginPageIndex(this);
                 if(beginPageIndex >= 0) {
                     if(isVirtualMode(this) && beginPageIndex + this._cache.length !== dataSource.pageIndex() && beginPageIndex - 1 !== dataSource.pageIndex()) {

--- a/js/ui/pivot_grid/ui.pivot_grid.data_controller.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.data_controller.js
@@ -880,11 +880,11 @@ export const DataController = Class.inherit((function() {
             if(rowsScrollController && columnsScrollController) {
                 rowsScrollController.viewportItemSize(contentParams.virtualRowHeight);
                 rowsScrollController.viewportSize(contentParams.viewportHeight / rowsScrollController.viewportItemSize());
-                rowsScrollController.setContentSize(contentParams.itemHeights);
+                rowsScrollController.setContentItemSizes(contentParams.itemHeights);
 
                 columnsScrollController.viewportItemSize(contentParams.virtualColumnWidth);
                 columnsScrollController.viewportSize(contentParams.viewportWidth / columnsScrollController.viewportItemSize());
-                columnsScrollController.setContentSize(contentParams.itemWidths);
+                columnsScrollController.setContentItemSizes(contentParams.itemWidths);
 
                 deferUpdate(function() {
                     columnsScrollController.loadIfNeed();

--- a/testing/helpers/gridBaseMocks.js
+++ b/testing/helpers/gridBaseMocks.js
@@ -153,7 +153,7 @@ module.exports = function($, gridCore, columnResizingReordering, domUtils, commo
 
             viewportItemSize: function() {},
 
-            setContentSize: function() {},
+            setContentItemSizes: function() {},
 
             setViewportItemIndex: function(index) {
                 options.viewportItemIndex = index;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -4820,6 +4820,49 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
         assert.equal(items[pageSize].dataIndex, 1);
     });
 
+    QUnit.test('New mode. Load params are synchronized after scrolling', function(assert) {
+        // arrange
+        const getData = function(count) {
+            const items = [];
+            for(let i = 0; i < count; i++) {
+                items.push({
+                    id: i + 1,
+                    name: `Name ${i + 1}`
+                });
+            }
+            return items;
+        };
+        this.applyOptions({
+            scrolling: {
+                newMode: true,
+                rowRenderingMode: 'virtual',
+                rowPageSize: 5
+            }
+        });
+        this.dataController.init();
+        this.setupDataSource({
+            data: getData(200),
+            pageSize: 10
+        });
+
+        // act
+        this.dataController.viewportSize(15);
+
+        // assert
+        assert.strictEqual(this.dataController.dataSource().loadPageCount(), 1, 'initial load page count');
+        assert.strictEqual(this.dataController.items().length, 10, 'initial loaded items count');
+
+        // act
+        this.dataController.setViewportPosition(500);
+        this.clock.tick();
+
+        // assert
+        assert.deepEqual(this.dataController.getLoadPageParams(), { pageIndex: 2, loadPageCount: 3, skipForCurrentPage: 5 }, 'load page params after scrolling');
+        assert.deepEqual(this.dataController.pageIndex(), 2, 'page index after scrolling');
+        assert.strictEqual(this.dataController.dataSource().loadPageCount(), 3, 'load page count after scrolling');
+        assert.deepEqual(this.dataController.items()[0].data, { id: 21, name: 'Name 21' }, 'first loaded item');
+        assert.deepEqual(this.dataController.items()[29].data, { id: 50, name: 'Name 50' }, 'last loaded item');
+    });
 });
 
 QUnit.module('Infinite scrolling', {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataSource.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataSource.tests.js
@@ -441,7 +441,7 @@ QUnit.module('Grid DataSource', {
     });
 
     QUnit.test('groupingHelper when remoteOperations is auto and ArrayStore', function(assert) {
-    // act
+        // act
         const dataSource = createDataSource({
             store: TEN_NUMBERS,
             remoteOperations: 'auto'
@@ -452,7 +452,7 @@ QUnit.module('Grid DataSource', {
     });
 
     QUnit.test('groupingHelper when remoteOperations is auto and CustomStore', function(assert) {
-    // act
+        // act
         const dataSource = createDataSource({
             load: function() { },
             remoteOperations: 'auto'
@@ -463,7 +463,7 @@ QUnit.module('Grid DataSource', {
     });
 
     QUnit.test('groupingHelper when remoteOperations is auto and ODataStore', function(assert) {
-    // act
+        // act
         const dataSource = createDataSource({
             store: {
                 type: 'odata',
@@ -536,7 +536,7 @@ QUnit.module('Grid DataSource', {
 
     // T474591
     QUnit.test('No error when store returned non-array', function(assert) {
-    // arrange
+        // arrange
         const source = createDataSource({
             load: function() {
                 return $.Deferred().resolve({ /* no data property */ });
@@ -551,7 +551,7 @@ QUnit.module('Grid DataSource', {
     });
 
     QUnit.test('createOffsetFilter should generate filters with =/<> filter operations for boolean values', function(assert) {
-    // arrange
+        // arrange
 
         const booleanValues = [null, false, true];
         const descValues = [false, true];
@@ -579,7 +579,7 @@ QUnit.module('Grid DataSource', {
     });
 
     QUnit.test('Custom store with remote paging and with local filtering', function(assert) {
-    // arrange
+        // arrange
         let loadArgs = [];
         const source = createDataSource({
             remoteOperations: { paging: true },
@@ -615,7 +615,7 @@ QUnit.module('Grid DataSource', {
 
     // T748688
     QUnit.test('Custom store with remote paging and with local sorting', function(assert) {
-    // arrange
+        // arrange
         let loadArgs = [];
         const source = createDataSource({
             remoteOperations: { paging: true },
@@ -1119,7 +1119,7 @@ QUnit.module('Grouping with basic remoteOperations', {
         // act
         source.load();
         source.changed.add(function() {
-        // assert
+            // assert
             assert.equal(source.itemsCount(), 3);
             assert.deepEqual(source.items(), [{
                 key: 1, items: null,
@@ -1956,7 +1956,7 @@ QUnit.module('Grouping with basic remoteOperations', {
 
     // T545211
     QUnit.test('Ungrouping with custom store - there are no exceptions when remote paging', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const dataSource = createDataSource({
             load: function() {
@@ -1974,14 +1974,14 @@ QUnit.module('Grouping with basic remoteOperations', {
         dataSource.load();
 
         try {
-        // act
+            // act
             dataSource.group(null);
             dataSource.load();
 
             // assert
             assert.ok(true, 'There are no exceptions');
         } catch(error) {
-        // assert
+            // assert
             assert.ok(false, 'exception was threw:' + error);
         }
     });
@@ -2556,7 +2556,7 @@ QUnit.module('Grouping with basic remoteOperations. Second level', {
 
     // T307341
     QUnit.test('Update group offset for expanded grouped row of the first level when change sortOrder of the first level group field', function(assert) {
-    // arrange
+        // arrange
         this.array = [
             { field1: 1, field2: 2, field3: 3 },
             { field1: 1, field2: 2, field3: 4 },
@@ -2813,20 +2813,26 @@ QUnit.module('Remote group paging', {
             pageSize: 3
         });
 
-        loadStub.onCall(0).returns($.Deferred().resolve({ data: [
-            { key: 'test1', items: null, count: 3 },
-            { key: 'test2', items: null, count: 3 },
-            { key: 'test3', items: null, count: 3 }
-        ], totalCount: 9, groupCount: 3 }));
+        loadStub.onCall(0).returns($.Deferred().resolve({
+            data: [
+                { key: 'test1', items: null, count: 3 },
+                { key: 'test2', items: null, count: 3 },
+                { key: 'test3', items: null, count: 3 }
+            ], totalCount: 9, groupCount: 3
+        }));
 
-        loadStub.onCall(1).returns($.Deferred().resolve({ data: [
-            { key: 'test1', items: null, count: 3 }
-        ], totalCount: 9, groupCount: 3 }));
+        loadStub.onCall(1).returns($.Deferred().resolve({
+            data: [
+                { key: 'test1', items: null, count: 3 }
+            ], totalCount: 9, groupCount: 3
+        }));
 
-        loadStub.onCall(2).returns($.Deferred().resolve({ data: [
-            { name: 'test1', id: 1 },
-            { name: 'test1 ', id: 2 }
-        ] }));
+        loadStub.onCall(2).returns($.Deferred().resolve({
+            data: [
+                { name: 'test1', id: 1 },
+                { name: 'test1 ', id: 2 }
+            ]
+        }));
 
         dataSource.load();
 
@@ -2861,10 +2867,12 @@ QUnit.module('Remote group paging', {
     QUnit.test('Expand group if group key is object', function(assert) {
         const dataSource = this.createDataSource({
             load: function() {
-                return $.Deferred().resolve({ data: [
-                    { key: { groupId: 1, groupName: 'test 1' }, items: [{ id: 1 }] },
-                    { key: { groupId: 2, groupName: 'test 2' }, items: [{ id: 2 }] }
-                ], totalCount: 2, groupCount: 2 });
+                return $.Deferred().resolve({
+                    data: [
+                        { key: { groupId: 1, groupName: 'test 1' }, items: [{ id: 1 }] },
+                        { key: { groupId: 2, groupName: 'test 2' }, items: [{ id: 2 }] }
+                    ], totalCount: 2, groupCount: 2
+                });
             },
             group: 'group'
         });
@@ -3258,9 +3266,9 @@ QUnit.module('Remote group paging', {
 
     QUnit.test('Expand third level group', function(assert) {
         const array = [
-        /* 1 */
-        /* 2 */
-        /* 3 */
+            /* 1 */
+            /* 2 */
+            /* 3 */
             { field1: 1, field2: 2, field3: 3, id: 1 },
             { field1: 1, field2: 2, field3: 3, id: 2 },
             /* 2 */ { field1: 2, field2: 2, field3: 4, id: 3 },
@@ -3500,7 +3508,7 @@ QUnit.module('Remote group paging', {
 
     // T850299
     QUnit.test('Remote group paging should work correctly after sorting if grouping by 2 columns', function(assert) {
-    // arrange
+        // arrange
         let items;
         let subgroups;
 
@@ -3644,7 +3652,7 @@ QUnit.module('Remote group paging', {
 
     // T454240
     QUnit.test('Error when store not returned groupCount', function(assert) {
-    // arrange
+        // arrange
         assert.expect(1);
 
         const dataSource = this.createDataSource({
@@ -3654,18 +3662,18 @@ QUnit.module('Remote group paging', {
         // act
         dataSource.load()
             .done(() => {
-            // assert
+                // assert
                 assert.ok(false, 'exception should be rised');
             })
             .fail((e) => {
-            // assert
+                // assert
                 assert.ok(e.message.indexOf('E4022') >= 0, 'name of error');
             });
     });
 
     // T477410
     QUnit.test('Error when store not returned groupCount during expand not last level group', function(assert) {
-    // arrange
+        // arrange
         assert.expect(1);
 
         const brokeOptions = {};
@@ -3680,18 +3688,18 @@ QUnit.module('Remote group paging', {
 
         dataSource.changeRowExpand([1])
             .done(() => {
-            // assert
+                // assert
                 assert.ok(false, 'exception should be rised');
             })
             .fail((e) => {
-            // assert
+                // assert
                 assert.ok(e.message.indexOf('E4022') >= 0, 'name of error');
             });
     });
 
     // T477410
     QUnit.test('Exception when store not returned totalCount after full reload', function(assert) {
-    // arrange
+        // arrange
         const brokeOptions = {};
         const dataSource = this.createDataSource({
             group: ['field1']
@@ -3713,7 +3721,7 @@ QUnit.module('Remote group paging', {
 
     // T754708
     QUnit.test('The collapseAll method should work after expanding group row', function(assert) {
-    // arrange
+        // arrange
         const dataSource = this.createDataSource({
             group: 'field2',
             pageSize: 2
@@ -3760,7 +3768,7 @@ QUnit.module('Remote group paging', {
 
     // T754708
     QUnit.test('The expandAll method  should work after collapsing group row', function(assert) {
-    // arrange
+        // arrange
         const dataSource = this.createDataSource({
             group: 'field2',
             pageSize: 2
@@ -4507,7 +4515,7 @@ QUnit.module('Remote group paging', {
 
                 // T112478
                 QUnit.test('collapseAll for remote data', function(assert) {
-                // arrange
+                    // arrange
                     const source = this.createDataSource({
                         load: function() { return [{ group: 'group 1', text: 'text 1' }, { group: 'group 1', text: 'text 2' }, { group: 'group 2', text: 'text 3' }]; },
                         totalCount: function() { return -1; },
@@ -5054,13 +5062,13 @@ QUnit.module('Remote group paging', {
                 assert.equal(source.totalItemsCount(), 15);
                 assert.deepEqual(this.processItems(source.items()), [{
                     key: 1, isContinuationOnNextPage: true, items:
-                [
-                    {
-                        key: 2,
-                        isContinuationOnNextPage: true,
-                        items: [{ field1: 1, field2: 2, field3: 3 }]
-                    }
-                ]
+                        [
+                            {
+                                key: 2,
+                                isContinuationOnNextPage: true,
+                                items: [{ field1: 1, field2: 2, field3: 3 }]
+                            }
+                        ]
                 }]);
             });
 
@@ -5133,10 +5141,10 @@ QUnit.module('Remote group paging', {
                 assert.equal(source.totalItemsCount(), 4);
                 assert.deepEqual(this.processItems(source.items()), [{
                     key: 1, items:
-                [
-                    { key: 2, items: null },
-                    { key: 3, items: null }
-                ]
+                        [
+                            { key: 2, items: null },
+                            { key: 3, items: null }
+                        ]
                 }]);
             });
 
@@ -5158,10 +5166,10 @@ QUnit.module('Remote group paging', {
                 assert.equal(source.totalItemsCount(), 5);
                 assert.deepEqual(this.processItems(source.items()), [{
                     key: 1, items:
-                [
-                    { key: 2, items: null },
-                    { key: 3, items: null }
-                ]
+                        [
+                            { key: 2, items: null },
+                            { key: 3, items: null }
+                        ]
                 }]);
             });
 
@@ -5177,10 +5185,10 @@ QUnit.module('Remote group paging', {
                 assert.equal(source.totalItemsCount(), 5);
                 assert.deepEqual(this.processItems(source.items()), [{
                     key: 1, items:
-                [
-                    { key: 2, items: null },
-                    { key: 3, items: null }
-                ]
+                        [
+                            { key: 2, items: null },
+                            { key: 3, items: null }
+                        ]
                 }]);
             });
 
@@ -5247,10 +5255,10 @@ QUnit.module('Remote group paging', {
                 assert.equal(source.totalItemsCount(), 4);
                 assert.deepEqual(this.processItems(source.items()), [{
                     key: 1, items:
-                [
-                    { key: 3, items: null },
-                    { key: 2, items: null }
-                ]
+                        [
+                            { key: 3, items: null },
+                            { key: 2, items: null }
+                        ]
                 }]);
             });
 
@@ -6897,5 +6905,62 @@ QUnit.module('Custom Load', {
         assert.deepEqual(dataSource.items(), [1, 1, 2, 2, 3], 'items on page');
         assert.deepEqual(dataSource.totalCount(), 10, 'totalCount');
         assert.deepEqual(loadingCount, 2, 'loading count');
+    });
+});
+
+
+QUnit.module('New virtual scrolling mode', {
+    beforeEach: function() {
+        this.clock = sinon.useFakeTimers();
+        this.createDataSource = function(options) {
+            return createDataSource($.extend({
+                store: TEN_NUMBERS,
+                paginate: true,
+                scrolling: {
+                    newMode: true,
+                    mode: 'virtual',
+                    rowRenderingMode: 'virtual'
+                },
+                remoteOperations: { filtering: true, sorting: true, paging: true }
+            }, options));
+        };
+    },
+    afterEach: function() {
+        this.clock.restore();
+    }
+}, () => {
+    QUnit.test('loadPageCount affects the take parameter', function(assert) {
+        // arrange
+        const dataSource = this.createDataSource({
+            pageSize: 3
+        });
+        const dataLoadingHandler = dataSource._dataLoadingHandler;
+        const takeValues = [];
+
+        dataSource._dataLoadingHandler = function(options) {
+            dataLoadingHandler.apply(dataSource, arguments);
+            takeValues.push(options.storeLoadOptions.take);
+        };
+        dataSource._dataSource.off('customizeStoreLoadOptions', dataLoadingHandler);
+        dataSource._dataSource.on('customizeStoreLoadOptions', dataSource._dataLoadingHandler);
+
+        try {
+            // act
+            dataSource.loadPageCount(2);
+            dataSource.load();
+
+            // assert
+            assert.strictEqual(takeValues[0], 6, 'first take value');
+
+            // act
+            dataSource.loadPageCount(3);
+            dataSource.load();
+
+            // assert
+            assert.strictEqual(takeValues[1], 9, 'second take value');
+        } finally {
+            dataSource._dataSource.off('customizeStoreLoadOptions', dataSource._dataLoadingHandler);
+            dataSource._dataSource.on('customizeStoreLoadOptions', dataLoadingHandler);
+        }
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
@@ -5509,7 +5509,7 @@ QUnit.module('Virtual scrolling', {
             rowsView._dataController.getItemSize = x.getItemSize;
             rowsView._dataController.getItemSizes = x.getItemSizes;
             rowsView._dataController.viewportItemSize = x.viewportItemSize;
-            rowsView._dataController.setContentSize = x.setContentSize;
+            rowsView._dataController.setContentItemSizes = x.setContentItemSizes;
             rowsView._dataController.setViewportPosition = x.setViewportPosition;
             rowsView._dataController.getItemIndexByPosition = x.getItemIndexByPosition;
             rowsView._dataController._setViewportPositionCore = x._setViewportPositionCore;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
@@ -902,14 +902,6 @@ QUnit.module('VirtualScrollingController. New mode', {
         pageIndex.restore();
     });
 
-    QUnit.test('load does set loading page indexes', function(assert) {
-        // act
-        this.scrollController.load();
-
-        // assert
-        assert.deepEqual(this.scrollController._loadingPageIndexes, {}, '_loadingPageIndexes is empty');
-    });
-
     QUnit.test('Viewport params at the top', function(assert) {
         const viewportSize = 25;
         this.scrollController.viewportSize(viewportSize);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
@@ -51,6 +51,16 @@ function resetMock(mock) {
     });
 }
 
+function getContentSizes(size, count) {
+    const items = [];
+
+    for(let i = 0; i < count; i++) {
+        items.push(size);
+    }
+
+    return items;
+}
+
 const moduleConfig = {
     beforeEach: function() {
         mockComponent.option.withArgs('scrolling.mode').returns('virtual');
@@ -184,23 +194,24 @@ QUnit.module('VirtualScrollingController. Virtual scrolling mode', moduleConfig,
         }]);
     });
 
-    QUnit.test('setContentSize. No items', function(assert) {
+    QUnit.test('setContentItemSizes. No items', function(assert) {
         this.scrollController.viewportSize(12);
-        this.scrollController.setContentSize(0);
-
+        this.scrollController.setContentItemSizes([]);
         const virtualContentSize = this.scrollController.getVirtualContentSize();
 
         assert.ok(virtualContentSize);
         assert.strictEqual(virtualContentSize, DEFAULT_TOTAL_ITEMS_COUNT * this.scrollController.viewportItemSize());
     });
 
-    QUnit.test('setContentSize. When items', function(assert) {
+    QUnit.test('setContentItemSizes. When items', function(assert) {
         this.scrollController.viewportSize(12);
         this.scrollController.load();
 
         const contentSize = 200;
 
-        this.scrollController.setContentSize(contentSize);
+        const contentSizes = getContentSizes(20, 10);
+
+        this.scrollController.setContentItemSizes(contentSizes);
 
         assert.strictEqual(this.scrollController.getVirtualContentSize(), (DEFAULT_TOTAL_ITEMS_COUNT - mockDataSource.pageSize()) * this.scrollController.viewportItemSize() + contentSize);
         assert.strictEqual(this.scrollController.beginPageIndex(), 0);
@@ -219,7 +230,10 @@ QUnit.module('Virtual scrolling', {
         this.scrollController.viewportSize(12);
         this.scrollController.load();
         this.contentSize = 400;
-        this.scrollController.setContentSize(this.contentSize);
+
+        const contentSizes = getContentSizes(20, 20);
+
+        this.scrollController.setContentItemSizes(contentSizes);
         mockDataSource.load.reset();
         this.externalDataChangedHandler.reset();
     },
@@ -491,9 +505,9 @@ QUnit.module('Virtual scrolling', {
         const realItemSize = 10;
         const realItemSizes = Array.apply(null, Array(20)).map(() => realItemSize);
 
-        this.scrollController.setContentSize(realItemSizes);
+        this.scrollController.setContentItemSizes(realItemSizes);
         this.scrollController.setViewportPosition(1000);
-        this.scrollController.setContentSize(realItemSizes);
+        this.scrollController.setContentItemSizes(realItemSizes);
 
         assert.strictEqual(this.scrollController.getVirtualContentSize(), (DEFAULT_TOTAL_ITEMS_COUNT - 2 * mockDataSource.pageSize() - realItemSizes.length) * this.scrollController.viewportItemSize() + 2 * realItemSizes.length * realItemSize);
     });
@@ -522,9 +536,11 @@ QUnit.module('Virtual scrolling', {
     QUnit.test('setViewport position. DataSource with too many items', function(assert) {
         mockDataSource.totalItemsCount.returns(100000000000);
 
-        this.scrollController.setContentSize(this.contentSize);
-
+        const contentSizes = getContentSizes(20, 20);
+        this.scrollController.setContentItemSizes(contentSizes);
+        this.scrollController.reset();
         this.scrollController.setViewportPosition(CONTENT_HEIGHT_LIMIT / 2);
+
 
         assert.roughEqual(this.scrollController.getVirtualContentSize(), CONTENT_HEIGHT_LIMIT + this.contentSize, 1.1);
 
@@ -558,7 +574,8 @@ QUnit.module('Subscribe to external scrollable events', {
         this.scrollController.viewportSize(12);
         this.scrollController.load();
         this.contentSize = 400;
-        this.scrollController.setContentSize(this.contentSize);
+        const contentSizes = getContentSizes(20, 20);
+        this.scrollController.setContentItemSizes(contentSizes);
         mockDataSource.load.reset();
         this.externalDataChangedHandler.reset();
         this.clock = sinon.useFakeTimers(),

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
@@ -858,6 +858,58 @@ QUnit.module('VirtualScrollingController. New mode', {
         moduleConfig.afterEach.call(this);
     }
 }, () => {
+    QUnit.test('virtualItemsCount does not call data source methods', function(assert) {
+        // arrange
+        const pageIndex = sinon.stub(mockDataSource, 'pageIndex');
+
+        // act
+        this.scrollController.virtualItemsCount();
+
+        // assert
+        assert.notOk(pageIndex.called, 'pageIndex not called');
+        assert.notOk(mockDataSource.pageSize.called, 'pageSize not called');
+
+        pageIndex.restore();
+    });
+
+    QUnit.test('setViewportItemIndex does not call data source and virtual scrolling controller methods', function(assert) {
+        // arrange
+        const pageCount = sinon.stub(mockDataSource, 'pageCount');
+        const load = sinon.stub(this.scrollController, 'load');
+
+        // act
+        this.scrollController.setViewportItemIndex(1);
+
+        // assert
+        assert.notOk(pageCount.called, 'pageCount not called');
+        assert.notOk(mockDataSource.pageSize.called, 'pageSize not called');
+        assert.notOk(load.called, 'load is not called');
+
+        pageCount.restore();
+        load.restore();
+    });
+
+    QUnit.test('pageIndex calls pageIndex of the data source', function(assert) {
+        // arrange
+        const pageIndex = sinon.stub(mockDataSource, 'pageIndex');
+
+        // act
+        this.scrollController.pageIndex(1);
+
+        // assert
+        assert.ok(pageIndex.called, 'pageIndex is called');
+
+        pageIndex.restore();
+    });
+
+    QUnit.test('load does set loading page indexes', function(assert) {
+        // act
+        this.scrollController.load();
+
+        // assert
+        assert.deepEqual(this.scrollController._loadingPageIndexes, {}, '_loadingPageIndexes is empty');
+    });
+
     QUnit.test('Viewport params at the top', function(assert) {
         const viewportSize = 25;
         this.scrollController.viewportSize(viewportSize);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.tests.js
@@ -847,3 +847,51 @@ QUnit.module('Subscribe to external scrollable events', {
     });
 });
 
+
+QUnit.module('VirtualScrollingController. New mode', {
+    beforeEach: function() {
+        moduleConfig.beforeEach.call(this);
+        mockComponent.option.withArgs('scrolling.rowRenderingMode').returns('virtual');
+        mockComponent.option.withArgs('scrolling.newMode').returns(true);
+    },
+    afterEach: function() {
+        moduleConfig.afterEach.call(this);
+    }
+}, () => {
+    QUnit.test('Viewport params at the top', function(assert) {
+        const viewportSize = 25;
+        this.scrollController.viewportSize(viewportSize);
+        const viewportParams = this.scrollController.getViewportParams();
+        const virtualItemsCount = this.scrollController.virtualItemsCount();
+
+        // assert
+        assert.deepEqual(virtualItemsCount, { begin: 0, end: DEFAULT_TOTAL_ITEMS_COUNT - 26 }, 'virtual items');
+        assert.deepEqual(viewportParams, { skip: 0, take: viewportSize + 1 }, 'viewport params');
+    });
+
+    QUnit.test('Viewport params at the middle', function(assert) {
+        const viewportSize = 25;
+        this.scrollController.viewportSize(viewportSize);
+        const viewportItemIndex = DEFAULT_TOTAL_ITEMS_COUNT / 2;
+        this.scrollController.setViewportItemIndex(viewportItemIndex);
+        const viewportParams = this.scrollController.getViewportParams();
+        const virtualItemsCount = this.scrollController.virtualItemsCount();
+
+        // assert
+        assert.deepEqual(virtualItemsCount, { begin: Math.floor(viewportItemIndex), end: 9974 }, 'virtual items');
+        assert.deepEqual(viewportParams, { skip: Math.floor(viewportItemIndex), take: viewportSize + 1 }, 'viewport params');
+    });
+
+    QUnit.test('Viewport params at the bottom', function(assert) {
+        const viewportSize = 25;
+        this.scrollController.viewportSize(viewportSize);
+        const viewportItemIndex = 19985;
+        this.scrollController.setViewportItemIndex(19985);
+        const viewportParams = this.scrollController.getViewportParams();
+        const virtualItemsCount = this.scrollController.virtualItemsCount();
+
+        // assert
+        assert.deepEqual(virtualItemsCount, { begin: viewportItemIndex, end: 0 }, 'virtual items');
+        assert.deepEqual(viewportParams, { skip: viewportItemIndex, take: DEFAULT_TOTAL_ITEMS_COUNT - viewportItemIndex }, 'viewport params');
+    });
+});

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/dataController.tests.js
@@ -4475,16 +4475,16 @@ QUnit.module('Virtual scrolling', {
         assert.strictEqual(columnsScrollController.viewportItemSize.firstCall.args[0], 15);
 
         assert.strictEqual(columnsScrollController.viewportSize.lastCall.args[0], 15);
-        assert.strictEqual(columnsScrollController.setContentSize.lastCall.args[0], itemWidths);
+        assert.strictEqual(columnsScrollController.setContentItemSizes.lastCall.args[0], itemWidths);
 
         assert.strictEqual(rowsScrollController.viewportSize.lastCall.args[0], 10);
-        assert.strictEqual(rowsScrollController.setContentSize.lastCall.args[0], itemHeights);
+        assert.strictEqual(rowsScrollController.setContentItemSizes.lastCall.args[0], itemHeights);
 
         assert.strictEqual(rowsScrollController.loadIfNeed.callCount, 1);
         assert.strictEqual(columnsScrollController.loadIfNeed.callCount, 1);
 
-        assert.ok(rowsScrollController.loadIfNeed.calledAfter(rowsScrollController.setContentSize));
-        assert.ok(columnsScrollController.loadIfNeed.calledAfter(columnsScrollController.setContentSize));
+        assert.ok(rowsScrollController.loadIfNeed.calledAfter(rowsScrollController.setContentItemSizes));
+        assert.ok(columnsScrollController.loadIfNeed.calledAfter(columnsScrollController.setContentItemSizes));
 
         assert.deepEqual(result, {
             contentLeft: 150,


### PR DESCRIPTION
Added the capability to calculate how many pages should be loaded on a single load operation. This is done by calculating the loadPageCount option at the DataSourceAdapter level using the **skip** and **take** parameters. These params are calculated based on the view port size. Note, that this logic operates only if the "scrolling.newMode" option is set to true. The option is added temporarily for preventing the current behavior from breaking.