### PR TITLE
DataGrid — change color of deleted row in batch mode

### DIFF
--- a/scss/widgets/generic/gridBase/_colors.scss
+++ b/scss/widgets/generic/gridBase/_colors.scss
@@ -98,8 +98,8 @@ $datagrid-menu-icon-color: null !default;
 * $type color
 */
 $datagrid-cell-modified-border-color: null !default;
-$datagrid-cell-removed-border-color: darken($base-bg, 25%) !default;
-$datagrid-row-removed-bg: darken($base-bg, 25%) !default;
+$datagrid-cell-removed-border-color: $datagrid-border-color !default;
+$datagrid-row-removed-bg: $datagrid-border-color !default;
 
 /**
 * $name 45. Invalidate data faded color
@@ -527,3 +527,4 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/softblue/grid/text-stub.png') !default;
 }
 
+$datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;

--- a/scss/widgets/generic/gridBase/_colors.scss
+++ b/scss/widgets/generic/gridBase/_colors.scss
@@ -98,7 +98,8 @@ $datagrid-menu-icon-color: null !default;
 * $type color
 */
 $datagrid-cell-modified-border-color: null !default;
-$datagrid-row-removed-bg: color.change($base-success, $alpha: 0.5) !default;
+$datagrid-cell-removed-border-color: darken($base-bg, 25%) !default;
+$datagrid-row-removed-bg: darken($base-bg, 25%) !default;
 
 /**
 * $name 45. Invalidate data faded color

--- a/scss/widgets/generic/gridBase/_colors.scss
+++ b/scss/widgets/generic/gridBase/_colors.scss
@@ -98,8 +98,9 @@ $datagrid-menu-icon-color: null !default;
 * $type color
 */
 $datagrid-cell-modified-border-color: null !default;
