### PR TITLE
DataGrid - The command column doesn't appear/disappear when changing Editing.allow (T1012892)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -1112,7 +1112,6 @@ export const columnsControllerModule = {
                         case 'groupPanel':
                         case 'regenerateColumnsByVisibleItems':
                         case 'customizeColumns':
-                        case 'editing':
                         case 'columnHidingEnabled':
                         case 'dateSerializationFormat':
                         case 'columnResizingMode':
@@ -1120,16 +1119,7 @@ export const columnsControllerModule = {
                         case 'columnWidth': {
                             args.handled = true;
                             const ignoreColumnOptionNames = args.fullName === 'columnWidth' && ['width'];
-                            const isEditingPopup = args.fullName?.indexOf('editing.popup') === 0;
-                            const isEditingForm = args.fullName?.indexOf('editing.form') === 0;
-                            const isEditRowKey = args.fullName?.indexOf('editing.editRowKey') === 0;
-                            const isEditColumnName = args.fullName?.indexOf('editing.editColumnName') === 0;
-                            const isChanges = args.fullName?.indexOf('editing.changes') === 0;
-                            const needReinit = !isEditingPopup && !isEditingForm && !isEditRowKey && !isChanges && !isEditColumnName;
-
-                            if(needReinit) {
-                                this.reinit(ignoreColumnOptionNames);
-                            }
+                            this.reinit(ignoreColumnOptionNames);
                             break;
                         }
                         case 'rtlEnabled':

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -33,6 +33,8 @@ import {
     EDIT_MODE_ROW,
     EDIT_MODES,
     ROW_BASED_MODES,
+    EDIT_MODE_POPUP,
+    EDIT_MODE_FORM
 } from './ui.grid_core.editing_constants';
 
 const READONLY_CLASS = 'readonly';
@@ -449,12 +451,13 @@ const EditingController = modules.ViewController.inherit((function() {
         optionChanged: function(args) {
             if(args.name === 'editing') {
                 const fullName = args.fullName;
+                const editMode = this.option('editing.mode');
 
                 if(fullName === EDITING_EDITROWKEY_OPTION_NAME) {
                     this._handleEditRowKeyChange(args);
                 } else if(fullName === EDITING_CHANGES_OPTION_NAME) {
                     this._handleChangesChange(args);
-                } else if(!args.handled) {
+                } else if(editMode !== EDIT_MODE_POPUP && editMode !== EDIT_MODE_FORM) {
                     this.init();
                     this.resetChanges();
                     this._resetEditColumnName();

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -33,8 +33,6 @@ import {
     EDIT_MODE_ROW,
     EDIT_MODES,
     ROW_BASED_MODES,
-    EDIT_MODE_POPUP,
-    EDIT_MODE_FORM
 } from './ui.grid_core.editing_constants';
 
 const READONLY_CLASS = 'readonly';
@@ -451,13 +449,13 @@ const EditingController = modules.ViewController.inherit((function() {
         optionChanged: function(args) {
             if(args.name === 'editing') {
                 const fullName = args.fullName;
-                const editMode = this.option('editing.mode');
 
                 if(fullName === EDITING_EDITROWKEY_OPTION_NAME) {
                     this._handleEditRowKeyChange(args);
                 } else if(fullName === EDITING_CHANGES_OPTION_NAME) {
                     this._handleChangesChange(args);
-                } else if(editMode !== EDIT_MODE_POPUP && editMode !== EDIT_MODE_FORM) {
+                } else if(!args.handled) {
+                    this._columnsController.reinit();
                     this.init();
                     this.resetChanges();
                     this._resetEditColumnName();

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -228,11 +228,11 @@ export const editingFormBasedModule = {
                                     editPopup.option(args.value);
                                 }
                             }
+                            args.handled = true;
                         } else if(editPopup?.option('visible') && fullName.indexOf('editing.form') === 0) {
                             this._repaintEditPopup();
+                            args.handled = true;
                         }
-
-                        args.handled = true;
                     }
 
                     this.callBase.apply(this, arguments);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -3398,6 +3398,34 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         assert.strictEqual($addRowButton.length, 1, 'add row button is rendered');
     });
 
+    // T1012892
+    QUnit.test('change editing.allowUpdating option should update editing column', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            dataSource: [{ a: 1 }, { a: 2 }, { a: 3 }]
+        });
+
+        // assert
+        let $deleteButton = dataGrid.$element().find('.dx-command-edit .dx-link-edit');
+        assert.strictEqual($deleteButton.length, 0, 'edit button is not visible');
+
+        // act
+        dataGrid.option('editing.allowUpdating', true);
+        this.clock.tick();
+
+        // assert
+        $deleteButton = dataGrid.$element().find('.dx-command-edit .dx-link-edit');
+        assert.strictEqual($deleteButton.length, dataGrid.totalCount(), 'edit button is visible');
+
+        // act
+        dataGrid.option('editing.allowUpdating', false);
+        this.clock.tick();
+
+        // assert
+        $deleteButton = dataGrid.$element().find('.dx-command-edit .dx-link-edit');
+        assert.strictEqual($deleteButton.length, 0, 'edit button is not visible');
+    });
+
     // T749733
     QUnit.test('Change editing.popup option should not reload data', function(assert) {
         // arrange


### PR DESCRIPTION
Ticket: https://devexpress.com/issue=T1012892

Cherry picks: 

- https://github.com/DevExpress/DevExtreme/pull/18308

---

Bug appeared after this changes (file `ui.grid_core.editing.js`, func `optionChanged` on line R 559), when form based editing file was added.

`else` -> `else if (!args.handled)`

https://github.com/DevExpress/DevExtreme/pull/16123/files#diff-262df002b9658f4dd9b587248b787c621b3145adac4eacf9e5d187bc450aaa4aR559

But in [columns controller](https://github.com/DevExpress/DevExtreme/blob/21_2/js/ui/grid_core/ui.grid_core.columns_controller.js#L1115) when changing `editing.*`, `handled` is always set to `true`, so I changed condition in  `ui.grid_core.editing.js`