### PR TITLE
DataGrid - displays two loading indicators if the widget contains fixed columns (T1011801)

### DIFF
--- a/scss/widgets/base/_gridBase.scss
+++ b/scss/widgets/base/_gridBase.scss
@@ -850,12 +850,6 @@
       .dx-scrollable-scrollbar {
         z-index: 3;
       }
-
-      .dx-#{$widget-name}-content:not(.dx-#{$widget-name}-content-fixed) {
-        .dx-#{$widget-name}-bottom-load-panel {
-          visibility: hidden;
-        }
-      }
     }
 
     .dx-#{$widget-name}-content {

--- a/scss/widgets/base/_gridBase.scss
+++ b/scss/widgets/base/_gridBase.scss
@@ -850,6 +850,12 @@
       .dx-scrollable-scrollbar {
         z-index: 3;
       }
+
+      .dx-#{$widget-name}-content:not(.dx-#{$widget-name}-content-fixed) {
+        .dx-#{$widget-name}-bottom-load-panel {
+          visibility: hidden;
+        }
+      }
     }
 
     .dx-#{$widget-name}-content {

--- a/scss/widgets/generic/gridBase/_index.scss
+++ b/scss/widgets/generic/gridBase/_index.scss
@@ -922,6 +922,7 @@ $generic-grid-base-checkbox-indeterminate-icon-size: 6px;
 
   .dx-#{$widget-name}-bottom-load-panel {
     border-top: $datagrid-border;
+    background-color: $datagrid-base-background-color;
   }
 
   .dx-#{$widget-name}-pager {

--- a/scss/widgets/material/gridBase/_index.scss
+++ b/scss/widgets/material/gridBase/_index.scss
@@ -1103,6 +1103,7 @@ $material-grid-base-cell-padding: $material-grid-base-cell-vertical-padding $mat
 
   .dx-#{$widget-name}-bottom-load-panel {
     border-top: $datagrid-border;
+    background-color: $datagrid-base-background-color;
   }
 
   .dx-#{$widget-name}-summary-item {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
@@ -3257,7 +3257,6 @@ QUnit.module('Fixed columns with real dataController and columnController', {
     // T829901
     QUnit.test('The load panel should not be displayed when fixing and unfixing the column', function(assert) {
         // arrange
-        $('#qunit-fixture').attr('id', 'qunit-fixture-visible');
         const that = this;
         const $testElement = $('#container').width(400);
         const generateData = () => {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
@@ -3288,11 +3288,6 @@ QUnit.module('Fixed columns with real dataController and columnController', {
         // assert
         assert.strictEqual($testElement.find('.dx-datagrid-bottom-load-panel').length, 2, 'load panel count');
 
-        const fixedLoadPanel = $testElement.find('.dx-datagrid-bottom-load-panel.dx-datagrid-content-fixed');
-        const notFixedLoadPanel = $testElement.find('.dx-datagrid-bottom-load-panel:not(.dx-datagrid-content-fixed)');
-        assert.notStrictEqual(fixedLoadPanel.css('visibility'), 'hidden', 'first load panel is visible');
-        assert.strictEqual(notFixedLoadPanel.css('visibility'), 'hidden', 'second load panel is hidden');
-
         // act
         that.columnOption(0, 'fixed', false);
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
@@ -3257,6 +3257,7 @@ QUnit.module('Fixed columns with real dataController and columnController', {
     // T829901
     QUnit.test('The load panel should not be displayed when fixing and unfixing the column', function(assert) {
         // arrange
+        $('#qunit-fixture').attr('id', 'qunit-fixture-visible');
         const that = this;
         const $testElement = $('#container').width(400);
         const generateData = () => {
@@ -3287,6 +3288,7 @@ QUnit.module('Fixed columns with real dataController and columnController', {
 
         // assert
         assert.strictEqual($testElement.find('.dx-datagrid-bottom-load-panel').length, 2, 'load panel count');
+        assert.strictEqual($testElement.find('.dx-datagrid-bottom-load-panel').css('background-color'), 'rgb(255, 255, 255)', 'load panel background'); // T1011801
 
         // act
         that.columnOption(0, 'fixed', false);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
@@ -3288,6 +3288,11 @@ QUnit.module('Fixed columns with real dataController and columnController', {
         // assert
         assert.strictEqual($testElement.find('.dx-datagrid-bottom-load-panel').length, 2, 'load panel count');
 
+        const fixedLoadPanel = $testElement.find('.dx-datagrid-bottom-load-panel.dx-datagrid-content-fixed');
+        const notFixedLoadPanel = $testElement.find('.dx-datagrid-bottom-load-panel:not(.dx-datagrid-content-fixed)');
+        assert.notStrictEqual(fixedLoadPanel.css('visibility'), 'hidden', 'first load panel is visible');
+        assert.strictEqual(notFixedLoadPanel.css('visibility'), 'hidden', 'second load panel is hidden');
+
         // act
         that.columnOption(0, 'fixed', false);
 


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/18266