### PR TITLE
DataGrid - Field is not updating correctly with cell.setValue method (T1009772)

### DIFF
--- a/js/data/array_utils.js
+++ b/js/data/array_utils.js
@@ -246,6 +246,7 @@ function indexByKey(keyInfo, array, key) {
 export {
     applyBatch,
     createObjectWithChanges,
+    cloneInstance,
     update,
     insert,
     remove,

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -107,6 +107,14 @@ const isEditingOrShowEditorAlwaysDataCell = function(isEditRow, cellOptions) {
     return cellOptions.rowType === 'data' && isEditorCell;
 };
 
+const applyChangesOneLevel = function(obj, changes) {
+    obj = { ...obj };
+    Object.keys(changes).forEach(key=> {
+        delete obj[key];
+    });
+    return createObjectWithChanges(obj, changes);
+};
+
 const EditingController = modules.ViewController.inherit((function() {
     const getEditingTexts = (options) => {
         const editingTexts = options.component.option('editing.texts') || {};
@@ -1855,20 +1863,14 @@ const EditingController = modules.ViewController.inherit((function() {
 
             if(change) {
                 if(options.data) {
-                    Object.keys(options.data).forEach((key) => {
-                        delete change.data[key];
-                    });
-                    change.data = createObjectWithChanges(change.data, options.data);
+                    change.data = applyChangesOneLevel(change.data, options.data);
                 }
                 if((!change.type || !options.data) && options.type) {
                     change.type = options.type;
                 }
                 if(row) {
                     row.oldData = this._getOldData(row.key);
-                    Object.keys(options.data).forEach((key) => {
-                        delete row.data[key];
-                    });
-                    row.data = createObjectWithChanges(row.data, options.data);
+                    row.data = applyChangesOneLevel(row.data, options.data);
                 }
             }
 

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1855,6 +1855,9 @@ const EditingController = modules.ViewController.inherit((function() {
 
             if(change) {
                 if(options.data) {
+                    Object.keys(options.data).forEach((key) => {
+                        delete change.data[key];
+                    });
                     change.data = createObjectWithChanges(change.data, options.data);
                 }
                 if((!change.type || !options.data) && options.type) {
@@ -1862,6 +1865,9 @@ const EditingController = modules.ViewController.inherit((function() {
                 }
                 if(row) {
                     row.oldData = this._getOldData(row.key);
+                    Object.keys(options.data).forEach((key) => {
+                        delete row.data[key];
+                    });
                     row.data = createObjectWithChanges(row.data, options.data);
                 }
             }

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -4,14 +4,14 @@ import eventsEngine from '../../events/core/events_engine';
 import Guid from '../../core/guid';
 import { isDefined, isObject, isFunction, isEmptyObject } from '../../core/utils/type';
 import { each } from '../../core/utils/iterator';
-import { extend, extendFromObject } from '../../core/utils/extend';
+import { extend } from '../../core/utils/extend';
 import { deepExtendArraySafe } from '../../core/utils/object';
 import modules from './ui.grid_core.modules';
 import { name as clickEventName } from '../../events/click';
 import { name as doubleClickEvent } from '../../events/double_click';
 import pointerEvents from '../../events/pointer';
 import gridCoreUtils from './ui.grid_core.utils';
-import { createObjectWithChanges } from '../../data/array_utils';
+import { createObjectWithChanges, cloneInstance } from '../../data/array_utils';
 import { addNamespace } from '../../events/utils/index';
 import { confirm } from '../dialog';
 import messageLocalization from '../../localization/message';
@@ -108,15 +108,11 @@ const isEditingOrShowEditorAlwaysDataCell = function(isEditRow, cellOptions) {
     return cellOptions.rowType === 'data' && isEditorCell;
 };
 
-const applyChangesOneLevel = function(target, changes) {
-    const result = target ? Object.create(Object.getPrototypeOf(target)) : {};
-    const targetWithoutPrototype = extendFromObject({}, target);
-    deepExtendArraySafe(result, targetWithoutPrototype, true, true);
-
+const createObjectWithChangesOnOneLevel = function(target, changes) {
+    const result = cloneInstance(target);
     Object.keys(changes).forEach(key=> {
         delete result[key];
     });
-
     return deepExtendArraySafe(result, changes, true, true);
 };
 
@@ -1868,14 +1864,14 @@ const EditingController = modules.ViewController.inherit((function() {
 
             if(change) {
                 if(options.data) {
-                    change.data = applyChangesOneLevel(change.data, options.data);
+                    change.data = createObjectWithChangesOnOneLevel(change.data, options.data);
                 }
                 if((!change.type || !options.data) && options.type) {
                     change.type = options.type;
                 }
                 if(row) {
                     row.oldData = this._getOldData(row.key);
-                    row.data = applyChangesOneLevel(row.data, options.data);
+                    row.data = createObjectWithChangesOnOneLevel(row.data, options.data);
                 }
             }
 

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -4,7 +4,8 @@ import eventsEngine from '../../events/core/events_engine';
 import Guid from '../../core/guid';
 import { isDefined, isObject, isFunction, isEmptyObject } from '../../core/utils/type';
 import { each } from '../../core/utils/iterator';
-import { extend } from '../../core/utils/extend';
+import { extend, extendFromObject } from '../../core/utils/extend';
+import { deepExtendArraySafe } from '../../core/utils/object';
 import modules from './ui.grid_core.modules';
 import { name as clickEventName } from '../../events/click';
 import { name as doubleClickEvent } from '../../events/double_click';
@@ -107,12 +108,16 @@ const isEditingOrShowEditorAlwaysDataCell = function(isEditRow, cellOptions) {
     return cellOptions.rowType === 'data' && isEditorCell;
 };
 
-const applyChangesOneLevel = function(obj, changes) {
-    obj = { ...obj };
+const applyChangesOneLevel = function(target, changes) {
+    const result = target ? Object.create(Object.getPrototypeOf(target)) : {};
+    const targetWithoutPrototype = extendFromObject({}, target);
+    deepExtendArraySafe(result, targetWithoutPrototype, true, true);
+
     Object.keys(changes).forEach(key=> {
-        delete obj[key];
+        delete result[key];
     });
-    return createObjectWithChanges(obj, changes);
+
+    return deepExtendArraySafe(result, changes, true, true);
 };
 
 const EditingController = modules.ViewController.inherit((function() {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -10032,6 +10032,22 @@ QUnit.module('Editing with real dataController', {
             assert.equal($(this.getCellElement(0, 0)).text(), 'test', 'cell was modified');
         });
     });
+
+    // T1009772
+    QUnit.test('Editing does not merge changes when value of cell is object', function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+        rowsView.render(testElement);
+
+        // act
+        this.cellValue(0, 0, { a: 1, b: 1 });
+        this.cellValue(0, 0, { a: 2 });
+        this.saveEditData();
+
+        // assert
+        assert.deepEqual(this.cellValue(0, 0), { a: 2 }, 'value didn\'t merge');
+    });
 });
 
 QUnit.module('Refresh modes', {


### PR DESCRIPTION
Ticket:  https://devexpress.com/issue=T1009772

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/18228
- https://github.com/DevExpress/DevExtreme/pull/18227

---

In method `_addChange` new changes were added using [`createObjectWithChanges`], which led to object values to be merged instead of overwritten. 

Using of [`createObjectWithChanges`] seems to be important because of using safe extending, so I copied its code as `createObjectWithChangesOnOneLevel` and added deleting of previous values. Unfortunately, I can't just delete keys before calling this func: object needs to be copied before that, and it's important to save prototype

[`createObjectWithChanges`]: https://github.com/DevExpress/DevExtreme/blob/21_2/js/data/array_utils.js#L100-L104