### PR TITLE
Fix MultiTagPreparingEvent

### DIFF
--- a/js/ui/tag_box.d.ts
+++ b/js/ui/tag_box.d.ts
@@ -76,9 +76,9 @@ export type KeyUpEvent = ComponentNativeEvent<dxTagBox>;
 
 /** @public */
 export type MultiTagPreparingEvent = ComponentEvent<dxTagBox> & Cancelable & {
-    multiTagElement: TElement;
+    readonly multiTagElement: TElement;
     readonly selectedItems?: Array<string | number | any>;
-    readonly text?: string;
+    text?: string;
 }
 
 /** @public */


### PR DESCRIPTION
I've updated the type according to the [documentation](https://js.devexpress.com/Documentation/21_1/ApiReference/UI_Components/dxTagBox/Configuration/#onMultiTagPreparing).