### PR TITLE
datagrid - fixes unstable tests

### DIFF
--- a/testing/testcafe/model/dataGrid/index.ts
+++ b/testing/testcafe/model/dataGrid/index.ts
@@ -111,6 +111,15 @@ export default class DataGrid extends Widget {
     )();
   }
 
+  getScrollRight(): Promise<number> {
+    const { getGridInstance } = this;
+    return ClientFunction(() => {
+      const dataGrid = getGridInstance() as any;
+      const scrollable = dataGrid.getScrollable();
+      return scrollable.scrollWidth() - scrollable.clientWidth() - scrollable.scrollLeft();
+    }, { dependencies: { getGridInstance } })();
+  }
+
   getScrollWidth(): Promise<number> {
     const { getGridInstance } = this;
 
@@ -170,6 +179,22 @@ export default class DataGrid extends Widget {
         return value !== 'undefined' ? dataGrid.option(name, value) : dataGrid.option(name);
       },
       { dependencies: { getGridInstance, name, value } },
+    )();
+  }
+
+  apiColumnOption(id: any, name: any, value: any = 'empty'): Promise<any> {
+    const { getGridInstance } = this;
+
+    return ClientFunction(
+      () => {
+        const dataGrid = getGridInstance() as any;
+        return value !== 'empty' ? dataGrid.columnOption(id, name, value === 'undefined' ? undefined : value) : dataGrid.columnOption(id, name);
+      },
+      {
+        dependencies: {
+          getGridInstance, id, name, value,
+        },
+      },
     )();
   }
 

--- a/testing/testcafe/tests/dataGrid/scrolling.ts
+++ b/testing/testcafe/tests/dataGrid/scrolling.ts
@@ -290,7 +290,7 @@ test('Scroll position after grouping when RTL (T388508)', async (t) => {
     .eql(300);
 
   // act
-  await dataGrid.scrollTo({ left: 100 });
+  await dataGrid.scrollTo({ x: 100 });
   const scrollRight = await dataGrid.getScrollRight();
   await dataGrid.apiColumnOption('field1', 'groupIndex', 0);
 

--- a/testing/testcafe/tests/dataGrid/scrolling.ts
+++ b/testing/testcafe/tests/dataGrid/scrolling.ts
@@ -206,7 +206,7 @@ test('DataGrid should not reset its top scroll position after cell modification 
   },
 }));
 
