### PR TITLE
DataGrid - cellTemplate stops responding after drag and drop if a component has fixed column (T1013088)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.row_dragging.js
+++ b/js/ui/grid_core/ui.grid_core.row_dragging.js
@@ -41,12 +41,6 @@ const RowDraggingExtender = {
         columnsController.columnOption('type:drag', 'visible', isHandleColumnVisible);
     },
 
-    _togglePointerEventsStyle: function(toggle) {
-        // T929503
-        const $el = this._sortableFixed?.$element();
-        $el?.css('pointerEvents', toggle ? 'auto' : '');
-    },
-
     _renderContent: function() {
         const rowDragging = this.option('rowDragging');
         const allowReordering = this._allowReordering();
@@ -56,6 +50,10 @@ const RowDraggingExtender = {
         const sortableFixedName = '_sortableFixed';
         const currentSortableName = isFixedTableRendering ? sortableFixedName : sortableName;
         const anotherSortableName = isFixedTableRendering ? sortableName : sortableFixedName;
+        const togglePointerEventsStyle = (toggle) => {
+            // T929503
+            this[sortableFixedName]?.$element().css('pointerEvents', toggle ? 'auto' : '');
+        };
 
         if((allowReordering || this[currentSortableName]) && $content.length) {
             this[currentSortableName] = this._createComponent($content, Sortable, extend({
@@ -77,15 +75,18 @@ const RowDraggingExtender = {
                     rowDragging.onDragStart?.(e);
                 },
                 onDragEnter: () => {
-                    this._togglePointerEventsStyle(true);
+                    togglePointerEventsStyle(true);
                 },
                 onDragLeave: () => {
-                    this._togglePointerEventsStyle(false);
+                    togglePointerEventsStyle(false);
                 },
                 onDragEnd: (e) => {
-                    this._togglePointerEventsStyle(false);
-                    e.toComponent.getView('rowsView')._togglePointerEventsStyle(false);
+                    togglePointerEventsStyle(false);
                     rowDragging.onDragEnd?.(e);
+                },
+                onAdd: (e) => {
+                    togglePointerEventsStyle(false);
+                    rowDragging.onAdd?.(e);
                 },
                 dropFeedbackMode: rowDragging.dropFeedbackMode,
                 onOptionChanged: (e) => {

--- a/js/ui/grid_core/ui.grid_core.row_dragging.js
+++ b/js/ui/grid_core/ui.grid_core.row_dragging.js
@@ -41,6 +41,12 @@ const RowDraggingExtender = {
         columnsController.columnOption('type:drag', 'visible', isHandleColumnVisible);
     },
 
+    _togglePointerEventsStyle: function(toggle) {
+        // T929503
+        const $el = this._sortableFixed?.$element();
+        $el?.css('pointerEvents', toggle ? 'auto' : '');
+    },
+
     _renderContent: function() {
         const rowDragging = this.option('rowDragging');
         const allowReordering = this._allowReordering();
@@ -50,10 +56,6 @@ const RowDraggingExtender = {
         const sortableFixedName = '_sortableFixed';
         const currentSortableName = isFixedTableRendering ? sortableFixedName : sortableName;
         const anotherSortableName = isFixedTableRendering ? sortableName : sortableFixedName;
-        const togglePointerEventsStyle = (toggle) => {
-            // T929503
-            this[sortableFixedName]?.$element().css('pointerEvents', toggle ? 'auto' : '');
-        };
 
         if((allowReordering || this[currentSortableName]) && $content.length) {
             this[currentSortableName] = this._createComponent($content, Sortable, extend({
@@ -75,13 +77,14 @@ const RowDraggingExtender = {
                     rowDragging.onDragStart?.(e);
                 },
                 onDragEnter: () => {
-                    togglePointerEventsStyle(true);
+                    this._togglePointerEventsStyle(true);
                 },
                 onDragLeave: () => {
-                    togglePointerEventsStyle(false);
+                    this._togglePointerEventsStyle(false);
                 },
                 onDragEnd: (e) => {
-                    togglePointerEventsStyle(false);
+                    this._togglePointerEventsStyle(false);
+                    e.toComponent.getView('rowsView')._togglePointerEventsStyle(false);
                     rowDragging.onDragEnd?.(e);
                 },
                 dropFeedbackMode: rowDragging.dropFeedbackMode,

--- a/testing/testcafe/tests/dataGrid/rowDragging.ts
+++ b/testing/testcafe/tests/dataGrid/rowDragging.ts
@@ -28,6 +28,11 @@ async function moveRow(grid: any, rowIndex: number, x: number, y: number): Promi
         pageX: cellOffset.left + x,
         pageY: cellOffset.top + y,
         pointers: [{ pointerId: 1 }],
+      }))
+      .trigger($.Event('dxpointerup', {
+        pageX: cellOffset.left + x,
+        pageY: cellOffset.top + y,
+        pointers: [{ pointerId: 1 }],
       }));
   },
   {
@@ -152,6 +157,18 @@ test('The cross-component drag and drop rows should work when there are fixed co
     .ok()
     .expect(getPlaceholderOffset())
     .eql(dataRowOffset);
+
+  const [fixedPointerEvents, otherFixedPointerEvents] = await ClientFunction(() => [
+    $('.dx-datagrid-rowsview .dx-datagrid-content-fixed:eq(0)').css('pointer-events'),
+    $('.dx-datagrid-rowsview .dx-datagrid-content-fixed:eq(1)').css('pointer-events'),
+  ], { dependencies: { dataGrid, otherDataGrid } })();
+
+  // T1013088
+  await t
+    .expect(fixedPointerEvents)
+    .eql('none')
+    .expect(otherFixedPointerEvents)
+    .eql('none');
 }).before(async (t) => {
   await t.maximizeWindow();
 

--- a/testing/testcafe/tests/dataGrid/rowDragging.ts
+++ b/testing/testcafe/tests/dataGrid/rowDragging.ts
@@ -1,4 +1,4 @@
-import { ClientFunction } from 'testcafe';
+import { ClientFunction, Selector } from 'testcafe';
 import url from '../../helpers/getPageUrl';
 import createWidget, { disposeWidgets } from '../../helpers/createWidget';
 import DataGrid from '../../model/dataGrid';
@@ -25,11 +25,6 @@ async function moveRow(grid: any, rowIndex: number, x: number, y: number): Promi
         pointers: [{ pointerId: 1 }],
       }))
       .trigger($.Event('dxpointermove', {
-        pageX: cellOffset.left + x,
-        pageY: cellOffset.top + y,
-        pointers: [{ pointerId: 1 }],
-      }))
-      .trigger($.Event('dxpointerup', {
         pageX: cellOffset.left + x,
         pageY: cellOffset.top + y,
         pointers: [{ pointerId: 1 }],
@@ -157,6 +152,92 @@ test('The cross-component drag and drop rows should work when there are fixed co
     .ok()
     .expect(getPlaceholderOffset())
     .eql(dataRowOffset);
+}).before(async (t) => {
+  await t.maximizeWindow();
+
+  await ClientFunction(() => {
+    $('body').css('display', 'flex');
+    $('#container, #otherContainer').css({
+      display: 'inline-block',
+      width: '50%',
+    });
+  })();
+
+  return Promise.all([
+    createWidget('dxDataGrid', {
+      width: 400,
+      dataSource: [
+        {
+          id: 1, name: 'Name 1', age: 19,
+        },
+        {
+          id: 2, name: 'Name 2', age: 11,
+        },
+        {
+          id: 3, name: 'Name 3', age: 15,
+        },
+        {
+          id: 4, name: 'Name 4', age: 16,
+        },
+        {
+          id: 5, name: 'Name 5', age: 25,
+        },
+        {
+          id: 6, name: 'Name 6', age: 18,
+        },
+        {
+          id: 7, name: 'Name 7', age: 21,
+        },
+        {
+          id: 8, name: 'Name 8', age: 14,
+        },
+      ],
+      columns: [{ dataField: 'id', fixed: true }, 'name', 'age'],
+      rowDragging: {
+        group: 'shared',
+      },
+    }),
+    createWidget('dxDataGrid', {
+      width: 400,
+      dataSource: [
+        {
+          id: 1, name: 'Name 1', age: 19,
+        },
+        {
+          id: 2, name: 'Name 2', age: 11,
+        },
+        {
+          id: 3, name: 'Name 3', age: 15,
+        },
+        {
+          id: 4, name: 'Name 4', age: 16,
+        },
+        {
+          id: 5, name: 'Name 5', age: 25,
+        },
+        {
+          id: 6, name: 'Name 6', age: 18,
+        },
+        {
+          id: 7, name: 'Name 7', age: 21,
+        },
+        {
+          id: 8, name: 'Name 8', age: 14,
+        },
+      ],
+      columns: [{ dataField: 'id', fixed: true }, 'name', 'age'],
+      rowDragging: {
+        group: 'shared',
+      },
+    }, false, '#otherContainer'),
+  ]);
+});
+
+test('The cross-component drag and drop rows should not block rows', async (t) => {
+  const dataGrid = new DataGrid('#container');
+  const otherDataGrid = new DataGrid('#otherContainer');
+
+  await t.drag(Selector('.dx-command-drag').nth(2), 500, 0);
 
   const [fixedPointerEvents, otherFixedPointerEvents] = await ClientFunction(() => [
     $('.dx-datagrid-rowsview .dx-datagrid-content-fixed:eq(0)').css('pointer-events'),
@@ -239,7 +320,7 @@ test('The cross-component drag and drop rows should work when there are fixed co
           id: 7, name: 'Name 7', age: 21,
         },
         {
-          id: 8, name: 'Name 8', age: 14,
+          id: 8, name: 'Name 8', age: 15,
         },
       ],
       columns: [{ dataField: 'id', fixed: true }, 'name', 'age'],


### PR DESCRIPTION
Ticket: https://devexpress.com/issue=T1013088

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/18342
- https://github.com/DevExpress/DevExtreme/pull/18341

---

On dragging rows on event `onDragEnter` fixed table's `pointer-events` css property was set to `auto`, and supposed to be cleaned on event `onDragEnd`. But this event called `togglePointerEventsStyle` only on "from" grid, so I added calling this method on "to" grid