### PR TITLE
Add version number in GA cache key

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,9 +26,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .\node_modules
-        key: ${{ runner.os }}-node-modules-key-${{ hashFiles('**/package.json') }}
+        key: ${{ runner.os }}-node-modules-key-v2-${{ hashFiles('**/package.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-modules-key
+          ${{ runner.os }}-node-modules-key-v2
 
     - name: Run npm install
       run: npm install --no-package-lock --no-audit --no-fund

--- a/.github/workflows/qunit_tests.yml
+++ b/.github/workflows/qunit_tests.yml
@@ -32,9 +32,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package.json') }}
+        key: ${{ runner.os }}-node-modules-v2-${{ hashFiles('**/package.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-modules
+          ${{ runner.os }}-node-modules-v2
 
     - name: Run npm install
       run: npm install --no-package-lock --no-audit --no-fund

--- a/.github/workflows/renovation.yml
+++ b/.github/workflows/renovation.yml
@@ -19,9 +19,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package.json') }}
+        key: ${{ runner.os }}-node-modules-v2-${{ hashFiles('**/package.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-modules
+          ${{ runner.os }}-node-modules-v2
 
     - name: Run npm install
       run: npm install --no-package-lock --no-audit --no-fund

--- a/.github/workflows/testcafe_tests.yml
+++ b/.github/workflows/testcafe_tests.yml
@@ -23,9 +23,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package.json') }}
+        key: ${{ runner.os }}-node-modules-v2-${{ hashFiles('**/package.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-modules
+          ${{ runner.os }}-node-modules-v2
 
     - name: Run npm install
       run: npm install --no-package-lock --no-audit --no-fund

--- a/.github/workflows/themebuilder_dart_tests.yml
+++ b/.github/workflows/themebuilder_dart_tests.yml
@@ -15,9 +15,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .\node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package.json') }}
+        key: ${{ runner.os }}-node-modules-v2-${{ hashFiles('**/package.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-modules
+          ${{ runner.os }}-node-modules-v2
 
     - name: Run npm install
       run: npm install --no-package-lock --no-audit --no-fund


### PR DESCRIPTION
There is currently no native solution to clear the cache in GitHub Actions. 
But we can change 'key' and 'restore-keys' in 'actions/cache@v2' to use a new cache. 
