### PR TITLE
Fix unexpected 'Runner stalled' message + add suite testing time to output 

### DIFF
--- a/testing/runner/Views/Main/RunAll.cshtml
+++ b/testing/runner/Views/Main/RunAll.cshtml
@@ -407,6 +407,7 @@
             if($.now() - lastTestCaseDoneTime > 1000) {
                 lastTestCaseDoneTime = $.now();
                 notifyDeviceTestManager("QUnit.testCaseDone");
+                notifyIsAlive();
             }
 
             if(testSuite && StringEndsWith(qunitData.suiteUrl, escape(testSuite.name))) {
@@ -444,7 +445,7 @@
 
             if(suite) {
                 suite.finalize(passed, qunitData.total);
-                notifySuiteFinalized(suite.name, passed);
+                notifySuiteFinalized(suite.name, passed, qunitData.runtime);
             }
         };
 
@@ -477,9 +478,13 @@
             }
         }
 
-        function notifySuiteFinalized(name, passed) {
+        function notifySuiteFinalized(name, passed, runtime) {
             var url = @Html.Raw(Json.Serialize(Url.Action("NotifySuiteFinalized")));
-            $.post(url, { name: name, passed: passed });
+            $.post(url, { name: name, passed: passed, runtime: runtime });
+        }
+        function notifyIsAlive(){
+            var url = @Html.Raw(Json.Serialize(Url.Action("NotifyIsAlive")));
+            $.post(url);
         }
 
         function roundTime(time) {


### PR DESCRIPTION
This fixes 'Runner stalled' message for suites running more than 5 minutes by updating the `LastSuiteTime.txt` file every ~1 second if at least one test passed at this period of time.

This prevents the `start_runner_watchdog` (see `docker-ci.sh`) function from killing the test task when we have a long-running suite, but tests are not actually stuck.