### PR TITLE
DataGrid: Fix mac shortcuts

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -274,6 +274,8 @@ const KeyboardNavigationController = core.ViewController.inherit({
 
     // #region Key_Handlers
     _keyDownHandler: function(e) {
+        const isCommandKeyPressed = e.ctrl || e.metaKey;
+
         const isEditing = this._editingController.isEditing();
         let needStopPropagation = true;
         const originalEvent = e.originalEvent;
@@ -314,7 +316,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                     break;
 
                 case 'A':
-                    if(e.ctrl) {
+                    if(isCommandKeyPressed) {
                         this._ctrlAKeyHandler(e, isEditing);
                     } else {
                         this._beginFastEditing(e.originalEvent);
@@ -334,7 +336,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                     break;
 
                 case 'F':
-                    if(e.ctrl) {
+                    if(isCommandKeyPressed) {
                         this._ctrlFKeyHandler(e);
                     } else {
                         this._beginFastEditing(e.originalEvent);
@@ -471,7 +473,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
         }
     },
     _ctrlAKeyHandler: function(eventArgs, isEditing) {
-        if(!isEditing && eventArgs.ctrl && !eventArgs.alt && this.option('selection.mode') === 'multiple' && this.option('selection.allowSelectAll')) {
+        if(!isEditing && !eventArgs.alt && this.option('selection.mode') === 'multiple' && this.option('selection.allowSelectAll')) {
             this._selectionController.selectAll();
             eventArgs.originalEvent.preventDefault();
         }

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -6,7 +6,7 @@ import gridCoreUtils from './ui.grid_core.utils';
 import { isDefined, isEmptyObject } from '../../core/utils/type';
 import { inArray } from '../../core/utils/array';
 import { focused } from '../widget/selectors';
-import { addNamespace, createEvent } from '../../events/utils/index';
+import { addNamespace, createEvent, isCommandKeyPressed } from '../../events/utils/index';
 import pointerEvents from '../../events/pointer';
 import { name as clickEventName } from '../../events/click';
 import { noop } from '../../core/utils/common';
@@ -274,8 +274,6 @@ const KeyboardNavigationController = core.ViewController.inherit({
 
     // #region Key_Handlers
     _keyDownHandler: function(e) {
-        const isCommandKeyPressed = e.ctrl || e.metaKey;
-
         const isEditing = this._editingController.isEditing();
         let needStopPropagation = true;
         const originalEvent = e.originalEvent;
@@ -316,7 +314,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                     break;
 
                 case 'A':
-                    if(isCommandKeyPressed) {
+                    if(isCommandKeyPressed(e.originalEvent)) {
                         this._ctrlAKeyHandler(e, isEditing);
                     } else {
                         this._beginFastEditing(e.originalEvent);
@@ -336,7 +334,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                     break;
 
                 case 'F':
-                    if(isCommandKeyPressed) {
+                    if(isCommandKeyPressed(e.originalEvent)) {
                         this._ctrlFKeyHandler(e);
                     } else {
                         this._beginFastEditing(e.originalEvent);

--- a/js/ui/grid_core/ui.grid_core.sorting.js
+++ b/js/ui/grid_core/ui.grid_core.sorting.js
@@ -5,7 +5,7 @@ import { isDefined } from '../../core/utils/type';
 import { extend } from '../../core/utils/extend';
 import sortingMixin from '../grid_core/ui.grid_core.sorting_mixin';
 import messageLocalization from '../../localization/message';
-import { addNamespace } from '../../events/utils/index';
+import { addNamespace, isCommandKeyPressed } from '../../events/utils/index';
 
 const COLUMN_HEADERS_VIEW_NAMESPACE = 'dxDataGridColumnHeadersView';
 
@@ -50,7 +50,7 @@ const ColumnHeadersViewSortingExtender = extend({}, sortingMixin, {
         if(column && !isDefined(column.groupIndex) && !column.command) {
             if(event.shiftKey) {
                 keyName = 'shift';
-            } else if(event.ctrlKey) {
+            } else if(isCommandKeyPressed(event)) {
                 keyName = 'ctrl';
             }
             setTimeout(() => {

--- a/testing/helpers/grid/keyboardNavigationHelper.js
+++ b/testing/helpers/grid/keyboardNavigationHelper.js
@@ -121,9 +121,11 @@ export function triggerKeyDown(key, ctrl, shift, target, result) {
         stopPropagation: false
     };
     let alt = false;
+    let meta = false;
     if(typeof ctrl === 'object') {
         alt = ctrl.alt;
         shift = ctrl.shift;
+        meta = ctrl.meta;
         ctrl = ctrl.ctrl;
     }
 
@@ -135,6 +137,7 @@ export function triggerKeyDown(key, ctrl, shift, target, result) {
         ctrlKey: ctrl,
         shiftKey: shift,
         altKey: alt,
+        metaKey: meta,
         target: target && target[0] || target,
         type: 'keydown',
         preventDefault: function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsHeadersView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsHeadersView.tests.js
@@ -2852,6 +2852,32 @@ QUnit.module('Multiple sorting', {
             cellWidthDiff: -12
         });
     });
+
+    ['ctrlKey', 'metaKey'].forEach((key) => {
+        QUnit.test(`${key} + click should reset sort order`, function(assert) {
+            // arrange
+            const $testElement = this.$element().addClass('dx-widget');
+            const options = {
+                sorting: {
+                    mode: 'multiple'
+                }
+            };
+
+            this.setupDataGrid(options);
+
+            // act
+            this.columnHeadersView.render($testElement);
+            const $headerCells = $testElement.find('.dx-header-row').children();
+
+            $headerCells.eq(1).trigger($.Event('dxclick', {[key]: true}));
+            this.clock.tick();
+
+            let cols = this.columnsController.getVisibleColumns();
+            assert.strictEqual(cols[0].sortOrder, undefined, 'first column has not sort order');
+            assert.strictEqual(cols[1].sortOrder, undefined, 'second column has not sort order');
+            assert.strictEqual(cols[2].sortOrder, 'asc', 'third column has sort order');
+        });
+    });
 });
 
 QUnit.module('Headers with RTL', {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsHeadersView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsHeadersView.tests.js
@@ -2869,10 +2869,10 @@ QUnit.module('Multiple sorting', {
             this.columnHeadersView.render($testElement);
             const $headerCells = $testElement.find('.dx-header-row').children();
 
-            $headerCells.eq(1).trigger($.Event('dxclick', {[key]: true}));
+            $headerCells.eq(1).trigger($.Event('dxclick', { [key]: true }));
             this.clock.tick();
 
-            let cols = this.columnsController.getVisibleColumns();
+            const cols = this.columnsController.getVisibleColumns();
             assert.strictEqual(cols[0].sortOrder, undefined, 'first column has not sort order');
             assert.strictEqual(cols[1].sortOrder, undefined, 'second column has not sort order');
             assert.strictEqual(cols[2].sortOrder, 'asc', 'third column has sort order');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
@@ -3470,7 +3470,7 @@ QUnit.module('Keyboard keys', {
     }, {
         ctrl: true
     }].forEach((keyConfig) => {
-        let keyName = keyConfig.meta ? "Command" : "Ctrl";
+        const keyName = keyConfig.meta ? 'Command' : 'Ctrl';
 
         QUnit.testInActiveWindow(`${keyName} + F`, function(assert) {
             // arrange
@@ -3536,7 +3536,7 @@ QUnit.module('Keyboard keys', {
 
             this.focusFirstCell();
 
-            const isPreventDefaultCalled = this.triggerKeyDown('A', {...keyConfig, alt: true }).preventDefault;
+            const isPreventDefaultCalled = this.triggerKeyDown('A', { ...keyConfig, alt: true }).preventDefault;
 
             // assert
             assert.notOk(this.selectionOptions.isSelectAllCalled, 'selectAll is not called');
@@ -3564,7 +3564,7 @@ QUnit.module('Keyboard keys', {
     });
 
     QUnit.testInActiveWindow('key A_T103450 ', function(assert) {
-            // arrange, act
+        // arrange, act
         setupModules(this);
         $.extend(this.options.editing, { mode: 'batch', allowUpdating: true });
         this.options.selection = { mode: 'multiple' };

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
@@ -3465,98 +3465,106 @@ QUnit.module('Keyboard keys', {
         assert.equal($('#container .dx-group-row').first().attr('tabIndex'), '0', 'first group row has tabIndex');
     });
 
-    QUnit.testInActiveWindow('Ctrl + F', function(assert) {
-        // arrange
-        setupModules(this);
+    [{
+        meta: true,
+    }, {
+        ctrl: true
+    }].forEach((keyConfig) => {
+        let keyName = keyConfig.meta ? "Command" : "Ctrl";
 
-        // act
-        this.options.searchPanel = {
-            visible: true
-        };
+        QUnit.testInActiveWindow(`${keyName} + F`, function(assert) {
+            // arrange
+            setupModules(this);
 
-        this.gridView.render($('#container'));
+            // act
+            this.options.searchPanel = {
+                visible: true
+            };
 
-        $(this.rowsView.element()).click();
+            this.gridView.render($('#container'));
 
-        const isPreventDefaultCalled = this.triggerKeyDown('F', true).preventDefault;
-        const $searchPanelElement = $('.dx-datagrid-search-panel');
+            $(this.rowsView.element()).click();
 
-        // assert
-        assert.ok($searchPanelElement.hasClass('dx-state-focused'), 'search panel has focus class');
-        assert.ok($searchPanelElement.find(':focus').hasClass('dx-texteditor-input'), 'search panel\'s editor is focused');
-        assert.ok(isPreventDefaultCalled, 'preventDefault is called');
-    });
+            const isPreventDefaultCalled = this.triggerKeyDown('F', keyConfig).preventDefault;
+            const $searchPanelElement = $('.dx-datagrid-search-panel');
 
-    QUnit.testInActiveWindow('Select all rows by Ctrl + A do not work when allowSelectAll is false', function(assert) {
-        // arrange
-        setupModules(this);
+            // assert
+            assert.ok($searchPanelElement.hasClass('dx-state-focused'), 'search panel has focus class');
+            assert.ok($searchPanelElement.find(':focus').hasClass('dx-texteditor-input'), 'search panel\'s editor is focused');
+            assert.ok(isPreventDefaultCalled, 'preventDefault is called');
+        });
 
-        // arrange, act
-        this.options.selection = { mode: 'multiple' };
-        this.gridView.render($('#container'));
+        QUnit.testInActiveWindow(`Select all rows by ${keyName} + A do not work when allowSelectAll is false`, function(assert) {
+            // arrange
+            setupModules(this);
 
-        this.focusFirstCell();
+            // arrange, act
+            this.options.selection = { mode: 'multiple' };
+            this.gridView.render($('#container'));
 
-        this.triggerKeyDown('A', true);
+            this.focusFirstCell();
 
-        // assert
-        assert.ok(!this.selectionOptions.isSelectAllCalled, 'selectAll is not called');
-    });
+            this.triggerKeyDown('A', keyConfig);
 
-    QUnit.testInActiveWindow('Select all rows by Ctrl + A when allowSelectAll is true', function(assert) {
-        // arrange, act
-        setupModules(this);
+            // assert
+            assert.ok(!this.selectionOptions.isSelectAllCalled, 'selectAll is not called');
+        });
 
-        this.options.selection = { mode: 'multiple', allowSelectAll: true };
-        this.gridView.render($('#container'));
+        QUnit.testInActiveWindow(`Select all rows by ${keyName} + A when allowSelectAll is true`, function(assert) {
+            // arrange, act
+            setupModules(this);
 
-        this.focusFirstCell();
+            this.options.selection = { mode: 'multiple', allowSelectAll: true };
+            this.gridView.render($('#container'));
 
-        const isPreventDefaultCalled = this.triggerKeyDown('A', true).preventDefault;
+            this.focusFirstCell();
 
-        // assert
-        assert.ok(this.selectionOptions.isSelectAllCalled, 'selection rows count');
-        assert.ok(isPreventDefaultCalled, 'preventDefault is called');
-    });
+            const isPreventDefaultCalled = this.triggerKeyDown('A', keyConfig).preventDefault;
 
-    // T518574
-    QUnit.testInActiveWindow('Select all should not work on AltGr + A when allowSelectAll is true', function(assert) {
-        // arrange, act
-        setupModules(this);
+            // assert
+            assert.ok(this.selectionOptions.isSelectAllCalled, 'selection rows count');
+            assert.ok(isPreventDefaultCalled, 'preventDefault is called');
+        });
 
-        this.options.selection = { mode: 'multiple', allowSelectAll: true };
-        this.gridView.render($('#container'));
+        // T518574
+        QUnit.testInActiveWindow(`Select all should not work on ${keyName} + AltGr + A when allowSelectAll is true`, function(assert) {
+            // arrange, act
+            setupModules(this);
 
-        this.focusFirstCell();
+            this.options.selection = { mode: 'multiple', allowSelectAll: true };
+            this.gridView.render($('#container'));
 
-        const isPreventDefaultCalled = this.triggerKeyDown('A', { ctrl: true, alt: true }).preventDefault;
+            this.focusFirstCell();
 
-        // assert
-        assert.notOk(this.selectionOptions.isSelectAllCalled, 'selectAll is not called');
-        assert.notOk(isPreventDefaultCalled, 'preventDefault is not called');
-    });
+            const isPreventDefaultCalled = this.triggerKeyDown('A', {...keyConfig, alt: true }).preventDefault;
 
-    QUnit.testInActiveWindow('Ctrl + A when cell is editing does not prevent default handler', function(assert) {
-        // arrange, act
-        setupModules(this);
+            // assert
+            assert.notOk(this.selectionOptions.isSelectAllCalled, 'selectAll is not called');
+            assert.notOk(isPreventDefaultCalled, 'preventDefault is not called');
+        });
 
-        $.extend(this.options.editing, { mode: 'batch' });
-        this.options.selection = { mode: 'multiple', allowSelectAll: true };
-        this.gridView.render($('#container'));
+        QUnit.testInActiveWindow(`${keyName} + A when cell is editing does not prevent default handler`, function(assert) {
+            // arrange, act
+            setupModules(this);
 
-        this.editingController.editCell(0, 0);
-        this.clock.tick();
-        this.focusFirstCell();
+            $.extend(this.options.editing, { mode: 'batch' });
+            this.options.selection = { mode: 'multiple', allowSelectAll: true };
+            this.gridView.render($('#container'));
 
-        const isPreventDefaultCalled = this.triggerKeyDown('A', true).preventDefault;
+            this.editingController.editCell(0, 0);
+            this.clock.tick();
+            this.focusFirstCell();
 
-        // assert
-        assert.ok(!this.selectionOptions.isSelectAllCalled, 'The select all is not called');
-        assert.ok(!isPreventDefaultCalled, 'preventDefault is not called');
+            const isPreventDefaultCalled = this.triggerKeyDown('A', keyConfig).preventDefault;
+
+            // assert
+            assert.ok(!this.selectionOptions.isSelectAllCalled, 'The select all is not called');
+            assert.ok(!isPreventDefaultCalled, 'preventDefault is not called');
+        });
     });
 
     QUnit.testInActiveWindow('key A_T103450 ', function(assert) {
-        // arrange, act
+            // arrange, act
         setupModules(this);
         $.extend(this.options.editing, { mode: 'batch', allowUpdating: true });
         this.options.selection = { mode: 'multiple' };


### PR DESCRIPTION
Add support for `⌘` key in DataGrid

I used `isCommandKeyPressed` function from `js/events/utils/index.js` where it was possible

Unfortunately, I couldn't use that function in `js/ui/grid_core/ui.grid_core.keyboard_navigation.js`, because keyboard processor 
use `ctrl` field instead of `ctrlKey`

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/17542