### PR TITLE
Form - Move "layoutManager._renderHelpText" to "form.utils.js" v2 (#18383)

### DIFF
--- a/js/ui/form/ui.form.layout_manager.js
+++ b/js/ui/form/ui.form.layout_manager.js
@@ -28,7 +28,6 @@ import {
     LAYOUT_MANAGER_ONE_COLUMN,
     FIELD_ITEM_OPTIONAL_CLASS,
     FIELD_ITEM_REQUIRED_CLASS,
-    FIELD_ITEM_HELP_TEXT_CLASS,
     FIELD_ITEM_CONTENT_WRAPPER_CLASS,
     FORM_LAYOUT_MANAGER_CLASS,
     LABEL_VERTICAL_ALIGNMENT_CLASS,
@@ -46,7 +45,7 @@ import '../number_box';
 import '../check_box';
 import '../date_box';
 import '../button';
-import { renderLabel } from './ui.form.utils';
+import { renderLabel, renderHelpText } from './ui.form.utils';
 
 const FORM_EDITOR_BY_DEFAULT = 'dxTextBox';
 const FIELD_ITEM_REQUIRED_MARK_CLASS = 'dx-field-item-required-mark';
@@ -685,7 +684,20 @@ const LayoutManager = Widget.inherit({
             }
         }
 
-        that._renderHelpText(item, $editor, helpID);
+        const helpText = item.helpText;
+        const isSimpleItem = item.itemType === SIMPLE_ITEM_TYPE;
+
+        if(helpText && isSimpleItem) {
+            const $editorParent = $editor.parent();
+
+            // TODO: DOM hierarchy is changed here: new node is added between $editor and $editor.parent()
+            $editorParent.append(
+                $('<div>')
+                    .addClass(FIELD_ITEM_CONTENT_WRAPPER_CLASS)
+                    .append($editor)
+                    .append(renderHelpText(helpText, helpID))
+            );
+        }
 
         that._attachClickHandler($label, $editor, item.editorType);
     },
@@ -1017,23 +1029,6 @@ const LayoutManager = Widget.inherit({
         }
     },
 
-    _renderHelpText: function(fieldItem, $editor, helpID) {
-        const helpText = fieldItem.helpText;
-        const isSimpleItem = fieldItem.itemType === SIMPLE_ITEM_TYPE;
-
-        if(helpText && isSimpleItem) {
-            const $editorWrapper = $('<div>').addClass(FIELD_ITEM_CONTENT_WRAPPER_CLASS);
-
-            $editor.wrap($editorWrapper);
-
-            $('<div>')
-                .addClass(FIELD_ITEM_HELP_TEXT_CLASS)
-                .attr('id', helpID)
-                .text(helpText)
-                .appendTo($editor.parent());
-        }
-    },
-
     _attachClickHandler: function($label, $editor, editorType) {
         const isBooleanEditors = editorType === 'dxCheckBox' || editorType === 'dxSwitch';
 
@@ -1240,7 +1235,6 @@ module.exports.__internals = {
     LABEL_VERTICAL_ALIGNMENT_CLASS: LABEL_VERTICAL_ALIGNMENT_CLASS,
     FORM_LAYOUT_MANAGER_CLASS: FORM_LAYOUT_MANAGER_CLASS,
     FIELD_ITEM_CONTENT_WRAPPER_CLASS: FIELD_ITEM_CONTENT_WRAPPER_CLASS,
-    FIELD_ITEM_HELP_TEXT_CLASS: FIELD_ITEM_HELP_TEXT_CLASS,
     FIELD_ITEM_LABEL_CONTENT_CLASS: FIELD_ITEM_LABEL_CONTENT_CLASS,
     FIELD_ITEM_LABEL_TEXT_CLASS: FIELD_ITEM_LABEL_TEXT_CLASS,
     FIELD_ITEM_REQUIRED_CLASS: FIELD_ITEM_REQUIRED_CLASS,

--- a/js/ui/form/ui.form.utils.js
+++ b/js/ui/form/ui.form.utils.js
@@ -10,6 +10,7 @@ import {
     FIELD_ITEM_LABEL_CONTENT_CLASS,
     FIELD_ITEM_LABEL_LOCATION_CLASS,
     FIELD_ITEM_LABEL_CLASS,
+    FIELD_ITEM_HELP_TEXT_CLASS
 } from './constants';
 
 export const createItemPathByIndex = (index, isTabs) => `${isTabs ? 'tabs' : 'items'}[${index}]`;
@@ -100,6 +101,13 @@ export const renderLabel = ({ text, id, location, alignment, labelID = null, mar
             )
         );
 };
+
+export function renderHelpText(helpText, helpID) {
+    return $('<div>')
+        .addClass(FIELD_ITEM_HELP_TEXT_CLASS)
+        .attr('id', helpID)
+        .text(helpText);
+}
 
 function _renderLabelMark({ isRequiredMark, requiredMark, isOptionalMark, optionalMark }) {
     if(!isRequiredMark && !isOptionalMark) {

--- a/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.form/formLayoutManager.markup.tests.js
@@ -1,7 +1,25 @@
 import $ from 'jquery';
 import consoleUtils from 'core/utils/console';
 import responsiveBoxScreenMock from '../../helpers/responsiveBoxScreenMock.js';
-import { __internals as internals } from 'ui/form/ui.form.layout_manager';
+import {
+    FORM_LAYOUT_MANAGER_CLASS,
+    FIELD_ITEM_CLASS,
+    FIELD_ITEM_LABEL_CLASS,
+    LABEL_HORIZONTAL_ALIGNMENT_CLASS,
+    FIELD_ITEM_LABEL_LOCATION_CLASS,
+    FIELD_ITEM_CONTENT_CLASS,
+    FIELD_ITEM_CONTENT_LOCATION_CLASS,
+    FIELD_ITEM_REQUIRED_CLASS,
+    FIELD_ITEM_OPTIONAL_CLASS,
+    FIELD_ITEM_REQUIRED_MARK_CLASS,
+    FIELD_ITEM_OPTIONAL_MARK_CLASS,
+    FIELD_ITEM_LABEL_ALIGN_CLASS,
+    LABEL_VERTICAL_ALIGNMENT_CLASS,
+    FIELD_ITEM_CONTENT_WRAPPER_CLASS,
+    FIELD_ITEM_HELP_TEXT_CLASS,
+    FIELD_EMPTY_ITEM_CLASS,
+    LAYOUT_MANAGER_ONE_COLUMN
+} from 'ui/form/constants';
 import config from 'core/config';
 import typeUtils from 'core/utils/type';
 import { inArray } from 'core/utils/array';
@@ -79,16 +97,16 @@ QUnit.module('Layout manager', () => {
             onContentReady: contentReadyStub
         });
 
-        assert.ok($testContainer.hasClass(internals.FORM_LAYOUT_MANAGER_CLASS), 'layout manager is rendered');
+        assert.ok($testContainer.hasClass(FORM_LAYOUT_MANAGER_CLASS), 'layout manager is rendered');
         assert.equal($testContainer.find('.dx-responsivebox').length, 1, 'responsive box is rendered');
-        assert.equal($testContainer.find('.' + internals.FIELD_ITEM_CLASS).length, 1, 'field items is rendered');
-        assert.ok($testContainer.find('.' + internals.FIELD_ITEM_CLASS).hasClass(internals.LABEL_HORIZONTAL_ALIGNMENT_CLASS), 'field item has default label-align class');
-        assert.equal($testContainer.find('.' + internals.FIELD_ITEM_LABEL_CLASS).length, 1, 'label is rendered');
-        assert.ok($testContainer.find('.' + internals.FIELD_ITEM_LABEL_CLASS).hasClass(internals.FIELD_ITEM_LABEL_LOCATION_CLASS + 'left'), 'label\'s location is left by default');
-        assert.equal($testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' .dx-texteditor').length, 1, 'editor is rendered');
-        assert.ok(!$testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' .dx-texteditor').hasClass(READONLY_STATE_CLASS), 'editor is not read only');
-        assert.ok($testContainer.find('.' + internals.FIELD_ITEM_CLASS + '> .' + internals.FIELD_ITEM_CONTENT_CLASS).hasClass(internals.FIELD_ITEM_CONTENT_LOCATION_CLASS + 'right'), 'Field item content has a right css class');
-        assert.equal($testContainer.find('.' + internals.FIELD_ITEM_CLASS + '> .' + internals.FIELD_ITEM_CONTENT_CLASS + '> .dx-texteditor').length, 1, 'editor has field-item-content class');
+        assert.equal($testContainer.find('.' + FIELD_ITEM_CLASS).length, 1, 'field items is rendered');
+        assert.ok($testContainer.find('.' + FIELD_ITEM_CLASS).hasClass(LABEL_HORIZONTAL_ALIGNMENT_CLASS), 'field item has default label-align class');
+        assert.equal($testContainer.find('.' + FIELD_ITEM_LABEL_CLASS).length, 1, 'label is rendered');
+        assert.ok($testContainer.find('.' + FIELD_ITEM_LABEL_CLASS).hasClass(FIELD_ITEM_LABEL_LOCATION_CLASS + 'left'), 'label\'s location is left by default');
+        assert.equal($testContainer.find('.' + FIELD_ITEM_CLASS + ' .dx-texteditor').length, 1, 'editor is rendered');
+        assert.ok(!$testContainer.find('.' + FIELD_ITEM_CLASS + ' .dx-texteditor').hasClass(READONLY_STATE_CLASS), 'editor is not read only');
+        assert.ok($testContainer.find('.' + FIELD_ITEM_CLASS + '> .' + FIELD_ITEM_CONTENT_CLASS).hasClass(FIELD_ITEM_CONTENT_LOCATION_CLASS + 'right'), 'Field item content has a right css class');
+        assert.equal($testContainer.find('.' + FIELD_ITEM_CLASS + '> .' + FIELD_ITEM_CONTENT_CLASS + '> .dx-texteditor').length, 1, 'editor has field-item-content class');
         assert.equal(contentReadyStub.callCount, windowUtils.hasWindow() ? 1 : 0, 'contentReady event');
     });
 
