### PR TITLE
Use intersection for JQueryPromise type

### DIFF
--- a/js/data/custom_store.d.ts
+++ b/js/data/custom_store.d.ts
@@ -17,7 +17,7 @@ export interface CustomStoreOptions extends StoreOptions<CustomStore> {
      * @prevFileNamespace DevExpress.data
      * @public
      */
-    byKey?: ((key: any | string | number) => Promise<any> | JQueryPromise<any>);
+    byKey?: ((key: any | string | number) => Promise<any> & JQueryPromise<any>);
     /**
      * @docid CustomStoreOptions.cacheRawData
      * @type boolean
@@ -34,7 +34,7 @@ export interface CustomStoreOptions extends StoreOptions<CustomStore> {
      * @prevFileNamespace DevExpress.data
      * @public
      */
-    insert?: ((values: any) => Promise<any> | JQueryPromise<any>);
+    insert?: ((values: any) => Promise<any> & JQueryPromise<any>);
     /**
      * @docid CustomStoreOptions.load
      * @type function
@@ -43,7 +43,7 @@ export interface CustomStoreOptions extends StoreOptions<CustomStore> {
      * @prevFileNamespace DevExpress.data
      * @public
      */
-    load?: ((options: LoadOptions) => Promise<any> | JQueryPromise<any> | Array<any>);
+    load?: ((options: LoadOptions) => (Promise<any> & JQueryPromise<any>) | Array<any>);
     /**
      * @docid CustomStoreOptions.loadMode
      * @type string
@@ -61,7 +61,7 @@ export interface CustomStoreOptions extends StoreOptions<CustomStore> {
      * @prevFileNamespace DevExpress.data
      * @public
      */
-    remove?: ((key: any | string | number) => Promise<void> | JQueryPromise<void>);
+    remove?: ((key: any | string | number) => Promise<void> & JQueryPromise<void>);
     /**
      * @docid CustomStoreOptions.totalCount
      * @type function
@@ -72,7 +72,7 @@ export interface CustomStoreOptions extends StoreOptions<CustomStore> {
      * @prevFileNamespace DevExpress.data
      * @public
      */
-    totalCount?: ((loadOptions: { filter?: any, group?: any }) => Promise<number> | JQueryPromise<number>);
+    totalCount?: ((loadOptions: { filter?: any, group?: any }) => Promise<number> & JQueryPromise<number>);
     /**
      * @docid CustomStoreOptions.update
      * @type function
@@ -82,7 +82,7 @@ export interface CustomStoreOptions extends StoreOptions<CustomStore> {
      * @prevFileNamespace DevExpress.data
      * @public
      */
-    update?: ((key: any | string | number, values: any) => Promise<any> | JQueryPromise<any>);
+    update?: ((key: any | string | number, values: any) => Promise<any> & JQueryPromise<any>);
     /**
      * @docid CustomStoreOptions.useDefaultSearch
      * @type boolean

--- a/js/file_management/custom_provider.d.ts
+++ b/js/file_management/custom_provider.d.ts
@@ -16,7 +16,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    abortFileUpload?: ((file: File, uploadInfo: UploadInfo, destinationDirectory: FileSystemItem) => Promise<any> | JQueryPromise<any> | any);
+    abortFileUpload?: ((file: File, uploadInfo: UploadInfo, destinationDirectory: FileSystemItem) => (Promise<any> & JQueryPromise<any>) | any);
 
     /**
      * @docid CustomFileSystemProviderOptions.copyItem
@@ -27,7 +27,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    copyItem?: ((item: FileSystemItem, destinationDirectory: FileSystemItem) => Promise<any> | JQueryPromise<any> | any);
+    copyItem?: ((item: FileSystemItem, destinationDirectory: FileSystemItem) => (Promise<any> & JQueryPromise<any>) | any);
 
     /**
      * @docid CustomFileSystemProviderOptions.createDirectory
@@ -38,7 +38,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    createDirectory?: ((parentDirectory: FileSystemItem, name: string) => Promise<any> | JQueryPromise<any> | any);
+    createDirectory?: ((parentDirectory: FileSystemItem, name: string) => (Promise<any> & JQueryPromise<any>) | any);
 
     /**
      * @docid CustomFileSystemProviderOptions.deleteItem
@@ -48,7 +48,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    deleteItem?: ((item: FileSystemItem) => Promise<any> | JQueryPromise<any> | any);
+    deleteItem?: ((item: FileSystemItem) => (Promise<any> & JQueryPromise<any>) | any);
 
     /**
      * @docid CustomFileSystemProviderOptions.downloadItems
@@ -67,7 +67,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    getItems?: ((parentDirectory: FileSystemItem) => Promise<Array<any>> | JQueryPromise<Array<any>> | Array<any>);
+    getItems?: ((parentDirectory: FileSystemItem) => (Promise<Array<any>> & JQueryPromise<Array<any>)> | Array<any>);
 
     /**
      * @docid CustomFileSystemProviderOptions.getItemsContent
@@ -77,7 +77,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    getItemsContent?: ((items: Array<FileSystemItem>) => Promise<any> | JQueryPromise<any> | any);
+    getItemsContent?: ((items: Array<FileSystemItem>) => (Promise<any> & JQueryPromise<any>) | any);
 
     /**
      * @docid CustomFileSystemProviderOptions.hasSubDirectoriesExpr
@@ -96,7 +96,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    moveItem?: ((item: FileSystemItem, destinationDirectory: FileSystemItem) => Promise<any> | JQueryPromise<any> | any);
+    moveItem?: ((item: FileSystemItem, destinationDirectory: FileSystemItem) => (Promise<any> & JQueryPromise<any>) | any);
 
     /**
      * @docid CustomFileSystemProviderOptions.renameItem
@@ -107,7 +107,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    renameItem?: ((item: FileSystemItem, newName: string) => Promise<any> | JQueryPromise<any> | any);
+    renameItem?: ((item: FileSystemItem, newName: string) => (Promise<any> & JQueryPromise<any>) | any);
 
     /**
      * @docid CustomFileSystemProviderOptions.uploadFileChunk
@@ -119,7 +119,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    uploadFileChunk?: ((file: File, uploadInfo: UploadInfo, destinationDirectory: FileSystemItem) => Promise<any> | JQueryPromise<any> | any);
+    uploadFileChunk?: ((file: File, uploadInfo: UploadInfo, destinationDirectory: FileSystemItem) => (Promise<any> & JQueryPromise<any>) | any);
 }
 
 /**

--- a/js/file_management/custom_provider.d.ts
+++ b/js/file_management/custom_provider.d.ts
@@ -67,7 +67,7 @@ export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseO
      * @prevFileNamespace DevExpress.fileManagement
      * @public
      */
-    getItems?: ((parentDirectory: FileSystemItem) => (Promise<Array<any>> & JQueryPromise<Array<any>)> | Array<any>);
+    getItems?: ((parentDirectory: FileSystemItem) => (Promise<Array<any>> & JQueryPromise<Array<any>>) | Array<any>);
 
     /**
      * @docid CustomFileSystemProviderOptions.getItemsContent

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -353,7 +353,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onInitNewRow?: ((e: { component?: T, element?: dxElement, model?: any, data?: any, promise?: Promise<void> | JQueryPromise<void> }) => any);
+    onInitNewRow?: ((e: { component?: T, element?: dxElement, model?: any, data?: any, promise?: Promise<void> & JQueryPromise<void> }) => any);
     /**
      * @docid GridBaseOptions.onKeyDown
      * @type function(e)
@@ -437,7 +437,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowInserting?: ((e: { component?: T, element?: dxElement, model?: any, data?: any, cancel?: boolean | Promise<void> | JQueryPromise<void> }) => any);
+    onRowInserting?: ((e: { component?: T, element?: dxElement, model?: any, data?: any, cancel?: boolean | (Promise<void> & JQueryPromise<void>) }) => any);
     /**
      * @docid GridBaseOptions.onRowRemoved
      * @type function(e)
@@ -463,7 +463,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowRemoving?: ((e: { component?: T, element?: dxElement, model?: any, data?: any, key?: any, cancel?: boolean | Promise<void> | JQueryPromise<void> }) => any);
+    onRowRemoving?: ((e: { component?: T, element?: dxElement, model?: any, data?: any, key?: any, cancel?: boolean | (Promise<void> & JQueryPromise<void>) }) => any);
     /**
      * @docid GridBaseOptions.onRowUpdated
      * @type function(e)
@@ -490,7 +490,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowUpdating?: ((e: { component?: T, element?: dxElement, model?: any, oldData?: any, newData?: any, key?: any, cancel?: boolean | Promise<void> | JQueryPromise<void> }) => any);
+    onRowUpdating?: ((e: { component?: T, element?: dxElement, model?: any, oldData?: any, newData?: any, key?: any, cancel?: boolean | (Promise<void> & JQueryPromise<void>) }) => any);
     /**
      * @docid GridBaseOptions.onRowValidating
      * @type function(e)
@@ -507,7 +507,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowValidating?: ((e: { component?: T, element?: dxElement, model?: any, brokenRules?: Array<RequiredRule | NumericRule | RangeRule | StringLengthRule | CustomRule | CompareRule | PatternRule | EmailRule | AsyncRule>, isValid?: boolean, key?: any, newData?: any, oldData?: any, errorText?: string, promise?: Promise<void> | JQueryPromise<void> }) => any);
+    onRowValidating?: ((e: { component?: T, element?: dxElement, model?: any, brokenRules?: Array<RequiredRule | NumericRule | RangeRule | StringLengthRule | CustomRule | CompareRule | PatternRule | EmailRule | AsyncRule>, isValid?: boolean, key?: any, newData?: any, oldData?: any, errorText?: string, promise?: (Promise<void> & JQueryPromise<void>) }) => any);
     /**
      * @docid GridBaseOptions.onSelectionChanged
      * @type function(e)
@@ -577,7 +577,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    rowDragging?: { allowDropInsideItem?: boolean, allowReordering?: boolean, autoScroll?: boolean, boundary?: string | Element | JQuery, container?: string | Element | JQuery, cursorOffset?: string | { x?: number, y?: number }, data?: any, dragDirection?: 'both' | 'horizontal' | 'vertical', dragTemplate?: template | ((dragInfo: { itemData?: any, itemElement?: dxElement }, containerElement: dxElement) => string | Element | JQuery), dropFeedbackMode?: 'push' | 'indicate', filter?: string, group?: string, handle?: string, onAdd?: ((e: { event?: event, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean }) => any), onDragChange?: ((e: { event?: event, cancel?: boolean, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean }) => any), onDragEnd?: ((e: { event?: event, cancel?: boolean, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean }) => any), onDragMove?: ((e: { event?: event, cancel?: boolean, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean }) => any), onDragStart?: ((e: { event?: event, cancel?: boolean, itemData?: any, itemElement?: dxElement, fromIndex?: number, fromData?: any }) => any), onRemove?: ((e: { event?: event, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any }) => any), onReorder?: ((e: { event?: event, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean, promise?: Promise<void> | JQueryPromise<void> }) => any), scrollSensitivity?: number, scrollSpeed?: number, showDragIcons?: boolean };
+    rowDragging?: { allowDropInsideItem?: boolean, allowReordering?: boolean, autoScroll?: boolean, boundary?: string | Element | JQuery, container?: string | Element | JQuery, cursorOffset?: string | { x?: number, y?: number }, data?: any, dragDirection?: 'both' | 'horizontal' | 'vertical', dragTemplate?: template | ((dragInfo: { itemData?: any, itemElement?: dxElement }, containerElement: dxElement) => string | Element | JQuery), dropFeedbackMode?: 'push' | 'indicate', filter?: string, group?: string, handle?: string, onAdd?: ((e: { event?: event, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean }) => any), onDragChange?: ((e: { event?: event, cancel?: boolean, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean }) => any), onDragEnd?: ((e: { event?: event, cancel?: boolean, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean }) => any), onDragMove?: ((e: { event?: event, cancel?: boolean, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean }) => any), onDragStart?: ((e: { event?: event, cancel?: boolean, itemData?: any, itemElement?: dxElement, fromIndex?: number, fromData?: any }) => any), onRemove?: ((e: { event?: event, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any }) => any), onReorder?: ((e: { event?: event, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean, promise?: (Promise<void> & JQueryPromise<void>) }) => any), scrollSensitivity?: number, scrollSpeed?: number, showDragIcons?: boolean };
     /**
      * @docid GridBaseOptions.scrolling
      * @type object
@@ -655,7 +655,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    stateStoring?: { customLoad?: (() => Promise<any> | JQueryPromise<any>), customSave?: ((gridState: any) => any), enabled?: boolean, savingTimeout?: number, storageKey?: string, type?: 'custom' | 'localStorage' | 'sessionStorage' };
+    stateStoring?: { customLoad?: (() => Promise<any> & JQueryPromise<any>), customSave?: ((gridState: any) => any), enabled?: boolean, savingTimeout?: number, storageKey?: string, type?: 'custom' | 'localStorage' | 'sessionStorage' };
     /**
      * @docid GridBaseOptions.twoWayBindingEnabled
      * @type boolean
@@ -1827,7 +1827,7 @@ export interface GridBaseColumn {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    setCellValue?: ((newData: any, value: any, currentRowData: any) => void | Promise<void> | JQueryPromise<void>);
+    setCellValue?: ((newData: any, value: any, currentRowData: any) => void | (Promise<void> & JQueryPromise<void>));
     /**
      * @docid GridBaseColumn.showEditorAlways
      * @type boolean

--- a/js/ui/defer_rendering.d.ts
+++ b/js/ui/defer_rendering.d.ts
@@ -44,7 +44,7 @@ export interface dxDeferRenderingOptions extends WidgetOptions<dxDeferRendering>
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    renderWhen?: Promise<void> | JQueryPromise<void> | boolean;
+    renderWhen?: (Promise<void> & JQueryPromise<void>) | boolean;
     /**
      * @docid dxDeferRenderingOptions.showLoadIndicator
      * @type bool

--- a/js/ui/file_uploader.d.ts
+++ b/js/ui/file_uploader.d.ts
@@ -24,7 +24,7 @@ export interface dxFileUploaderOptions extends EditorOptions<dxFileUploader> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    abortUpload?: ((file: File, uploadInfo?: UploadInfo) => Promise<any> | JQueryPromise<any> | any);
+    abortUpload?: ((file: File, uploadInfo?: UploadInfo) => (Promise<any> & JQueryPromise<any>) | any);
     /**
      * @docid dxFileUploaderOptions.accept
      * @type string
@@ -275,7 +275,7 @@ export interface dxFileUploaderOptions extends EditorOptions<dxFileUploader> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    uploadChunk?: ((file: File, uploadInfo: UploadInfo) => Promise<any> | JQueryPromise<any> | any);
+    uploadChunk?: ((file: File, uploadInfo: UploadInfo) => (Promise<any> & JQueryPromise<any>) | any);
     /**
      * @docid dxFileUploaderOptions.uploadFailedMessage
      * @type string
@@ -293,7 +293,7 @@ export interface dxFileUploaderOptions extends EditorOptions<dxFileUploader> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    uploadFile?: ((file: File, progressCallback: Function) => Promise<any> | JQueryPromise<any> | any);
+    uploadFile?: ((file: File, progressCallback: Function) => (Promise<any> & JQueryPromise<any>) | any);
     /**
      * @docid dxFileUploaderOptions.uploadHeaders
      * @type object

--- a/js/ui/list.d.ts
+++ b/js/ui/list.d.ts
@@ -255,7 +255,7 @@ export interface dxListOptions extends CollectionWidgetOptions<dxList>, SearchBo
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onItemDeleting?: ((e: { component?: dxList, element?: dxElement, model?: any, itemData?: any, itemElement?: dxElement, itemIndex?: number | any, cancel?: boolean | Promise<void> | JQueryPromise<void> }) => any);
+    onItemDeleting?: ((e: { component?: dxList, element?: dxElement, model?: any, itemData?: any, itemElement?: dxElement, itemIndex?: number | any, cancel?: boolean | (Promise<void> & JQueryPromise<void>) }) => any);
     /**
      * @docid dxListOptions.onItemHold
      * @extends Action

--- a/js/ui/pivot_grid.d.ts
+++ b/js/ui/pivot_grid.d.ts
@@ -270,7 +270,7 @@ export interface dxPivotGridOptions extends WidgetOptions<dxPivotGrid> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    stateStoring?: { customLoad?: (() => Promise<any> | JQueryPromise<any>), customSave?: ((state: any) => any), enabled?: boolean, savingTimeout?: number, storageKey?: string, type?: 'custom' | 'localStorage' | 'sessionStorage' };
+    stateStoring?: { customLoad?: (() => Promise<any> & JQueryPromise<any>), customSave?: ((state: any) => any), enabled?: boolean, savingTimeout?: number, storageKey?: string, type?: 'custom' | 'localStorage' | 'sessionStorage' };
     /**
      * @docid dxPivotGridOptions.texts
      * @type object

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -298,7 +298,7 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onAppointmentAdding?: ((e: { component: dxScheduler, element: dxElement, model?: any, appointmentData: any, cancel: boolean | Promise<boolean> | JQueryPromise<boolean> }) => any);
+    onAppointmentAdding?: ((e: { component: dxScheduler, element: dxElement, model?: any, appointmentData: any, cancel: boolean | (Promise<boolean> & JQueryPromise<boolean>) }) => any);
     /**
      * @docid dxSchedulerOptions.onAppointmentClick
      * @type function(e)|string
@@ -369,7 +369,7 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onAppointmentDeleting?: ((e: { component: dxScheduler, element: dxElement, model?: any, appointmentData: any, cancel: boolean | Promise<boolean> | JQueryPromise<boolean> }) => any);
+    onAppointmentDeleting?: ((e: { component: dxScheduler, element: dxElement, model?: any, appointmentData: any, cancel: boolean | (Promise<boolean> & JQueryPromise<boolean>) }) => any);
     /**
      * @docid dxSchedulerOptions.onAppointmentFormCreated
      * @extends Action
@@ -434,7 +434,7 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onAppointmentUpdating?: ((e: { component: dxScheduler, element: dxElement, model?: any, oldData?: any, newData?: any, cancel?: boolean | Promise<boolean> | JQueryPromise<boolean> }) => any);
+    onAppointmentUpdating?: ((e: { component: dxScheduler, element: dxElement, model?: any, oldData?: any, newData?: any, cancel?: boolean | (Promise<boolean> & JQueryPromise<boolean>) }) => any);
     /**
      * @docid dxSchedulerOptions.onCellClick
      * @type function(e)|string

--- a/js/ui/select_box.d.ts
+++ b/js/ui/select_box.d.ts
@@ -44,7 +44,7 @@ export interface dxSelectBoxOptions<T = dxSelectBox> extends dxDropDownListOptio
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onCustomItemCreating?: ((e: { component?: T, element?: dxElement, model?: any, text?: string, customItem?: string | any | Promise<any> | JQueryPromise<any> }) => any);
+    onCustomItemCreating?: ((e: { component?: T, element?: dxElement, model?: any, text?: string, customItem?: string | any | (Promise<any> & JQueryPromise<any>) }) => any);
     /**
      * @docid dxSelectBoxOptions.openOnFieldClick
      * @default true

--- a/js/ui/sortable.d.ts
+++ b/js/ui/sortable.d.ts
@@ -218,7 +218,7 @@ export interface dxSortableOptions extends DraggableBaseOptions<dxSortable> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onReorder?: ((e: { component?: dxSortable, element?: dxElement, model?: any, event?: event, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean, promise?: Promise<void> | JQueryPromise<void> }) => any);
+    onReorder?: ((e: { component?: dxSortable, element?: dxElement, model?: any, event?: event, itemData?: any, itemElement?: dxElement, fromIndex?: number, toIndex?: number, fromComponent?: dxSortable | dxDraggable, toComponent?: dxSortable | dxDraggable, fromData?: any, toData?: any, dropInsideItem?: boolean, promise?: Promise<void> & JQueryPromise<void> }) => any);
 }
 /**
  * @docid dxSortable

--- a/js/ui/tree_view.d.ts
+++ b/js/ui/tree_view.d.ts
@@ -41,7 +41,7 @@ export interface dxTreeViewOptions extends HierarchicalCollectionWidgetOptions<d
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    createChildren?: ((parentNode: dxTreeViewNode) => Promise<any> | JQueryPromise<any> | Array<any>);
+    createChildren?: ((parentNode: dxTreeViewNode) => (Promise<any> & JQueryPromise<any>) | Array<any>);
     /**
      * @docid  dxTreeViewOptions.dataSource
      * @type string|Array<dxTreeViewItem>|DataSource|DataSourceOptions

--- a/js/ui/validation_engine.d.ts
+++ b/js/ui/validation_engine.d.ts
@@ -151,7 +151,7 @@ export interface AsyncRule {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    validationCallback?: ((options: { value?: string | number, rule?: any, validator?: any, data?: any, column?: any, formItem?: any }) => Promise<any> | JQueryPromise<any>);
+    validationCallback?: ((options: { value?: string | number, rule?: any, validator?: any, data?: any, column?: any, formItem?: any }) => Promise<any> & JQueryPromise<any>);
 }
 
 export interface CompareRule {

--- a/js/ui/validation_group.d.ts
+++ b/js/ui/validation_group.d.ts
@@ -61,7 +61,7 @@ export interface dxValidationGroupResult {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    complete?: Promise<dxValidationGroupResult> | JQueryPromise<dxValidationGroupResult>;
+    complete?: Promise<dxValidationGroupResult> & JQueryPromise<dxValidationGroupResult>;
     /**
      * @docid dxValidationGroupResult.isValid
      * @type boolean

--- a/js/ui/validator.d.ts
+++ b/js/ui/validator.d.ts
@@ -120,7 +120,7 @@ export interface dxValidatorResult {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    complete?: Promise<dxValidatorResult> | JQueryPromise<dxValidatorResult>;
+    complete?: Promise<dxValidatorResult> & JQueryPromise<dxValidatorResult>;
     /**
      * @docid dxValidatorResult.isValid
      * @type boolean

--- a/js/viz/core/base_widget.d.ts
+++ b/js/viz/core/base_widget.d.ts
@@ -231,7 +231,7 @@ export interface BaseWidgetExport {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    svgToCanvas?: ((svg: SVGElement, canvas: HTMLCanvasElement) => Promise<void> | JQueryPromise<void>);
+    svgToCanvas?: ((svg: SVGElement, canvas: HTMLCanvasElement) => Promise<void> & JQueryPromise<void>);
 }
 export interface BaseWidgetLoadingIndicator {
     /**


### PR DESCRIPTION
This is required to fix problems when `JQueryPromise` is an empty interface (non-JQuery projects). In this case `Promise<T> | JQueryPromise<T>` is equivalent to `{}` which makes all `Promise` fields unaccessible. (T972047)