### PR TITLE
Renovated component: options set to undefined should fall it back to default options considering defaultOptionRules

### DIFF
--- a/js/core/options/index.js
+++ b/js/core/options/index.js
@@ -126,6 +126,7 @@ export class Options {
         const options = this._getByRules(rules);
 
         this.silent(options);
+        this._patchedDefault = extend({}, options);
     }
 
     dispose() {

--- a/js/core/options/index.js
+++ b/js/core/options/index.js
@@ -126,7 +126,6 @@ export class Options {
         const options = this._getByRules(rules);
 
         this.silent(options);
-        this._patchedDefault = extend({}, options);
     }
 
     dispose() {

--- a/js/renovation/component_wrapper/__tests__/component.test.tsx
+++ b/js/renovation/component_wrapper/__tests__/component.test.tsx
@@ -6,6 +6,7 @@ import renderer, { dxElementWrapper } from '../../../core/renderer';
 import './utils/test_components/empty_test_widget';
 import './utils/test_components/test_widget';
 import './utils/test_components/options_check_widget';
+import TestWidgetWrapper from './utils/test_components/base_test_widget';
 import './utils/test_components/templated_test_widget';
 import {
   defaultEvent,
@@ -429,6 +430,31 @@ describe('option', () => {
       oneWayNullWithValue: undefined,
       twoWayWithValue: undefined,
       twoWayNullWithValue: undefined,
+    });
+  });
+
+  it('convert undefined to null or default value including custom default option rules', () => {
+    TestWidgetWrapper.defaultOptions({
+      device: () => true,
+      options: {
+        oneWayWithValue: 5,
+        twoWayWithValue: '5',
+      },
+    });
+
+    $('#component').dxOptionsCheckWidget({
+      oneWayWithValue: 15,
+      twoWayWithValue: '15',
+    });
+
+    $('#component').dxOptionsCheckWidget({
+      oneWayWithValue: undefined,
+      twoWayWithValue: undefined,
+    });
+
+    expect($('#component').dxOptionsCheckWidget('getLastPassedProps')).toMatchObject({
+      oneWayWithValue: 5,
+      twoWayWithValue: '5',
     });
   });
 

--- a/js/renovation/component_wrapper/component.ts
+++ b/js/renovation/component_wrapper/component.ts
@@ -12,14 +12,11 @@ import { isDefined, isRenderer } from '../../core/utils/type';
 import { InfernoEffectHost } from "@devextreme/vdom";
 import { TemplateWrapper } from "./template_wrapper";
 
-function setDefaultOptionValue(options, defaultValueGetter) {
-  return (name) => {
-    if (options.hasOwnProperty(name) && options[name] === undefined) {
-      const defaultValue = defaultValueGetter(name); 
-      options[name] = defaultValue;
-    }
+const setDefaultOptionValue = (options, defaultValueGetter) => (name) => {
+  if (options.hasOwnProperty(name) && options[name] === undefined) {
+    options[name] = defaultValueGetter(name);
   }
-}
+};
 
 export default class ComponentWrapper extends DOMComponent {
   // NOTE: We should declare all instance options with '!' because of DOMComponent life cycle

--- a/js/renovation/component_wrapper/component.ts
+++ b/js/renovation/component_wrapper/component.ts
@@ -12,6 +12,15 @@ import { isDefined, isRenderer } from '../../core/utils/type';
 import { InfernoEffectHost } from "@devextreme/vdom";
 import { TemplateWrapper } from "./template_wrapper";
 
+function setDefaultOptionValue(options, defaultValueGetter) {
+  return (name) => {
+    if (options.hasOwnProperty(name) && options[name] === undefined) {
+      const defaultValue = defaultValueGetter(name); 
+      options[name] = defaultValue;
+    }
+  }
+}
+
 export default class ComponentWrapper extends DOMComponent {
   // NOTE: We should declare all instance options with '!' because of DOMComponent life cycle
   _actionsMap!: {
@@ -151,15 +160,6 @@ export default class ComponentWrapper extends DOMComponent {
     return this._elementAttr;
   }
 
-  _setDefaultOptionValue(options, defaultValueGetter) {
-    return (name) => {
-      if (options.hasOwnProperty(name) && options[name] === undefined) {
-        const defaultValue = defaultValueGetter(name); 
-        options[name] = defaultValue;
-      }
-    }
-  }
-
   _silent(name, value) {
     (this as unknown as { _options })
       ._options.silent(name, value);
@@ -182,18 +182,18 @@ export default class ComponentWrapper extends DOMComponent {
     const defaultProps = this._viewComponent.defaultProps;
 
     allowNull.forEach(
-      this._setDefaultOptionValue(options, () => null)
+      setDefaultOptionValue(options, () => null)
     );
 
     Object.keys(defaultProps).forEach(
-      this._setDefaultOptionValue(
+      setDefaultOptionValue(
         options,
         (name: string) => this._getDefaultOptionValue(name, defaultProps[name])
       )
     );
 
     twoWay.forEach(([name, defaultValue]) => {
-        this._setDefaultOptionValue(
+        setDefaultOptionValue(
           options, 
           (name) => this._getDefaultOptionValue(name, defaultValue)
         )(name);

--- a/js/renovation/component_wrapper/editor.ts
+++ b/js/renovation/component_wrapper/editor.ts
@@ -70,9 +70,8 @@ export default class Editor extends Component {
   }
 
   _bindInnerWidgetOptions(innerWidget: Component, optionsContainer: unknown): void {
-    const syncOptions = (): void => (this as unknown as { _options })
-      ._options.silent(optionsContainer, extend({},
-        innerWidget.option()));
+    const innerWidgetOptions = extend({}, innerWidget.option());
+    const syncOptions = (): void => this._silent(optionsContainer, innerWidgetOptions);
 
     syncOptions();
     innerWidget.on('optionChanged', syncOptions);


### PR DESCRIPTION
…

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
