### PR TITLE
LDML Date Parser: getRegExpInfo should return correct regular expression for unambiguous not separated `formats` and throw warning message in another case. (T1008667) (#18117)

### DIFF
--- a/js/localization/globalize/date.js
+++ b/js/localization/globalize/date.js
@@ -772,8 +772,8 @@ if(Globalize && Globalize.formatDate) {
                 };
             }
 
-            return Globalize.parseDate(text, format);
-
+            const parsedDate = Globalize.parseDate(text, format);
+            return parsedDate ? parsedDate : this.callBase(text, format);
         },
 
         _isAcceptableFormat: function(format) {

--- a/js/localization/ldml/date.parser.js
+++ b/js/localization/ldml/date.parser.js
@@ -1,4 +1,5 @@
 import { escapeRegExp } from '../../core/utils/common';
+import { logger } from '../../core/utils/console';
 
 const FORMAT_TYPES = {
     '3': 'abbreviated',
@@ -14,7 +15,7 @@ const monthRegExpGenerator = function(count, dateParts) {
             }).join('|');
         }).join('|');
     }
-    return '0?[1-9]|1[012]';
+    return count === 2 ? '1[012]|0?[1-9]' : '0??[1-9]|1[012]';
 };
 
 const PATTERN_REGEXPS = {
@@ -23,7 +24,7 @@ const PATTERN_REGEXPS = {
         return `\\${dateParts.getTimeSeparator()}${countSuffix}`;
     },
     y: function(count) {
-        return '[0-9]+';
+        return count === 2 ? `[0-9]{${count}}` : '[0-9]+?';
     },
     M: monthRegExpGenerator,
     L: monthRegExpGenerator,
@@ -40,25 +41,25 @@ const PATTERN_REGEXPS = {
         return dateParts.getPeriodNames(FORMAT_TYPES[count < 3 ? 3 : count], 'format').join('|');
     },
     d: function(count) {
-        return '0?[1-9]|[12][0-9]|3[01]';
+        return count === 2 ? '3[01]|[12][0-9]|0?[1-9]' : '0??[1-9]|[12][0-9]|3[01]';
     },
     H: function(count) {
-        return '0?[0-9]|1[0-9]|2[0-3]';
+        return count === 2 ? '2[0-3]|1[0-9]|0?[0-9]' : '0??[0-9]|1[0-9]|2[0-3]';
     },
     h: function(count) {
-        return '0?[1-9]|1[012]';
+        return count === 2 ? '1[012]|0?[1-9]' : '0??[1-9]|1[012]';
     },
     m: function(count) {
-        return '0?[0-9]|[1-5][0-9]';
+        return count === 2 ? '[1-5][0-9]|0?[0-9]' : '0??[0-9]|[1-5][0-9]';
     },
     s: function(count) {
-        return '0?[0-9]|[1-5][0-9]';
+        return count === 2 ? '[1-5][0-9]|0?[0-9]' : '0??[0-9]|[1-5][0-9]';
     },
     S: function(count) {
-        return '[0-9]{1,' + count + '}';
+        return `[0-9]{1,${count}}`;
     },
     w: function(count) {
-        return '0?[0-9]|[1-5][0-9]';
+        return count === 2 ? '[1-5][0-9]|0?[0-9]' : '0??[0-9]|[1-5][0-9]';
     }
 };
 
