### PR TITLE
DateBox mask: refactor renderDateParts util to prevent Rollup bundler warning logging (#17749)

### DIFF
--- a/js/ui/date_box/ui.date_box.mask.parts.js
+++ b/js/ui/date_box/ui.date_box.mask.parts.js
@@ -101,7 +101,7 @@ export const renderDateParts = (text, regExpInfo) => {
             caret: { start: start, end: end },
             pattern: pattern,
             text: result[i],
-            limits: getLimits.bind(this, pattern[0]),
+            limits: (...args) => getLimits(pattern[0], ...args),
             setter: PATTERN_SETTERS[pattern[0]] || noop,
             getter: getter
         });


### PR DESCRIPTION
cherry picked from (commit) [96b223d92b55465a44d3d2e0e874c20c4dc17ead]
