### PR TITLE
Themes Engine does not force layout before the page was loaded

### DIFF
--- a/js/ui/themes.js
+++ b/js/ui/themes.js
@@ -39,7 +39,7 @@ function readThemeMarker() {
     let result;
 
     try {
-        result = element.css('fontFamily');
+        result = window.getComputedStyle(element.get(0))['fontFamily'];
         if(!result) {
             return null;
         }


### PR DESCRIPTION
Cherry picked from [commit](https://github.com/jacksonrr3/DevExtreme/commit/d66345f675189bb43d95855a258961496b84ff99)
