### PR TITLE
TreeList: Fix restoring row focus after filtering is cleared (T996500)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -307,6 +307,8 @@ const FocusController = core.ViewController.inherit((function() {
                     this._navigateToRow(focusedRowKey, true).done(focusedRowIndex => {
                         if(currentFocusedRowIndex >= 0 && focusedRowIndex < 0) {
                             this._focusRowByIndex();
+                        } else if(currentFocusedRowIndex < 0 && focusedRowIndex >= 0) {
+                            keyboardController.setFocusedRowIndex(focusedRowIndex);
                         }
                     });
                 }

--- a/js/ui/tree_list/ui.tree_list.focus.js
+++ b/js/ui/tree_list/ui.tree_list.focus.js
@@ -98,7 +98,7 @@ core.registerModule('focus', extend(true, {}, focusModule, {
                                 return that.keyOf(node.data) === key;
                             });
 
-                            let pageIndex = that.pageIndex();
+                            let pageIndex = -1;
 
                             if(offset >= 0) {
                                 pageIndex = Math.floor(offset / that.pageSize());


### PR DESCRIPTION
See https://devexpress.com/issue=T996500