@@ -108,7 +126,7 @@ QUnit.module('Layout manager', () => {
             }]
         });
 
-        assert.equal($testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' .dx-texteditor-input').attr('alt'), 'test', 'attr merge successfully');
+        assert.equal($testContainer.find('.' + FIELD_ITEM_CLASS + ' .dx-texteditor-input').attr('alt'), 'test', 'attr merge successfully');
     });
 
     test('Default render with template', function(assert) {
@@ -145,7 +163,7 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $items = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $items = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($items.length, 2, 'field items is rendered');
     });
@@ -161,23 +179,23 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $items = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $items = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($items.length, 2, 'field items is rendered');
 
         const $requiredItem = $items.eq(0);
         const $optionalItem = $items.eq(1);
 
-        assert.ok($requiredItem.hasClass(internals.FIELD_ITEM_REQUIRED_CLASS), 'field item has required class');
-        assert.ok(!$requiredItem.hasClass(internals.FIELD_ITEM_OPTIONAL_CLASS), 'field item hasn\'t optional class');
-        assert.ok($requiredItem.find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).length, 'field item has required mark');
-        assert.ok(!$requiredItem.find('.' + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).length, 'field item hasn\'t optional mark');
+        assert.ok($requiredItem.hasClass(FIELD_ITEM_REQUIRED_CLASS), 'field item has required class');
+        assert.ok(!$requiredItem.hasClass(FIELD_ITEM_OPTIONAL_CLASS), 'field item hasn\'t optional class');
+        assert.ok($requiredItem.find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).length, 'field item has required mark');
+        assert.ok(!$requiredItem.find('.' + FIELD_ITEM_OPTIONAL_MARK_CLASS).length, 'field item hasn\'t optional mark');
 
 
-        assert.ok(!$optionalItem.hasClass(internals.FIELD_ITEM_REQUIRED_CLASS), 'field item hasn\'t required class');
-        assert.ok($optionalItem.hasClass(internals.FIELD_ITEM_OPTIONAL_CLASS), 'field item has optional class');
-        assert.ok(!$optionalItem.find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).length, 'field item hasn\'t required mark');
-        assert.ok(!$optionalItem.find('.' + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).length, 'field item hasn\'t optional mark');
+        assert.ok(!$optionalItem.hasClass(FIELD_ITEM_REQUIRED_CLASS), 'field item hasn\'t required class');
+        assert.ok($optionalItem.hasClass(FIELD_ITEM_OPTIONAL_CLASS), 'field item has optional class');
+        assert.ok(!$optionalItem.find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).length, 'field item hasn\'t required mark');
+        assert.ok(!$optionalItem.find('.' + FIELD_ITEM_OPTIONAL_MARK_CLASS).length, 'field item hasn\'t optional mark');
     });
 
     test('Show optional marks', function(assert) {
@@ -188,15 +206,15 @@ QUnit.module('Layout manager', () => {
             }],
             showOptionalMark: true
         });