-$datagrid-cell-removed-border-color: $datagrid-border-color !default;
-$datagrid-row-removed-bg: $datagrid-border-color !default;
+$datagrid-cell-removed-border-color: null !default;
+$datagrid-row-removed-bg: null !default;
+$datagrid-cell-removed-text-color: null !default;
 
 /**
 * $name 45. Invalidate data faded color
@@ -245,6 +246,9 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-overlay-border-radius: $base-border-radius-large !default; // TODO: may be not need
   $datagrid-column-separator-bg: color.change($base-accent, $alpha: 0.5) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/carmine/grid/text-stub.png') !default;
+  $datagrid-cell-removed-border-color: $datagrid-border-color !default;
+  $datagrid-row-removed-bg: $datagrid-border-color !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
 @if $color == "contrast" {
@@ -285,6 +289,9 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-overlay-border-radius: $base-border-radius + 2px !default;
   $datagrid-column-separator-bg: darken($datagrid-base-background-color, 13.5%) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/contrast/grid/text-stub.png') !default;
+  $datagrid-cell-removed-border-color: $base-accent !default;
+  $datagrid-row-removed-bg: $base-accent !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
 @if $color == "dark" {
@@ -325,6 +332,9 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-overlay-border-radius: $base-border-radius-large !default; // TODO: may be not need
   $datagrid-column-separator-bg: color.change($base-accent, $alpha: 0.5) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/dark/grid/text-stub.png') !default;
+  $datagrid-cell-removed-border-color: $datagrid-border-color !default;
+  $datagrid-row-removed-bg: $datagrid-border-color !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
 @if $color == "darkmoon" {
@@ -365,6 +375,9 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-overlay-border-radius: $base-border-radius-large !default;
   $datagrid-column-separator-bg: color.change($base-accent, $alpha: 0.5) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/darkmoon/grid/text-stub.png') !default;
+  $datagrid-cell-removed-border-color: $datagrid-border-color !default;
+  $datagrid-row-removed-bg: $datagrid-border-color !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
 @if $color == "darkviolet" {
@@ -405,6 +418,9 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-overlay-border-radius: $base-border-radius-large !default; // TODO: may be not need
   $datagrid-column-separator-bg: color.change($base-accent, $alpha: 0.5) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/darkviolet/grid/text-stub.png') !default;
+  $datagrid-cell-removed-border-color: $datagrid-border-color !default;
+  $datagrid-row-removed-bg: $datagrid-border-color !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
 @if $color == "greenmist" {
@@ -445,6 +461,9 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-overlay-border-radius: $base-border-radius-large !default; // TODO: may be not need
   $datagrid-column-separator-bg: color.change($base-accent, $alpha: 0.5) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/greenmist/grid/text-stub.png') !default;
+  $datagrid-cell-removed-border-color: $datagrid-border-color !default;
+  $datagrid-row-removed-bg: $datagrid-border-color !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
 @if $color == "light" {
@@ -485,6 +504,9 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-overlay-border-radius: $base-border-radius-large !default; // TODO: may be not need
   $datagrid-column-separator-bg: color.change($base-accent, $alpha: 0.5) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/light/grid/text-stub.png') !default;
+  $datagrid-cell-removed-border-color: $datagrid-border-color !default;
+  $datagrid-row-removed-bg: $datagrid-border-color !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
 @if $color == "softblue" {
@@ -525,6 +547,8 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-overlay-border-radius: $base-border-radius-large !default; // TODO: may be not need
   $datagrid-column-separator-bg: color.change($base-accent, $alpha: 0.5) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/generic/color-schemes/softblue/grid/text-stub.png') !default;
+  $datagrid-cell-removed-border-color: $datagrid-border-color !default;
+  $datagrid-row-removed-bg: $datagrid-border-color !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
-$datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;

--- a/scss/widgets/generic/gridBase/_index.scss
+++ b/scss/widgets/generic/gridBase/_index.scss
@@ -725,8 +725,8 @@ $generic-grid-base-checkbox-indeterminate-icon-size: 6px;
 
     .dx-row-removed > td {
       background-color: $datagrid-row-removed-bg;
-      border-top: 1px solid $datagrid-cell-modified-border-color;
-      border-bottom: 1px solid $datagrid-cell-modified-border-color;
+      border-top: 1px solid $datagrid-cell-removed-border-color;
+      border-bottom: 1px solid $datagrid-cell-removed-border-color;
     }
 
     @include dx-set-checkbox-border-color-as-background();

--- a/scss/widgets/generic/gridBase/_index.scss
+++ b/scss/widgets/generic/gridBase/_index.scss
@@ -727,6 +727,7 @@ $generic-grid-base-checkbox-indeterminate-icon-size: 6px;
       background-color: $datagrid-row-removed-bg;
       border-top: 1px solid $datagrid-cell-removed-border-color;
       border-bottom: 1px solid $datagrid-cell-removed-border-color;
+      color: $datagrid-cell-removed-text-color;
     }
 
     @include dx-set-checkbox-border-color-as-background();

--- a/scss/widgets/material/gridBase/_colors.scss
+++ b/scss/widgets/material/gridBase/_colors.scss
@@ -79,8 +79,8 @@ $datagrid-menu-icon-color: lighten($base-icon-color, 33.7%) !default;
 * $type color
 */
 $datagrid-cell-modified-border-color: color.change($base-success, $alpha: 0.32) !default;
