### PR TITLE
DataGrid - Fix T970651: Unnecessary "cancel changes" buttons are shown for the grid when a cell is validated if the onFocusedCellChanging event is handled and the e.isHighlighted option is enabled (#16363)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -1207,10 +1207,10 @@ export default {
                         const rowOptions = $focus?.closest('.dx-row').data('options');
                         const change = rowOptions ? this.getController('editing').getChangeByKey(rowOptions.key) : null;
                         const column = $cell && this.getController('columns').getVisibleColumns()[$cell.index()];
+                        const isCellModified = (change?.data?.[column?.name] !== undefined) && !this._editingController.isSaving();
                         let revertTooltip;
 
-                        if((validationResult && validationResult.status === VALIDATION_STATUS.invalid)
-                            || (change?.type === 'update' && !this._editingController.isSaving())) {
+                        if((validationResult?.status === VALIDATION_STATUS.invalid) || isCellModified) {
                             if(this._editingController.getEditMode() === EDIT_MODE_CELL) {
                                 revertTooltip = this._showRevertButton($focus);
                             }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -27,7 +27,7 @@ import DataGridWrapper from '../../helpers/wrappers/dataGridWrappers.js';
 
 QUnit.testStart(function() {
     const markup =
-'<style>\
+        '<style>\
     .qunit-fixture-static {\
         position: absolute !important;\
         left: 0 !important;\
@@ -121,7 +121,7 @@ QUnit.module('Editing', {
 }, () => {
 
     QUnit.test('editing with allowUpdating true', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -141,7 +141,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('no Edit link when editing with allowUpdating true and mode is batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -159,7 +159,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('no Edit link when editing with allowUpdating true and mode is cell', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -177,7 +177,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('editing with allowUpdating, allowAdding, allowDeleting false', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -196,7 +196,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('editing with allowDeleting true', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -216,7 +216,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Header Panel when editing with allowAdding true', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
@@ -240,7 +240,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Header Panel when editing with mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const testElement = $('#container');
@@ -268,7 +268,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Toolbar menu hidden when click on edit button', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
@@ -304,7 +304,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Header Panel when editing with mode "cell"', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const testElement = $('#container');
@@ -329,7 +329,7 @@ QUnit.module('Editing', {
 
     // T112623
     QUnit.test('Header Panel when allowUpdating false, allowAdding true, allowDeleting true and mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         let $button;
@@ -360,7 +360,7 @@ QUnit.module('Editing', {
 
     // T112623
     QUnit.test('Header Panel when allowUpdating false, allowAdding false, allowDeleting true and mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         let $button;
@@ -391,7 +391,7 @@ QUnit.module('Editing', {
 
     // T112623
     QUnit.test('Header Panel when allowUpdating false, allowAdding true, allowDeleting false and mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         let $button;
@@ -422,7 +422,7 @@ QUnit.module('Editing', {
 
     // T112623
     QUnit.test('Header Panel when allowUpdating false, allowAdding false, allowDeleting false and mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         let $button;
@@ -452,7 +452,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Save changes button click call saveEditData', function(assert) {
-    // arrange
+        // arrange
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
         let saveEditDataCallCount = 0;
@@ -487,7 +487,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Cancel changes button click call cancelEditData', function(assert) {
-    // arrange
+        // arrange
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
         let cancelEditDataCallCount = 0;
@@ -530,7 +530,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Edit Row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let editRowCallCount = 0;
@@ -573,7 +573,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Edit Row and focus not first input', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -604,7 +604,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('onRowClick not handled when click on Edit link', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let editRowCallCount = 0;
@@ -643,7 +643,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('isEditCell', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -671,7 +671,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Edit Cell when row mode do not work on cell click', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let editCellCallCount = 0;
@@ -698,7 +698,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Edit Cell when batch mode on cell click', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let editCellCallCount = 0;
@@ -727,7 +727,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Edit cell on row click when a table is contained inside a cell', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let testRowIndex;
@@ -766,7 +766,7 @@ QUnit.module('Editing', {
 
     // T261231
     QUnit.test('Edit Cell when batch mode by API call for readonly cell', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -798,7 +798,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('batch mode - correct render boolean cell and functionality on cell click (showEditorAlways)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -835,7 +835,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('batch mode - correct render boolean cell when cancel onEditingStart (showEditorAlways)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -871,7 +871,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('batch mode - correct render boolean cell with allowEditing is false', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -902,7 +902,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('row mode - correct render boolean cell and functionality (showEditorAlways)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -940,7 +940,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('row mode - correct render editor cell and functionality (showEditorAlways)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -981,7 +981,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('row mode - correct render boolean cell with allowEditing is false', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1017,7 +1017,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Enable readOnly for editor', function(assert) {
-    // arrange
+        // arrange
         const options = {
             column: {
                 showEditorAlways: true
@@ -1036,7 +1036,7 @@ QUnit.module('Editing', {
 
     // T124946
     QUnit.test('Api method editCell when allowUpdating false', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1058,7 +1058,7 @@ QUnit.module('Editing', {
 
     // T310531
     QUnit.test('Api method editCell with column by dataField', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1079,7 +1079,7 @@ QUnit.module('Editing', {
 
     // T310531
     QUnit.test('Api method editCell with column by wrong dataField', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1132,7 +1132,7 @@ QUnit.module('Editing', {
 
     // T113719
     QUnit.test('Edit Cell with editCellTemplate when batch mode on cell click', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1167,7 +1167,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Remove Row without message', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let removeKey;
@@ -1200,7 +1200,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Remove row when batch editing', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let removeKey;
@@ -1238,7 +1238,7 @@ QUnit.module('Editing', {
     QUnit.test('Remove row with message', function(assert) {
         fx.off = true;
         try {
-        // arrange
+            // arrange
             const that = this;
             const rowsView = this.rowsView;
             let removeKey;
@@ -1293,7 +1293,7 @@ QUnit.module('Editing', {
     QUnit.test('Remove row with message ("cell" edit mode)', function(assert) {
         fx.off = true;
         try {
-        // arrange
+            // arrange
             const that = this;
             const rowsView = this.rowsView;
             let removeKey;
@@ -1347,7 +1347,7 @@ QUnit.module('Editing', {
     QUnit.test('Not remove row with message', function(assert) {
         fx.off = true;
         try {
-        // arrange
+            // arrange
             const that = this;
             const rowsView = this.rowsView;
             let removeKey;
@@ -1397,7 +1397,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Save Row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1441,7 +1441,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Save Row for calculated column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1480,7 +1480,7 @@ QUnit.module('Editing', {
 
     // T174245
     QUnit.test('Save row without changes data', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1507,7 +1507,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Serialize value before saving', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1552,7 +1552,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Cancel Editing Row when row mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1578,7 +1578,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Close Editing Cell when batch mode on click outside dataGrid', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let updateArgs;
@@ -1696,7 +1696,7 @@ QUnit.module('Editing', {
 
     // T113152
     QUnit.test('Not close Editing Cell in batch mode on click editor popup', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1760,7 +1760,7 @@ QUnit.module('Editing', {
 
     // T869676
     QUnit.test('Not close Editing Cell in batch mode on click add button and cell inside editor popup', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1813,7 +1813,7 @@ QUnit.module('Editing', {
 
     // T318313
     QUnit.test('Close Editing Cell when grid in popup', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const popupInstance = $('<div/>').appendTo($('#container')).dxPopup({
@@ -1846,7 +1846,7 @@ QUnit.module('Editing', {
 
     // T213164
     QUnit.test('Not close Editing Cell in batch mode on click detached element', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -1883,7 +1883,7 @@ QUnit.module('Editing', {
 
     // T110581
     QUnit.testInActiveWindow('Not close Editing Cell in batch mode on click focus overlay', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -1911,7 +1911,7 @@ QUnit.module('Editing', {
 
 
     QUnit.test('Save changes when batch mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const updateArgs = [];
@@ -2046,7 +2046,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Cancel changes when batch mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const updateArgs = [];
@@ -2102,7 +2102,7 @@ QUnit.module('Editing', {
 
     // T407180
     QUnit.test('Save changes when batch mode when one the changes is canceled from event', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const updateArgs = [];
@@ -2160,7 +2160,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Close Editing Cell when batch mode on click inside freespace row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let updateArgs;
@@ -2201,7 +2201,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Save Editing Cell when batch mode on click another cell', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let updateArgs;
@@ -2250,7 +2250,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Cancel Editing Row after change page', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -2280,7 +2280,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Title of delete dialog is not displayed when title text is empty or undefined', function(assert) {
-    // arrange
+        // arrange
 
         $.extend(this.options.editing, {
             allowUpdating: true,
@@ -2300,7 +2300,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Title of delete dialog is displayed when title text is defined', function(assert) {
-    // arrange
+        // arrange
 
         $.extend(this.options.editing, {
             allowUpdating: true,
@@ -2322,7 +2322,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Close editing cell when cell is contained table inside', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let isCellClosed = false;
@@ -2361,7 +2361,7 @@ QUnit.module('Editing', {
 
     // T287356
     QUnit.test('Not apply column options to cell editor', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -2383,7 +2383,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Apply column editorOptions to cell editor', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -2406,7 +2406,7 @@ QUnit.module('Editing', {
 
     // T529043
     QUnit.test('The first cell should not be switched to the editing state when clicking on grid inside cellTemplate', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let $mainTable;
         const rowsView = that.rowsView;
@@ -2444,7 +2444,7 @@ QUnit.module('Editing', {
 
     // T531154
     QUnit.test('The cell should be editable after cancel removing the row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let countCallOnRowRemoving = 0;
         const rowsView = that.rowsView;
@@ -2480,7 +2480,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Edit Row with useIcons is true', function(assert) {
-    // arrange
+        // arrange
         let $editCellElement;
         const $testElement = $('#container');
 
@@ -2527,7 +2527,7 @@ QUnit.module('Editing', {
 
     if(browser.msie && parseInt(browser.version) <= 11) {
         QUnit.test('Update value for row edit mode', function(assert) {
-        // arrange
+            // arrange
             $.extend(this.options.editing, {
                 allowUpdating: true,
                 mode: 'row'
@@ -2564,7 +2564,7 @@ QUnit.module('Editing', {
         });
 
         QUnit.test('Update value for form edit mode', function(assert) {
-        // arrange
+            // arrange
             $.extend(this.options.editing, {
                 allowUpdating: true,
                 mode: 'form'
@@ -2601,7 +2601,7 @@ QUnit.module('Editing', {
         });
 
         QUnit.test('Do not update value on keyup event for row edit mode', function(assert) {
-        // arrange
+            // arrange
             $.extend(this.options.editing, {
                 allowUpdating: true,
                 mode: 'row'
@@ -2637,7 +2637,7 @@ QUnit.module('Editing', {
         });
 
         QUnit.test('Do not update value on keyup event for form edit mode', function(assert) {
-        // arrange
+            // arrange
             $.extend(this.options.editing, {
                 allowUpdating: true,
                 mode: 'form'
@@ -2675,7 +2675,7 @@ QUnit.module('Editing', {
 
     // T620297
     QUnit.test('The text of the colorBox should not be overlaps in a grid cell', function(assert) {
-    // arrange
+        // arrange
         const DEFAULT_COLORBOX_INPUT_PADDING_LEFT = '40px';
 
         const rowsView = this.rowsView;
@@ -2700,7 +2700,7 @@ QUnit.module('Editing', {
 
     // T682033
     QUnit.testInActiveWindow('Focus overlay should not be shown in batch editing mode when editing is disabled', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -2727,7 +2727,7 @@ QUnit.module('Editing', {
 
     // T713844
     QUnit.test('Set editor mode via editorOptions', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -2748,7 +2748,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Batch mode - Edit cell on click (startEditAction is \'click\')', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -2772,7 +2772,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Batch mode - Edit Cell on double click (startEditAction is \'dblClick\')', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -2796,7 +2796,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Batch mode - Closing edited cell should work on click when startEditAction is \'dblClick\'', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -2831,7 +2831,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Batch mode - Clicking on the edited cell should not close it when startEditAction is \'dblClick\'', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -2858,7 +2858,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('Batch mode - The allowUpdating callback should not be called on click when startEditAction is \'dblClick\'', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const allowUpdating = sinon.spy();
@@ -2879,7 +2879,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('editingController.addDeferred should add the same deferred object only once', function(assert) {
-    // arrange
+        // arrange
         const deferred1 = new Deferred();
         const deferred2 = new Deferred();
 
@@ -2910,7 +2910,7 @@ QUnit.module('Editing', {
     });
 
     QUnit.test('editingController.executeOperation - only the last operation should be executed', function(assert) {
-    // arrange
+        // arrange
         let value = 0;
         const deferred1 = new Deferred();
         const func = function() {
@@ -3000,7 +3000,7 @@ QUnit.module('Editing with real dataController', {
 
     // B254105
     QUnit.test('Reset editing after refresh dataSource', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         this.rowsView.render($('#container'));
 
@@ -3018,7 +3018,7 @@ QUnit.module('Editing with real dataController', {
 
     // B254503
     QUnit.test('no editing column when not has columns', function(assert) {
-    // arrange
+        // arrange
         const that = this;
 
         that.options.columns = [];
@@ -3038,7 +3038,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Close Editing Cell and edit new cell on click', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const headerPanel = this.headerPanel;
@@ -3088,7 +3088,7 @@ QUnit.module('Editing with real dataController', {
     });
     // T919206
     QUnit.test('Reset modified cell class (T919206)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -3112,7 +3112,7 @@ QUnit.module('Editing with real dataController', {
 
     // T181661
     QUnit.test('Close Editing Cell on hold', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -3147,7 +3147,7 @@ QUnit.module('Editing with real dataController', {
 
     // T458921
     QUnit.test('Cancel Editing Row should not update all rows when form mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -3175,7 +3175,7 @@ QUnit.module('Editing with real dataController', {
 
     // T677605
     QUnit.test('The "Cancel" button of the Editing form should be clicked once to close it when rowTemplate is used', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -3209,7 +3209,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Edit number cell via keyboard arrows (arrow up key)', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
 
         const UP_KEY = 'ArrowUp';
@@ -3240,7 +3240,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Edit number cell via keyboard arrows (arrow down key)', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
 
         const DOWN_KEY = 'ArrowDown';
@@ -3272,7 +3272,7 @@ QUnit.module('Editing with real dataController', {
 
     // T136710
     QUnit.test('Close Editing Number Cell and edit next cell on tab key', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const headerPanel = this.headerPanel;
@@ -3321,7 +3321,7 @@ QUnit.module('Editing with real dataController', {
 
     // T150178
     QUnit.test('Remove the inserted row with edit mode batch and hidden column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -3400,7 +3400,7 @@ QUnit.module('Editing with real dataController', {
 
             // T861092
             QUnit.test(testName + ' (cell edit mode)', function(assert) {
-            // arrange
+                // arrange
                 const that = this;
 
                 $.extend(that.options.editing, {
@@ -3437,7 +3437,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('AddRow method should return Deferred', function(assert) {
-    // arrange
+        // arrange
         $.extend(this.options.editing, {
             mode: 'batch',
             allowAdding: true
@@ -3595,7 +3595,7 @@ QUnit.module('Editing with real dataController', {
 
     // T181647
     QUnit.test('Edit other row after inserting row when edit mode row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -3617,7 +3617,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Insert Row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
@@ -3659,7 +3659,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Insert Row without dataSource', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -3730,7 +3730,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Insert row when set onRowInserting', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const originalInsert = that.dataController.store().insert;
@@ -3745,7 +3745,7 @@ QUnit.module('Editing with real dataController', {
         });
 
         that.dataController.store().insert = function(values) {
-        // assert
+            // assert
             assert.deepEqual(values, {
                 Test1: 'test1',
                 Test2: 'test2'
@@ -3755,7 +3755,7 @@ QUnit.module('Editing with real dataController', {
         };
 
         that.options.onRowInserting = function(params) {
-        // assert
+            // assert
             assert.ok(params.data.__KEY__);
             delete params.data.__KEY__;
             assert.deepEqual(params.data, {}, 'parameter data');
@@ -3810,7 +3810,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Insert row when set onRowInserted', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -3824,7 +3824,7 @@ QUnit.module('Editing with real dataController', {
         });
 
         that.options.onRowInserted = function(params) {
-        // assert
+            // assert
             assert.ok(params.data.__KEY__);
             assert.deepEqual(params.key, params.data, 'parameter key'); // T457499
             delete params.data.__KEY__;
@@ -3853,7 +3853,7 @@ QUnit.module('Editing with real dataController', {
 
     // T457499
     QUnit.test('onRowInserted - Check key after insert row when custom store', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let countCallOnRowInserted = 0;
         const rowsView = this.rowsView;
@@ -3902,7 +3902,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('onRowUpdated - Check data after update row when custom store', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let countCallOnRowUpdated = 0;
         const rowsView = this.rowsView;
@@ -3947,7 +3947,7 @@ QUnit.module('Editing with real dataController', {
 
     // T147816
     QUnit.test('Insert rows with edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -3982,7 +3982,7 @@ QUnit.module('Editing with real dataController', {
         that.addRow();
 
         $.when(that.saveEditData()).done(function() {
-        // assert
+            // assert
             assert.ok(parameters[0].data.__KEY__);
             assert.deepEqual(parameters[0].key, parameters[0].data, 'parameter key the first inserted row'); // T457499
             delete parameters[0].data.__KEY__;
@@ -3998,7 +3998,7 @@ QUnit.module('Editing with real dataController', {
 
     // T278457
     QUnit.test('Insert several rows and remove they with edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -4029,7 +4029,7 @@ QUnit.module('Editing with real dataController', {
         that.deleteRow(8);
 
         $.when(that.saveEditData()).done(function() {
-        // assert
+            // assert
             assert.equal(removeParameters.length, 2, 'remove count');
             assert.ok(removeParameters[0].data.__KEY__, 'internal key field exists for inserted row 0');
             assert.ok(removeParameters[1].data.__KEY__, 'internal key field exists for inserted row 1');
@@ -4044,7 +4044,7 @@ QUnit.module('Editing with real dataController', {
 
     // T808395
     QUnit.test('First cell should be focused after inserting new row if startEditAction is \'dblClick\'', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
@@ -4068,7 +4068,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Insert Row when batch editing', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
@@ -4134,7 +4134,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Insert Row when "cell" edit mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = that.headerPanel;
         const rowsView = that.rowsView;
@@ -4184,7 +4184,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Insert Row when "cell" edit mode and the new value is not accepted yet', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
@@ -4218,7 +4218,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.testInActiveWindow('Insert Row after scrolling', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const done = assert.async();
         const headerPanel = this.headerPanel;
@@ -4240,7 +4240,7 @@ QUnit.module('Editing with real dataController', {
         const headerPanelElement = that.gridContainer.find('.dx-datagrid-header-panel').first();
 
         rowsView.scrollChanged.add(function() {
-        // act
+            // act
             that.click(headerPanelElement, '.dx-datagrid-addrow-button');
 
             // assert
@@ -4265,7 +4265,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Update cell when edit mode batch and set onRowUpdating', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const originalUpdate = that.dataController.store().update;
@@ -4280,7 +4280,7 @@ QUnit.module('Editing with real dataController', {
         });
 
         that.dataController.store().update = function(key, values) {
-        // assert
+            // assert
             assert.deepEqual(values, {
                 age: 15,
                 lastName: 'John',
@@ -4295,7 +4295,7 @@ QUnit.module('Editing with real dataController', {
         };
 
         that.options.onRowUpdating = function(params) {
-        // assert
+            // assert
             assert.deepEqual(params.newData, {
                 name: 'Test1',
             }, 'parameter new data');
@@ -4390,7 +4390,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Update cell when edit mode batch and cancel in onRowUpdating is deferred and resolved', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -4442,11 +4442,11 @@ QUnit.module('Editing with real dataController', {
 
         // assert
         assert.equal(that.dataController.store().update.callCount, 1, 'update called one time');
-        assert.deepEqual(that.dataController.store().update.lastCall.args, [ that.array[0], { name: 'Test1', room: 666 } ], 'update args');
+        assert.deepEqual(that.dataController.store().update.lastCall.args, [that.array[0], { name: 'Test1', room: 666 }], 'update args');
     });
 
     QUnit.test('Update cell when edit mode batch and cancel in onRowUpdating is Promise and resolved', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -4497,7 +4497,7 @@ QUnit.module('Editing with real dataController', {
         assert.ok(!that.dataController.store().update.called, 'update is not called');
         cancelPromise.then(function() {
             assert.equal(that.dataController.store().update.callCount, 1, 'update called one time');
-            assert.deepEqual(that.dataController.store().update.lastCall.args, [ that.array[0], { name: 'Test1', room: 666 } ], 'update args');
+            assert.deepEqual(that.dataController.store().update.lastCall.args, [that.array[0], { name: 'Test1', room: 666 }], 'update args');
         });
 
         // act
@@ -4507,7 +4507,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Update cell when edit mode batch and cancel in onRowUpdating is deferred and resolved with true', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -4568,7 +4568,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Update cell when edit mode batch and cancel in onRowUpdating is deferred and rejected', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -4626,7 +4626,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Update cell when edit mode bath and set onRowUpdated', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -4640,7 +4640,7 @@ QUnit.module('Editing with real dataController', {
         });
 
         that.options.onRowUpdated = function(params) {
-        // assert
+            // assert
             assert.deepEqual(params.data, { name: 'Test' }, 'parameter data');
             assert.deepEqual(params.key, {
                 'age': 15,
@@ -4684,7 +4684,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Highlight modified boolean editor', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const booleanColumnIndex = that.options.columns.length;
@@ -4728,7 +4728,7 @@ QUnit.module('Editing with real dataController', {
 
     // T389185
     QUnit.test('Not highlight calculated column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -4756,7 +4756,7 @@ QUnit.module('Editing with real dataController', {
 
     // T246535
     QUnit.test('oldData on rowUpdating for checkbox editor', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let rowUpdatingCallCount = 0;
@@ -4768,7 +4768,7 @@ QUnit.module('Editing with real dataController', {
         });
 
         that.options.onRowUpdating = function(e) {
-        // assert
+            // assert
             assert.deepEqual(e.oldData, {
                 age: 15,
                 lastName: 'John',
@@ -4802,7 +4802,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('onRowUpdating should raise once if eventArgs.cancel is true for the checkBox data editor in cell edit mode (T656376)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let rowUpdatingCallCount = 0;
@@ -4834,7 +4834,7 @@ QUnit.module('Editing with real dataController', {
 
     // T172738
     QUnit.test('Highlight modified with option showEditorAlways true on column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -4865,7 +4865,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('onEditingStart should not have key if row is inserted and showEditorAlways true on column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -4894,7 +4894,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('onRowUpdating should have oldData parameter if modify column with showEditorAlways true and with validationRules', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -4925,7 +4925,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Cancel Inserting Row after change page', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const headerPanel = this.headerPanel;
         const rowsView = this.rowsView;
@@ -4960,7 +4960,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Remove row and Recover row when batch editing', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5001,7 +5001,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Remove row when set onRowRemoving', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5080,7 +5080,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Remove row when set onRowRemoved', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5130,7 +5130,7 @@ QUnit.module('Editing with real dataController', {
 
     // T741746
     QUnit.test('deleteRow should not work if adding is started', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5164,7 +5164,7 @@ QUnit.module('Editing with real dataController', {
 
     // T850905
     QUnit.test('deleteRow should works if updating is started', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5195,7 +5195,7 @@ QUnit.module('Editing with real dataController', {
 
     // T850905
     QUnit.test('deleteRow should works if cell value is changed', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5227,7 +5227,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('deleteRow should works in row editing mode if boolean column and validation are exist (T865833, T864931)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5256,7 +5256,7 @@ QUnit.module('Editing with real dataController', {
 
     // T804894
     QUnit.test('addRow should not work if updating is started with validation error', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -5339,7 +5339,7 @@ QUnit.module('Editing with real dataController', {
 
     // T100624
     QUnit.test('Edit Cell when the width of the columns in percent', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5370,7 +5370,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Close current editor when clicked on not editable cells_B255594', function(assert) {
-    // arrange
+        // arrange
         let isCloseEditCell;
         const testElement = $('#container');
 
@@ -5404,7 +5404,7 @@ QUnit.module('Editing with real dataController', {
 
     // T107779
     QUnit.test('Column currency format after editing', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5446,7 +5446,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Add cell modified by batch edit mode_T118843', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -5496,7 +5496,7 @@ QUnit.module('Editing with real dataController', {
 
     // T136710
     QUnit.test('Add modified cell by batch edit mode when delayed template used (KO)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -5535,7 +5535,7 @@ QUnit.module('Editing with real dataController', {
 
 
     QUnit.test('Append editorCell css class for row editing', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5561,7 +5561,7 @@ QUnit.module('Editing with real dataController', {
 
     // T136485
     QUnit.test('Batch editing with complex keys', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
         const dataField = 'name';
         const newValue = 'Alex1';
@@ -5586,7 +5586,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Close editing cell when using "cell" edit mode on click outside dataGrid and save data', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let updateArgs;
@@ -5622,7 +5622,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Cell should be closed on click outside dataGrid after changes in several cells if "cell" edit mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5662,7 +5662,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('When select all items editing row must have not \'dx-selection\' class', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const rowClass = 'dx-row';
         const rowSelectionClass = 'dx-selection';
@@ -5691,7 +5691,7 @@ QUnit.module('Editing with real dataController', {
 
     // T186404
     QUnit.test('When select all items row with modified cell must have \'dx-selection\' class', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const rowClass = 'dx-row';
         const rowSelectionClass = 'dx-selection';
@@ -5726,7 +5726,7 @@ QUnit.module('Editing with real dataController', {
 
     // T716667
     QUnit.test('Editing cell should not be closed on click if column is fixed to right', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -5764,7 +5764,7 @@ QUnit.module('Editing with real dataController', {
 
     // B255559
     QUnit.test('Selection don\'t working for a inserted row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -5799,7 +5799,7 @@ QUnit.module('Editing with real dataController', {
 
     // T195944, T292164
     QUnit.testInActiveWindow('Save edit data in cell mode on value change when showEditorAlways is true', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         let saveEditDataCallCount = 0;
@@ -5851,7 +5851,7 @@ QUnit.module('Editing with real dataController', {
 
     // T425994, T429166, T469944
     QUnit.testInActiveWindow('Cell should save focus state after data saving in cell editing mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         let saveEditDataCallCount = 0;
@@ -5895,7 +5895,7 @@ QUnit.module('Editing with real dataController', {
 
     // T463800
     QUnit.testInActiveWindow('Focus should not returns to previous cell after data saving in cell editing mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -5931,7 +5931,7 @@ QUnit.module('Editing with real dataController', {
 
     // T383760
     QUnit.testInActiveWindow('Update be called once in cell mode on value change for boolean editor', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         let updateCallCount = 0;
@@ -5982,7 +5982,7 @@ QUnit.module('Editing with real dataController', {
 
     // T246542
     QUnit.test('Error during save changes in batch mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const updateArgs = [];
@@ -6080,7 +6080,7 @@ QUnit.module('Editing with real dataController', {
 
     // T555797
     QUnit.testInActiveWindow('Focus position should be correct after editing in cell editing mode if data source is remote', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -6126,7 +6126,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.testInActiveWindow('Focus position should be retured after editing in cell editing mode if remote updating return error', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -6196,7 +6196,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('isEditing parameter of the row when edit mode is \'row\'', function(assert) {
-    // arrange
+        // arrange
         this.rowsView.render($('#container'));
 
         // act
@@ -6208,7 +6208,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('isEditing parameter of the cell when edit mode is \'batch\'', function(assert) {
-    // arrange
+        // arrange
         let isEditingCell;
         let isEditingRow;
 
@@ -6258,7 +6258,7 @@ QUnit.module('Editing with real dataController', {
 
     // T316439
     QUnit.testInActiveWindow('Hide focus overlay before update on editing cell', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -6284,7 +6284,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Get first editable column index when form edit mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -6310,7 +6310,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Get first editable column index when form edit mode and custom form items is defined', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -6348,7 +6348,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Get correct first editable column index when form edit mode and form items are changed dynamically', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -6378,7 +6378,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Get correct first editable column index when visible option for item set via formItem option', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -6410,7 +6410,7 @@ QUnit.module('Editing with real dataController', {
 
     // T664284
     QUnit.test('Form should be updated after change editing.form options if editing mode is popup', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -6443,7 +6443,7 @@ QUnit.module('Editing with real dataController', {
 
     // T528580
     QUnit.test('Save edit data when update fails in batch edit mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const deferreds = [];
         const rowsView = this.rowsView;
@@ -6482,7 +6482,7 @@ QUnit.module('Editing with real dataController', {
 
     // T539602
     QUnit.test('loadingChanged should be called before editing oeprations', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const deferreds = [];
         const rowsView = this.rowsView;
@@ -6524,7 +6524,7 @@ QUnit.module('Editing with real dataController', {
 
     // T533546
     QUnit.testInActiveWindow('The lookup column should keep focus after changing value when it has \'setCellValue\' option', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let $cellElement;
         const rowsView = that.rowsView;
@@ -6569,7 +6569,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.testInActiveWindow('The focus should be saved after changing value in cascade non-lookup column in row editing mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -6616,7 +6616,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.testInActiveWindow('The focus should be saved after changing value in cascade non-lookup column in batch editing mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -6658,7 +6658,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Batch mode - Correct insert row index for a new row when a previous new row is deleted_T541129', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -6722,7 +6722,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Restore a height of rowsView when editing is canceled with empty data', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         $.extend(this.options.editing, {
@@ -6753,7 +6753,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Height of rowsView should more than height of editor form when row is inserted', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         $.extend(this.options.editing, {
@@ -6779,7 +6779,7 @@ QUnit.module('Editing with real dataController', {
 
     // T601360
     QUnit.test('repaintRows should be skipped on saving', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         $.extend(this.options.editing, {
@@ -6848,7 +6848,7 @@ QUnit.module('Editing with real dataController', {
 
     // T607746
     QUnit.test('The cellValue method should work correctly with visible index', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
 
         this.options.columns = ['name', 'age', { dataField: 'lastName', visibleIndex: 0 }];
@@ -6865,7 +6865,7 @@ QUnit.module('Editing with real dataController', {
 
     // T612318
     QUnit.test('EditorPreparing and EditorPrepared events should have correct parameters for the select column', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
         const editorPreparingHandler = sinon.spy();
         const editorPreparedHandler = sinon.spy();
@@ -6897,7 +6897,7 @@ QUnit.module('Editing with real dataController', {
 
     // T624036
     QUnit.test('Edit row should not throw an exception after change edit mode', function(assert) {
-    // arrange
+        // arrange
         fx.off = true;
 
         const $testElement = $('#container');
@@ -6920,7 +6920,7 @@ QUnit.module('Editing with real dataController', {
         });
 
         try {
-        // act
+            // act
             this.columnsController.optionChanged({ name: 'editing', fullName: 'editing' });
             this.editRow(0);
 
@@ -6928,7 +6928,7 @@ QUnit.module('Editing with real dataController', {
             assert.strictEqual(this.dataController.items().length, 1, 'item count');
             assert.ok(this.editingController._editPopup.option('visible'), 'edit popup is visible');
         } catch(e) {
-        // assert
+            // assert
             assert.ok(false, 'exception');
         } finally {
             fx.off = false;
@@ -6937,7 +6937,7 @@ QUnit.module('Editing with real dataController', {
 
     // T642523
     QUnit.test('Add row when data items are an instance of the class and one of the fields has getter', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let items;
         const rowsView = this.rowsView;
@@ -6993,9 +6993,9 @@ QUnit.module('Editing with real dataController', {
     });
 
     if(device.ios || device.android) {
-    // T322738
+        // T322738
         QUnit.testInActiveWindow('Native click is used when allowUpdating is true', function(assert) {
-        // arrange
+            // arrange
             const that = this;
             const rowsView = this.rowsView;
             const testElement = $('#container');
@@ -7014,7 +7014,7 @@ QUnit.module('Editing with real dataController', {
 
         // T322738
         QUnit.testInActiveWindow('Native click is not used when allowUpdating is false', function(assert) {
-        // arrange
+            // arrange
             const that = this;
             const rowsView = this.rowsView;
             const testElement = $('#container');
@@ -7034,7 +7034,7 @@ QUnit.module('Editing with real dataController', {
 
     // T105941
     QUnit.testInActiveWindow('Focused cell when editing cell in batch mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -7069,7 +7069,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.testInActiveWindow('Focused cell when editing cell in batch mode when fixed columns', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -7105,7 +7105,7 @@ QUnit.module('Editing with real dataController', {
 
     // T180058
     QUnit.testInActiveWindow('Focused last cell width when editing cell in batch mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -7133,7 +7133,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Lookup editor with calculateDisplayValue', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -7173,7 +7173,7 @@ QUnit.module('Editing with real dataController', {
 
     // T822553
     QUnit.test('Clear lookup editor with calculateDisplayValue', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -7250,7 +7250,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Lookup editor in row mode do not update row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -7288,7 +7288,7 @@ QUnit.module('Editing with real dataController', {
 
     // T379396
     QUnit.test('Lookup editor must be closed after save edit data when rowsView have no scrollable', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -7331,7 +7331,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Lookup editor with dataSource function', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container');
@@ -7374,7 +7374,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Change value with custom setCellValue', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let params;
         const rowsView = this.rowsView;
@@ -7419,7 +7419,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Changing the current row data in the setCellValue should not be applied', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -7456,7 +7456,7 @@ QUnit.module('Editing with real dataController', {
 
     // T816256
     QUnit.test('Validation state should not be reset after change value for column with setCellValue if editing mode is form', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -7492,7 +7492,7 @@ QUnit.module('Editing with real dataController', {
 
     // T844143
     QUnit.test('Validation should not occur for new row after change value for column with setCellValue if editing mode is form', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -7532,7 +7532,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('cellValue', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -7583,7 +7583,7 @@ QUnit.module('Editing with real dataController', {
 
     // T501819
     QUnit.test('Change array cell value in batch edit mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -7609,7 +7609,7 @@ QUnit.module('Editing with real dataController', {
 
     // T440578
     QUnit.test('cellValue should works with beginUpdate/endUpdate', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -7649,7 +7649,7 @@ QUnit.module('Editing with real dataController', {
 
     // T355235
     QUnit.test('cellValue in onCellPrepared', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -7719,7 +7719,7 @@ QUnit.module('Editing with real dataController', {
 
     // T266499
     QUnit.test('columnOption in onEditingStart and onInitNewRow', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let initNewRowCallCount = 0;
@@ -7764,7 +7764,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('hasChanges with rowIndex', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = $('#container');
@@ -7785,7 +7785,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Get first editable column index when there is custom select column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -7813,7 +7813,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Add a custom link for the \'buttons\' command column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let $linkElements;
         const rowsView = that.rowsView;
@@ -7857,7 +7857,7 @@ QUnit.module('Editing with real dataController', {
 
     // T814768
     QUnit.test('Button with svg icon in command column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const $testElement = $('#container');
 
@@ -7888,7 +7888,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Add a custom icon for the \'buttons\' command column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -7924,7 +7924,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Add a custom cssClass for image icons in the \'buttons\' command column (T807766)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -7949,7 +7949,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('dx-svg-icon should not have \'pointerEvents: none\' if a column button set using svg icon (T863635)', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
         this.options.columns.push({
             type: 'buttons',
@@ -7970,7 +7970,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Add a custom command column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -8015,7 +8015,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Changing edit icon in the \'buttons\' command column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -8043,7 +8043,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('The custom link of the \'buttons\' command column should only be visible when the row is not editable', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let $linkElements;
         const rowsView = that.rowsView;
@@ -8084,7 +8084,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Clicking on the edit link should not work when the link is set via the \'buttons\' option and allowUpdating is false', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -8114,7 +8114,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Set edit button for a specific row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -8138,7 +8138,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('Set delete button for a specific row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -8163,7 +8163,7 @@ QUnit.module('Editing with real dataController', {
 
     // T697205
     QUnit.test('The button column should not be shown in the edit form', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -8230,7 +8230,7 @@ QUnit.module('Editing with real dataController', {
 
     // T725319
     QUnit.test('Load panel should be hidden when changing loadPanel.enabled while loading', function(assert) {
-    // arrange
+        // arrange
         fx.off = true;
 
         try {
@@ -8278,7 +8278,7 @@ QUnit.module('Editing with real dataController', {
 
     // T737789
     QUnit.test('The command column caption should be applied', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const columnHeadersView = that.columnHeadersView;
         const $testElement = $('#container');
@@ -8308,7 +8308,7 @@ QUnit.module('Editing with real dataController', {
     });
 
     QUnit.test('The command column buttons should not be trimmed', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -8345,7 +8345,7 @@ QUnit.module('Editing with real dataController', {
 
     // T741679
     QUnit.test('A dependent cascading editor should be updated when a master cell value is changed if showEditorAlways is enabled in batch mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -8391,7 +8391,7 @@ QUnit.module('Editing with real dataController', {
 
     // T832801
     QUnit.test('The current editable row should close when adding a new row in \'row\' mode', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const $testElement = $('#container');
 
@@ -8417,11 +8417,11 @@ QUnit.module('Editing with real dataController', {
 
     // T858174
     QUnit.test('The modified cell should be correctly rendered after editing when cellTemplate is specified (React)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const $testElement = $('#container');
         const template = sinon.spy(function(options) {
-        // deferUpdate is called in template in devextreme-react
+            // deferUpdate is called in template in devextreme-react
             commonUtils.deferUpdate(() => {
                 options.container.text('test_' + options.model.text);
                 options.onRendered();
@@ -8465,7 +8465,7 @@ QUnit.module('Editing with real dataController', {
         [false, true].forEach(repaintChangesOnly => {
             [false, true].forEach(doubleChange => {
                 QUnit.test(`Editor value and lookup items should be updated after cascading update (editingMode=${editingMode}, repaintChangesOnly=${repaintChangesOnly}, doubleChange=${doubleChange})`, function(assert) {
-                // arrange
+                    // arrange
                     const rowsView = this.rowsView;
                     const $testElement = $('#container');
                     let dataSourceCallCount = 0;
@@ -8538,7 +8538,7 @@ QUnit.module('Editing with real dataController', {
                     const checkEditorRecreating = (dataField, isRecreated) => {
                         const editorName = `${dataField}Editor`;
                         const editor = getEditor(dataField);
-                        assert.strictEqual(editor !== this[editorName], isRecreated, `${dataField} is ${isRecreated ? '' : 'not' } recreated`);
+                        assert.strictEqual(editor !== this[editorName], isRecreated, `${dataField} is ${isRecreated ? '' : 'not'} recreated`);
                         this[editorName] = editor;
                     };
 
@@ -10188,7 +10188,7 @@ QUnit.module('Refresh modes', {
 }, () => {
 
     QUnit.test('Editing with refresh mode full', function(assert) {
-    // arrange
+        // arrange
         this.setupModules();
 
         // act
@@ -10204,7 +10204,7 @@ QUnit.module('Refresh modes', {
     });
 
     QUnit.test('Editing with refresh mode reshape', function(assert) {
-    // arrange
+        // arrange
         this.options.editing.refreshMode = 'reshape';
         this.setupModules();
 
@@ -10226,7 +10226,7 @@ QUnit.module('Refresh modes', {
     });
 
     QUnit.test('Editing with refresh mode repaint', function(assert) {
-    // arrange
+        // arrange
         this.options.editing.refreshMode = 'repaint';
         this.setupModules();
 
@@ -10254,7 +10254,7 @@ QUnit.module('Refresh modes', {
     });
 
     QUnit.test('Editing with refresh mode repaint if store returns data', function(assert) {
-    // arrange
+        // arrange
         this.options.editing.refreshMode = 'repaint';
         const array = this.array;
         this.options.dataSource = {
@@ -10296,7 +10296,7 @@ QUnit.module('Refresh modes', {
     });
 
     QUnit.test('Load after editing with refresh mode repaint and remoteOperations', function(assert) {
-    // arrange
+        // arrange
         this.options.editing.refreshMode = 'repaint';
         this.options.remoteOperations = { sorting: true, filtering: true };
         this.options.columns.push({ dataField: 'id', sortOrder: 'asc' });
@@ -10317,7 +10317,7 @@ QUnit.module('Refresh modes', {
     });
 
     QUnit.test('Editing with refresh mode repaint with repaintChangesOnly', function(assert) {
-    // arrange
+        // arrange
         this.options.editing.refreshMode = 'repaint';
         this.options.repaintChangesOnly = true;
         this.setupModules();
@@ -10342,7 +10342,7 @@ QUnit.module('Refresh modes', {
     });
 
     QUnit.test('Editing with refresh mode repaint and with grouping', function(assert) {
-    // arrange
+        // arrange
         this.options.editing.refreshMode = 'repaint';
         this.options.dataSource.group = 'name';
 
@@ -10385,7 +10385,7 @@ QUnit.module('Refresh modes', {
 
     // T689906
     QUnit.test('The cell should be editable when there is a fixed column and repaintChangesOnly is true', function(assert) {
-    // arrange
+        // arrange
         let $cellElement;
 
         $.extend(this.options.editing, {
@@ -10416,7 +10416,7 @@ QUnit.module('Refresh modes', {
     });
 
     QUnit.test('The cell should be editable after selecting the row when repaintChangesOnly is true', function(assert) {
-    // arrange
+        // arrange
 
         $.extend(this.options.editing, {
             mode: 'cell',
@@ -10448,7 +10448,7 @@ QUnit.module('Refresh modes', {
 
     // T690041
     QUnit.test('Changing edit icon in the \'buttons\' command column if repaintChangesOnly is true', function(assert) {
-    // arrange
+        // arrange
         let $linkElements;
 
         $.extend(this.options.editing, {
@@ -10486,7 +10486,7 @@ QUnit.module('Refresh modes', {
 
     // T700691
     QUnit.test('Custom button click should be prevented', function(assert) {
-    // arrange
+        // arrange
         const event = $.Event('click');
 
         this.options.columns = [
@@ -10495,7 +10495,7 @@ QUnit.module('Refresh modes', {
                 buttons: [
                     {
                         text: 'Test',
-                        onClick: function() {}
+                        onClick: function() { }
                     }
                 ]
             },
@@ -10616,7 +10616,7 @@ QUnit.module('Editing with validation', {
 }, () => {
 
     QUnit.test('CheckBox should save intermediate state after validation when editing mode is batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -10649,7 +10649,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Edit cell when edit mode batch and set validate in column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -10709,7 +10709,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Save edit data when edit mode batch and set validate in column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -10772,7 +10772,7 @@ QUnit.module('Editing with validation', {
 
     // T620368
     QUnit.test('Save hidden column edit data when edit mode batch and column validation', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -10791,7 +10791,8 @@ QUnit.module('Editing with validation', {
             columns: [
                 {
                     dataField: 'name',
-                    validationRules: [{ type: 'required' }] },
+                    validationRules: [{ type: 'required' }]
+                },
                 {
                     dataField: 'age',
                     validationRules: [{ type: 'range', min: 1, max: 100 }]
@@ -10845,7 +10846,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Save edit data for inserted row when set validate in column and edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -10903,7 +10904,7 @@ QUnit.module('Editing with validation', {
 
     // T823583
     QUnit.test('Insert row when grouped column is required', function(assert) {
-    // arrange
+        // arrange
         const that = this;
 
         that.rowsView.render($('#container'));
@@ -10942,7 +10943,7 @@ QUnit.module('Editing with validation', {
 
     // T420231
     QUnit.test('Invalid date cell must be highlighted in batch editing mode for inserted row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -10971,7 +10972,7 @@ QUnit.module('Editing with validation', {
 
     // T186431
     QUnit.test('Save edit data for inserted row without validation in columns and edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11004,7 +11005,7 @@ QUnit.module('Editing with validation', {
 
     // T183300
     QUnit.test('Edit the inserted row for the first time when set validate in columns, edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11041,7 +11042,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Insert row with set validate in columns, edit mode batch and hidden column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11103,7 +11104,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Button inside the selectBox is not clicked', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = $('#container').children();
@@ -11135,7 +11136,7 @@ QUnit.module('Editing with validation', {
 
     // T174596
     QUnit.test('Validation after inserting several rows and saving in batch edit mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11189,7 +11190,7 @@ QUnit.module('Editing with validation', {
 
     // T181732
     QUnit.test('Validation during editing inserted row when edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11254,7 +11255,7 @@ QUnit.module('Editing with validation', {
 
     // T183295
     QUnit.test('Focused cell with validation when edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11275,7 +11276,7 @@ QUnit.module('Editing with validation', {
         });
 
         const callBackFunc = function() {
-        // assert
+            // assert
             assert.ok(testElement.find('td').eq(1).hasClass('dx-datagrid-invalid'), 'failed validation');
             // assert.ok(testElement.find("td").eq(1).children().hasClass("dx-focused"), "has class dx-focused");
 
@@ -11299,7 +11300,7 @@ QUnit.module('Editing with validation', {
 
     // T629168
     QUnit.test('Cell\'s height is increasing on resize if validation applied and batch edit mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11342,7 +11343,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Edit row when set validate in column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11401,7 +11402,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Insert row when set validate in column and edit mode row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11456,7 +11457,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Insert row with set validate in columns, edit mode row and hidden column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -11506,7 +11507,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Show tooltip on focus with set validate in column and edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const $testElement = renderer('#container');
@@ -11671,7 +11672,7 @@ QUnit.module('Editing with validation', {
 
     // T183197
     QUnit.test('Show tooltip on focus for last row with set validate in column and edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = renderer('#container');
@@ -11747,7 +11748,7 @@ QUnit.module('Editing with validation', {
 
     // T200857
     QUnit.test('Show tooltip on focus when one row with set validate in column and edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const testElement = renderer('#container');
@@ -11812,7 +11813,7 @@ QUnit.module('Editing with validation', {
 
     // T470216
     QUnit.testInActiveWindow('Tooltip should be positioned by left side when the drop-down editor is shown', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let tooltipInstance;
         const rowsView = that.rowsView;
@@ -11879,7 +11880,7 @@ QUnit.module('Editing with validation', {
 
     // T741739
     QUnit.testInActiveWindow('Tooltip should be positioned by left side if column dataType and alignment are not defined', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = renderer('#container');
@@ -11917,7 +11918,7 @@ QUnit.module('Editing with validation', {
 
     // T523770
     QUnit.test('Invalid message and revert button should not be overlapped when the drop-down editor is shown for first column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = renderer('#container');
@@ -11968,7 +11969,7 @@ QUnit.module('Editing with validation', {
 
     // T523770
     QUnit.test('Invalid message and revert button should not be overlapped when the drop-down editor is shown for last column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = renderer('#container');
@@ -12022,7 +12023,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Show error rows on save inserted rows when set validate in column and edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -12069,7 +12070,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Show error row on save inserted row when promise is used in rowValidating', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
         const errorText = 'Test';
@@ -12115,7 +12116,7 @@ QUnit.module('Editing with validation', {
 
     // T241920
     QUnit.testInActiveWindow('Cell editor invalid value don\'t miss focus on saveEditData', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -12160,7 +12161,7 @@ QUnit.module('Editing with validation', {
 
     // T284398
     QUnit.testInActiveWindow('Show invalid message on focus for an invalid cell of the inserted row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -12208,7 +12209,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Show error row on save inserted Row after scrolling when set validate in column and edit mode row', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const that = this;
         const rowsView = this.rowsView;
@@ -12228,7 +12229,7 @@ QUnit.module('Editing with validation', {
         });
 
         rowsView.scrollChanged.add(function() {
-        // act
+            // act
             that.addRow();
 
             // assert
@@ -12353,7 +12354,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Edit cell when edit mode cell and set validate in column', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -12402,7 +12403,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.testInActiveWindow('Show the revert button when an edit cell to invalid value when the edit mode cell is enabled', function(assert) {
-    // arrange
+        // arrange
 
         this.rowsView.render(this.gridContainer);
 
@@ -12447,7 +12448,7 @@ QUnit.module('Editing with validation', {
 
     // T297742
     QUnit.testInActiveWindow('Show the revert button when an edit cell, server returns error and the edit mode cell is enabled', function(assert) {
-    // arrange
+        // arrange
 
         this.rowsView.render(this.gridContainer);
 
@@ -12492,8 +12493,50 @@ QUnit.module('Editing with validation', {
         assert.equal($('.dx-revert-button').length, 1, 'revert button');
     });
 
+    // T970651
+    QUnit.testInActiveWindow('Show the revert button only for modified cell', function(assert) {
+        // arrange
+
+        this.rowsView.render(this.gridContainer);
+
+        this.applyOptions({
+            showColumnHeaders: true,
+            editing: {
+                mode: 'cell'
+            },
+            columns: [
+                { dataField: 'name', validationRules: [{ type: 'required' }] },
+                { dataField: 'age' },
+                { dataField: 'lastName' }
+            ]
+        });
+
+        // act
+        this.editCell(0, 0);
+        this.clock.tick();
+
+        const $cells = $(this.rowsView.element().find('tbody > tr').first().find('td'));
+        const inputElement = getInputElements($cells).first();
+        this.focus(this.getCellElement(0, 0));
+        inputElement.val('');
+        inputElement.trigger('change');
+        this.clock.tick();
+
+        // assert
+        assert.equal($('.dx-revert-button').length, 1, 'revert button was shown');
+
+        // act
+        this.editCell(0, 1);
+        this.clock.tick();
+        this.focus(this.getCellElement(0, 1));
+        this.clock.tick();
+
+        // assert
+        assert.equal($('.dx-revert-button').length, 0, 'revert button was hidden');
+    });
+
     QUnit.testInActiveWindow('Change hint for revert button', function(assert) {
-    // arrange
+        // arrange
         this.rowsView.render(this.gridContainer);
 
         this.applyOptions({
@@ -12523,7 +12566,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Revert is hidden when value is valid', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         let $cells;
 
@@ -12566,7 +12609,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.testInActiveWindow('Revert to an old value when the revert button is clicked', function(assert) {
-    // arrange
+        // arrange
         let $revertButton;
         let $cells;
 
@@ -12610,10 +12653,10 @@ QUnit.module('Editing with validation', {
 
     // T633351
     QUnit.testInActiveWindow('Revert to an old value when the revert button and nested dataObject modified', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
-        this.options.dataSource.store = [ { A: { name: 'Alex' }, lastName: 'Smith' }];
+        this.options.dataSource.store = [{ A: { name: 'Alex' }, lastName: 'Smith' }];
 
         this.rowsView.render(testElement);
 
@@ -12622,7 +12665,7 @@ QUnit.module('Editing with validation', {
                 allowUpdating: true,
                 mode: 'batch'
             },
-            columns: [ { dataField: 'A.name', dataType: 'string' }, 'lastName']
+            columns: [{ dataField: 'A.name', dataType: 'string' }, 'lastName']
         });
 
         // act
@@ -12644,7 +12687,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Revert button is not shown when a cell is not defined', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.rowsView.render(testElement);
@@ -12669,7 +12712,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.testInActiveWindow('Save a valid value for an invalid cell when focus in other invalid cell', function(assert) {
-    // arrange
+        // arrange
         let $cells;
 
         this.rowsView.render(this.gridContainer);
@@ -12681,9 +12724,11 @@ QUnit.module('Editing with validation', {
             columns: [
                 {
                     dataField: 'name',
-                    validationRules: [{ type: 'compare', comparisonTarget: function() {
-                        return 'Test';
-                    } }]
+                    validationRules: [{
+                        type: 'compare', comparisonTarget: function() {
+                            return 'Test';
+                        }
+                    }]
                 },
                 {
                     dataField: 'age',
@@ -12733,7 +12778,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Keep cell editing when onRowUpdating is canceled (cell edit mode)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const editingController = that.editingController;
@@ -12772,7 +12817,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Insert row when set validate in column and edit mode cell', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -12870,7 +12915,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Edit cell with edit mode batch and change page', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -12936,7 +12981,7 @@ QUnit.module('Editing with validation', {
 
     // T836508
     QUnit.test('Edit invalid cell from another page if edit mode is batch and recalculateWhileEditing is true', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -12980,7 +13025,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Row with invalid cell from another page should not be removed after refresh', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13021,7 +13066,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Row with invalid cell from another page should not be removed after paging', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13070,7 +13115,7 @@ QUnit.module('Editing with validation', {
 
     // T709466
     QUnit.test('Edit cell with edit mode batch and change page if hidden column has empty validationRules', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13141,7 +13186,7 @@ QUnit.module('Editing with validation', {
 
     // T495625
     QUnit.test('Row with invalid values should move to current page after saving if cancel updating in onRowUpdating event', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13195,7 +13240,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Edit cell with edit mode batch and sorting', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13264,7 +13309,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Edit cell with edit mode batch and filtering', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13330,7 +13375,7 @@ QUnit.module('Editing with validation', {
 
     // T186431
     QUnit.test('Save edit data for inserted row without validation in columns and edit mode cell', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13363,7 +13408,7 @@ QUnit.module('Editing with validation', {
 
     // T238387
     QUnit.test('Call onRowValidating when validation passed for edit mode batch', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let countCallOnRowValidating = 0;
@@ -13403,7 +13448,7 @@ QUnit.module('Editing with validation', {
 
     // T238387
     QUnit.test('Call onRowValidating when validation passed for edit mode row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let countCallOnRowValidating = 0;
@@ -13439,7 +13484,7 @@ QUnit.module('Editing with validation', {
 
     // T330770
     QUnit.test('Do not call onRowValidating on row deleting for edit mode row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         let countCallOnRowValidating = 0;
@@ -13516,7 +13561,7 @@ QUnit.module('Editing with validation', {
 
     // T393606
     QUnit.test('Not create validator for group column with validationRules when edit mode is \'row\'', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -13543,7 +13588,7 @@ QUnit.module('Editing with validation', {
 
     // T393606
     QUnit.test('Not create validator for group column with validationRules when edit mode is \'form\'', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -13577,7 +13622,7 @@ QUnit.module('Editing with validation', {
 
     // T631975
     QUnit.test('Required mark should be rendered for column with validationRules when edit mode is \'form\'', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
         const $testElement = $('#container');
@@ -13617,7 +13662,7 @@ QUnit.module('Editing with validation', {
 
     // T472946
     QUnit.test('Inserting row - Editor should not be validated when edit mode is \'form\'', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
 
         this.rowsView.render($testElement);
@@ -13645,7 +13690,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('It\'s impossible to save new data when editing form is invalid', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -13685,7 +13730,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('CustomRule.validationCallback accepts extra parameters', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
         const validationCallback = sinon.spy(function() { return true; });
@@ -13725,7 +13770,7 @@ QUnit.module('Editing with validation', {
 
     // T506863
     QUnit.testInActiveWindow('Show the revert button when a row updating is canceled', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
 
         this.applyOptions({
@@ -13761,7 +13806,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Show error message on save inserted rows when edit mode is \'popup\'', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const $testElement = $('#container');
 
@@ -13796,7 +13841,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Edit cell with custom validation (edit mode is batch)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let rowData;
         let $cellElements;
@@ -13857,7 +13902,7 @@ QUnit.module('Editing with validation', {
 
     // T535329
     QUnit.test('Cell edit mode - The validation should work correctly when there is column with \'showEditorAlways\' enabled', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let brokenRules;
         const rowsView = this.rowsView;
@@ -13898,7 +13943,7 @@ QUnit.module('Editing with validation', {
 
     // T535329
     QUnit.test('Cell edit mode - The validation should not work for column with \'showEditorAlways\' enabled when inserting row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -13929,7 +13974,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.testInActiveWindow('Batch edit mode - Validation message should be shown when column has showEditorAlways', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
 
@@ -13964,7 +14009,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.testInActiveWindow('Show validation message for CheckBox editor', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
 
         this.applyOptions({
@@ -13999,7 +14044,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.testInActiveWindow('Empty validation message is not shown', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -14037,7 +14082,7 @@ QUnit.module('Editing with validation', {
 
     // T593542
     QUnit.testInActiveWindow('SelectBox should be closed on focus another editor if its value is not valid', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let $cellElements;
         let $selectBoxInput;
@@ -14122,7 +14167,7 @@ QUnit.module('Editing with validation', {
 
     // T653933
     QUnit.test('Validation error message should not hide behind a grouped row when there are fixed columns', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
 
@@ -14168,7 +14213,7 @@ QUnit.module('Editing with validation', {
 
     // T707313
     QUnit.test('The validation message should not be overlapped by the fixed column (on left side)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
 
@@ -14209,7 +14254,7 @@ QUnit.module('Editing with validation', {
 
     // T707313
     QUnit.test('The validation message should not be overlapped by the fixed column (on right side)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
 
@@ -14264,7 +14309,7 @@ QUnit.module('Editing with validation', {
 
     // T707313
     QUnit.test('The validation message should be decreased when there is not enough visible area', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = that.rowsView;
 
@@ -14379,7 +14424,7 @@ QUnit.module('Editing with validation', {
 
     // T829925
     QUnit.test('No exceptions on editing a column with given setCellValue when repaintChangedOnly is true', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
 
         this.rowsView.render($testElement);
@@ -14416,7 +14461,7 @@ QUnit.module('Editing with validation', {
         assert.ok(validator, 'editor has validator');
 
         try {
-        // arrange
+            // arrange
             const validatorOptions = validator.option();
 
             // act
@@ -14433,13 +14478,13 @@ QUnit.module('Editing with validation', {
             assert.strictEqual(validatorOptionsAfterEditing.validationGroup, validatorOptions.validationGroup, 'validationGroup');
             assert.strictEqual(validatorOptionsAfterEditing.dataGetter, validatorOptions.dataGetter, 'dataGetter');
         } catch(e) {
-        // assert
+            // assert
             assert.ok(false, 'exception');
         }
     });
 
     QUnit.test('validatingController.isInvalidCell - cell should be invalid', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -14466,7 +14511,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('validatingController.validateCell should not call the validate method of the current validator', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
         const done = assert.async();
@@ -14493,7 +14538,7 @@ QUnit.module('Editing with validation', {
         validator.validate = sinon.spy();
 
         this.validatingController.validateCell(validator).done(result => {
-        // assert
+            // assert
             assert.strictEqual(result.status, 'invalid', 'status === "invalid"');
             assert.equal(result.brokenRules.length, 1, 'one rule should be broken');
             assert.equal(validator.validate.callCount, 0, 'validator.validate should not be called');
@@ -14503,7 +14548,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('validatingController - validation result should be cached', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -14544,7 +14589,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('validatingController - validation result should be cached with hidden validation', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -14681,7 +14726,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('validatingController - all validation results of a certain row should be removed', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -14728,7 +14773,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Row - An untouched cell should not be validated (T872003)', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -14775,7 +14820,7 @@ QUnit.module('Editing with validation', {
     // T865329
     [true, false].forEach(withConfirm => {
         QUnit.test('Validation should not block deleting newly added row in cell edit mode ' + (withConfirm ? '(with confirm)' : '(no confirm)'), function(assert) {
-        // arrange
+            // arrange
             const rowsView = this.rowsView;
             const testElement = $('#container');
             let visibleRows;
@@ -14819,7 +14864,7 @@ QUnit.module('Editing with validation', {
             this.clock.tick();
 
             if(withConfirm) {
-            // assert
+                // assert
                 const dialog = $('body').find('.dx-dialog').first();
 
                 assert.ok(dialog.length, 'dialog was shown');
@@ -14839,7 +14884,7 @@ QUnit.module('Editing with validation', {
     // T865329
     [true, false].forEach((withConfirm) => {
         QUnit.test('Deleting should be blocked while editing newly added row in cell edit mode' + withConfirm ? '(with confirm)' : '(no confirm)', function(assert) {
-        // arrange
+            // arrange
             const rowsView = this.rowsView;
             const testElement = $('#container');
             let visibleRows;
@@ -14900,7 +14945,7 @@ QUnit.module('Editing with validation', {
     [false, true].forEach((allowUpdating) => {
         [false, true].forEach((allowEditing) => {
             QUnit.test(`Row(allowUpdating: ${allowUpdating}, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator if a row is not in editing mode(T871515)`, function(assert) {
-            // arrange
+                // arrange
                 const rowsView = this.rowsView;
                 const testElement = $('#container');
 
@@ -14943,7 +14988,7 @@ QUnit.module('Editing with validation', {
     ['Cell', 'Batch'].forEach((mode) => {
         [true, false].forEach((allowEditing) => {
             QUnit.test(`${mode}(allowUpdating: false, column.allowEditing: ${allowEditing}) - Cell with validation rules should not have a validator(T871515)`, function(assert) {
-            // arrange
+                // arrange
                 const rowsView = this.rowsView;
                 const testElement = $('#container');
 
@@ -14982,7 +15027,7 @@ QUnit.module('Editing with validation', {
             });
 
             QUnit.test(`${mode}(allowUpdating: true, column.allowEditing: ${allowEditing}) - Cell with validation rules should have a validator(T871515)`, function(assert) {
-            // arrange
+                // arrange
                 const rowsView = this.rowsView;
                 const testElement = $('#container');
 
@@ -15016,7 +15061,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Cell mode(setCellValue) - The value of an invalid dependent cell should be updated in a new row(T872751)', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -15068,7 +15113,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Cell mode(setCellValue) - The value of an invalid dependent cell should be updated in a modified row(T872751)', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -15123,7 +15168,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Cell mode(calculateCellValue) - The value of an invalid dependent cell should be updated in a new row(T872751)', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -15174,7 +15219,7 @@ QUnit.module('Editing with validation', {
     });
 
     QUnit.test('Cell mode(calculateCellValue) - The value of an invalid dependent cell should be updated in a modified row(T872751)', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.rowsView;
         const testElement = $('#container');
 
@@ -15421,7 +15466,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
 }, () => {
 
     QUnit.test('When showing dxDataGrid in detail, \'select all\' function of master grid must select only master\'s rows', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const rowClass = 'dx-row';
         const rowSelectionClass = 'dx-selection';
@@ -15446,7 +15491,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
 
     // T174302
     QUnit.test('Insert row without column with group closed', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -15475,7 +15520,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
 
     // T187148
     QUnit.test('Grouping when columns with showEditorAlways true', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -15498,7 +15543,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
 
     // T199291
     QUnit.test('Grouping when column with showWhenGrouped true', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -15551,7 +15596,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
 
     // T469436
     QUnit.test('isEditing parameter of the row when there is grouping and edit mode is \'row\'', function(assert) {
-    // arrange
+        // arrange
 
         this.rowsView.render($('#container'));
         this.applyOptions({
@@ -15573,7 +15618,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
 
     // T607622
     QUnit.test('Editable data should not be reset in batch edit mode when collapsing a group row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const $testElement = $('#container');
 
@@ -15601,7 +15646,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
     });
 
     QUnit.test('Editing controller should correct the editing row index after expand the row above (T660472, T579296)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const $testElement = $('#container');
 
@@ -15627,7 +15672,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
 
     // T752381
     QUnit.test('Close edit form after collapse group row', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const $testElement = $('#container');
 
@@ -15700,7 +15745,7 @@ QUnit.module('Editing with scrolling', {
 
     // T258714
     QUnit.test('Uploading items when virtual scrolling after insert row', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.scrolling = {
@@ -15730,7 +15775,7 @@ QUnit.module('Editing with scrolling', {
 
     // T258714
     QUnit.test('Change page index when virtual scrolling after insert row', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         let changeType;
 
@@ -15775,7 +15820,7 @@ QUnit.module('Editing with scrolling', {
 
     // T258714
     QUnit.test('Uploading items when infinite scrolling after insert row', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.scrolling = {
@@ -15855,7 +15900,7 @@ QUnit.module('Editing with scrolling', {
 
     // T258714
     QUnit.test('Edit row after the virtual scrolling when there is inserted row', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.scrolling = {
@@ -15894,7 +15939,7 @@ QUnit.module('Editing with scrolling', {
 
     // T626571
     QUnit.test('Validation show only one message for editing cell in virtual mode', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.scrolling = {
@@ -15947,7 +15992,7 @@ QUnit.module('Editing with scrolling', {
 
     // T676492
     QUnit.test('Validation is hiding when some data rows are removing from DOM in virtual mode', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.scrolling = {
@@ -16003,7 +16048,7 @@ QUnit.module('Editing with scrolling', {
 
     // T635322
     QUnit.test('Error row should be visible after editing', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.scrolling = {
@@ -16045,7 +16090,7 @@ QUnit.module('Editing with scrolling', {
 
     // T538954
     QUnit.test('Position of the inserted row if masterDetail is used', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.dataSource = generateDataSource(10, 1);
@@ -16076,7 +16121,7 @@ QUnit.module('Editing with scrolling', {
 
     // T538954
     QUnit.test('Position of the inserted row if top visible row is master detail', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.dataSource = generateDataSource(10, 1);
@@ -16110,7 +16155,7 @@ QUnit.module('Editing with scrolling', {
 
     // T601854
     QUnit.test('Editing if unbound column presents and form edit mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -16118,7 +16163,7 @@ QUnit.module('Editing with scrolling', {
             allowUpdating: true,
             mode: 'form'
         });
-        that.options.columns = ['C0', { }];
+        that.options.columns = ['C0', {}];
         that.options.dataSource.store = [{ C0: 0 }, { C0: 1 }];
 
         that.setupDataGrid();
@@ -16133,7 +16178,7 @@ QUnit.module('Editing with scrolling', {
 
     // T538954
     QUnit.test('Position of the inserted row if top visible row is adaptive detail', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         testElement.width(150);
@@ -16165,7 +16210,7 @@ QUnit.module('Editing with scrolling', {
 
     // T343567
     QUnit.test('Save edit data with set onRowValidating and infinite scrolling', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -16212,7 +16257,7 @@ QUnit.module('Editing with scrolling', {
     });
 
     QUnit.test('Save inserted data with set onRowValidating and infinite scrolling', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -16267,7 +16312,7 @@ QUnit.module('Editing with scrolling', {
 
     // T258714
     QUnit.test('Edit row after the infinite scrolling when there is inserted row', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.scrolling = {
@@ -16306,7 +16351,7 @@ QUnit.module('Editing with scrolling', {
 
     // T600046
     QUnit.test('Position of the inserted row if grouping is used', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.keyExpr = 'column2';
@@ -16341,7 +16386,7 @@ QUnit.module('Editing with scrolling', {
 
     // T672237
     QUnit.test('cancelEditData after scrolling if scrolling mode is editing', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.scrolling = {
@@ -16377,7 +16422,7 @@ QUnit.module('Editing with scrolling', {
 
     ['virtual', 'standard'].forEach(rowRenderingMode => {
         QUnit.test(`Add new row items on 'append' if scrolling.mode: 'virtual', scrolling.rowRenderingMode: ${rowRenderingMode} (T812340)`, function(assert) {
-        // arrange
+            // arrange
             this.options = $.extend(this.options, {
                 dataSource: generateDataSource(50, 2),
                 keyExpr: 'column1',
@@ -16423,7 +16468,7 @@ QUnit.module('Editing with scrolling', {
         });
 
         QUnit.test(`Add new row items on "prepend" if scrolling.mode: 'virtual', scrolling.rowRenderingMode: ${rowRenderingMode} (T812340)`, function(assert) {
-        // arrange
+            // arrange
             this.options = $.extend(this.options, {
                 dataSource: generateDataSource(50, 2),
                 keyExpr: 'column1',
@@ -16470,7 +16515,7 @@ QUnit.module('Editing with scrolling', {
     });
 
     QUnit.test('DataGrid should show error message on adding row if dataSource is not specified (T711831)', function(assert) {
-    // arrange
+        // arrange
         let errorCode;
         let widgetName;
 
@@ -16726,7 +16771,7 @@ QUnit.module('Edit Form', {
 
     // T434382
     QUnit.test('Render detail form with band columns', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const $testElement = $('#container');
 
@@ -17253,7 +17298,7 @@ QUnit.module('Edit Form', {
 
     // T425138
     QUnit.test('getCellElement', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const $testElement = $('#container');
 
@@ -17278,7 +17323,7 @@ QUnit.module('Edit Form', {
 
     // T425138
     QUnit.test('getCellElement when form with custom items', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const $testElement = $('#container');
 
@@ -17307,7 +17352,7 @@ QUnit.module('Edit Form', {
 
     // T435429
     QUnit.test('Render editors after repaint of form', function(assert) {
-    // arrange
+        // arrange
         this.setupModules(this);
 
         const that = this;
@@ -17333,7 +17378,7 @@ QUnit.module('Edit Form', {
     });
 
     QUnit.test('Values of the editors should be correct after repaint on form', function(assert) {
-    // arrange
+        // arrange
         this.setupModules(this);
 
         const that = this;
@@ -17358,7 +17403,7 @@ QUnit.module('Edit Form', {
 
     // T562662
     QUnit.test('Render detail form row - creation а validator should not throw an exception when editCellTemplate  specified for column', function(assert) {
-    // arrange
+        // arrange
         this.setupModules(this);
 
         const $testElement = $('#container');
@@ -17374,20 +17419,20 @@ QUnit.module('Edit Form', {
         });
 
         try {
-        // act
+            // act
             this.editRow(0);
 
             // assert
             assert.ok(true, 'no exceptions');
         } catch(e) {
-        // assert
+            // assert
             assert.ok(false, 'exception');
         }
     });
 
     // T554950
     QUnit.testInActiveWindow('Focus on lookup column should be preserved after changing a value in lookup', function(assert) {
-    // arrange
+        // arrange
         this.options.keyboardNavigation = {
             enabled: true
         };
@@ -17433,7 +17478,7 @@ QUnit.module('Edit Form', {
 
     // T822877
     QUnit.testInActiveWindow('Focus on column with setCellValue should be preserved after changing a value if fixed columns are exist', function(assert) {
-    // arrange
+        // arrange
         this.options.keyboardNavigation = {
             enabled: true
         };
@@ -17502,7 +17547,7 @@ QUnit.module('Edit Form', {
 
     // T627688
     QUnit.test('getCellElement for a hidden column', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
 
         $.extend(this.options.editing, {
@@ -17628,7 +17673,7 @@ QUnit.module('Edit Form', {
     });
 
     QUnit.test('Edit form when form items are specified with editorType', function(assert) {
-    // arrange
+        // arrange
 
         this.options.editing.form = {
             items: [{ dataField: 'name', editorType: 'dxAutocomplete' }]
@@ -17651,7 +17696,7 @@ QUnit.module('Edit Form', {
     });
 
     QUnit.test('Edit form when group form items are specified and simple form items have editor type', function(assert) {
-    // arrange
+        // arrange
 
         this.options.editing.form = {
             items: [{ itemType: 'group', items: [{ dataField: 'name', editorType: 'dxAutocomplete' }] }]
@@ -17674,10 +17719,10 @@ QUnit.module('Edit Form', {
     });
 
     QUnit.test('Edit form when tabbed form items are specified and simple form items have editor type', function(assert) {
-    // arrange
+        // arrange
 
         this.options.editing.form = {
-            items: [{ itemType: 'tabbed', tabs: [ { items: [{ dataField: 'name', editorType: 'dxAutocomplete' }] }] }]
+            items: [{ itemType: 'tabbed', tabs: [{ items: [{ dataField: 'name', editorType: 'dxAutocomplete' }] }] }]
         };
 
         this.setupModules(this);
@@ -17697,7 +17742,7 @@ QUnit.module('Edit Form', {
     });
 
     QUnit.test('Edit form when formItem is specified with editorType in the column', function(assert) {
-    // arrange
+        // arrange
 
         this.columns[0].formItem = { editorType: 'dxAutocomplete' };
         this.setupModules(this);
@@ -17717,7 +17762,7 @@ QUnit.module('Edit Form', {
     });
 
     QUnit.test('Edit form when formItem is specified with editorType in the column and the editorName is overridden on the onEditorPreparing event', function(assert) {
-    // arrange
+        // arrange
 
         this.options.onEditorPreparing = (e) => {
             if(e.dataField === 'name') {
@@ -17742,7 +17787,7 @@ QUnit.module('Edit Form', {
     });
 
     QUnit.test('Edit form when the editorType is specified in the column.formItem and editing.form.items', function(assert) {
-    // arrange
+        // arrange
 
         this.options.editing.form = {
             items: [{ dataField: 'name', editorType: 'dxColorBox' }]
@@ -17765,7 +17810,7 @@ QUnit.module('Edit Form', {
     });
 
     QUnit.test('The edit form should not be rerendered when setCellValue is set for the column and repaintChangesOnly is true', function(assert) {
-    // arrange
+        // arrange
         this.options.repaintChangesOnly = true;
         this.columns[0] = { dataField: 'name', setCellValue: function() { this.defaultSetCellValue.apply(this, arguments); } };
         this.setupModules(this);
@@ -17797,7 +17842,7 @@ QUnit.module('Edit Form', {
 
     // T848729
     QUnit.test('The onRowClick event should not be fired when clicking on a save button in the edit form', function(assert) {
-    // arrange
+        // arrange
         this.options.loadingTimeout = 30;
         this.options.repaintChangesOnly = true;
         this.options.editing.texts = {
@@ -17839,7 +17884,7 @@ QUnit.module('Edit Form', {
 
     // T869892
     QUnit.test('setCellValue\'s currentRowData argument should be correct if repaintChangesOnly', function(assert) {
-    // arrange
+        // arrange
         const changeValue = function(newValue) {
             const editor = $('.dx-texteditor-input').eq(0);
 
@@ -17875,7 +17920,7 @@ QUnit.module('Edit Form', {
         let oldValue = 'Alex';
 
         for(let i = 1; i < 5; i++) {
-        // act
+            // act
             const newValue = `Test${i}`;
 
             changeValue(newValue);
@@ -18425,7 +18470,7 @@ QUnit.module('Editing - "popup" mode', {
 
     // T534503
     QUnit.testInActiveWindow('Form should repaint after change data of the column with \'setCellValue\' option', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let callSetCellValue;
 
@@ -18463,7 +18508,7 @@ QUnit.module('Editing - "popup" mode', {
 
     // T702664
     QUnit.testInActiveWindow('Form should restore focus to item in group after change data of the column with \'setCellValue\' option', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let callSetCellValue;
 
@@ -18513,7 +18558,7 @@ QUnit.module('Editing - "popup" mode', {
 
     // T613963
     QUnit.testInActiveWindow('Form should repaint after change lookup dataSource', function(assert) {
-    // arrange
+        // arrange
         const that = this;
 
         that.columns[4] = {
@@ -18585,7 +18630,7 @@ QUnit.module('Editing - "popup" mode', {
 
     // T610885
     QUnit.test('The data passed to the editCellTemplate callback should be updated after editing cell (in the scenario with cascaded editors)', function(assert) {
-    // arrange
+        // arrange
         const template = sinon.spy();
 
         this.options.columns = [{
@@ -18615,7 +18660,7 @@ QUnit.module('Editing - "popup" mode', {
     });
 
     QUnit.test('In popup editing mode need to repaint only changed fields with repaintChangesOnly (T753269)', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const orders = [
             { Id: 1, Name: 'Paul Henriot', City: 'Reims', Country: 'France' },
@@ -18688,7 +18733,7 @@ QUnit.module('Editing - "popup" mode', {
     });
 
     QUnit.test('Popup should have scrollbar', function(assert) {
-    // arrange
+        // arrange
         const that = this;
 
         that.options.editing.allowAdding = true;
@@ -18726,7 +18771,7 @@ QUnit.module('Editing - "popup" mode', {
 
     // T680925
     QUnit.test('No exceptions on editing data when validationRules and editCellTemplate are specified in column', function(assert) {
-    // arrange
+        // arrange
         this.columns[0].editCellTemplate = function(container) {
             $(container).append($('<input type=\'text\' />'));
         };
@@ -18737,14 +18782,14 @@ QUnit.module('Editing - "popup" mode', {
         sinon.spy(errors, 'log');
 
         try {
-        // act
+            // act
             this.editRow(0);
 
             // assert
             assert.equal(errors.log.callCount, 1, 'one error is occured');
             assert.equal(errors.log.lastCall.args[0], 'E1050', 'Error code');
         } catch(e) {
-        // assert
+            // assert
             assert.ok(false, 'exception');
         } finally {
             fx.off = false;
@@ -18754,9 +18799,9 @@ QUnit.module('Editing - "popup" mode', {
 
     // T721896
     QUnit.test('Validator should be rendered if deferUpdate is used in editCellTemplate', function(assert) {
-    // arrange
+        // arrange
         this.columns[0].editCellTemplate = function(container, options) {
-        // deferUpdate is called in template in devextreme-react
+            // deferUpdate is called in template in devextreme-react
             commonUtils.deferUpdate(() => {
                 $('<div>').appendTo(container).dxTextBox({
                     value: options.value
@@ -18769,7 +18814,7 @@ QUnit.module('Editing - "popup" mode', {
         fx.off = true;
 
         try {
-        // act
+            // act
             this.editRow(0);
 
             // assert
@@ -18782,7 +18827,7 @@ QUnit.module('Editing - "popup" mode', {
     });
 
     QUnit.test('The editCellTemplate should be called once for the form when adding a new row', function(assert) {
-    // arrange
+        // arrange
         const editCellTemplate = sinon.spy(function() {
             return $('<div class=\'myEditor\'/>').text('<input />');
         });
@@ -18850,7 +18895,7 @@ QUnit.module('Promises in callbacks and events', {
                 const deferred = $.Deferred();
                 this.deferred = deferred;
                 newData.name = value;
-                setTimeout(() =>{
+                setTimeout(() => {
                     newData.age = 99;
                     deferred.resolve();
                 }, 100);
@@ -18904,7 +18949,7 @@ QUnit.module('Promises in callbacks and events', {
 }, () => {
 
     QUnit.test('Saving on enter key while editing cell with async setCellValue works correctly', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -18931,7 +18976,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Closing cell editor with async setCellValue works', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -18956,7 +19001,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Cancel changes after closing cell editor with async setCellValue', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -18983,7 +19028,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Changing editing cell save data when promises are used', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rowsView = this.rowsView;
         const testElement = $('#container');
@@ -19010,7 +19055,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Error row should be shown if promise returned from setCellValue is rejected', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -19038,7 +19083,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Closing cell should work after promise returned from setCellValue is rejected', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -19060,7 +19105,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     const onInitNewRowTest = function(assert, that, mode) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         let visibleRows;
         const rowData = { room: 42 };
@@ -19118,7 +19163,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     const failingOnInitNewRowTest = function(assert, that, mode) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         let visibleRows;
         const rowData = { room: 42 };
@@ -19174,7 +19219,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Adding multiple rows with async onInitNewRow and batch mode', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const that = this;
         let visibleRows;
@@ -19229,7 +19274,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Adding multiple rows with async onInitNewRow and cell mode', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const that = this;
         let visibleRows;
@@ -19282,7 +19327,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Adding multiple rows with async onInitNewRow and row mode', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const that = this;
         let visibleRows;
@@ -19335,7 +19380,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Adding multiple rows with async onInitNewRow (mixed failures and success) and batch mode', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const that = this;
         let visibleRows;
@@ -19400,7 +19445,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Adding multiple rows with async onInitNewRow (mixed failures and success) and cell mode', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const that = this;
         let visibleRows;
@@ -19463,7 +19508,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Adding multiple rows with async onInitNewRow (mixed failures and success) and row mode', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         const that = this;
         let visibleRows;
@@ -19526,7 +19571,7 @@ QUnit.module('Promises in callbacks and events', {
     });
 
     QUnit.test('Adding row and editing another row when the onInitNewRow event is asynchronous and row mode is set', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
 
         this.options.columns = ['room'];


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