-        const $items = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $items = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($items.length, 1, 'field items is rendered');
 
         const $optionalItem = $items.eq(0);
-        assert.ok(!$optionalItem.hasClass(internals.FIELD_ITEM_REQUIRED_CLASS), 'field item hasn\'t required class');
-        assert.ok($optionalItem.hasClass(internals.FIELD_ITEM_OPTIONAL_CLASS), 'field item has optional class');
-        assert.ok(!$optionalItem.find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).length, 'field item hasn\'t required mark');
-        assert.ok($optionalItem.find('.' + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).length, 'field item hasn optional mark');
+        assert.ok(!$optionalItem.hasClass(FIELD_ITEM_REQUIRED_CLASS), 'field item hasn\'t required class');
+        assert.ok($optionalItem.hasClass(FIELD_ITEM_OPTIONAL_CLASS), 'field item has optional class');
+        assert.ok(!$optionalItem.find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).length, 'field item hasn\'t required mark');
+        assert.ok($optionalItem.find('.' + FIELD_ITEM_OPTIONAL_MARK_CLASS).length, 'field item hasn optional mark');
     });
 
     test('Render custom marks', function(assert) {
@@ -213,13 +231,13 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $items = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $items = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         const $requiredItem = $items.eq(0);
         const $optionalItem = $items.eq(1);
 
-        assert.equal($.trim($requiredItem.find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).text()), '+', 'custom required mark');
-        assert.equal($.trim($optionalItem.find('.' + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).text()), '-', 'custom optional mark');
+        assert.equal($.trim($requiredItem.find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).text()), '+', 'custom required mark');
+        assert.equal($.trim($optionalItem.find('.' + FIELD_ITEM_OPTIONAL_MARK_CLASS).text()), '-', 'custom optional mark');
     });
 
     test('Change marks', function(assert) {
@@ -239,12 +257,12 @@ QUnit.module('Layout manager', () => {
         instance.option('optionalMark', '-');
         instance.option('requiredMark', '+');
 
-        const $items = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $items = $testContainer.find('.' + FIELD_ITEM_CLASS);
         const $requiredItem = $items.eq(0);
         const $optionalItem = $items.eq(1);
 
-        assert.equal($.trim($requiredItem.find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).text()), '+', 'custom required mark');
-        assert.equal($.trim($optionalItem.find('.' + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).text()), '-', 'custom optional mark');
+        assert.equal($.trim($requiredItem.find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).text()), '+', 'custom required mark');
+        assert.equal($.trim($optionalItem.find('.' + FIELD_ITEM_OPTIONAL_MARK_CLASS).text()), '-', 'custom optional mark');
     });
 
     test('Change marks visibility', function(assert) {
@@ -259,7 +277,7 @@ QUnit.module('Layout manager', () => {
             }]
         });
         const instance = $testContainer.dxLayoutManager('instance');
