### PR TITLE
Renovation: Use own inferno hydrate

### DIFF
--- a/js/renovation/component_wrapper/__tests__/component.test.tsx
+++ b/js/renovation/component_wrapper/__tests__/component.test.tsx
@@ -697,7 +697,7 @@ describe('templates and slots', () => {
     });
     const root = $('#component').children('.templates-root')[0];
 
-    expect($(root.firstChild)[0].nextSibling).toBe(template[0]);
+    expect($(root.firstChild)[0]).toBe(template[0]);
   });
 });
 

--- a/js/renovation/component_wrapper/__tests__/component.test.tsx
+++ b/js/renovation/component_wrapper/__tests__/component.test.tsx
@@ -358,6 +358,17 @@ describe('Widget\'s container manipulations', () => {
 
     expect($('#components').children().get(1)).toBe($('#component').get(0));
   });
+
+  it('should be rendered not in "div" container', () => {
+    document.body.innerHTML = `
+      <div id="components">
+          <a id="component"></a>
+      </div>
+      `;
+
+    expect(() => $('#component').dxTestWidget({})).not.toThrowError();
+    expect($('#component')[0].nodeName.toLowerCase()).toBe('a');
+  });
 });
 
 describe('option', () => {
@@ -686,7 +697,7 @@ describe('templates and slots', () => {
     });
     const root = $('#component').children('.templates-root')[0];
 
-    expect($(root.firstChild)[0]).toBe(template[0]);
+    expect($(root.firstChild)[0].nextSibling).toBe(template[0]);
   });
 });
 

--- a/js/renovation/component_wrapper/component.ts
+++ b/js/renovation/component_wrapper/component.ts
@@ -1,7 +1,6 @@
 /* eslint-disable */
-import { render, createRef, RefObject, Fragment } from "inferno";
+import { render, createRef, RefObject } from "inferno";
 import { createElement } from 'inferno-create-element';
-import { hydrate } from 'inferno-hydrate';
 import $ from '../../core/renderer';
 import domAdapter from '../../core/dom_adapter';
 import DOMComponent from '../../core/dom_component';
@@ -9,7 +8,7 @@ import { extend } from '../../core/utils/extend';
 import { getPublicElement } from '../../core/element';
 import { isDefined, isRenderer } from '../../core/utils/type';
 
-import { InfernoEffectHost } from "@devextreme/vdom";
+import { InfernoEffectHost, hydrate } from "@devextreme/vdom";
 import { TemplateWrapper } from "./template_wrapper";
 
 
