### PR TITLE
DataGrid: Fix editing cells when a column is bound to nested objects that are instances of a class (T1009400)

### DIFF
--- a/js/data/array_utils.js
+++ b/js/data/array_utils.js
@@ -1,4 +1,4 @@
-import { isPlainObject, isEmptyObject, isDefined } from '../core/utils/type';
+import { isPlainObject, isEmptyObject, isDefined, isObject } from '../core/utils/type';
 import config from '../core/config';
 import Guid from '../core/guid';
 import { extend, extendFromObject } from '../core/utils/extend';
@@ -80,11 +80,26 @@ function setDataByKeyMapValue(array, key, data) {
     }
 }
 
-function createObjectWithChanges(target, changes) {
-    const result = target ? Object.create(Object.getPrototypeOf(target)) : {};
-    const targetWithoutPrototype = extendFromObject({}, target);
+function cloneInstance(instance) {
+    const result = instance ? Object.create(Object.getPrototypeOf(instance)) : {};
+    const instanceWithoutPrototype = extendFromObject({}, instance);
 
-    deepExtendArraySafe(result, targetWithoutPrototype, true, true);
+    for(const name in instanceWithoutPrototype) {
+        const prop = instanceWithoutPrototype[name];
+
+        if(isObject(prop) && !isPlainObject(prop)) {
+            instanceWithoutPrototype[name] = cloneInstance(prop);
+        }
+    }
+
+    deepExtendArraySafe(result, instanceWithoutPrototype, true, true);
+
+    return result;
+}
+
+function createObjectWithChanges(target, changes) {
+    const result = cloneInstance(target);
+
     return deepExtendArraySafe(result, changes, true, true);
 }
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8625,6 +8625,75 @@ QUnit.module('Editing with real dataController', {
         });
     });
 
+    // T1009400
+    QUnit.test('Roll back modified data when there are nested data items as class instances', function(assert) {
+        // arrange
+        let items;
+        const rowsView = this.rowsView;
+        const $testElement = $('#container');
+        const checkClassInstances = (items) => {
+            assert.ok(Object.prototype.isPrototypeOf.call(Data, items[0].data), 'item is an instance of the Data class');
+            assert.ok(Object.prototype.isPrototypeOf.call(Prop1, items[0].data.prop1), 'item prop is an instance of the Prop1 class');
+            assert.ok(Object.prototype.isPrototypeOf.call(Prop2, items[0].data.prop1.prop2), 'item prop is an instance of the Prop2 class');
+        };
+
+        class Data {
+            prop1
+        }
+        class Prop1 {
+            prop2
+        }
+
+        class Prop2 {
+            name
+        }
+
+        const dataSource = [{
+            prop1: {
+                prop2: {
+                    field: 'test'
+                }
+            }
+        }];
+        Object.setPrototypeOf(dataSource[0], Data);
+        Object.setPrototypeOf(dataSource[0].prop1, Prop1);
+        Object.setPrototypeOf(dataSource[0].prop1.prop2, Prop2);
+
+        $.extend(this.options.editing, {
+            mode: 'cell',
+            allowUpdating: true
+        });
+        this.options.dataSource = dataSource;
+        this.option('columns', ['prop1.prop2.field']);
+
+        this.dataController.init();
+        this.columnsController.init();
+        rowsView.render($testElement);
+
+        // assert
+        items = this.dataController.items();
+        checkClassInstances(items);
+        assert.strictEqual(items[0].data.prop1.prop2.field, 'test', 'item prop value');
+        assert.strictEqual(dataSource[0].prop1.prop2.field, 'test', 'datasource item prop value');
+
+        // act
+        this.cellValue(0, 0, 'abc');
+
+        // assert
+        items = this.dataController.items();
+        checkClassInstances(items);
+        assert.strictEqual(items[0].data.prop1.prop2.field, 'abc', 'item prop value');
+        assert.strictEqual(dataSource[0].prop1.prop2.field, 'test', 'datasource item prop value');
+
+        // act
+        this.cancelEditData();
+
+        // assert
+        items = this.dataController.items();
+        checkClassInstances(items);
+        assert.strictEqual(items[0].data.prop1.prop2.field, 'test', 'item prop value');
+        assert.strictEqual(dataSource[0].prop1.prop2.field, 'test', 'datasource item prop value');
+    });
 
     QUnit.module('Editing state', {
         beforeEach: function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8637,16 +8637,9 @@ QUnit.module('Editing with real dataController', {
             assert.ok(Object.prototype.isPrototypeOf.call(Prop2, items[0].data.prop1.prop2), 'item prop is an instance of the Prop2 class');
         };
 
-        class Data {
-            prop1
-        }
-        class Prop1 {
-            prop2
-        }
-
-        class Prop2 {
-            name
-        }
+        function Data(prop1) { }
+        function Prop1(prop2) { }
+        function Prop2(name) { }
 
         const dataSource = [{
             prop1: {


### PR DESCRIPTION
See https://devexpress.com/issue=T1009400