### PR TITLE
Knockout integration render template with error for renovated component.

### DIFF
--- a/js/integration/knockout/component_registrator.js
+++ b/js/integration/knockout/component_registrator.js
@@ -5,6 +5,8 @@ import Callbacks from '../../core/utils/callbacks';
 import { isPlainObject } from '../../core/utils/type';
 import registerComponentCallbacks from '../../core/component_registrator_callbacks';
 import Widget from '../../ui/widget/ui.widget';
+import VizWidget from '../../viz/core/base_widget';
+import ComponentWrapper from '../../renovation/component_wrapper/common/component';
 import Draggable from '../../ui/draggable';
 import { KoTemplate } from './template';
 import Editor from '../../ui/editor/editor';
@@ -208,7 +210,8 @@ if(ko) {
                 createComponent();
 
                 return {
-                    controlsDescendantBindings: componentClass.subclassOf(Widget) || componentClass.subclassOf(Draggable)
+                    controlsDescendantBindings: componentClass.subclassOf(Widget) || componentClass.subclassOf(VizWidget) || componentClass.subclassOf(Draggable) ||
+                    componentClass.subclassOf(ComponentWrapper)
                 };
             }
         };

--- a/testing/tests/DevExpress.knockout/button.tests.js
+++ b/testing/tests/DevExpress.knockout/button.tests.js
@@ -1,0 +1,24 @@
+import $ from 'jquery';
+import ko from 'knockout';
+
+import 'ui/button';
+import 'integration/knockout';
+
+QUnit.module('Render', () => {
+    // T831205
+    QUnit.test('Widget rendering when buttonTemplate is used', function(assert) {
+        const markup =
+        '<div id="button-with-template" data-bind="dxButton: { template: \'testTemplate\' }">\
+            <div data-options="dxTemplate: { name: \'testTemplate\' }">\
+                <div id="template" data-bind="text: $root.text"></div>\
+            </div>\
+        </div>';
+
+        $(markup).appendTo($('#qunit-fixture'));
+
+        const $element = $('#button-with-template');
+
+        ko.applyBindings({ text: 'test-text' }, $element[0]);
+        assert.equal($('#template').eq(0).text().trim(), 'test-text', 'template text rendered');
+    });
+});


### PR DESCRIPTION
The error "You cannot apply bindings multiple times to the same element." 
has occurred because init handler return wrong controlsDescendantBindings for renovated component

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