-        const $items = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $items = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         instance.option('showOptionalMark', true);
         instance.option('showRequiredMark', false);
@@ -267,8 +285,8 @@ QUnit.module('Layout manager', () => {
         const $requiredItem = $items.eq(0);
         const $optionalItem = $items.eq(1);
 
-        assert.ok($requiredItem.find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).length, 'Item has no required mark');
-        assert.ok(!$optionalItem.find('.' + internals.FIELD_ITEM_OPTIONAL_MARK_CLASS).length, 'Item has optional mark');
+        assert.ok($requiredItem.find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).length, 'Item has no required mark');
+        assert.ok(!$optionalItem.find('.' + FIELD_ITEM_OPTIONAL_MARK_CLASS).length, 'Item has optional mark');
     });
 
     test('Render read only layoutManager', function(assert) {
@@ -280,7 +298,7 @@ QUnit.module('Layout manager', () => {
             }]
         });
 
-        assert.ok($testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' .dx-texteditor').hasClass(READONLY_STATE_CLASS), 'editor is read only');
+        assert.ok($testContainer.find('.' + FIELD_ITEM_CLASS + ' .dx-texteditor').hasClass(READONLY_STATE_CLASS), 'editor is read only');
     });
 
     test('Render label by default', function(assert) {
@@ -296,13 +314,13 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_LABEL_CLASS).first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_LABEL_CLASS).first();
 
         assert.equal($label.length, 1, 'label is rendered');
-        assert.ok($label.hasClass(internals.FIELD_ITEM_LABEL_LOCATION_CLASS + 'left'), 'label\'s location is left by default');
+        assert.ok($label.hasClass(FIELD_ITEM_LABEL_LOCATION_CLASS + 'left'), 'label\'s location is left by default');
         assert.equal($label.text(), 'Name', 'text of label');
         assert.equal($label.attr('for'), 'dx_FormID_name', 'text of label');
-        assert.ok($label.parent().hasClass(internals.LABEL_HORIZONTAL_ALIGNMENT_CLASS), 'field item contains label has horizontal align class');
+        assert.ok($label.parent().hasClass(LABEL_HORIZONTAL_ALIGNMENT_CLASS), 'field item contains label has horizontal align class');
     });
 
     test('Baseline align of label for large editors is applied when browser is supported flex', function(assert) {
@@ -318,11 +336,11 @@ QUnit.module('Layout manager', () => {
 
         layoutManager._hasBrowserFlex = () => true;
         layoutManager.option('items', items);
-        const $items = $testContainer.find(`.${internals.FIELD_ITEM_CLASS}`);
+        const $items = $testContainer.find(`.${FIELD_ITEM_CLASS}`);
 
         $items.toArray().forEach((item, index) => {
             const hasBaseLine = index > 1;
-            assert.equal($(item).hasClass(internals.FIELD_ITEM_LABEL_ALIGN_CLASS), hasBaseLine, `item ${!hasBaseLine ? 'doesn\'t' : ''} have baseline alignment class`);
+            assert.equal($(item).hasClass(FIELD_ITEM_LABEL_ALIGN_CLASS), hasBaseLine, `item ${!hasBaseLine ? 'doesn\'t' : ''} have baseline alignment class`);
         });
     });
 
@@ -338,10 +356,10 @@ QUnit.module('Layout manager', () => {
             }))
         });
 
-        const $items = $testContainer.find(`.${internals.FIELD_ITEM_CLASS}`);
+        const $items = $testContainer.find(`.${FIELD_ITEM_CLASS}`);
 
         $items.toArray().forEach(item => {
-            assert.notOk($(item).hasClass(internals.FIELD_ITEM_LABEL_ALIGN_CLASS), 'item doesn\'t have baseline alignment class');
+            assert.notOk($(item).hasClass(FIELD_ITEM_LABEL_ALIGN_CLASS), 'item doesn\'t have baseline alignment class');
         });
     });
 
@@ -357,7 +375,7 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' label').first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_CLASS + ' label').first();
         const $input = $testContainer.find('input');
 
         assert.ok($input.attr('id'), 'input has ID');
@@ -374,9 +392,9 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $fieldItemChildren = $testContainer.find('.' + internals.FIELD_ITEM_CLASS).children();
+        const $fieldItemChildren = $testContainer.find('.' + FIELD_ITEM_CLASS).children();
 
-        assert.ok($fieldItemChildren.first().hasClass(internals.FIELD_ITEM_LABEL_LOCATION_CLASS + 'top'), 'check location class');
+        assert.ok($fieldItemChildren.first().hasClass(FIELD_ITEM_LABEL_LOCATION_CLASS + 'top'), 'check location class');
         assert.ok($fieldItemChildren.first().is('label'), 'Label is the first child');
     });
 
@@ -390,9 +408,9 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $fieldItemChildren = $testContainer.find('.' + internals.FIELD_ITEM_CLASS).children();
+        const $fieldItemChildren = $testContainer.find('.' + FIELD_ITEM_CLASS).children();
 