-test('Ungrouping after grouping should works correctly if row rendering mode is virtual', async (t) => {
+test('Ungrouping after grouping should work correctly if row rendering mode is virtual', async (t) => {
   const dataGrid = new DataGrid('#container');
 
   // act

--- a/testing/testcafe/tests/dataGrid/scrolling.ts
+++ b/testing/testcafe/tests/dataGrid/scrolling.ts
@@ -1,6 +1,9 @@
+import { Selector } from 'testcafe';
 import url from '../../helpers/getPageUrl';
 import createWidget from '../../helpers/createWidget';
 import DataGrid from '../../model/dataGrid';
+
+const groupRow = Selector('.dx-group-row');
 
 async function getMaxRightOffset(dataGrid: DataGrid): Promise<number> {
   const scrollWidth = await dataGrid.getScrollWidth();
@@ -229,6 +232,11 @@ test('Ungrouping after grouping should work correctly if row rendering mode is v
 
   // act
   await dataGrid.apiColumnOption('group', 'groupIndex', 'undefined');
+
+  await t
+    .expect(groupRow.exists)
+    .notOk();
+
   visibleRows = await dataGrid.apiGetVisibleRows();
 
   // assert
@@ -284,6 +292,11 @@ test('Scroll position after grouping when RTL (T388508)', async (t) => {
   await dataGrid.scrollTo({ left: 100 });
   const scrollRight = await dataGrid.getScrollRight();
   await dataGrid.apiColumnOption('field1', 'groupIndex', 0);
+
+  await t
+    .expect(groupRow.exists)
+    .ok();
+
   const visibleRows = await dataGrid.apiGetVisibleRows();
   const scrollRightAfterGrouping = await dataGrid.getScrollRight();
 

--- a/testing/testcafe/tests/dataGrid/scrolling.ts
+++ b/testing/testcafe/tests/dataGrid/scrolling.ts
@@ -237,7 +237,7 @@ test('Ungrouping after grouping should work correctly if row rendering mode is v
     .eql('data')
     .expect(visibleRows[0].key)
     .eql(1);
-}).before(() => {
+}).before(async () => {
   const getItems = function (): Record<string, unknown>[] {
     const items: Record<string, unknown>[] = [];
     for (let i = 1; i <= 25; i += 1) {
@@ -293,7 +293,7 @@ test('Scroll position after grouping when RTL (T388508)', async (t) => {
     .eql('group')
     .expect(Math.floor(scrollRightAfterGrouping))
     .eql(Math.floor(scrollRight));
-}).before(() => createWidget('dxDataGrid', {
+}).before(async () => createWidget('dxDataGrid', {
   width: 200,
   rtlEnabled: true,
   columns: [

--- a/testing/testcafe/tests/dataGrid/scrolling.ts
+++ b/testing/testcafe/tests/dataGrid/scrolling.ts
@@ -233,6 +233,7 @@ test('Ungrouping after grouping should work correctly if row rendering mode is v
   // act
   await dataGrid.apiColumnOption('group', 'groupIndex', 'undefined');
 
+  // assert
   await t
     .expect(groupRow.exists)
     .notOk();
@@ -293,6 +294,7 @@ test('Scroll position after grouping when RTL (T388508)', async (t) => {
   const scrollRight = await dataGrid.getScrollRight();
   await dataGrid.apiColumnOption('field1', 'groupIndex', 0);
 
+  // assert
   await t
     .expect(groupRow.exists)
     .ok();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/scrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/scrolling.integration.tests.js
@@ -102,45 +102,6 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         assert.equal($('.dx-scrollable').dxScrollable('instance').scrollLeft(), 100);
     });
 
-    // T388508
-    QUnit.test('Scroll position after grouping when RTL', function(assert) {
-        // arrange
-        const done = assert.async();
-        const dataGrid = createDataGrid({
-            width: 200,
-            rtlEnabled: true,
-            columns: [{ dataField: 'field1', width: 100 }, { dataField: 'field2', width: 100 }, { dataField: 'field3', width: 100 }, { dataField: 'field4', width: 100 }, { dataField: 'field5', width: 100 }],
-            dataSource: [{ field1: '1', field2: '2', field3: '3', field4: '4' }]
-        });
-        const getRightScrollOffset = function(scrollable) {
-            return scrollable.scrollWidth() - scrollable.clientWidth() - scrollable.scrollLeft();
-        };
-
-        this.clock.tick();
-        const scrollable = $('.dx-scrollable').dxScrollable('instance');
-
-        // assert
-        assert.equal(scrollable.scrollLeft(), 300, 'scroll position');
-
-        this.clock.restore();
-        scrollable.scrollTo({ x: 100 });
-        const scrollRight = getRightScrollOffset(scrollable);
-
-        setTimeout(function() {
-            // act
-            dataGrid.columnOption('field1', 'groupIndex', 0);
-
-            setTimeout(function() {
-                // assert
-
-                const scrollRightAfterGrouping = getRightScrollOffset(scrollable);
-                assert.ok($(dataGrid.$element()).find('.dx-datagrid-rowsview').find('tbody > tr').first().hasClass('dx-group-row'));
-                assert.equal(scrollRightAfterGrouping, scrollRight, 'scroll position after grouping');
-                done();
-            });
-        });
-    });
-
     QUnit.test('Scroller state', function(assert) {
         const dataGrid = createDataGrid({ width: 120, height: 230 });
         assert.ok(dataGrid);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -1068,59 +1068,6 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
     const realSetTimeout = window.setTimeout;
 
-    QUnit.test('ungrouping after grouping should works correctly if row rendering mode is virtual', function(assert) {
-        this.clock.restore();
-        const done = assert.async();
-        // arrange, act
-        const array = [];
-
-        for(let i = 1; i <= 25; i++) {
-            array.push({ id: i, group: 'group' + (i % 8 + 1) });
-        }
-
-        const dataGrid = $('#dataGrid').dxDataGrid({
-            height: 400,
-            loadingTimeout: null,
-            keyExpr: 'id',
-            dataSource: array,
-            scrolling: {
-                mode: 'virtual',
-                rowRenderingMode: 'virtual',
-                updateTimeout: 0,
-                useNative: false
-            },
-            grouping: {
-                autoExpandAll: false,
-            },
-            groupPanel: {
-                visible: true
-            },
-            paging: {
-                pageSize: 10
-            }
-        }).dxDataGrid('instance');
-
-        // act
-        dataGrid.getScrollable().scrollTo({ top: 500 });
-        dataGrid.columnOption('group', 'groupIndex', 0);
-
-        // assert
-        let visibleRows = dataGrid.getVisibleRows();
-        assert.equal(visibleRows.length, 8, 'visible row count');
-        assert.deepEqual(visibleRows[0].key, ['group1'], 'first visible row key');
-        assert.deepEqual(visibleRows[7].key, ['group8'], 'last visible row key');
-
-        // act
-        realSetTimeout(function() {
-            dataGrid.columnOption('group', 'groupIndex', undefined);
-
-            // assert
-            visibleRows = dataGrid.getVisibleRows();
-            assert.deepEqual(visibleRows[0].key, 1, 'first visible row key');
-            done();
-        });
-    });
-
     // T644981
     QUnit.test('ungrouping after grouping and scrolling should works correctly with large amount of data if row rendering mode is virtual', function(assert) {
         this.clock.restore();


### PR DESCRIPTION
The following tests were rewritten using TestCafe:

- "ungrouping after grouping should works correctly if row rendering mode is virtual" (virtualScrolling.integration.tests.js)
- "Scroll position after grouping when RTL" (scrolling.integration.tests.js)