### PR TITLE
GridCore - add sortOrder option to columnChooser

### DIFF
--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -1084,7 +1084,13 @@ export interface ColumnChooser {
      * @docid GridBaseOptions.columnChooser.width
      * @default 250
      */
-    width?: number
+    width?: number,
+    /**
+     * @docid GridBaseOptions.columnChooser.sortOrder
+     * @type Enums.SortOrder
+     * @default undefined
+     */
+    sortOrder?: 'asc' | 'desc'
 }
 
 export interface ColumnFixing {
@@ -3065,7 +3071,7 @@ export type RowDraggingRemoveEvent = RowDraggingEventInfo<dxDataGrid>;
 /** @public */
 export type RowDraggingReorderEvent = RowDraggingEventInfo<dxDataGrid> & DragReorderInfo;
 
-/** @public */ 
+/** @public */
 export type ColumnButtonClickEvent = NativeEventInfo<dxDataGrid> & {
   row?: RowObject;
   column?: Column;

--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -960,6 +960,20 @@ export const columnsControllerModule = {
                 return column;
             };
 
+            const sortColumns = (columns, sortOrder) => {
+                if(sortOrder !== 'asc' && sortOrder !== 'desc') {
+                    return columns;
+                }
+
+                const sign = sortOrder === 'asc' ? 1 : -1;
+
+                columns.sort(function(column1, column2) {
+                    return sign * column1.caption.localeCompare(column2.caption);
+                });
+
+                return columns;
+            };
+
             return {
                 _getExpandColumnOptions: function() {
                     return {
@@ -1583,9 +1597,12 @@ export const columnsControllerModule = {
                     return result;
                 },
                 getChooserColumns: function(getAllColumns) {
-                    const columns = getAllColumns ? this.getColumns() : this.getInvisibleColumns();
+                    let columns = getAllColumns ? this.getColumns() : this.getInvisibleColumns();
+                    columns = grep(columns, function(column) { return column.showInColumnChooser; });
 
-                    return grep(columns, function(column) { return column.showInColumnChooser; });
+                    const sortOrder = this.option('columnChooser.sortOrder');
+
+                    return sortColumns(columns, sortOrder);
                 },
                 allowMoveColumn: function(fromVisibleIndex, toVisibleIndex, sourceLocation, targetLocation) {
                     const that = this;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnChooser.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnChooser.integration.tests.js
@@ -83,6 +83,82 @@ QUnit.module('Column chooser', baseModuleConfig, () => {
         assert.ok($overlayWrapper.hasClass('dx-datagrid-column-chooser-mode-select'), 'has select mode class');
     });
 
+    QUnit.test('Correct runtime changing of sortOrder (string)', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            loadingTimeout: null,
+            columns: [{
+                dataField: 'field1',
+                caption: 'B',
+                visible: false
+            }, {
+                dataField: 'field2',
+                caption: 'A',
+                visible: false
+            }],
+            columnChooser: {
+                sortOrder: 'asc'
+            },
+            dataSource: []
+        });
+
+        // act
+        dataGrid.showColumnChooser();
+
+        let $overlayWrapper = dataGrid.getView('columnChooserView')._popupContainer.$wrapper();
+
+        // assert
+        assert.strictEqual($overlayWrapper.find('.dx-treeview-item').eq(0).text(), 'A', 'first column');
+        assert.strictEqual($overlayWrapper.find('.dx-treeview-item').eq(1).text(), 'B', 'first column');
+
+        // act
+        dataGrid.option('columnChooser.sortOrder', 'desc');
+
+        $overlayWrapper = dataGrid.getView('columnChooserView')._popupContainer.$wrapper();
+
+        // assert
+        assert.strictEqual($overlayWrapper.find('.dx-treeview-item').eq(0).text(), 'B', 'first column');
+        assert.strictEqual($overlayWrapper.find('.dx-treeview-item').eq(1).text(), 'A', 'first column');
+    });
+
+    QUnit.test('Correct runtime changing of sortOrder (object)', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            loadingTimeout: null,
+            columns: [{
+                dataField: 'field1',
+                caption: 'B',
+                visible: false
+            }, {
+                dataField: 'field2',
+                caption: 'A',
+                visible: false
+            }],
+            columnChooser: {
+                sortOrder: 'asc'
+            },
+            dataSource: []
+        });
+
+        // act
+        dataGrid.showColumnChooser();
+
+        let $overlayWrapper = dataGrid.getView('columnChooserView')._popupContainer.$wrapper();
+
+        // assert
+        assert.strictEqual($overlayWrapper.find('.dx-treeview-item').eq(0).text(), 'A', 'first column');
+        assert.strictEqual($overlayWrapper.find('.dx-treeview-item').eq(1).text(), 'B', 'second column');
+
+        // act
+        dataGrid.option({ columnChooser: { sortOrder: 'desc' } });
+
+        $overlayWrapper = dataGrid.getView('columnChooserView')._popupContainer.$wrapper();
+
+        // assert
+        assert.strictEqual($overlayWrapper.find('.dx-treeview-item').eq(0).text(), 'B', 'first column');
+        assert.strictEqual($overlayWrapper.find('.dx-treeview-item').eq(1).text(), 'A', 'second column');
+    });
+
     QUnit.test('ColumnChooser\'s treeView get correct default config (without checkboxes)', function(assert) {
         // arrange
         const dataGrid = createDataGrid({
@@ -106,5 +182,6 @@ QUnit.module('Column chooser', baseModuleConfig, () => {
         // assert
         assert.ok(!$overlayWrapper.find('.dx-checkbox').length, 'There aren\'t checkboxes in columnChooser');
     });
+
 
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -587,9 +587,9 @@ QUnit.module('initialization from options', { beforeEach: setupModule, afterEach
     QUnit.test('getVisibleColumns when all columns grouped', function(assert) {
         this.applyOptions({
             columns: [
-                { dataField: 'TestField1', headerCaption: 'Custom Title 1', groupIndex: 0 },
-                { dataField: 'TestField2', headerCaption: 'Custom Title 2', groupIndex: 1 },
-                { dataField: 'TestField3', headerCaption: 'Custom Title 3', groupIndex: 2 },
+                { dataField: 'TestField1', caption: 'Custom Title 1', groupIndex: 0 },
+                { dataField: 'TestField2', caption: 'Custom Title 2', groupIndex: 1 },
+                { dataField: 'TestField3', caption: 'Custom Title 3', groupIndex: 2 },
             ]
         });
 
@@ -679,9 +679,9 @@ QUnit.module('initialization from options', { beforeEach: setupModule, afterEach
         // arrange
         this.applyOptions({
             columns: [
-                { dataField: 'TestField1', headerCaption: 'Custom Title 1' },
-                { dataField: 'TestField2', headerCaption: 'Custom Title 2', visible: false },
-                { dataField: 'TestField3', headerCaption: 'Custom Title 3', visible: false },
+                { dataField: 'TestField1', caption: 'Custom Title 1' },
+                { dataField: 'TestField2', caption: 'Custom Title 2', visible: false },
+                { dataField: 'TestField3', caption: 'Custom Title 3', visible: false },
             ]
         });
 
@@ -973,9 +973,9 @@ QUnit.module('initialization from options', { beforeEach: setupModule, afterEach
         // arrange
         this.applyOptions({
             columns: [
-                { dataField: 'TestField1', headerCaption: 'Custom Title 1' },
-                { dataField: 'TestField2', headerCaption: 'Custom Title 2', visible: false },
-                { dataField: 'TestField3', headerCaption: 'Custom Title 3', visible: false },
+                { dataField: 'TestField1', caption: 'Custom Title 1' },
+                { dataField: 'TestField2', caption: 'Custom Title 2', visible: false },
+                { dataField: 'TestField3', caption: 'Custom Title 3', visible: false },
             ]
         });
 
@@ -994,10 +994,10 @@ QUnit.module('initialization from options', { beforeEach: setupModule, afterEach
         // arrange
         this.applyOptions({
             columns: [
-                { dataField: 'TestField1', headerCaption: 'Custom Title 1' },
-                { dataField: 'TestField2', headerCaption: 'Custom Title 2', visible: false },
-                { dataField: 'TestField3', headerCaption: 'Custom Title 3', visible: false, showInColumnChooser: false },
-                { dataField: 'TestField4', headerCaption: 'Custom Title 4', visible: false },
+                { dataField: 'TestField1', caption: 'Custom Title 1' },
+                { dataField: 'TestField2', caption: 'Custom Title 2', visible: false },
+                { dataField: 'TestField3', caption: 'Custom Title 3', visible: false, showInColumnChooser: false },
+                { dataField: 'TestField4', caption: 'Custom Title 4', visible: false },
             ]
         });
 
@@ -1009,6 +1009,50 @@ QUnit.module('initialization from options', { beforeEach: setupModule, afterEach
         assert.equal(chooserColumns.length, 2, 'count chooser columns');
         assert.strictEqual(chooserColumns[0].dataField, 'TestField2', 'dataField column');
         assert.strictEqual(chooserColumns[1].dataField, 'TestField4', 'dataField column');
+    });
+
+    QUnit.test('getChooserColumns with sort ordering (asc)', function(assert) {
+        // arrange
+        this.applyOptions({
+            columns: [
+                { dataField: '1', caption: 'A', visible: false },
+                { dataField: '2', caption: 'C', visible: false },
+                { dataField: '3', caption: 'B', visible: false },
+            ],
+            columnChooser: {
+                sortOrder: 'asc'
+            }
+        });
+
+        // act
+        const chooserColumns = this.columnsController.getChooserColumns();
+
+        // assert
+        assert.strictEqual(chooserColumns[0].dataField, '1', 'dataField column');
+        assert.strictEqual(chooserColumns[1].dataField, '3', 'dataField column');
+        assert.strictEqual(chooserColumns[2].dataField, '2', 'dataField column');
+    });
+
+    QUnit.test('getChooserColumns with sort ordering (desc)', function(assert) {
+        // arrange
+        this.applyOptions({
+            columns: [
+                { dataField: '1', caption: 'A', visible: false },
+                { dataField: '2', caption: 'C', visible: false },
+                { dataField: '3', caption: 'B', visible: false },
+            ],
+            columnChooser: {
+                sortOrder: 'desc'
+            }
+        });
+
+        // act
+        const chooserColumns = this.columnsController.getChooserColumns();
+
+        // assert
+        assert.strictEqual(chooserColumns[0].dataField, '2', 'dataField column');
+        assert.strictEqual(chooserColumns[1].dataField, '3', 'dataField column');
+        assert.strictEqual(chooserColumns[2].dataField, '1', 'dataField column');
     });
 
     QUnit.test('column with calculateCellValue', function(assert) {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -5701,6 +5701,10 @@ declare module DevExpress.ui {
        * [descr:GridBaseOptions.columnChooser.width]
        */
       width?: number;
+      /**
+       * [descr:GridBaseOptions.columnChooser.sortOrder]
+       */
+      sortOrder?: 'asc' | 'desc';
     }
     /**
      * @deprecated Warning! This type is used for internal purposes. Do not import it directly.


### PR DESCRIPTION
Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/17698

---

I added option `columnChooser.sortOrder?: "asc" | "desc"` to DataGrid. 

Behavior:

- `"asc"` — sort alphabetically ascending
- `"desc"` — sort alphabetically descending
- `undefined` — sort by column's view index in grid (as it was previously)