### PR TITLE
File Manager - Fix resetting of the dxTreeView scroll position in the navPane after refresh (T968173)

### DIFF
--- a/js/ui/file_manager/ui.file_manager.files_tree_view.js
+++ b/js/ui/file_manager/ui.file_manager.files_tree_view.js
@@ -9,6 +9,7 @@ import TreeViewSearch from '../tree_view/ui.tree_view.search';
 
 import FileManagerFileActionsButton from './ui.file_manager.file_actions_button';
 import { Deferred } from '../../core/utils/deferred';
+import { hasWindow } from '../../core/utils/window';
 
 const FILE_MANAGER_DIRS_TREE_CLASS = 'dx-filemanager-dirs-tree';
 const FILE_MANAGER_DIRS_TREE_FOCUSED_ITEM_CLASS = 'dx-filemanager-focused-item';
@@ -59,7 +60,8 @@ class FileManagerFilesTreeView extends Widget {
         this._actions = {
             onClick: this._createActionByOption('onClick'),
             onDirectoryClick: this._createActionByOption('onDirectoryClick'),
-            onFilesTreeViewContentReady: this._createActionByOption('onFilesTreeViewContentReady')
+            onFilesTreeViewContentReady: this._createActionByOption('onFilesTreeViewContentReady'),
+            onCurrentDirectorySet: this._createActionByOption('onCurrentDirectorySet')
         };
     }
 
@@ -81,6 +83,7 @@ class FileManagerFilesTreeView extends Widget {
     _onFilesTreeViewItemRendered({ itemData }) {
         const currentDirectory = this._getCurrentDirectory();
         if(currentDirectory && currentDirectory.fileItem.equals(itemData.fileItem)) {
+            this._actions.onCurrentDirectorySet();
             this._updateFocusedElement();
         }
     }
@@ -149,6 +152,20 @@ class FileManagerFilesTreeView extends Widget {
         }
     }
 