-        assert.ok($fieldItemChildren.last().hasClass(internals.FIELD_ITEM_LABEL_LOCATION_CLASS + 'bottom'), 'check location class');
+        assert.ok($fieldItemChildren.last().hasClass(FIELD_ITEM_LABEL_LOCATION_CLASS + 'bottom'), 'check location class');
         assert.ok($fieldItemChildren.last().is('label'), 'Label is the last child');
     });
 
@@ -407,9 +425,9 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' label').first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_CLASS + ' label').first();
 
-        assert.ok($label.parent().hasClass(internals.LABEL_VERTICAL_ALIGNMENT_CLASS), 'Field item contains label that has vertical align');
+        assert.ok($label.parent().hasClass(LABEL_VERTICAL_ALIGNMENT_CLASS), 'Field item contains label that has vertical align');
         assert.equal($label.css('textAlign'), 'left', 'Label has text-align left');
     });
 
@@ -424,9 +442,9 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' label').first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_CLASS + ' label').first();
 
-        assert.ok($label.parent().hasClass(internals.LABEL_VERTICAL_ALIGNMENT_CLASS), 'Field item contains label that has vertical align');
+        assert.ok($label.parent().hasClass(LABEL_VERTICAL_ALIGNMENT_CLASS), 'Field item contains label that has vertical align');
         assert.equal($label.css('textAlign'), 'center', 'Label has text-align center');
     });
 
@@ -441,9 +459,9 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' label').first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_CLASS + ' label').first();
 
-        assert.ok($label.parent().hasClass(internals.LABEL_VERTICAL_ALIGNMENT_CLASS), 'Field item contains label that has vertical align');
+        assert.ok($label.parent().hasClass(LABEL_VERTICAL_ALIGNMENT_CLASS), 'Field item contains label that has vertical align');
         assert.equal($label.css('textAlign'), 'right', 'Label has text-align right');
     });
 
@@ -457,9 +475,9 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $fieldItem = $testContainer.find('.' + internals.FIELD_ITEM_CLASS).first();
+        const $fieldItem = $testContainer.find('.' + FIELD_ITEM_CLASS).first();
 
-        assert.ok($fieldItem.hasClass(internals.LABEL_HORIZONTAL_ALIGNMENT_CLASS), 'Field item contains label that has horizontal align');
+        assert.ok($fieldItem.hasClass(LABEL_HORIZONTAL_ALIGNMENT_CLASS), 'Field item contains label that has horizontal align');
     });
 
     test('Render label with default position and alignment left', function(assert) {
@@ -472,7 +490,7 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' label').first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_CLASS + ' label').first();
 
         assert.equal($label.css('textAlign'), 'left', 'Label has text-align left');
     });
@@ -487,7 +505,7 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' label').first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_CLASS + ' label').first();
 
         assert.equal($label.css('textAlign'), 'center', 'Label has text-align center');
     });
@@ -500,7 +518,7 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_LABEL_CLASS).first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_LABEL_CLASS).first();
 
         assert.equal($label.text(), 'Name:', 'text of label');
     });
@@ -513,7 +531,7 @@ QUnit.module('Layout manager', () => {
             }]
         });
 
-        assert.ok(!$testContainer.find('.' + internals.FIELD_ITEM_LABEL_CLASS).length);
+        assert.ok(!$testContainer.find('.' + FIELD_ITEM_LABEL_CLASS).length);
     });
 
     test('If item is not visible we will not render them', function(assert) {
@@ -527,11 +545,11 @@ QUnit.module('Layout manager', () => {
                 dataField: 'Phone'
             }]
         });
-        const $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($fieldItems.length, 2, 'We have only two visible items');
-        assert.equal($fieldItems.first().find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'First Name', 'Correct first item rendered');
-        assert.equal($fieldItems.last().find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'Phone', 'Correct second item rendered');
+        assert.equal($fieldItems.first().find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'First Name', 'Correct first item rendered');
+        assert.equal($fieldItems.last().find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'Phone', 'Correct second item rendered');
     });
 
     test('Item should be removed from DOM if it\'s visibility changed', function(assert) {
@@ -545,27 +563,27 @@ QUnit.module('Layout manager', () => {
             }]
         });
         const instance = $testContainer.dxLayoutManager('instance');
-        let $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        let $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($fieldItems.length, 3, 'We have 3 visible items');
 
         instance.option('items[1].visible', false);
-        $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($fieldItems.length, 2, 'We have 2 visible items');
-        assert.equal($fieldItems.first().find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'First Name', 'Correct first item rendered');
-        assert.equal($fieldItems.last().find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'Phone', 'Correct second item rendered');
+        assert.equal($fieldItems.first().find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'First Name', 'Correct first item rendered');
+        assert.equal($fieldItems.last().find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'Phone', 'Correct second item rendered');
     });
 
     test('Render items as array of strings', function(assert) {
         const $testContainer = $('#container').dxLayoutManager({
             items: ['FirstName', 'LastName']
         });
-        const $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($fieldItems.length, 2, 'We have two items');
-        assert.equal($fieldItems.first().find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'First Name', 'Correct first item rendered');
-        assert.equal($fieldItems.last().find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'Last Name', 'Correct second item rendered');
+        assert.equal($fieldItems.first().find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'First Name', 'Correct first item rendered');
+        assert.equal($fieldItems.last().find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'Last Name', 'Correct second item rendered');
     });
 
     test('Render mixed set of items(2 as strings, 1 as object)', function(assert) {
@@ -574,12 +592,12 @@ QUnit.module('Layout manager', () => {
                 dataField: 'Nickname'
             }, 'LastName']
         });
