### PR TITLE
DropDownList-based editors: contentReady should be fired after base content rendering (T971115)

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -461,8 +461,6 @@ const DropDownList = DropDownEditor.inherit({
         return this.callBase().concat([!canListHaveFocus && this._list]);
     },
 
-    _fireContentReadyAction: noop,
-
     _setAriaTargetForList: function() {
         this._list._getAriaTarget = this._getAriaTarget.bind(this);
     },

--- a/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
@@ -995,57 +995,6 @@ QUnit.module('ContentReady event', {
         this.clock.restore();
     }
 }, () => {
-    QUnit.skip('ContentReady should be raised when widget non-dropdown part is rendered (deferRendering is true)', function(assert) {
-        assert.expect(4);
-
-        $('#autocomplete').dxAutocomplete({
-            value: 'text',
-            focusStateEnabled: true,
-            deferRendering: true,
-            onContentReady: (e) => {
-                assert.ok(true, 'ContentReady is raised');
-                assert.ok(e.component, 'Component info should be passed');
-                assert.ok(e.element, 'Element info should be passed');
-                assert.strictEqual($(e.element).text(), 'text', 'Text is correct');
-            }
-        });
-    });
-
-    QUnit.test('ContentReady should be raised when list is rendered after its first opening (deferRendering is true)', function(assert) {
-        assert.expect(3);
-
-        const autocomplete = $('#autocomplete').dxAutocomplete({
-            dataSource: ['item 1', 'item 2', 'item 3'],
-            searchTimeout: 0,
-            focusStateEnabled: true,
-            deferRendering: true
-        }).dxAutocomplete('instance');
-
-        autocomplete.on('contentReady', (e) => {
-            assert.ok(true, 'ContentReady is raised');
-            assert.ok(e.component, 'Component info should be passed');
-            assert.ok(e.element, 'Element info should be passed');
-        });
-
-        autocomplete.open();
-    });
-
-    QUnit.skip('ContentReady should be raised when list is rendered after its first opening (deferRendering is false)', function(assert) {
-        assert.expect(6);
-
-        $('#autocomplete').dxAutocomplete({
-            dataSource: ['item 1', 'item 2', 'item 3'],
-            searchTimeout: 0,
-            focusStateEnabled: true,
-            deferRendering: false,
-            onContentReady: (e) => {
-                assert.ok(true, 'ContentReady is raised');
-                assert.ok(e.component, 'Component info should be passed');
-                assert.ok(e.element, 'Element info should be passed');
-            }
-        }).dxAutocomplete('instance');
-    });
-
     QUnit.test('ContentReady should be raised after items loading', function(assert) {
         assert.expect(5);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -442,59 +442,6 @@ QUnit.module('items & dataSource', moduleConfig, () => {
         assert.equal($.trim($('.dx-list-item').text()), 'test', 'template rendered');
     });
 
-    QUnit.test('contentReady action fires when dataSource loaded', function(assert) {
-        let contentReadyFired = 0;
-
-        const $dropDownList = $('#dropDownList').dxDropDownList({
-            dataSource: [1],
-            deferRendering: true,
-            onContentReady() {
-                contentReadyFired++;
-            }
-        });
-
-        assert.equal(contentReadyFired, 0, 'no content ready before opening');
-        $dropDownList.dxDropDownList('open');
-        this.clock.tick();
-
-        assert.equal(contentReadyFired, 1, 'content ready fired when content is rendered');
-
-        $dropDownList.dxDropDownList('close');
-        $dropDownList.dxDropDownList('open');
-
-        assert.equal(contentReadyFired, 1, 'content ready not fired when reopen dropdown');
-    });
-
-    QUnit.test('contentReady action fires when readOnly=true', function(assert) {
-        const contentReadyActionStub = sinon.stub();
-
-        const $dropDownList = $('#dropDownList').dxDropDownList({
-            readOnly: true,
-            dataSource: [1],
-            onContentReady: contentReadyActionStub,
-            deferRendering: true
-        });
-
-        $dropDownList.dxDropDownList('open');
-
-        assert.ok(contentReadyActionStub.called, 'content ready fired when content is rendered');
-    });
-
-    QUnit.test('contentReady action fires when disabled=true', function(assert) {
-        const contentReadyActionStub = sinon.stub();
-
-        const $dropDownList = $('#dropDownList').dxDropDownList({
-            disabled: true,
-            dataSource: [1],
-            onContentReady: contentReadyActionStub,
-            deferRendering: true
-        });
-
-        $dropDownList.dxDropDownList('open');
-
-        assert.ok(contentReadyActionStub.called, 'content ready fired when content is rendered');
-    });
-
     QUnit.test('dataSource with Guid key', function(assert) {
         const guidKey1 = 'bd330029-8106-6d2d-5371-f27325155e99';
         const dataSource = new DataSource({
@@ -1289,7 +1236,6 @@ QUnit.module('popup', moduleConfig, () => {
             id: 2,
             value: 'value12'
         }];
-        const onContentReadySpy = sinon.spy();
         const dropDownList = $('#dropDownList').dxDropDownList({
             displayExpr: 'value',
             valueExpr: 'id',
@@ -1298,8 +1244,7 @@ QUnit.module('popup', moduleConfig, () => {
                 paginate: true,
                 pageSize: 2
             }),
-            opened: true,
-            onContentReady: onContentReadySpy
+            opened: true
         }).dxDropDownList('instance');
         const listInstance = $(`.${LIST_CLASS}`).dxList('instance');
         listInstance.option({
@@ -1736,3 +1681,59 @@ QUnit.module(
 
     }
 );
+
+QUnit.module('contentReady', {
+    beforeEach: function() {
+        fx.off = true;
+
+        this.contentReadyActionStub = sinon.stub();
+        this.$dropDownList = $('#dropDownList').dxDropDownList({
+            onContentReady: this.contentReadyActionStub,
+            deferRendering: true
+        });
+        this.instance = this.$dropDownList.dxDropDownList('instance');
+    },
+    afterEach: function() {
+        fx.off = false;
+    }
+}, () => {
+    QUnit.test('fires on base content rendering', function(assert) {
+        assert.strictEqual(this.contentReadyActionStub.callCount, 1, 'content ready is fired');
+    });
+
+    QUnit.test('fires after popup first rendering', function(assert) {
+        this.instance.open();
+
+        assert.strictEqual(this.contentReadyActionStub.callCount, 2, 'content ready is fired after popup first opening');
+    });
+
+    QUnit.test('does not fire after reopening', function(assert) {
+        this.instance.open();
+        this.instance.close();
+        this.instance.open();
+
+        assert.strictEqual(this.contentReadyActionStub.callCount, 2, 'content ready is not fired after reopening');
+    });
+
+    QUnit.test('fires on popup rendering without opening', function(assert) {
+        this.instance.option('deferRendering', false);
+
+        assert.strictEqual(this.contentReadyActionStub.callCount, 2, 'content ready is fired on popup rendering');
+    });
+
+    QUnit.test('fires on popup first opening when readOnly=true', function(assert) {
+        this.instance.option('readOnly', true);
+
+        this.instance.open();
+
+        assert.strictEqual(this.contentReadyActionStub.callCount, 2, 'content ready is fired on popup rendering');
+    });
+
+    QUnit.test('fires on popup first opening when disabled=true', function(assert) {
+        this.instance.option('disabled', true);
+
+        this.instance.open();
+
+        assert.strictEqual(this.contentReadyActionStub.callCount, 2, 'content ready is fired on popup rendering');
+    });
+});


### PR DESCRIPTION
…
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
