### PR TITLE
 DataGrid - Pager's container is not hidden whereas its content is not visible (T1011042)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.pager.js
+++ b/js/ui/grid_core/ui.grid_core.pager.js
@@ -13,14 +13,11 @@ const getPageIndex = function(dataController) {
 
 const PagerView = modules.View.inherit({
     init: function() {
-        const that = this;
-        const dataController = that.getController('data');
+        const dataController = this.getController('data');
 
-        that._isVisible = false;
-
-        dataController.changed.add(function(e) {
+        dataController.changed.add((e) => {
             if(e && e.repaintChangesOnly) {
-                const pager = that._getPager();
+                const pager = this._getPager();
                 if(pager) {
                     pager.option({
                         pageIndex: getPageIndex(dataController),
@@ -30,10 +27,10 @@ const PagerView = modules.View.inherit({
                         hasKnownLastPage: dataController.hasKnownLastPage()
                     });
                 } else {
-                    that.render();
+                    this.render();
                 }
             } else if(!e || e.changeType !== 'update' && e.changeType !== 'updateSelection') {
-                that.render();
+                this.render();
             }
         });
     },
@@ -112,15 +109,11 @@ const PagerView = modules.View.inherit({
     },
 
     isVisible: function() {
-        const that = this;
-        const dataController = that.getController('data');
-        const pagerOptions = that.option('pager');
+        const dataController = this.getController('data');
+        const pagerOptions = this.option('pager');
         let pagerVisible = pagerOptions && pagerOptions.visible;
-        const scrolling = that.option('scrolling');
+        const scrolling = this.option('scrolling');
 
-        if(that._isVisible) {
-            return true;
-        }
         if(pagerVisible === 'auto') {
             if(scrolling && (scrolling.mode === 'virtual' || scrolling.mode === 'infinite')) {
                 pagerVisible = false;
@@ -128,7 +121,6 @@ const PagerView = modules.View.inherit({
                 pagerVisible = dataController.pageCount() > 1 || (dataController.isLoaded() && !dataController.hasKnownLastPage());
             }
         }
-        that._isVisible = pagerVisible;
         return pagerVisible;
     },
 
@@ -137,13 +129,12 @@ const PagerView = modules.View.inherit({
     },
 
     optionChanged: function(args) {
-        const that = this;
         const name = args.name;
         const isPager = name === 'pager';
         const isPaging = name === 'paging';
         const isDataSource = name === 'dataSource';
         const isScrolling = name === 'scrolling';
-        const dataController = that.getController('data');
+        const dataController = this.getController('data');
 
         if(isPager || isPaging || isScrolling || isDataSource) {
             args.handled = true;
@@ -153,16 +144,13 @@ const PagerView = modules.View.inherit({
             }
 
             if(isPager || isPaging) {
-                that._pageSizes = null;
-            }
-            if(isPager || isPaging || isScrolling) {
-                that._isVisible = false;
+                this._pageSizes = null;
             }
 
             if(!isDataSource) {
-                that._invalidate();
-                if(hasWindow() && isPager && that.component) {
-                    that.component.resize();
+                this._invalidate();
+                if(hasWindow() && isPager && this.component) {
+                    this.component.resize();
                 }
             }
         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
@@ -548,10 +548,8 @@ QUnit.module('Pager', {
         this.options.pager = { visible: 'auto' };
         this.dataControllerOptions.pageCount = 2;
 
-        pagerView.isVisible();
-
         // assert
-        assert.equal(pagerView._isVisible, true, 'isVisible');
+        assert.equal(pagerView.isVisible(), true, 'isVisible');
 
         // act
         pagerView.component.resize = function() {
@@ -563,7 +561,7 @@ QUnit.module('Pager', {
         pagerView.option('dataSource', [{}]);
 
         // assert
-        assert.equal(pagerView._isVisible, true, 'isVisible');
+        assert.equal(pagerView.isVisible(), true, 'isVisible');
         assert.equal(isInvalidateCalled, undefined, 'invalidate');
         assert.equal(isResizeCalled, undefined, 'resize');
     });
@@ -679,7 +677,7 @@ QUnit.module('Pager', {
         this.option('paging.pageSize', 6);
 
         // assert
-        assert.ok(this.pagerView._isVisible, 'pager visible');
+        assert.ok(this.pagerView.isVisible(), 'pager visible');
         assert.strictEqual(this.pagerView._invalidate.callCount, 0, 'render not execute');
         this.pagerView._invalidate.restore();
     });
@@ -743,6 +741,52 @@ QUnit.module('Pager', {
 
         // assert
         assert.equal(this.pagerView.element().find('.dx-info').css('direction'), 'rtl', 'infoText has rtl direction');
+    });
+
+    QUnit.test('Pager container should be hidden when its content is not visible (T1011042)', function(assert) {
+        // arrange
+        const $testElement = $('#container');
+
+        this.options.pager.allowedPageSizes = [2, 4, 6];
+        this.dataControllerOptions = {
+            pageSize: 4,
+            pageCount: 2,
+            pageIndex: 0,
+            totalCount: 6
+        };
+        this.pagerView.render($testElement);
+        sinon.spy(this.pagerView, '_invalidate');
+
+        // act
+        this.dataController.skipProcessingPagingChange = function() { return true; };
+        this.option('paging.pageSize', 6);
+
+        // assert
+        assert.ok(this.pagerView.isVisible(), 'pager visible');
+        assert.strictEqual(this.pagerView._invalidate.callCount, 0, 'render not execute');
+        this.pagerView._invalidate.restore();
+    });
+
+    // T1011042
+    QUnit.test('Pager container is hidden after refresh if its content is not visible', function(assert) {
+        // arrange
+        const $testElement = $('#container');
+
+        this.dataControllerOptions = {};
+        this.options.pager = {
+            visible: 'auto'
+        };
+        this.pagerView.render($testElement);
+
+        // assert
+        assert.strictEqual($('.dx-datagrid-pager').length, 1, 'pager container exists');
+        assert.notOk($('.dx-datagrid-pager').hasClass('dx-hidden'), 'pager container is visible');
+
+        // act
+        this.dataController.updatePagesCount(1);
+
+        // assert
+        assert.ok($('.dx-datagrid-pager').hasClass('dx-hidden'), 'pager is not visible');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
@@ -743,30 +743,6 @@ QUnit.module('Pager', {
         assert.equal(this.pagerView.element().find('.dx-info').css('direction'), 'rtl', 'infoText has rtl direction');
     });
 
-    QUnit.test('Pager container should be hidden when its content is not visible (T1011042)', function(assert) {
-        // arrange
-        const $testElement = $('#container');
-
-        this.options.pager.allowedPageSizes = [2, 4, 6];
-        this.dataControllerOptions = {
-            pageSize: 4,
-            pageCount: 2,
-            pageIndex: 0,
-            totalCount: 6
-        };
-        this.pagerView.render($testElement);
-        sinon.spy(this.pagerView, '_invalidate');
-
-        // act
-        this.dataController.skipProcessingPagingChange = function() { return true; };
-        this.option('paging.pageSize', 6);
-
-        // assert
-        assert.ok(this.pagerView.isVisible(), 'pager visible');
-        assert.strictEqual(this.pagerView._invalidate.callCount, 0, 'render not execute');
-        this.pagerView._invalidate.restore();
-    });
-
     // T1011042
     QUnit.test('Pager container is hidden after refresh if its content is not visible', function(assert) {
         // arrange


### PR DESCRIPTION
Ticket: https://devexpress.com/issue=T1011042

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/18207
- https://github.com/DevExpress/DevExtreme/pull/18208

---

Pager container visibility was incorrect because of `_isVisible` field. It seems that this field isn't needed