### PR TITLE
DataGrid — clears selection when toggling the showCheckBoxesMode option (T1008562)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.selection.js
+++ b/js/ui/grid_core/ui.grid_core.selection.js
@@ -279,34 +279,34 @@ const SelectionController = gridCore.Controller.inherit((function() {
         },
 
         optionChanged: function(args) {
-            const that = this;
-
-            that.callBase(args);
+            this.callBase(args);
 
             switch(args.name) {
                 case 'selection': {
-                    const oldSelectionMode = that._selectionMode;
+                    const oldSelectionMode = this._selectionMode;
 
-                    that.init();
+                    this.init();
 
-                    const selectionMode = that._selectionMode;
-                    let selectedRowKeys = that.option('selectedRowKeys');
+                    if(args.fullName !== 'selection.showCheckBoxesMode') {
+                        const selectionMode = this._selectionMode;
+                        let selectedRowKeys = this.option('selectedRowKeys');
 
-                    if(oldSelectionMode !== selectionMode) {
-                        if(selectionMode === 'single') {
-                            if(selectedRowKeys.length > 1) {
-                                selectedRowKeys = [selectedRowKeys[0]];
+                        if(oldSelectionMode !== selectionMode) {
+                            if(selectionMode === 'single') {
+                                if(selectedRowKeys.length > 1) {
+                                    selectedRowKeys = [selectedRowKeys[0]];
+                                }
+                            } else if(selectionMode !== 'multiple') {
+                                selectedRowKeys = [];
                             }
-                        } else if(selectionMode !== 'multiple') {
-                            selectedRowKeys = [];
                         }
+
+                        this.selectRows(selectedRowKeys).always(() => {
+                            this._fireSelectionChanged();
+                        });
                     }
 
-                    that.selectRows(selectedRowKeys).always(function() {
-                        that._fireSelectionChanged();
-                    });
-
-                    that.getController('columns').updateColumns();
+                    this.getController('columns').updateColumns();
                     args.handled = true;
                     break;
                 }
@@ -316,8 +316,8 @@ const SelectionController = gridCore.Controller.inherit((function() {
                     break;
                 case 'selectedRowKeys': {
                     const value = args.value || [];
-                    if(Array.isArray(value) && !that._selectedItemsInternalChange && (that.component.getDataSource() || !value.length)) {
-                        that.selectRows(value);
+                    if(Array.isArray(value) && !this._selectedItemsInternalChange && (this.component.getDataSource() || !value.length)) {
+                        this.selectRows(value);
                     }
                     args.handled = true;
                     break;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
@@ -910,9 +910,10 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         dataGrid.option('selection.showCheckBoxesMode', 'none');
 
         // assert
-        dataGrid.getSelectedRowKeys().done((keys) => selectedKeysBefore = keys);
+        let selectedKeysAfter;
+        dataGrid.getSelectedRowKeys().done((keys) => selectedKeysAfter = keys);
         this.clock.tick();
-        assert.deepEqual(selectedKeysBefore, [1]);
+        assert.deepEqual(selectedKeysAfter, [1]);
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
@@ -884,6 +884,36 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         assert.notOk($(dataGrid.getRowElement(0)).hasClass('dx-selection'), 'no dx-selection on the first row');
         assert.ok($(dataGrid.getRowElement(1)).hasClass('dx-selection'), 'dx-selection on the second row');
     });
+
+    // T1008562
+    QUnit.test('selection.showCheckBoxesMode changing does not clear selection', function(assert) {
+        // arrange, act
+        const dataGrid = createDataGrid({
+            dataSource: [{ field1: 1, field2: 1 }, { field1: 2, field2: 2 }],
+            keyExpr: 'field1',
+            selection: {
+                mode: 'multiple',
+                showCheckBoxesMode: 'onClick',
+                deferred: true
+            },
+        });
+        dataGrid.selectRows([1]);
+        this.clock.tick();
+
+        // assert
+        let selectedKeysBefore;
+        dataGrid.getSelectedRowKeys().done((keys) => selectedKeysBefore = keys);
+        this.clock.tick();
+        assert.deepEqual(selectedKeysBefore, [1]);
+
+        // act
+        dataGrid.option('selection.showCheckBoxesMode', 'none');
+
+        // assert
+        dataGrid.getSelectedRowKeys().done((keys) => selectedKeysBefore = keys);
+        this.clock.tick();
+        assert.deepEqual(selectedKeysBefore, [1]);
+    });
 });
 
 QUnit.module('columnWidth auto option', {


### PR DESCRIPTION
- Ticket: https://devexpress.com/issue=T1008562

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/18170
- https://github.com/DevExpress/DevExtreme/pull/18188

---

I edited `optionChanged` method in `ui.grid_core.selection`.  Previously it cleared `selectedRowKeys` on changing options `showCheckBoxesMode`, which isn't necessary

Other options in `selection.*`:

- `allowSelectAll` — this option is checked in method `_updateSelectAllValue`, which is added to `selectionChanged` event. It may be unsafe to skip updating on this option, cause in updating we fire this event
- `deferred` — obviously can't skip updating
- `mode` — obviously can't skip updating
- `selectAllMode` — breaks `'change selectAllMode to \'allPages\' at runtime'` test
