### PR TITLE
DateBox with mask enabled should select first date part on date parts render even if input is not active element (T976144) (#16559)

### DIFF
--- a/js/ui/date_box/ui.date_box.mask.js
+++ b/js/ui/date_box/ui.date_box.mask.js
@@ -363,7 +363,9 @@ const DateBoxMask = DateBoxBase.inherit({
 
         if(text) {
             this._dateParts = renderDateParts(text, this._regExpInfo);
-            this._isFocused() && this._selectNextPart();
+            if(!this._input().is(':hidden')) {
+                this._selectNextPart();
+            }
         }
     },
 


### PR DESCRIPTION
… 

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
