### PR TITLE
Get rid of default export in the viz/export module (T1014891) (#18367)

### DIFF
--- a/js/viz/export.js
+++ b/js/viz/export.js
@@ -1,2 +1,1 @@
-import * as Export from './core/export';
-export default Export;
+export * from './core/export';


### PR DESCRIPTION
Cherry picked from commit d64de1c3814cd0520e581faa7cbdc18a202ff0d8
