### PR TITLE
Toolbar - renovation: text, disabled, html, visible, cssClass, locateInMenu, location props for 'options.items'

### DIFF
--- a/js/renovation/ui/toolbar/__tests__/toolbar.test.tsx
+++ b/js/renovation/ui/toolbar/__tests__/toolbar.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Toolbar, ToolbarProps, viewFunction as ToolbarView } from '../toolbar';
+import { Toolbar, viewFunction as ToolbarView } from '../toolbar';
+import { ToolbarProps } from '../toolbar_props';
 import { DomComponentWrapper } from '../../common/dom_component_wrapper';
 import LegacyToolbar from '../../../../ui/toolbar';
-
-jest.mock('../../../../ui/number_box', () => jest.fn());
 
 describe('Toolbar', () => {
   describe('View', () => {

--- a/js/renovation/ui/toolbar/toolbar.tsx
+++ b/js/renovation/ui/toolbar/toolbar.tsx
@@ -1,11 +1,13 @@
+/* eslint-disable max-classes-per-file */
+
 import {
-  Component, ComponentBindings, JSXComponent,
+  Component, JSXComponent,
 } from '@devextreme-generator/declarations';
 /* eslint-disable import/named */
 import LegacyToolbar from '../../../ui/toolbar';
 
 import { DomComponentWrapper } from '../common/dom_component_wrapper';
-import { BaseWidgetProps } from '../common/base_props';
+import { ToolbarProps } from './toolbar_props';
 
 export const viewFunction = ({
   props,
@@ -18,73 +20,6 @@ export const viewFunction = ({
     {...restAttributes}
   />
 );
-
-@ComponentBindings()
-export class ToolbarProps extends BaseWidgetProps {
-
-  /*
-  TODO: old API
-
-    dataSource
-    disabled
-    elementAttr
-    height
-    hint
-    hoverStateEnabled
-    itemComponent
-    itemHoldTimeout
-    itemRender
-    items[]
-    itemTemplate
-    menuItemComponent
-    menuItemRender
-    menuItemTemplate
-    noDataText
-    onContentReady
-    onDisposing
-    onInitialized
-    onItemClick
-    onItemContextMenu
-    onItemHold
-    onItemRendered
-    onOptionChanged
-    renderAs
-    rtlEnabled
-    visible
-    width
-
-    Methods:
-
-    beginUpdate()
-    defaultOptions(rule)
-    dispose()
-    element()
-    endUpdate()
-    getDataSource()
-    getInstance(element)
-    instance()
-    off(eventName)
-    off(eventName, eventHandler)
-    on(eventName, eventHandler)
-    on(events)
-    option()
-    option(optionName)
-    option(optionName, optionValue)
-    option(options)
-    repaint()
-    resetOption(optionName)
-
-    Events:
-    contentReady
-    disposing
-    initialized
-    itemClick
-    itemContextMenu
-    itemHold
-    itemRendered
-    optionChanged
-  */
-}
 
 @Component({
   defaultOptionRules: null,

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -163,7 +163,7 @@ export class ToolbarItem extends CollectionWidgetItem {
   //
   // - react (for demo purposes only, will be available in future releases):
   // it is not a 'native' way, use this instead:
-  // <Toolbar> <Item><dxButton text="My Button" /></Item> </Toolbar>
+  // <Toolbar> <Item><Button text="My Button" /></Item> </Toolbar>
   //
   //
   @OneWay()
@@ -178,7 +178,7 @@ export class ToolbarItem extends CollectionWidgetItem {
   //
   // - react (for demo purposes only, will be available in future releases):
   // it is not a 'native' way, use this instead:
-  // <Toolbar> <Item><dxButton text="My Button" /></Item> </Toolbar>
+  // <Toolbar> <Item><Button text="My Button" /></Item> </Toolbar>
   //
   @Nested()
   options?: ToolbarButtonProps;
@@ -191,7 +191,7 @@ export class ToolbarItem extends CollectionWidgetItem {
   //
   // - react (for demo purposes only, will be available in future releases):
   // it is not a 'native' way, use this instead:
-  // <Toolbar> <Item><dxButton text={itemInMenu ? "My Button" : ""} /></Item> </Toolbar>
+  // <Toolbar> <Item><Button text={itemInMenu ? "My Button" : ""} /></Item> </Toolbar>
   //
   @OneWay()
   showText?: 'always' | 'inMenu';
@@ -203,7 +203,7 @@ export class ToolbarItem extends CollectionWidgetItem {
 }
 
 // it is not a 'native' way, use this instead:
-// <Toolbar> <Item><dxButton text="My Button" /></Item> </Toolbar>
+// <Toolbar> <Item><Button text="My Button" /></Item> </Toolbar>
 @ComponentBindings()
 export class ToolbarButtonProps {
   //

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -20,7 +20,6 @@ export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
   //
   // - TODO: prepare jquery, angular, vue code samples
   //
-
   @Nested() items?: (string | ToolbarItem)[]; // TODO: any
 
   /*

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -49,6 +49,8 @@ export class CollectionWidgetItem {
   // it is not a 'native' way, use this instead:
   // <Toolbar> <Item>text2</Item> </Toolbar>
   //
+  // - TODO: prepare jquery, angular, vue code samples
+  //
   @OneWay()
   text?: string;
 
@@ -60,6 +62,8 @@ export class CollectionWidgetItem {
   //
   // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item disabled>your markup</Item> </Toolbar>
+  //
+  // - TODO: prepare jquery, angular, vue code samples
   //
   @OneWay()
   disabled?: boolean;
@@ -74,6 +78,8 @@ export class CollectionWidgetItem {
   // it is not a 'native' way, use this instead:
   // <Toolbar> <Item><h1>text3<h1></Item> </Toolbar>
   //
+  // - TODO: prepare jquery, angular, vue code samples
+  //
   @OneWay()
   html?: string;
 
@@ -85,6 +91,8 @@ export class CollectionWidgetItem {
   //
   // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item visible={false}>your markup</Item> </Toolbar>
+  //
+  // - TODO: prepare jquery, angular, vue code samples
   //
   @OneWay()
   visible?: boolean;
@@ -100,6 +108,8 @@ export class CollectionWidgetItem {
   // - react (for demo purposes only, will be available in future releases):
   // it is not a 'native' way, use this instead:
   // <Toolbar> <Item>put here your markup</Item> </Toolbar>
+  //
+  // - TODO: prepare jquery, angular, vue code samples
   //
   // @OneWay()
   // template?:
@@ -124,6 +134,8 @@ export class ToolbarItem extends CollectionWidgetItem {
   // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item cssClass={'my_class'}>your markup</Item> </Toolbar>
   //
+  // - TODO: prepare jquery, angular, vue code samples
+  //
   @OneWay()
   cssClass?: string;
 
@@ -136,6 +148,8 @@ export class ToolbarItem extends CollectionWidgetItem {
   // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item locateInMenu={'always'}>your markup</Item> </Toolbar>
   //
+  // - TODO: prepare jquery, angular, vue code samples
+  //
   @OneWay()
   locateInMenu?: 'always' | 'auto' | 'never';
 
@@ -147,6 +161,8 @@ export class ToolbarItem extends CollectionWidgetItem {
   //
   // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item location={'before'}>your markup</Item> </Toolbar>
+  //
+  // - TODO: prepare jquery, angular, vue code samples
   //
   @OneWay()
   location?: 'after' | 'before' | 'center';
@@ -165,6 +181,7 @@ export class ToolbarItem extends CollectionWidgetItem {
   // it is not a 'native' way, use this instead:
   // <Toolbar> <Item><Button text="My Button" /></Item> </Toolbar>
   //
+  // - TODO: prepare jquery, angular, vue code samples
   //
   @OneWay()
   widget?: 'dxButton' | 'dxCheckBox' | 'dxTextBox';
@@ -180,6 +197,8 @@ export class ToolbarItem extends CollectionWidgetItem {
   // it is not a 'native' way, use this instead:
   // <Toolbar> <Item><Button text="My Button" /></Item> </Toolbar>
   //
+  // - TODO: prepare jquery, angular, vue code samples
+  //
   @Nested()
   options?: ToolbarButtonProps;
 
@@ -192,6 +211,8 @@ export class ToolbarItem extends CollectionWidgetItem {
   // - react (for demo purposes only, will be available in future releases):
   // it is not a 'native' way, use this instead:
   // <Toolbar> <Item><Button text={itemInMenu ? "My Button" : ""} /></Item> </Toolbar>
+  //
+  // - TODO: prepare jquery, angular, vue code samples
   //
   @OneWay()
   showText?: 'always' | 'inMenu';

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -111,10 +111,16 @@ export class CollectionWidgetItem {
 export class ToolbarItem extends CollectionWidgetItem {
   // js\ui\toolbar.d.ts - export interface dxToolbarItem extends CollectionWidgetItem {
 
-  /*
+  @OneWay()
   cssClass?: string;
+
+  @OneWay()
   locateInMenu?: 'always' | 'auto' | 'never';
+
+  @OneWay()
   location?: 'after' | 'before' | 'center';
+
+  /*
   menuItemTemplate?: template | (() => string | UserDefinedElement);
   options?: any;
   showText?: 'always' | 'inMenu';

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -3,8 +3,6 @@
 import {
   ComponentBindings, OneWay, Nested,
 } from '@devextreme-generator/declarations';
-import type { UserDefinedElement } from '../../../core/element'; // eslint-disable-line import/named
-import type { template } from '../../../core/templates/template';
 
 import { BaseWidgetProps } from '../common/base_props';
 
@@ -165,17 +163,44 @@ export class CollectionWidgetItem {
 export class ToolbarItem extends CollectionWidgetItem {
   // js\ui\toolbar.d.ts - export interface dxToolbarItem extends CollectionWidgetItem {
 
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ text: 'text4', cssClass: 'my_class' }]} />
+  //
+  // - react:
+  // <Toolbar> <Item text={"text1"} cssClass={'my_class'}/> </Toolbar>
+  //
   @OneWay()
   cssClass?: string;
 
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ text: 'text2', locateInMenu: 'always' }]} />
+  //
+  // - react:
+  // <Toolbar> <Item text={"text2"} locateInMenu={'always'}/> </Toolbar>
+  //
   @OneWay()
   locateInMenu?: 'always' | 'auto' | 'never';
 
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ text: 'text4', location: 'before' }]} />
+  //
+  // - react:
+  // <Toolbar> <Item text={"text3"} location={'before'}/> </Toolbar>
+  //
   @OneWay()
   location?: 'after' | 'before' | 'center';
 
-  @OneWay()
-  menuItemTemplate?: template | (() => string | UserDefinedElement);
+  // @OneWay()
+  // menuItemTemplate?: template | (() => string | UserDefinedElement);
 
   /*
   ? menuItemTemplate?: template | (() => string | UserDefinedElement);

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 
 import {
-  ComponentBindings, OneWay, Nested,
+  ComponentBindings, OneWay, Nested, Event,
 } from '@devextreme-generator/declarations';
 
 import { BaseWidgetProps } from '../common/base_props';
@@ -12,7 +12,7 @@ export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
 
   // Use cases (see ToolbarItem for more cases):
   //
-  // - renoV syntax:
+  // - in a RenoV component:
   // <Toolbar items={["text1"]}></Toolbar>
   // <Toolbar items={[{ text: 'item2' }]} />
   //
@@ -23,8 +23,7 @@ export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
   // - TODO: prepare jquery, angular, vue code samples
   //
 
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  @Nested() items?: (string | ToolbarItem | any)[];
+  @Nested() items?: (string | ToolbarItem)[]; // TODO: any
 
   /*
   TODO: old API
@@ -96,11 +95,12 @@ export class CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
+  // - in a RenoV component:
   // <Toolbar items={[{ text: 'item2' }]} />
   //
   // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item text={"text2"}/> </Toolbar>
+  // it is not a 'native' way, use this instead:
+  // <Toolbar> <Item>text2</Item> </Toolbar>
   //
   @OneWay()
   text?: string;
@@ -108,11 +108,11 @@ export class CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
+  // - in a RenoV component:
   // <Toolbar items={[{ text: 'text4', disabled: true }]} />
   //
   // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item text={"text4"} disabled /> </Toolbar>
+  // <Toolbar> <Item disabled>your markup</Item> </Toolbar>
   //
   @OneWay()
   disabled?: boolean;
@@ -120,11 +120,12 @@ export class CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
+  // - in a RenoV component:
   // <Toolbar items={[{ html: '<h1>text3<h1>' }]} />
   //
   // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item html={"<h1>text3<h1>"}/> </Toolbar>
+  // it is not a 'native' way, use this instead:
+  // <Toolbar> <Item><h1>text3<h1></Item> </Toolbar>
   //
   @OneWay()
   html?: string;
@@ -132,11 +133,11 @@ export class CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
+  // - in a RenoV component:
   // <Toolbar items={[{ text: 'text5', visible: false }]} />
   //
   // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item text={"text5"} visible={false} /> </Toolbar>
+  // <Toolbar> <Item visible={false}>your markup</Item> </Toolbar>
   //
   @OneWay()
   visible?: boolean;
@@ -146,11 +147,12 @@ export class CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
+  // - in a RenoV component (not 'native'):
   // <Toolbar items={[{ text: 'text5', template: ???? }]} /> - how to use it?
   //
   // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item>text5</Item> </Toolbar> - 'text5' DOM element is not created
+  // it is not a 'native' way, use this instead:
+  // <Toolbar> <Item>put here your markup</Item> </Toolbar>
   //
   // @OneWay()
   // template?:
@@ -169,11 +171,11 @@ export class ToolbarItem extends CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
-  // <Toolbar items={[{ text: 'text4', cssClass: 'my_class' }]} />
+  // - in a RenoV component:
+  // <Toolbar items={[{ cssClass: 'my_class' }]} />
   //
   // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item text={"text1"} cssClass={'my_class'}/> </Toolbar>
+  // <Toolbar> <Item cssClass={'my_class'}>your markup</Item> </Toolbar>
   //
   @OneWay()
   cssClass?: string;
@@ -181,11 +183,11 @@ export class ToolbarItem extends CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
+  // - in a RenoV component:
   // <Toolbar items={[{ text: 'text2', locateInMenu: 'always' }]} />
   //
   // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item text={"text2"} locateInMenu={'always'}/> </Toolbar>
+  // <Toolbar> <Item locateInMenu={'always'}>your markup</Item> </Toolbar>
   //
   @OneWay()
   locateInMenu?: 'always' | 'auto' | 'never';
@@ -193,11 +195,11 @@ export class ToolbarItem extends CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
+  // - in a RenoV component:
   // <Toolbar items={[{ text: 'text4', location: 'before' }]} />
   //
   // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item text={"text3"} location={'before'}/> </Toolbar>
+  // <Toolbar> <Item location={'before'}>your markup</Item> </Toolbar>
   //
   @OneWay()
   location?: 'after' | 'before' | 'center';
@@ -205,25 +207,89 @@ export class ToolbarItem extends CollectionWidgetItem {
   //
   // Use cases:
   //
-  // - renoV syntax:
+  // - in a RenoV component (not 'native'):
   // <Toolbar items={[{ widget: 'dxButton' }]} />
-  //
-  // - react (for demo purposes only, will be available in future releases):
-  // <Toolbar> <Item widget='dxButton'></Item> </Toolbar>
-  //
   // TODO:
   // - Error if used in TestComponent in playground\react with dxAutocomplete | dxDateBox |
   //   dxMenu | dxSelectBox | dxTabs | dxButtonGroup | dxDropDownButton:
   //   TypeError: (0 , _renderer.default)(...)[component] is not a function
   //
+  // - react (for demo purposes only, will be available in future releases):
+  // it is not a 'native' way, use this instead:
+  // <Toolbar> <Item><dxButton text="My Button" /></Item> </Toolbar>
+  //
+  //
   @OneWay()
   widget?: 'dxButton' | 'dxCheckBox' | 'dxTextBox';
 
+  // Use cases:
+  //
+  // - in a RenoV component:
+  // <Toolbar items={[{ widget: 'dxButton', options: { text: 'my button' } }]} />
+  //
+  // TODO: any
+  //
+  // - react (for demo purposes only, will be available in future releases):
+  // it is not a 'native' way, use this instead:
+  // <Toolbar> <Item><dxButton text="My Button" /></Item> </Toolbar>
+  //
+  @Nested()
+  options?: ToolbarButtonProps;
+
+  //
+  // Use cases:
+  //
+  // - in a RenoV component:
+  // <Toolbar items={[{ text: 'text4', location: 'before' }]} />
+  //
+  // - react (for demo purposes only, will be available in future releases):
+  // it is not a 'native' way, use this instead:
+  // <Toolbar> <Item><dxButton text={itemInMenu ? "My Button" : ""} /></Item> </Toolbar>
+  //
+  @OneWay()
+  showText?: 'always' | 'inMenu';
+
   /*
   TODO:
-
   menuItemTemplate?: template | (() => string | UserDefinedElement);
-  options?: any;
-  showText?: 'always' | 'inMenu';
+  */
+}
+
+// it is not a 'native' way, use this instead:
+// <Toolbar> <Item><dxButton text="My Button" /></Item> </Toolbar>
+@ComponentBindings()
+export class ToolbarButtonProps {
+  //
+  // Use cases:
+  //
+  // - in a RenoV component:
+  // <Toolbar items={[{ widget: 'dxButton', options: { text: 'my button' } }]} />
+  //
+  @OneWay()
+  text?: string;
+
+  //
+  // Use cases:
+  //
+  // - in a RenoV component:
+  // <Toolbar items={[{ widget: 'dxButton', options: { type: 'danger' } }]} />
+  //
+  @OneWay()
+  type?: 'back' | 'danger' | 'default' | 'normal' | 'success';
+
+  //
+  // Use cases:
+  //
+  // - in a RenoV component:
+  // <Toolbar items={[
+  //   { widget: 'dxButton', options: { text: 'my button', onClick: () => console.log('hi') } }
+  // ]} />
+  //
+  @Event()
+  onClick?:
+  | (() => void); // TODO: args, return value
+
+  /*
+  TODO: many props
   */
 }

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -202,13 +202,28 @@ export class ToolbarItem extends CollectionWidgetItem {
   @OneWay()
   location?: 'after' | 'before' | 'center';
 
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ widget: 'dxButton' }]} />
+  //
+  // - react (for demo purposes only, will be available in future releases):
+  // <Toolbar> <Item widget='dxButton'></Item> </Toolbar>
+  //
+  // TODO:
+  // - Error if used in TestComponent in playground\react with dxAutocomplete | dxDateBox |
+  //   dxMenu | dxSelectBox | dxTabs | dxButtonGroup | dxDropDownButton:
+  //   TypeError: (0 , _renderer.default)(...)[component] is not a function
+  //
+  @OneWay()
+  widget?: 'dxButton' | 'dxCheckBox' | 'dxTextBox';
+
   /*
   TODO:
 
   menuItemTemplate?: template | (() => string | UserDefinedElement);
   options?: any;
   showText?: 'always' | 'inMenu';
-  widget?: 'dxAutocomplete' | 'dxButton' | 'dxCheckBox' | 'dxDateBox' | 'dxMenu' | 'dxSelectBox'
-    | 'dxTabs' | 'dxTextBox' | 'dxButtonGroup' | 'dxDropDownButton';
   */
 }

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -3,7 +3,7 @@
 import {
   ComponentBindings, OneWay, Nested,
 } from '@devextreme-generator/declarations';
-import type { UserDefinedElement, DxElement } from '../../../core/element'; // eslint-disable-line import/named
+import type { UserDefinedElement } from '../../../core/element'; // eslint-disable-line import/named
 import type { template } from '../../../core/templates/template';
 
 import { BaseWidgetProps } from '../common/base_props';
@@ -12,8 +12,18 @@ import { BaseWidgetProps } from '../common/base_props';
 export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
   @OneWay() itemHoldTimeout?: number;
 
+  // Use cases (see ToolbarItem for more cases):
+  //
+  // - renoV syntax:
+  // <Toolbar items={["text1"]}></Toolbar>
+  // <Toolbar items={[{ text: 'item2' }]} />
+  //
+  // - react:
+  // <Toolbar items={["text1"]}></Toolbar>
+  // <Toolbar> <Item text={"text2"}/> </Toolbar>
+
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  @Nested() items?: (string | ToolbarItem | any)[]; // items?: Array<string | dxToolbarItem | any>;
+  @Nested() items?: (string | ToolbarItem | any)[];
 
   /*
   TODO: old API
@@ -82,29 +92,73 @@ export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
 export class CollectionWidgetItem {
   // js\ui\collection\ui.collection_widget.base.d.ts - export interface CollectionWidgetItem {
 
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ text: 'item2' }]} />
+  //
+  // - react:
+  // <Toolbar> <Item text={"text2"}/> </Toolbar>
+  //
   @OneWay()
   text?: string;
 
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ text: 'text4', disabled: true }]} />
+  //
+  // - react:
+  // <Toolbar> <Item text={"text4"} disabled /> </Toolbar>
+  //
   @OneWay()
   disabled?: boolean;
 
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ html: '<h1>text3<h1>' }]} />
+  //
+  // - react:
+  // <Toolbar> <Item html={"<h1>text3<h1>"}/> </Toolbar>
+  //
   @OneWay()
   html?: string;
 
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ text: 'text5', visible: false }]} />
+  //
+  // - react:
+  // <Toolbar> <Item text={"text5"} visible={false} /> </Toolbar>
+  //
   @OneWay()
   visible?: boolean;
 
-  // TODO in react: <Item template={() => (<div>qwe</div>)}/>
-  // TODO in react: <Item><div>text8</div></Item>
-  // TODO in react: <Item>text8</Item>
-  @OneWay()
-  template?:
-  | template
-  | ((
-    itemData: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    itemIndex: number,
-    itemElement: DxElement
-  ) => string | UserDefinedElement);
+  //
+  // TODO: doesn't work
+  //
+  // Use cases:
+  //
+  // - renoV syntax:
+  // <Toolbar items={[{ text: 'text5', template: ???? }]} /> - how to use it?
+  //
+  // - react:
+  // <Toolbar> <Item>text5</Item> </Toolbar> - 'text5' DOM element is not created
+  //
+  // @OneWay()
+  // template?:
+  // | template
+  // | ((
+  //   itemData: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  //   itemIndex: number,
+  //   itemElement: DxElement
+  // ) => string | UserDefinedElement);
 }
 
 @ComponentBindings()
@@ -120,8 +174,11 @@ export class ToolbarItem extends CollectionWidgetItem {
   @OneWay()
   location?: 'after' | 'before' | 'center';
 
-  /*
+  @OneWay()
   menuItemTemplate?: template | (() => string | UserDefinedElement);
+
+  /*
+  ? menuItemTemplate?: template | (() => string | UserDefinedElement);
   options?: any;
   showText?: 'always' | 'inMenu';
   widget?: 'dxAutocomplete' | 'dxButton' | 'dxCheckBox' | 'dxDateBox' | 'dxMenu' | 'dxSelectBox'

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -8,8 +8,6 @@ import { BaseWidgetProps } from '../common/base_props';
 
 @ComponentBindings()
 export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
-  @OneWay() itemHoldTimeout?: number;
-
   // Use cases (see ToolbarItem for more cases):
   //
   // - in a RenoV component:
@@ -26,65 +24,15 @@ export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
   @Nested() items?: (string | ToolbarItem)[]; // TODO: any
 
   /*
-  TODO: old API
+    TODO
 
-    dataSource
-    disabled
-    elementAttr
-    height
-    hint
-    hoverStateEnabled
-    itemComponent
-    itemHoldTimeout
-    itemRender
-    itemTemplate
-    menuItemComponent
-    menuItemRender
-    menuItemTemplate
-    noDataText
-    onContentReady
-    onDisposing
-    onInitialized
-    onItemClick
-    onItemContextMenu
-    onItemHold
-    onItemRendered
-    onOptionChanged
-    renderAs
-    rtlEnabled
-    visible
-    width
+    dataSource?: string | Array<string | dxToolbarItem | any> |
+      Store | DataSource | DataSourceOptions;
+    menuItemTemplate?: template |
+      ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
 
-    Methods:
+    CollectionWidgetOptions<dxToolbar> members
 
-    beginUpdate()
-    defaultOptions(rule)
-    dispose()
-    element()
-    endUpdate()
-    getDataSource()
-    getInstance(element)
-    instance()
-    off(eventName)
-    off(eventName, eventHandler)
-    on(eventName, eventHandler)
-    on(events)
-    option()
-    option(optionName)
-    option(optionName, optionValue)
-    option(options)
-    repaint()
-    resetOption(optionName)
-
-    Events:
-    contentReady
-    disposing
-    initialized
-    itemClick
-    itemContextMenu
-    itemHold
-    itemRendered
-    optionChanged
   */
 }
 

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -16,9 +16,12 @@ export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
   // <Toolbar items={["text1"]}></Toolbar>
   // <Toolbar items={[{ text: 'item2' }]} />
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar items={["text1"]}></Toolbar>
   // <Toolbar> <Item text={"text2"}/> </Toolbar>
+  //
+  // - TODO: prepare jquery, angular, vue code samples
+  //
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   @Nested() items?: (string | ToolbarItem | any)[];
@@ -96,7 +99,7 @@ export class CollectionWidgetItem {
   // - renoV syntax:
   // <Toolbar items={[{ text: 'item2' }]} />
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item text={"text2"}/> </Toolbar>
   //
   @OneWay()
@@ -108,7 +111,7 @@ export class CollectionWidgetItem {
   // - renoV syntax:
   // <Toolbar items={[{ text: 'text4', disabled: true }]} />
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item text={"text4"} disabled /> </Toolbar>
   //
   @OneWay()
@@ -120,7 +123,7 @@ export class CollectionWidgetItem {
   // - renoV syntax:
   // <Toolbar items={[{ html: '<h1>text3<h1>' }]} />
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item html={"<h1>text3<h1>"}/> </Toolbar>
   //
   @OneWay()
@@ -132,7 +135,7 @@ export class CollectionWidgetItem {
   // - renoV syntax:
   // <Toolbar items={[{ text: 'text5', visible: false }]} />
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item text={"text5"} visible={false} /> </Toolbar>
   //
   @OneWay()
@@ -146,7 +149,7 @@ export class CollectionWidgetItem {
   // - renoV syntax:
   // <Toolbar items={[{ text: 'text5', template: ???? }]} /> - how to use it?
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item>text5</Item> </Toolbar> - 'text5' DOM element is not created
   //
   // @OneWay()
@@ -169,7 +172,7 @@ export class ToolbarItem extends CollectionWidgetItem {
   // - renoV syntax:
   // <Toolbar items={[{ text: 'text4', cssClass: 'my_class' }]} />
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item text={"text1"} cssClass={'my_class'}/> </Toolbar>
   //
   @OneWay()
@@ -181,7 +184,7 @@ export class ToolbarItem extends CollectionWidgetItem {
   // - renoV syntax:
   // <Toolbar items={[{ text: 'text2', locateInMenu: 'always' }]} />
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item text={"text2"} locateInMenu={'always'}/> </Toolbar>
   //
   @OneWay()
@@ -193,17 +196,16 @@ export class ToolbarItem extends CollectionWidgetItem {
   // - renoV syntax:
   // <Toolbar items={[{ text: 'text4', location: 'before' }]} />
   //
-  // - react:
+  // - react (for demo purposes only, will be available in future releases):
   // <Toolbar> <Item text={"text3"} location={'before'}/> </Toolbar>
   //
   @OneWay()
   location?: 'after' | 'before' | 'center';
 
-  // @OneWay()
-  // menuItemTemplate?: template | (() => string | UserDefinedElement);
-
   /*
-  ? menuItemTemplate?: template | (() => string | UserDefinedElement);
+  TODO:
+
+  menuItemTemplate?: template | (() => string | UserDefinedElement);
   options?: any;
   showText?: 'always' | 'inMenu';
   widget?: 'dxAutocomplete' | 'dxButton' | 'dxCheckBox' | 'dxDateBox' | 'dxMenu' | 'dxSelectBox'

--- a/js/renovation/ui/toolbar/toolbar_props.tsx
+++ b/js/renovation/ui/toolbar/toolbar_props.tsx
@@ -1,0 +1,124 @@
+/* eslint-disable max-classes-per-file */
+
+import {
+  ComponentBindings, OneWay, Nested,
+} from '@devextreme-generator/declarations';
+import type { UserDefinedElement, DxElement } from '../../../core/element'; // eslint-disable-line import/named
+import type { template } from '../../../core/templates/template';
+
+import { BaseWidgetProps } from '../common/base_props';
+
+@ComponentBindings()
+export class ToolbarProps extends BaseWidgetProps { // js\ui\toolbar.d.ts
+  @OneWay() itemHoldTimeout?: number;
+
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  @Nested() items?: (string | ToolbarItem | any)[]; // items?: Array<string | dxToolbarItem | any>;
+
+  /*
+  TODO: old API
+
+    dataSource
+    disabled
+    elementAttr
+    height
+    hint
+    hoverStateEnabled
+    itemComponent
+    itemHoldTimeout
+    itemRender
+    itemTemplate
+    menuItemComponent
+    menuItemRender
+    menuItemTemplate
+    noDataText
+    onContentReady
+    onDisposing
+    onInitialized
+    onItemClick
+    onItemContextMenu
+    onItemHold
+    onItemRendered
+    onOptionChanged
+    renderAs
+    rtlEnabled
+    visible
+    width
+
+    Methods:
+
+    beginUpdate()
+    defaultOptions(rule)
+    dispose()
+    element()
+    endUpdate()
+    getDataSource()
+    getInstance(element)
+    instance()
+    off(eventName)
+    off(eventName, eventHandler)
+    on(eventName, eventHandler)
+    on(events)
+    option()
+    option(optionName)
+    option(optionName, optionValue)
+    option(options)
+    repaint()
+    resetOption(optionName)
+
+    Events:
+    contentReady
+    disposing
+    initialized
+    itemClick
+    itemContextMenu
+    itemHold
+    itemRendered
+    optionChanged
+  */
+}
+
+@ComponentBindings()
+export class CollectionWidgetItem {
+  // js\ui\collection\ui.collection_widget.base.d.ts - export interface CollectionWidgetItem {
+
+  @OneWay()
+  text?: string;
+
+  @OneWay()
+  disabled?: boolean;
+
+  @OneWay()
+  html?: string;
+
+  @OneWay()
+  visible?: boolean;
+
+  // TODO in react: <Item template={() => (<div>qwe</div>)}/>
+  // TODO in react: <Item><div>text8</div></Item>
+  // TODO in react: <Item>text8</Item>
+  @OneWay()
+  template?:
+  | template
+  | ((
+    itemData: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    itemIndex: number,
+    itemElement: DxElement
+  ) => string | UserDefinedElement);
+}
+
+@ComponentBindings()
+export class ToolbarItem extends CollectionWidgetItem {
+  // js\ui\toolbar.d.ts - export interface dxToolbarItem extends CollectionWidgetItem {
+
+  /*
+  cssClass?: string;
+  locateInMenu?: 'always' | 'auto' | 'never';
+  location?: 'after' | 'before' | 'center';
+  menuItemTemplate?: template | (() => string | UserDefinedElement);
+  options?: any;
+  showText?: 'always' | 'inMenu';
+  widget?: 'dxAutocomplete' | 'dxButton' | 'dxCheckBox' | 'dxDateBox' | 'dxMenu' | 'dxSelectBox'
+    | 'dxTabs' | 'dxTextBox' | 'dxButtonGroup' | 'dxDropDownButton';
+  */
+}


### PR DESCRIPTION
Add props to use a wrapped Toolbar in a RenoV TestComponent:

```
import {
  Component, JSXComponent, ComponentBindings,
} from '@devextreme-generator/declarations';
import { BaseWidgetProps } from '../common/base_props';
import { Toolbar } from './toolbar';

@ComponentBindings()
export class TestComponentProps extends BaseWidgetProps {
}

export const viewFunction = ({ props, restAttributes }: TestComponent): JSX.Element => (
  <div>
    <Toolbar items={[{ widget: 'dxButton', options: { text: 'my button', onClick: () => console.log('hi') } }]} />
  </div>
);

@Component({
  defaultOptionRules: null,
  view: viewFunction,
})

export class TestComponent extends JSXComponent<TestComponentProps>() {}
```