### PR TITLE
temp WA for 'integration-data-generator' error

### DIFF
--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -844,12 +844,6 @@ export interface dxTreeListOptions extends GridBaseOptions<dxTreeList> {
      * @type object
      */
     selection?: Selection;
-    /**
-     * @docid
-     * @default undefined
-     * @public
-     */
-     toolbar?: dxTreeListToolbar;
 }
 
 /**

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -20424,10 +20424,6 @@ declare module DevExpress.ui {
      * [descr:dxTreeListOptions.selection]
      */
     selection?: DevExpress.ui.dxTreeList.Selection;
-    /**
-     * [descr:dxTreeListOptions.toolbar]
-     */
-    toolbar?: dxTreeListToolbar;
   }
   /**
    * @deprecated 


### PR DESCRIPTION
Temporarily removing the `dxTreeListToolbar` property to fix the `Build.v21.2.DevExtreme` task