@@ -270,29 +269,10 @@ export default class ComponentWrapper extends DOMComponent {
 
   _extractDefaultSlot() {
     if (this.option('_hasAnonymousTemplateContent')) {
-      const dummyDivRefCallback: (ref: any) => void = (dummyDivRef) => {
-        if (dummyDivRef) {
-          const { parentNode } = dummyDivRef;
-          if (parentNode) {
-            parentNode.removeChild(dummyDivRef);
-            this._getTemplate(this._templateManager.anonymousTemplateName).render(
-              {
-                container: getPublicElement($(parentNode)),
-                transclude: true,
-              }
-            );
-          }
-        }
-      };
-
-      return createElement(
-        Fragment,
-        {},
-        createElement('div', {
-          style: { display: 'none' },
-          ref: dummyDivRefCallback,
-        })
-      );
+      return createElement(TemplateWrapper, {
+        template: this._getTemplate(this._templateManager.anonymousTemplateName),
+        transclude: true,
+      });
     }
     return null;
   }

--- a/js/renovation/component_wrapper/template_wrapper.ts
+++ b/js/renovation/component_wrapper/template_wrapper.ts
@@ -27,6 +27,7 @@ export class TemplateWrapper extends InfernoComponent<TemplateWrapperProps> {
     if (node) {
       const { parentNode } = node;
       if (parentNode) {
+        parentNode.removeChild(node);
         const $parent = $(parentNode as Element);
         const $children = $parent.contents();
 
@@ -48,6 +49,7 @@ export class TemplateWrapper extends InfernoComponent<TemplateWrapperProps> {
         return (): void => {
           // NOTE: order is important
           removeDifferentElements($children, $parent.contents());
+          parentNode.appendChild(node);
         };
       }
     }

--- a/js/renovation/component_wrapper/template_wrapper.ts
+++ b/js/renovation/component_wrapper/template_wrapper.ts
@@ -1,50 +1,59 @@
 import { InfernoComponent, InfernoEffect } from '@devextreme/vdom';
-import { createElement } from 'inferno-create-element';
-import { createRef } from 'inferno';
+// eslint-disable-next-line spellcheck/spell-checker
+import { findDOMfromVNode } from 'inferno';
 import $ from '../../core/renderer';
 import domAdapter from '../../core/dom_adapter';
 import { getPublicElement } from '../../core/element';
 import { removeDifferentElements } from './utils';
 import Number from '../../core/polyfills/number';
+import { FunctionTemplate } from '../../core/templates/function_template';
+import { EffectReturn } from '../utils/effect_return';
 
-interface TemplateProps { template: any; model: { data: any; index: number } }
+interface TemplateWrapperProps {
+  template: FunctionTemplate;
+  model?: { data: Record<string, unknown>; index: number };
+  transclude?: boolean;
+}
 
-export class TemplateWrapper extends InfernoComponent<TemplateProps> {
-  constructor(props) {
+export class TemplateWrapper extends InfernoComponent<TemplateWrapperProps> {
+  constructor(props: TemplateWrapperProps) {
     super(props);
     this.renderTemplate = this.renderTemplate.bind(this);
   }
 
-  dummyDivRef = createRef<any>();
+  renderTemplate(): EffectReturn {
+    // eslint-disable-next-line spellcheck/spell-checker
+    const node = findDOMfromVNode(this.$LI, true);
+    if (node) {
+      const { parentNode } = node;
+      if (parentNode) {
+        const $parent = $(parentNode as Element);
+        const $children = $parent.contents();
 
-  renderTemplate(): () => void {
-    const { parentNode } = this.dummyDivRef.current;
-    parentNode?.removeChild(this.dummyDivRef.current);
-    const $parent = $(parentNode);
-    const $children = $parent.contents();
+        const { data, index } = this.props.model ?? { data: {} };
 
-    const { data, index } = this.props.model;
+        Object.keys(data).forEach((name) => {
+          if (data[name] && domAdapter.isNode(data[name])) {
+            data[name] = getPublicElement($(data[name] as Element));
+          }
+        });
 
-    Object.keys(data).forEach((name) => {
-      if (data[name] && domAdapter.isNode(data[name])) {
-        data[name] = getPublicElement($(data[name]));
+        this.props.template.render({
+          container: getPublicElement($parent),
+          transclude: this.props.transclude,
+          ...(!this.props.transclude ? { model: data } : {}),
+          ...(!this.props.transclude && Number.isFinite(index) ? { index } : {}),
+        });
+
+        return (): void => {
+          // NOTE: order is important
+          removeDifferentElements($children, $parent.contents());
+        };
       }
-    });
+    }
 
-    this.props.template.render({
-      container: getPublicElement($parent),
-      model: data,
-      ...(Number.isFinite(index) ? { index } : {}),
-    });
-
-    return (): void => {
-      // NOTE: order is important
-      removeDifferentElements($children, $parent.contents());
-      parentNode.appendChild(this.dummyDivRef.current);
-    };
+    return undefined;
   }
-
-  component;
 
   createEffects(): InfernoEffect[] {
     return [new InfernoEffect(this.renderTemplate, [this.props.template])];
@@ -55,10 +64,7 @@ export class TemplateWrapper extends InfernoComponent<TemplateProps> {
     this._effects[0].update([this.props.template]);
   }
 
-  render(): JSX.Element {
-    return createElement('div', {
-      style: { display: 'none' },
-      ref: this.dummyDivRef,
-    });
+  render(): JSX.Element | null {
+    return null;
   }
 }


### PR DESCRIPTION
Added possibility to render our components in non `div` elements.
Reworked templates system (for compatibility with new `hydrate` behavior).