+    _saveScrollTopPosition() {
+        if(!hasWindow()) {
+            return;
+        }
+        this._scrollTopPosition = this._filesTreeView._scrollableContainer.scrollTop();
+    }
+
+    restoreScrollTopPosition() {
+        if(!hasWindow()) {
+            return;
+        }
+        setTimeout(() => this._filesTreeView._scrollableContainer.scrollTo(this._scrollTopPosition));
+    }
+
     _updateFocusedElement() {
         const directoryInfo = this._getCurrentDirectory();
         const $element = this._getItemElementByKey(directoryInfo?.getInternalKey());
@@ -204,6 +221,7 @@ class FileManagerFilesTreeView extends Widget {
             case 'onClick':
             case 'onDirectoryClick':
             case 'onFilesTreeViewContentReady':
+            case 'onCurrentDirectorySet':
                 this._actions[name] = this._createActionByOption(name);
                 break;
             default:
@@ -234,6 +252,7 @@ class FileManagerFilesTreeView extends Widget {
 
     refresh() {
         this._$focusedElement = null;
+        this._saveScrollTopPosition();
         this._filesTreeView.option('dataSource', []);
     }
 

--- a/js/ui/file_manager/ui.file_manager.files_tree_view.js
+++ b/js/ui/file_manager/ui.file_manager.files_tree_view.js
@@ -163,7 +163,7 @@ class FileManagerFilesTreeView extends Widget {
         if(!hasWindow()) {
             return;
         }
-        setTimeout(() => this._filesTreeView._scrollableContainer.scrollTo(this._scrollTopPosition));
+        setTimeout(() => this._filesTreeView?._scrollableContainer?.scrollTo(this._scrollTopPosition || 0));
     }
 
     _updateFocusedElement() {

--- a/js/ui/file_manager/ui.file_manager.files_tree_view.js
+++ b/js/ui/file_manager/ui.file_manager.files_tree_view.js
@@ -163,10 +163,7 @@ class FileManagerFilesTreeView extends Widget {
         if(!hasWindow() || !isNumeric(this._scrollTopPosition)) {
             return;
         }
-        this._scrollRestoreTimeout = setTimeout(() => {
-            delete this._scrollRestoreTimeout;
-            this._filesTreeView._scrollableContainer.scrollTo(this._scrollTopPosition);
-        });
+        setTimeout(() => this._filesTreeView._scrollableContainer.scrollTo(this._scrollTopPosition));
     }
 
     _updateFocusedElement() {

--- a/js/ui/file_manager/ui.file_manager.files_tree_view.js
+++ b/js/ui/file_manager/ui.file_manager.files_tree_view.js
@@ -163,7 +163,10 @@ class FileManagerFilesTreeView extends Widget {
         if(!hasWindow()) {
             return;
         }
-        setTimeout(() => this._filesTreeView?._scrollableContainer?.scrollTo(this._scrollTopPosition || 0));
+        this._scrollRestoreTimeout = setTimeout(() => {
+            delete this._scrollRestoreTimeout;
+            this._filesTreeView._scrollableContainer.scrollTo(this._scrollTopPosition || 0);
+        });
     }
 
     _updateFocusedElement() {

--- a/js/ui/file_manager/ui.file_manager.files_tree_view.js
+++ b/js/ui/file_manager/ui.file_manager.files_tree_view.js
@@ -10,6 +10,7 @@ import TreeViewSearch from '../tree_view/ui.tree_view.search';
 import FileManagerFileActionsButton from './ui.file_manager.file_actions_button';
 import { Deferred } from '../../core/utils/deferred';
 import { hasWindow } from '../../core/utils/window';
+import { isNumeric } from '../../core/utils/type';
 
 const FILE_MANAGER_DIRS_TREE_CLASS = 'dx-filemanager-dirs-tree';
 const FILE_MANAGER_DIRS_TREE_FOCUSED_ITEM_CLASS = 'dx-filemanager-focused-item';
@@ -60,8 +61,7 @@ class FileManagerFilesTreeView extends Widget {
         this._actions = {
             onClick: this._createActionByOption('onClick'),
             onDirectoryClick: this._createActionByOption('onDirectoryClick'),
-            onFilesTreeViewContentReady: this._createActionByOption('onFilesTreeViewContentReady'),
-            onCurrentDirectorySet: this._createActionByOption('onCurrentDirectorySet')
+            onFilesTreeViewContentReady: this._createActionByOption('onFilesTreeViewContentReady')
         };
     }
 
@@ -83,8 +83,8 @@ class FileManagerFilesTreeView extends Widget {
     _onFilesTreeViewItemRendered({ itemData }) {
         const currentDirectory = this._getCurrentDirectory();
         if(currentDirectory && currentDirectory.fileItem.equals(itemData.fileItem)) {
-            this._actions.onCurrentDirectorySet();
             this._updateFocusedElement();
+            this._restoreScrollTopPosition();
         }
     }
 
@@ -159,13 +159,13 @@ class FileManagerFilesTreeView extends Widget {
         this._scrollTopPosition = this._filesTreeView._scrollableContainer.scrollTop();
     }
 
-    restoreScrollTopPosition() {
-        if(!hasWindow()) {
+    _restoreScrollTopPosition() {
+        if(!hasWindow() || !isNumeric(this._scrollTopPosition)) {
             return;
         }
         this._scrollRestoreTimeout = setTimeout(() => {
             delete this._scrollRestoreTimeout;
-            this._filesTreeView._scrollableContainer.scrollTo(this._scrollTopPosition || 0);
+            this._filesTreeView._scrollableContainer.scrollTo(this._scrollTopPosition);
         });
     }
 
@@ -224,7 +224,6 @@ class FileManagerFilesTreeView extends Widget {
             case 'onClick':
             case 'onDirectoryClick':
             case 'onFilesTreeViewContentReady':
-            case 'onCurrentDirectorySet':
                 this._actions[name] = this._createActionByOption(name);
                 break;
             default:

--- a/js/ui/file_manager/ui.file_manager.js
+++ b/js/ui/file_manager/ui.file_manager.js
@@ -165,8 +165,7 @@ class FileManager extends Widget {
             getDirectories: this.getDirectories.bind(this),
             getCurrentDirectory: this._getCurrentDirectory.bind(this),
             onDirectoryClick: this._onFilesTreeViewDirectoryClick.bind(this),
-            onClick: () => this._setItemsViewAreaActive(false),
-            onCurrentDirectorySet: () => this._filesTreeView?.restoreScrollTopPosition()
+            onClick: () => this._setItemsViewAreaActive(false)
         });
 
         this._filesTreeView.updateCurrentDirectory();

--- a/js/ui/file_manager/ui.file_manager.js
+++ b/js/ui/file_manager/ui.file_manager.js
@@ -165,7 +165,8 @@ class FileManager extends Widget {
             getDirectories: this.getDirectories.bind(this),
             getCurrentDirectory: this._getCurrentDirectory.bind(this),
             onDirectoryClick: this._onFilesTreeViewDirectoryClick.bind(this),
-            onClick: () => this._setItemsViewAreaActive(false)
+            onClick: () => this._setItemsViewAreaActive(false),
+            onCurrentDirectorySet: () => this._filesTreeView?.restoreScrollTopPosition()
         });
 
         this._filesTreeView.updateCurrentDirectory();

--- a/testing/helpers/fileManagerHelpers.js
+++ b/testing/helpers/fileManagerHelpers.js
@@ -157,6 +157,10 @@ export class FileManagerWrapper {
         return result;
     }
 
+    getTreeViewScrollableContainer() {
+        return this.getDirsTree().find(`.${Consts.SCROLLABLE_CONTAINER_ClASS}`);
+    }
+
     getFocusedItemText() {
         return this._$element.find(`.${Consts.CONTAINER_CLASS} .${Consts.FOCUSED_ITEM_CLASS} span`).text();
     }

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/scroll.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/scroll.tests.js
@@ -167,4 +167,27 @@ QUnit.module('Scroll', moduleConfig, () => {
 
         assert.strictEqual(this.wrapper.getThumbnailsViewScrollableContainer().scrollTop(), scrollPosition, 'scroll position is the same');
     });
+
+    test('NavPane - must keep scroll position after refresh', function(assert) {
+        const originalFunc = renderer.fn.width;
+        renderer.fn.width = () => 1200;
+
+        this.fileManager.option({
+            width: 500,
+            height: 250,
+            currentPath: 'Folder 1/Folder 1.1/Folder 1.1.1/Folder 1.1.1.1/Folder 1.1.1.1.1'
+        });
+        this.clock.tick(400);
+
+        const scrollPosition = 64;
+        this.wrapper.getTreeViewScrollableContainer().scrollTop(scrollPosition);
+        this.clock.tick(400);
+
+        this.fileManager.refresh();
+        this.clock.tick(800);
+
+        assert.strictEqual(this.wrapper.getTreeViewScrollableContainer().scrollTop(), scrollPosition, 'scroll position is the same');
+
+        renderer.fn.width = originalFunc;
+    });
 });


### PR DESCRIPTION
… navPane after refresh (T968173)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