-        const $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($fieldItems.length, 3, 'We have three items');
-        assert.equal($fieldItems.first().find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'First Name', 'Correct first item rendered');
-        assert.equal($fieldItems.eq(1).find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'Nickname', 'Correct second item rendered');
-        assert.equal($fieldItems.last().find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'Last Name', 'Correct third item rendered');
+        assert.equal($fieldItems.first().find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'First Name', 'Correct first item rendered');
+        assert.equal($fieldItems.eq(1).find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'Nickname', 'Correct second item rendered');
+        assert.equal($fieldItems.last().find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'Last Name', 'Correct third item rendered');
     });
 
     test('If label is not visible we will not render them', function(assert) {
@@ -591,11 +609,11 @@ QUnit.module('Layout manager', () => {
                 }
             }]
         });
-        const $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($fieldItems.length, 1, 'We have only one item');
-        assert.equal($fieldItems.find('.' + internals.FIELD_ITEM_LABEL_CLASS).length, 0, 'We have\'t labels');
-        assert.equal($fieldItems.find('.' + internals.FIELD_ITEM_CONTENT_CLASS).length, 1, 'We have widget in field');
+        assert.equal($fieldItems.find('.' + FIELD_ITEM_LABEL_CLASS).length, 0, 'We have\'t labels');
+        assert.equal($fieldItems.find('.' + FIELD_ITEM_CONTENT_CLASS).length, 1, 'We have widget in field');
     });
 
     test('Render label with horizontal alignment (right) ', function(assert) {
@@ -608,10 +626,10 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $fieldItem = $testContainer.find('.' + internals.FIELD_ITEM_CLASS).first();
+        const $fieldItem = $testContainer.find('.' + FIELD_ITEM_CLASS).first();
 
-        assert.ok($fieldItem.find('.' + internals.FIELD_ITEM_LABEL_CLASS).hasClass(internals.FIELD_ITEM_LABEL_LOCATION_CLASS + 'right'), 'check location class');
-        assert.ok($fieldItem.hasClass(internals.LABEL_HORIZONTAL_ALIGNMENT_CLASS), 'Field item contains label that has horizontal align');
+        assert.ok($fieldItem.find('.' + FIELD_ITEM_LABEL_CLASS).hasClass(FIELD_ITEM_LABEL_LOCATION_CLASS + 'right'), 'check location class');
+        assert.ok($fieldItem.hasClass(LABEL_HORIZONTAL_ALIGNMENT_CLASS), 'Field item contains label that has horizontal align');
     });
 
     test('Default render with label', function(assert) {
@@ -626,7 +644,7 @@ QUnit.module('Layout manager', () => {
 
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' label').first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_CLASS + ' label').first();
 
         assert.equal($label.text(), 'New label:', 'text of label');
     });
@@ -643,7 +661,7 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $label = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' label').first();
+        const $label = $testContainer.find('.' + FIELD_ITEM_CLASS + ' label').first();
 
         assert.equal($label.text(), 'New label', 'text of label');
     });
@@ -664,7 +682,7 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $input = $testContainer.find('.' + internals.FIELD_ITEM_CLASS + ' .dx-texteditor input').first();
+        const $input = $testContainer.find('.' + FIELD_ITEM_CLASS + ' .dx-texteditor input').first();
 
         assert.equal($input.attr('id'), 'dx_FormID_name', 'id attr of input');
     });
@@ -703,7 +721,7 @@ QUnit.module('Layout manager', () => {
                 editorType: 'dxTextBox'
             }]
         });
-        const $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
 
         assert.equal($fieldItems.length, 3, 'Render 3 items');
@@ -869,7 +887,7 @@ QUnit.module('Layout manager', () => {
             editorType: 'dxDateBox'
         }]);
 
-        const $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.ok($fieldItems.eq(0).find('.dx-numberbox').length, 'First item is dxNumberBox');
         assert.ok($fieldItems.eq(1).find('.dx-datebox').length, 'Second item is dxDateBox');
