### PR TITLE
DataGrid: Fix duplicate digit in column editor when editing starts when editOnKeyPress is set to 'true' and format.precision is specified in editorOptions (T998365)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1578,7 +1578,9 @@ const KeyboardNavigationController = core.ViewController.inherit({
         const keyPressEvent = createEvent(eventArgs, { type: 'keypress', target: $input.get(0) });
         const inputEvent = createEvent(eventArgs, { type: 'input', target: $input.get(0) });
 
+        $input.get(0).select();
         eventsEngine.trigger($input, keyDownEvent);
+
         if(!keyDownEvent.isDefaultPrevented()) {
             eventsEngine.trigger($input, keyPressEvent);
             if(!keyPressEvent.isDefaultPrevented()) {

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1578,15 +1578,23 @@ const KeyboardNavigationController = core.ViewController.inherit({
         const keyPressEvent = createEvent(eventArgs, { type: 'keypress', target: $input.get(0) });
         const inputEvent = createEvent(eventArgs, { type: 'input', target: $input.get(0) });
 
-        !browser.msie && $input.get(0).select();
+        $input.get(0).select();
         eventsEngine.trigger($input, keyDownEvent);
 
         if(!keyDownEvent.isDefaultPrevented()) {
             eventsEngine.trigger($input, keyPressEvent);
             if(!keyPressEvent.isDefaultPrevented()) {
                 const timeout = browser.mozilla ? 25 : 0; // T882996
+
                 setTimeout(() => {
                     $input.val(editorValue);
+
+                    if(browser.msie) {
+                        gridCoreUtils.setSelectionRange($input.get(0), {
+                            selectionStart: editorValue.length,
+                            selectionEnd: editorValue.length
+                        });
+                    }
 
                     const $widgetContainer = $input.closest(`.${WIDGET_CLASS}`);
                     eventsEngine.off($widgetContainer, 'focusout'); // for NumberBox to save entered symbol

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1578,7 +1578,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
         const keyPressEvent = createEvent(eventArgs, { type: 'keypress', target: $input.get(0) });
         const inputEvent = createEvent(eventArgs, { type: 'input', target: $input.get(0) });
 
-        $input.get(0).select();
+        !browser.msie && $input.get(0).select();
         eventsEngine.trigger($input, keyDownEvent);
 
         if(!keyDownEvent.isDefaultPrevented()) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
@@ -2783,7 +2783,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(0, 1);
         this.triggerKeyDown('A');
-        this.clock.tick();
+        this.clock.tick(200);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
@@ -2861,5 +2861,47 @@ QUnit.module('Customize keyboard navigation', {
 
             assert.strictEqual($input.val(), 'a', 'entered value is correct');
         });
+
+        // T998365
+        testInDesktop(`${mode} - Input value should not be duplicated for a number column with format when editOnKeyPress is enabled'`, function(assert) {
+            // arrange
+            this.options = {
+                editing: {
+                    mode: mode.toLowerCase(),
+                    allowUpdating: true
+                },
+                keyboardNavigation: {
+                    editOnKeyPress: true
+                }
+            };
+
+            this.data = [{ name: 'Alex', room: 5 }];
+
+            this.columns = [
+                { dataField: 'name' },
+                {
+                    dataField: 'room',
+                    dataType: 'number',
+                    editorOptions: {
+                        type: 'number',
+                        format: {
+                            precision: 1
+                        }
+                    }
+                }
+            ];
+
+            this.setupModule();
+            this.renderGridView();
+
+            // act
+            this.focusCell(1, 0);
+            this.triggerKeyDown('5');
+            this.clock.tick(300);
+
+            // assert
+            const $input = $('.dx-row .dx-texteditor-input').eq(0);
+            assert.equal($input.val(), '5', 'input value');
+        });
     });
 });


### PR DESCRIPTION
See https://devexpress.com/issue=T998365