### PR TITLE
Fix formatMessage declaration accordingly the actual API

### DIFF
--- a/js/localization.d.ts
+++ b/js/localization.d.ts
@@ -28,7 +28,7 @@ export function formatDate(value: Date, format: format): string;
  * @prevFileNamespace DevExpress
  * @public
  */
-export function formatMessage(key: string, value: string | Array<string>): string;
+export function formatMessage(key: string, ...values: Array<string>): string;
 
 /**
  * @docid localization.formatNumber


### PR DESCRIPTION
Fix for [T992566](https://supportcenter.devexpress.com/internal/ticket/details/T992566).
In fact this method does not expect an array as a second argument but it allows to set any count of arguments instead.
https://github.com/DevExpress/DevExtreme/blob/21_1/js/localization/message.js#L115