@@ -1013,7 +1031,7 @@ QUnit.module('Layout manager', () => {
         const $editors = $testContainer.find('.dx-texteditor');
 
         assert.equal($editors.length, 1, 'There is only one editor');
-        assert.equal($testContainer.find('.' + internals.FIELD_ITEM_LABEL_CLASS).text(), 'Age', 'Correct field rendered');
+        assert.equal($testContainer.find('.' + FIELD_ITEM_LABEL_CLASS).text(), 'Age', 'Correct field rendered');
     });
 
     test('CustomizeItem work well after option change', function(assert) {
@@ -1304,27 +1322,27 @@ QUnit.module('Layout manager', () => {
         const $testContainer = $('#container');
 
         $testContainer.dxLayoutManager({
-            layoutData: {
-                name: 'Alex',
-                lastName: 'Johnson',
-                state: 'CA'
-            },
-            items: [{
-                dataField: 'name',
-                helpText: 'Type a name'
-            }, {
-                dataField: 'lastName'
-            }]
+            items: [
+                { dataField: 'field1', helpText: 'field1 help text' },
+                { dataField: 'field1', helpText: null },
+                { dataField: 'field1', helpText: undefined },
+                'field3',
+                { dataField: 'field2' },
+                { itemType: 'empty', helpText: 'should be rendered for simple only' },
+                { itemType: 'group', helpText: 'should be rendered for simple only' },
+                { itemType: 'tabbed', helpText: 'should be rendered for simple only' },
+                { itemType: 'button', helpText: 'should be rendered for simple only' },
+            ]
         });
 
-        const $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
-        assert.equal($fieldItems.eq(0).find('.' + internals.FIELD_ITEM_CONTENT_WRAPPER_CLASS).length, 1, 'First field item has widget wrapper');
-        assert.equal($fieldItems.eq(0).find('.' + internals.FIELD_ITEM_HELP_TEXT_CLASS).length, 1, 'First field item has help text element');
-        assert.equal($fieldItems.eq(0).find('.' + internals.FIELD_ITEM_HELP_TEXT_CLASS).text(), 'Type a name', 'Correct help text');
+        assert.equal($testContainer.find('.' + FIELD_ITEM_CONTENT_WRAPPER_CLASS).length, 1, 'FIELD_ITEM_CONTENT_WRAPPER_CLASS.length');
+        assert.equal($testContainer.find('.' + FIELD_ITEM_HELP_TEXT_CLASS).length, 1, 'FIELD_ITEM_HELP_TEXT_CLASS.length');
 
-        assert.equal($fieldItems.eq(1).find('.' + internals.FIELD_ITEM_CONTENT_WRAPPER_CLASS).length, 0, 'Second field item has\'t widget wrapper');
-        assert.equal($fieldItems.eq(1).find('.' + internals.FIELD_ITEM_HELP_TEXT_CLASS).length, 0, 'Second field item has\'t help text element');
+        const $fieldHelpText = $fieldItems.eq(0).find('>.' + FIELD_ITEM_CONTENT_WRAPPER_CLASS + '>.' + FIELD_ITEM_HELP_TEXT_CLASS + ':last-child');
+        assert.equal($fieldHelpText.length, 1, '$field1HelpText.length');
+        assert.equal($fieldHelpText.text(), 'field1 help text');
     });
 
     test('Change the order of items', function(assert) {
@@ -1440,7 +1458,7 @@ QUnit.module('Layout manager', () => {
             }, 'profession']
         });
 
-        assert.equal($testContainer.find('.' + internals.FIELD_EMPTY_ITEM_CLASS).length, 1);
+        assert.equal($testContainer.find('.' + FIELD_EMPTY_ITEM_CLASS).length, 1);
     });
 
     test('Templates of form\'s items render with deferring_T638831', function(assert) {
@@ -2092,7 +2110,7 @@ QUnit.module('Render multiple columns', () => {
             }
         });
 
-        assert.equal($container.find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).length, 2, '2 validation marks rendered');
+        assert.equal($container.find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).length, 2, '2 validation marks rendered');
 
         assert.equal($container.find('.dx-validator [id=\'dx_FormID_LastName\']').length, 1, 'validator for lastName');
         assert.equal($container.find('.dx-validator [id=\'dx_FormID_FirstName\']').length, 1, 'validator for lastName');
@@ -2137,8 +2155,8 @@ QUnit.module('Render multiple columns', () => {
             }]
         });
 
-        assert.equal($container.find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).length, 3, '3 required marks rendered');
-        assert.equal($container.find('.' + internals.FIELD_ITEM_CLASS).first().find('.' + internals.FIELD_ITEM_REQUIRED_MARK_CLASS).length, 0, 'First item does not have required mark');
+        assert.equal($container.find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).length, 3, '3 required marks rendered');
+        assert.equal($container.find('.' + FIELD_ITEM_CLASS).first().find('.' + FIELD_ITEM_REQUIRED_MARK_CLASS).length, 0, 'First item does not have required mark');
     });
 });
 
@@ -2168,7 +2186,7 @@ QUnit.module('Templates', () => {
             }]
         });
 
-        const $fieldItemWidget = $testContainer.find('.' + internals.FIELD_ITEM_CONTENT_CLASS);
+        const $fieldItemWidget = $testContainer.find('.' + FIELD_ITEM_CONTENT_CLASS);
         const spanText = $fieldItemWidget.find('span').text();
         const textArea = $fieldItemWidget.find('.dx-textarea').dxTextArea('instance');
         const layoutManager = $testContainer.dxLayoutManager('instance');
@@ -2225,7 +2243,7 @@ QUnit.module('Templates', () => {
             }]
         });
 
-        const $fieldItemWidget = $testContainer.find('.' + internals.FIELD_ITEM_CONTENT_CLASS);
+        const $fieldItemWidget = $testContainer.find('.' + FIELD_ITEM_CONTENT_CLASS);
         const textArea = $fieldItemWidget.find('.dx-textarea').dxTextArea('instance');
         const layoutManager = $testContainer.dxLayoutManager('instance');
 
