### PR TITLE
DataGrid - add disable option to buttons

### DIFF
--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -199,7 +199,7 @@ export interface RowDraggingTemplateDataModel {
   readonly itemElement: DxElement;
 }
 
-export interface FilterPanelCustomizeTextArg<T> { 
+export interface FilterPanelCustomizeTextArg<T> {
   readonly component: T,
   readonly filterValue: any,
   readonly text: string
@@ -3065,7 +3065,7 @@ export type RowDraggingRemoveEvent = RowDraggingEventInfo<dxDataGrid>;
 /** @public */
 export type RowDraggingReorderEvent = RowDraggingEventInfo<dxDataGrid> & DragReorderInfo;
 
-/** @public */ 
+/** @public */
 export type ColumnButtonClickEvent = NativeEventInfo<dxDataGrid> & {
   row?: RowObject;
   column?: Column;
@@ -4589,6 +4589,17 @@ export interface ColumnButton extends ColumnButtonBase {
      * @public
      */
     visible?: boolean | ((options: { component?: dxDataGrid, row?: RowObject, column?: Column }) => boolean);
+    /**
+     * @docid dxDataGridColumnButton.visible
+     * @default false
+     * @type_function_param1 options:object
+     * @type_function_param1_field1 component:dxDataGrid
+     * @type_function_param1_field2 row:dxDataGridRowObject
+     * @type_function_param1_field3 column:dxDataGridColumn
+     * @type_function_return Boolean
+     * @public
+     */
+    disabled?: boolean | ((options: { component?: dxDataGrid, row?: RowObject, column?: Column }) => boolean);
 }
 
 /**

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -298,6 +298,12 @@ const EditingController = modules.ViewController.inherit((function() {
             return isFunction(visible) ? visible.call(button, { component: options.component, row: options.row, column: options.column }) : visible;
         },
 
+        _isButtonDisabled: function(button, options) {
+            const disabled = button.disabled;
+
+            return isFunction(disabled) ? disabled.call(button, { component: options.component, row: options.row, column: options.column }) : disabled;
+        },
+
         _getButtonConfig: function(button, options) {
             const config = isObject(button) ? button : {};
             const buttonName = getButtonName(button);
@@ -1911,9 +1917,9 @@ const EditingController = modules.ViewController.inherit((function() {
             let icon = EDIT_ICON_CLASS[button.name];
             const useIcons = this.option('editing.useIcons');
             let $button = $('<a>')
-                .attr('href', '#')
-                .addClass(LINK_CLASS)
-                .addClass(button.cssClass);
+            .attr('href', '#')
+            .addClass(LINK_CLASS)
+            .addClass(button.cssClass);
 
             if(button.template) {
                 this._rowsView.renderTemplate($container, button.template, options, true);
@@ -1941,11 +1947,16 @@ const EditingController = modules.ViewController.inherit((function() {
                     $button.attr('title', button.hint);
                 }
 
-                eventsEngine.on($button, addNamespace('click', EDITING_NAMESPACE), this.createAction(function(e) {
-                    button.onClick.call(button, extend({}, e, { row: options.row, column: options.column }));
-                    e.event.preventDefault();
-                    e.event.stopPropagation();
-                }));
+                if(this._isButtonDisabled(button, options)) {
+                    $button.addClass('dx-state-disabled');
+                } else {
+                    eventsEngine.on($button, addNamespace('click', EDITING_NAMESPACE), this.createAction(function(e) {
+                        button.onClick.call(button, extend({}, e, { row: options.row, column: options.column }));
+                        e.event.preventDefault();
+                        e.event.stopPropagation();
+                    }));
+                }
+
                 $container.append($button, '&nbsp;');
             }
         },

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -301,7 +301,7 @@ const EditingController = modules.ViewController.inherit((function() {
         _isButtonDisabled: function(button, options) {
             const disabled = button.disabled;
 
-            return isFunction(disabled) ? disabled.call(button, { component: options.component, row: options.row, column: options.column }) : disabled;
+            return isFunction(disabled) ? disabled.call(button, { component: options.component, row: options.row, column: options.column }) : !!disabled;
         },
 
         _getButtonConfig: function(button, options) {

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1917,9 +1917,9 @@ const EditingController = modules.ViewController.inherit((function() {
             let icon = EDIT_ICON_CLASS[button.name];
             const useIcons = this.option('editing.useIcons');
             let $button = $('<a>')
-            .attr('href', '#')
-            .addClass(LINK_CLASS)
-            .addClass(button.cssClass);
+                .attr('href', '#')
+                .addClass(LINK_CLASS)
+                .addClass(button.cssClass);
 
             if(button.template) {
                 this._rowsView.renderTemplate($container, button.template, options, true);

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1329,6 +1329,17 @@ export interface ColumnButton extends ColumnButtonBase {
      * @public
      */
     visible?: boolean | ((options: { readonly component: dxTreeList, row?: RowObject, readonly column: Column }) => boolean);
+    /**
+     * @docid dxTreeListColumnButton.visible
+     * @default false
+     * @type_function_param1 options:object
+     * @type_function_param1_field1 component:dxTreeList
+     * @type_function_param1_field2 row:dxTreeListRowObject
+     * @type_function_param1_field3 column:dxTreeListColumn
+     * @type_function_return Boolean
+     * @public
+     */
+    disabled?: boolean | ((options: { readonly component: dxTreeList, row?: RowObject, readonly column: Column }) => boolean);
 }
 
 /**

--- a/scss/widgets/base/_gridBase.scss
+++ b/scss/widgets/base/_gridBase.scss
@@ -486,10 +486,6 @@
 
         .dx-link {
           display: inline-block;
-
-          &.dx-state-disabled {
-            opacity: 0.5;
-          }
         }
       }
 

--- a/scss/widgets/base/_gridBase.scss
+++ b/scss/widgets/base/_gridBase.scss
@@ -486,6 +486,10 @@
 
         .dx-link {
           display: inline-block;
+
+          &.dx-state-disabled {
+            opacity: 0.5;
+          }
         }
       }
 

--- a/scss/widgets/generic/gridBase/_colors.scss
+++ b/scss/widgets/generic/gridBase/_colors.scss
@@ -202,6 +202,9 @@ $datagrid-columnchooser-overlay-border-radius: null !default;
 $datagrid-column-separator-bg: null !default;
 $datagrid-text-stub-background-image-path: null !default;
 
+$datagrid-text-link-disabled-opacity: 0.5 !default;
+$datagrid-icon-link-disabled-opacity: 0.6 !default;
+
 @if $color == "carmine" {
   $datagrid-columnchooser-item-color: $base-label-color !default;
   $datagrid-block-separator-bg: darken($datagrid-base-background-color, 6.5%) !default;

--- a/scss/widgets/generic/gridBase/_index.scss
+++ b/scss/widgets/generic/gridBase/_index.scss
@@ -392,6 +392,14 @@ $generic-grid-base-checkbox-indeterminate-icon-size: 6px;
       .dx-command-edit {
         width: $generic-grid-base-command-edit-column-width;
         min-width: $generic-grid-base-command-edit-column-width;
+
+        .dx-link.dx-state-disabled {
+          opacity: $datagrid-text-link-disabled-opacity;
+
+          &.dx-link-icon {
+            opacity: $datagrid-icon-link-disabled-opacity;
+          }
+        }
       }
 
       .dx-command-expand {

--- a/scss/widgets/material/gridBase/_colors.scss
+++ b/scss/widgets/material/gridBase/_colors.scss
@@ -161,6 +161,9 @@ $datagrid-active-header-filter-icon-color: $base-accent !default;
 $datagrid-text-stub-background-image-path: null !default;
 $datagrid-filter-panel-color: $base-accent !default;
 
+$datagrid-text-link-disabled-opacity: 0.38 !default;
+$datagrid-icon-link-disabled-opacity: 0.6 !default;
+
 @if $mode == "light" {
   $datagrid-columnchooser-item-color: color.change($datagrid-base-color, $alpha: 0.54) !default;
   $datagrid-block-separator-bg: darken($datagrid-base-background-color, 12%) !default;

--- a/scss/widgets/material/gridBase/_index.scss
+++ b/scss/widgets/material/gridBase/_index.scss
@@ -288,6 +288,14 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
               width: auto;
             }
           }
+
+          .dx-link.dx-state-disabled {
+            opacity: $datagrid-text-link-disabled-opacity;
+
+            &.dx-link-icon {
+              opacity: $datagrid-icon-link-disabled-opacity;
+            }
+          }
         }
 
         &.dx-command-expand,

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -2988,7 +2988,7 @@ QUnit.module('Editing with real dataController', {
         };
     },
     afterEach: function() {
-        // this.dispose();
+        this.dispose();
         this.clock.restore();
     }
 }, () => {
@@ -8108,52 +8108,11 @@ QUnit.module('Editing with real dataController', {
             assert.strictEqual(this, args[0].component, 'right component');
 
             const $row = this.getRowElement(i);
-            const $link = $row.children().last().find('.dx-link').first();
+            const $link = $($row[0]).find('.dx-command-edit').first().find('.dx-link').first();
 
             const mustHaveClass = row.data.stateId === 1;
             assert.strictEqual($link.hasClass('dx-state-disabled'), mustHaveClass, 'row\'s state is right');
         });
-    });
-
-    QUnit.test('Should not be able to click on disabled edit link', function(assert) {
-        // arrange
-        const rowsView = this.rowsView;
-        const $testElement = $('#container');
-
-        let clicked = false;
-
-        this.options.columns.push({
-            type: 'buttons',
-            buttons: [{
-                text: 'My button',
-                disabled: true,
-                onClick: function() {
-                    clicked = true;
-                }
-            }]
-        });
-        this.columnsController.reset();
-        rowsView.render($testElement);
-
-        let $linkElement = $testElement.find('.dx-command-edit').first().find('.dx-link').first();
-
-        // act
-        $linkElement.trigger('click');
-        this.clock.tick();
-
-        // assert
-        assert.ok(!clicked, 'not clicked when disabled');
-
-        // arrange
-        this.columnOption(5, 'buttons[0].disabled', false);
-        $linkElement = $testElement.find('.dx-command-edit').first().find('.dx-link').first();
-
-        // act
-        $linkElement.trigger('click');
-        this.clock.tick();
-
-        // assert
-        assert.ok(clicked, 'clicked when isn\'t disabled');
     });
 
     QUnit.test('Clicking on the edit link should not work when the link is set via the \'buttons\' option and allowUpdating is false', function(assert) {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -5619,6 +5619,16 @@ declare module DevExpress.ui {
             row?: RowObject;
             column?: Column;
           }) => boolean);
+      /**
+       * [descr:dxDataGridColumnButton.visible]
+       */
+      disabled?:
+        | boolean
+        | ((options: {
+            component?: dxDataGrid;
+            row?: RowObject;
+            column?: Column;
+          }) => boolean);
     }
     /**
      * [descr:GridBaseColumnButton]
@@ -19535,6 +19545,16 @@ declare module DevExpress.ui {
        * [descr:dxTreeListColumnButton.visible]
        */
       visible?:
+        | boolean
+        | ((options: {
+            readonly component: dxTreeList;
+            row?: RowObject;
+            readonly column: Column;
+          }) => boolean);
+      /**
+       * [descr:dxTreeListColumnButton.visible]
+       */
+      disabled?:
         | boolean
         | ((options: {
             readonly component: dxTreeList;


### PR DESCRIPTION
Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/17721

---

I add `disabled` option that to DataGrid's button. The behavior is the same as `visibility`: it can be `boolean` or function

![image](https://user-images.githubusercontent.com/84017191/120439577-59d60200-c38b-11eb-8559-0de7c4d10f12.png)

(every second button is disabled)

Branch [__PG__DataGrid_add_disable_option_to_buttons_21_1](https://github.com/pomahtri/DevExtreme/tree/__PG__DataGrid_add_disable_option_to_buttons_21_1) from my repo contains AngularJS playground if you want to test it and compare styles with common buttons