### PR TITLE
Fix  unexpected 'Runner stalled' message + add suite testing time to output

### DIFF
--- a/testing/runner/Controllers/MainController.cs
+++ b/testing/runner/Controllers/MainController.cs
@@ -94,7 +94,7 @@ namespace Runner.Controllers
         }
 
         [HttpPost]
-        public void NotifySuiteFinalized(string name, bool passed)
+        public void NotifySuiteFinalized(string name, bool passed, int runtime)
         {
             Response.ContentType = "text/plain";
             lock (IO_SYNC)
@@ -111,11 +111,21 @@ namespace Runner.Controllers
                     Console.Write("FAIL");
                 }
                 Console.ResetColor();
-                Console.WriteLine("] " + name);
+                TimeSpan runSpan = TimeSpan.FromMilliseconds(runtime);
+                Console.WriteLine($"] {name} in {Math.Round(runSpan.TotalSeconds, 3)}s");
 
-                if (_runFlags.IsContinuousIntegration)
-                    IOFile.WriteAllText(Path.Combine(_env.ContentRootPath, "testing/LastSuiteTime.txt"), DateTime.Now.ToString("s"));
+                NotifyIsAlive();
             }
+        }
+
+        static readonly object IOLock = new object();
+
+        [HttpPost]
+        public void NotifyIsAlive() {
+            if (_runFlags.IsContinuousIntegration)
+                lock (IOLock) {
+                    IOFile.WriteAllText(Path.Combine(_env.ContentRootPath, "testing/LastSuiteTime.txt"), DateTime.Now.ToString("s"));
+                }
         }
 
         [HttpPost]

--- a/testing/runner/Views/Main/RunAll.cshtml
+++ b/testing/runner/Views/Main/RunAll.cshtml
@@ -404,6 +404,7 @@
             if($.now() - lastTestCaseDoneTime > 1000) {
                 lastTestCaseDoneTime = $.now();
                 notifyDeviceTestManager("QUnit.testCaseDone");
+                notifyIsAlive();
             }
 
             if(testSuite && StringEndsWith(qunitData.suiteUrl, escape(testSuite.name))) {
@@ -441,7 +442,7 @@
 
             if(suite) {
                 suite.finalize(passed, qunitData.total);
-                notifySuiteFinalized(suite.name, passed);
+                notifySuiteFinalized(suite.name, passed, qunitData.runtime);
             }
         };
 
@@ -474,9 +475,13 @@
             }
         }
 
-        function notifySuiteFinalized(name, passed) {
+        function notifySuiteFinalized(name, passed, runtime) {
             var url = @Html.Raw(Json.Serialize(Url.Action("NotifySuiteFinalized")));
-            $.post(url, { name: name, passed: passed });
+            $.post(url, { name: name, passed: passed, runtime: runtime });
+        }
+        function notifyIsAlive(){
+            var url = @Html.Raw(Json.Serialize(Url.Action("NotifyIsAlive")));
+            $.post(url);
         }
 
         function roundTime(time) {


### PR DESCRIPTION
This fixes 'Runner stalled' message for suites running more than 5 minutes by updating the `LastSuiteTime.txt` file every ~1 second if at least one test passed at this period of time.

This prevents the `start_runner_watchdog` (see `docker-ci.sh`) function from killing the test task when we have a long-running suite, but tests are not actually stuck.