### PR TITLE
Renovation: Change accessKey default from null to undefined for type consistansy

### DIFF
--- a/js/renovation/ui/common/__tests__/widget.test.tsx
+++ b/js/renovation/ui/common/__tests__/widget.test.tsx
@@ -861,7 +861,7 @@ describe('Widget', () => {
       const defaultProps = new WidgetProps();
 
       expect(defaultProps).toEqual({
-        accessKey: null,
+        accessKey: undefined,
         activeStateEnabled: false,
         disabled: false,
         focusStateEnabled: false,

--- a/js/renovation/ui/data_grid/common/data_grid_props.tsx
+++ b/js/renovation/ui/data_grid/common/data_grid_props.tsx
@@ -1302,7 +1302,8 @@ export class DataGridProps extends BaseWidgetProps implements Options {
 
   @OneWay() wordWrapEnabled?: boolean;
 
-  @TwoWay() filterValue?: string | any[] | ((...args: any[]) => any) | null = null;
+  // TODO Vitik: Default should be null, but declaration doesnt support it
+  @TwoWay() filterValue?: string | any[] | ((...args: any[]) => any) = [];
 
   @TwoWay() focusedColumnIndex = -1;
 

--- a/js/renovation/ui/data_grid/common/data_grid_props.tsx
+++ b/js/renovation/ui/data_grid/common/data_grid_props.tsx
@@ -8,7 +8,7 @@ import {
   Template,
 } from 'devextreme-generator/component_declaration/common';
 import DxDataGrid from '../../../../ui/data_grid';
-import type { /* Options, */ dxDataGridColumn, dxDataGridRowObject } from '../../../../ui/data_grid';
+import type { Options, dxDataGridColumn, dxDataGridRowObject } from '../../../../ui/data_grid';
 import { BaseWidgetProps } from '../../../utils/base_props';
 
 import type { dxFilterBuilderOptions } from '../../../../ui/filter_builder';
@@ -1176,7 +1176,7 @@ export class DataGridExport {
 }
 
 @ComponentBindings()
-export class DataGridProps extends BaseWidgetProps /* implements Options */ {
+export class DataGridProps extends BaseWidgetProps implements Options {
   @Nested() columns?: (DataGridColumn | string)[];
 
   @Nested() editing?: DataGridEditing;
@@ -1302,7 +1302,7 @@ export class DataGridProps extends BaseWidgetProps /* implements Options */ {
 
   @OneWay() wordWrapEnabled?: boolean;
 
-  @TwoWay() filterValue: string | any[] | ((...args: any[]) => any) | null = null;
+  @TwoWay() filterValue?: string | any[] | ((...args: any[]) => any);
 
   @TwoWay() focusedColumnIndex = -1;
 
@@ -1389,7 +1389,8 @@ export class DataGridProps extends BaseWidgetProps /* implements Options */ {
     isExpanded?: boolean;
     isNewRow?: boolean;
     cellElement?: dxElement;
-    watch?: ((...args: any[]) => any);
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    watch?: Function;
     oldValue?: any;
   }) => any;
 

--- a/js/renovation/ui/data_grid/common/data_grid_props.tsx
+++ b/js/renovation/ui/data_grid/common/data_grid_props.tsx
@@ -1302,7 +1302,7 @@ export class DataGridProps extends BaseWidgetProps implements Options {
 
   @OneWay() wordWrapEnabled?: boolean;
 
-  @TwoWay() filterValue?: string | any[] | ((...args: any[]) => any);
+  @TwoWay() filterValue?: string | any[] | ((...args: any[]) => any) | null = null;
 
   @TwoWay() focusedColumnIndex = -1;
 

--- a/js/renovation/utils/base_props.ts
+++ b/js/renovation/utils/base_props.ts
@@ -4,7 +4,7 @@ import {
 
 @ComponentBindings()
 export class BaseWidgetProps {
-  @OneWay() accessKey?: string | null = null;
+  @OneWay() accessKey?: string;
 
   @OneWay() activeStateEnabled?: boolean = false;
 

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -486,7 +486,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    filterValue?: string | Array<any> | Function | null;
+    filterValue?: string | Array<any> | Function;
     /**
      * @docid
      * @default -1

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -486,7 +486,7 @@ export interface GridBaseOptions<T = GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    filterValue?: string | Array<any> | Function;
+    filterValue?: string | Array<any> | Function | null;
     /**
      * @docid
      * @default -1

--- a/js/ui/widget/ui.widget.d.ts
+++ b/js/ui/widget/ui.widget.d.ts
@@ -9,7 +9,7 @@ import {
 export interface WidgetOptions<T = Widget> extends DOMComponentOptions<T> {
     /**
      * @docid
-     * @default null
+     * @default undefined
      * @prevFileNamespace DevExpress.ui
      * @public
      */

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -51,7 +51,7 @@ const Widget = DOMComponent.inherit({
 
             tabIndex: 0,
 
-            accessKey: null,
+            accessKey: undefined,
 
             /**
             * @name WidgetOptions.onFocusIn

--- a/testing/helpers/dropDownOptions.js
+++ b/testing/helpers/dropDownOptions.js
@@ -1,5 +1,5 @@
 const defaultDropDownOptions = {
-    accessKey: null,
+    accessKey: undefined,
     animation: {
         hide: {
             duration: 400,


### PR DESCRIPTION
Add Options interface implementation to renovated DataGridOptions for check backward compatibility.