### PR TITLE
DataGrid & TreeList - add return promise to navigateToRow method

### DIFF
--- a/js/renovation/ui/grids/data_grid/data_grid.tsx
+++ b/js/renovation/ui/grids/data_grid/data_grid.tsx
@@ -279,7 +279,7 @@ export class DataGrid extends JSXComponent(DataGridProps) implements DataGridFor
   }
 
   @Method()
-  navigateToRow(key: any): void {
+  navigateToRow(key: any): DxPromise<number> {
     return this.instance?.navigateToRow(key);
   }
 

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -199,7 +199,7 @@ export interface RowDraggingTemplateDataModel {
   readonly itemElement: DxElement;
 }
 
-export interface FilterPanelCustomizeTextArg<T> { 
+export interface FilterPanelCustomizeTextArg<T> {
   readonly component: T,
   readonly filterValue: any,
   readonly text: string
@@ -2427,8 +2427,9 @@ export interface GridBase {
      * @param1 key:any
      * @prevFileNamespace DevExpress.ui
      * @public
+     * @return Promise<number>
      */
-    navigateToRow(key: any): void;
+    navigateToRow(key: any): DxPromise<number>;
     /**
      * @docid
      * @publicName pageCount()
@@ -3407,7 +3408,7 @@ export type RowDraggingRemoveEvent = RowDraggingEventInfo<dxDataGrid>;
 /** @public */
 export type RowDraggingReorderEvent = RowDraggingEventInfo<dxDataGrid> & DragReorderInfo;
 
-/** @public */ 
+/** @public */
 export type ColumnButtonClickEvent = NativeEventInfo<dxDataGrid> & {
   row?: RowObject;
   column?: Column;
@@ -4844,7 +4845,7 @@ declare class dxDataGrid extends Widget implements GridBase {
     isRowFocused(key: any): boolean;
     isRowSelected(key: any): boolean;
     keyOf(obj: any): any;
-    navigateToRow(key: any): void;
+    navigateToRow(key: any): DxPromise<number>;
     pageCount(): number;
     pageIndex(): number;
     pageIndex(newIndex: number): DxPromise<void>;

--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -867,7 +867,7 @@ export const focusModule = {
                         const scrollHandler = () => {
                             scrollable.off('scroll', scrollHandler);
                             d.resolve();
-                        }
+                        };
 
                         if(scrollTop !== currentScrollTop) {
                             scrollable.on('scroll', scrollHandler);

--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -180,7 +180,7 @@ const FocusController = core.ViewController.inherit((function() {
             if(!this.isAutoNavigateToFocusedRow()) {
                 this.option('focusedRowIndex', -1);
             }
-            this._navigateToRow(key);
+            return this._navigateToRow(key);
         },
         _navigateToRow: function(key, needFocusRow) {
             const that = this;
@@ -235,7 +235,8 @@ const FocusController = core.ViewController.inherit((function() {
             if(needFocusRow) {
                 this._triggerUpdateFocusedRow(key, deferred);
             } else {
-                this.getView('rowsView').scrollToRowElement(key);
+                const focusedRowIndex = this.getFocusedRowIndexByKey(key);
+                this.getView('rowsView').scrollToRowElement(key, deferred).done(() => deferred.resolve(focusedRowIndex));
             }
         },
         _navigateToVirtualRow: function(key, deferred, needFocusRow) {
@@ -249,15 +250,20 @@ const FocusController = core.ViewController.inherit((function() {
                 const focusedRowIndex = rowIndex + dataController.getRowIndexOffset(true);
                 const offset = rowsScrollController.getItemOffset(focusedRowIndex);
 
-                if(needFocusRow) {
-                    const triggerUpdateFocusedRow = function() {
-                        that.component.off('contentReady', triggerUpdateFocusedRow);
+                const triggerUpdateFocusedRow = function() {
+                    that.component.off('contentReady', triggerUpdateFocusedRow);
+
+                    if(needFocusRow) {
                         that._triggerUpdateFocusedRow(key, deferred);
-                    };
-                    that.component.on('contentReady', triggerUpdateFocusedRow);
-                }
+                    } else {
+                        deferred.resolve(focusedRowIndex);
+                    }
+                };
+                that.component.on('contentReady', triggerUpdateFocusedRow);
 
                 scrollable.scrollTo({ y: offset });
+            } else {
+                deferred.resolve(-1);
             }
         },
 
@@ -266,18 +272,22 @@ const FocusController = core.ViewController.inherit((function() {
             const focusedRowIndex = this.getFocusedRowIndexByKey(key);
 
             if(this._isValidFocusedRowIndex(focusedRowIndex)) {
+                let d;
+
                 if(this.option('focusedRowEnabled')) {
                     dataController.updateItems({
                         changeType: 'updateFocusedRow',
                         focusedRowKey: key
                     });
                 } else {
-                    this.getView('rowsView').scrollToRowElement(key);
+                    d = this.getView('rowsView').scrollToRowElement(key);
                 }
 
-                this.getController('keyboardNavigation').setFocusedRowIndex(focusedRowIndex);
+                when(d).done(() => {
+                    this.getController('keyboardNavigation').setFocusedRowIndex(focusedRowIndex);
 
-                deferred && deferred.resolve(focusedRowIndex);
+                    deferred && deferred.resolve(focusedRowIndex);
+                });
             } else {
                 deferred && deferred.resolve(-1);
             }
@@ -832,16 +842,43 @@ export const focusModule = {
                 scrollToRowElement: function(key) {
                     const rowIndex = this.getController('data').getRowIndexByKey(key);
                     const $row = $(this.getRow(rowIndex));
-                    this.scrollToElementVertically($row);
+
+                    return this.scrollToElementVertically($row);
                 },
 
                 scrollToElementVertically: function($row) {
                     const scrollable = this.getScrollable();
+
                     if(scrollable) {
                         const position = scrollable.getScrollElementPosition($row, 'vertical');
-                        scrollable.scrollTo({ top: position });
+
+                        return this._scrollTopPosition(position);
                     }
-                }
+
+                    return (new Deferred()).resolve();
+                },
+
+                _scrollTopPosition: function(scrollTop) {
+                    const d = new Deferred();
+                    const scrollable = this.getScrollable();
+
+                    if(scrollable) {
+                        const currentScrollTop = scrollable.scrollTop();
+                        const scrollHandler = () => {
+                            scrollable.off('scroll', scrollHandler);
+                            d.resolve();
+                        }
+
+                        if(scrollTop !== currentScrollTop) {
+                            scrollable.on('scroll', scrollHandler);
+                            scrollable.scrollTo({ top: scrollTop });
+
+                            return d.promise();
+                        }
+                    }
+
+                    return d.resolve();
+                },
             }
         }
     }

--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -236,7 +236,9 @@ const FocusController = core.ViewController.inherit((function() {
                 this._triggerUpdateFocusedRow(key, deferred);
             } else {
                 const focusedRowIndex = this.getFocusedRowIndexByKey(key);
-                this.getView('rowsView').scrollToRowElement(key, deferred).done(() => deferred.resolve(focusedRowIndex));
+                this.getView('rowsView').scrollToRowElement(key, deferred).done(function() {
+                    deferred.resolve(focusedRowIndex);
+                });
             }
         },
         _navigateToVirtualRow: function(key, deferred, needFocusRow) {

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1229,7 +1229,7 @@ export default class dxTreeList extends Widget implements GridBase {
     isRowFocused(key: any): boolean;
     isRowSelected(key: any): boolean;
     keyOf(obj: any): any;
-    navigateToRow(key: any): void;
+    navigateToRow(key: any): DxPromise<number>;
     pageCount(): number;
     pageIndex(): number;
     pageIndex(newIndex: number): DxPromise<void>;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -3432,7 +3432,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getScrollable()._container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(500);
 
         // assert
         assert.strictEqual(d.state(), 'resolved', 'row is navigated');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -3432,7 +3432,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getScrollable()._container()).trigger('scroll');
-        this.clock.tick(500);
+        this.clock.tick();
 
         // assert
         assert.strictEqual(d.state(), 'resolved', 'row is navigated');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -3281,6 +3281,150 @@ QUnit.module('API methods', baseModuleConfig, () => {
         assert.strictEqual(visibleColumns[1].dataField, 'field2', 'dataField of the second column in the second row');
         assert.strictEqual(visibleColumns[2].dataField, 'field3', 'dataField of the third column in the second row');
     });
+
+    QUnit.test('navigateToRow should return promise', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            loadingTimeout: null,
+            dataSource: [{ 'id': 0 }, { 'id': 1 }, { 'id': 2 }, { 'id': 3 }],
+            keyExpr: 'id',
+            paging: {
+                pageSize: 2
+            }
+        });
+        const callback = sinon.spy();
+
+        // act
+        const d = dataGrid.navigateToRow(3);
+
+        // assert
+        assert.ok(typeUtils.isFunction(d.promise), 'type object is the Deferred');
+        d.done(callback);
+
+        assert.strictEqual(d.state(), "resolved", 'row is navigated');
+
+        // promise value should be an index of row in this page
+        // for row with id `3` it is `1`
+        assert.strictEqual(callback.getCall(0).args[0], 1, 'promise value is correct');
+    });
+
+    QUnit.test('navigateToRow should return promise: remoteOperations is true', function(assert) {
+        // arrange
+        let items = [];
+        let deferred;
+        const dataStore = new ArrayStore([ { 'id': 0 }, { 'id': 1 }, { 'id': 2 }, { 'id': 3 } ]);
+
+        const dataGrid = createDataGrid({
+            loadingTimeout: null,
+            remoteOperations: true,
+            dataSource: {
+                key: "id",
+                load: function (loadOptions) {
+                    deferred = $.Deferred();
+
+                    dataStore.load(loadOptions).done(function(data) {
+                        items = data;
+                    });
+
+                    return deferred.promise();
+                }
+            },
+            paging: {
+                pageSize: 2
+            }
+        });
+        const callback = sinon.spy();
+
+        // act
+        deferred.resolve(items, { totalCount: 4 }); // resolve first page that is already visible
+
+        // assert
+        assert.strictEqual(dataGrid.getVisibleRows().length, 2, 'visible row count is correct');
+
+        // act
+        const d = dataGrid.navigateToRow(3).done(callback);
+
+        // assert
+        assert.ok(typeUtils.isFunction(d.promise), 'type object is the Deferred');
+        assert.strictEqual(d.state(), 'pending', 'page isn\'t resolved yet');
+
+        // act
+        deferred.resolve(items);                    // search for item's index
+        deferred.resolve(items, { totalCount: 3 }); // search for item's page
+        deferred.resolve(items, { totalCount: 4 }); // resolve second page
+
+        // assert
+        assert.strictEqual(d.state(), 'resolved', 'page is resolved');
+
+        // promise value should be an index of row in this page
+        // for row with id `3` it is `1`
+        assert.strictEqual(callback.getCall(0).args[0], 1, 'promise value is correct');
+    });
+
+    QUnit.test('navigateToRow should return promise: one large page', function(assert) {
+        // arrange
+        const data = [...Array(20).keys()].map(i => ({id: i}));
+
+        const dataGrid = createDataGrid({
+            loadingTimeout: null,
+            dataSource: data,
+            keyExpr: 'id',
+            paging: {
+                pageSize: 20
+            },
+            scrolling: {
+                useNative: true
+            },
+            height: 100
+        });
+
+        // act
+        const d = dataGrid.navigateToRow(15);
+
+        // assert
+        assert.ok(typeUtils.isFunction(d.promise), 'type object is the Deferred');
+        assert.strictEqual(d.state(), "pending", 'row is not navigated');
+
+        // act
+        $(dataGrid.getScrollable()._container()).trigger('scroll'); // need to trigger scroll manually to resolve deffered
+
+        // assert
+        assert.strictEqual(d.state(), "resolved", 'row is navigated');
+    });
+
+    QUnit.test('navigateToRow should return promise: virtual scrolling', function(assert) {
+        // arrange
+        const data = [...Array(20).keys()].map(i => ({ id: i }));
+
+        const dataGrid = createDataGrid({
+            loadingTimeout: null,
+            dataSource: data,
+            keyExpr: 'id',
+            paging: {
+                pageSize: 20
+            },
+            scrolling: {
+                useNative: true,
+                mode: "virtual",
+                rowRenderingMode: "virtual"
+            },
+            height: 100
+        });
+
+        // act
+        const d = dataGrid.navigateToRow(18);
+
+        // assert
+        assert.ok(typeUtils.isFunction(d.promise), 'type object is the Deferred');
+        assert.strictEqual(d.state(), "pending", 'row is not navigated');
+
+        // act
+        $(dataGrid.getScrollable()._container()).trigger('scroll');
+        this.clock.tick(500);
+
+        // assert
+        assert.strictEqual(d.state(), "resolved", 'row is navigated');
+    });
 });
 
 QUnit.module('templates', baseModuleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -3301,7 +3301,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         assert.ok(typeUtils.isFunction(d.promise), 'type object is the Deferred');
         d.done(callback);
 
-        assert.strictEqual(d.state(), "resolved", 'row is navigated');
+        assert.strictEqual(d.state(), 'resolved', 'row is navigated');
 
         // promise value should be an index of row in this page
         // for row with id `3` it is `1`
@@ -3318,8 +3318,8 @@ QUnit.module('API methods', baseModuleConfig, () => {
             loadingTimeout: null,
             remoteOperations: true,
             dataSource: {
-                key: "id",
-                load: function (loadOptions) {
+                key: 'id',
+                load: function(loadOptions) {
                     deferred = $.Deferred();
 
                     dataStore.load(loadOptions).done(function(data) {
@@ -3349,7 +3349,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         assert.strictEqual(d.state(), 'pending', 'page isn\'t resolved yet');
 
         // act
-        deferred.resolve(items);                    // search for item's index
+        deferred.resolve(items); // search for item's index
         deferred.resolve(items, { totalCount: 3 }); // search for item's page
         deferred.resolve(items, { totalCount: 4 }); // resolve second page
 
@@ -3363,7 +3363,13 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
     QUnit.test('navigateToRow should return promise: one large page', function(assert) {
         // arrange
-        const data = [...Array(20).keys()].map(i => ({id: i}));
+        const data = [];
+
+        for(let i = 0; i < 20; i++) {
+            data.push({
+                id: i
+            });
+        }
 
         const dataGrid = createDataGrid({
             loadingTimeout: null,
@@ -3383,18 +3389,24 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // assert
         assert.ok(typeUtils.isFunction(d.promise), 'type object is the Deferred');
-        assert.strictEqual(d.state(), "pending", 'row is not navigated');
+        assert.strictEqual(d.state(), 'pending', 'row is not navigated');
 
         // act
         $(dataGrid.getScrollable()._container()).trigger('scroll'); // need to trigger scroll manually to resolve deffered
 
         // assert
-        assert.strictEqual(d.state(), "resolved", 'row is navigated');
+        assert.strictEqual(d.state(), 'resolved', 'row is navigated');
     });
 
     QUnit.test('navigateToRow should return promise: virtual scrolling', function(assert) {
         // arrange
-        const data = [...Array(20).keys()].map(i => ({ id: i }));
+        const data = [];
+
+        for(let i = 0; i < 20; i++) {
+            data.push({
+                id: i
+            });
+        }
 
         const dataGrid = createDataGrid({
             loadingTimeout: null,
@@ -3405,8 +3417,8 @@ QUnit.module('API methods', baseModuleConfig, () => {
             },
             scrolling: {
                 useNative: true,
-                mode: "virtual",
-                rowRenderingMode: "virtual"
+                mode: 'virtual',
+                rowRenderingMode: 'virtual'
             },
             height: 100
         });
@@ -3416,14 +3428,14 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // assert
         assert.ok(typeUtils.isFunction(d.promise), 'type object is the Deferred');
-        assert.strictEqual(d.state(), "pending", 'row is not navigated');
+        assert.strictEqual(d.state(), 'pending', 'row is not navigated');
 
         // act
         $(dataGrid.getScrollable()._container()).trigger('scroll');
         this.clock.tick(500);
 
         // assert
-        assert.strictEqual(d.state(), "resolved", 'row is navigated');
+        assert.strictEqual(d.state(), 'resolved', 'row is navigated');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
@@ -1548,6 +1548,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
     QUnit.test('TreeList navigateTo', function(assert) {
         // arrange
         const treeList = createTreeList({
+            loadingTimeout: null,
             dataSource: generateData(10),
             paging: {
                 pageSize: 4
@@ -1556,8 +1557,6 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
         const callback = sinon.spy();
 
         // act
-        this.clock.tick();
-
         const d = treeList.navigateToRow(12);
         d.done(callback);
 
@@ -1575,6 +1574,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
     QUnit.test('TreeList navigateTo to the same page with expand', function(assert) {
         // arrange
         const treeList = createTreeList({
+            loadingTimeout: null,
             dataSource: generateData(10),
             paging: {
                 pageSize: 4
@@ -1603,6 +1603,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
     QUnit.test('TreeList navigateTo to the collapsed child row when scrolling is standard', function(assert) {
         // arrange
         const treeList = createTreeList({
+            loadingTimeout: null,
             height: 100,
             dataSource: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, {
                 id: 5,
@@ -1611,17 +1612,19 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
             scrolling: {
                 mode: 'standard',
             },
+            paging: {
+                enabled: true
+            },
             keyExpr: 'id',
             parentIdExpr: 'parent_id',
             columns: ['id']
         });
         const callback = sinon.spy();
 
-        this.clock.tick();
-
         const d = treeList.navigateToRow(5);
         d.done(callback);
 
+        $(treeList.getScrollable()._container()).trigger('scroll');
         this.clock.tick();
 
         // assert

--- a/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
@@ -1546,40 +1546,54 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
     });
 
     QUnit.test('TreeList navigateTo', function(assert) {
-        // arrange, act
+        // arrange
         const treeList = createTreeList({
             dataSource: generateData(10),
             paging: {
                 pageSize: 4
             }
         });
+        const callback = sinon.spy();
 
+        // act
         this.clock.tick();
 
-        treeList.navigateToRow(12);
+        const d = treeList.navigateToRow(12);
+        d.done(callback);
+
         this.clock.tick();
 
         // assert
+        assert.strictEqual(d.state(), 'resolved', 'promise is resolved');
+        assert.strictEqual(callback.getCall(0).args[0], 6, 'promise value is correct');
+
         assert.deepEqual(treeList.option('expandedRowKeys'), [11], 'parent node is expanded');
         assert.equal(treeList.pageIndex(), 1, 'page is changed');
         assert.ok(treeList.getRowIndexByKey(12) >= 0, 'key is visible');
     });
 
     QUnit.test('TreeList navigateTo to the same page with expand', function(assert) {
-        // arrange, act
+        // arrange
         const treeList = createTreeList({
             dataSource: generateData(10),
             paging: {
                 pageSize: 4
             }
         });
+        const callback = sinon.spy();
 
+        // act
         this.clock.tick();
 
-        treeList.navigateToRow(2);
+        const d = treeList.navigateToRow(2);
+        d.done(callback);
+
         this.clock.tick();
 
         // assert
+        assert.strictEqual(d.state(), 'resolved', 'promise is resolved');
+        assert.strictEqual(callback.getCall(0).args[0], 1, 'promise value is correct');
+
         assert.deepEqual(treeList.option('expandedRowKeys'), [1], 'parent node is expanded');
         assert.equal(treeList.pageIndex(), 0, 'page is not changed');
         assert.ok(treeList.getRowIndexByKey(2) >= 0, 'key is visible');
@@ -1601,13 +1615,19 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
             parentIdExpr: 'parent_id',
             columns: ['id']
         });
+        const callback = sinon.spy();
 
         this.clock.tick();
 
-        treeList.navigateToRow(5);
+        const d = treeList.navigateToRow(5);
+        d.done(callback);
+
         this.clock.tick();
 
         // assert
+        assert.strictEqual(d.state(), 'resolved', 'promise is resolved');
+        assert.strictEqual(callback.getCall(0).args[0], 4, 'promise value is correct');
+
         assert.deepEqual(treeList.option('expandedRowKeys'), [4], 'parent node is expanded');
         assert.ok(treeList.getRowIndexByKey(5) >= 0, 'key is visible');
     });

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -5134,7 +5134,7 @@ declare module DevExpress.ui {
     isRowFocused(key: any): boolean;
     isRowSelected(key: any): boolean;
     keyOf(obj: any): any;
-    navigateToRow(key: any): void;
+    navigateToRow(key: any): DevExpress.core.utils.DxPromise<number>;
     pageCount(): number;
     pageIndex(): number;
     pageIndex(newIndex: number): DevExpress.core.utils.DxPromise<void>;
@@ -19125,7 +19125,7 @@ declare module DevExpress.ui {
     isRowFocused(key: any): boolean;
     isRowSelected(key: any): boolean;
     keyOf(obj: any): any;
-    navigateToRow(key: any): void;
+    navigateToRow(key: any): DevExpress.core.utils.DxPromise<number>;
     pageCount(): number;
     pageIndex(): number;
     pageIndex(newIndex: number): DevExpress.core.utils.DxPromise<void>;
@@ -20859,7 +20859,7 @@ declare module DevExpress.ui {
     /**
      * [descr:GridBase.navigateToRow(key)]
      */
-    navigateToRow(key: any): void;
+    navigateToRow(key: any): DevExpress.core.utils.DxPromise<number>;
     /**
      * [descr:GridBase.pageCount()]
      */


### PR DESCRIPTION
Cherry Picks:

- https://github.com/DevExpress/DevExtreme/pull/17618

---

Now `FocusController.navigateToRow` returns same promise as private method `_navigateToRow` returns. I got to change some others methods because deffered wasn't resolved in all cases. Also I added DataGrid tests for cases when:

- option `remoteOperations` is turned on (to check exactly when promise is resolved)
- `virtualScrolling` is turned on
- for page with lots of data and small height (to check that promise is resolved after scrolling)

and return value checking in TreeList tests, so all cases of `_navigateToRow` seemed to be covered.

Also I change typing in .d.ts files: now `navigateToRow()`'s return value is `DxPromise<number>`
 