### PR TITLE
Editors custom buttons - save correct styling mode after buttons option changes (T992034)

### DIFF
--- a/js/ui/text_box/ui.text_editor.base.js
+++ b/js/ui/text_box/ui.text_editor.base.js
@@ -744,6 +744,7 @@ const TextEditorBase = Editor.inherit({
                 this._$afterButtonsContainer && this._$afterButtonsContainer.remove();
                 this._buttonCollection.clean();
                 this._renderButtonContainers();
+                this._updateButtonsStyling(this.option('stylingMode'));
                 break;
             case 'displayValueFormatter':
                 this._invalidate();

--- a/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
@@ -938,6 +938,33 @@ module('collection updating', () => {
             customButton = textBox.getButton('custom');
             assert.notStrictEqual(customButton.option('stylingMode'), 'text');
         });
+
+        test('custom button should have \'text\' styling mode if editor has stylingMode = \'underlined\' and buttons config was changed (T992034)', function(assert) {
+            const $textBox = $('<div>').dxTextBox({
+                showClearButton: false,
+                stylingMode: 'underlined',
+                value: 'text',
+                buttons: ['clear', {
+                    name: 'custom',
+                    location: 'after',
+                    options: {
+                        text: 'custom'
+                    }
+                }]
+            });
+            const textBox = $textBox.dxTextBox('instance');
+
+            textBox.option('buttons', [{
+                name: 'custom',
+                location: 'after',
+                options: {
+                    text: 'custom1'
+                }
+            }]);
+
+            const customButton = textBox.getButton('custom');
+            assert.strictEqual(customButton.option('stylingMode'), 'text');
+        });
     });
 
     module('numberBox', () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/actionButtons.test.js
@@ -940,27 +940,22 @@ module('collection updating', () => {
         });
 
         test('custom button should have \'text\' styling mode if editor has stylingMode = \'underlined\' and buttons config was changed (T992034)', function(assert) {
+            const buttonConfig = {
+                name: 'custom',
+                location: 'after',
+                options: {
+                    text: 'custom'
+                }
+            };
             const $textBox = $('<div>').dxTextBox({
                 showClearButton: false,
                 stylingMode: 'underlined',
                 value: 'text',
-                buttons: ['clear', {
-                    name: 'custom',
-                    location: 'after',
-                    options: {
-                        text: 'custom'
-                    }
-                }]
+                buttons: [buttonConfig]
             });
             const textBox = $textBox.dxTextBox('instance');
 
-            textBox.option('buttons', [{
-                name: 'custom',
-                location: 'after',
-                options: {
-                    text: 'custom1'
-                }
-            }]);
+            textBox.option('buttons', [buttonConfig]);
 
             const customButton = textBox.getButton('custom');
             assert.strictEqual(customButton.option('stylingMode'), 'text');


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