-$datagrid-cell-removed-border-color: darken($base-bg, 30%) !default;
-$datagrid-row-removed-bg: darken($base-bg, 30%) !default;
+$datagrid-cell-removed-border-color: $datagrid-border-color !default;
+$datagrid-row-removed-bg: $datagrid-border-color !default;
 
 /**
 * $name 45. Invalidate data faded color
@@ -194,3 +194,4 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/material/color-schemes/dark/grid/text-stub.png') !default;
 }
 
+$datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;

--- a/scss/widgets/material/gridBase/_colors.scss
+++ b/scss/widgets/material/gridBase/_colors.scss
@@ -81,6 +81,7 @@ $datagrid-menu-icon-color: lighten($base-icon-color, 33.7%) !default;
 $datagrid-cell-modified-border-color: color.change($base-success, $alpha: 0.32) !default;
 $datagrid-cell-removed-border-color: $datagrid-border-color !default;
 $datagrid-row-removed-bg: $datagrid-border-color !default;
+$datagrid-cell-removed-text-color: null !default;
 
 /**
 * $name 45. Invalidate data faded color
@@ -178,6 +179,7 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-item-bg: $datagrid-columnchooser-bg !default;
   $datagrid-row-alternation-bg: darken($datagrid-base-background-color, 4%) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/material/color-schemes/light/grid/text-stub.png') !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
 @if $mode == "dark" {
@@ -192,6 +194,6 @@ $datagrid-icon-link-disabled-opacity: $button-disabled-icon-opacity;
   $datagrid-columnchooser-item-bg: lighten($datagrid-columnchooser-bg, 3%) !default;
   $datagrid-row-alternation-bg: lighten($datagrid-base-background-color, 4%) !default;
   $datagrid-text-stub-background-image-path: data-uri('images/widgets/material/color-schemes/dark/grid/text-stub.png') !default;
+  $datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;
 }
 
-$datagrid-cell-removed-text-color: $datagrid-columnchooser-item-color !default;

--- a/scss/widgets/material/gridBase/_colors.scss
+++ b/scss/widgets/material/gridBase/_colors.scss
@@ -79,7 +79,8 @@ $datagrid-menu-icon-color: lighten($base-icon-color, 33.7%) !default;
 * $type color
 */
 $datagrid-cell-modified-border-color: color.change($base-success, $alpha: 0.32) !default;
-$datagrid-row-removed-bg: color.change($base-success, $alpha: 0.32) !default;
+$datagrid-cell-removed-border-color: darken($base-bg, 30%) !default;
+$datagrid-row-removed-bg: darken($base-bg, 30%) !default;
 
 /**
 * $name 45. Invalidate data faded color

--- a/scss/widgets/material/gridBase/_index.scss
+++ b/scss/widgets/material/gridBase/_index.scss
@@ -942,6 +942,7 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
       background-color: $datagrid-row-removed-bg;
       border-top: 1px solid $datagrid-cell-removed-border-color;
       border-bottom: 1px solid $datagrid-cell-removed-border-color;
+      color: $datagrid-cell-removed-text-color;
     }
 
     .dx-adaptive-detail-row {

--- a/scss/widgets/material/gridBase/_index.scss
+++ b/scss/widgets/material/gridBase/_index.scss
@@ -940,8 +940,8 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
 
     .dx-row-removed > td {
       background-color: $datagrid-row-removed-bg;
-      border-top: 1px solid $datagrid-cell-modified-border-color;
-      border-bottom: 1px solid $datagrid-cell-modified-border-color;
+      border-top: 1px solid $datagrid-cell-removed-border-color;
+      border-bottom: 1px solid $datagrid-cell-removed-border-color;
     }
 
     .dx-adaptive-detail-row {


### PR DESCRIPTION
I changed background color of deleted rows. Now value for background color is the same as border, except `contrast` theme, where value is accent color of the theme

- Demo: https://pomahtri.github.io/DataGridDeletedRowColor/
- Demo with previous colors: https://js.devexpress.com/Demos/WidgetsGallery/Demo/DataGrid/BatchEditing/Angular/Light/

---
About duplicating scss variables it themes: it's required because of `contrast` theme, where value for these variables is different.

I tried to set default value outside of themes (instead of `null`) and then reset it in `contrast`, but it didn't work. I checked others variables in different themes, there are a lot of duplicates too, so it seems not to be bad practice

---

|from this|to that|
|-|-|
| ![image](https://user-images.githubusercontent.com/84017191/124235060-7e093800-db1d-11eb-8c4e-783eef969a88.png) | ![image](https://user-images.githubusercontent.com/84017191/124235255-ae50d680-db1d-11eb-8222-e840d3bfeb5a.png) |

