### PR TITLE
DataGrid - Multiple Selection - The row becomes blue except for the column with checkboxes (T1016005)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1066,7 +1066,9 @@ const KeyboardNavigationController = core.ViewController.inherit({
 
         this._isHiddenFocus = disableFocus;
 
-        if(isGroupRow($row) || this.isRowFocusType()) {
+        const isRowFocus = isGroupRow($row) || this.isRowFocusType();
+
+        if(isRowFocus) {
             $focusElement = $row;
             if(focusedView) {
                 this.setFocusedRowIndex(this._getRowIndex($row));
@@ -1095,7 +1097,9 @@ const KeyboardNavigationController = core.ViewController.inherit({
             }
             if(disableFocus) {
                 $focusElement.addClass(CELL_FOCUS_DISABLED_CLASS);
-                $cell.addClass(CELL_FOCUS_DISABLED_CLASS);
+                if(isRowFocus) {
+                    $cell.addClass(CELL_FOCUS_DISABLED_CLASS);
+                }
             } else {
                 this._editorFactory.focus($focusElement);
             }

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1094,7 +1094,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                 eventsEngine.trigger($focusElement, 'focus');
             }
             if(disableFocus) {
-                $focusElement.addClass(CELL_FOCUS_DISABLED_CLASS);
+                $cell.addClass(CELL_FOCUS_DISABLED_CLASS);
             } else {
                 this._editorFactory.focus($focusElement);
             }

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1094,6 +1094,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                 eventsEngine.trigger($focusElement, 'focus');
             }
             if(disableFocus) {
+                $focusElement.addClass(CELL_FOCUS_DISABLED_CLASS);
                 $cell.addClass(CELL_FOCUS_DISABLED_CLASS);
             } else {
                 this._editorFactory.focus($focusElement);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -3551,9 +3551,32 @@ QUnit.module('View\'s focus', {
         this.clock.tick();
 
         // assert
-        assert.ok($inputElement.closest('td').hasClass('dx-focused'), 'cell is marked as focused');
         assert.ok($inputElement.is(':focus'), 'input is focused');
     });
+
+    QUnit.testInActiveWindow('Cell with checkbox should be focused with other row (T1016005)', function(assert) {
+        // arrange
+        this.dataGrid.option({
+            dataSource: [{ id: 1 }],
+            keyExpr: 'id',
+            columns: ['id'],
+            selection: {
+                mode: 'multiple'
+            },
+            focusedRowEnabled: true,
+        });
+        this.clock.tick();
+
+        const $checkbox = $(this.dataGrid.element()).find('.dx-datagrid-rowsview .dx-checkbox');
+
+        // act
+        $checkbox.trigger('dxpointerdown').trigger('dxclick');
+        this.clock.tick();
+
+        // assert
+        assert.strictEqual($checkbox.parent('td').css('background-color'), 'rgb(92, 149, 197)', 'cell is focused');
+    });
+
 
     QUnit.testInActiveWindow('The expand button of the master cell should not lose its tabindex when a row in a detail grid is switched to editing mode (T969832)', function(assert) {
         // arrange

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -3576,6 +3576,7 @@ QUnit.module('View\'s focus', {
         // assert
         assert.ok($checkbox.parents('tr').hasClass('dx-row-focused'), 'row is focused');
         assert.ok(!$checkbox.parent('td').hasClass('dx-focused'), 'cell is not focused');
+        assert.ok($checkbox.parent('td').hasClass('dx-cell-focus-disabled'), 'cell focus is disabled');
     });
 
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -3574,7 +3574,8 @@ QUnit.module('View\'s focus', {
         this.clock.tick();
 
         // assert
-        assert.strictEqual($checkbox.parent('td').css('background-color'), 'rgb(92, 149, 197)', 'cell is focused');
+        assert.ok($checkbox.parents('tr').hasClass('dx-row-focused'), 'row is focused');
+        assert.ok(!$checkbox.parent('td').hasClass('dx-focused'), 'cell is not focused');
     });
 
 


### PR DESCRIPTION
Ticket: https://devexpress.com/issue=T1016005

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/18435
- https://github.com/DevExpress/DevExtreme/pull/18436

---

When focusing, cell was checked not to have class `dx-cell-focus-disabled`: https://github.com/DevExpress/DevExtreme/blob/21_2/js/ui/grid_core/ui.grid_core.editor_factory.js#L55

But that class was added to row, not to cell: https://github.com/DevExpress/DevExtreme/blob/21_2/js/ui/grid_core/ui.grid_core.keyboard_navigation.js#L1097

Replacing `$focusElement` to `$cell` led tests to fail, so I left both of them

---

Also I had to fix `'An input that resides in a group row template should be focused on click (T931756)'` test

It tested that `td` with `input` should be focused, but according to [this code](https://github.com/DevExpress/DevExtreme/blob/21_2/js/ui/grid_core/ui.grid_core.keyboard_navigation.js#L951) correct behavior is to disable focus on interactive elements (such as `input`)
