### PR TITLE
Refactor event types

### DIFF
--- a/js/events/index.d.ts
+++ b/js/events/index.d.ts
@@ -10,18 +10,18 @@ export interface EventType { }
  */
 export type TEvent = {} extends EventType ? dxEvent : EventType;
 
-export interface ComponentInitializedEvent<T> {
+export interface InitializedEventInfo<T> {
     readonly component?: T;
     readonly element?: TElement;
 }
 
-export interface ComponentEvent<T> {
+export interface EventInfo<T> {
     readonly component: T;
     readonly element: TElement;
     readonly model?: any;
 }
 
-export interface ComponentNativeEvent<T> {
+export interface NativeEventInfo<T> {
     readonly component: T;
     readonly element: TElement;
     readonly model?: any;

--- a/js/events/index.d.ts
+++ b/js/events/index.d.ts
@@ -10,17 +10,20 @@ export interface EventType { }
  */
 export type TEvent = {} extends EventType ? dxEvent : EventType;
 
+/** @public */
 export interface InitializedEventInfo<T> {
     readonly component?: T;
     readonly element?: TElement;
 }
 
+/** @public */
 export interface EventInfo<T> {
     readonly component: T;
     readonly element: TElement;
     readonly model?: any;
 }
 
+/** @public */
 export interface NativeEventInfo<T> {
     readonly component: T;
     readonly element: TElement;
@@ -28,6 +31,7 @@ export interface NativeEventInfo<T> {
     readonly event?: TEvent;
 }
 
+/** @public */
 export interface ChangedOptionInfo {
     readonly name: string;
     readonly fullName: string;
@@ -41,6 +45,7 @@ export interface ItemInfo {
     readonly itemIndex: number;
 }
 
+/** @public */
 export interface Cancelable {
     cancel?: boolean;
 }

--- a/js/ui/accordion.d.ts
+++ b/js/ui/accordion.d.ts
@@ -15,9 +15,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -29,34 +29,34 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxAccordion>;
+export type ContentReadyEvent = EventInfo<dxAccordion>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxAccordion>;
+export type DisposingEvent = EventInfo<dxAccordion>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxAccordion>;
+export type InitializedEvent = InitializedEventInfo<dxAccordion>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxAccordion> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxAccordion> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxAccordion> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxAccordion> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxAccordion> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxAccordion> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxAccordion> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxAccordion> & ItemInfo;
 
 /** @public */
-export type ItemTitleClickEvent = ComponentNativeEvent<dxAccordion> & ItemInfo;
+export type ItemTitleClickEvent = NativeEventInfo<dxAccordion> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxAccordion> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxAccordion> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxAccordion> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxAccordion> & SelectionChangedInfo;
 
 export interface dxAccordionOptions extends CollectionWidgetOptions<dxAccordion> {
     /**

--- a/js/ui/accordion.d.ts
+++ b/js/ui/accordion.d.ts
@@ -235,6 +235,7 @@ export interface dxAccordionItem extends CollectionWidgetItem {
     title?: string;
 }
 
+/** @public */
 export type Options = dxAccordionOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/action_sheet.d.ts
+++ b/js/ui/action_sheet.d.ts
@@ -13,9 +13,9 @@ import DataSource, {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -26,31 +26,31 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type CancelClickEvent = Cancelable & ComponentEvent<dxActionSheet>;
+export type CancelClickEvent = Cancelable & EventInfo<dxActionSheet>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxActionSheet>;
+export type ContentReadyEvent = EventInfo<dxActionSheet>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxActionSheet>;
+export type DisposingEvent = EventInfo<dxActionSheet>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxActionSheet>;
+export type InitializedEvent = InitializedEventInfo<dxActionSheet>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxActionSheet> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxActionSheet> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxActionSheet> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxActionSheet> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxActionSheet> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxActionSheet> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxActionSheet> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxActionSheet> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxActionSheet> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxActionSheet> & ChangedOptionInfo;
 
 export interface dxActionSheetOptions extends CollectionWidgetOptions<dxActionSheet> {
     /**

--- a/js/ui/action_sheet.d.ts
+++ b/js/ui/action_sheet.d.ts
@@ -26,7 +26,7 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type CancelClickEvent = ComponentEvent<dxActionSheet> & Cancelable;
+export type CancelClickEvent = Cancelable & ComponentEvent<dxActionSheet>;
 
 /** @public */
 export type ContentReadyEvent = ComponentEvent<dxActionSheet>;

--- a/js/ui/action_sheet.d.ts
+++ b/js/ui/action_sheet.d.ts
@@ -202,6 +202,7 @@ export interface dxActionSheetItem extends CollectionWidgetItem {
     type?: 'back' | 'danger' | 'default' | 'normal' | 'success';
 }
 
+/** @public */
 export type Options = dxActionSheetOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/autocomplete.d.ts
+++ b/js/ui/autocomplete.d.ts
@@ -132,6 +132,7 @@ export default class dxAutocomplete extends dxDropDownList {
     constructor(element: TElement, options?: dxAutocompleteOptions)
 }
 
+/** @public */
 export type Options = dxAutocompleteOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/autocomplete.d.ts
+++ b/js/ui/autocomplete.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -27,64 +27,64 @@ import {
 } from './editor/editor';
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxAutocomplete>;
+export type ChangeEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type ClosedEvent = ComponentEvent<dxAutocomplete>;
+export type ClosedEvent = EventInfo<dxAutocomplete>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxAutocomplete>;
+export type ContentReadyEvent = EventInfo<dxAutocomplete>;
 
 /** @public */
-export type CopyEvent = ComponentNativeEvent<dxAutocomplete>;
+export type CopyEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type CutEvent = ComponentNativeEvent<dxAutocomplete>;
+export type CutEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxAutocomplete>;
+export type DisposingEvent = EventInfo<dxAutocomplete>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxAutocomplete>;
+export type EnterKeyEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxAutocomplete>;
+export type FocusInEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxAutocomplete>;
+export type FocusOutEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxAutocomplete>;
+export type InitializedEvent = InitializedEventInfo<dxAutocomplete>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxAutocomplete>;
+export type InputEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxAutocomplete> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxAutocomplete> & ItemInfo;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxAutocomplete>;
+export type KeyDownEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxAutocomplete>;
+export type KeyPressEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxAutocomplete>;
+export type KeyUpEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type OpenedEvent = ComponentEvent<dxAutocomplete>;
+export type OpenedEvent = EventInfo<dxAutocomplete>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxAutocomplete> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxAutocomplete> & ChangedOptionInfo;
 
 /** @public */
-export type PasteEvent = ComponentNativeEvent<dxAutocomplete>;
+export type PasteEvent = NativeEventInfo<dxAutocomplete>;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxAutocomplete> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxAutocomplete> & SelectionChangedInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxAutocomplete> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxAutocomplete> & ValueChangedInfo;
 
 /** @public */
 export type DropDownButtonTemplateData = DropDownButtonTemplateDataModel;

--- a/js/ui/box.d.ts
+++ b/js/ui/box.d.ts
@@ -7,9 +7,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -20,28 +20,28 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxBox>;
+export type ContentReadyEvent = EventInfo<dxBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxBox>;
+export type DisposingEvent = EventInfo<dxBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxBox>;
+export type InitializedEvent = InitializedEventInfo<dxBox>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxBox> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxBox> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxBox> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxBox> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxBox> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxBox> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxBox> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxBox> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxBox> & ChangedOptionInfo;
 
 export interface dxBoxOptions extends CollectionWidgetOptions<dxBox> {
     /**

--- a/js/ui/box.d.ts
+++ b/js/ui/box.d.ts
@@ -132,6 +132,7 @@ export interface dxBoxItem extends CollectionWidgetItem {
     shrink?: number;
 }
 
+/** @public */
 export type Options = dxBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/button.d.ts
+++ b/js/ui/button.d.ts
@@ -146,6 +146,7 @@ export default class dxButton extends Widget {
     constructor(element: TElement, options?: dxButtonOptions)
 }
 
+/** @public */
 export type Options = dxButtonOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/button.d.ts
+++ b/js/ui/button.d.ts
@@ -7,9 +7,9 @@ import {
 } from '../core/templates/template';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -18,21 +18,21 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ClickEvent = ComponentNativeEvent<dxButton> & {
+export type ClickEvent = NativeEventInfo<dxButton> & {
     validationGroup?: any;
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxButton>;
+export type ContentReadyEvent = EventInfo<dxButton>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxButton>;
+export type DisposingEvent = EventInfo<dxButton>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxButton>;
+export type InitializedEvent = InitializedEventInfo<dxButton>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxButton> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxButton> & ChangedOptionInfo;
 
 /** @public */
 export type TemplateData = {

--- a/js/ui/button_group.d.ts
+++ b/js/ui/button_group.d.ts
@@ -181,6 +181,7 @@ export interface dxButtonGroupItem extends CollectionWidgetItem {
     type?: 'back' | 'danger' | 'default' | 'normal' | 'success';
 }
 
+/** @public */
 export type Options = dxButtonGroupOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/button_group.d.ts
+++ b/js/ui/button_group.d.ts
@@ -7,9 +7,9 @@ import {
 } from '../core/templates/template';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -24,22 +24,22 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxButtonGroup>;
+export type ContentReadyEvent = EventInfo<dxButtonGroup>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxButtonGroup>;
+export type DisposingEvent = EventInfo<dxButtonGroup>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxButtonGroup>;
+export type InitializedEvent = InitializedEventInfo<dxButtonGroup>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxButtonGroup> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxButtonGroup> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxButtonGroup> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxButtonGroup> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxButtonGroup> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxButtonGroup> & SelectionChangedInfo;
 
 export interface dxButtonGroupOptions extends WidgetOptions<dxButtonGroup> {
     /**

--- a/js/ui/calendar.d.ts
+++ b/js/ui/calendar.d.ts
@@ -175,6 +175,7 @@ export default class dxCalendar extends Editor {
     constructor(element: TElement, options?: dxCalendarOptions)
 }
 
+/** @public */
 export type Options = dxCalendarOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/calendar.d.ts
+++ b/js/ui/calendar.d.ts
@@ -3,8 +3,8 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent
+    EventInfo,
+    NativeEventInfo
 } from '../events/index';
 
 import {
@@ -23,10 +23,10 @@ export interface ComponentDisabledDate<T> {
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxCalendar>;
+export type ContentReadyEvent = EventInfo<dxCalendar>;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxCalendar> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxCalendar> & ValueChangedInfo;
 
 /** @public */
 export type CellTemplateData = {

--- a/js/ui/check_box.d.ts
+++ b/js/ui/check_box.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -15,19 +15,19 @@ import Editor, {
 } from './editor/editor';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxCheckBox>;
+export type ContentReadyEvent = EventInfo<dxCheckBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxCheckBox>;
+export type DisposingEvent = EventInfo<dxCheckBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxCheckBox>;
+export type InitializedEvent = InitializedEventInfo<dxCheckBox>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxCheckBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxCheckBox> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxCheckBox> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxCheckBox> & ValueChangedInfo;
 
 export interface dxCheckBoxOptions extends EditorOptions<dxCheckBox> {
     /**

--- a/js/ui/check_box.d.ts
+++ b/js/ui/check_box.d.ts
@@ -86,6 +86,7 @@ export default class dxCheckBox extends Editor {
     constructor(element: TElement, options?: dxCheckBoxOptions)
 }
 
+/** @public */
 export type Options = dxCheckBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/collection/ui.collection_widget.base.d.ts
+++ b/js/ui/collection/ui.collection_widget.base.d.ts
@@ -11,8 +11,8 @@ import DataSource, {
 } from '../../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
+    EventInfo,
+    NativeEventInfo,
     ItemInfo
 } from '../../events/index';
 
@@ -87,7 +87,7 @@ export interface CollectionWidgetOptions<T = CollectionWidget> extends WidgetOpt
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onItemClick?: ((e: ComponentNativeEvent<T> & ItemInfo) => void) | string;
+    onItemClick?: ((e: NativeEventInfo<T> & ItemInfo) => void) | string;
     /**
      * @docid
      * @default null
@@ -103,7 +103,7 @@ export interface CollectionWidgetOptions<T = CollectionWidget> extends WidgetOpt
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onItemContextMenu?: ((e: ComponentNativeEvent<T> & ItemInfo) => void);
+    onItemContextMenu?: ((e: NativeEventInfo<T> & ItemInfo) => void);
     /**
      * @docid
      * @default null
@@ -119,7 +119,7 @@ export interface CollectionWidgetOptions<T = CollectionWidget> extends WidgetOpt
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onItemHold?: ((e: ComponentNativeEvent<T> & ItemInfo) => void);
+    onItemHold?: ((e: NativeEventInfo<T> & ItemInfo) => void);
     /**
      * @docid
      * @default null
@@ -134,7 +134,7 @@ export interface CollectionWidgetOptions<T = CollectionWidget> extends WidgetOpt
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onItemRendered?: ((e: ComponentNativeEvent<T> & ItemInfo) => void);
+    onItemRendered?: ((e: NativeEventInfo<T> & ItemInfo) => void);
     /**
      * @docid
      * @default null
@@ -148,7 +148,7 @@ export interface CollectionWidgetOptions<T = CollectionWidget> extends WidgetOpt
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onSelectionChanged?: ((e: ComponentEvent<T> & SelectionChangedInfo) => void);
+    onSelectionChanged?: ((e: EventInfo<T> & SelectionChangedInfo) => void);
     /**
      * @docid
      * @default -1

--- a/js/ui/color_box.d.ts
+++ b/js/ui/color_box.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -23,55 +23,55 @@ import {
 } from './editor/editor';
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxColorBox>;
+export type ChangeEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type ClosedEvent = ComponentEvent<dxColorBox>;
+export type ClosedEvent = EventInfo<dxColorBox>;
 
 /** @public */
-export type CopyEvent = ComponentNativeEvent<dxColorBox>;
+export type CopyEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type CutEvent = ComponentNativeEvent<dxColorBox>;
+export type CutEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxColorBox>;
+export type DisposingEvent = EventInfo<dxColorBox>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxColorBox>;
+export type EnterKeyEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxColorBox>;
+export type FocusInEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxColorBox>;
+export type FocusOutEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxColorBox>;
+export type InitializedEvent = InitializedEventInfo<dxColorBox>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxColorBox>;
+export type InputEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxColorBox>;
+export type KeyDownEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxColorBox>;
+export type KeyPressEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxColorBox>;
+export type KeyUpEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type OpenedEvent = ComponentEvent<dxColorBox>;
+export type OpenedEvent = EventInfo<dxColorBox>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxColorBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxColorBox> & ChangedOptionInfo;
 
 /** @public */
-export type PasteEvent = ComponentNativeEvent<dxColorBox>;
+export type PasteEvent = NativeEventInfo<dxColorBox>;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxColorBox> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxColorBox> & ValueChangedInfo;
 
 /** @public */
 export type DropDownButtonTemplateData = DropDownButtonTemplateDataModel;

--- a/js/ui/color_box.d.ts
+++ b/js/ui/color_box.d.ts
@@ -143,6 +143,7 @@ export default class dxColorBox extends dxDropDownEditor {
     constructor(element: TElement, options?: dxColorBoxOptions)
 }
 
+/** @public */
 export type Options = dxColorBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/context_menu.d.ts
+++ b/js/ui/context_menu.d.ts
@@ -17,9 +17,9 @@ import DataSource, {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -37,45 +37,45 @@ import {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxContextMenu>;
+export type ContentReadyEvent = EventInfo<dxContextMenu>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxContextMenu>;
+export type DisposingEvent = EventInfo<dxContextMenu>;
 
 /** @public */
-export type HiddenEvent = ComponentEvent<dxContextMenu>;
+export type HiddenEvent = EventInfo<dxContextMenu>;
 
 /** @public */
-export type HidingEvent = Cancelable & ComponentEvent<dxContextMenu>;
+export type HidingEvent = Cancelable & EventInfo<dxContextMenu>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxContextMenu>;
+export type InitializedEvent = InitializedEventInfo<dxContextMenu>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxContextMenu> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxContextMenu> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxContextMenu> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxContextMenu> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxContextMenu> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxContextMenu> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxContextMenu> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxContextMenu> & ChangedOptionInfo;
 
 /** @public */
-export type PositioningEvent = ComponentNativeEvent<dxContextMenu> & {
+export type PositioningEvent = NativeEventInfo<dxContextMenu> & {
     readonly position: positionConfig;
 }
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxContextMenu> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxContextMenu> & SelectionChangedInfo;
 
 /** @public */
-export type ShowingEvent = Cancelable & ComponentEvent<dxContextMenu>;
+export type ShowingEvent = Cancelable & EventInfo<dxContextMenu>;
 
 /** @public */
-export type ShownEvent = ComponentEvent<dxContextMenu>;
+export type ShownEvent = EventInfo<dxContextMenu>;
 
 /** @public */
 export interface dxContextMenuOptions extends dxMenuBaseOptions<dxContextMenu> {

--- a/js/ui/context_menu.d.ts
+++ b/js/ui/context_menu.d.ts
@@ -46,7 +46,7 @@ export type DisposingEvent = ComponentEvent<dxContextMenu>;
 export type HiddenEvent = ComponentEvent<dxContextMenu>;
 
 /** @public */
-export type HidingEvent = ComponentEvent<dxContextMenu> & Cancelable;
+export type HidingEvent = Cancelable & ComponentEvent<dxContextMenu>;
 
 /** @public */
 export type InitializedEvent = ComponentInitializedEvent<dxContextMenu>;
@@ -72,7 +72,7 @@ export type PositioningEvent = ComponentNativeEvent<dxContextMenu> & {
 export type SelectionChangedEvent = ComponentEvent<dxContextMenu> & SelectionChangedInfo;
 
 /** @public */
-export type ShowingEvent = ComponentEvent<dxContextMenu> & Cancelable;
+export type ShowingEvent = Cancelable & ComponentEvent<dxContextMenu>;
 
 /** @public */
 export type ShownEvent = ComponentEvent<dxContextMenu>;

--- a/js/ui/context_menu.d.ts
+++ b/js/ui/context_menu.d.ts
@@ -269,6 +269,7 @@ export interface dxContextMenuItem extends dxMenuBaseItem {
     items?: Array<dxContextMenuItem>;
 }
 
+/** @public */
 export type Options = dxContextMenuOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/context_menu.d.ts
+++ b/js/ui/context_menu.d.ts
@@ -77,7 +77,6 @@ export type ShowingEvent = Cancelable & EventInfo<dxContextMenu>;
 /** @public */
 export type ShownEvent = EventInfo<dxContextMenu>;
 
-/** @public */
 export interface dxContextMenuOptions extends dxMenuBaseOptions<dxContextMenu> {
     /**
      * @docid

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -5079,6 +5079,7 @@ export interface RowObject {
     readonly values: Array<any>;
 }
 
+/** @public */
 export type Options = dxDataGridOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -20,9 +20,9 @@ import DataSource, {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -162,7 +162,7 @@ export interface ToolbarPreparingInfo {
   toolbarOptions: dxToolbarOptions;
 }
 
-export interface ComponentRowDraggingEvent<T extends GridBase> {
+export interface RowDraggingEventInfo<T extends GridBase> {
   readonly component: T;
   readonly event: TEvent;
   readonly itemData?: any;
@@ -175,7 +175,7 @@ export interface ComponentRowDraggingEvent<T extends GridBase> {
   readonly toData?: any;
 }
 
-export interface ComponentDragStartEvent<T extends GridBase> {
+export interface DragStartEventInfo<T extends GridBase> {
   readonly component: T;
   readonly event: TEvent;
   itemData?: any;
@@ -351,7 +351,7 @@ export interface RowDragging<T extends GridBase> {
      * @type_function_param1_field10 toData:any
      * @type_function_param1_field11 dropInsideItem:boolean
      */
-    onAdd?: ((e: ComponentRowDraggingEvent<T> & DragDropInfo) => void),
+    onAdd?: ((e: RowDraggingEventInfo<T> & DragDropInfo) => void),
     /**
      * @docid GridBaseOptions.rowDragging.onDragChange
      * @prevFileNamespace DevExpress.ui
@@ -369,7 +369,7 @@ export interface RowDragging<T extends GridBase> {
      * @type_function_param1_field11 toData:any
      * @type_function_param1_field12 dropInsideItem:boolean
      */
-    onDragChange?: ((e: Cancelable & ComponentRowDraggingEvent<T> & DragDropInfo) => void),
+    onDragChange?: ((e: Cancelable & RowDraggingEventInfo<T> & DragDropInfo) => void),
     /**
      * @docid GridBaseOptions.rowDragging.onDragEnd
      * @prevFileNamespace DevExpress.ui
@@ -387,7 +387,7 @@ export interface RowDragging<T extends GridBase> {
      * @type_function_param1_field11 toData:any
      * @type_function_param1_field12 dropInsideItem:boolean
      */
-    onDragEnd?: ((e: Cancelable & ComponentRowDraggingEvent<T> & DragDropInfo) => void),
+    onDragEnd?: ((e: Cancelable & RowDraggingEventInfo<T> & DragDropInfo) => void),
     /**
      * @docid GridBaseOptions.rowDragging.onDragMove
      * @prevFileNamespace DevExpress.ui
@@ -405,7 +405,7 @@ export interface RowDragging<T extends GridBase> {
      * @type_function_param1_field11 toData:any
      * @type_function_param1_field12 dropInsideItem:boolean
      */
-    onDragMove?: ((e: Cancelable & ComponentRowDraggingEvent<T> & DragDropInfo) => void),
+    onDragMove?: ((e: Cancelable & RowDraggingEventInfo<T> & DragDropInfo) => void),
     /**
      * @docid GridBaseOptions.rowDragging.onDragStart
      * @prevFileNamespace DevExpress.ui
@@ -418,7 +418,7 @@ export interface RowDragging<T extends GridBase> {
      * @type_function_param1_field6 fromIndex:number
      * @type_function_param1_field7 fromData:any
      */
-    onDragStart?: ((e: Cancelable & ComponentDragStartEvent<T>) => void),
+    onDragStart?: ((e: Cancelable & DragStartEventInfo<T>) => void),
     /**
      * @docid GridBaseOptions.rowDragging.onRemove
      * @prevFileNamespace DevExpress.ui
@@ -434,7 +434,7 @@ export interface RowDragging<T extends GridBase> {
      * @type_function_param1_field9 fromData:any
      * @type_function_param1_field10 toData:any
      */
-    onRemove?: ((e: ComponentRowDraggingEvent<T>) => void),
+    onRemove?: ((e: RowDraggingEventInfo<T>) => void),
     /**
      * @docid GridBaseOptions.rowDragging.onReorder
      * @prevFileNamespace DevExpress.ui
@@ -452,7 +452,7 @@ export interface RowDragging<T extends GridBase> {
      * @type_function_param1_field11 dropInsideItem:boolean
      * @type_function_param1_field12 promise:Promise<void>
      */
-    onReorder?: ((e: ComponentRowDraggingEvent<dxDataGrid> & DragReorderInfo) => void),
+    onReorder?: ((e: RowDraggingEventInfo<dxDataGrid> & DragReorderInfo) => void),
     /**
      * @docid GridBaseOptions.rowDragging.scrollSensitivity
      * @prevFileNamespace DevExpress.ui
@@ -719,7 +719,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onAdaptiveDetailRowPreparing?: ((e: ComponentEvent<T> & AdaptiveDetailRowPreparingInfo) => void);
+    onAdaptiveDetailRowPreparing?: ((e: EventInfo<T> & AdaptiveDetailRowPreparingInfo) => void);
     /**
      * @docid
      * @default null
@@ -732,7 +732,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onDataErrorOccurred?: ((e: ComponentEvent<T> & DataErrorOccurredInfo) => void);
+    onDataErrorOccurred?: ((e: EventInfo<T> & DataErrorOccurredInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -744,7 +744,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @action
      * @public
      */
-    onEditCanceled?: ((e: ComponentEvent<T> & DataChangeInfo) => void);
+    onEditCanceled?: ((e: EventInfo<T> & DataChangeInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -757,7 +757,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @action
      * @public
      */
-    onEditCanceling?: ((e: Cancelable & ComponentEvent<T> & DataChangeInfo) => void);
+    onEditCanceling?: ((e: Cancelable & EventInfo<T> & DataChangeInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -771,7 +771,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onInitNewRow?: ((e: ComponentEvent<T> & NewRowInfo) => void);
+    onInitNewRow?: ((e: EventInfo<T> & NewRowInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -785,7 +785,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onKeyDown?: ((e: ComponentNativeEvent<T> & KeyDownInfo) => void);
+    onKeyDown?: ((e: NativeEventInfo<T> & KeyDownInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -798,34 +798,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowCollapsed?: ((e: ComponentEvent<T> & RowKeyInfo) => void);
-    /**
-     * @docid
-     * @type_function_param1 e:object
-     * @type_function_param1_field1 component:this
-     * @type_function_param1_field2 element:TElement
-     * @type_function_param1_field3 model:any
-     * @type_function_param1_field4 key:any
-     * @type_function_param1_field5 cancel:boolean
-     * @default null
-     * @action
-     * @prevFileNamespace DevExpress.ui
-     * @public
-     */
-    onRowCollapsing?: ((e: Cancelable & ComponentEvent<T> & RowKeyInfo) => void);
-    /**
-     * @docid
-     * @type_function_param1 e:object
-     * @type_function_param1_field1 component:this
-     * @type_function_param1_field2 element:TElement
-     * @type_function_param1_field3 model:any
-     * @type_function_param1_field4 key:any
-     * @default null
-     * @action
-     * @prevFileNamespace DevExpress.ui
-     * @public
-     */
-    onRowExpanded?: ((e: ComponentEvent<T> & RowKeyInfo) => void);
+    onRowCollapsed?: ((e: EventInfo<T> & RowKeyInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -839,7 +812,34 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowExpanding?: ((e: Cancelable & ComponentEvent<T> & RowKeyInfo) => void);
+    onRowCollapsing?: ((e: Cancelable & EventInfo<T> & RowKeyInfo) => void);
+    /**
+     * @docid
+     * @type_function_param1 e:object
+     * @type_function_param1_field1 component:this
+     * @type_function_param1_field2 element:TElement
+     * @type_function_param1_field3 model:any
+     * @type_function_param1_field4 key:any
+     * @default null
+     * @action
+     * @prevFileNamespace DevExpress.ui
+     * @public
+     */
+    onRowExpanded?: ((e: EventInfo<T> & RowKeyInfo) => void);
+    /**
+     * @docid
+     * @type_function_param1 e:object
+     * @type_function_param1_field1 component:this
+     * @type_function_param1_field2 element:TElement
+     * @type_function_param1_field3 model:any
+     * @type_function_param1_field4 key:any
+     * @type_function_param1_field5 cancel:boolean
+     * @default null
+     * @action
+     * @prevFileNamespace DevExpress.ui
+     * @public
+     */
+    onRowExpanding?: ((e: Cancelable & EventInfo<T> & RowKeyInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -854,7 +854,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowInserted?: ((e: ComponentEvent<T> & RowInsertedInfo) => void);
+    onRowInserted?: ((e: EventInfo<T> & RowInsertedInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -868,7 +868,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowInserting?: ((e: ComponentEvent<T> & RowInsertingInfo) => void);
+    onRowInserting?: ((e: EventInfo<T> & RowInsertingInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -883,7 +883,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowRemoved?: ((e: ComponentEvent<T> & RowRemovedInfo) => void);
+    onRowRemoved?: ((e: EventInfo<T> & RowRemovedInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -898,7 +898,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowRemoving?: ((e: ComponentEvent<T> & RowRemovingInfo) => void);
+    onRowRemoving?: ((e: EventInfo<T> & RowRemovingInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -913,7 +913,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowUpdated?: ((e: ComponentEvent<T> & RowUpdatedInfo) => void);
+    onRowUpdated?: ((e: EventInfo<T> & RowUpdatedInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -929,7 +929,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowUpdating?: ((e: ComponentEvent<T> & RowUpdatingInfo) => void);
+    onRowUpdating?: ((e: EventInfo<T> & RowUpdatingInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -948,7 +948,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onRowValidating?: ((e: ComponentEvent<T> & RowValidatingInfo) => void);
+    onRowValidating?: ((e: EventInfo<T> & RowValidatingInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -960,7 +960,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @action
      * @public
      */
-    onSaved?: ((e: ComponentEvent<T> & DataChangeInfo) => void);
+    onSaved?: ((e: EventInfo<T> & DataChangeInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -974,7 +974,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @action
      * @public
      */
-    onSaving?: ((e: ComponentEvent<T> & SavingInfo) => void);
+    onSaving?: ((e: EventInfo<T> & SavingInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -990,7 +990,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onSelectionChanged?: ((e: ComponentEvent<T> & SelectionChangedInfo) => void);
+    onSelectionChanged?: ((e: EventInfo<T> & SelectionChangedInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -1003,7 +1003,7 @@ export interface GridBaseOptions<T extends GridBase> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onToolbarPreparing?: ((e: ComponentEvent<T> & ToolbarPreparingInfo) => void);
+    onToolbarPreparing?: ((e: EventInfo<T> & ToolbarPreparingInfo) => void);
     /**
      * @docid
      * @type object
@@ -3054,10 +3054,10 @@ export interface ColumnButtonBase {
 }
 
 /** @public */
-export type AdaptiveDetailRowPreparingEvent = ComponentEvent<dxDataGrid> & AdaptiveDetailRowPreparingInfo;
+export type AdaptiveDetailRowPreparingEvent = EventInfo<dxDataGrid> & AdaptiveDetailRowPreparingInfo;
 
 /** @public */
-export type CellClickEvent = ComponentNativeEvent<dxDataGrid> & {
+export type CellClickEvent = NativeEventInfo<dxDataGrid> & {
   readonly data: any;
   readonly key: any;
   readonly value?: any;
@@ -3072,7 +3072,7 @@ export type CellClickEvent = ComponentNativeEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type CellDblClickEvent = ComponentNativeEvent<dxDataGrid> & {
+export type CellDblClickEvent = NativeEventInfo<dxDataGrid> & {
   readonly data: any;
   readonly key: any;
   readonly value?: any;
@@ -3087,7 +3087,7 @@ export type CellDblClickEvent = ComponentNativeEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type CellHoverChangedEvent = ComponentEvent<dxDataGrid> & {
+export type CellHoverChangedEvent = EventInfo<dxDataGrid> & {
   readonly eventType: string;
   readonly data: any;
   readonly key: any;
@@ -3103,7 +3103,7 @@ export type CellHoverChangedEvent = ComponentEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type CellPreparedEvent = ComponentEvent<dxDataGrid> & {
+export type CellPreparedEvent = EventInfo<dxDataGrid> & {
   readonly data: any;
   readonly key: any;
   readonly value?: any;
@@ -3123,10 +3123,10 @@ export type CellPreparedEvent = ComponentEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxDataGrid>;
+export type ContentReadyEvent = EventInfo<dxDataGrid>;
 
 /** @public */
-export type ContextMenuPreparingEvent = ComponentEvent<dxDataGrid> & {
+export type ContextMenuPreparingEvent = EventInfo<dxDataGrid> & {
   items?: Array<any>;
   readonly target: string;
   readonly targetElement: TElement;
@@ -3137,26 +3137,26 @@ export type ContextMenuPreparingEvent = ComponentEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type DataErrorOccurredEvent = ComponentEvent<dxDataGrid> & DataErrorOccurredInfo;
+export type DataErrorOccurredEvent = EventInfo<dxDataGrid> & DataErrorOccurredInfo;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxDataGrid>;
+export type DisposingEvent = EventInfo<dxDataGrid>;
 
 /** @public */
-export type EditCanceledEvent = ComponentEvent<dxDataGrid> & DataChangeInfo;
+export type EditCanceledEvent = EventInfo<dxDataGrid> & DataChangeInfo;
 
 /** @public */
-export type EditCancelingEvent = Cancelable & ComponentEvent<dxDataGrid> & DataChangeInfo;
+export type EditCancelingEvent = Cancelable & EventInfo<dxDataGrid> & DataChangeInfo;
 
 /** @public */
-export type EditingStartEvent = Cancelable & ComponentEvent<dxDataGrid> & {
+export type EditingStartEvent = Cancelable & EventInfo<dxDataGrid> & {
   readonly data: any;
   readonly key: any;
   readonly column?: any;
 }
 
 /** @public */
-export type EditorPreparedEvent = ComponentEvent<dxDataGrid> & {
+export type EditorPreparedEvent = EventInfo<dxDataGrid> & {
   readonly parentType: string;
   readonly value?: any;
   readonly setValue?: any;
@@ -3171,7 +3171,7 @@ export type EditorPreparedEvent = ComponentEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type EditorPreparingEvent = ComponentEvent<dxDataGrid> & {
+export type EditorPreparingEvent = EventInfo<dxDataGrid> & {
   readonly parentType: string;
   readonly value?: any;
   readonly setValue?: any;
@@ -3189,10 +3189,10 @@ export type EditorPreparingEvent = ComponentEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type ExportedEvent  = ComponentEvent<dxDataGrid>;
+export type ExportedEvent  = EventInfo<dxDataGrid>;
 
 /** @public */
-export type ExportingEvent = Cancelable & ComponentEvent<dxDataGrid> & {
+export type ExportingEvent = Cancelable & EventInfo<dxDataGrid> & {
   fileName?: string;
 }
 
@@ -3206,7 +3206,7 @@ export type FileSavingEvent = Cancelable & {
 }
 
 /** @public */
-export type FocusedCellChangedEvent = ComponentEvent<dxDataGrid> & {
+export type FocusedCellChangedEvent = EventInfo<dxDataGrid> & {
   readonly cellElement: TElement;
   readonly columnIndex: number;
   readonly rowIndex: number;
@@ -3215,7 +3215,7 @@ export type FocusedCellChangedEvent = ComponentEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type FocusedCellChangingEvent = Cancelable & ComponentNativeEvent<dxDataGrid> & {
+export type FocusedCellChangingEvent = Cancelable & NativeEventInfo<dxDataGrid> & {
   readonly cellElement: TElement;
   readonly prevColumnIndex: number;
   readonly prevRowIndex: number;
@@ -3227,14 +3227,14 @@ export type FocusedCellChangingEvent = Cancelable & ComponentNativeEvent<dxDataG
 }
 
 /** @public */
-export type FocusedRowChangedEvent = ComponentEvent<dxDataGrid> & {
+export type FocusedRowChangedEvent = EventInfo<dxDataGrid> & {
   readonly rowElement: TElement;
   readonly rowIndex: number;
   readonly row?: RowObject;
 }
 
 /** @public */
-export type FocusedRowChangingEvent = Cancelable & ComponentNativeEvent<dxDataGrid> & {
+export type FocusedRowChangingEvent = Cancelable & NativeEventInfo<dxDataGrid> & {
   readonly rowElement: TElement;
   readonly prevRowIndex: number;
   newRowIndex: number;
@@ -3242,19 +3242,19 @@ export type FocusedRowChangingEvent = Cancelable & ComponentNativeEvent<dxDataGr
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxDataGrid>;
+export type InitializedEvent = InitializedEventInfo<dxDataGrid>;
 
 /** @public */
-export type InitNewRowEvent = ComponentEvent<dxDataGrid> & NewRowInfo;
+export type InitNewRowEvent = EventInfo<dxDataGrid> & NewRowInfo;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxDataGrid> & KeyDownInfo;
+export type KeyDownEvent = NativeEventInfo<dxDataGrid> & KeyDownInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxDataGrid> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxDataGrid> & ChangedOptionInfo;
 
 /** @public */
-export type RowClickEvent = ComponentNativeEvent<dxDataGrid> & {
+export type RowClickEvent = NativeEventInfo<dxDataGrid> & {
   readonly data: any;
   readonly key: any;
   readonly values: Array<any>;
@@ -3270,13 +3270,13 @@ export type RowClickEvent = ComponentNativeEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type RowCollapsedEvent = ComponentEvent<dxDataGrid> & RowKeyInfo;
+export type RowCollapsedEvent = EventInfo<dxDataGrid> & RowKeyInfo;
 
 /** @public */
-export type RowCollapsingEvent = Cancelable & ComponentEvent<dxDataGrid> & RowKeyInfo;
+export type RowCollapsingEvent = Cancelable & EventInfo<dxDataGrid> & RowKeyInfo;
 
 /** @public */
-export type RowDblClickEvent = ComponentNativeEvent<dxDataGrid> & {
+export type RowDblClickEvent = NativeEventInfo<dxDataGrid> & {
   readonly data: any;
   readonly key: any;
   readonly values: Array<any>;
@@ -3291,19 +3291,19 @@ export type RowDblClickEvent = ComponentNativeEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type RowExpandedEvent = ComponentEvent<dxDataGrid> & RowKeyInfo;
+export type RowExpandedEvent = EventInfo<dxDataGrid> & RowKeyInfo;
 
 /** @public */
-export type RowExpandingEvent = Cancelable & ComponentEvent<dxDataGrid> & RowKeyInfo;
+export type RowExpandingEvent = Cancelable & EventInfo<dxDataGrid> & RowKeyInfo;
 
 /** @public */
-export type RowInsertedEvent = ComponentEvent<dxDataGrid> & RowInsertedInfo;
+export type RowInsertedEvent = EventInfo<dxDataGrid> & RowInsertedInfo;
 
 /** @public */
-export type RowInsertingEvent = ComponentEvent<dxDataGrid> & RowInsertingInfo;
+export type RowInsertingEvent = EventInfo<dxDataGrid> & RowInsertingInfo;
 
 /** @public */
-export type RowPreparedEvent = ComponentEvent<dxDataGrid> & {
+export type RowPreparedEvent = EventInfo<dxDataGrid> & {
   readonly data: any;
   readonly key: any;
   readonly values: Array<any>;
@@ -3318,56 +3318,56 @@ export type RowPreparedEvent = ComponentEvent<dxDataGrid> & {
 }
 
 /** @public */
-export type RowRemovedEvent = ComponentEvent<dxDataGrid> & RowRemovedInfo;
+export type RowRemovedEvent = EventInfo<dxDataGrid> & RowRemovedInfo;
 
 /** @public */
-export type RowRemovingEvent = ComponentEvent<dxDataGrid> & RowRemovingInfo;
+export type RowRemovingEvent = EventInfo<dxDataGrid> & RowRemovingInfo;
 
 /** @public */
-export type RowUpdatedEvent = ComponentEvent<dxDataGrid> & RowUpdatedInfo;
+export type RowUpdatedEvent = EventInfo<dxDataGrid> & RowUpdatedInfo;
 
 /** @public */
-export type RowUpdatingEvent = ComponentEvent<dxDataGrid> & RowUpdatingInfo;
+export type RowUpdatingEvent = EventInfo<dxDataGrid> & RowUpdatingInfo;
 
 /** @public */
-export type RowValidatingEvent = ComponentEvent<dxDataGrid> & RowValidatingInfo;
+export type RowValidatingEvent = EventInfo<dxDataGrid> & RowValidatingInfo;
 
 /** @public */
-export type SavedEvent = ComponentEvent<dxDataGrid> & DataChangeInfo;
+export type SavedEvent = EventInfo<dxDataGrid> & DataChangeInfo;
 
 /** @public */
-export type SavingEvent = ComponentEvent<dxDataGrid> & SavingInfo;
+export type SavingEvent = EventInfo<dxDataGrid> & SavingInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxDataGrid> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxDataGrid> & SelectionChangedInfo;
 
 /** @public */
-export type ToolbarPreparingEvent = ComponentEvent<dxDataGrid> & ToolbarPreparingInfo;
+export type ToolbarPreparingEvent = EventInfo<dxDataGrid> & ToolbarPreparingInfo;
 
 
 /** @public */
-export type RowDraggingAddEvent = ComponentRowDraggingEvent<dxDataGrid> & DragDropInfo;
+export type RowDraggingAddEvent = RowDraggingEventInfo<dxDataGrid> & DragDropInfo;
 
 /** @public */
-export type RowDraggingChangeEvent = Cancelable & ComponentRowDraggingEvent<dxDataGrid> & DragDropInfo;
+export type RowDraggingChangeEvent = Cancelable & RowDraggingEventInfo<dxDataGrid> & DragDropInfo;
 
 /** @public */
-export type RowDraggingEndEvent = Cancelable & ComponentRowDraggingEvent<dxDataGrid> & DragDropInfo;
+export type RowDraggingEndEvent = Cancelable & RowDraggingEventInfo<dxDataGrid> & DragDropInfo;
 
 /** @public */
-export type RowDraggingMoveEvent = Cancelable & ComponentRowDraggingEvent<dxDataGrid> & DragDropInfo;
+export type RowDraggingMoveEvent = Cancelable & RowDraggingEventInfo<dxDataGrid> & DragDropInfo;
 
 /** @public */
-export type RowDraggingStartEvent = Cancelable & ComponentDragStartEvent<dxDataGrid>;
+export type RowDraggingStartEvent = Cancelable & DragStartEventInfo<dxDataGrid>;
 
 /** @public */
-export type RowDraggingRemoveEvent = ComponentRowDraggingEvent<dxDataGrid>;
+export type RowDraggingRemoveEvent = RowDraggingEventInfo<dxDataGrid>;
 
 /** @public */
-export type RowDraggingReorderEvent = ComponentRowDraggingEvent<dxDataGrid> & DragReorderInfo;
+export type RowDraggingReorderEvent = RowDraggingEventInfo<dxDataGrid> & DragReorderInfo;
 
 /** @public */ 
-export type ColumnButtonClickEvent = ComponentNativeEvent<dxDataGrid> & {
+export type ColumnButtonClickEvent = NativeEventInfo<dxDataGrid> & {
   row?: RowObject;
   column?: Column;
 }

--- a/js/ui/date_box.d.ts
+++ b/js/ui/date_box.d.ts
@@ -253,6 +253,7 @@ export default class dxDateBox extends dxDropDownEditor {
     open(): void;
 }
 
+/** @public */
 export type Options = dxDateBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/date_box.d.ts
+++ b/js/ui/date_box.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -28,58 +28,58 @@ import {
 } from './widget/ui.widget';
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxDateBox>;
+export type ChangeEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type ClosedEvent = ComponentEvent<dxDateBox>;
+export type ClosedEvent = EventInfo<dxDateBox>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxDateBox>;
+export type ContentReadyEvent = EventInfo<dxDateBox>;
 
 /** @public */
-export type CopyEvent = ComponentNativeEvent<dxDateBox>;
+export type CopyEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type CutEvent = ComponentNativeEvent<dxDateBox>;
+export type CutEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxDateBox>;
+export type DisposingEvent = EventInfo<dxDateBox>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxDateBox>;
+export type EnterKeyEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxDateBox>;
+export type FocusInEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxDateBox>;
+export type FocusOutEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxDateBox>;
+export type InitializedEvent = InitializedEventInfo<dxDateBox>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxDateBox>;
+export type InputEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxDateBox>;
+export type KeyDownEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxDateBox>;
+export type KeyPressEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxDateBox>;
+export type KeyUpEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type OpenedEvent = ComponentEvent<dxDateBox>;
+export type OpenedEvent = EventInfo<dxDateBox>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxDateBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxDateBox> & ChangedOptionInfo;
 
 /** @public */
-export type PasteEvent = ComponentNativeEvent<dxDateBox>;
+export type PasteEvent = NativeEventInfo<dxDateBox>;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxDateBox> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxDateBox> & ValueChangedInfo;
 
 /** @public */
 export type DisabledDate = ComponentDisabledDate<dxDateBox>;

--- a/js/ui/defer_rendering.d.ts
+++ b/js/ui/defer_rendering.d.ts
@@ -97,6 +97,7 @@ export default class dxDeferRendering extends Widget {
     constructor(element: TElement, options?: dxDeferRenderingOptions)
 }
 
+/** @public */
 export type Options = dxDeferRenderingOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/defer_rendering.d.ts
+++ b/js/ui/defer_rendering.d.ts
@@ -11,8 +11,8 @@ import {
 } from '../core/utils/deferred';
 
 import {
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -21,22 +21,22 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxDeferRendering>;
+export type ContentReadyEvent = EventInfo<dxDeferRendering>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxDeferRendering>;
+export type DisposingEvent = EventInfo<dxDeferRendering>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxDeferRendering>;
+export type InitializedEvent = InitializedEventInfo<dxDeferRendering>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxDeferRendering> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxDeferRendering> & ChangedOptionInfo;
 
 /** @public */
-export type RenderedEvent = ComponentEvent<dxDeferRendering>;
+export type RenderedEvent = EventInfo<dxDeferRendering>;
 
 /** @public */
-export type ShownEvent = ComponentEvent<dxDeferRendering>;
+export type ShownEvent = EventInfo<dxDeferRendering>;
 
 export interface dxDeferRenderingOptions extends WidgetOptions<dxDeferRendering> {
     /**

--- a/js/ui/diagram.d.ts
+++ b/js/ui/diagram.d.ts
@@ -12,8 +12,8 @@ import DataSource, {
 
 
 import {
-  ComponentEvent,
-  ComponentInitializedEvent,
+  EventInfo,
+  InitializedEventInfo,
   ChangedOptionInfo
 } from '../events/index';
 
@@ -23,7 +23,7 @@ import Widget, {
 
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxDiagram>;
+export type ContentReadyEvent = EventInfo<dxDiagram>;
 
 /** @public */
 export type CustomCommandEvent = {
@@ -33,26 +33,26 @@ export type CustomCommandEvent = {
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxDiagram>;
+export type DisposingEvent = EventInfo<dxDiagram>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxDiagram>;
+export type InitializedEvent = InitializedEventInfo<dxDiagram>;
 
 /** @public */
-export type ItemClickEvent = ComponentEvent<dxDiagram> & {
+export type ItemClickEvent = EventInfo<dxDiagram> & {
     readonly item: dxDiagramItem;
 }
 
 /** @public */
-export type ItemDblClickEvent = ComponentEvent<dxDiagram> & {
+export type ItemDblClickEvent = EventInfo<dxDiagram> & {
     readonly item: dxDiagramItem;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxDiagram> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxDiagram> & ChangedOptionInfo;
 
 /** @public */
-export type RequestEditOperationEvent = ComponentEvent<dxDiagram> & {
+export type RequestEditOperationEvent = EventInfo<dxDiagram> & {
     readonly operation: 'addShape' | 'addShapeFromToolbox' | 'deleteShape' | 'deleteConnector' | 'changeConnection' | 'changeConnectorPoints';
     readonly args: dxDiagramAddShapeArgs|dxDiagramAddShapeFromToolboxArgs|dxDiagramDeleteShapeArgs|dxDiagramDeleteConnectorArgs|dxDiagramChangeConnectionArgs|dxDiagramChangeConnectorPointsArgs|dxDiagramBeforeChangeShapeTextArgs|dxDiagramChangeShapeTextArgs|dxDiagramBeforeChangeConnectorTextArgs|dxDiagramChangeConnectorTextArgs|dxDiagramResizeShapeArgs|dxDiagramMoveShapeArgs;
     readonly reason: 'checkUIElementAvailability' | 'modelModification';
@@ -60,13 +60,13 @@ export type RequestEditOperationEvent = ComponentEvent<dxDiagram> & {
 }
 
 /** @public */
-export type RequestLayoutUpdateEvent = ComponentEvent<dxDiagram> & {
+export type RequestLayoutUpdateEvent = EventInfo<dxDiagram> & {
     readonly changes: any[];
     allowed?: boolean 
 }
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxDiagram> & {
+export type SelectionChangedEvent = EventInfo<dxDiagram> & {
     readonly items: Array<dxDiagramItem>;
 }
 

--- a/js/ui/diagram.d.ts
+++ b/js/ui/diagram.d.ts
@@ -1843,6 +1843,7 @@ export interface dxDiagramMoveShapeArgs {
   };
 }
 
+/** @public */
 export type Options = dxDiagramOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/draggable.d.ts
+++ b/js/ui/draggable.d.ts
@@ -248,6 +248,7 @@ export default class dxDraggable extends DOMComponent implements DraggableBase {
     constructor(element: TElement, options?: dxDraggableOptions)
 }
 
+/** @public */
 export type Options = dxDraggableOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/draggable.d.ts
+++ b/js/ui/draggable.d.ts
@@ -12,9 +12,9 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -115,10 +115,10 @@ export interface DraggableBaseOptions<T = DraggableBase & DOMComponent> extends 
 export interface DraggableBase { }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxDraggable>;
+export type DisposingEvent = EventInfo<dxDraggable>;
 
 /** @public */
-export type DragEndEvent = Cancelable & ComponentNativeEvent<dxDraggable> & {
+export type DragEndEvent = Cancelable & NativeEventInfo<dxDraggable> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
     readonly fromComponent: dxSortable | dxDraggable;
@@ -128,7 +128,7 @@ export type DragEndEvent = Cancelable & ComponentNativeEvent<dxDraggable> & {
 }
 
 /** @public */
-export type DragMoveEvent = Cancelable & ComponentNativeEvent<dxDraggable> & {
+export type DragMoveEvent = Cancelable & NativeEventInfo<dxDraggable> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
     readonly fromComponent: dxSortable | dxDraggable;
@@ -138,17 +138,17 @@ export type DragMoveEvent = Cancelable & ComponentNativeEvent<dxDraggable> & {
 }
 
 /** @public */
-export type DragStartEvent = Cancelable & ComponentNativeEvent<dxDraggable> & {
+export type DragStartEvent = Cancelable & NativeEventInfo<dxDraggable> & {
     itemData?: any;
     readonly itemElement?: TElement;
     readonly fromData?: any;
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxDraggable>;
+export type InitializedEvent = InitializedEventInfo<dxDraggable>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxDraggable> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxDraggable> & ChangedOptionInfo;
 
 
 /** @public */

--- a/js/ui/drawer.d.ts
+++ b/js/ui/drawer.d.ts
@@ -12,8 +12,8 @@ import {
 
 import {
     TEvent,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -22,13 +22,13 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxDrawer>;
+export type DisposingEvent = EventInfo<dxDrawer>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxDrawer>;
+export type InitializedEvent = InitializedEventInfo<dxDrawer>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxDrawer> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxDrawer> & ChangedOptionInfo;
 
 export interface dxDrawerOptions extends WidgetOptions<dxDrawer> {
     /**

--- a/js/ui/drawer.d.ts
+++ b/js/ui/drawer.d.ts
@@ -168,6 +168,7 @@ export default class dxDrawer extends Widget {
     toggle(): TPromise<void>;
 }
 
+/** @public */
 export type Options = dxDrawerOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/drop_down_box.d.ts
+++ b/js/ui/drop_down_box.d.ts
@@ -171,6 +171,7 @@ export default class dxDropDownBox extends dxDropDownEditor {
     getDataSource(): DataSource;
 }
 
+/** @public */
 export type Options = dxDropDownBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/drop_down_box.d.ts
+++ b/js/ui/drop_down_box.d.ts
@@ -11,9 +11,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -31,55 +31,55 @@ import {
 } from './editor/ui.data_expression';
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxDropDownBox>;
+export type ChangeEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type ClosedEvent = ComponentEvent<dxDropDownBox>;
+export type ClosedEvent = EventInfo<dxDropDownBox>;
 
 /** @public */
-export type CopyEvent = ComponentNativeEvent<dxDropDownBox>;
+export type CopyEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type CutEvent = ComponentNativeEvent<dxDropDownBox>;
+export type CutEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxDropDownBox>;
+export type DisposingEvent = EventInfo<dxDropDownBox>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxDropDownBox>;
+export type EnterKeyEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxDropDownBox>;
+export type FocusInEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxDropDownBox>;
+export type FocusOutEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxDropDownBox>;
+export type InitializedEvent = InitializedEventInfo<dxDropDownBox>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxDropDownBox>;
+export type InputEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxDropDownBox>;
+export type KeyDownEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxDropDownBox>;
+export type KeyPressEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxDropDownBox>;
+export type KeyUpEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type OpenedEvent = ComponentEvent<dxDropDownBox>;
+export type OpenedEvent = EventInfo<dxDropDownBox>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxDropDownBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxDropDownBox> & ChangedOptionInfo;
 
 /** @public */
-export type PasteEvent = ComponentNativeEvent<dxDropDownBox>;
+export type PasteEvent = NativeEventInfo<dxDropDownBox>;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxDropDownBox> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxDropDownBox> & ValueChangedInfo;
 
 /** @public */
 export type ContentTemplateData = {

--- a/js/ui/drop_down_button.d.ts
+++ b/js/ui/drop_down_button.d.ts
@@ -339,6 +339,7 @@ export interface dxDropDownButtonItem extends dxListItem {
     onClick?: ((e: { component?: dxDropDownButton, element?: TElement, model?: any, event?: TEvent }) => void) | string;
 }
 
+/** @public */
 export type Options = dxDropDownButtonOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/drop_down_button.d.ts
+++ b/js/ui/drop_down_button.d.ts
@@ -16,9 +16,9 @@ import DataSource, {
 
 import {
     TEvent,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
 } from '../events/index';
 
@@ -35,30 +35,30 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ButtonClickEvent = ComponentNativeEvent<dxDropDownButton> & {
+export type ButtonClickEvent = NativeEventInfo<dxDropDownButton> & {
     readonly selectedItem?: any;
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxDropDownButton>;
+export type ContentReadyEvent = EventInfo<dxDropDownButton>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxDropDownButton>;
+export type DisposingEvent = EventInfo<dxDropDownButton>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxDropDownButton>;
+export type InitializedEvent = InitializedEventInfo<dxDropDownButton>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxDropDownButton> & {
+export type ItemClickEvent = NativeEventInfo<dxDropDownButton> & {
     readonly itemData?: any;
     readonly itemElement: TElement;
 };
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxDropDownButton> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxDropDownButton> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentNativeEvent<dxDropDownButton> & {
+export type SelectionChangedEvent = NativeEventInfo<dxDropDownButton> & {
     readonly item: any;
     readonly previousItem: any;
 }

--- a/js/ui/drop_down_editor/ui.drop_down_editor.d.ts
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.d.ts
@@ -20,7 +20,7 @@ import {
 } from '../popup';
 
 import {
-    ComponentEvent
+    EventInfo
 } from '../../events/index';
 
 export interface DropDownButtonTemplateDataModel {
@@ -96,7 +96,7 @@ export interface dxDropDownEditorOptions<T = dxDropDownEditor> extends dxTextBox
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onClosed?: ((e: ComponentEvent<T>) => void);
+    onClosed?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -108,7 +108,7 @@ export interface dxDropDownEditorOptions<T = dxDropDownEditor> extends dxTextBox
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onOpened?: ((e: ComponentEvent<T>) => void);
+    onOpened?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default false

--- a/js/ui/drop_down_editor/ui.drop_down_list.d.ts
+++ b/js/ui/drop_down_editor/ui.drop_down_list.d.ts
@@ -9,8 +9,8 @@ import {
 import DataSource from '../../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
+    EventInfo,
+    NativeEventInfo,
     ItemInfo
 } from '../../events/index';
 
@@ -87,7 +87,7 @@ export interface dxDropDownListOptions<T = dxDropDownList> extends DataExpressio
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onItemClick?: ((e: ComponentNativeEvent<T> & ItemInfo) => void);
+    onItemClick?: ((e: NativeEventInfo<T> & ItemInfo) => void);
     /**
      * @docid
      * @default null
@@ -100,7 +100,7 @@ export interface dxDropDownListOptions<T = dxDropDownList> extends DataExpressio
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onSelectionChanged?: ((e: ComponentEvent<T> & SelectionChangedInfo) => void);
+    onSelectionChanged?: ((e: EventInfo<T> & SelectionChangedInfo) => void);
     /**
      * @docid
      * @default null
@@ -115,7 +115,7 @@ export interface dxDropDownListOptions<T = dxDropDownList> extends DataExpressio
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onValueChanged?: ((e:  ComponentNativeEvent<T> & ValueChangedInfo) => void);
+    onValueChanged?: ((e:  NativeEventInfo<T> & ValueChangedInfo) => void);
     /**
      * @docid
      * @default false

--- a/js/ui/editor/editor.d.ts
+++ b/js/ui/editor/editor.d.ts
@@ -3,7 +3,7 @@ import {
 } from '../../core/element';
 
 import {
-    ComponentNativeEvent
+    NativeEventInfo
 } from '../../events/index';
 
 import Widget, {
@@ -37,7 +37,7 @@ export interface EditorOptions<T = Editor> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onValueChanged?: ((e: ComponentNativeEvent<T> & ValueChangedInfo) => void);
+    onValueChanged?: ((e: NativeEventInfo<T> & ValueChangedInfo) => void);
     /**
      * @docid
      * @default false

--- a/js/ui/file_manager.d.ts
+++ b/js/ui/file_manager.d.ts
@@ -8,9 +8,9 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -34,10 +34,10 @@ import {
 
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxFileManager>;
+export type ContentReadyEvent = EventInfo<dxFileManager>;
 
 /** @public */
-export type ContextMenuItemClickEvent = ComponentNativeEvent<dxFileManager> & {
+export type ContextMenuItemClickEvent = NativeEventInfo<dxFileManager> & {
     readonly itemData: any;
     readonly itemElement: TElement;
     readonly itemIndex: number;
@@ -46,47 +46,47 @@ export type ContextMenuItemClickEvent = ComponentNativeEvent<dxFileManager> & {
 }
 
 /** @public */
-export type ContextMenuShowingEvent = Cancelable & ComponentNativeEvent<dxFileManager> & {
+export type ContextMenuShowingEvent = Cancelable & NativeEventInfo<dxFileManager> & {
     readonly fileSystemItem?: FileSystemItem;
     readonly targetElement?: TElement;
     readonly viewArea: 'navPane' | 'itemView';
 }
 
 /** @public */
-export type CurrentDirectoryChangedEvent = ComponentEvent<dxFileManager> & {
+export type CurrentDirectoryChangedEvent = EventInfo<dxFileManager> & {
     readonly directory: FileSystemItem;
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxFileManager>;
+export type DisposingEvent = EventInfo<dxFileManager>;
 
 /** @public */
-export type ErrorOccurredEvent =  ComponentEvent<dxFileManager> & {
+export type ErrorOccurredEvent =  EventInfo<dxFileManager> & {
     readonly errorCode?: number;
     errorText?: string;
     readonly fileSystemItem?: FileSystemItem;
 }
 
 /** @public */
-export type FocusedItemChangedEvent =  ComponentEvent<dxFileManager> & {
+export type FocusedItemChangedEvent =  EventInfo<dxFileManager> & {
     readonly item?: FileSystemItem;
     readonly itemElement?: TElement;
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxFileManager>;
+export type InitializedEvent = InitializedEventInfo<dxFileManager>;
 
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxFileManager> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxFileManager> & ChangedOptionInfo;
 
 /** @public */
-export type SelectedFileOpenedEvent = ComponentEvent<dxFileManager> & {
+export type SelectedFileOpenedEvent = EventInfo<dxFileManager> & {
     readonly file: FileSystemItem;
 }
 
 /** @public */
-export type SelectionChangedEvent =  ComponentEvent<dxFileManager> & {
+export type SelectionChangedEvent =  EventInfo<dxFileManager> & {
     readonly currentSelectedItemKeys: Array<string>;
     readonly currentDeselectedItemKeys: Array<string>;
     readonly selectedItems: Array<FileSystemItem>;
@@ -94,7 +94,7 @@ export type SelectionChangedEvent =  ComponentEvent<dxFileManager> & {
 }
 
 /** @public */
-export type ToolbarItemClickEvent = ComponentNativeEvent<dxFileManager> & {
+export type ToolbarItemClickEvent = NativeEventInfo<dxFileManager> & {
     readonly itemData: any;
     readonly itemElement: TElement;
     readonly itemIndex: number;

--- a/js/ui/file_manager.d.ts
+++ b/js/ui/file_manager.d.ts
@@ -685,6 +685,7 @@ export interface dxFileManagerDetailsColumn {
     width?: number | string;
 }
 
+/** @public */
 export type Options = dxFileManagerOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/file_uploader.d.ts
+++ b/js/ui/file_uploader.d.ts
@@ -562,6 +562,7 @@ export default class dxFileUploader extends Editor {
     removeFile(file: File): void;
 }
 
+/** @public */
 export type Options = dxFileUploaderOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/file_uploader.d.ts
+++ b/js/ui/file_uploader.d.ts
@@ -7,9 +7,9 @@ import {
 } from '../core/utils/deferred';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -20,39 +20,39 @@ import Editor, {
 import UploadInfo from '../file_management/upload_info';
 
 /** @public */
-export type BeforeSendEvent = ComponentEvent<dxFileUploader> & {
+export type BeforeSendEvent = EventInfo<dxFileUploader> & {
     readonly request: XMLHttpRequest;
     readonly file: File;
     readonly uploadInfo?: UploadInfo;
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxFileUploader>;
+export type ContentReadyEvent = EventInfo<dxFileUploader>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxFileUploader>;
+export type DisposingEvent = EventInfo<dxFileUploader>;
 
 /** @public */
-export type DropZoneEnterEvent = ComponentNativeEvent<dxFileUploader> & {
+export type DropZoneEnterEvent = NativeEventInfo<dxFileUploader> & {
     readonly dropZoneElement: TElement;
 }
 
 /** @public */
-export type DropZoneLeaveEvent = ComponentNativeEvent<dxFileUploader> & {
+export type DropZoneLeaveEvent = NativeEventInfo<dxFileUploader> & {
     readonly dropZoneElement: TElement;
 }
 
 /** @public */
-export type FilesUploadedEvent = ComponentEvent<dxFileUploader>;
+export type FilesUploadedEvent = EventInfo<dxFileUploader>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxFileUploader>;
+export type InitializedEvent = InitializedEventInfo<dxFileUploader>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxFileUploader> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxFileUploader> & ChangedOptionInfo;
 
 /** @public */
-export type ProgressEvent = ComponentNativeEvent<dxFileUploader> & {
+export type ProgressEvent = NativeEventInfo<dxFileUploader> & {
     readonly file: File;
     readonly segmentSize: number;
     readonly bytesLoaded: number;
@@ -61,21 +61,21 @@ export type ProgressEvent = ComponentNativeEvent<dxFileUploader> & {
 }
 
 /** @public */
-export type UploadAbortedEvent = ComponentNativeEvent<dxFileUploader> & {
+export type UploadAbortedEvent = NativeEventInfo<dxFileUploader> & {
     readonly file: File;
     readonly request: XMLHttpRequest;
     message: string
 }
 
 /** @public */
-export type UploadedEvent = ComponentNativeEvent<dxFileUploader> & {
+export type UploadedEvent = NativeEventInfo<dxFileUploader> & {
     readonly file: File;
     readonly request: XMLHttpRequest;
     message: string;
 }
 
 /** @public */
-export type UploadErrorEvent = ComponentNativeEvent<dxFileUploader> & {
+export type UploadErrorEvent = NativeEventInfo<dxFileUploader> & {
     readonly file: File;
     readonly request: XMLHttpRequest;
     readonly error: any;
@@ -83,13 +83,13 @@ export type UploadErrorEvent = ComponentNativeEvent<dxFileUploader> & {
 }
 
 /** @public */
-export type UploadStartedEvent = ComponentNativeEvent<dxFileUploader> & {
+export type UploadStartedEvent = NativeEventInfo<dxFileUploader> & {
     readonly file: File;
     readonly request: XMLHttpRequest 
 }
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxFileUploader> & {
+export type ValueChangedEvent = NativeEventInfo<dxFileUploader> & {
     readonly value?: Array<File>;
     readonly previousValue?: Array<File>;
 }

--- a/js/ui/filter_builder.d.ts
+++ b/js/ui/filter_builder.d.ts
@@ -14,8 +14,8 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -25,13 +25,13 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxFilterBuilder>;
+export type ContentReadyEvent = EventInfo<dxFilterBuilder>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxFilterBuilder>;
+export type DisposingEvent = EventInfo<dxFilterBuilder>;
 
 /** @public */
-export type EditorPreparedEvent = ComponentEvent<dxFilterBuilder> & {
+export type EditorPreparedEvent = EventInfo<dxFilterBuilder> & {
     readonly value?: any;
     readonly setValue: any;
     readonly editorElement: TElement;
@@ -46,7 +46,7 @@ export type EditorPreparedEvent = ComponentEvent<dxFilterBuilder> & {
 }
 
 /** @public */
-export type EditorPreparingEvent = Cancelable & ComponentEvent<dxFilterBuilder> & {
+export type EditorPreparingEvent = Cancelable & EventInfo<dxFilterBuilder> & {
     readonly value?: any;
     readonly setValue: any;
     readonly editorElement?: TElement;
@@ -62,13 +62,13 @@ export type EditorPreparingEvent = Cancelable & ComponentEvent<dxFilterBuilder> 
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxFilterBuilder>;
+export type InitializedEvent = InitializedEventInfo<dxFilterBuilder>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxFilterBuilder> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxFilterBuilder> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentEvent<dxFilterBuilder> & {
+export type ValueChangedEvent = EventInfo<dxFilterBuilder> & {
     readonly value?: any;
     readonly previousValue?: any;
 }

--- a/js/ui/filter_builder.d.ts
+++ b/js/ui/filter_builder.d.ts
@@ -547,6 +547,7 @@ export interface dxFilterBuilderField {
     trueText?: string;
 }
 
+/** @public */
 export type Options = dxFilterBuilderOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/form.d.ts
+++ b/js/ui/form.d.ts
@@ -11,8 +11,8 @@ import {
 } from '../core/templates/template';
 
 import {
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -47,27 +47,27 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxForm>;
+export type ContentReadyEvent = EventInfo<dxForm>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxForm>;
+export type DisposingEvent = EventInfo<dxForm>;
 
 /** @public */
-export type EditorEnterKeyEvent = ComponentEvent<dxForm> & {
+export type EditorEnterKeyEvent = EventInfo<dxForm> & {
     readonly dataField?: string;
 }
 
 /** @public */
-export type FieldDataChangedEvent = ComponentEvent<dxForm> & {
+export type FieldDataChangedEvent = EventInfo<dxForm> & {
     readonly dataField?: string;
     readonly value?: any;
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxForm>;
+export type InitializedEvent = InitializedEventInfo<dxForm>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxForm> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxForm> & ChangedOptionInfo;
 
 /** @public */
 export type GroupItemTemplateData = {

--- a/js/ui/form.d.ts
+++ b/js/ui/form.d.ts
@@ -868,6 +868,7 @@ export interface dxFormTabbedItem {
     visibleIndex?: number;
 }
 
+/** @public */
 export type Options = dxFormOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/gallery.d.ts
+++ b/js/ui/gallery.d.ts
@@ -11,9 +11,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -25,31 +25,31 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxGallery>;
+export type ContentReadyEvent = EventInfo<dxGallery>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxGallery>;
+export type DisposingEvent = EventInfo<dxGallery>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxGallery>;
+export type InitializedEvent = InitializedEventInfo<dxGallery>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxGallery> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxGallery> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxGallery> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxGallery> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxGallery> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxGallery> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxGallery> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxGallery> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxGallery> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxGallery> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxGallery> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxGallery> & SelectionChangedInfo;
 
 export interface dxGalleryOptions extends CollectionWidgetOptions<dxGallery> {
     /**

--- a/js/ui/gallery.d.ts
+++ b/js/ui/gallery.d.ts
@@ -224,6 +224,7 @@ export interface dxGalleryItem extends CollectionWidgetItem {
     imageSrc?: string;
 }
 
+/** @public */
 export type Options = dxGalleryOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/gantt.d.ts
+++ b/js/ui/gantt.d.ts
@@ -5,9 +5,9 @@ import {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -40,7 +40,7 @@ import {
 } from '../core/utils/deferred';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxGantt>;
+export type ContentReadyEvent = EventInfo<dxGantt>;
 
 /** @public */
 export type ContextMenuPreparingEvent = Cancelable & {
@@ -61,114 +61,114 @@ export type CustomCommandEvent = {
 }
 
 /** @public */
-export type DependencyDeletedEvent = ComponentEvent<dxGantt> & {
+export type DependencyDeletedEvent = EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type DependencyDeletingEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type DependencyDeletingEvent = Cancelable & EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type DependencyInsertedEvent = ComponentEvent<dxGantt> & {
+export type DependencyInsertedEvent = EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type DependencyInsertingEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type DependencyInsertingEvent = Cancelable & EventInfo<dxGantt> & {
     readonly values: any;
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxGantt>;
+export type DisposingEvent = EventInfo<dxGantt>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxGantt>;
+export type InitializedEvent = InitializedEventInfo<dxGantt>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxGantt> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxGantt> & ChangedOptionInfo;
 
 /** @public */
-export type ResourceAssignedEvent = ComponentEvent<dxGantt> & {
-    readonly values: any;
-    readonly key: any;
-}
-
-/** @public */
-export type ResourceAssigningEvent = Cancelable & ComponentEvent<dxGantt> & {
-    readonly values: any;
-}
-
-/** @public */
-export type ResourceDeletedEvent = ComponentEvent<dxGantt> & {
+export type ResourceAssignedEvent = EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type ResourceDeletingEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type ResourceAssigningEvent = Cancelable & EventInfo<dxGantt> & {
+    readonly values: any;
+}
+
+/** @public */
+export type ResourceDeletedEvent = EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type ResourceInsertedEvent = ComponentEvent<dxGantt> & {
+export type ResourceDeletingEvent = Cancelable & EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type ResourceInsertingEvent = Cancelable & ComponentEvent<dxGantt> & {
-    readonly values: any;
-}
-
-/** @public */
-export type ResourceUnassignedEvent = ComponentEvent<dxGantt> & {
+export type ResourceInsertedEvent = EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type ResourceUnassigningEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type ResourceInsertingEvent = Cancelable & EventInfo<dxGantt> & {
+    readonly values: any;
+}
+
+/** @public */
+export type ResourceUnassignedEvent = EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxGantt> & {
+export type ResourceUnassigningEvent = Cancelable & EventInfo<dxGantt> & {
+    readonly values: any;
+    readonly key: any;
+}
+
+/** @public */
+export type SelectionChangedEvent = EventInfo<dxGantt> & {
     readonly selectedRowKey?: any;
 }
 
 /** @public */
-export type TaskClickEvent = ComponentNativeEvent<dxGantt> & {
+export type TaskClickEvent = NativeEventInfo<dxGantt> & {
     readonly key?: any;
     readonly data?: any;
 }
 
 /** @public */
-export type TaskDblClickEvent = Cancelable & ComponentNativeEvent<dxGantt> & {
+export type TaskDblClickEvent = Cancelable & NativeEventInfo<dxGantt> & {
     readonly key?: any;
     readonly data?: any;
 }
 
 /** @public */
-export type TaskDeletedEvent = ComponentEvent<dxGantt> & {
+export type TaskDeletedEvent = EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type TaskDeletingEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type TaskDeletingEvent = Cancelable & EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type TaskEditDialogShowingEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type TaskEditDialogShowingEvent = Cancelable & EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
     readonly readOnlyFields?: Array<string>;
@@ -176,31 +176,31 @@ export type TaskEditDialogShowingEvent = Cancelable & ComponentEvent<dxGantt> & 
 }
 
 /** @public */
-export type TaskInsertedEvent = ComponentEvent<dxGantt> & {
+export type TaskInsertedEvent = EventInfo<dxGantt> & {
     readonly value?: any;
     readonly key: any;
 }
 
 /** @public */
-export type TaskInsertingEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type TaskInsertingEvent = Cancelable & EventInfo<dxGantt> & {
     readonly values: any;
 }
 
 /** @public */
-export type TaskMovingEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type TaskMovingEvent = Cancelable & EventInfo<dxGantt> & {
     readonly newValues: any;
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type TaskUpdatedEvent = ComponentEvent<dxGantt> & {
+export type TaskUpdatedEvent = EventInfo<dxGantt> & {
     readonly values: any;
     readonly key: any;
 }
 
 /** @public */
-export type TaskUpdatingEvent = Cancelable & ComponentEvent<dxGantt> & {
+export type TaskUpdatingEvent = Cancelable & EventInfo<dxGantt> & {
     readonly newValues: any;
     readonly values: any;
     readonly key: any

--- a/js/ui/gantt.d.ts
+++ b/js/ui/gantt.d.ts
@@ -1274,6 +1274,7 @@ export interface dxGanttStripLine {
     title?: string;
 }
 
+/** @public */
 export type Options = dxGanttOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/html_editor.d.ts
+++ b/js/ui/html_editor.d.ts
@@ -11,9 +11,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -27,25 +27,25 @@ import {
 } from './toolbar';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxHtmlEditor>;
+export type ContentReadyEvent = EventInfo<dxHtmlEditor>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxHtmlEditor>;
+export type DisposingEvent = EventInfo<dxHtmlEditor>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxHtmlEditor>;
+export type FocusInEvent = NativeEventInfo<dxHtmlEditor>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxHtmlEditor>;
+export type FocusOutEvent = NativeEventInfo<dxHtmlEditor>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxHtmlEditor>;
+export type InitializedEvent = InitializedEventInfo<dxHtmlEditor>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxHtmlEditor> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxHtmlEditor> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxHtmlEditor> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxHtmlEditor> & ValueChangedInfo;
 
 /** @public */
 export interface MentionTemplateData {

--- a/js/ui/html_editor.d.ts
+++ b/js/ui/html_editor.d.ts
@@ -572,6 +572,7 @@ export interface dxHtmlEditorVariables {
     escapeChar?: string | Array<string>;
 }
 
+/** @public */
 export type Options = dxHtmlEditorOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/list.d.ts
+++ b/js/ui/list.d.ts
@@ -801,6 +801,7 @@ export interface dxListItem extends CollectionWidgetItem {
     showChevron?: boolean;
 }
 
+/** @public */
 export type Options = dxListOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/list.d.ts
+++ b/js/ui/list.d.ts
@@ -15,9 +15,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -51,71 +51,71 @@ export interface ScrollInfo {
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxList>;
+export type ContentReadyEvent = EventInfo<dxList>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxList>;
+export type DisposingEvent = EventInfo<dxList>;
 
 /** @public */
-export type GroupRenderedEvent = ComponentEvent<dxList> & {
+export type GroupRenderedEvent = EventInfo<dxList> & {
     readonly groupData?: any;
     readonly groupElement?: TElement;
     readonly groupIndex?: number;
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxList>;
+export type InitializedEvent = InitializedEventInfo<dxList>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxList> & ListItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxList> & ListItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxList> & ListItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxList> & ListItemInfo;
 
 /** @public */
-export type ItemDeletedEvent = ComponentEvent<dxList> & ListItemInfo;
+export type ItemDeletedEvent = EventInfo<dxList> & ListItemInfo;
 
 /** @public */
-export type ItemDeletingEvent = ComponentEvent<dxList> & ListItemInfo & {
+export type ItemDeletingEvent = EventInfo<dxList> & ListItemInfo & {
     cancel?: boolean | TPromise<void>;
 }
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxList> & ListItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxList> & ListItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxList> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxList> & ItemInfo;
 
 /** @public */
-export type ItemReorderedEvent = ComponentEvent<dxList> & ListItemInfo & {
+export type ItemReorderedEvent = EventInfo<dxList> & ListItemInfo & {
     readonly fromIndex: number;
     readonly toIndex: number;
 }
 
 /** @public */
-export type ItemSwipeEvent = ComponentNativeEvent<dxList> & ListItemInfo & {
+export type ItemSwipeEvent = NativeEventInfo<dxList> & ListItemInfo & {
     readonly direction: string;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxList> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxList> & ChangedOptionInfo;
 
 /** @public */
-export type PageLoadingEvent = ComponentEvent<dxList>;
+export type PageLoadingEvent = EventInfo<dxList>;
 
 /** @public */
-export type PullRefreshEvent = ComponentEvent<dxList>;
+export type PullRefreshEvent = EventInfo<dxList>;
 
 /** @public */
-export type ScrollEvent = ComponentNativeEvent<dxList> & ScrollInfo;
+export type ScrollEvent = NativeEventInfo<dxList> & ScrollInfo;
 
 /** @public */
-export type SelectAllValueChangedEvent = ComponentEvent<dxList> & {
+export type SelectAllValueChangedEvent = EventInfo<dxList> & {
     readonly value: boolean;
 }
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxList> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxList> & SelectionChangedInfo;
 
 export interface dxListOptions extends CollectionWidgetOptions<dxList>, SearchBoxMixinOptions<dxList> {
     /**

--- a/js/ui/load_indicator.d.ts
+++ b/js/ui/load_indicator.d.ts
@@ -3,8 +3,8 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -13,16 +13,16 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxLoadIndicator>;
+export type ContentReadyEvent = EventInfo<dxLoadIndicator>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxLoadIndicator>;
+export type DisposingEvent = EventInfo<dxLoadIndicator>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxLoadIndicator>;
+export type InitializedEvent = InitializedEventInfo<dxLoadIndicator>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxLoadIndicator> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxLoadIndicator> & ChangedOptionInfo;
 
 export interface dxLoadIndicatorOptions extends WidgetOptions<dxLoadIndicator> {
     /**

--- a/js/ui/load_indicator.d.ts
+++ b/js/ui/load_indicator.d.ts
@@ -45,6 +45,7 @@ export default class dxLoadIndicator extends Widget {
     constructor(element: TElement, options?: dxLoadIndicatorOptions)
 }
 
+/** @public */
 export type Options = dxLoadIndicatorOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/load_panel.d.ts
+++ b/js/ui/load_panel.d.ts
@@ -4,8 +4,8 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -23,28 +23,28 @@ import dxOverlay, {
 } from './overlay';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxLoadPanel>;
+export type ContentReadyEvent = EventInfo<dxLoadPanel>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxLoadPanel>;
+export type DisposingEvent = EventInfo<dxLoadPanel>;
 
 /** @public */
-export type HidingEvent = Cancelable & ComponentEvent<dxLoadPanel>;
+export type HidingEvent = Cancelable & EventInfo<dxLoadPanel>;
 
 /** @public */
-export type HiddenEvent = ComponentEvent<dxLoadPanel>;
+export type HiddenEvent = EventInfo<dxLoadPanel>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxLoadPanel>;
+export type InitializedEvent = InitializedEventInfo<dxLoadPanel>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxLoadPanel> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxLoadPanel> & ChangedOptionInfo;
 
 /** @public */
-export type ShowingEvent = ComponentEvent<dxLoadPanel>;
+export type ShowingEvent = EventInfo<dxLoadPanel>;
 
 /** @public */
-export type ShownEvent = ComponentEvent<dxLoadPanel>;
+export type ShownEvent = EventInfo<dxLoadPanel>;
 
 export interface dxLoadPanelOptions extends dxOverlayOptions<dxLoadPanel> {
     /**

--- a/js/ui/load_panel.d.ts
+++ b/js/ui/load_panel.d.ts
@@ -29,7 +29,7 @@ export type ContentReadyEvent = ComponentEvent<dxLoadPanel>;
 export type DisposingEvent = ComponentEvent<dxLoadPanel>;
 
 /** @public */
-export type HidingEvent = ComponentEvent<dxLoadPanel> & Cancelable;
+export type HidingEvent = Cancelable & ComponentEvent<dxLoadPanel>;
 
 /** @public */
 export type HiddenEvent = ComponentEvent<dxLoadPanel>;

--- a/js/ui/load_panel.d.ts
+++ b/js/ui/load_panel.d.ts
@@ -183,6 +183,7 @@ export default class dxLoadPanel extends dxOverlay {
     constructor(element: TElement, options?: dxLoadPanelOptions)
 }
 
+/** @public */
 export type Options = dxLoadPanelOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/lookup.d.ts
+++ b/js/ui/lookup.d.ts
@@ -16,9 +16,9 @@ import {
 
 import {
     TEvent,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -48,43 +48,43 @@ import {
 } from './popup';
 
 /** @public */
-export type ClosedEvent = ComponentEvent<dxLookup>;
+export type ClosedEvent = EventInfo<dxLookup>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxLookup>;
+export type ContentReadyEvent = EventInfo<dxLookup>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxLookup>;
+export type DisposingEvent = EventInfo<dxLookup>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxLookup>;
+export type InitializedEvent = InitializedEventInfo<dxLookup>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxLookup> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxLookup> & ItemInfo;
 
 /** @public */
-export type OpenedEvent = ComponentEvent<dxLookup>;
+export type OpenedEvent = EventInfo<dxLookup>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxLookup> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxLookup> & ChangedOptionInfo;
 
 /** @public */
-export type PageLoadingEvent = ComponentEvent<dxLookup>;
+export type PageLoadingEvent = EventInfo<dxLookup>;
 
 /** @public */
-export type PullRefreshEvent = ComponentEvent<dxLookup>;
+export type PullRefreshEvent = EventInfo<dxLookup>;
 
 /** @public */
-export type ScrollEvent = ComponentNativeEvent<dxLookup> & ScrollInfo;
+export type ScrollEvent = NativeEventInfo<dxLookup> & ScrollInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxLookup> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxLookup> & SelectionChangedInfo;
 
 /** @public */
-export type TitleRenderedEvent = ComponentEvent<dxLookup> & TitleRenderedInfo;
+export type TitleRenderedEvent = EventInfo<dxLookup> & TitleRenderedInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxLookup> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxLookup> & ValueChangedInfo;
 
 export interface dxLookupOptions extends dxDropDownListOptions<dxLookup> {
     /**

--- a/js/ui/lookup.d.ts
+++ b/js/ui/lookup.d.ts
@@ -472,6 +472,7 @@ export default class dxLookup extends dxDropDownList {
     constructor(element: TElement, options?: dxLookupOptions)
 }
 
+/** @public */
 export type Options = dxLookupOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/map.d.ts
+++ b/js/ui/map.d.ts
@@ -419,6 +419,7 @@ export default class dxMap extends Widget {
     removeRoute(route: any | number | Array<any>): TPromise<void>;
 }
 
+/** @public */
 export type Options = dxMapOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/map.d.ts
+++ b/js/ui/map.d.ts
@@ -7,9 +7,9 @@ import {
 } from '../core/utils/deferred';
 
 import {
-  ComponentEvent,
-  ComponentNativeEvent,
-  ComponentInitializedEvent,
+  EventInfo,
+  NativeEventInfo,
+  InitializedEventInfo,
   ChangedOptionInfo
 } from '../events/index';
 
@@ -18,41 +18,41 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ClickEvent = ComponentNativeEvent<dxMap>;
+export type ClickEvent = NativeEventInfo<dxMap>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxMap>;
+export type DisposingEvent = EventInfo<dxMap>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxMap>;
+export type InitializedEvent = InitializedEventInfo<dxMap>;
 
 /** @public */
-export type MarkerAddedEvent = ComponentEvent<dxMap> & {
+export type MarkerAddedEvent = EventInfo<dxMap> & {
   readonly options: any;
   originalMarker: any;
 }
 
 /** @public */
-export type MarkerRemovedEvent = ComponentEvent<dxMap> & {
+export type MarkerRemovedEvent = EventInfo<dxMap> & {
   readonly options?: any;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxMap> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxMap> & ChangedOptionInfo;
 
 /** @public */
-export type ReadyEvent = ComponentEvent<dxMap> & {
+export type ReadyEvent = EventInfo<dxMap> & {
   originalMap: any;
 }
 
 /** @public */
-export type RouteAddedEvent = ComponentEvent<dxMap> & {
+export type RouteAddedEvent = EventInfo<dxMap> & {
   readonly options: any;
   originalRoute: any;
 }
 
 /** @public */
-export type RouteRemovedEvent = ComponentEvent<dxMap> & {
+export type RouteRemovedEvent = EventInfo<dxMap> & {
   readonly options?: any;
 }
 

--- a/js/ui/menu.d.ts
+++ b/js/ui/menu.d.ts
@@ -294,6 +294,7 @@ export interface dxMenuItem extends dxMenuBaseItem {
     items?: Array<dxMenuItem>;
 }
 
+/** @public */
 export type Options = dxMenuOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/menu.d.ts
+++ b/js/ui/menu.d.ts
@@ -54,7 +54,7 @@ export type SubmenuHiddenEvent = ComponentEvent<dxMenu> & {
 }
 
 /** @public */
-export type SubmenuHidingEvent = ComponentEvent<dxMenu> & Cancelable & {
+export type SubmenuHidingEvent = Cancelable & ComponentEvent<dxMenu> & {
     readonly rootItem?: TElement;
 }
 

--- a/js/ui/menu.d.ts
+++ b/js/ui/menu.d.ts
@@ -8,9 +8,9 @@ import DataSource, {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -25,46 +25,46 @@ import dxMenuBase, {
 } from './context_menu/ui.menu_base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxMenu>;
+export type ContentReadyEvent = EventInfo<dxMenu>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxMenu>;
+export type DisposingEvent = EventInfo<dxMenu>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxMenu>;
+export type InitializedEvent = InitializedEventInfo<dxMenu>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxMenu> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxMenu> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxMenu> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxMenu> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxMenu> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxMenu> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxMenu> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxMenu> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxMenu> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxMenu> & SelectionChangedInfo;
 
 /** @public */
-export type SubmenuHiddenEvent = ComponentEvent<dxMenu> & {
+export type SubmenuHiddenEvent = EventInfo<dxMenu> & {
     readonly rootItem?: TElement;
 }
 
 /** @public */
-export type SubmenuHidingEvent = Cancelable & ComponentEvent<dxMenu> & {
+export type SubmenuHidingEvent = Cancelable & EventInfo<dxMenu> & {
     readonly rootItem?: TElement;
 }
 
 /** @public */
-export type SubmenuShowingEvent = ComponentEvent<dxMenu> & {
+export type SubmenuShowingEvent = EventInfo<dxMenu> & {
     readonly rootItem?: TElement;
 }
 
 /** @public */
-export type SubmenuShownEvent = ComponentEvent<dxMenu> & {
+export type SubmenuShownEvent = EventInfo<dxMenu> & {
     readonly rootItem?: TElement;
 }
 

--- a/js/ui/multi_view.d.ts
+++ b/js/ui/multi_view.d.ts
@@ -7,9 +7,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -21,31 +21,31 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxMultiView>;
+export type ContentReadyEvent = EventInfo<dxMultiView>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxMultiView>;
+export type DisposingEvent = EventInfo<dxMultiView>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxMultiView>;
+export type InitializedEvent = InitializedEventInfo<dxMultiView>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxMultiView> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxMultiView> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxMultiView> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxMultiView> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxMultiView> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxMultiView> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxMultiView> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxMultiView> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxMultiView> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxMultiView> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxMultiView> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxMultiView> & SelectionChangedInfo;
 
 export interface dxMultiViewOptions<T = dxMultiView> extends CollectionWidgetOptions<T> {
     /**

--- a/js/ui/multi_view.d.ts
+++ b/js/ui/multi_view.d.ts
@@ -125,6 +125,7 @@ export default class dxMultiView extends CollectionWidget {
 export interface dxMultiViewItem extends CollectionWidgetItem {
 }
 
+/** @public */
 export type Options = dxMultiViewOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/nav_bar.d.ts
+++ b/js/ui/nav_bar.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -20,31 +20,31 @@ import dxTabs, {
 } from './tabs';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxNavBar>;
+export type ContentReadyEvent = EventInfo<dxNavBar>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxNavBar>;
+export type DisposingEvent = EventInfo<dxNavBar>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxNavBar>;
+export type InitializedEvent = InitializedEventInfo<dxNavBar>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxNavBar> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxNavBar> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxNavBar> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxNavBar> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxNavBar> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxNavBar> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxNavBar> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxNavBar> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxNavBar> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxNavBar> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxNavBar> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxNavBar> & SelectionChangedInfo;
 
 export interface dxNavBarOptions extends dxTabsOptions<dxNavBar> {
     /**

--- a/js/ui/nav_bar.d.ts
+++ b/js/ui/nav_bar.d.ts
@@ -80,6 +80,7 @@ export interface dxNavBarItem extends dxTabsItem {
     badge?: string;
 }
 
+/** @public */
 export type Options = dxNavBarOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/number_box.d.ts
+++ b/js/ui/number_box.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -23,52 +23,52 @@ import {
 } from './widget/ui.widget';
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxNumberBox>;
+export type ChangeEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxNumberBox>;
+export type ContentReadyEvent = EventInfo<dxNumberBox>;
 
 /** @public */
-export type CopyEvent = ComponentNativeEvent<dxNumberBox>;
+export type CopyEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type CutEvent = ComponentNativeEvent<dxNumberBox>;
+export type CutEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxNumberBox>;
+export type DisposingEvent = EventInfo<dxNumberBox>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxNumberBox>;
+export type EnterKeyEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxNumberBox>;
+export type FocusInEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxNumberBox>;
+export type FocusOutEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxNumberBox>;
+export type InitializedEvent = InitializedEventInfo<dxNumberBox>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxNumberBox>;
+export type InputEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxNumberBox>;
+export type KeyDownEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxNumberBox>;
+export type KeyPressEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxNumberBox>;
+export type KeyUpEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxNumberBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxNumberBox> & ChangedOptionInfo;
 
 /** @public */
-export type PasteEvent = ComponentNativeEvent<dxNumberBox>;
+export type PasteEvent = NativeEventInfo<dxNumberBox>;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxNumberBox> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxNumberBox> & ValueChangedInfo;
 
 export interface dxNumberBoxOptions extends dxTextEditorOptions<dxNumberBox> {
     /**

--- a/js/ui/number_box.d.ts
+++ b/js/ui/number_box.d.ts
@@ -159,6 +159,7 @@ export default class dxNumberBox extends dxTextEditor {
     constructor(element: TElement, options?: dxNumberBoxOptions)
 }
 
+/** @public */
 export type Options = dxNumberBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/overlay.d.ts
+++ b/js/ui/overlay.d.ts
@@ -17,7 +17,7 @@ import {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent
+    EventInfo
 } from '../events/index';
 
 import Widget, {
@@ -118,7 +118,7 @@ export interface dxOverlayOptions<T = dxOverlay> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onHidden?: ((e: ComponentEvent<T>) => void);
+    onHidden?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -131,7 +131,7 @@ export interface dxOverlayOptions<T = dxOverlay> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onHiding?: ((e: Cancelable & ComponentEvent<T>) => void);
+    onHiding?: ((e: Cancelable & EventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -143,7 +143,7 @@ export interface dxOverlayOptions<T = dxOverlay> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onShowing?: ((e: ComponentEvent<T>) => void);
+    onShowing?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -155,7 +155,7 @@ export interface dxOverlayOptions<T = dxOverlay> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onShown?: ((e: ComponentEvent<T>) => void);
+    onShown?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default { my: 'center', at: 'center', of: window }

--- a/js/ui/overlay.d.ts
+++ b/js/ui/overlay.d.ts
@@ -131,7 +131,7 @@ export interface dxOverlayOptions<T = dxOverlay> extends WidgetOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onHiding?: ((e: ComponentEvent<T> & Cancelable) => void);
+    onHiding?: ((e: Cancelable & ComponentEvent<T>) => void);
     /**
      * @docid
      * @default null

--- a/js/ui/pivot_grid.d.ts
+++ b/js/ui/pivot_grid.d.ts
@@ -8,9 +8,9 @@ import {
 
 import {
     Cancelable,
-    ComponentNativeEvent,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    NativeEventInfo,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -26,7 +26,7 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type CellClickEvent = Cancelable & ComponentNativeEvent<dxPivotGrid> & {
+export type CellClickEvent = Cancelable & NativeEventInfo<dxPivotGrid> & {
     readonly area?: string;
     readonly cellElement?: TElement;
     readonly cell?: dxPivotGridPivotGridCell;
@@ -38,7 +38,7 @@ export type CellClickEvent = Cancelable & ComponentNativeEvent<dxPivotGrid> & {
 }
 
 /** @public */
-export type CellPreparedEvent = ComponentEvent<dxPivotGrid> & {
+export type CellPreparedEvent = EventInfo<dxPivotGrid> & {
     readonly area?: string;
     readonly cellElement?: TElement;
     readonly cell?: dxPivotGridPivotGridCell;
@@ -47,10 +47,10 @@ export type CellPreparedEvent = ComponentEvent<dxPivotGrid> & {
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxPivotGrid>;
+export type ContentReadyEvent = EventInfo<dxPivotGrid>;
 
 /** @public */
-export type ContextMenuPreparingEvent = ComponentEvent<dxPivotGrid> & {
+export type ContextMenuPreparingEvent = EventInfo<dxPivotGrid> & {
     readonly area?: string;
     readonly cell?: dxPivotGridPivotGridCell;
     readonly cellElement?: TElement;
@@ -64,13 +64,13 @@ export type ContextMenuPreparingEvent = ComponentEvent<dxPivotGrid> & {
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxPivotGrid>;
+export type DisposingEvent = EventInfo<dxPivotGrid>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxPivotGrid>;
+export type ExportedEvent = EventInfo<dxPivotGrid>;
 
 /** @public */
-export type ExportingEvent = Cancelable & ComponentEvent<dxPivotGrid> & {
+export type ExportingEvent = Cancelable & EventInfo<dxPivotGrid> & {
     fileName?: string;
 }
 
@@ -84,10 +84,10 @@ export type FileSavingEvent = Cancelable & {
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxPivotGrid>;
+export type InitializedEvent = InitializedEventInfo<dxPivotGrid>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxPivotGrid> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxPivotGrid> & ChangedOptionInfo;
 
 export interface dxPivotGridOptions extends WidgetOptions<dxPivotGrid> {
     /**

--- a/js/ui/pivot_grid.d.ts
+++ b/js/ui/pivot_grid.d.ts
@@ -1057,6 +1057,7 @@ export interface dxPivotGridSummaryCell {
     value(postProcessed: boolean): any;
 }
 
+/** @public */
 export type Options = dxPivotGridOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/pivot_grid.d.ts
+++ b/js/ui/pivot_grid.d.ts
@@ -26,7 +26,7 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type CellClickEvent = ComponentNativeEvent<dxPivotGrid> & Cancelable & {
+export type CellClickEvent = Cancelable & ComponentNativeEvent<dxPivotGrid> & {
     readonly area?: string;
     readonly cellElement?: TElement;
     readonly cell?: dxPivotGridPivotGridCell;
@@ -70,7 +70,7 @@ export type DisposingEvent = ComponentEvent<dxPivotGrid>;
 export type ExportedEvent = ComponentEvent<dxPivotGrid>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxPivotGrid> & Cancelable & {
+export type ExportingEvent = Cancelable & ComponentEvent<dxPivotGrid> & {
     fileName?: string;
 }
 

--- a/js/ui/pivot_grid_field_chooser.d.ts
+++ b/js/ui/pivot_grid_field_chooser.d.ts
@@ -4,8 +4,8 @@ import {
 
 import {
     TEvent,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -18,10 +18,10 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxPivotGridFieldChooser>;
+export type ContentReadyEvent = EventInfo<dxPivotGridFieldChooser>;
 
 /** @public */
-export type ContextMenuPreparingEvent = ComponentEvent<dxPivotGridFieldChooser> & {
+export type ContextMenuPreparingEvent = EventInfo<dxPivotGridFieldChooser> & {
     readonly area?: string;
     readonly field?: PivotGridDataSourceField;
     readonly event?: TEvent;
@@ -29,13 +29,13 @@ export type ContextMenuPreparingEvent = ComponentEvent<dxPivotGridFieldChooser> 
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxPivotGridFieldChooser>;
+export type DisposingEvent = EventInfo<dxPivotGridFieldChooser>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxPivotGridFieldChooser>;
+export type InitializedEvent = InitializedEventInfo<dxPivotGridFieldChooser>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxPivotGridFieldChooser> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxPivotGridFieldChooser> & ChangedOptionInfo;
 
 export interface dxPivotGridFieldChooserOptions extends WidgetOptions<dxPivotGridFieldChooser> {
     /**

--- a/js/ui/pivot_grid_field_chooser.d.ts
+++ b/js/ui/pivot_grid_field_chooser.d.ts
@@ -247,6 +247,7 @@ export default class dxPivotGridFieldChooser extends Widget {
     updateDimensions(): void;
 }
 
+/** @public */
 export type Options = dxPivotGridFieldChooserOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/popover.d.ts
+++ b/js/ui/popover.d.ts
@@ -35,7 +35,7 @@ export type ContentReadyEvent = ComponentEvent<dxPopover>;
 export type DisposingEvent = ComponentEvent<dxPopover>;
 
 /** @public */
-export type HidingEvent = ComponentEvent<dxPopover> & Cancelable;
+export type HidingEvent = Cancelable & ComponentEvent<dxPopover>;
 
 /** @public */
 export type HiddenEvent = ComponentEvent<dxPopover>;

--- a/js/ui/popover.d.ts
+++ b/js/ui/popover.d.ts
@@ -17,8 +17,8 @@ import {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -29,31 +29,31 @@ import dxPopup, {
 } from './popup';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxPopover>;
+export type ContentReadyEvent = EventInfo<dxPopover>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxPopover>;
+export type DisposingEvent = EventInfo<dxPopover>;
 
 /** @public */
-export type HidingEvent = Cancelable & ComponentEvent<dxPopover>;
+export type HidingEvent = Cancelable & EventInfo<dxPopover>;
 
 /** @public */
-export type HiddenEvent = ComponentEvent<dxPopover>;
+export type HiddenEvent = EventInfo<dxPopover>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxPopover>;
+export type InitializedEvent = InitializedEventInfo<dxPopover>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxPopover> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxPopover> & ChangedOptionInfo;
 
 /** @public */
-export type ShowingEvent = ComponentEvent<dxPopover>;
+export type ShowingEvent = EventInfo<dxPopover>;
 
 /** @public */
-export type ShownEvent = ComponentEvent<dxPopover>;
+export type ShownEvent = EventInfo<dxPopover>;
 
 /** @public */
-export type TitleRenderedEvent = ComponentEvent<dxPopup> & TitleRenderedInfo;
+export type TitleRenderedEvent = EventInfo<dxPopup> & TitleRenderedInfo;
 
 export interface dxPopoverOptions<T = dxPopover> extends dxPopupOptions<T> {
     /**

--- a/js/ui/popover.d.ts
+++ b/js/ui/popover.d.ts
@@ -198,6 +198,7 @@ export default class dxPopover extends dxPopup {
     show(target: string | TElement): TPromise<boolean>;
 }
 
+/** @public */
 export type Options = dxPopoverOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/popup.d.ts
+++ b/js/ui/popup.d.ts
@@ -42,7 +42,7 @@ export type ContentReadyEvent = ComponentEvent<dxPopup>;
 export type DisposingEvent = ComponentEvent<dxPopup>;
 
 /** @public */
-export type HidingEvent = ComponentEvent<dxPopup> & Cancelable;
+export type HidingEvent = Cancelable & ComponentEvent<dxPopup>;
 
 /** @public */
 export type HiddenEvent = ComponentEvent<dxPopup>;

--- a/js/ui/popup.d.ts
+++ b/js/ui/popup.d.ts
@@ -16,9 +16,9 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -36,40 +36,40 @@ export interface TitleRenderedInfo {
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxPopup>;
+export type ContentReadyEvent = EventInfo<dxPopup>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxPopup>;
+export type DisposingEvent = EventInfo<dxPopup>;
 
 /** @public */
-export type HidingEvent = Cancelable & ComponentEvent<dxPopup>;
+export type HidingEvent = Cancelable & EventInfo<dxPopup>;
 
 /** @public */
-export type HiddenEvent = ComponentEvent<dxPopup>;
+export type HiddenEvent = EventInfo<dxPopup>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxPopup>;
+export type InitializedEvent = InitializedEventInfo<dxPopup>;
 
 /** @public */
-export type ShownEvent = ComponentEvent<dxPopup>;
+export type ShownEvent = EventInfo<dxPopup>;
 
 /** @public */
-export type ResizeEvent = ComponentNativeEvent<dxPopup> & ResizeInfo;
+export type ResizeEvent = NativeEventInfo<dxPopup> & ResizeInfo;
 
 /** @public */
-export type ResizeStartEvent = ComponentNativeEvent<dxPopup> & ResizeInfo;
+export type ResizeStartEvent = NativeEventInfo<dxPopup> & ResizeInfo;
 
 /** @public */
-export type ResizeEndEvent = ComponentNativeEvent<dxPopup> & ResizeInfo;
+export type ResizeEndEvent = NativeEventInfo<dxPopup> & ResizeInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxPopup> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxPopup> & ChangedOptionInfo;
 
 /** @public */
-export type ShowingEvent = ComponentEvent<dxPopup>;
+export type ShowingEvent = EventInfo<dxPopup>;
 
 /** @public */
-export type TitleRenderedEvent = ComponentEvent<dxPopup> & TitleRenderedInfo;
+export type TitleRenderedEvent = EventInfo<dxPopup> & TitleRenderedInfo;
 
 export interface dxPopupOptions<T = dxPopup> extends dxOverlayOptions<T> {
     /**

--- a/js/ui/popup.d.ts
+++ b/js/ui/popup.d.ts
@@ -319,6 +319,7 @@ export default class dxPopup extends dxOverlay {
     constructor(element: TElement, options?: dxPopupOptions)
 }
 
+/** @public */
 export type Options = dxPopupOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/progress_bar.d.ts
+++ b/js/ui/progress_bar.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -18,22 +18,22 @@ import dxTrackBar, {
 } from './track_bar';
 
 /** @public */
-export type CompleteEvent = ComponentNativeEvent<dxProgressBar>;
+export type CompleteEvent = NativeEventInfo<dxProgressBar>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxProgressBar>;
+export type ContentReadyEvent = EventInfo<dxProgressBar>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxProgressBar>;
+export type DisposingEvent = EventInfo<dxProgressBar>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxProgressBar>;
+export type InitializedEvent = InitializedEventInfo<dxProgressBar>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxProgressBar> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxProgressBar> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxProgressBar> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxProgressBar> & ValueChangedInfo;
 
 export interface dxProgressBarOptions extends dxTrackBarOptions<dxProgressBar> {
     /**

--- a/js/ui/progress_bar.d.ts
+++ b/js/ui/progress_bar.d.ts
@@ -86,6 +86,7 @@ export default class dxProgressBar extends dxTrackBar {
     constructor(element: TElement, options?: dxProgressBarOptions)
 }
 
+/** @public */
 export type Options = dxProgressBarOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/radio_group.d.ts
+++ b/js/ui/radio_group.d.ts
@@ -95,6 +95,7 @@ export default class dxRadioGroup extends Editor {
     getDataSource(): DataSource;
 }
 
+/** @public */
 export type Options = dxRadioGroupOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/radio_group.d.ts
+++ b/js/ui/radio_group.d.ts
@@ -5,9 +5,9 @@ import {
 import DataSource from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -21,19 +21,19 @@ import {
 } from './editor/ui.data_expression';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxRadioGroup>;
+export type ContentReadyEvent = EventInfo<dxRadioGroup>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxRadioGroup>;
+export type DisposingEvent = EventInfo<dxRadioGroup>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxRadioGroup>;
+export type InitializedEvent = InitializedEventInfo<dxRadioGroup>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxRadioGroup> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxRadioGroup> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxRadioGroup> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxRadioGroup> & ValueChangedInfo;
 
 export interface dxRadioGroupOptions extends EditorOptions<dxRadioGroup>, DataExpressionMixinOptions<dxRadioGroup> {
     /**

--- a/js/ui/range_slider.d.ts
+++ b/js/ui/range_slider.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -20,19 +20,19 @@ import {
 import dxTrackBar from './track_bar';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxRangeSlider>;
+export type ContentReadyEvent = EventInfo<dxRangeSlider>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxRangeSlider>;
+export type DisposingEvent = EventInfo<dxRangeSlider>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxRangeSlider>;
+export type InitializedEvent = InitializedEventInfo<dxRangeSlider>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxRangeSlider> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxRangeSlider> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxRangeSlider> & ValueChangedInfo & {
+export type ValueChangedEvent = NativeEventInfo<dxRangeSlider> & ValueChangedInfo & {
     readonly start?: number;
     readonly end?: number;
     readonly value?: Array<number>;

--- a/js/ui/range_slider.d.ts
+++ b/js/ui/range_slider.d.ts
@@ -102,6 +102,7 @@ export default class dxRangeSlider extends dxTrackBar {
     constructor(element: TElement, options?: dxRangeSliderOptions)
 }
 
+/** @public */
 export type Options = dxRangeSliderOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/resizable.d.ts
+++ b/js/ui/resizable.d.ts
@@ -7,9 +7,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -25,22 +25,22 @@ export interface ResizeInfo {
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxResizable>;
+export type DisposingEvent = EventInfo<dxResizable>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxResizable>;
+export type InitializedEvent = InitializedEventInfo<dxResizable>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxResizable> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxResizable> & ChangedOptionInfo;
 
 /** @public */
-export type ResizeEvent = ComponentNativeEvent<dxResizable> & ResizeInfo;
+export type ResizeEvent = NativeEventInfo<dxResizable> & ResizeInfo;
 
 /** @public */
-export type ResizeStartEvent = ComponentNativeEvent<dxResizable> & ResizeInfo;
+export type ResizeStartEvent = NativeEventInfo<dxResizable> & ResizeInfo;
 
 /** @public */
-export type ResizeEndEvent = ComponentNativeEvent<dxResizable> & ResizeInfo;
+export type ResizeEndEvent = NativeEventInfo<dxResizable> & ResizeInfo;
 
 export interface dxResizableOptions extends DOMComponentOptions<dxResizable> {
     /**

--- a/js/ui/resizable.d.ts
+++ b/js/ui/resizable.d.ts
@@ -154,6 +154,7 @@ export default class dxResizable extends DOMComponent {
     constructor(element: TElement, options?: dxResizableOptions)
 }
 
+/** @public */
 export type Options = dxResizableOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/responsive_box.d.ts
+++ b/js/ui/responsive_box.d.ts
@@ -7,9 +7,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-  ComponentEvent,
-  ComponentNativeEvent,
-  ComponentInitializedEvent,
+  EventInfo,
+  NativeEventInfo,
+  InitializedEventInfo,
   ChangedOptionInfo,
   ItemInfo
 } from '../events/index';
@@ -20,28 +20,28 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxResponsiveBox>;
+export type ContentReadyEvent = EventInfo<dxResponsiveBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxResponsiveBox>;
+export type DisposingEvent = EventInfo<dxResponsiveBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxResponsiveBox>;
+export type InitializedEvent = InitializedEventInfo<dxResponsiveBox>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxResponsiveBox> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxResponsiveBox> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxResponsiveBox> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxResponsiveBox> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxResponsiveBox> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxResponsiveBox> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxResponsiveBox> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxResponsiveBox> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxResponsiveBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxResponsiveBox> & ChangedOptionInfo;
 
 export interface dxResponsiveBoxOptions extends CollectionWidgetOptions<dxResponsiveBox> {
     /**

--- a/js/ui/responsive_box.d.ts
+++ b/js/ui/responsive_box.d.ts
@@ -208,6 +208,7 @@ export interface dxResponsiveBoxItem extends CollectionWidgetItem {
     } | Array<{ col?: number, colspan?: number, row?: number, rowspan?: number, screen?: string }>;
 }
 
+/** @public */
 export type Options = dxResponsiveBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -1288,6 +1288,7 @@ export interface dxSchedulerAppointment extends CollectionWidgetItem {
     visible?: boolean;
 }
 
+/** @public */
 export type Options = dxSchedulerOptions;
 
 /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -18,9 +18,9 @@ import DataSource, {
 
 import {
     TEvent,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     Cancelable
 } from '../events/index';
@@ -54,92 +54,92 @@ interface TargetedAppointmentInfo {
 }
 
 /** @public */
-export type AppointmentAddedEvent = ComponentEvent<dxScheduler> & {
+export type AppointmentAddedEvent = EventInfo<dxScheduler> & {
   readonly appointmentData: any;
   readonly error?: Error;
 }
 
 /** @public */
-export type AppointmentAddingEvent = ComponentEvent<dxScheduler> & {
+export type AppointmentAddingEvent = EventInfo<dxScheduler> & {
   readonly appointmentData: any;
   cancel: boolean | TPromise<boolean>;
 }
 
 /** @public */
-export type AppointmentClickEvent = Cancelable & ComponentNativeEvent<dxScheduler> & TargetedAppointmentInfo & {
+export type AppointmentClickEvent = Cancelable & NativeEventInfo<dxScheduler> & TargetedAppointmentInfo & {
   readonly appointmentElement: TElement;
 }
 
 /** @public */
-export type AppointmentContextMenuEvent = ComponentNativeEvent<dxScheduler> & TargetedAppointmentInfo &{
+export type AppointmentContextMenuEvent = NativeEventInfo<dxScheduler> & TargetedAppointmentInfo &{
   readonly appointmentElement: TElement;
 }
 
 /** @public */
-export type AppointmentDblClickEvent = Cancelable & ComponentNativeEvent<dxScheduler> & TargetedAppointmentInfo & {
+export type AppointmentDblClickEvent = Cancelable & NativeEventInfo<dxScheduler> & TargetedAppointmentInfo & {
   readonly appointmentElement: TElement;
 }
 
 /** @public */
-export type AppointmentDeletedEvent = ComponentEvent<dxScheduler> & {
+export type AppointmentDeletedEvent = EventInfo<dxScheduler> & {
   readonly appointmentData: any;
   readonly error?: Error;
 }
 
 /** @public */
-export type AppointmentDeletingEvent = ComponentEvent<dxScheduler> & {
+export type AppointmentDeletingEvent = EventInfo<dxScheduler> & {
   readonly appointmentData: any;
   cancel: boolean | TPromise<boolean>;
 }
 
 /** @public */
-export type AppointmentFormOpeningEvent = Cancelable & ComponentEvent<dxScheduler> & {
+export type AppointmentFormOpeningEvent = Cancelable & EventInfo<dxScheduler> & {
   readonly appointmentData?: any;
   readonly form: dxForm;
   readonly popup: dxPopup;
 }
 
 /** @public */
-export type AppointmentRenderedEvent = ComponentEvent<dxScheduler> & TargetedAppointmentInfo & {
+export type AppointmentRenderedEvent = EventInfo<dxScheduler> & TargetedAppointmentInfo & {
   readonly appointmentElement: TElement;
 }
 
 /** @public */
-export type AppointmentUpdatedEvent = ComponentEvent<dxScheduler> & {
+export type AppointmentUpdatedEvent = EventInfo<dxScheduler> & {
   readonly appointmentData: any;
   readonly error?: Error;
 }
 
 /** @public */
-export type AppointmentUpdatingEvent = ComponentEvent<dxScheduler> & {
+export type AppointmentUpdatingEvent = EventInfo<dxScheduler> & {
   readonly oldData: any;
   readonly newData: any;
   cancel?: boolean | TPromise<boolean>;
 }
 
 /** @public */
-export type CellClickEvent = Cancelable & ComponentNativeEvent<dxScheduler> & {
+export type CellClickEvent = Cancelable & NativeEventInfo<dxScheduler> & {
   readonly cellData: any;
   readonly cellElement: TElement;
 }
 
 /** @public */
-export type CellContextMenuEvent = ComponentNativeEvent<dxScheduler> & {
+export type CellContextMenuEvent = NativeEventInfo<dxScheduler> & {
   readonly cellData: any;
   readonly cellElement: TElement;
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxScheduler>;
+export type ContentReadyEvent = EventInfo<dxScheduler>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxScheduler>;
+export type DisposingEvent = EventInfo<dxScheduler>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxScheduler>;
+export type InitializedEvent = InitializedEventInfo<dxScheduler>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxScheduler> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxScheduler> & ChangedOptionInfo;
 
 /** @public */
 export type AppointmentDraggingAddEvent = AppointmentDraggingEvent & {

--- a/js/ui/scroll_view.d.ts
+++ b/js/ui/scroll_view.d.ts
@@ -7,36 +7,36 @@ import {
 } from '../core/utils/deferred';
 
 import {
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
 import dxScrollable, {
     dxScrollableOptions,
-    ComponentScrollEvent
+    ScrollEventInfo
 } from './scroll_view/ui.scrollable';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxScrollView>;
+export type DisposingEvent = EventInfo<dxScrollView>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxScrollView>;
+export type InitializedEvent = InitializedEventInfo<dxScrollView>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxScrollView> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxScrollView> & ChangedOptionInfo;
 
 /** @public */
-export type PullDownEvent = ComponentEvent<dxScrollView>;
+export type PullDownEvent = EventInfo<dxScrollView>;
 
 /** @public */
-export type ReachBottomEvent = ComponentEvent<dxScrollView>;
+export type ReachBottomEvent = EventInfo<dxScrollView>;
 
 /** @public */
-export type ScrollEvent = ComponentScrollEvent<dxScrollView>;
+export type ScrollEvent = ScrollEventInfo<dxScrollView>;
 
 /** @public */
-export type UpdatedEvent = ComponentScrollEvent<dxScrollView>;
+export type UpdatedEvent = ScrollEventInfo<dxScrollView>;
 
 export interface dxScrollViewOptions extends dxScrollableOptions<dxScrollView> {
     /**

--- a/js/ui/scroll_view.d.ts
+++ b/js/ui/scroll_view.d.ts
@@ -125,6 +125,7 @@ export default class dxScrollView extends dxScrollable {
     release(preventScrollBottom: boolean): TPromise<void>;
 }
 
+/** @public */
 export type Options = dxScrollViewOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/scroll_view/ui.scrollable.d.ts
+++ b/js/ui/scroll_view/ui.scrollable.d.ts
@@ -11,10 +11,10 @@ import {
 } from '../../core/utils/deferred';
 
 import {
-    ComponentNativeEvent
+    NativeEventInfo
 } from '../../events/index';
 
-export interface ComponentScrollEvent<T = dxScrollable> extends ComponentNativeEvent<T> {
+export interface ScrollEventInfo<T = dxScrollable> extends NativeEventInfo<T> {
     readonly scrollOffset?: any;
     readonly reachedLeft?: boolean;
     readonly reachedRight?: boolean;
@@ -63,7 +63,7 @@ export interface dxScrollableOptions<T = dxScrollable> extends DOMComponentOptio
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onScroll?: ((e: ComponentScrollEvent<T>) => void);
+    onScroll?: ((e: ScrollEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -81,7 +81,7 @@ export interface dxScrollableOptions<T = dxScrollable> extends DOMComponentOptio
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onUpdated?: ((e: ComponentScrollEvent<T>) => void);
+    onUpdated?: ((e: ScrollEventInfo<T>) => void);
     /**
      * @docid
      * @default false [for](non-touch_devices)

--- a/js/ui/select_box.d.ts
+++ b/js/ui/select_box.d.ts
@@ -11,9 +11,9 @@ import {
 } from '../core/templates/template';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -40,66 +40,66 @@ export interface CustomItemCreatingInfo {
 }
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxSelectBox>;
+export type ChangeEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type ClosedEvent = ComponentEvent<dxSelectBox>;
+export type ClosedEvent = EventInfo<dxSelectBox>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxSelectBox>;
+export type ContentReadyEvent = EventInfo<dxSelectBox>;
 
 /** @public */
-export type CopyEvent = ComponentNativeEvent<dxSelectBox>;
+export type CopyEvent = NativeEventInfo<dxSelectBox>;
 /** @public */
-export type CustomItemCreatingEvent = ComponentEvent<dxSelectBox> & CustomItemCreatingInfo;
+export type CustomItemCreatingEvent = EventInfo<dxSelectBox> & CustomItemCreatingInfo;
 
 /** @public */
-export type CutEvent = ComponentNativeEvent<dxSelectBox>;
+export type CutEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSelectBox>;
+export type DisposingEvent = EventInfo<dxSelectBox>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxSelectBox>;
+export type EnterKeyEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxSelectBox>;
+export type FocusInEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxSelectBox>;
+export type FocusOutEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSelectBox>;
+export type InitializedEvent = InitializedEventInfo<dxSelectBox>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxSelectBox>;
+export type InputEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxSelectBox> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxSelectBox> & ItemInfo;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxSelectBox>;
+export type KeyDownEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxSelectBox>;
+export type KeyPressEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxSelectBox>;
+export type KeyUpEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type OpenedEvent = ComponentEvent<dxSelectBox>;
+export type OpenedEvent = EventInfo<dxSelectBox>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSelectBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSelectBox> & ChangedOptionInfo;
 
 /** @public */
-export type PasteEvent = ComponentNativeEvent<dxSelectBox>;
+export type PasteEvent = NativeEventInfo<dxSelectBox>;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxSelectBox> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxSelectBox> & SelectionChangedInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxSelectBox> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxSelectBox> & ValueChangedInfo;
 
 /** @public */
 export type DropDownButtonTemplateData = DropDownButtonTemplateDataModel;

--- a/js/ui/select_box.d.ts
+++ b/js/ui/select_box.d.ts
@@ -185,6 +185,7 @@ export default class dxSelectBox extends dxDropDownList {
     constructor(element: TElement, options?: dxSelectBoxOptions)
 }
 
+/** @public */
 export type Options = dxSelectBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/slide_out.d.ts
+++ b/js/ui/slide_out.d.ts
@@ -15,9 +15,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -29,37 +29,37 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxSlideOut>;
+export type ContentReadyEvent = EventInfo<dxSlideOut>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSlideOut>;
+export type DisposingEvent = EventInfo<dxSlideOut>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSlideOut>;
+export type InitializedEvent = InitializedEventInfo<dxSlideOut>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxSlideOut> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxSlideOut> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxSlideOut> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxSlideOut> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxSlideOut> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxSlideOut> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxSlideOut> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxSlideOut> & ItemInfo;
 
 /** @public */
-export type MenuGroupRenderedEvent = ComponentEvent<dxSlideOut>;
+export type MenuGroupRenderedEvent = EventInfo<dxSlideOut>;
 
 /** @public */
-export type MenuItemRenderedEvent = ComponentEvent<dxSlideOut>;
+export type MenuItemRenderedEvent = EventInfo<dxSlideOut>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSlideOut> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSlideOut> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxSlideOut> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxSlideOut> & SelectionChangedInfo;
 
 export interface dxSlideOutOptions extends CollectionWidgetOptions<dxSlideOut> {
     /**

--- a/js/ui/slide_out.d.ts
+++ b/js/ui/slide_out.d.ts
@@ -227,6 +227,7 @@ export interface dxSlideOutItem extends CollectionWidgetItem {
     menuTemplate?: template | (() => string | TElement);
 }
 
+/** @public */
 export type Options = dxSlideOutOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/slide_out_view.d.ts
+++ b/js/ui/slide_out_view.d.ts
@@ -11,8 +11,8 @@ import {
 } from '../core/templates/template';
 
 import {
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -21,13 +21,13 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSlideOutView>;
+export type DisposingEvent = EventInfo<dxSlideOutView>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSlideOutView>;
+export type InitializedEvent = InitializedEventInfo<dxSlideOutView>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSlideOutView> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSlideOutView> & ChangedOptionInfo;
 
 export interface dxSlideOutViewOptions extends WidgetOptions<dxSlideOutView> {
     /**

--- a/js/ui/slide_out_view.d.ts
+++ b/js/ui/slide_out_view.d.ts
@@ -122,6 +122,7 @@ export default class dxSlideOutView extends Widget {
     toggleMenuVisibility(): TPromise<void>;
 }
 
+/** @public */
 export type Options = dxSlideOutViewOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/slider.d.ts
+++ b/js/ui/slider.d.ts
@@ -175,6 +175,7 @@ export interface dxSliderBaseOptions<T> extends dxTrackBarOptions<T> {
     };
 }
 
+/** @public */
 export type Options = dxSliderOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/slider.d.ts
+++ b/js/ui/slider.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -22,19 +22,19 @@ import {
 } from './widget/ui.widget';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxSlider>;
+export type ContentReadyEvent = EventInfo<dxSlider>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSlider>;
+export type DisposingEvent = EventInfo<dxSlider>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSlider>;
+export type InitializedEvent = InitializedEventInfo<dxSlider>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSlider> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSlider> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxSlider> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxSlider> & ValueChangedInfo;
 
 export interface dxSliderOptions extends dxSliderBaseOptions<dxSlider> {
     /**

--- a/js/ui/sortable.d.ts
+++ b/js/ui/sortable.d.ts
@@ -15,9 +15,9 @@ import {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -44,10 +44,10 @@ export interface AddEvent {
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSortable>;
+export type DisposingEvent = EventInfo<dxSortable>;
 
 /** @public */
-export type DragChangeEvent = Cancelable & ComponentNativeEvent<dxSortable> & {
+export type DragChangeEvent = Cancelable & NativeEventInfo<dxSortable> & {
     readonly itemData?: any;
     readonly itemElement: TElement;
     readonly fromIndex?: number;
@@ -60,7 +60,7 @@ export type DragChangeEvent = Cancelable & ComponentNativeEvent<dxSortable> & {
 }
 
 /** @public */
-export type DragEndEvent = Cancelable & ComponentNativeEvent<dxSortable> & {
+export type DragEndEvent = Cancelable & NativeEventInfo<dxSortable> & {
     readonly itemData?: any;
     readonly itemElement: TElement;
     readonly fromIndex: number;
@@ -73,7 +73,7 @@ export type DragEndEvent = Cancelable & ComponentNativeEvent<dxSortable> & {
 }
 
 /** @public */
-export type DragMoveEvent = Cancelable & ComponentNativeEvent<dxSortable> & {
+export type DragMoveEvent = Cancelable & NativeEventInfo<dxSortable> & {
     readonly itemData?: any;
     readonly itemElement: TElement;
     readonly fromIndex: number;
@@ -86,7 +86,7 @@ export type DragMoveEvent = Cancelable & ComponentNativeEvent<dxSortable> & {
 }
 
 /** @public */
-export type DragStartEvent = Cancelable & ComponentNativeEvent<dxSortable> & {
+export type DragStartEvent = Cancelable & NativeEventInfo<dxSortable> & {
     itemData?: any;
     readonly itemElement: TElement;
     readonly fromIndex: number;
@@ -94,13 +94,13 @@ export type DragStartEvent = Cancelable & ComponentNativeEvent<dxSortable> & {
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSortable>;
+export type InitializedEvent = InitializedEventInfo<dxSortable>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSortable> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSortable> & ChangedOptionInfo;
 
 /** @public */
-export type RemoveEvent = ComponentNativeEvent<dxSortable> & {
+export type RemoveEvent = NativeEventInfo<dxSortable> & {
     readonly itemData?: any;
     readonly itemElement: TElement;
     readonly fromIndex: number;
@@ -112,7 +112,7 @@ export type RemoveEvent = ComponentNativeEvent<dxSortable> & {
 }
 
 /** @public */
-export type ReorderEvent = ComponentNativeEvent<dxSortable> & {
+export type ReorderEvent = NativeEventInfo<dxSortable> & {
     readonly itemData?: any;
     readonly itemElement: TElement;
     readonly fromIndex: number;

--- a/js/ui/sortable.d.ts
+++ b/js/ui/sortable.d.ts
@@ -364,6 +364,7 @@ export default class dxSortable extends DOMComponent implements DraggableBase {
     update(): void;
 }
 
+/** @public */
 export type Options = dxSortableOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/speed_dial_action.d.ts
+++ b/js/ui/speed_dial_action.d.ts
@@ -98,6 +98,7 @@ export default class dxSpeedDialAction extends Widget {
     constructor(element: TElement, options?: dxSpeedDialActionOptions)
 }
 
+/** @public */
 export type Options = dxSpeedDialActionOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/speed_dial_action.d.ts
+++ b/js/ui/speed_dial_action.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -14,23 +14,23 @@ import Widget, {
 } from './widget/ui.widget';
 
 /** @public */
-export type ClickEvent = ComponentNativeEvent<dxSpeedDialAction> & {
+export type ClickEvent = NativeEventInfo<dxSpeedDialAction> & {
     actionElement?: TElement
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxSpeedDialAction> & {
+export type ContentReadyEvent = EventInfo<dxSpeedDialAction> & {
     actionElement?: TElement
 };
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSpeedDialAction>;
+export type DisposingEvent = EventInfo<dxSpeedDialAction>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSpeedDialAction>;
+export type InitializedEvent = InitializedEventInfo<dxSpeedDialAction>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSpeedDialAction> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSpeedDialAction> & ChangedOptionInfo;
 
 export interface dxSpeedDialActionOptions extends WidgetOptions<dxSpeedDialAction> {
     /**

--- a/js/ui/switch.d.ts
+++ b/js/ui/switch.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -15,19 +15,19 @@ import Editor, {
 } from './editor/editor';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxSwitch>;
+export type ContentReadyEvent = EventInfo<dxSwitch>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSwitch>;
+export type DisposingEvent = EventInfo<dxSwitch>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSwitch>;
+export type InitializedEvent = InitializedEventInfo<dxSwitch>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSwitch> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSwitch> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxSwitch> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxSwitch> & ValueChangedInfo;
 
 export interface dxSwitchOptions extends EditorOptions<dxSwitch> {
     /**

--- a/js/ui/switch.d.ts
+++ b/js/ui/switch.d.ts
@@ -93,6 +93,7 @@ export default class dxSwitch extends Editor {
     constructor(element: TElement, options?: dxSwitchOptions)
 }
 
+/** @public */
 export type Options = dxSwitchOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/tab_panel.d.ts
+++ b/js/ui/tab_panel.d.ts
@@ -11,9 +11,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -28,46 +28,46 @@ import dxMultiView, {
 } from './multi_view';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTabPanel>;
+export type ContentReadyEvent = EventInfo<dxTabPanel>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTabPanel>;
+export type DisposingEvent = EventInfo<dxTabPanel>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTabPanel>;
+export type InitializedEvent = InitializedEventInfo<dxTabPanel>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxTabPanel> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxTabPanel> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxTabPanel> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxTabPanel> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxTabPanel> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxTabPanel> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxTabPanel> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxTabPanel> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTabPanel> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTabPanel> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxTabPanel> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxTabPanel> & SelectionChangedInfo;
 
 /** @public */
-export type TitleClickEvent = ComponentNativeEvent<dxTabPanel> & {
+export type TitleClickEvent = NativeEventInfo<dxTabPanel> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
 }
 
 /** @public */
-export type TitleHoldEvent = ComponentNativeEvent<dxTabPanel> & {
+export type TitleHoldEvent = NativeEventInfo<dxTabPanel> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
 }
 
 /** @public */
-export type TitleRenderedEvent = ComponentEvent<dxTabPanel> & {
+export type TitleRenderedEvent = EventInfo<dxTabPanel> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
 }

--- a/js/ui/tab_panel.d.ts
+++ b/js/ui/tab_panel.d.ts
@@ -238,6 +238,7 @@ export interface dxTabPanelItem extends dxMultiViewItem {
     title?: string;
 }
 
+/** @public */
 export type Options = dxTabPanelOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/tabs.d.ts
+++ b/js/ui/tabs.d.ts
@@ -7,9 +7,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -21,31 +21,31 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTabs>;
+export type ContentReadyEvent = EventInfo<dxTabs>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTabs>;
+export type DisposingEvent = EventInfo<dxTabs>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTabs>;
+export type InitializedEvent = InitializedEventInfo<dxTabs>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxTabs> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxTabs> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxTabs> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxTabs> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxTabs> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxTabs> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxTabs> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxTabs> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTabs> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTabs> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxTabs> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxTabs> & SelectionChangedInfo;
 
 export interface dxTabsOptions<T = dxTabs> extends CollectionWidgetOptions<T> {
     /**

--- a/js/ui/tabs.d.ts
+++ b/js/ui/tabs.d.ts
@@ -153,6 +153,7 @@ export interface dxTabsItem extends CollectionWidgetItem {
     icon?: string;
 }
 
+/** @public */
 export type Options = dxTabsOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/tag_box.d.ts
+++ b/js/ui/tag_box.d.ts
@@ -8,9 +8,9 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -33,70 +33,70 @@ import dxSelectBox, {
 } from './select_box';
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxTagBox>;
+export type ChangeEvent = NativeEventInfo<dxTagBox>;
 
 /** @public */
-export type ClosedEvent = ComponentEvent<dxTagBox>;
+export type ClosedEvent = EventInfo<dxTagBox>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTagBox>;
+export type ContentReadyEvent = EventInfo<dxTagBox>;
 
 /** @public */
-export type CustomItemCreatingEvent = ComponentEvent<dxTagBox> & CustomItemCreatingInfo;
+export type CustomItemCreatingEvent = EventInfo<dxTagBox> & CustomItemCreatingInfo;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTagBox>;
+export type DisposingEvent = EventInfo<dxTagBox>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxTagBox>;
+export type EnterKeyEvent = NativeEventInfo<dxTagBox>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxTagBox>;
+export type FocusInEvent = NativeEventInfo<dxTagBox>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxTagBox>;
+export type FocusOutEvent = NativeEventInfo<dxTagBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTagBox>;
+export type InitializedEvent = InitializedEventInfo<dxTagBox>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxTagBox>;
+export type InputEvent = NativeEventInfo<dxTagBox>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxTagBox> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxTagBox> & ItemInfo;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxTagBox>;
+export type KeyDownEvent = NativeEventInfo<dxTagBox>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxTagBox>;
+export type KeyPressEvent = NativeEventInfo<dxTagBox>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxTagBox>;
+export type KeyUpEvent = NativeEventInfo<dxTagBox>;
 
 /** @public */
-export type MultiTagPreparingEvent = Cancelable & ComponentEvent<dxTagBox> & {
+export type MultiTagPreparingEvent = Cancelable & EventInfo<dxTagBox> & {
     readonly multiTagElement: TElement;
     readonly selectedItems?: Array<string | number | any>;
     text?: string;
 }
 
 /** @public */
-export type OpenedEvent = ComponentEvent<dxTagBox>;
+export type OpenedEvent = EventInfo<dxTagBox>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTagBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTagBox> & ChangedOptionInfo;
 
 /** @public */
-export type SelectAllValueChangedEvent = ComponentEvent<dxTagBox> & {
+export type SelectAllValueChangedEvent = EventInfo<dxTagBox> & {
     readonly value: boolean;
 }
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxTagBox> & SelectionChangedInfo<string | number | any>;
+export type SelectionChangedEvent = EventInfo<dxTagBox> & SelectionChangedInfo<string | number | any>;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxTagBox> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxTagBox> & ValueChangedInfo;
 
 /** @public */
 export type DropDownButtonTemplateData = DropDownButtonTemplateDataModel;

--- a/js/ui/tag_box.d.ts
+++ b/js/ui/tag_box.d.ts
@@ -241,6 +241,7 @@ export default class dxTagBox extends dxSelectBox {
     constructor(element: TElement, options?: dxTagBoxOptions)
 }
 
+/** @public */
 export type Options = dxTagBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/tag_box.d.ts
+++ b/js/ui/tag_box.d.ts
@@ -75,7 +75,7 @@ export type KeyPressEvent = ComponentNativeEvent<dxTagBox>;
 export type KeyUpEvent = ComponentNativeEvent<dxTagBox>;
 
 /** @public */
-export type MultiTagPreparingEvent = ComponentEvent<dxTagBox> & Cancelable & {
+export type MultiTagPreparingEvent = Cancelable & ComponentEvent<dxTagBox> & {
     readonly multiTagElement: TElement;
     readonly selectedItems?: Array<string | number | any>;
     text?: string;

--- a/js/ui/text_area.d.ts
+++ b/js/ui/text_area.d.ts
@@ -108,6 +108,7 @@ export default class dxTextArea extends dxTextBox {
     constructor(element: TElement, options?: dxTextAreaOptions)
 }
 
+/** @public */
 export type Options = dxTextAreaOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/text_area.d.ts
+++ b/js/ui/text_area.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -18,52 +18,52 @@ import dxTextBox, {
 } from './text_box';
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxTextArea>;
+export type ChangeEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTextArea>;
+export type ContentReadyEvent = EventInfo<dxTextArea>;
 
 /** @public */
-export type CopyEvent = ComponentNativeEvent<dxTextArea>;
+export type CopyEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type CutEvent = ComponentNativeEvent<dxTextArea>;
+export type CutEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTextArea>;
+export type DisposingEvent = EventInfo<dxTextArea>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxTextArea>;
+export type EnterKeyEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxTextArea>;
+export type FocusInEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxTextArea>;
+export type FocusOutEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTextArea>;
+export type InitializedEvent = InitializedEventInfo<dxTextArea>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxTextArea>;
+export type InputEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxTextArea>;
+export type KeyDownEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxTextArea>;
+export type KeyPressEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxTextArea>;
+export type KeyUpEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTextArea> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTextArea> & ChangedOptionInfo;
 
 /** @public */
-export type PasteEvent = ComponentNativeEvent<dxTextArea>;
+export type PasteEvent = NativeEventInfo<dxTextArea>;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxTextArea> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxTextArea> & ValueChangedInfo;
 
 export interface dxTextAreaOptions extends dxTextBoxOptions<dxTextArea> {
     /**

--- a/js/ui/text_box.d.ts
+++ b/js/ui/text_box.d.ts
@@ -102,6 +102,7 @@ export default class dxTextBox extends dxTextEditor {
     constructor(element: TElement, options?: dxTextBoxOptions)
 }
 
+/** @public */
 export type Options = dxTextBoxOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/text_box.d.ts
+++ b/js/ui/text_box.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -18,52 +18,52 @@ import dxTextEditor, {
 } from './text_box/ui.text_editor.base';
 
 /** @public */
-export type ChangeEvent = ComponentNativeEvent<dxTextBox>;
+export type ChangeEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTextBox>;
+export type ContentReadyEvent = EventInfo<dxTextBox>;
 
 /** @public */
-export type CopyEvent = ComponentNativeEvent<dxTextBox>;
+export type CopyEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type CutEvent = ComponentNativeEvent<dxTextBox>;
+export type CutEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTextBox>;
+export type DisposingEvent = EventInfo<dxTextBox>;
 
 /** @public */
-export type EnterKeyEvent = ComponentNativeEvent<dxTextBox>;
+export type EnterKeyEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type FocusInEvent = ComponentNativeEvent<dxTextBox>;
+export type FocusInEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type FocusOutEvent = ComponentNativeEvent<dxTextBox>;
+export type FocusOutEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTextBox>;
+export type InitializedEvent = InitializedEventInfo<dxTextBox>;
 
 /** @public */
-export type InputEvent = ComponentNativeEvent<dxTextBox>;
+export type InputEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxTextBox>;
+export type KeyDownEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type KeyPressEvent = ComponentNativeEvent<dxTextBox>;
+export type KeyPressEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type KeyUpEvent = ComponentNativeEvent<dxTextBox>;
+export type KeyUpEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTextBox> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTextBox> & ChangedOptionInfo;
 
 /** @public */
-export type PasteEvent = ComponentNativeEvent<dxTextBox>;
+export type PasteEvent = NativeEventInfo<dxTextBox>;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxTextBox> & ValueChangedInfo;
+export type ValueChangedEvent = NativeEventInfo<dxTextBox> & ValueChangedInfo;
 
 export interface dxTextBoxOptions<T = dxTextBox> extends dxTextEditorOptions<T> {
     /**

--- a/js/ui/text_box/ui.text_editor.base.d.ts
+++ b/js/ui/text_box/ui.text_editor.base.d.ts
@@ -3,7 +3,7 @@ import {
 } from '../../core/element';
 
 import {
-    ComponentNativeEvent
+    NativeEventInfo
 } from '../../events/index';
 
 import dxButton, {
@@ -91,7 +91,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onChange?: ((e: ComponentNativeEvent<T>) => void);
+    onChange?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -104,7 +104,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onCopy?: ((e: ComponentNativeEvent<T>) => void);
+    onCopy?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -117,7 +117,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onCut?: ((e: ComponentNativeEvent<T>) => void);
+    onCut?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -130,7 +130,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onEnterKey?: ((e: ComponentNativeEvent<T>) => void);
+    onEnterKey?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -143,7 +143,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onFocusIn?: ((e: ComponentNativeEvent<T>) => void);
+    onFocusIn?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -156,7 +156,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onFocusOut?: ((e: ComponentNativeEvent<T>) => void);
+    onFocusOut?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -169,7 +169,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onInput?: ((e: ComponentNativeEvent<T>) => void);
+    onInput?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -182,7 +182,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onKeyDown?: ((e: ComponentNativeEvent<T>) => void);
+    onKeyDown?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -196,7 +196,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onKeyPress?: ((e: ComponentNativeEvent<T>) => void);
+    onKeyPress?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -209,7 +209,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onKeyUp?: ((e: ComponentNativeEvent<T>) => void);
+    onKeyUp?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -222,7 +222,7 @@ export interface dxTextEditorOptions<T = dxTextEditor> extends EditorOptions<T> 
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onPaste?: ((e: ComponentNativeEvent<T>) => void);
+    onPaste?: ((e: NativeEventInfo<T>) => void);
     /**
      * @docid
      * @default ""

--- a/js/ui/tile_view.d.ts
+++ b/js/ui/tile_view.d.ts
@@ -166,6 +166,7 @@ export interface dxTileViewItem extends CollectionWidgetItem {
     widthRatio?: number;
 }
 
+/** @public */
 export type Options = dxTileViewOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/tile_view.d.ts
+++ b/js/ui/tile_view.d.ts
@@ -7,9 +7,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -20,28 +20,28 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTileView>;
+export type ContentReadyEvent = EventInfo<dxTileView>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTileView>;
+export type DisposingEvent = EventInfo<dxTileView>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTileView>;
+export type InitializedEvent = InitializedEventInfo<dxTileView>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxTileView> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxTileView> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxTileView> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxTileView> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxTileView> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxTileView> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxTileView> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxTileView> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTileView> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTileView> & ChangedOptionInfo;
 
 export interface dxTileViewOptions extends CollectionWidgetOptions<dxTileView> {
     /**

--- a/js/ui/toast.d.ts
+++ b/js/ui/toast.d.ts
@@ -182,6 +182,7 @@ export default class dxToast extends dxOverlay {
     constructor(element: TElement, options?: dxToastOptions)
 }
 
+/** @public */
 export type Options = dxToastOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/toast.d.ts
+++ b/js/ui/toast.d.ts
@@ -30,7 +30,7 @@ export type ContentReadyEvent = ComponentEvent<dxToast>;
 export type DisposingEvent = ComponentEvent<dxToast>;
 
 /** @public */
-export type HidingEvent = ComponentEvent<dxToast> & Cancelable;
+export type HidingEvent = Cancelable & ComponentEvent<dxToast>;
 
 /** @public */
 export type HiddenEvent = ComponentEvent<dxToast>;

--- a/js/ui/toast.d.ts
+++ b/js/ui/toast.d.ts
@@ -13,8 +13,8 @@ import {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -24,28 +24,28 @@ import dxOverlay, {
 } from './overlay';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxToast>;
+export type ContentReadyEvent = EventInfo<dxToast>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxToast>;
+export type DisposingEvent = EventInfo<dxToast>;
 
 /** @public */
-export type HidingEvent = Cancelable & ComponentEvent<dxToast>;
+export type HidingEvent = Cancelable & EventInfo<dxToast>;
 
 /** @public */
-export type HiddenEvent = ComponentEvent<dxToast>;
+export type HiddenEvent = EventInfo<dxToast>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxToast>;
+export type InitializedEvent = InitializedEventInfo<dxToast>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxToast> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxToast> & ChangedOptionInfo;
 
 /** @public */
-export type ShowingEvent = ComponentEvent<dxToast>;
+export type ShowingEvent = EventInfo<dxToast>;
 
 /** @public */
-export type ShownEvent = ComponentEvent<dxToast>;
+export type ShownEvent = EventInfo<dxToast>;
 
 export interface dxToastOptions extends dxOverlayOptions<dxToast> {
     /**

--- a/js/ui/toolbar.d.ts
+++ b/js/ui/toolbar.d.ts
@@ -11,9 +11,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -24,28 +24,28 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxToolbar>;
+export type ContentReadyEvent = EventInfo<dxToolbar>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxToolbar>;
+export type DisposingEvent = EventInfo<dxToolbar>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxToolbar>;
+export type InitializedEvent = InitializedEventInfo<dxToolbar>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxToolbar> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxToolbar> & ItemInfo;
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxToolbar> & ItemInfo;
+export type ItemContextMenuEvent = NativeEventInfo<dxToolbar> & ItemInfo;
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxToolbar> & ItemInfo;
+export type ItemHoldEvent = NativeEventInfo<dxToolbar> & ItemInfo;
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxToolbar> & ItemInfo;
+export type ItemRenderedEvent = NativeEventInfo<dxToolbar> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxToolbar> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxToolbar> & ChangedOptionInfo;
 
 export interface dxToolbarOptions extends CollectionWidgetOptions<dxToolbar> {
     /**

--- a/js/ui/toolbar.d.ts
+++ b/js/ui/toolbar.d.ts
@@ -154,6 +154,7 @@ export interface dxToolbarItem extends CollectionWidgetItem {
     widget?: 'dxAutocomplete' | 'dxButton' | 'dxCheckBox' | 'dxDateBox' | 'dxMenu' | 'dxSelectBox' | 'dxTabs' | 'dxTextBox' | 'dxButtonGroup' | 'dxDropDownButton';
 }
 
+/** @public */
 export type Options = dxToolbarOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/tooltip.d.ts
+++ b/js/ui/tooltip.d.ts
@@ -52,6 +52,7 @@ export default class dxTooltip extends dxPopover {
     constructor(element: TElement, options?: dxTooltipOptions)
 }
 
+/** @public */
 export type Options = dxTooltipOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/tooltip.d.ts
+++ b/js/ui/tooltip.d.ts
@@ -4,8 +4,8 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -14,28 +14,28 @@ import dxPopover, {
 } from './popover';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTooltip>;
+export type ContentReadyEvent = EventInfo<dxTooltip>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTooltip>;
+export type DisposingEvent = EventInfo<dxTooltip>;
 
 /** @public */
-export type HidingEvent = Cancelable & ComponentEvent<dxTooltip>;
+export type HidingEvent = Cancelable & EventInfo<dxTooltip>;
 
 /** @public */
-export type HiddenEvent = ComponentEvent<dxTooltip>;
+export type HiddenEvent = EventInfo<dxTooltip>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTooltip>;
+export type InitializedEvent = InitializedEventInfo<dxTooltip>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTooltip> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTooltip> & ChangedOptionInfo;
 
 /** @public */
-export type ShowingEvent = ComponentEvent<dxTooltip>;
+export type ShowingEvent = EventInfo<dxTooltip>;
 
 /** @public */
-export type ShownEvent = ComponentEvent<dxTooltip>;
+export type ShownEvent = EventInfo<dxTooltip>;
 
 export interface dxTooltipOptions extends dxPopoverOptions<dxTooltip> {
 }

--- a/js/ui/tooltip.d.ts
+++ b/js/ui/tooltip.d.ts
@@ -20,7 +20,7 @@ export type ContentReadyEvent = ComponentEvent<dxTooltip>;
 export type DisposingEvent = ComponentEvent<dxTooltip>;
 
 /** @public */
-export type HidingEvent = ComponentEvent<dxTooltip> & Cancelable;
+export type HidingEvent = Cancelable & ComponentEvent<dxTooltip>;
 
 /** @public */
 export type HiddenEvent = ComponentEvent<dxTooltip>;

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -15,9 +15,9 @@ import DataSource from '../data/data_source';
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -34,8 +34,8 @@ import {
     AdaptiveDetailRowPreparingInfo,
     DataErrorOccurredInfo,
     DataChangeInfo,
-    ComponentDragStartEvent,
-    ComponentRowDraggingEvent,
+    DragStartEventInfo,
+    RowDraggingEventInfo,
     DragDropInfo,
     DragReorderInfo,
     KeyDownInfo,
@@ -73,21 +73,21 @@ interface CellInfo {
 }
 
 /** @public */
-export type AdaptiveDetailRowPreparingEvent = ComponentEvent<dxTreeList> & AdaptiveDetailRowPreparingInfo;
+export type AdaptiveDetailRowPreparingEvent = EventInfo<dxTreeList> & AdaptiveDetailRowPreparingInfo;
 
 /** @public */
-export type CellClickEvent = ComponentNativeEvent<dxTreeList> & CellInfo;
+export type CellClickEvent = NativeEventInfo<dxTreeList> & CellInfo;
 
 /** @public */
-export type CellDblClickEvent = ComponentNativeEvent<dxTreeList> & CellInfo;
+export type CellDblClickEvent = NativeEventInfo<dxTreeList> & CellInfo;
 
 /** @public */
-export type CellHoverChangedEvent = ComponentEvent<dxTreeList> & CellInfo & {
+export type CellHoverChangedEvent = EventInfo<dxTreeList> & CellInfo & {
     readonly eventType: string;
 }
 
 /** @public */
-export type CellPreparedEvent = ComponentEvent<dxTreeList> & CellInfo & {
+export type CellPreparedEvent = EventInfo<dxTreeList> & CellInfo & {
     readonly isSelected?: boolean;
     readonly isExpanded?: boolean;
     readonly isNewRow?: boolean;
@@ -96,10 +96,10 @@ export type CellPreparedEvent = ComponentEvent<dxTreeList> & CellInfo & {
 }
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTreeList>;
+export type ContentReadyEvent = EventInfo<dxTreeList>;
 
 /** @public */
-export type ContextMenuPreparingEvent = ComponentEvent<dxTreeList> & {
+export type ContextMenuPreparingEvent = EventInfo<dxTreeList> & {
     items?: Array<any>;
     readonly target: string;
     readonly targetElement: TElement;
@@ -110,26 +110,26 @@ export type ContextMenuPreparingEvent = ComponentEvent<dxTreeList> & {
 }
 
 /** @public */
-export type DataErrorOccurredEvent = ComponentEvent<dxTreeList> & DataErrorOccurredInfo;
+export type DataErrorOccurredEvent = EventInfo<dxTreeList> & DataErrorOccurredInfo;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTreeList>;
+export type DisposingEvent = EventInfo<dxTreeList>;
 
 /** @public */
-export type EditCanceledEvent = ComponentEvent<dxTreeList> & DataChangeInfo;
+export type EditCanceledEvent = EventInfo<dxTreeList> & DataChangeInfo;
 
 /** @public */
-export type EditCancelingEvent = Cancelable & ComponentEvent<dxTreeList> & DataChangeInfo;
+export type EditCancelingEvent = Cancelable & EventInfo<dxTreeList> & DataChangeInfo;
 
 /** @public */
-export type EditingStartEvent = Cancelable & ComponentEvent<dxTreeList> & {
+export type EditingStartEvent = Cancelable & EventInfo<dxTreeList> & {
     readonly data: any;
     readonly key: any;
     readonly column: any;
 }
 
 /** @public */
-export type EditorPreparedEvent = ComponentEvent<dxTreeList> & {
+export type EditorPreparedEvent = EventInfo<dxTreeList> & {
     readonly parentType: string;
     readonly value?: any;
     readonly setValue?: any;
@@ -144,7 +144,7 @@ export type EditorPreparedEvent = ComponentEvent<dxTreeList> & {
 }
 
 /** @public */
-export type EditorPreparingEvent = Cancelable & ComponentEvent<dxTreeList> & {
+export type EditorPreparingEvent = Cancelable & EventInfo<dxTreeList> & {
     readonly parentType: string;
     readonly value?: any;
     readonly setValue?: any;
@@ -161,7 +161,7 @@ export type EditorPreparingEvent = Cancelable & ComponentEvent<dxTreeList> & {
 }
 
 /** @public */
-export type FocusedCellChangedEvent = ComponentEvent<dxTreeList> & {
+export type FocusedCellChangedEvent = EventInfo<dxTreeList> & {
     readonly cellElement: TElement;
     readonly columnIndex: number;
     readonly rowIndex: number;
@@ -170,7 +170,7 @@ export type FocusedCellChangedEvent = ComponentEvent<dxTreeList> & {
 }
 
 /** @public */
-export type FocusedCellChangingEvent = Cancelable & ComponentNativeEvent<dxTreeList> & {
+export type FocusedCellChangingEvent = Cancelable & NativeEventInfo<dxTreeList> & {
     readonly cellElement: TElement;
     readonly prevColumnIndex: number;
     readonly prevRowIndex: number;
@@ -182,14 +182,14 @@ export type FocusedCellChangingEvent = Cancelable & ComponentNativeEvent<dxTreeL
 }
 
 /** @public */
-export type FocusedRowChangedEvent = ComponentEvent<dxTreeList> & {
+export type FocusedRowChangedEvent = EventInfo<dxTreeList> & {
     readonly rowElement: TElement;
     readonly rowIndex: number;
     readonly row: RowObject;
 }
 
 /** @public */
-export type FocusedRowChangingEvent = ComponentNativeEvent<dxTreeList> & {
+export type FocusedRowChangingEvent = NativeEventInfo<dxTreeList> & {
     readonly rowElement: TElement;
     readonly prevRowIndex: number;
     newRowIndex: number;
@@ -197,24 +197,24 @@ export type FocusedRowChangingEvent = ComponentNativeEvent<dxTreeList> & {
 }
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTreeList>;
+export type InitializedEvent = InitializedEventInfo<dxTreeList>;
 
 /** @public */
-export type InitNewRowEvent = ComponentEvent<dxTreeList> & NewRowInfo;
+export type InitNewRowEvent = EventInfo<dxTreeList> & NewRowInfo;
 
 /** @public */
-export type KeyDownEvent = ComponentNativeEvent<dxTreeList> & KeyDownInfo;
+export type KeyDownEvent = NativeEventInfo<dxTreeList> & KeyDownInfo;
 
 /** @public */
-export type NodesInitializedEvent = ComponentEvent<dxTreeList> & {
+export type NodesInitializedEvent = EventInfo<dxTreeList> & {
     readonly root: Node;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTreeList> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTreeList> & ChangedOptionInfo;
 
 /** @public */
-export type RowClickEvent = ComponentNativeEvent<dxTreeList> & {
+export type RowClickEvent = NativeEventInfo<dxTreeList> & {
     readonly data: any;
     readonly key: any;
     readonly values: Array<any>;
@@ -231,13 +231,13 @@ export type RowClickEvent = ComponentNativeEvent<dxTreeList> & {
 }
 
 /** @public */
-export type RowCollapsedEvent = ComponentEvent<dxTreeList> & RowKeyInfo;
+export type RowCollapsedEvent = EventInfo<dxTreeList> & RowKeyInfo;
 
 /** @public */
-export type RowCollapsingEvent = Cancelable & ComponentEvent<dxTreeList> & RowKeyInfo;
+export type RowCollapsingEvent = Cancelable & EventInfo<dxTreeList> & RowKeyInfo;
 
 /** @public */
-export type RowDblClickEvent = ComponentNativeEvent<dxTreeList> & {
+export type RowDblClickEvent = NativeEventInfo<dxTreeList> & {
     readonly data: any;
     readonly key: any;
     readonly values: Array<any>;
@@ -251,19 +251,19 @@ export type RowDblClickEvent = ComponentNativeEvent<dxTreeList> & {
 }
 
 /** @public */
-export type RowExpandedEvent = ComponentEvent<dxTreeList> & RowKeyInfo;
+export type RowExpandedEvent = EventInfo<dxTreeList> & RowKeyInfo;
 
 /** @public */
-export type RowExpandingEvent = Cancelable & ComponentEvent<dxTreeList> & RowKeyInfo;
+export type RowExpandingEvent = Cancelable & EventInfo<dxTreeList> & RowKeyInfo;
 
 /** @public */
-export type RowInsertedEvent = ComponentEvent<dxTreeList> & RowInsertedInfo;
+export type RowInsertedEvent = EventInfo<dxTreeList> & RowInsertedInfo;
 
 /** @public */
-export type RowInsertingEvent = ComponentEvent<dxTreeList> & RowInsertingInfo;
+export type RowInsertingEvent = EventInfo<dxTreeList> & RowInsertingInfo;
 
 /** @public */
-export type RowPreparedEvent = ComponentEvent<dxTreeList> & {
+export type RowPreparedEvent = EventInfo<dxTreeList> & {
     readonly data: any;
     readonly key: any;
     readonly values: Array<any>;
@@ -279,57 +279,57 @@ export type RowPreparedEvent = ComponentEvent<dxTreeList> & {
 }
 
 /** @public */
-export type RowRemovedEvent = ComponentEvent<dxTreeList> & RowRemovedInfo;
+export type RowRemovedEvent = EventInfo<dxTreeList> & RowRemovedInfo;
 
 /** @public */
-export type RowRemovingEvent = ComponentEvent<dxTreeList> & RowRemovingInfo;
+export type RowRemovingEvent = EventInfo<dxTreeList> & RowRemovingInfo;
 
 /** @public */
-export type RowUpdatedEvent = ComponentEvent<dxTreeList> & RowUpdatedInfo;
+export type RowUpdatedEvent = EventInfo<dxTreeList> & RowUpdatedInfo;
 
 /** @public */
-export type RowUpdatingEvent = ComponentEvent<dxTreeList> & RowUpdatingInfo;
+export type RowUpdatingEvent = EventInfo<dxTreeList> & RowUpdatingInfo;
 
 /** @public */
-export type RowValidatingEvent = ComponentEvent<dxTreeList> & RowValidatingInfo;
+export type RowValidatingEvent = EventInfo<dxTreeList> & RowValidatingInfo;
 
 /** @public */
-export type SavedEvent = ComponentEvent<dxTreeList> & DataChangeInfo;
+export type SavedEvent = EventInfo<dxTreeList> & DataChangeInfo;
 
 /** @public */
-export type SavingEvent = ComponentEvent<dxTreeList> & SavingInfo;
+export type SavingEvent = EventInfo<dxTreeList> & SavingInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxTreeList> & SelectionChangedInfo;
+export type SelectionChangedEvent = EventInfo<dxTreeList> & SelectionChangedInfo;
 
 /** @public */
-export type ToolbarPreparingEvent = ComponentEvent<dxTreeList> & ToolbarPreparingInfo;
-
-
-/** @public */
-export type RowDraggingAddEvent = ComponentRowDraggingEvent<dxTreeList> & DragDropInfo;
-
-/** @public */
-export type RowDraggingChangeEvent = Cancelable & ComponentRowDraggingEvent<dxTreeList> & DragDropInfo;
-
-/** @public */
-export type RowDraggingEndEvent = Cancelable & ComponentRowDraggingEvent<dxTreeList> & DragDropInfo;
-
-/** @public */
-export type RowDraggingMoveEvent = Cancelable & ComponentRowDraggingEvent<dxTreeList> & DragDropInfo;
-
-/** @public */
-export type RowDraggingStartEvent = Cancelable & ComponentDragStartEvent<dxTreeList>;
-
-/** @public */
-export type RowDraggingRemoveEvent = ComponentRowDraggingEvent<dxTreeList>;
-
-/** @public */
-export type RowDraggingReorderEvent = ComponentRowDraggingEvent<dxTreeList> & DragReorderInfo;
+export type ToolbarPreparingEvent = EventInfo<dxTreeList> & ToolbarPreparingInfo;
 
 
 /** @public */
-export type ColumnButtonClickEvent = ComponentNativeEvent<dxTreeList> & {
+export type RowDraggingAddEvent = RowDraggingEventInfo<dxTreeList> & DragDropInfo;
+
+/** @public */
+export type RowDraggingChangeEvent = Cancelable & RowDraggingEventInfo<dxTreeList> & DragDropInfo;
+
+/** @public */
+export type RowDraggingEndEvent = Cancelable & RowDraggingEventInfo<dxTreeList> & DragDropInfo;
+
+/** @public */
+export type RowDraggingMoveEvent = Cancelable & RowDraggingEventInfo<dxTreeList> & DragDropInfo;
+
+/** @public */
+export type RowDraggingStartEvent = Cancelable & DragStartEventInfo<dxTreeList>;
+
+/** @public */
+export type RowDraggingRemoveEvent = RowDraggingEventInfo<dxTreeList>;
+
+/** @public */
+export type RowDraggingReorderEvent = RowDraggingEventInfo<dxTreeList> & DragReorderInfo;
+
+
+/** @public */
+export type ColumnButtonClickEvent = NativeEventInfo<dxTreeList> & {
     row?: RowObject;
     column?: Column;
 }

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1486,6 +1486,7 @@ export interface RowObject {
     readonly values: Array<any>;
 }
 
+/** @public */
 export type Options = dxTreeListOptions;
 
 export type IOptions = dxTreeListOptions;

--- a/js/ui/tree_view.d.ts
+++ b/js/ui/tree_view.d.ts
@@ -11,9 +11,9 @@ import DataSource, {
 } from '../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -30,16 +30,16 @@ import {
 } from './widget/ui.search_box_mixin';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxTreeView>;
+export type ContentReadyEvent = EventInfo<dxTreeView>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTreeView>;
+export type DisposingEvent = EventInfo<dxTreeView>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTreeView>;
+export type InitializedEvent = InitializedEventInfo<dxTreeView>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxTreeView> & {
+export type ItemClickEvent = NativeEventInfo<dxTreeView> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
     readonly itemIndex?: number | any;
@@ -47,7 +47,7 @@ export type ItemClickEvent = ComponentNativeEvent<dxTreeView> & {
 }
 
 /** @public */
-export type ItemCollapsedEvent = ComponentNativeEvent<dxTreeView> & {
+export type ItemCollapsedEvent = NativeEventInfo<dxTreeView> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
     readonly itemIndex?: number;
@@ -55,7 +55,7 @@ export type ItemCollapsedEvent = ComponentNativeEvent<dxTreeView> & {
 }
 
 /** @public */
-export type ItemContextMenuEvent = ComponentNativeEvent<dxTreeView> & {
+export type ItemContextMenuEvent = NativeEventInfo<dxTreeView> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
     readonly itemIndex?: number | any;
@@ -63,7 +63,7 @@ export type ItemContextMenuEvent = ComponentNativeEvent<dxTreeView> & {
 }
 
 /** @public */
-export type ItemExpandedEvent = ComponentNativeEvent<dxTreeView> & {
+export type ItemExpandedEvent = NativeEventInfo<dxTreeView> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
     readonly itemIndex?: number;
@@ -71,7 +71,7 @@ export type ItemExpandedEvent = ComponentNativeEvent<dxTreeView> & {
 }
 
 /** @public */
-export type ItemHoldEvent = ComponentNativeEvent<dxTreeView> & {
+export type ItemHoldEvent = NativeEventInfo<dxTreeView> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
     readonly itemIndex?: number;
@@ -79,7 +79,7 @@ export type ItemHoldEvent = ComponentNativeEvent<dxTreeView> & {
 }
 
 /** @public */
-export type ItemRenderedEvent = ComponentNativeEvent<dxTreeView> & {
+export type ItemRenderedEvent = NativeEventInfo<dxTreeView> & {
     readonly itemData?: any;
     readonly itemElement?: TElement;
     readonly itemIndex?: number;
@@ -87,7 +87,7 @@ export type ItemRenderedEvent = ComponentNativeEvent<dxTreeView> & {
 }
 
 /** @public */
-export type ItemSelectionChangedEvent = ComponentEvent<dxTreeView> & {
+export type ItemSelectionChangedEvent = EventInfo<dxTreeView> & {
     readonly node?: dxTreeViewNode;
     readonly itemElement?: TElement;
     readonly itemData?: any;
@@ -95,15 +95,15 @@ export type ItemSelectionChangedEvent = ComponentEvent<dxTreeView> & {
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTreeView> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTreeView> & ChangedOptionInfo;
 
 /** @public */
-export type SelectAllValueChangedEvent = ComponentEvent<dxTreeView> & {
+export type SelectAllValueChangedEvent = EventInfo<dxTreeView> & {
     readonly value?: boolean;
 }
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxTreeView>;
+export type SelectionChangedEvent = EventInfo<dxTreeView>;
 
 export interface dxTreeViewOptions extends HierarchicalCollectionWidgetOptions<dxTreeView>, SearchBoxMixinOptions<dxTreeView> {
     /**

--- a/js/ui/tree_view.d.ts
+++ b/js/ui/tree_view.d.ts
@@ -698,6 +698,7 @@ export interface dxTreeViewNode {
     text?: string;
 }
 
+/** @public */
 export type Options = dxTreeViewOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/validation_group.d.ts
+++ b/js/ui/validation_group.d.ts
@@ -106,6 +106,7 @@ export interface dxValidationGroupResult {
     validators?: Array<any>;
 }
 
+/** @public */
 export type Options = dxValidationGroupOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/validation_group.d.ts
+++ b/js/ui/validation_group.d.ts
@@ -11,8 +11,8 @@ import {
 } from '../core/utils/deferred';
 
 import {
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -29,13 +29,13 @@ import {
 } from './validation_rules';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxValidationGroup>;
+export type DisposingEvent = EventInfo<dxValidationGroup>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxValidationGroup>;
+export type InitializedEvent = InitializedEventInfo<dxValidationGroup>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxValidationGroup> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxValidationGroup> & ChangedOptionInfo;
 
 export interface dxValidationGroupOptions extends DOMComponentOptions<dxValidationGroup> {
 }

--- a/js/ui/validation_summary.d.ts
+++ b/js/ui/validation_summary.d.ts
@@ -50,6 +50,7 @@ export default class dxValidationSummary extends CollectionWidget {
     constructor(element: TElement, options?: dxValidationSummaryOptions)
 }
 
+/** @public */
 export type Options = dxValidationSummaryOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/validation_summary.d.ts
+++ b/js/ui/validation_summary.d.ts
@@ -3,9 +3,9 @@ import {
 } from '../core/element';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo,
     ItemInfo
 } from '../events/index';
@@ -15,19 +15,19 @@ import CollectionWidget, {
 } from './collection/ui.collection_widget.base';
 
 /** @public */
-export type ContentReadyEvent = ComponentEvent<dxValidationSummary>;
+export type ContentReadyEvent = EventInfo<dxValidationSummary>;
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxValidationSummary>;
+export type DisposingEvent = EventInfo<dxValidationSummary>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxValidationSummary>;
+export type InitializedEvent = InitializedEventInfo<dxValidationSummary>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxValidationSummary> & ItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxValidationSummary> & ItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxValidationSummary> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxValidationSummary> & ChangedOptionInfo;
 
 export interface dxValidationSummaryOptions extends CollectionWidgetOptions<dxValidationSummary> {
     /**

--- a/js/ui/validator.d.ts
+++ b/js/ui/validator.d.ts
@@ -11,8 +11,8 @@ import {
 } from '../core/utils/deferred';
 
 import {
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -22,13 +22,13 @@ import {
 } from './validation_rules';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxValidator>;
+export type DisposingEvent = EventInfo<dxValidator>;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxValidator>;
+export type InitializedEvent = InitializedEventInfo<dxValidator>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxValidator> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxValidator> & ChangedOptionInfo;
 
 /** @public */
 export type ValidatedEvent = {

--- a/js/ui/validator.d.ts
+++ b/js/ui/validator.d.ts
@@ -210,6 +210,7 @@ export interface dxValidatorResult {
     value?: any;
 }
 
+/** @public */
 export type Options = dxValidatorOptions;
 
 /** @deprecated use Options instead */

--- a/js/ui/widget/ui.widget.d.ts
+++ b/js/ui/widget/ui.widget.d.ts
@@ -7,7 +7,7 @@ import {
 } from '../../core/element';
 
 import {
-    ComponentEvent
+    EventInfo
 } from '../../events/index';
 
 export interface WidgetOptions<T = Widget> extends DOMComponentOptions<T> {
@@ -64,7 +64,7 @@ export interface WidgetOptions<T = Widget> extends DOMComponentOptions<T> {
      * @prevFileNamespace DevExpress.ui
      * @public
      */
-    onContentReady?: ((e: ComponentEvent<T>) => void);
+    onContentReady?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default 0

--- a/js/viz/bar_gauge.d.ts
+++ b/js/viz/bar_gauge.d.ts
@@ -13,8 +13,8 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -32,7 +32,7 @@ import BaseWidget, {
     BaseWidgetOptions,
     BaseWidgetTooltip,
     Font,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -81,34 +81,34 @@ export interface TooltipInfo {
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxBarGauge>;
+export type DisposingEvent = EventInfo<dxBarGauge>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxBarGauge>;
+export type DrawnEvent = EventInfo<dxBarGauge>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxBarGauge>;
+export type ExportedEvent = EventInfo<dxBarGauge>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxBarGauge> & ExportInfo;
+export type ExportingEvent = EventInfo<dxBarGauge> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxBarGauge>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxBarGauge>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxBarGauge> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxBarGauge> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxBarGauge>;
+export type InitializedEvent = InitializedEventInfo<dxBarGauge>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxBarGauge> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxBarGauge> & ChangedOptionInfo;
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxBarGauge> & TooltipInfo;
+export type TooltipHiddenEvent = EventInfo<dxBarGauge> & TooltipInfo;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxBarGauge> & TooltipInfo;
+export type TooltipShownEvent = EventInfo<dxBarGauge> & TooltipInfo;
 
 export interface dxBarGaugeOptions extends BaseWidgetOptions<dxBarGauge> {
     /**

--- a/js/viz/bar_gauge.d.ts
+++ b/js/viz/bar_gauge.d.ts
@@ -444,6 +444,7 @@ export default class dxBarGauge extends BaseWidget {
     values(values: Array<number>): void;
 }
 
+/** @public */
 export type Options = dxBarGaugeOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/bullet.d.ts
+++ b/js/viz/bullet.d.ts
@@ -4,13 +4,13 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
 import {
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -20,34 +20,34 @@ import BaseSparkline, {
 } from './sparklines/base_sparkline';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxBullet>;
+export type DisposingEvent = EventInfo<dxBullet>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxBullet>;
+export type DrawnEvent = EventInfo<dxBullet>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxBullet>;
+export type ExportedEvent = EventInfo<dxBullet>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxBullet> & ExportInfo;
+export type ExportingEvent = EventInfo<dxBullet> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxBullet>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxBullet>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxBullet> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxBullet> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxBullet>;
+export type InitializedEvent = InitializedEventInfo<dxBullet>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxBullet> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxBullet> & ChangedOptionInfo;
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxBullet>;
+export type TooltipHiddenEvent = EventInfo<dxBullet>;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxBullet>;
+export type TooltipShownEvent = EventInfo<dxBullet>;
 
 
 export interface dxBulletOptions extends BaseSparklineOptions<dxBullet> {

--- a/js/viz/bullet.d.ts
+++ b/js/viz/bullet.d.ts
@@ -131,6 +131,7 @@ export default class dxBullet extends BaseSparkline {
     constructor(element: TElement, options?: dxBulletOptions)
 }
 
+/** @public */
 export type Options = dxBulletOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/chart.d.ts
+++ b/js/viz/chart.d.ts
@@ -5843,6 +5843,7 @@ export interface dxChartSeriesTypesStockSeriesLabel extends dxChartSeriesTypesCo
     customizeText?: ((pointInfo: any) => string);
 }
 
+/** @public */
 export type Options = dxChartOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/chart.d.ts
+++ b/js/viz/chart.d.ts
@@ -4,9 +4,9 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -42,7 +42,7 @@ import {
     Font,
     WordWrapType,
     VizTextOverflowType,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo,
 } from './core/base_widget';
@@ -54,70 +54,70 @@ interface SeriesInteractionInfo {
 }
 
 /** @public */
-export type ArgumentAxisClickEvent = ComponentNativeEvent<dxChart> & {
+export type ArgumentAxisClickEvent = NativeEventInfo<dxChart> & {
     readonly argument: Date | number | string;
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxChart>;
+export type DisposingEvent = EventInfo<dxChart>;
 
 /** @public */
-export type DoneEvent = ComponentEvent<dxChart>;
+export type DoneEvent = EventInfo<dxChart>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxChart>;
+export type DrawnEvent = EventInfo<dxChart>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxChart>;
+export type ExportedEvent = EventInfo<dxChart>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxChart> & ExportInfo;
+export type ExportingEvent = EventInfo<dxChart> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxChart>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxChart>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxChart> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxChart> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxChart>;
+export type InitializedEvent = InitializedEventInfo<dxChart>;
 
 /** @public */
-export type LegendClickEvent  = ComponentNativeEvent<dxChart> & {
+export type LegendClickEvent  = NativeEventInfo<dxChart> & {
     readonly target: chartSeriesObject;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxChart> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxChart> & ChangedOptionInfo;
 
 /** @public */
-export type PointClickEvent = ComponentNativeEvent<dxChart> & PointInteractionInfo;
+export type PointClickEvent = NativeEventInfo<dxChart> & PointInteractionInfo;
 
 /** @public */
-export type PointHoverChangedEvent = ComponentEvent<dxChart> & PointInteractionInfo;
+export type PointHoverChangedEvent = EventInfo<dxChart> & PointInteractionInfo;
 
 /** @public */
-export type PointSelectionChangedEvent = ComponentEvent<dxChart> & PointInteractionInfo;
+export type PointSelectionChangedEvent = EventInfo<dxChart> & PointInteractionInfo;
 
 /** @public */
-export type SeriesClickEvent = ComponentNativeEvent<dxChart> & {
+export type SeriesClickEvent = NativeEventInfo<dxChart> & {
     readonly target: chartSeriesObject;
 }
 
 /** @public */
-export type SeriesHoverChangedEvent = ComponentEvent<dxChart> & SeriesInteractionInfo;
+export type SeriesHoverChangedEvent = EventInfo<dxChart> & SeriesInteractionInfo;
 
 /** @public */
-export type SeriesSelectionChangedEvent = ComponentEvent<dxChart> & SeriesInteractionInfo;
+export type SeriesSelectionChangedEvent = EventInfo<dxChart> & SeriesInteractionInfo;
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxChart> & TooltipInfo;
+export type TooltipHiddenEvent = EventInfo<dxChart> & TooltipInfo;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxChart> & TooltipInfo;
+export type TooltipShownEvent = EventInfo<dxChart> & TooltipInfo;
 
 /** @public */
-export type ZoomEndEvent = Cancelable & ComponentNativeEvent<dxChart> & {
+export type ZoomEndEvent = Cancelable & NativeEventInfo<dxChart> & {
     readonly rangeStart: Date | number;
     readonly rangeEnd: Date | number;
     readonly axis: chartAxisObject;
@@ -129,7 +129,7 @@ export type ZoomEndEvent = Cancelable & ComponentNativeEvent<dxChart> & {
 }
 
 /** @public */
-export type ZoomStartEvent = Cancelable & ComponentNativeEvent<dxChart> & {
+export type ZoomStartEvent = Cancelable & NativeEventInfo<dxChart> & {
     readonly axis: chartAxisObject;
     readonly range: VizRange;
     readonly actionType?: 'zoom' | 'pan';

--- a/js/viz/chart_components/base_chart.d.ts
+++ b/js/viz/chart_components/base_chart.d.ts
@@ -16,8 +16,8 @@ import DataSource, {
 } from '../../data/data_source';
 
 import {
-    ComponentEvent,
-    ComponentNativeEvent
+    EventInfo,
+    NativeEventInfo
 } from '../../events/index';
 
 import {
@@ -135,7 +135,7 @@ export interface BaseChartOptions<T = BaseChart> extends BaseWidgetOptions<T> {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onDone?: ((e: ComponentEvent<T>) => void);
+    onDone?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -150,7 +150,7 @@ export interface BaseChartOptions<T = BaseChart> extends BaseWidgetOptions<T> {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onPointClick?: ((e: ComponentNativeEvent<T> & PointInteractionInfo) => void) | string;
+    onPointClick?: ((e: NativeEventInfo<T> & PointInteractionInfo) => void) | string;
     /**
      * @docid
      * @type_function_param1 e:object
@@ -162,7 +162,7 @@ export interface BaseChartOptions<T = BaseChart> extends BaseWidgetOptions<T> {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onPointHoverChanged?: ((e: ComponentEvent<T> & PointInteractionInfo) => void);
+    onPointHoverChanged?: ((e: EventInfo<T> & PointInteractionInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -174,7 +174,7 @@ export interface BaseChartOptions<T = BaseChart> extends BaseWidgetOptions<T> {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onPointSelectionChanged?: ((e: ComponentEvent<T> & PointInteractionInfo) => void);
+    onPointSelectionChanged?: ((e: EventInfo<T> & PointInteractionInfo) => void);
     /**
      * @docid
      * @default null
@@ -188,7 +188,7 @@ export interface BaseChartOptions<T = BaseChart> extends BaseWidgetOptions<T> {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onTooltipHidden?: ((e: ComponentEvent<T> & TooltipInfo) => void);
+    onTooltipHidden?: ((e: EventInfo<T> & TooltipInfo) => void);
     /**
      * @docid
      * @default null
@@ -202,7 +202,7 @@ export interface BaseChartOptions<T = BaseChart> extends BaseWidgetOptions<T> {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onTooltipShown?: ((e: ComponentEvent<T> & TooltipInfo) => void);
+    onTooltipShown?: ((e: EventInfo<T> & TooltipInfo) => void);
     /**
      * @docid
      * @extends CommonVizPalette

--- a/js/viz/circular_gauge.d.ts
+++ b/js/viz/circular_gauge.d.ts
@@ -167,6 +167,7 @@ export default class dxCircularGauge extends BaseGauge {
     constructor(element: TElement, options?: dxCircularGaugeOptions)
 }
 
+/** @public */
 export type Options = dxCircularGaugeOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/circular_gauge.d.ts
+++ b/js/viz/circular_gauge.d.ts
@@ -4,13 +4,13 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
 import {
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -26,34 +26,34 @@ import {
 } from './gauges/base_gauge';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxCircularGauge>;
+export type DisposingEvent = EventInfo<dxCircularGauge>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxCircularGauge>;
+export type DrawnEvent = EventInfo<dxCircularGauge>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxCircularGauge>;
+export type ExportedEvent = EventInfo<dxCircularGauge>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxCircularGauge> & ExportInfo;
+export type ExportingEvent = EventInfo<dxCircularGauge> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxCircularGauge>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxCircularGauge>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxCircularGauge> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxCircularGauge> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxCircularGauge>;
+export type InitializedEvent = InitializedEventInfo<dxCircularGauge>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxCircularGauge> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxCircularGauge> & ChangedOptionInfo;
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxCircularGauge> & TooltipInfo;
+export type TooltipHiddenEvent = EventInfo<dxCircularGauge> & TooltipInfo;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxCircularGauge> & TooltipInfo;
+export type TooltipShownEvent = EventInfo<dxCircularGauge> & TooltipInfo;
 
 export interface dxCircularGaugeOptions extends BaseGaugeOptions<dxCircularGauge> {
     /**

--- a/js/viz/core/base_widget.d.ts
+++ b/js/viz/core/base_widget.d.ts
@@ -15,7 +15,7 @@ import {
 } from '../../core/utils/deferred';
 
 import {
-    ComponentEvent
+    EventInfo
 } from '../../events/index';
 
 import {
@@ -38,7 +38,7 @@ export interface IncidentInfo {
   readonly target: any;
 }
 
-export interface ComponentFileSavingEvent<T> {
+export interface FileSavingEventInfo<T> {
   readonly component: T;
   readonly element: TElement;
   readonly fileName: string;
@@ -95,7 +95,7 @@ export interface BaseWidgetOptions<T = BaseWidget> extends DOMComponentOptions<T
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onDrawn?: ((e: ComponentEvent<T>) => void);
+    onDrawn?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -107,7 +107,7 @@ export interface BaseWidgetOptions<T = BaseWidget> extends DOMComponentOptions<T
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onExported?: ((e: ComponentEvent<T>) => void);
+    onExported?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -122,7 +122,7 @@ export interface BaseWidgetOptions<T = BaseWidget> extends DOMComponentOptions<T
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onExporting?: ((e: ComponentEvent<T> & ExportInfo) => void);
+    onExporting?: ((e: EventInfo<T> & ExportInfo) => void);
     /**
      * @docid
      * @type_function_param1 e:object
@@ -137,7 +137,7 @@ export interface BaseWidgetOptions<T = BaseWidget> extends DOMComponentOptions<T
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onFileSaving?: ((e: ComponentFileSavingEvent<T>) => void);
+    onFileSaving?: ((e: FileSavingEventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -150,7 +150,7 @@ export interface BaseWidgetOptions<T = BaseWidget> extends DOMComponentOptions<T
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onIncidentOccurred?: ((e: ComponentEvent<T> & IncidentInfo) => void);
+    onIncidentOccurred?: ((e: EventInfo<T> & IncidentInfo) => void);
     /**
      * @docid
      * @default false

--- a/js/viz/funnel.d.ts
+++ b/js/viz/funnel.d.ts
@@ -17,9 +17,9 @@ import DataSource, {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -40,7 +40,7 @@ import BaseWidget, {
     Font,
     WordWrapType,
     VizTextOverflowType,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -64,40 +64,40 @@ interface FunnelItemInfo {
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxFunnel>;
+export type DisposingEvent = EventInfo<dxFunnel>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxFunnel>;
+export type DrawnEvent = EventInfo<dxFunnel>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxFunnel>;
+export type ExportedEvent = EventInfo<dxFunnel>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxFunnel> & ExportInfo;
+export type ExportingEvent = EventInfo<dxFunnel> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxFunnel>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxFunnel>;
 
 /** @public */
-export type HoverChangedEvent = ComponentEvent<dxFunnel> & FunnelItemInfo;
+export type HoverChangedEvent = EventInfo<dxFunnel> & FunnelItemInfo;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxFunnel> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxFunnel> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxFunnel>;
+export type InitializedEvent = InitializedEventInfo<dxFunnel>;
 
 /** @public */
-export type ItemClickEvent = ComponentNativeEvent<dxFunnel> & FunnelItemInfo;
+export type ItemClickEvent = NativeEventInfo<dxFunnel> & FunnelItemInfo;
 
 /** @public */
-export type LegendClickEvent = ComponentNativeEvent<dxFunnel> & FunnelItemInfo;
+export type LegendClickEvent = NativeEventInfo<dxFunnel> & FunnelItemInfo;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxFunnel> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxFunnel> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxFunnel> & FunnelItemInfo;
+export type SelectionChangedEvent = EventInfo<dxFunnel> & FunnelItemInfo;
 
 
 export interface dxFunnelOptions extends BaseWidgetOptions<dxFunnel> {

--- a/js/viz/funnel.d.ts
+++ b/js/viz/funnel.d.ts
@@ -792,6 +792,7 @@ export interface dxFunnelItem {
     value?: number;
 }
 
+/** @public */
 export type Options = dxFunnelOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/gauges/base_gauge.d.ts
+++ b/js/viz/gauges/base_gauge.d.ts
@@ -12,7 +12,7 @@ import {
 } from '../../core/templates/template';
 
 import {
-    ComponentEvent
+    EventInfo
 } from '../../events/index';
 
 import {
@@ -65,7 +65,7 @@ export interface BaseGaugeOptions<T = BaseGauge> extends BaseWidgetOptions<T> {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onTooltipHidden?: ((e: ComponentEvent<T> & TooltipInfo) => void);
+    onTooltipHidden?: ((e: EventInfo<T> & TooltipInfo) => void);
     /**
      * @docid
      * @default null
@@ -79,7 +79,7 @@ export interface BaseGaugeOptions<T = BaseGauge> extends BaseWidgetOptions<T> {
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onTooltipShown?: ((e: ComponentEvent<T> & TooltipInfo) => void);
+    onTooltipShown?: ((e: EventInfo<T> & TooltipInfo) => void);
     /**
      * @docid
      * @type object

--- a/js/viz/linear_gauge.d.ts
+++ b/js/viz/linear_gauge.d.ts
@@ -4,13 +4,13 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
 import {
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -26,34 +26,34 @@ import {
 } from './gauges/base_gauge';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxLinearGauge>;
+export type DisposingEvent = EventInfo<dxLinearGauge>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxLinearGauge>;
+export type DrawnEvent = EventInfo<dxLinearGauge>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxLinearGauge>;
+export type ExportedEvent = EventInfo<dxLinearGauge>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxLinearGauge> & ExportInfo;
+export type ExportingEvent = EventInfo<dxLinearGauge> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxLinearGauge>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxLinearGauge>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxLinearGauge> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxLinearGauge> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxLinearGauge>;
+export type InitializedEvent = InitializedEventInfo<dxLinearGauge>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxLinearGauge> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxLinearGauge> & ChangedOptionInfo;
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxLinearGauge> & TooltipInfo;
+export type TooltipHiddenEvent = EventInfo<dxLinearGauge> & TooltipInfo;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxLinearGauge> & TooltipInfo;
+export type TooltipShownEvent = EventInfo<dxLinearGauge> & TooltipInfo;
 
 
 export interface dxLinearGaugeOptions extends BaseGaugeOptions<dxLinearGauge> {

--- a/js/viz/linear_gauge.d.ts
+++ b/js/viz/linear_gauge.d.ts
@@ -190,6 +190,7 @@ export default class dxLinearGauge extends BaseGauge {
     constructor(element: TElement, options?: dxLinearGaugeOptions)
 }
 
+/** @public */
 export type Options = dxLinearGaugeOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/pie_chart.d.ts
+++ b/js/viz/pie_chart.d.ts
@@ -998,6 +998,7 @@ export interface pieChartSeriesObject extends baseSeriesObject {
   isHovered(): boolean;
 }
 
+/** @public */
 export type Options = dxPieChartOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/pie_chart.d.ts
+++ b/js/viz/pie_chart.d.ts
@@ -8,9 +8,9 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -47,7 +47,7 @@ import {
     WordWrapType,
     VizTextOverflowType,
     BaseWidgetAnnotationConfig,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -57,52 +57,52 @@ export type SegmentsDirectionType = 'anticlockwise' | 'clockwise';
 
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxPieChart>;
+export type DisposingEvent = EventInfo<dxPieChart>;
 
 /** @public */
-export type DoneEvent = ComponentEvent<dxPieChart>;
+export type DoneEvent = EventInfo<dxPieChart>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxPieChart>;
+export type DrawnEvent = EventInfo<dxPieChart>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxPieChart>;
+export type ExportedEvent = EventInfo<dxPieChart>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxPieChart> & ExportInfo;
+export type ExportingEvent = EventInfo<dxPieChart> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxPieChart>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxPieChart>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxPieChart> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxPieChart> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxPieChart>;
+export type InitializedEvent = InitializedEventInfo<dxPieChart>;
 
 /** @public */
-export type LegendClickEvent = ComponentNativeEvent<dxPieChart> & {
+export type LegendClickEvent = NativeEventInfo<dxPieChart> & {
   readonly target: string | number;
   readonly points: Array<piePointObject>;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxPieChart> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxPieChart> & ChangedOptionInfo;
 
 /** @public */
-export type PointClickEvent = ComponentNativeEvent<dxPieChart> & PointInteractionInfo;
+export type PointClickEvent = NativeEventInfo<dxPieChart> & PointInteractionInfo;
 
 /** @public */
-export type PointHoverChangedEvent = ComponentEvent<dxPieChart> & PointInteractionInfo;
+export type PointHoverChangedEvent = EventInfo<dxPieChart> & PointInteractionInfo;
 
 /** @public */
-export type PointSelectionChangedEvent = ComponentEvent<dxPieChart> & PointInteractionInfo;
+export type PointSelectionChangedEvent = EventInfo<dxPieChart> & PointInteractionInfo;
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxPieChart> & TooltipInfo;
+export type TooltipHiddenEvent = EventInfo<dxPieChart> & TooltipInfo;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxPieChart> & TooltipInfo;
+export type TooltipShownEvent = EventInfo<dxPieChart> & TooltipInfo;
 
 
 /**

--- a/js/viz/polar_chart.d.ts
+++ b/js/viz/polar_chart.d.ts
@@ -2521,6 +2521,7 @@ export interface polarPointObject extends basePointObject {
 export interface polarChartSeriesObject extends baseSeriesObject {
 }
 
+/** @public */
 export type Options = dxPolarChartOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/polar_chart.d.ts
+++ b/js/viz/polar_chart.d.ts
@@ -5,9 +5,9 @@ import {
 import {
     TEvent,
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -46,7 +46,7 @@ import {
 
 import {
     Font,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -58,70 +58,70 @@ interface SeriesInteractionInfo {
 }
 
 /** @public */
-export type ArgumentAxisClickEvent = ComponentNativeEvent<dxPolarChart> & {
+export type ArgumentAxisClickEvent = NativeEventInfo<dxPolarChart> & {
     readonly argument: Date | number | string;
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxPolarChart>;
+export type DisposingEvent = EventInfo<dxPolarChart>;
 
 /** @public */
-export type DoneEvent = ComponentEvent<dxPolarChart>;
+export type DoneEvent = EventInfo<dxPolarChart>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxPolarChart>;
+export type DrawnEvent = EventInfo<dxPolarChart>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxPolarChart>;
+export type ExportedEvent = EventInfo<dxPolarChart>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxPolarChart> & ExportInfo;
+export type ExportingEvent = EventInfo<dxPolarChart> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxPolarChart>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxPolarChart>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxPolarChart> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxPolarChart> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxPolarChart>;
+export type InitializedEvent = InitializedEventInfo<dxPolarChart>;
 
 /** @public */
-export type LegendClickEvent = ComponentNativeEvent<dxPolarChart> & {
+export type LegendClickEvent = NativeEventInfo<dxPolarChart> & {
     readonly target: polarChartSeriesObject;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxPolarChart> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxPolarChart> & ChangedOptionInfo;
 
 /** @public */
-export type PointClickEvent = ComponentNativeEvent<dxPolarChart> & PointInteractionInfo;
+export type PointClickEvent = NativeEventInfo<dxPolarChart> & PointInteractionInfo;
 
 /** @public */
-export type PointHoverChangedEvent = ComponentEvent<dxPolarChart> & PointInteractionInfo;
+export type PointHoverChangedEvent = EventInfo<dxPolarChart> & PointInteractionInfo;
 
 /** @public */
-export type PointSelectionChangedEvent = ComponentEvent<dxPolarChart> & PointInteractionInfo;
+export type PointSelectionChangedEvent = EventInfo<dxPolarChart> & PointInteractionInfo;
 
 /** @public */
-export type SeriesClickEvent = ComponentNativeEvent<dxPolarChart> & {
+export type SeriesClickEvent = NativeEventInfo<dxPolarChart> & {
     readonly target: polarChartSeriesObject;
 }
 
 /** @public */
-export type SeriesHoverChangedEvent = ComponentEvent<dxPolarChart> & SeriesInteractionInfo;
+export type SeriesHoverChangedEvent = EventInfo<dxPolarChart> & SeriesInteractionInfo;
 
 /** @public */
-export type SeriesSelectionChangedEvent = ComponentEvent<dxPolarChart> & SeriesInteractionInfo;
+export type SeriesSelectionChangedEvent = EventInfo<dxPolarChart> & SeriesInteractionInfo;
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxPolarChart> & TooltipInfo;
+export type TooltipHiddenEvent = EventInfo<dxPolarChart> & TooltipInfo;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxPolarChart> & TooltipInfo;
+export type TooltipShownEvent = EventInfo<dxPolarChart> & TooltipInfo;
 
 /** @public */
-export type ZoomEndEvent = Cancelable & ComponentNativeEvent<dxPolarChart> & {
+export type ZoomEndEvent = Cancelable & NativeEventInfo<dxPolarChart> & {
     readonly axis: chartAxisObject;
     readonly range: VizRange;
     readonly previousRange: VizRange;
@@ -130,7 +130,7 @@ export type ZoomEndEvent = Cancelable & ComponentNativeEvent<dxPolarChart> & {
     readonly shift: number;
 }
 /** @public */
-export type ZoomStartEvent = Cancelable & ComponentNativeEvent<dxPolarChart> & {
+export type ZoomStartEvent = Cancelable & NativeEventInfo<dxPolarChart> & {
     readonly axis: chartAxisObject;
     readonly range: VizRange;
     readonly actionType: 'zoom' | 'pan';

--- a/js/viz/range_selector.d.ts
+++ b/js/viz/range_selector.d.ts
@@ -13,9 +13,9 @@ import DataSource, {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -38,37 +38,37 @@ import BaseWidget, {
     BaseWidgetOptions,
     BaseWidgetTooltip,
     Font,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxRangeSelector>;
+export type DisposingEvent = EventInfo<dxRangeSelector>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxRangeSelector>;
+export type DrawnEvent = EventInfo<dxRangeSelector>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxRangeSelector>;
+export type ExportedEvent = EventInfo<dxRangeSelector>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxRangeSelector> & ExportInfo;
+export type ExportingEvent = EventInfo<dxRangeSelector> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxRangeSelector>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxRangeSelector>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxRangeSelector> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxRangeSelector> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxRangeSelector>;
+export type InitializedEvent = InitializedEventInfo<dxRangeSelector>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxRangeSelector> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxRangeSelector> & ChangedOptionInfo;
 
 /** @public */
-export type ValueChangedEvent = ComponentNativeEvent<dxRangeSelector> & {
+export type ValueChangedEvent = NativeEventInfo<dxRangeSelector> & {
   readonly value: Array<number | string | Date>,
   readonly previousValue: Array<number | string | Date>,
 }

--- a/js/viz/range_selector.d.ts
+++ b/js/viz/range_selector.d.ts
@@ -916,6 +916,7 @@ export default class dxRangeSelector extends BaseWidget {
     setValue(value: Array<number | string | Date> | VizRange): void;
 }
 
+/** @public */
 export type Options = dxRangeSelectorOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/sankey.d.ts
+++ b/js/viz/sankey.d.ts
@@ -824,6 +824,7 @@ export interface dxSankeyNode {
     title?: string;
 }
 
+/** @public */
 export type Options = dxSankeyOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/sankey.d.ts
+++ b/js/viz/sankey.d.ts
@@ -17,9 +17,9 @@ import DataSource, {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -27,7 +27,7 @@ import BaseWidget, {
     BaseWidgetOptions,
     BaseWidgetTooltip,
     Font,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -35,45 +35,45 @@ import BaseWidget, {
 import { HatchingDirectionType } from './common';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSankey>;
+export type DisposingEvent = EventInfo<dxSankey>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxSankey>;
+export type DrawnEvent = EventInfo<dxSankey>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxSankey>;
+export type ExportedEvent = EventInfo<dxSankey>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxSankey> & ExportInfo;
+export type ExportingEvent = EventInfo<dxSankey> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxSankey>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxSankey>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxSankey> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxSankey> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSankey>;
+export type InitializedEvent = InitializedEventInfo<dxSankey>;
 
 /** @public */
-export type LinkClickEvent = ComponentNativeEvent<dxSankey> & {
+export type LinkClickEvent = NativeEventInfo<dxSankey> & {
     readonly target: dxSankeyLink;
 }
 /** @public */
-export type LinkHoverEvent = ComponentEvent<dxSankey> & {
+export type LinkHoverEvent = EventInfo<dxSankey> & {
     readonly target: dxSankeyLink;
 }
 /** @public */
-export type NodeClickEvent = ComponentNativeEvent<dxSankey> & {
+export type NodeClickEvent = NativeEventInfo<dxSankey> & {
     readonly target: dxSankeyNode;
 }
 /** @public */
-export type NodeHoverEvent = ComponentEvent<dxSankey> & {
+export type NodeHoverEvent = EventInfo<dxSankey> & {
     readonly target: dxSankeyNode;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSankey> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSankey> & ChangedOptionInfo;
 
 
 export interface dxSankeyOptions extends BaseWidgetOptions<dxSankey> {

--- a/js/viz/sparkline.d.ts
+++ b/js/viz/sparkline.d.ts
@@ -226,6 +226,7 @@ export default class dxSparkline extends BaseSparkline {
     getDataSource(): DataSource;
 }
 
+/** @public */
 export type Options = dxSparklineOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/sparkline.d.ts
+++ b/js/viz/sparkline.d.ts
@@ -4,8 +4,8 @@ import {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -15,7 +15,7 @@ import DataSource, {
 
 
 import {
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -25,34 +25,34 @@ import BaseSparkline, {
 } from './sparklines/base_sparkline';
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxSparkline>;
+export type DisposingEvent = EventInfo<dxSparkline>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxSparkline>;
+export type DrawnEvent = EventInfo<dxSparkline>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxSparkline>;
+export type ExportedEvent = EventInfo<dxSparkline>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxSparkline> & ExportInfo;
+export type ExportingEvent = EventInfo<dxSparkline> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxSparkline>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxSparkline>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxSparkline> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxSparkline> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxSparkline>;
+export type InitializedEvent = InitializedEventInfo<dxSparkline>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxSparkline> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxSparkline> & ChangedOptionInfo;
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxSparkline>;
+export type TooltipHiddenEvent = EventInfo<dxSparkline>;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxSparkline>;
+export type TooltipShownEvent = EventInfo<dxSparkline>;
 
 
 export interface dxSparklineOptions extends BaseSparklineOptions<dxSparkline> {

--- a/js/viz/sparklines/base_sparkline.d.ts
+++ b/js/viz/sparklines/base_sparkline.d.ts
@@ -7,7 +7,7 @@ import {
 } from '../../core/templates/template';
 
 import {
-    ComponentEvent
+    EventInfo
 } from '../../events/index';
 
 import BaseWidget, {
@@ -45,7 +45,7 @@ export interface BaseSparklineOptions<T = BaseSparkline> extends BaseWidgetOptio
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onTooltipHidden?: ((e: ComponentEvent<T>) => void);
+    onTooltipHidden?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @default null
@@ -58,7 +58,7 @@ export interface BaseSparklineOptions<T = BaseSparkline> extends BaseWidgetOptio
      * @prevFileNamespace DevExpress.viz
      * @public
      */
-    onTooltipShown?: ((e: ComponentEvent<T>) => void);
+    onTooltipShown?: ((e: EventInfo<T>) => void);
     /**
      * @docid
      * @prevFileNamespace DevExpress.viz

--- a/js/viz/tree_map.d.ts
+++ b/js/viz/tree_map.d.ts
@@ -17,9 +17,9 @@ import DataSource, {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -30,7 +30,7 @@ import BaseWidget, {
     Font,
     WordWrapType,
     VizTextOverflowType,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -40,54 +40,54 @@ export interface InteractionInfo {
 }
 
 /** @public */
-export type ClickEvent = ComponentNativeEvent<dxTreeMap> & {
+export type ClickEvent = NativeEventInfo<dxTreeMap> & {
   readonly node: dxTreeMapNode
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxTreeMap>;
+export type DisposingEvent = EventInfo<dxTreeMap>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxTreeMap>;
+export type DrawnEvent = EventInfo<dxTreeMap>;
 
 /** @public */
-export type DrillEvent = ComponentEvent<dxTreeMap> & {
+export type DrillEvent = EventInfo<dxTreeMap> & {
   readonly node: dxTreeMapNode;
 }
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxTreeMap>;
+export type ExportedEvent = EventInfo<dxTreeMap>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxTreeMap> & ExportInfo;
+export type ExportingEvent = EventInfo<dxTreeMap> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxTreeMap>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxTreeMap>;
 
 /** @public */
-export type HoverChangedEvent = ComponentEvent<dxTreeMap> & InteractionInfo;
+export type HoverChangedEvent = EventInfo<dxTreeMap> & InteractionInfo;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxTreeMap> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxTreeMap> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxTreeMap>;
+export type InitializedEvent = InitializedEventInfo<dxTreeMap>;
 
 /** @public */
-export type NodesInitializedEvent = ComponentEvent<dxTreeMap> & {
+export type NodesInitializedEvent = EventInfo<dxTreeMap> & {
     readonly root: dxTreeMapNode;
 }
 
 /** @public */
-export type NodesRenderingEvent = ComponentEvent<dxTreeMap> & {
+export type NodesRenderingEvent = EventInfo<dxTreeMap> & {
     readonly node: dxTreeMapNode;
 }
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxTreeMap> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxTreeMap> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxTreeMap> & InteractionInfo;
+export type SelectionChangedEvent = EventInfo<dxTreeMap> & InteractionInfo;
 
 
 export interface dxTreeMapOptions extends BaseWidgetOptions<dxTreeMap> {

--- a/js/viz/tree_map.d.ts
+++ b/js/viz/tree_map.d.ts
@@ -837,6 +837,7 @@ export interface dxTreeMapNode {
     value(): number;
 }
 
+/** @public */
 export type Options = dxTreeMapOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/vector_map.d.ts
+++ b/js/viz/vector_map.d.ts
@@ -1036,6 +1036,7 @@ export default class dxVectorMap extends BaseWidget {
     zoomFactor(zoomFactor: number): void;
 }
 
+/** @public */
 export type Options = dxVectorMapOptions;
 
 /** @deprecated use Options instead */

--- a/js/viz/vector_map.d.ts
+++ b/js/viz/vector_map.d.ts
@@ -16,9 +16,9 @@ import DataSource, {
 
 import {
     Cancelable,
-    ComponentEvent,
-    ComponentNativeEvent,
-    ComponentInitializedEvent,
+    EventInfo,
+    NativeEventInfo,
+    InitializedEventInfo,
     ChangedOptionInfo
 } from '../events/index';
 
@@ -37,7 +37,7 @@ import BaseWidget, {
     BaseWidgetTooltip,
     Font,
     BaseWidgetAnnotationConfig,
-    ComponentFileSavingEvent,
+    FileSavingEventInfo,
     ExportInfo,
     IncidentInfo
 } from './core/base_widget';
@@ -51,52 +51,52 @@ export interface TooltipInfo {
 }
 
 /** @public */
-export type CenterChangedEvent = ComponentEvent<dxVectorMap> & {
+export type CenterChangedEvent = EventInfo<dxVectorMap> & {
     readonly center: Array<number>;
 }
 
 /** @public */
-export type ClickEvent = ComponentNativeEvent<dxVectorMap> & {
+export type ClickEvent = NativeEventInfo<dxVectorMap> & {
     readonly target: MapLayerElement;
 }
 
 /** @public */
-export type DisposingEvent = ComponentEvent<dxVectorMap>;
+export type DisposingEvent = EventInfo<dxVectorMap>;
 
 /** @public */
-export type DrawnEvent = ComponentEvent<dxVectorMap>;
+export type DrawnEvent = EventInfo<dxVectorMap>;
 
 /** @public */
-export type ExportedEvent = ComponentEvent<dxVectorMap>;
+export type ExportedEvent = EventInfo<dxVectorMap>;
 
 /** @public */
-export type ExportingEvent = ComponentEvent<dxVectorMap> & ExportInfo;
+export type ExportingEvent = EventInfo<dxVectorMap> & ExportInfo;
 
 /** @public */
-export type FileSavingEvent = Cancelable & ComponentFileSavingEvent<dxVectorMap>;
+export type FileSavingEvent = Cancelable & FileSavingEventInfo<dxVectorMap>;
 
 /** @public */
-export type IncidentOccurredEvent = ComponentEvent<dxVectorMap> & IncidentInfo;
+export type IncidentOccurredEvent = EventInfo<dxVectorMap> & IncidentInfo;
 
 /** @public */
-export type InitializedEvent = ComponentInitializedEvent<dxVectorMap>;
+export type InitializedEvent = InitializedEventInfo<dxVectorMap>;
 
 /** @public */
-export type OptionChangedEvent = ComponentEvent<dxVectorMap> & ChangedOptionInfo;
+export type OptionChangedEvent = EventInfo<dxVectorMap> & ChangedOptionInfo;
 
 /** @public */
-export type SelectionChangedEvent = ComponentEvent<dxVectorMap> & {
+export type SelectionChangedEvent = EventInfo<dxVectorMap> & {
     readonly target: MapLayerElement;
 }
 
 /** @public */
-export type TooltipHiddenEvent = ComponentEvent<dxVectorMap> & TooltipInfo;
+export type TooltipHiddenEvent = EventInfo<dxVectorMap> & TooltipInfo;
 
 /** @public */
-export type TooltipShownEvent = ComponentEvent<dxVectorMap> & TooltipInfo;
+export type TooltipShownEvent = EventInfo<dxVectorMap> & TooltipInfo;
 
 /** @public */
-export type ZoomFactorChangedEvent = ComponentEvent<dxVectorMap> & {
+export type ZoomFactorChangedEvent = EventInfo<dxVectorMap> & {
     readonly zoomFactor: number;
 }
 


### PR DESCRIPTION
1. ComponentXXXEvent naming pattern changed to XXXEventInfo
2. `@public` doc-tag added for public Options type and removed from internal ones
3. `Cancelable` type is now the first type in all intersections for better readability