### PR TITLE
Fix french spelling of "drop file"

### DIFF
--- a/js/localization/messages/fr.json
+++ b/js/localization/messages/fr.json
@@ -57,7 +57,7 @@
         "dxDateBox-validation-datetime": "La valeur doit être une date ou une heure.",
 
         "dxFileUploader-selectFile": "Choisissez un fichier",
-        "dxFileUploader-dropFile": "Enlever fichier",
+        "dxFileUploader-dropFile": "Déposez un fichier",
         "dxFileUploader-bytes": "Bytes",
         "dxFileUploader-kb": "kb",
         "dxFileUploader-Mb": "Mb",


### PR DESCRIPTION
The old spelling meant "take off the file"

1. What did you do? 
I changed a french translation that did not meant anything.
2. How did you do it?
I tried to keep the overall translation context 
3. How should we verify this?
This may help https://www.linguee.com/english-french/translation/drop+file.html
