### PR TITLE
Update ui.scheduler.appointments.strategy.horizontal_month_line.js

### DIFF
--- a/js/ui/scheduler/rendering_strategies/ui.scheduler.appointments.strategy.horizontal_month_line.js
+++ b/js/ui/scheduler/rendering_strategies/ui.scheduler.appointments.strategy.horizontal_month_line.js
@@ -20,7 +20,8 @@ class HorizontalMonthLineRenderingStrategy extends HorizontalAppointmentsStrateg
 
     _getDurationInDays(startDate, endDate) {
         const adjustedDuration = this._adjustDurationByDaylightDiff(endDate.getTime() - startDate.getTime(), startDate, endDate);
-        return (adjustedDuration / dateUtils.dateToMilliseconds('day')) || ZERO_APPOINTMENT_DURATION_IN_DAYS;
+//         return (adjustedDuration / dateUtils.dateToMilliseconds('day')) || ZERO_APPOINTMENT_DURATION_IN_DAYS;
+        return ZERO_APPOINTMENT_DURATION_IN_DAYS;
     }
 
     getDeltaTime(args, initialSize) {


### PR DESCRIPTION
Edited _getDurationInDays function to return always ZERO_APPOINTMENT_DURATION_IN_DAYS so that appointment width will be limited to only one cell in month view also