@@ -2312,7 +2330,7 @@ QUnit.module('Accessibility', () => {
             }]
         });
 
-        const $fieldItems = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItems = $testContainer.find('.' + FIELD_ITEM_CLASS);
 
         assert.equal($fieldItems.first().find('input').attr('aria-required'), 'false', 'First item isn\'t required');
         assert.equal($fieldItems.last().find('input').attr('aria-required'), 'true', 'Second item is required');
@@ -2328,9 +2346,9 @@ QUnit.module('Accessibility', () => {
             }]
         });
 
-        const $fieldItem = $testContainer.find('.' + internals.FIELD_ITEM_CLASS);
+        const $fieldItem = $testContainer.find('.' + FIELD_ITEM_CLASS);
         const itemDescribedBy = $fieldItem.find('input').attr('aria-describedby');
-        const helpTextID = $fieldItem.find('.' + internals.FIELD_ITEM_HELP_TEXT_CLASS).attr('id');
+        const helpTextID = $fieldItem.find('.' + FIELD_ITEM_HELP_TEXT_CLASS).attr('id');
 
         assert.equal(itemDescribedBy, helpTextID, 'Help text id and input\'s describedby attributes are equal');
     });
@@ -2343,7 +2361,7 @@ QUnit.module('Accessibility', () => {
         items.forEach(({ dataField, editorType }) => {
             const editor = layoutManager.getEditor(dataField);
             const $ariaTarget = editor._getAriaTarget();
-            const $label = editor.$element().closest(`.${internals.FIELD_ITEM_CLASS}`).children().first();
+            const $label = editor.$element().closest(`.${FIELD_ITEM_CLASS}`).children().first();
             const editorClassName = `dx-${editorType.toLowerCase().substr(2)}`;
 
             if(inArray(editorClassName, editorClassesRequiringIdForLabel) !== -1) {
@@ -2381,7 +2399,7 @@ QUnit.module('Layout manager responsibility', {
             onLayoutChanged: () => {}
         });
 
-        assert.ok(!$testContainer.hasClass(internals.LAYOUT_MANAGER_ONE_COLUMN), 'Layout manager hasn\'t one column mode');
+        assert.ok(!$testContainer.hasClass(LAYOUT_MANAGER_ONE_COLUMN), 'Layout manager hasn\'t one column mode');
     });
 
     test('Small screen size', function(assert) {
@@ -2399,7 +2417,7 @@ QUnit.module('Layout manager responsibility', {
 
         this.updateScreenSize(600);
 
-        assert.ok($testContainer.hasClass(internals.LAYOUT_MANAGER_ONE_COLUMN), 'Layout manager has one column mode');
+        assert.ok($testContainer.hasClass(LAYOUT_MANAGER_ONE_COLUMN), 'Layout manager has one column mode');
     });
 });
 
@@ -2878,13 +2896,13 @@ QUnit.module('Supported editors', () => {
         const $testContainer = layoutManager.$element();
 
         checkSupportedEditors((editor, className) => {
-            assert.notOk($testContainer.find(`.${internals.FIELD_ITEM_CLASS} .${className}`).hasClass(READONLY_STATE_CLASS), `${editor}: editor is not read only`);
+            assert.notOk($testContainer.find(`.${FIELD_ITEM_CLASS} .${className}`).hasClass(READONLY_STATE_CLASS), `${editor}: editor is not read only`);
         });
 
         layoutManager.option('readOnly', true);
 
         checkSupportedEditors((editor, className) => {
-            assert.ok($testContainer.find(`.${internals.FIELD_ITEM_CLASS} .${className}`).hasClass(READONLY_STATE_CLASS), `${editor}: editor is read only`);
+            assert.ok($testContainer.find(`.${FIELD_ITEM_CLASS} .${className}`).hasClass(READONLY_STATE_CLASS), `${editor}: editor is read only`);
         });
     });
 
@@ -2893,7 +2911,7 @@ QUnit.module('Supported editors', () => {
         const $testContainer = layoutManager.$element();
 
         checkSupportedEditors((editor, className) => {
-            assert.ok($testContainer.find(`.${internals.FIELD_ITEM_CLASS} .${className}`).hasClass(READONLY_STATE_CLASS), `${editor}: editor is read only`);
+            assert.ok($testContainer.find(`.${FIELD_ITEM_CLASS} .${className}`).hasClass(READONLY_STATE_CLASS), `${editor}: editor is read only`);
         });
     });
 
@@ -2905,7 +2923,7 @@ QUnit.module('Supported editors', () => {
         layoutManager.option('readOnly', false);
 
         checkSupportedEditors((editor, className) => {
-            assert.ok($testContainer.find(`.${internals.FIELD_ITEM_CLASS} .${className}`).hasClass(READONLY_STATE_CLASS), `${editor}: editor is read only`);
+            assert.ok($testContainer.find(`.${FIELD_ITEM_CLASS} .${className}`).hasClass(READONLY_STATE_CLASS), `${editor}: editor is read only`);
         });
     });
 


### PR DESCRIPTION
(cherry picked from commit f98f3e8f64401eca7bb3a3fbfc64cdec19076bbf)