@@ -155,6 +156,9 @@ const PATTERN_SETTERS = {
 
 const getSameCharCount = function(text, index) {
     const char = text[index];
+    if(!char) {
+        return 0;
+    }
     let count = 0;
 
     do {
@@ -181,8 +185,8 @@ export const getRegExpInfo = function(format, dateParts) {
 
     const addPreviousStub = function() {
         if(stubText) {
-            patterns.push('\'' + stubText + '\'');
-            regexpText += escapeRegExp(stubText) + ')';
+            patterns.push(`'${stubText}'`);
+            regexpText += `${escapeRegExp(stubText)})`;
             stubText = '';
         }
     };
@@ -206,7 +210,7 @@ export const getRegExpInfo = function(format, dateParts) {
             addPreviousStub();
             patterns.push(pattern);
 
-            regexpText += '(' + regexpPart(count, dateParts) + ')';
+            regexpText += `(${regexpPart(count, dateParts)})`;
             i += count - 1;
         } else {
             if(!stubText) {
@@ -217,11 +221,43 @@ export const getRegExpInfo = function(format, dateParts) {
     }
 
     addPreviousStub();
+    if(!isPossibleForParsingFormat(patterns)) {
+        logger.warn(`The following format may be parsed incorrectly: ${format}.`);
+    }
 
     return {
         patterns: patterns,
-        regexp: new RegExp('^' + regexpText + '$', 'i')
+        regexp: new RegExp(`^${regexpText}$`, 'i')
     };
+};
+
+const digitFieldSymbols = ['d', 'H', 'h', 'm', 's', 'w', 'M', 'L', 'Q'];
+export const isPossibleForParsingFormat = function(patterns) {
+    const isDigitPattern = (pattern) => {
+        if(!pattern) {
+            return false;
+        }
+        const char = pattern[0];
+        return ['y', 'S'].includes(char) || digitFieldSymbols.includes(char) && pattern.length < 3;
+    };
+
+    const isAmbiguousDigitPattern = (pattern) => {
+        return pattern[0] !== 'S' && pattern.length !== 2;
+    };
+
+    let possibleForParsing = true;
+    let ambiguousDigitPatternsCount = 0;
+    return patterns.every((pattern, index, patterns) => {
+        if(isDigitPattern(pattern)) {
+            if(isAmbiguousDigitPattern(pattern)) {
+                possibleForParsing = (++ambiguousDigitPatternsCount) < 2;
+            }
+            if(!isDigitPattern(patterns[index + 1])) {
+                ambiguousDigitPatternsCount = 0;
+            }
+        }
+        return possibleForParsing;
+    });
 };
 
 export const getPatternSetters = function() {

--- a/js/localization/ldml/date.parser.js
+++ b/js/localization/ldml/date.parser.js
@@ -238,7 +238,8 @@ export const isPossibleForParsingFormat = function(patterns) {
             return false;
         }
         const char = pattern[0];
-        return ['y', 'S'].includes(char) || digitFieldSymbols.includes(char) && pattern.length < 3;
+        const yearOrFractionalSecond = char === 'y' || char === 'S';
+        return yearOrFractionalSecond || digitFieldSymbols.includes(char) && pattern.length < 3;
     };
 
     const isAmbiguousDigitPattern = (pattern) => {

--- a/js/localization/ldml/date.parser.js
+++ b/js/localization/ldml/date.parser.js
@@ -239,7 +239,8 @@ export const isPossibleForParsingFormat = function(patterns) {
         }
         const char = pattern[0];
         const yearOrFractionalSecond = char === 'y' || char === 'S';
-        return yearOrFractionalSecond || digitFieldSymbols.includes(char) && pattern.length < 3;
+        const digitFieldSymbol = digitFieldSymbols.indexOf(char) !== -1;
+        return yearOrFractionalSecond || digitFieldSymbol && pattern.length < 3;
     };
 
     const isAmbiguousDigitPattern = (pattern) => {

--- a/testing/tests/DevExpress.localization/ldml.tests.js
+++ b/testing/tests/DevExpress.localization/ldml.tests.js
@@ -466,7 +466,8 @@ QUnit.module('number formatter', () => {
             }
         };
 
-        Object.entries(formatsTestsData).forEach(([ format, { text, expected } ]) => {
+        Object.keys(formatsTestsData).forEach((format) => {
+            const { text, expected } = formatsTestsData[format];
             const regExpInfo = getRegExpInfo(format);
             const parenthesizedResult = regExpInfo.regexp.exec(text).slice(1);
             assert.deepEqual(parenthesizedResult, expected, `Fromat '${format}' parse dateString '${text}' - ok.`);
@@ -495,7 +496,8 @@ QUnit.module('number formatter', () => {
             'QQQ y MMM d HHs': 0,
         };
 
-        Object.entries(expectedWarningsCount).forEach(([ format, warningCalls ]) => {
+        Object.keys(expectedWarningsCount).forEach((format) => {
+            const warningCalls = expectedWarningsCount[format];
             spy.callCount = 0;
             getRegExpInfo(format, dateLocalization);
             assert.equal(spy.callCount, warningCalls, `Format '${format}' calls ${warningCalls} warnings.`);

--- a/testing/tests/DevExpress.localization/ldml.tests.js
+++ b/testing/tests/DevExpress.localization/ldml.tests.js
@@ -8,6 +8,7 @@ const defaultDateNames = require('localization/default_date_names');
 const numberLocalization = require('localization/number');
 const dateLocalization = require('localization/date');
 const extend = require('core/utils/extend').extend;
+const console = require('core/utils/console').logger;
 
 require('localization/currency');
 
@@ -411,5 +412,93 @@ QUnit.module('number formatter', () => {
             dateLocalization.getTimeSeparator = baseGetTimeSeparator;
         }
 
+    });
+
+    QUnit.test('getRegExpInfo should return correct regular expression for unambiguous not separated `formats`(T1008667)', function(assert) {
+        const formatsTestsData = {
+            'yyyyMMdd': {
+                text: '11111111',
+                expected: ['1111', '11', '11']
+            },
+            'ddMMyyyy': {
+                text: '11121212',
+                expected: ['11', '12', '1212']
+            },
+            'MMdyy': {
+                text: '11212',
+                expected: ['11', '2', '12']
+            },
+            'dMMyy': {
+                text: '11111',
+                expected: ['1', '11', '11']
+            },
+            'MMddyy': {
+                text: '111111',
+                expected: ['11', '11', '11']
+            },
+            'wwhhmms': {
+                text: '10101012',
+                expected: ['10', '10', '10', '12']
+            },
+            'wwHHmms': {
+                text: '1012100',
+                expected: ['10', '12', '10', '0']
+            },
+            'hhmmsSSS': {
+                text: '12100001',
+                expected: ['12', '10', '0', '001']
+            },
+            'HHmmsSSS': {
+                text: '121001001',
+                expected: ['12', '10', '01', '001']
+            },
+            'hhmmsSS': {
+                text: '12101201',
+                expected: ['12', '10', '12', '01']
+            },
+            'HHmmsSS': {
+                text: '1210001',
+                expected: ['12', '10', '0', '01']
+            },
+            'HHmms.SSS': {
+                text: '121010.34',
+                expected: ['12', '10', '10', '.', '34']
+            }
+        };
+
+        Object.entries(formatsTestsData).forEach(([ format, { text, expected } ]) => {
+            const regExpInfo = getRegExpInfo(format);
+            const parenthesizedResult = regExpInfo.regexp.exec(text).slice(1);
+            assert.deepEqual(parenthesizedResult, expected, `Fromat '${format}' parse dateString '${text}' - ok.`);
+        });
+    });
+
+    QUnit.test('getRegExpInfo should throw a warning message if there are two or more ambiguous patterns at the sequence of non separated digit patterns in the `format`!', function(assert) {
+        const spy = sinon.spy(console, 'warn');
+        const expectedWarningsCount = {
+            'd': 0,
+            'dd': 0,
+            'dm': 1,
+            'dmm': 0,
+            'dMMy': 1,
+            'dMMyy': 0,
+            'dMMMy': 0,
+            'ddMMyy': 0,
+            'dMMyyyy': 1,
+            'MMddyyyy': 0,
+            'QQQdMMM hm': 1,
+            'EEEdMMM hmm': 0,
+            'ydMMM aaahhm': 1,
+            'hhmmS': 0,
+            'hhmmsSS': 0,
+            'QQQyMMMdHHs': 1,
+            'QQQ y MMM d HHs': 0,
+        };
+
+        Object.entries(expectedWarningsCount).forEach(([ format, warningCalls ]) => {
+            spy.callCount = 0;
+            getRegExpInfo(format, dateLocalization);
+            assert.equal(spy.callCount, warningCalls, `Format '${format}' calls ${warningCalls} warnings.`);
+        });
     });
 });

--- a/testing/tests/DevExpress.localization/localization.globalize.tests.js
+++ b/testing/tests/DevExpress.localization/localization.globalize.tests.js
@@ -296,6 +296,12 @@ define(function(require, exports, module) {
         QUnit.test('format: { time: \'medium\' }', function(assert) {
             assert.equal(dateLocalization.format(new Date(2015, 1, 2, 3, 4, 5, 6), { time: 'medium' }), '3:04:05 AM', 'with object format');
         });
+
+        QUnit.test('Parse custom format', function(assert) {
+            const expected = new Date(2010, 2, 2).toString();
+            assert.equal(dateLocalization.parse('20100302', 'yyyyMMdd'), expected, 'Format \'yyyyMMdd\' parse ok');
+            assert.equal(dateLocalization.parse('02mar10', 'dMyyyy'), expected, 'Format \'dMyyyy\' parse ok');
+        });
     });
 
     QUnit.module('Localization message (custom locales)', {


### PR DESCRIPTION
Cherry picked from commit ad3992db94de23f2c8e27f60615851d41d28bf01
