### PR TITLE
DateBox should not raise any errors when useMaskBehavior is enabled, locale digits are different to arabic digits and Fractional Seconds in the "displayFormat" (#18166)

### DIFF
--- a/js/ui/date_box/ui.date_box.mask.js
+++ b/js/ui/date_box/ui.date_box.mask.js
@@ -329,10 +329,20 @@ const DateBoxMask = DateBoxBase.inherit({
 
     _prepareRegExpInfo() {
         this._regExpInfo = getRegExpInfo(this._getFormatPattern(), dateLocalization);
-        const regExp = this._regExpInfo.regexp;
-        const flags = regExp.flags;
-        const convertedRegExp = numberLocalization.convertDigits(this._regExpInfo.regexp.source, false);
-        this._regExpInfo.regexp = RegExp(convertedRegExp, flags);
+        const regexp = this._regExpInfo.regexp;
+        const source = regexp.source;
+        const flags = regexp.flags;
+        const quantifierRegexp = new RegExp(/(\{[0-9]+,?[0-9]*\})/);
+
+        const convertedSource = source
+            .split(quantifierRegexp)
+            .map((sourcePart) => {
+                return quantifierRegexp.test(sourcePart) ?
+                    sourcePart :
+                    numberLocalization.convertDigits(sourcePart, false);
+            })
+            .join('');
+        this._regExpInfo.regexp = new RegExp(convertedSource, flags);
     },
 
     _initMaskState() {

--- a/testing/tests/DevExpress.localization/localization.globalize.widgets.tests.js
+++ b/testing/tests/DevExpress.localization/localization.globalize.widgets.tests.js
@@ -150,6 +150,26 @@ QUnit.module('DateBox', commonEnvironment, () => {
         }
     });
 
+    QUnit.test('DateBox should not raise error when digits are not default arabic digits and Fractional Seconds in the "displayFormat"', function(assert) {
+        const originalCulture = Globalize.locale().locale;
+
+        try {
+            Globalize.locale('ar');
+
+            const dateBox = $('#dateBox').dxDateBox({
+                value: new Date('2014-09-08T08:02:17.12'),
+                useMaskBehavior: true,
+                displayFormat: 'HH:mm:ss.SS'
+            }).dxDateBox('instance');
+
+            assert.strictEqual(dateBox.option('text'), '٠٨:٠٢:١٧.١٢', 'date is localized');
+        } catch(e) {
+            assert.ok(false, `Error occured: ${e.message}`);
+        } finally {
+            Globalize.locale(originalCulture);
+        }
+    });
+
     QUnit.test('DateBox should not raise error when digits are Farsi digits', function(assert) {
         const originalCulture = Globalize.locale().locale;
 

--- a/testing/tests/DevExpress.localization/localization.intl.widgets.tests.js
+++ b/testing/tests/DevExpress.localization/localization.intl.widgets.tests.js
@@ -107,6 +107,24 @@ QUnit.module('Intl localization', () => {
                 locale(currentLocale);
             }
         });
+
+        QUnit.test('DateBox should not raise error when digits are not default arabic digits and Fractional Seconds in the "displayFormat"', function(assert) {
+            const currentLocale = locale();
+            try {
+                locale('mr');
+                const dateBox = $('#dateBox').dxDateBox({
+                    value: new Date('2014-09-08T08:02:17.12'),
+                    useMaskBehavior: true,
+                    displayFormat: 'HH:mm:ss.SS'
+                }).dxDateBox('instance');
+
+                assert.strictEqual(dateBox.option('text'), '०८:०२:१७.१२', 'date is localized');
+            } catch(e) {
+                assert.ok(false, `Error occured: ${e.message}`);
+            } finally {
+                locale(currentLocale);
+            }
+        });
     });
 });
 


### PR DESCRIPTION
Cherry picked from commit ae6caae695436d641d1c78b971b56bd934a1a762
