### PR TITLE
Scheduler - Getting rid of an extra methods

### DIFF
--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
@@ -1204,15 +1204,6 @@ class SchedulerWorkSpace extends WidgetObserver {
         });
     }
 
-    _getCellPositionByIndex(index, inAllDayRow) {
-        const cellCoordinates = this._getCellCoordinatesByIndex(index);
-
-        return this._getCellPosition(
-            cellCoordinates,
-            inAllDayRow && !this._isVerticalGroupedWorkSpace(),
-        );
-    }
-
     _getCellPosition(cellCoordinates, isAllDayPanel) {
         const {
             dateTableCellsMeta,

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space_month.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space_month.js
@@ -227,22 +227,6 @@ class SchedulerWorkSpaceMonth extends SchedulerWorkSpace {
         return true;
     }
 
-    _getCellPositionByIndex(index, groupIndex) {
-        const position = super._getCellPositionByIndex(index);
-        const rowIndex = this._getCellCoordinatesByIndex(index).rowIndex;
-        let calculatedTopOffset;
-        if(!this._isVerticalGroupedWorkSpace()) {
-            calculatedTopOffset = this.getCellHeight() * rowIndex;
-        } else {
-            calculatedTopOffset = this.getCellHeight() * (rowIndex + groupIndex * this._getRowCount());
-        }
-
-        if(calculatedTopOffset) {
-            position.top = calculatedTopOffset;
-        }
-        return position;
-    }
-
     _getHeaderDate() {
         return this._getViewStartByOptions();
     }


### PR DESCRIPTION
Removing unused methods in Workspace:
`_getCellPositionByIndex(index, inAllDayRow)`
