### PR TITLE
Add public types for Items, RowObjects, Cells

### DIFF
--- a/js/excel_exporter.d.ts
+++ b/js/excel_exporter.d.ts
@@ -10,12 +10,11 @@ import { ExportLoadPanel } from './exporter/export_load_panel';
 export type DataGridCell = ExcelDataGridCell;
 
 /**
- * @docid
  * @namespace DevExpress.excelExporter
  * @type object
  * @deprecated Use DataGridCell instead
  */
-interface ExcelDataGridCell {
+export interface ExcelDataGridCell {
     /**
      * @docid
      * @public
@@ -70,12 +69,10 @@ interface ExcelDataGridCell {
 export type PivotGridCell = ExcelPivotGridCell;
 
 /**
- * @docid
  * @namespace DevExpress.excelExporter
- * @inherits dxPivotGridPivotGridCell
  * @deprecated Use PivotGridCell instead
  */
-interface ExcelPivotGridCell extends Cell {
+export interface ExcelPivotGridCell extends Cell {
     /**
      * @docid
      * @public

--- a/js/excel_exporter.d.ts
+++ b/js/excel_exporter.d.ts
@@ -11,7 +11,6 @@ export type DataGridCell = ExcelDataGridCell;
 
 /**
  * @namespace DevExpress.excelExporter
- * @type object
  * @deprecated Use DataGridCell instead
  */
 export interface ExcelDataGridCell {

--- a/js/excel_exporter.d.ts
+++ b/js/excel_exporter.d.ts
@@ -1,14 +1,21 @@
 import { DxPromise } from './core/utils/deferred';
 import dxDataGrid, { Column } from './ui/data_grid';
-import dxPivotGrid, { dxPivotGridPivotGridCell } from './ui/pivot_grid';
+import dxPivotGrid, { Cell } from './ui/pivot_grid';
 import { ExportLoadPanel } from './exporter/export_load_panel';
+
+/**
+ * @public
+ * @namespace DevExpress.excelExporter
+ */
+export type DataGridCell = ExcelDataGridCell;
 
 /**
  * @docid
  * @namespace DevExpress.excelExporter
  * @type object
+ * @deprecated Use DataGridCell instead
  */
-export interface ExcelDataGridCell {
+interface ExcelDataGridCell {
     /**
      * @docid
      * @public
@@ -57,11 +64,18 @@ export interface ExcelDataGridCell {
 }
 
 /**
+ * @public
+ * @namespace DevExpress.excelExporter
+ */
+export type PivotGridCell = ExcelPivotGridCell;
+
+/**
  * @docid
  * @namespace DevExpress.excelExporter
  * @inherits dxPivotGridPivotGridCell
+ * @deprecated Use PivotGridCell instead
  */
-export interface ExcelPivotGridCell extends dxPivotGridPivotGridCell {
+interface ExcelPivotGridCell extends Cell {
     /**
      * @docid
      * @public
@@ -211,7 +225,7 @@ export interface ExcelExportPivotGridProps extends ExcelExportBaseProps {
      * @type_function_param1_field2 excelCell:Object
      * @public
      */
-    customizeCell?: ((options: { pivotCell?: ExcelPivotGridCell, excelCell?: any}) => void);
+    customizeCell?: ((options: { pivotCell?: PivotGridCell, excelCell?: any}) => void);
 }
 
 /**

--- a/js/excel_exporter.js
+++ b/js/excel_exporter.js
@@ -6,6 +6,12 @@ import { exportPivotGrid } from './exporter/exceljs/export_pivot_grid';
 * @section utils
 */
 
+/**
+ * @name ExcelPivotGridCell
+ * @namespace DevExpress.excelExporter
+ * @inherits dxPivotGridPivotGridCell
+ */
+
 export {
     exportDataGrid,
     exportPivotGrid

--- a/js/ui/accordion.d.ts
+++ b/js/ui/accordion.d.ts
@@ -81,10 +81,11 @@ export interface dxAccordionOptions extends CollectionWidgetOptions<dxAccordion>
     collapsible?: boolean;
     /**
      * @docid
+     * @type string | Array<string | dxAccordionItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxAccordionItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @default true
@@ -132,10 +133,11 @@ export interface dxAccordionOptions extends CollectionWidgetOptions<dxAccordion>
     itemTitleTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
     /**
      * @docid
+     * @type Array<string | dxAccordionItem | any>
      * @fires dxAccordionOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxAccordionItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default false
@@ -206,10 +208,14 @@ export default class dxAccordion extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
+ * @public
+ * @namespace DevExpress.ui.dxAccordion
+ */
+export type Item = dxAccordionItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
- * @type object
  */
 export interface dxAccordionItem extends CollectionWidgetItem {
     /**

--- a/js/ui/accordion.js
+++ b/js/ui/accordion.js
@@ -436,3 +436,9 @@ const Accordion = CollectionWidget.inherit({
 registerComponent('dxAccordion', Accordion);
 
 export default Accordion;
+
+/**
+ * @name dxAccordionItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/action_sheet.d.ts
+++ b/js/ui/action_sheet.d.ts
@@ -68,16 +68,18 @@ export interface dxActionSheetOptions extends CollectionWidgetOptions<dxActionSh
     cancelText?: string;
     /**
      * @docid
+     * @type string | Array<string | dxActionSheetItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxActionSheetItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
+     * @type Array<string | dxActionSheetItem | any>
      * @fires dxActionSheetOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxActionSheetItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default null
@@ -163,10 +165,14 @@ export default class dxActionSheet extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
+ * @public
+ * @namespace DevExpress.ui.dxActionSheet
+ */
+export type Item = dxActionSheetItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
- * @type object
  */
 export interface dxActionSheetItem extends CollectionWidgetItem {
     /**

--- a/js/ui/action_sheet.js
+++ b/js/ui/action_sheet.js
@@ -406,3 +406,9 @@ const ActionSheet = CollectionWidget.inherit({
 registerComponent('dxActionSheet', ActionSheet);
 
 export default ActionSheet;
+
+/**
+ * @name dxActionSheetItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/box.d.ts
+++ b/js/ui/box.d.ts
@@ -66,10 +66,11 @@ export interface dxBoxOptions extends CollectionWidgetOptions<dxBox> {
     crossAlign?: 'center' | 'end' | 'start' | 'stretch';
     /**
      * @docid
+     * @type string | Array<string | dxBoxItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxBoxItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @type Enums.BoxDirection
@@ -79,10 +80,11 @@ export interface dxBoxOptions extends CollectionWidgetOptions<dxBox> {
     direction?: 'col' | 'row';
     /**
      * @docid
+     * @type Array<string | dxBoxItem | any>
      * @fires dxBoxOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxBoxItem | any>;
+    items?: Array<string | Item | any>;
 }
 /**
  * @docid
@@ -97,10 +99,14 @@ export default class dxBox extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
+ * @public
+ * @namespace DevExpress.ui.dxBox
+ */
+export type Item = dxBoxItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
- * @type object
  */
 export interface dxBoxItem extends CollectionWidgetItem {
     /**

--- a/js/ui/box.js
+++ b/js/ui/box.js
@@ -706,3 +706,9 @@ Box.ItemClass = BoxItem;
 registerComponent('dxBox', Box);
 
 export default Box;
+
+/**
+ * @name dxBoxItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/button_group.d.ts
+++ b/js/ui/button_group.d.ts
@@ -148,10 +148,14 @@ export default class dxButtonGroup extends Widget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
+ * @public
+ * @namespace DevExpress.ui.dxButtonGroup
+ */
+export type Item = dxButtonGroupItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
- * @type object
  */
 export interface dxButtonGroupItem extends CollectionWidgetItem {
     /**

--- a/js/ui/button_group.d.ts
+++ b/js/ui/button_group.d.ts
@@ -70,9 +70,10 @@ export interface dxButtonGroupOptions extends WidgetOptions<dxButtonGroup> {
     hoverStateEnabled?: boolean;
     /**
      * @docid
+     * @type Array<dxButtonGroupItem>
      * @public
      */
-    items?: Array<dxButtonGroupItem>;
+    items?: Array<Item>;
     /**
      * @docid
      * @default 'text'

--- a/js/ui/button_group.js
+++ b/js/ui/button_group.js
@@ -237,3 +237,10 @@ const ButtonGroup = Widget.inherit({
 registerComponent('dxButtonGroup', ButtonGroup);
 
 export default ButtonGroup;
+
+
+/**
+ * @name dxButtonGroupItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/context_menu.d.ts
+++ b/js/ui/context_menu.d.ts
@@ -95,15 +95,17 @@ export interface dxContextMenuOptions extends dxMenuBaseOptions<dxContextMenu> {
     closeOnOutsideClick?: boolean | ((event: DxEvent) => boolean);
     /**
      * @docid
+     * @type string | Array<dxContextMenuItem> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<dxContextMenuItem> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<Item> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
+     * @type Array<dxContextMenuItem>
      * @public
      */
-    items?: Array<dxContextMenuItem>;
+    items?: Array<Item>;
     /**
      * @docid
      * @default null
@@ -244,10 +246,14 @@ export default class dxContextMenu extends dxMenuBase {
 }
 
 /**
- * @docid
- * @inherits dxMenuBaseItem
+ * @public
+ * @namespace DevExpress.ui.dxContextMenu
+ */
+export type Item = dxContextMenuItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
- * @type object
  */
 export interface dxContextMenuItem extends dxMenuBaseItem {
     /**

--- a/js/ui/context_menu.js
+++ b/js/ui/context_menu.js
@@ -1,3 +1,9 @@
 import ContextMenu from './context_menu/ui.context_menu';
 
 export default ContextMenu;
+
+/**
+ * @name dxContextMenuItem
+ * @inherits dxMenuBaseItem
+ * @type object
+ */

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -28,7 +28,7 @@ import {
 } from '../events/index';
 
 import {
-    ExcelDataGridCell
+    DataGridCell as ExcelCell
 } from '../excel_exporter';
 
 import {
@@ -3686,7 +3686,7 @@ export interface ExcelCellInfo {
   font?: ExcelFont;
   readonly value?: string | number | Date;
   numberFormat?: string;
-  gridCell?: ExcelDataGridCell;
+  gridCell?: ExcelCell;
 }
 
 export interface Export {

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -3900,6 +3900,7 @@ export interface CustomSummaryInfo {
   readonly groupIndex?: number;
 }
 
+/** @public */
 export interface Summary {
   /**
    * @docid dxDataGridOptions.summary.calculateCustomSummary

--- a/js/ui/diagram.d.ts
+++ b/js/ui/diagram.d.ts
@@ -1162,7 +1162,7 @@ export default class dxDiagram extends Widget {
  * @inherits dxDiagramItem
  * @namespace DevExpress.ui
  */
-export interface dxDiagramConnector extends Item {
+export interface dxDiagramConnector extends dxDiagramItem {
     /**
      * @docid
      * @public
@@ -1254,7 +1254,7 @@ export interface dxDiagramItem {
  * @inherits dxDiagramItem
  * @namespace DevExpress.ui
  */
-export interface dxDiagramShape extends Item {
+export interface dxDiagramShape extends dxDiagramItem {
     /**
      * @docid
      * @public

--- a/js/ui/diagram.d.ts
+++ b/js/ui/diagram.d.ts
@@ -42,12 +42,12 @@ export type InitializedEvent = InitializedEventInfo<dxDiagram>;
 
 /** @public */
 export type ItemClickEvent = EventInfo<dxDiagram> & {
-    readonly item: dxDiagramItem;
+    readonly item: Item;
 }
 
 /** @public */
 export type ItemDblClickEvent = EventInfo<dxDiagram> & {
-    readonly item: dxDiagramItem;
+    readonly item: Item;
 }
 
 /** @public */
@@ -69,7 +69,7 @@ export type RequestLayoutUpdateEvent = EventInfo<dxDiagram> & {
 
 /** @public */
 export type SelectionChangedEvent = EventInfo<dxDiagram> & {
-    readonly items: Array<dxDiagramItem>;
+    readonly items: Array<Item>;
 }
 
 /** @public */
@@ -1089,7 +1089,7 @@ export default class dxDiagram extends Widget {
      * @return dxDiagramItem
      * @public
      */
-    getItemByKey(key: Object): dxDiagramItem;
+    getItemByKey(key: Object): Item;
     /**
      * @docid
      * @publicName getItemById(id)
@@ -1097,35 +1097,35 @@ export default class dxDiagram extends Widget {
      * @return dxDiagramItem
      * @public
      */
-    getItemById(id: string): dxDiagramItem;
+    getItemById(id: string): Item;
     /**
      * @docid
      * @publicName getItems()
      * @return Array<dxDiagramItem>
      * @public
      */
-     getItems(): Array<dxDiagramItem>;
+     getItems(): Array<Item>;
     /**
      * @docid
      * @publicName getSelectedItems()
      * @return Array<dxDiagramItem>
      * @public
      */
-     getSelectedItems(): Array<dxDiagramItem>;
+     getSelectedItems(): Array<Item>;
     /**
      * @docid
      * @publicName setSelectedItems(items)
      * @param1 items:Array<dxDiagramItem>
      * @public
      */
-     setSelectedItems(items: Array<dxDiagramItem>): void;
+     setSelectedItems(items: Array<Item>): void;
     /**
      * @docid
      * @publicName scrollToItem(item)
      * @param1 item:dxDiagramItem
      * @public
      */
-     scrollToItem(item: dxDiagramItem): void;
+     scrollToItem(item: Item): void;
     /**
      * @docid
      * @publicName export()
@@ -1162,7 +1162,7 @@ export default class dxDiagram extends Widget {
  * @inherits dxDiagramItem
  * @namespace DevExpress.ui
  */
-export interface dxDiagramConnector extends dxDiagramItem {
+export interface dxDiagramConnector extends Item {
     /**
      * @docid
      * @public
@@ -1216,7 +1216,13 @@ export interface dxDiagramConnector extends dxDiagramItem {
 }
 
 /**
- * @docid
+ * @public
+ * @namespace DevExpress.ui.dxDiagram
+ */
+export type Item = dxDiagramItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxDiagramItem {
@@ -1248,7 +1254,7 @@ export interface dxDiagramItem {
  * @inherits dxDiagramItem
  * @namespace DevExpress.ui
  */
-export interface dxDiagramShape extends dxDiagramItem {
+export interface dxDiagramShape extends Item {
     /**
      * @docid
      * @public

--- a/js/ui/drop_down_button.d.ts
+++ b/js/ui/drop_down_button.d.ts
@@ -73,10 +73,11 @@ export type SelectionChangedEvent = NativeEventInfo<dxDropDownButton> & {
 export interface dxDropDownButtonOptions extends WidgetOptions<dxDropDownButton> {
     /**
      * @docid
+     * @type string | Array<dxDropDownButtonItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<dxDropDownButtonItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @default true
@@ -136,10 +137,11 @@ export interface dxDropDownButtonOptions extends WidgetOptions<dxDropDownButton>
     itemTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
     /**
      * @docid
+     * @type Array<dxDropDownButtonItem | any>
      * @default null
      * @public
      */
-    items?: Array<dxDropDownButtonItem | any>;
+    items?: Array<Item | any>;
     /**
      * @docid
      * @default 'this'
@@ -298,9 +300,13 @@ export default class dxDropDownButton extends Widget {
 }
 
 /**
- * @docid
- * @inherits dxListItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxDropDownButton
+ */
+export type Item = dxDropDownButtonItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxDropDownButtonItem extends dxListItem {

--- a/js/ui/drop_down_button.js
+++ b/js/ui/drop_down_button.js
@@ -696,3 +696,9 @@ const DropDownButton = Widget.inherit({
 
 registerComponent('dxDropDownButton', DropDownButton);
 export default DropDownButton;
+
+/**
+ * @name dxDropDownButtonItem
+ * @inherits dxListItem
+ * @type object
+ */

--- a/js/ui/file_manager.d.ts
+++ b/js/ui/file_manager.d.ts
@@ -444,11 +444,17 @@ export interface dxFileManagerContextMenu {
      * @default [ "create", "upload", "rename", "move", "copy", "delete", "refresh", "download" ]
      * @public
      */
-    items?: Array<dxFileManagerContextMenuItem | 'create' | 'upload' | 'refresh' | 'download' | 'move' | 'copy' | 'rename' | 'delete'>;
+    items?: Array<ContextMenuItem | 'create' | 'upload' | 'refresh' | 'download' | 'move' | 'copy' | 'rename' | 'delete'>;
 }
+
 /**
- * @docid
- * @inherits dxContextMenuItem
+ * @public
+ * @namespace DevExpress.ui.dxFileManager
+ */
+export type ContextMenuItem = dxFileManagerContextMenuItem;
+
+/**
+ * @deprecated Use ContexMenuItem instead
  * @namespace DevExpress.ui
  */
 export interface dxFileManagerContextMenuItem extends dxContextMenuItem {
@@ -488,19 +494,24 @@ export interface dxFileManagerToolbar {
      * @default [ "download", "separator", "move", "copy", "rename", "separator", "delete", "clearSelection", { name: "separator", location: "after" }, "refresh" ]
      * @public
      */
-    fileSelectionItems?: Array<dxFileManagerToolbarItem | 'showNavPane' | 'create' | 'upload' | 'refresh' | 'switchView' | 'download' | 'move' | 'copy' | 'rename' | 'delete' | 'clearSelection' | 'separator'>;
+    fileSelectionItems?: Array<ToolbarItem | 'showNavPane' | 'create' | 'upload' | 'refresh' | 'switchView' | 'download' | 'move' | 'copy' | 'rename' | 'delete' | 'clearSelection' | 'separator'>;
     /**
      * @docid
      * @type Array<dxFileManagerToolbarItem,Enums.FileManagerToolbarItem>
      * @default [ "showNavPane", "create", "upload", "switchView", { name: "separator", location: "after" }, "refresh" ]
      * @public
      */
-    items?: Array<dxFileManagerToolbarItem | 'showNavPane' | 'create' | 'upload' | 'refresh' | 'switchView' | 'download' | 'move' | 'copy' | 'rename' | 'delete' | 'clearSelection' | 'separator'>;
+    items?: Array<ToolbarItem | 'showNavPane' | 'create' | 'upload' | 'refresh' | 'switchView' | 'download' | 'move' | 'copy' | 'rename' | 'delete' | 'clearSelection' | 'separator'>;
 }
 
 /**
- * @docid
- * @inherits dxToolbarItem
+ * @public
+ * @namespace DevExpress.ui.dxFileManager
+ */
+export type ToolbarItem = dxFileManagerToolbarItem;
+
+/**
+ * @deprecated Use ToolbarItem instead
  * @namespace DevExpress.ui
  */
 export interface dxFileManagerToolbarItem extends dxToolbarItem {

--- a/js/ui/file_manager.js
+++ b/js/ui/file_manager.js
@@ -2,3 +2,13 @@ import FileManager from './file_manager/ui.file_manager';
 export default FileManager;
 
 // STYLE fileManager
+
+/**
+ * @name dxFileManagerContextMenuItem
+ * @inherits dxContextMenuItem
+ */
+
+/**
+ * @name dxFileManagerToolbarItem
+ * @inherits dxToolbarItem
+ */

--- a/js/ui/form.d.ts
+++ b/js/ui/form.d.ts
@@ -122,7 +122,7 @@ export interface dxFormOptions extends WidgetOptions<dxForm> {
      * @type_function_param1 item:dxFormSimpleItem|dxFormGroupItem|dxFormTabbedItem|dxFormEmptyItem|dxFormButtonItem
      * @public
      */
-    customizeItem?: ((item: dxFormSimpleItem | dxFormGroupItem | dxFormTabbedItem | dxFormEmptyItem | dxFormButtonItem) => void);
+    customizeItem?: ((item: Item) => void);
     /**
      * @docid
      * @default {}
@@ -132,10 +132,11 @@ export interface dxFormOptions extends WidgetOptions<dxForm> {
     formData?: any;
     /**
      * @docid
+     * @type Array<dxFormSimpleItem | dxFormGroupItem | dxFormTabbedItem | dxFormEmptyItem | dxFormButtonItem>
      * @default undefined
      * @public
      */
-    items?: Array<dxFormSimpleItem | dxFormGroupItem | dxFormTabbedItem | dxFormEmptyItem | dxFormButtonItem>;
+    items?: Array<Item>;
     /**
      * @docid
      * @type Enums.FormLabelLocation
@@ -332,10 +333,19 @@ export default class dxForm extends Widget {
 }
 
 /**
- * @docid
- * @publicName ButtonItem
- * @section FormItems
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxForm
+ */
+ export type Item = SimpleItem | GroupItem | TabbedItem | EmptyItem | ButtonItem ;
+
+/**
+ * @public
+ * @namespace DevExpress.ui.dxForm
+ */
+export type ButtonItem = dxFormButtonItem;
+
+/**
+ * @deprecated Use ButtonItem instead
  * @namespace DevExpress.ui
  */
 export interface dxFormButtonItem {
@@ -399,10 +409,13 @@ export interface dxFormButtonItem {
 }
 
 /**
- * @docid
- * @publicName EmptyItem
- * @section FormItems
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxForm
+ */
+export type EmptyItem = dxFormEmptyItem;
+
+/**
+ * @deprecated Use EmptyItem instead
  * @namespace DevExpress.ui
  */
 export interface dxFormEmptyItem {
@@ -446,10 +459,13 @@ export interface dxFormEmptyItem {
 }
 
 /**
- * @docid
- * @publicName GroupItem
- * @section FormItems
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxForm
+ */
+export type GroupItem = dxFormGroupItem;
+
+/**
+ * @deprecated Use GroupItem instead
  * @namespace DevExpress.ui
  */
 export interface dxFormGroupItem {
@@ -500,10 +516,11 @@ export interface dxFormGroupItem {
     itemType?: 'empty' | 'group' | 'simple' | 'tabbed' | 'button';
     /**
      * @docid
+     * @type Array<dxFormSimpleItem | dxFormGroupItem | dxFormTabbedItem | dxFormEmptyItem | dxFormButtonItem>
      * @default undefined
      * @public
      */
-    items?: Array<dxFormSimpleItem | dxFormGroupItem | dxFormTabbedItem | dxFormEmptyItem | dxFormButtonItem>;
+    items?: Array<Item>;
     /**
      * @docid
      * @default undefined
@@ -535,10 +552,13 @@ export interface dxFormGroupItem {
 }
 
 /**
- * @docid
- * @publicName SimpleItem
- * @section FormItems
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxForm
+ */
+export type SimpleItem = dxFormSimpleItem;
+
+/**
+ * @deprecated Use SimpleItem instead
  * @namespace DevExpress.ui
  */
 export interface dxFormSimpleItem {
@@ -665,10 +685,13 @@ export interface dxFormSimpleItem {
 }
 
 /**
- * @docid
- * @publicName TabbedItem
- * @section FormItems
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxForm
+ */
+export type TabbedItem = dxFormTabbedItem;
+
+/**
+ * @deprecated Use TabbedItem instead
  * @namespace DevExpress.ui
  */
 export interface dxFormTabbedItem {
@@ -743,9 +766,10 @@ export interface dxFormTabbedItem {
       icon?: string,
       /**
        * @docid
+       * @type Array<dxFormSimpleItem | dxFormGroupItem | dxFormTabbedItem | dxFormEmptyItem | dxFormButtonItem>
        * @default undefined
        */
-      items?: Array<dxFormSimpleItem | dxFormGroupItem | dxFormTabbedItem | dxFormEmptyItem | dxFormButtonItem>,
+      items?: Array<Item>,
       /**
        * @docid
        * @type_function_param1 tabData:object

--- a/js/ui/form.js
+++ b/js/ui/form.js
@@ -1,2 +1,37 @@
 import Form from './form/ui.form';
 export default Form;
+
+/**
+ * @name dxFormSimpleItem
+ * @publicName SimpleItem
+ * @section FormItems
+ * @type object
+ */
+
+/**
+ * @name dxFormTabbedItem
+ * @publicName TabbedItem
+ * @section FormItems
+ * @type object
+ */
+
+/**
+ * @name dxFormGroupItem
+ * @publicName GroupItem
+ * @section FormItems
+ * @type object
+ */
+
+/**
+ * @name dxFormEmptyItem
+ * @publicName EmptyItem
+ * @section FormItems
+ * @type object
+ */
+
+/**
+ * @name dxFormButtonItem
+ * @publicName ButtonItem
+ * @section FormItems
+ * @type object
+ */

--- a/js/ui/gallery.d.ts
+++ b/js/ui/gallery.d.ts
@@ -72,10 +72,11 @@ export interface dxGalleryOptions extends CollectionWidgetOptions<dxGallery> {
     animationEnabled?: boolean;
     /**
      * @docid
+     * @type string | Array<string | dxGalleryItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxGalleryItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @default true [for](desktop)
@@ -96,10 +97,11 @@ export interface dxGalleryOptions extends CollectionWidgetOptions<dxGallery> {
     initialItemWidth?: number;
     /**
      * @docid
+     * @type Array<string | dxGalleryItem | any>
      * @fires dxGalleryOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxGalleryItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default false
@@ -192,9 +194,13 @@ export default class dxGallery extends CollectionWidget {
 }
 
 /**
- * @docid
- * @type object
- * @inherits CollectionWidgetItem
+ * @public
+ * @namespace DevExpress.ui.dxGallery
+ */
+export type Item = dxGalleryItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxGalleryItem extends CollectionWidgetItem {

--- a/js/ui/gallery.js
+++ b/js/ui/gallery.js
@@ -1163,3 +1163,9 @@ const Gallery = CollectionWidget.inherit({
 registerComponent('dxGallery', Gallery);
 
 export default Gallery;
+
+/**
+ * @name dxGalleryItem
+ * @type object
+ * @inherits CollectionWidgetItem
+ */

--- a/js/ui/gantt.d.ts
+++ b/js/ui/gantt.d.ts
@@ -1111,7 +1111,7 @@ export interface dxGanttToolbar {
      * @type Array<dxGanttToolbarItem,Enums.GanttToolbarItem>
      * @public
      */
-    items?: Array<dxGanttToolbarItem | 'separator' | 'undo' | 'redo' | 'expandAll' | 'collapseAll' | 'addTask' | 'deleteTask' | 'zoomIn' | 'zoomOut' | 'taskDetails' | 'fullScreen' | 'resourceManager'>;
+    items?: Array<ToolbarItem | 'separator' | 'undo' | 'redo' | 'expandAll' | 'collapseAll' | 'addTask' | 'deleteTask' | 'zoomIn' | 'zoomOut' | 'taskDetails' | 'fullScreen' | 'resourceManager'>;
 }
 
 /**
@@ -1131,12 +1131,17 @@ export interface dxGanttContextMenu {
      * @type Array<dxGanttContextMenuItem,Enums.GanttContextMenuItem>
      * @public
      */
-    items?: Array<dxGanttContextMenuItem | 'undo' | 'redo' | 'expandAll' | 'collapseAll' | 'addTask' | 'deleteTask' | 'zoomIn' | 'zoomOut' | 'deleteDependency' | 'taskDetails' | 'resourceManager'>;
+    items?: Array<ContextMenuItem | 'undo' | 'redo' | 'expandAll' | 'collapseAll' | 'addTask' | 'deleteTask' | 'zoomIn' | 'zoomOut' | 'deleteDependency' | 'taskDetails' | 'resourceManager'>;
 }
 
 /**
- * @docid
- * @inherits dxToolbarItem
+ * @public
+ * @namespace DevExpress.ui.dxGantt
+ */
+export type ToolbarItem = dxGanttToolbarItem;
+
+/**
+ * @deprecated Use ToolbarItem instead
  * @namespace DevExpress.ui
  */
 export interface dxGanttToolbarItem extends dxToolbarItem {
@@ -1156,8 +1161,13 @@ export interface dxGanttToolbarItem extends dxToolbarItem {
 }
 
 /**
- * @docid
- * @inherits dxContextMenuItem
+ * @public
+ * @namespace DevExpress.ui.dxGantt
+ */
+export type ContextMenuItem = dxGanttContextMenuItem;
+
+/**
+ * @deprecated Use ContextMenuItem instead
  * @namespace DevExpress.ui
  */
 export interface dxGanttContextMenuItem extends dxContextMenuItem {

--- a/js/ui/gantt.js
+++ b/js/ui/gantt.js
@@ -1,2 +1,12 @@
 import Gantt from './gantt/ui.gantt';
 export default Gantt;
+
+/**
+ * @name dxGanttToolbarItem
+ * @inherits dxToolbarItem
+ */
+
+/**
+ * @name dxGanttContextMenuItem
+ * @inherits dxContextMenuItem
+ */

--- a/js/ui/html_editor.d.ts
+++ b/js/ui/html_editor.d.ts
@@ -505,7 +505,7 @@ export interface dxHtmlEditorToolbar {
      * @type Array<dxHtmlEditorToolbarItem,Enums.HtmlEditorToolbarItem>
      * @public
      */
-    items?: Array<dxHtmlEditorToolbarItem | 'background' | 'bold' | 'color' | 'font' | 'italic' | 'link' | 'image' | 'size' | 'strike' | 'subscript' | 'superscript' | 'underline' | 'blockquote' | 'header' | 'increaseIndent' | 'decreaseIndent' | 'orderedList' | 'bulletList' | 'alignLeft' | 'alignCenter' | 'alignRight' | 'alignJustify' | 'codeBlock' | 'variable' | 'separator' | 'undo' | 'redo' | 'clear' | 'insertTable' | 'insertRowAbove' | 'insertRowBelow' | 'insertColumnLeft' | 'insertColumnRight' | 'deleteColumn' | 'deleteRow' | 'deleteTable'>;
+    items?: Array<ToolbarItem | 'background' | 'bold' | 'color' | 'font' | 'italic' | 'link' | 'image' | 'size' | 'strike' | 'subscript' | 'superscript' | 'underline' | 'blockquote' | 'header' | 'increaseIndent' | 'decreaseIndent' | 'orderedList' | 'bulletList' | 'alignLeft' | 'alignCenter' | 'alignRight' | 'alignJustify' | 'codeBlock' | 'variable' | 'separator' | 'undo' | 'redo' | 'clear' | 'insertTable' | 'insertRowAbove' | 'insertRowBelow' | 'insertColumnLeft' | 'insertColumnRight' | 'deleteColumn' | 'deleteRow' | 'deleteTable'>;
     /**
      * @docid
      * @default true
@@ -515,8 +515,13 @@ export interface dxHtmlEditorToolbar {
 }
 
 /**
- * @docid
- * @inherits dxToolbarItem
+ * @public
+ * @namespace DevExpress.ui.dxHtmlEditor
+ */
+export type ToolbarItem = dxHtmlEditorToolbarItem;
+
+/**
+ * @deprecated Use ToolbarItem instead
  * @namespace DevExpress.ui
  */
 export interface dxHtmlEditorToolbarItem extends dxToolbarItem {

--- a/js/ui/html_editor.js
+++ b/js/ui/html_editor.js
@@ -1,2 +1,7 @@
 import HtmlEditor from './html_editor/ui.html_editor';
 export default HtmlEditor;
+
+/**
+ * @name dxHtmlEditorToolbarItem
+ * @inherits dxToolbarItem
+ */

--- a/js/ui/list.d.ts
+++ b/js/ui/list.d.ts
@@ -152,10 +152,11 @@ export interface dxListOptions extends CollectionWidgetOptions<dxList>, SearchBo
     collapsibleGroups?: boolean;
     /**
      * @docid
+     * @type string | Array<string | dxListItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxListItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @default undefined
@@ -214,10 +215,11 @@ export interface dxListOptions extends CollectionWidgetOptions<dxList>, SearchBo
     itemDragging?: dxSortableOptions;
     /**
      * @docid
+     * @type Array<string | dxListItem | any>
      * @fires dxListOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxListItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default []
@@ -709,9 +711,13 @@ export default class dxList extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxList
+ */
+export type Item = dxListItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxListItem extends CollectionWidgetItem {

--- a/js/ui/list.js
+++ b/js/ui/list.js
@@ -5,3 +5,9 @@ import registerComponent from '../core/component_registrator';
 registerComponent('dxList', ListEdit);
 
 export default ListEdit;
+
+/**
+ * @name dxListItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/menu.d.ts
+++ b/js/ui/menu.d.ts
@@ -84,10 +84,11 @@ export interface dxMenuOptions extends dxMenuBaseOptions<dxMenu> {
     adaptivityEnabled?: boolean;
     /**
      * @docid
+     * @type string | Array<dxMenuItem> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<dxMenuItem> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<Item> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @default false
@@ -96,9 +97,10 @@ export interface dxMenuOptions extends dxMenuBaseOptions<dxMenu> {
     hideSubmenuOnMouseLeave?: boolean;
     /**
      * @docid
+     * @type Array<dxMenuItem>
      * @public
      */
-    items?: Array<dxMenuItem>;
+    items?: Array<Item>;
     /**
      * @docid
      * @default null
@@ -265,9 +267,13 @@ export interface dxMenuBaseItem extends CollectionWidgetItem {
 }
 
 /**
- * @docid
- * @inherits dxMenuBaseItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxMenu
+ */
+export type Item = dxMenuItem;
+
+/**
+ * @deprecated
  * @namespace DevExpress.ui
  */
 export interface dxMenuItem extends dxMenuBaseItem {

--- a/js/ui/menu.js
+++ b/js/ui/menu.js
@@ -1,3 +1,9 @@
 import Menu from './menu/ui.menu';
 
 export default Menu;
+
+/**
+ * @name dxMenuItem
+ * @inherits dxMenuBaseItem
+ * @type object
+ */

--- a/js/ui/multi_view.d.ts
+++ b/js/ui/multi_view.d.ts
@@ -62,10 +62,11 @@ export interface dxMultiViewOptions<T = dxMultiView> extends CollectionWidgetOpt
     animationEnabled?: boolean;
     /**
      * @docid
+     * @type string | Array<string | dxMultiViewItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxMultiViewItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @default true
@@ -80,10 +81,11 @@ export interface dxMultiViewOptions<T = dxMultiView> extends CollectionWidgetOpt
     focusStateEnabled?: boolean;
     /**
      * @docid
+     * @type Array<string | dxMultiViewItem | any>
      * @fires dxMultiViewOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxMultiViewItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default false
@@ -116,9 +118,13 @@ export default class dxMultiView extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxMultiView
+ */
+export type Item = dxMultiViewItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxMultiViewItem extends CollectionWidgetItem {

--- a/js/ui/multi_view.js
+++ b/js/ui/multi_view.js
@@ -434,3 +434,9 @@ const MultiView = CollectionWidget.inherit({
 registerComponent('dxMultiView', MultiView);
 
 export default MultiView;
+
+/**
+ * @name dxMultiViewItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/nav_bar.d.ts
+++ b/js/ui/nav_bar.d.ts
@@ -71,9 +71,13 @@ export default class dxNavBar extends dxTabs {
 }
 
 /**
- * @docid
- * @inherits dxTabsItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxNavBar
+ */
+export type Item = dxNavBarItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxNavBarItem extends dxTabsItem {

--- a/js/ui/nav_bar.js
+++ b/js/ui/nav_bar.js
@@ -60,3 +60,9 @@ NavBar.ItemClass = NavBarItem;
 registerComponent('dxNavBar', NavBar);
 
 export default NavBar;
+
+/**
+ * @name dxNavBarItem
+ * @inherits dxTabsItem
+ * @type object
+ */

--- a/js/ui/pivot_grid.d.ts
+++ b/js/ui/pivot_grid.d.ts
@@ -12,7 +12,7 @@ import {
 } from '../events/index';
 
 import PivotGridDataSource, {
-    PivotGridDataSourceField,
+    Field,
     PivotGridDataSourceOptions
 } from './pivot_grid/data_source';
 
@@ -26,19 +26,19 @@ import Widget, {
 export type CellClickEvent = Cancelable & NativeEventInfo<dxPivotGrid> & {
     readonly area?: string;
     readonly cellElement?: DxElement;
-    readonly cell?: dxPivotGridPivotGridCell;
+    readonly cell?: Cell;
     readonly rowIndex?: number;
     readonly columnIndex?: number;
-    readonly columnFields?: Array<PivotGridDataSourceField>;
-    readonly rowFields?: Array<PivotGridDataSourceField>;
-    readonly dataFields?: Array<PivotGridDataSourceField>;
+    readonly columnFields?: Array<Field>;
+    readonly rowFields?: Array<Field>;
+    readonly dataFields?: Array<Field>;
 }
 
 /** @public */
 export type CellPreparedEvent = EventInfo<dxPivotGrid> & {
     readonly area?: string;
     readonly cellElement?: DxElement;
-    readonly cell?: dxPivotGridPivotGridCell;
+    readonly cell?: Cell;
     readonly rowIndex?: number;
     readonly columnIndex?: number
 }
@@ -49,14 +49,14 @@ export type ContentReadyEvent = EventInfo<dxPivotGrid>;
 /** @public */
 export type ContextMenuPreparingEvent = EventInfo<dxPivotGrid> & {
     readonly area?: string;
-    readonly cell?: dxPivotGridPivotGridCell;
+    readonly cell?: Cell;
     readonly cellElement?: DxElement;
     readonly columnIndex?: number;
     readonly rowIndex?: number;
-    readonly dataFields?: Array<PivotGridDataSourceField>;
-    readonly rowFields?: Array<PivotGridDataSourceField>;
-    readonly columnFields?: Array<PivotGridDataSourceField>;
-    readonly field?: PivotGridDataSourceField;
+    readonly dataFields?: Array<Field>;
+    readonly rowFields?: Array<Field>;
+    readonly columnFields?: Array<Field>;
+    readonly field?: Field;
     items?: Array<any>;
 }
 
@@ -731,11 +731,18 @@ export default class dxPivotGrid extends Widget {
 }
 
 /**
+ * @public
+ * @namespace DevExpress.ui.dxPivotGrid
+ */
+export type Cell = dxPivotGridPivotGridCell;
+
+/**
  * @docid
  * @type object
  * @namespace DevExpress.ui
+ * @deprecated Use Cell instead
  */
-export interface dxPivotGridPivotGridCell {
+interface dxPivotGridPivotGridCell {
     /**
      * @docid
      * @public
@@ -792,145 +799,6 @@ export interface dxPivotGridPivotGridCell {
      * @public
      */
     value?: any;
-}
-
-/**
- * @docid
- * @type object
- * @namespace DevExpress.ui
- */
-export interface dxPivotGridSummaryCell {
-    /**
-     * @docid
-     * @publicName child(direction, fieldValue)
-     * @param1 direction:string
-     * @param2 fieldValue:number|string
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    child(direction: string, fieldValue: number | string): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName children(direction)
-     * @param1 direction:string
-     * @return Array<dxPivotGridSummaryCell>
-     * @public
-     */
-    children(direction: string): Array<dxPivotGridSummaryCell>;
-    /**
-     * @docid
-     * @publicName field(area)
-     * @param1 area:string
-     * @return PivotGridDataSourceOptions.fields
-     * @public
-     */
-    field(area: string): PivotGridDataSourceField;
-    /**
-     * @docid
-     * @publicName grandTotal()
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    grandTotal(): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName grandTotal(direction)
-     * @param1 direction:string
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    grandTotal(direction: string): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName isPostProcessed(field)
-     * @param1 field:PivotGridDataSourceOptions.fields|string
-     * @return boolean
-     * @public
-     */
-    isPostProcessed(field: PivotGridDataSourceField | string): boolean;
-    /**
-     * @docid
-     * @publicName next(direction)
-     * @param1 direction:string
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    next(direction: string): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName next(direction, allowCrossGroup)
-     * @param1 direction:string
-     * @param2 allowCrossGroup:bool
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    next(direction: string, allowCrossGroup: boolean): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName parent(direction)
-     * @param1 direction:string
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    parent(direction: string): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName prev(direction)
-     * @param1 direction:string
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    prev(direction: string): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName prev(direction, allowCrossGroup)
-     * @param1 direction:string
-     * @param2 allowCrossGroup:bool
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    prev(direction: string, allowCrossGroup: boolean): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName slice(field, value)
-     * @param1 field:PivotGridDataSourceOptions.fields
-     * @param2 value:number|string
-     * @return dxPivotGridSummaryCell
-     * @public
-     */
-    slice(field: PivotGridDataSourceField, value: number | string): dxPivotGridSummaryCell;
-    /**
-     * @docid
-     * @publicName value()
-     * @return any
-     * @public
-     */
-    value(): any;
-    /**
-     * @docid
-     * @publicName value(field)
-     * @param1 field:PivotGridDataSourceOptions.fields|string
-     * @return any
-     * @public
-     */
-    value(field: PivotGridDataSourceField | string): any;
-    /**
-     * @docid
-     * @publicName value(field, postProcessed)
-     * @param1 field:PivotGridDataSourceOptions.fields|string
-     * @param2 postProcessed:boolean
-     * @return any
-     * @public
-     */
-    value(field: PivotGridDataSourceField | string, postProcessed: boolean): any;
-    /**
-     * @docid
-     * @publicName value(postProcessed)
-     * @param1 postProcessed:boolean
-     * @return any
-     * @public
-     */
-    value(postProcessed: boolean): any;
 }
 
 /** @public */

--- a/js/ui/pivot_grid.d.ts
+++ b/js/ui/pivot_grid.d.ts
@@ -13,7 +13,8 @@ import {
 
 import PivotGridDataSource, {
     Field,
-    PivotGridDataSourceOptions
+    PivotGridDataSourceOptions,
+    dxPivotGridSummaryCell as SummaryCell
 } from './pivot_grid/data_source';
 
 import dxPopup from './popup';
@@ -742,7 +743,7 @@ export type Cell = dxPivotGridPivotGridCell;
  * @namespace DevExpress.ui
  * @deprecated Use Cell instead
  */
-interface dxPivotGridPivotGridCell {
+export interface dxPivotGridPivotGridCell {
     /**
      * @docid
      * @public
@@ -800,6 +801,8 @@ interface dxPivotGridPivotGridCell {
      */
     value?: any;
 }
+
+export type dxPivotGridSummaryCell = SummaryCell;
 
 /** @public */
 export type Properties = dxPivotGridOptions;

--- a/js/ui/pivot_grid.d.ts
+++ b/js/ui/pivot_grid.d.ts
@@ -738,8 +738,6 @@ export default class dxPivotGrid extends Widget {
 export type Cell = dxPivotGridPivotGridCell;
 
 /**
- * @docid
- * @type object
  * @namespace DevExpress.ui
  * @deprecated Use Cell instead
  */

--- a/js/ui/pivot_grid/data_source.d.ts
+++ b/js/ui/pivot_grid/data_source.d.ts
@@ -156,7 +156,7 @@ interface dxPivotGridSummaryCell {
 }
 
 /** @namespace DevExpress.data */
-interface PivotGridDataSourceOptions {
+export interface PivotGridDataSourceOptions {
     /**
      * @docid
      * @type Array<Object>
@@ -244,7 +244,7 @@ export type Field = PivotGridDataSourceField;
  * @namespace DevExpress.data
  * @deprecated Use Field instead
  */
-interface PivotGridDataSourceField {
+export interface PivotGridDataSourceField {
     /**
      * @docid PivotGridDataSourceOptions.fields.allowCrossGroupCalculation
      * @default false

--- a/js/ui/pivot_grid/data_source.d.ts
+++ b/js/ui/pivot_grid/data_source.d.ts
@@ -155,7 +155,10 @@ interface dxPivotGridSummaryCell {
     value(postProcessed: boolean): any;
 }
 
-/** @namespace DevExpress.data */
+/**
+ * @namespace DevExpress.data
+ * @deprecated use Properties instead
+ */
 export interface PivotGridDataSourceOptions {
     /**
      * @docid
@@ -693,3 +696,9 @@ export default class PivotGridDataSource {
      */
     state(state: any): void;
 }
+
+/**
+ * @public
+ * @namespace DevExpress.data.PivotGridDataSource
+ */
+export type Properties = PivotGridDataSourceOptions;

--- a/js/ui/pivot_grid/data_source.d.ts
+++ b/js/ui/pivot_grid/data_source.d.ts
@@ -155,10 +155,7 @@ interface dxPivotGridSummaryCell {
     value(postProcessed: boolean): any;
 }
 
-/**
- * @namespace DevExpress.data
- * @deprecated use Properties instead
- */
+/** @namespace DevExpress.data */
 export interface PivotGridDataSourceOptions {
     /**
      * @docid
@@ -696,9 +693,3 @@ export default class PivotGridDataSource {
      */
     state(state: any): void;
 }
-
-/**
- * @public
- * @namespace DevExpress.data.PivotGridDataSource
- */
-export type Properties = PivotGridDataSourceOptions;

--- a/js/ui/pivot_grid/data_source.d.ts
+++ b/js/ui/pivot_grid/data_source.d.ts
@@ -9,10 +9,6 @@ import Store, {
 import DataSource from '../../data/data_source';
 
 import {
-    dxPivotGridSummaryCell
-} from '../pivot_grid';
-
-import {
     format
 } from '../widget/ui.widget';
 
@@ -20,15 +16,154 @@ import XmlaStore, {
     XmlaStoreOptions
 } from './xmla_store';
 
+/**
+ * @docid
+ * @type object
+ * @namespace DevExpress.ui
+ */
+interface dxPivotGridSummaryCell {
+    /**
+     * @docid
+     * @publicName child(direction, fieldValue)
+     * @param1 direction:string
+     * @param2 fieldValue:number|string
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    child(direction: string, fieldValue: number | string): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName children(direction)
+     * @param1 direction:string
+     * @return Array<dxPivotGridSummaryCell>
+     * @public
+     */
+    children(direction: string): Array<dxPivotGridSummaryCell>;
+    /**
+     * @docid
+     * @publicName field(area)
+     * @param1 area:string
+     * @return PivotGridDataSourceOptions.fields
+     * @public
+     */
+    field(area: string): Field;
+    /**
+     * @docid
+     * @publicName grandTotal()
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    grandTotal(): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName grandTotal(direction)
+     * @param1 direction:string
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    grandTotal(direction: string): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName isPostProcessed(field)
+     * @param1 field:PivotGridDataSourceOptions.fields|string
+     * @return boolean
+     * @public
+     */
+    isPostProcessed(field: Field | string): boolean;
+    /**
+     * @docid
+     * @publicName next(direction)
+     * @param1 direction:string
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    next(direction: string): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName next(direction, allowCrossGroup)
+     * @param1 direction:string
+     * @param2 allowCrossGroup:bool
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    next(direction: string, allowCrossGroup: boolean): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName parent(direction)
+     * @param1 direction:string
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    parent(direction: string): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName prev(direction)
+     * @param1 direction:string
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    prev(direction: string): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName prev(direction, allowCrossGroup)
+     * @param1 direction:string
+     * @param2 allowCrossGroup:bool
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    prev(direction: string, allowCrossGroup: boolean): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName slice(field, value)
+     * @param1 field:PivotGridDataSourceOptions.fields
+     * @param2 value:number|string
+     * @return dxPivotGridSummaryCell
+     * @public
+     */
+    slice(field: Field, value: number | string): dxPivotGridSummaryCell;
+    /**
+     * @docid
+     * @publicName value()
+     * @return any
+     * @public
+     */
+    value(): any;
+    /**
+     * @docid
+     * @publicName value(field)
+     * @param1 field:PivotGridDataSourceOptions.fields|string
+     * @return any
+     * @public
+     */
+    value(field: Field | string): any;
+    /**
+     * @docid
+     * @publicName value(field, postProcessed)
+     * @param1 field:PivotGridDataSourceOptions.fields|string
+     * @param2 postProcessed:boolean
+     * @return any
+     * @public
+     */
+    value(field: Field | string, postProcessed: boolean): any;
+    /**
+     * @docid
+     * @publicName value(postProcessed)
+     * @param1 postProcessed:boolean
+     * @return any
+     * @public
+     */
+    value(postProcessed: boolean): any;
+}
+
 /** @namespace DevExpress.data */
-export interface PivotGridDataSourceOptions {
+interface PivotGridDataSourceOptions {
     /**
      * @docid
      * @type Array<Object>
      * @default undefined
      * @public
      */
-    fields?: Array<PivotGridDataSourceField>;
+    fields?: Array<Field>;
     /**
      * @docid
      * @type Filter expression
@@ -47,7 +182,7 @@ export interface PivotGridDataSourceOptions {
      * @action
      * @public
      */
-    onFieldsPrepared?: ((fields: Array<PivotGridDataSourceField>) => void);
+    onFieldsPrepared?: ((fields: Array<Field>) => void);
     /**
      * @docid
      * @type_function_param1 error:Object
@@ -98,8 +233,18 @@ export interface PivotGridDataSourceOptions {
       type?: 'array' | 'local' | 'odata' | 'xmla'
     };
 }
-/** @namespace DevExpress.data */
-export interface PivotGridDataSourceField {
+
+/**
+ * @public
+ * @namespace DevExpress.data.PivotGridDataSource
+ */
+export type Field = PivotGridDataSourceField;
+
+/**
+ * @namespace DevExpress.data
+ * @deprecated Use Field instead
+ */
+interface PivotGridDataSourceField {
     /**
      * @docid PivotGridDataSourceOptions.fields.allowCrossGroupCalculation
      * @default false
@@ -440,14 +585,14 @@ export default class PivotGridDataSource {
      * @return Array<PivotGridDataSourceOptions.fields>
      * @public
      */
-    fields(): Array<PivotGridDataSourceField>;
+    fields(): Array<Field>;
     /**
      * @docid
      * @publicName fields(fields)
      * @param1 fields:Array<PivotGridDataSourceOptions.fields>
      * @public
      */
-    fields(fields: Array<PivotGridDataSourceField>): void;
+    fields(fields: Array<Field>): void;
     /**
      * @docid
      * @publicName filter()
@@ -470,7 +615,7 @@ export default class PivotGridDataSource {
      * @return Array<PivotGridDataSourceOptions.fields>
      * @public
      */
-    getAreaFields(area: string, collectGroups: boolean): Array<PivotGridDataSourceField>;
+    getAreaFields(area: string, collectGroups: boolean): Array<Field>;
     /**
      * @docid
      * @publicName getData()

--- a/js/ui/pivot_grid_field_chooser.d.ts
+++ b/js/ui/pivot_grid_field_chooser.d.ts
@@ -10,7 +10,7 @@ import {
 } from '../events/index';
 
 import PivotGridDataSource, {
-    PivotGridDataSourceField
+    Field
 } from './pivot_grid/data_source';
 
 import Widget, {
@@ -23,7 +23,7 @@ export type ContentReadyEvent = EventInfo<dxPivotGridFieldChooser>;
 /** @public */
 export type ContextMenuPreparingEvent = EventInfo<dxPivotGridFieldChooser> & {
     readonly area?: string;
-    readonly field?: PivotGridDataSourceField;
+    readonly field?: Field;
     readonly event?: DxEvent;
     items?: Array<any>;
 }

--- a/js/ui/popup.d.ts
+++ b/js/ui/popup.d.ts
@@ -205,7 +205,7 @@ export interface dxPopupOptions<T = dxPopup> extends dxOverlayOptions<T> {
      * @type Array<Object>
      * @public
      */
-    toolbarItems?: Array<dxPopupToolbarItem>;
+    toolbarItems?: Array<ToolbarItem>;
     /**
      * @docid
      * @type_function_return number|string
@@ -229,7 +229,17 @@ export interface dxPopupAnimation extends dxOverlayAnimation {
      */
     show?: animationConfig;
 }
-/** @namespace DevExpress.ui */
+
+/**
+ * @public
+ * @namespace DevExpress.ui.dxPopup
+ */
+export type ToolbarItem = dxPopupToolbarItem;
+
+/**
+ * @deprecated Use ToolbarItem instead
+ * @namespace DevExpress.ui
+ */
 export interface dxPopupToolbarItem {
     /**
      * @docid dxPopupOptions.toolbarItems.disabled
@@ -305,4 +315,3 @@ export type Options = dxPopupOptions;
 
 /** @deprecated use Properties instead */
 export type IOptions = dxPopupOptions;
-export type ToolbarItem = dxPopupToolbarItem;

--- a/js/ui/responsive_box.d.ts
+++ b/js/ui/responsive_box.d.ts
@@ -79,10 +79,11 @@ export interface dxResponsiveBoxOptions extends CollectionWidgetOptions<dxRespon
     }>;
     /**
      * @docid
+     * @type string | Array<string | dxResponsiveBoxItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxResponsiveBoxItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @type_function_return number|string
@@ -92,10 +93,11 @@ export interface dxResponsiveBoxOptions extends CollectionWidgetOptions<dxRespon
     height?: number | string | (() => number | string);
     /**
      * @docid
+     * @type Array<string | dxResponsiveBoxItem | any>
      * @fires dxResponsiveBoxOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxResponsiveBoxItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @public
@@ -156,9 +158,13 @@ export default class dxResponsiveBox extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxResponsiveBox
+ */
+export type Item = dxResponsiveBoxItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxResponsiveBoxItem extends CollectionWidgetItem {

--- a/js/ui/responsive_box.js
+++ b/js/ui/responsive_box.js
@@ -663,3 +663,9 @@ const ResponsiveBox = CollectionWidget.inherit({
 registerComponent('dxResponsiveBox', ResponsiveBox);
 
 export default ResponsiveBox;
+
+/**
+ * @name dxResponsiveBoxItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/slide_out.d.ts
+++ b/js/ui/slide_out.d.ts
@@ -85,16 +85,18 @@ export interface dxSlideOutOptions extends CollectionWidgetOptions<dxSlideOut> {
     contentTemplate?: template | ((container: DxElement) => string | UserDefinedElement);
     /**
      * @docid
+     * @type string | Array<string | dxSlideOutItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxSlideOutItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
+     * @type Array<string | dxSlideOutItem | any>
      * @fires dxSlideOutOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxSlideOutItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default "menuGroup"
@@ -205,9 +207,13 @@ export default class dxSlideOut extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxSlideOut
+ */
+export type Item = dxSlideOutItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxSlideOutItem extends CollectionWidgetItem {

--- a/js/ui/slide_out.js
+++ b/js/ui/slide_out.js
@@ -363,3 +363,9 @@ const SlideOut = CollectionWidget.inherit({
 registerComponent('dxSlideOut', SlideOut);
 
 export default SlideOut;
+
+/**
+ * @name dxSlideOutItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/tab_panel.d.ts
+++ b/js/ui/tab_panel.d.ts
@@ -89,10 +89,11 @@ export interface dxTabPanelOptions extends dxMultiViewOptions<dxTabPanel> {
     animationEnabled?: boolean;
     /**
      * @docid
+     * @type string | Array<string | dxTabPanelItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxTabPanelItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @default true
@@ -111,10 +112,11 @@ export interface dxTabPanelOptions extends dxMultiViewOptions<dxTabPanel> {
     itemTitleTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
     /**
      * @docid
+     * @type Array<string | dxTabPanelItem | any>
      * @fires dxTabPanelOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxTabPanelItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default null
@@ -200,9 +202,13 @@ export default class dxTabPanel extends dxMultiView {
 }
 
 /**
- * @docid
- * @inherits dxMultiViewItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxTabPanel
+ */
+export type Item = dxTabPanelItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxTabPanelItem extends dxMultiViewItem {

--- a/js/ui/tab_panel.js
+++ b/js/ui/tab_panel.js
@@ -377,3 +377,9 @@ TabPanel.ItemClass = TabPanelItem;
 registerComponent('dxTabPanel', TabPanel);
 
 export default TabPanel;
+
+/**
+ * @name dxTabPanelItem
+ * @inherits dxMultiViewItem
+ * @type object
+ */

--- a/js/ui/tabs.d.ts
+++ b/js/ui/tabs.d.ts
@@ -56,10 +56,11 @@ export type SelectionChangedEvent = EventInfo<dxTabs> & SelectionChangedInfo;
 export interface dxTabsOptions<T = dxTabs> extends CollectionWidgetOptions<T> {
     /**
      * @docid
+     * @type string | Array<string | dxTabsItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxTabsItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @default true [for](desktop)
@@ -74,10 +75,11 @@ export interface dxTabsOptions<T = dxTabs> extends CollectionWidgetOptions<T> {
     hoverStateEnabled?: boolean;
     /**
      * @docid
+     * @type Array<string | dxTabsItem | any>
      * @fires dxTabsOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxTabsItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default false
@@ -130,9 +132,13 @@ export default class dxTabs extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxTabs
+ */
+export type Item = dxTabsItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxTabsItem extends CollectionWidgetItem {

--- a/js/ui/tabs.js
+++ b/js/ui/tabs.js
@@ -466,3 +466,9 @@ Tabs.ItemClass = TabsItem;
 registerComponent('dxTabs', Tabs);
 
 export default Tabs;
+
+/**
+ * @name dxTabsItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/tile_view.d.ts
+++ b/js/ui/tile_view.d.ts
@@ -70,10 +70,11 @@ export interface dxTileViewOptions extends CollectionWidgetOptions<dxTileView> {
     baseItemWidth?: number;
     /**
      * @docid
+     * @type string | Array<string | dxTileViewItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxTileViewItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @type Enums.Orientation
@@ -108,10 +109,11 @@ export interface dxTileViewOptions extends CollectionWidgetOptions<dxTileView> {
     itemMargin?: number;
     /**
      * @docid
+     * @type Array<string | dxTileViewItem | any>
      * @fires dxTileViewOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxTileViewItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default false
@@ -139,9 +141,13 @@ export default class dxTileView extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxTileView
+ */
+export type Item = dxTileViewItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxTileViewItem extends CollectionWidgetItem {

--- a/js/ui/tile_view.js
+++ b/js/ui/tile_view.js
@@ -502,3 +502,9 @@ const TileView = CollectionWidget.inherit({
 registerComponent('dxTileView', TileView);
 
 export default TileView;
+
+/**
+ * @name dxTileViewItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/toolbar.d.ts
+++ b/js/ui/toolbar.d.ts
@@ -57,16 +57,18 @@ export type OptionChangedEvent = EventInfo<dxToolbar> & ChangedOptionInfo;
 export interface dxToolbarOptions extends CollectionWidgetOptions<dxToolbar> {
     /**
      * @docid
+     * @type string | Array<string | dxToolbarItem | any> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<string | dxToolbarItem | any> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<string | Item | any> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
+     * @type Array<string | dxToolbarItem | any>
      * @fires dxToolbarOptions.onOptionChanged
      * @public
      */
-    items?: Array<string | dxToolbarItem | any>;
+    items?: Array<string | Item | any>;
     /**
      * @docid
      * @default "menuItem"
@@ -99,9 +101,13 @@ export default class dxToolbar extends CollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxToolbar
+ * */
+export type Item = dxToolbarItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxToolbarItem extends CollectionWidgetItem {

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -328,3 +328,9 @@ const Toolbar = ToolbarBase.inherit({
 registerComponent('dxToolbar', Toolbar);
 
 export default Toolbar;
+
+/**
+ * @name dxToolbarItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1377,7 +1377,7 @@ export interface Node {
 /**
  * @public
  * @namespace DevExpress.ui
- * @deprecated
+ * @deprecated Use RowObject instead
  */
 export type dxTreeListRowObject = RowObject;
 

--- a/js/ui/tree_view.d.ts
+++ b/js/ui/tree_view.d.ts
@@ -128,10 +128,11 @@ export interface dxTreeViewOptions extends HierarchicalCollectionWidgetOptions<d
     createChildren?: ((parentNode: dxTreeViewNode) => PromiseLike<any> | Array<any>);
     /**
      * @docid
+     * @type string | Array<dxTreeViewItem> | Store | DataSource | DataSourceOptions
      * @default null
      * @public
      */
-    dataSource?: string | Array<dxTreeViewItem> | Store | DataSource | DataSourceOptions;
+    dataSource?: string | Array<Item> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
      * @type Enums.TreeViewDataStructure
@@ -173,9 +174,10 @@ export interface dxTreeViewOptions extends HierarchicalCollectionWidgetOptions<d
     hasItemsExpr?: string | Function;
     /**
      * @docid
+     * @type Array<dxTreeViewItem>
      * @public
      */
-    items?: Array<dxTreeViewItem>;
+    items?: Array<Item>;
     /**
      * @docid
      * @default null
@@ -554,9 +556,13 @@ export default class dxTreeView extends HierarchicalCollectionWidget {
 }
 
 /**
- * @docid
- * @inherits CollectionWidgetItem
- * @type object
+ * @public
+ * @namespace DevExpress.ui.dxTreeView
+ */
+export type Item = dxTreeViewItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.ui
  */
 export interface dxTreeViewItem extends CollectionWidgetItem {

--- a/js/ui/tree_view.js
+++ b/js/ui/tree_view.js
@@ -1,2 +1,8 @@
 import TreeView from './tree_view/ui.tree_view.search';
 export default TreeView;
+
+/**
+ * @name dxTreeViewItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/js/viz/bar_gauge.d.ts
+++ b/js/viz/bar_gauge.d.ts
@@ -60,10 +60,15 @@ export interface BarGaugeBarInfo {
     value?: number;
 }
 
+
 /**
- * @docid
- * @inherits BaseLegendItem
- * @type object
+ * @public
+ * @namespace DevExpress.viz.dxBarGauge
+ */
+export type LegendItem = BarGaugeLegendItem;
+
+/**
+ * @deprecated Use LegendItem instead
  * @namespace DevExpress.viz
  */
 export interface BarGaugeLegendItem extends BaseLegendItem {
@@ -311,7 +316,7 @@ export interface dxBarGaugeLegend extends BaseLegend {
      * @type_function_return Array<BarGaugeLegendItem>
      * @public
      */
-    customizeItems?: ((items: Array<BarGaugeLegendItem>) => Array<BarGaugeLegendItem>);
+    customizeItems?: ((items: Array<LegendItem>) => Array<LegendItem>);
     /**
      * @docid dxBarGaugeOptions.legend.customizeText
      * @type_function_param1 arg:object
@@ -336,7 +341,7 @@ export interface dxBarGaugeLegend extends BaseLegend {
      * @type_function_return string|SVGElement|jQuery
      * @public
      */
-    markerTemplate?: template | ((legendItem: BarGaugeLegendItem, element: SVGGElement) => string | UserDefinedElement<SVGElement>);
+    markerTemplate?: template | ((legendItem: LegendItem, element: SVGGElement) => string | UserDefinedElement<SVGElement>);
     /**
      * @docid dxBarGaugeOptions.legend.visible
      * @default false

--- a/js/viz/bar_gauge.js
+++ b/js/viz/bar_gauge.js
@@ -1,2 +1,8 @@
 import { dxBarGauge } from './gauges/bar_gauge';
 export default dxBarGauge;
+
+/**
+ * @name BarGaugeLegendItem
+ * @inherits BaseLegendItem
+ * @type object
+ */

--- a/js/viz/funnel.d.ts
+++ b/js/viz/funnel.d.ts
@@ -47,22 +47,28 @@ import BaseWidget, {
     IncidentInfo
 } from './core/base_widget';
 
+
 /**
- * @docid
- * @inherits BaseLegendItem
- * @type object
+ * @public
+ * @namespace DevExpress.viz.dxFunnel
+ */
+export type LegendItem = FunnelLegendItem;
+
+/**
+ * @deprecated Use LegendItem instead
  * @namespace DevExpress.viz
  */
 export interface FunnelLegendItem extends BaseLegendItem {
     /**
      * @docid
+     * @type dxFunnelItem
      * @public
      */
-    item?: dxFunnelItem;
+    item?: Item;
 }
 
 interface FunnelItemInfo {
-  readonly item: dxFunnelItem
+  readonly item: Item
 }
 
 /** @public */
@@ -363,7 +369,7 @@ export interface dxFunnelOptions extends BaseWidgetOptions<dxFunnel> {
        * @type_function_return string
        * @notUsedInTheme
        */
-      customizeText?: ((itemInfo: { item?: dxFunnelItem, value?: number, valueText?: string, percent?: number, percentText?: string }) => string),
+      customizeText?: ((itemInfo: { item?: Item, value?: number, valueText?: string, percent?: number, percentText?: string }) => string),
       /**
        * @docid
        * @default '#767676' [prop](color)
@@ -544,14 +550,14 @@ export interface dxFunnelLegend extends BaseLegend {
      * @type_function_return string
      * @public
      */
-    customizeHint?: ((itemInfo: { item?: dxFunnelItem, text?: string }) => string);
+    customizeHint?: ((itemInfo: { item?: Item, text?: string }) => string);
     /**
      * @docid dxFunnelOptions.legend.customizeItems
      * @type_function_param1 items:Array<FunnelLegendItem>
      * @type_function_return Array<FunnelLegendItem>
      * @public
      */
-    customizeItems?: ((items: Array<FunnelLegendItem>) => Array<FunnelLegendItem>);
+    customizeItems?: ((items: Array<LegendItem>) => Array<LegendItem>);
     /**
      * @docid dxFunnelOptions.legend.customizeText
      * @type_function_param1 itemInfo:object
@@ -561,7 +567,7 @@ export interface dxFunnelLegend extends BaseLegend {
      * @notUsedInTheme
      * @public
      */
-    customizeText?: ((itemInfo: { item?: dxFunnelItem, text?: string }) => string);
+    customizeText?: ((itemInfo: { item?: Item, text?: string }) => string);
     /**
      * @docid dxFunnelOptions.legend.markerTemplate
      * @default undefined
@@ -570,7 +576,7 @@ export interface dxFunnelLegend extends BaseLegend {
      * @type_function_return string|SVGElement|jQuery
      * @public
      */
-    markerTemplate?: template | ((legendItem: FunnelLegendItem, element: SVGGElement) => string | UserDefinedElement<SVGElement>);
+    markerTemplate?: template | ((legendItem: LegendItem, element: SVGGElement) => string | UserDefinedElement<SVGElement>);
     /**
      * @docid dxFunnelOptions.legend.visible
      * @default false
@@ -593,7 +599,7 @@ export interface dxFunnelTooltip extends BaseWidgetTooltip {
      * @default undefined
      * @public
      */
-    contentTemplate?: template | ((info: { item?: dxFunnelItem, value?: number, valueText?: string, percent?: number, percentText?: string }, element: DxElement) => string | UserDefinedElement);
+    contentTemplate?: template | ((info: { item?: Item, value?: number, valueText?: string, percent?: number, percentText?: string }, element: DxElement) => string | UserDefinedElement);
     /**
      * @docid dxFunnelOptions.tooltip.customizeTooltip
      * @default undefined
@@ -606,7 +612,7 @@ export interface dxFunnelTooltip extends BaseWidgetTooltip {
      * @type_function_return object
      * @public
      */
-    customizeTooltip?: ((info: { item?: dxFunnelItem, value?: number, valueText?: string, percent?: number, percentText?: string }) => any);
+    customizeTooltip?: ((info: { item?: Item, value?: number, valueText?: string, percent?: number, percentText?: string }) => any);
 }
 /**
  * @docid
@@ -630,7 +636,7 @@ export default class dxFunnel extends BaseWidget {
      * @return Array<dxFunnelItem>
      * @public
      */
-    getAllItems(): Array<dxFunnelItem>;
+    getAllItems(): Array<Item>;
     getDataSource(): DataSource;
     /**
      * @docid
@@ -641,8 +647,12 @@ export default class dxFunnel extends BaseWidget {
 }
 
 /**
- * @docid
- * @publicName Item
+ * @namespace DevExpress.viz.dxFunnel
+ */
+export type Item = dxFunnelItem;
+
+/**
+ * @deprecated Use Item instead
  * @namespace DevExpress.viz
  */
 export interface dxFunnelItem {

--- a/js/viz/funnel.js
+++ b/js/viz/funnel.js
@@ -16,3 +16,14 @@ dxFunnel.addPlugin(pluginTooltip);
 dxFunnel.addPlugin(pluginLoadingIndicator);
 
 export default dxFunnel;
+
+/**
+ * @name FunnelLegendItem
+ * @inherits BaseLegendItem
+ * @type object
+ */
+
+/**
+ * @name dxFunnelItem
+ * @publicName Item
+ */

--- a/js/viz/pie_chart.d.ts
+++ b/js/viz/pie_chart.d.ts
@@ -105,9 +105,13 @@ export type TooltipHiddenEvent = EventInfo<dxPieChart> & TooltipInfo;
 export type TooltipShownEvent = EventInfo<dxPieChart> & TooltipInfo;
 
 /**
- * @docid
- * @type object
- * @inherits BaseLegendItem
+ * @public
+ * @namespace DevExpress.viz.dxPieChart
+ */
+export type LegendItem = PieChartLegendItem;
+
+/**
+ * @deprecated Use LegendItem instead
  * @namespace DevExpress.viz
  */
 export interface PieChartLegendItem extends BaseLegendItem {
@@ -407,7 +411,7 @@ export interface dxPieChartLegend extends BaseChartLegend {
      * @type_function_return Array<PieChartLegendItem>
      * @public
      */
-    customizeItems?: ((items: Array<PieChartLegendItem>) => Array<PieChartLegendItem>);
+    customizeItems?: ((items: Array<LegendItem>) => Array<LegendItem>);
     /**
      * @docid dxPieChartOptions.legend.customizeText
      * @type_function_param1 pointInfo:object
@@ -434,7 +438,7 @@ export interface dxPieChartLegend extends BaseChartLegend {
      * @type_function_return string|SVGElement|jQuery
      * @public
      */
-    markerTemplate?: template | ((legendItem: PieChartLegendItem, element: SVGGElement) => string | UserDefinedElement<SVGElement>);
+    markerTemplate?: template | ((legendItem: LegendItem, element: SVGGElement) => string | UserDefinedElement<SVGElement>);
 }
 /**
  * @docid

--- a/js/viz/pie_chart.js
+++ b/js/viz/pie_chart.js
@@ -533,3 +533,9 @@ dxPieChart.addPlugin(plugins.pieChart);
 registerComponent('dxPieChart', dxPieChart);
 
 export default dxPieChart;
+
+/**
+ * @name PieChartLegendItem
+ * @type object
+ * @inherits BaseLegendItem
+ */

--- a/js/viz/vector_map.d.ts
+++ b/js/viz/vector_map.d.ts
@@ -208,9 +208,13 @@ export interface MapLayerElement {
 }
 
 /**
- * @docid
- * @inherits BaseLegendItem
- * @type object
+ * @public
+ * @namespace DevExpress.viz.dxVectorMap
+ */
+export type LegendItem = VectorMapLegendItem;
+
+/**
+ * @deprecated Use LegendItem instead
  * @namespace DevExpress.viz
  */
 export interface VectorMapLegendItem extends BaseLegendItem {
@@ -731,7 +735,7 @@ export interface dxVectorMapLegends extends BaseLegend {
      * @type_function_return Array<VectorMapLegendItem>
      * @public
      */
-    customizeItems?: ((items: Array<VectorMapLegendItem>) => Array<VectorMapLegendItem>);
+    customizeItems?: ((items: Array<LegendItem>) => Array<LegendItem>);
     /**
      * @docid dxVectorMapOptions.legends.customizeText
      * @type_function_param1 itemInfo:object
@@ -778,7 +782,7 @@ export interface dxVectorMapLegends extends BaseLegend {
      * @type_function_return string|SVGElement|jQuery
      * @public
      */
-    markerTemplate?: template | ((legendItem: VectorMapLegendItem, element: SVGGElement) => string | UserDefinedElement<SVGElement>);
+    markerTemplate?: template | ((legendItem: LegendItem, element: SVGGElement) => string | UserDefinedElement<SVGElement>);
     /**
      * @docid dxVectorMapOptions.legends.source
      * @notUsedInTheme

--- a/js/viz/vector_map.js
+++ b/js/viz/vector_map.js
@@ -1,2 +1,8 @@
 import VectorMap from './vector_map/vector_map';
 export default VectorMap;
+
+/**
+ * @name VectorMapLegendItem
+ * @inherits BaseLegendItem
+ * @type object
+ */

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2350,7 +2350,6 @@ declare module DevExpress.data {
     wordWrapEnabled?: boolean;
   }
   /**
-   * @deprecated use Properties instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface PivotGridDataSourceOptions {
@@ -2686,7 +2685,6 @@ declare module DevExpress.data {
 }
 declare module DevExpress.data.PivotGridDataSource {
   export type Field = PivotGridDataSourceField;
-  export type Properties = PivotGridDataSourceOptions;
 }
 declare module DevExpress.data.utils {
   /**

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -4525,7 +4525,7 @@ declare module DevExpress.ui {
         DevExpress.ui.CollectionWidget.SelectionChangedInfo;
   }
   /**
-   * [descr:dxButtonGroupItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxButtonGroupItem extends CollectionWidgetItem {
@@ -22005,6 +22005,9 @@ declare module DevExpress.ui.dialog {
    * [descr:ui.dialog.custom(options)]
    */
   export function custom(options: CustomDialogOptions): any;
+}
+declare module DevExpress.ui.dxButtonGroup {
+  export type Item = dxButtonGroupItem;
 }
 declare module DevExpress.ui.dxForm {
   export type ButtonItem = dxFormButtonItem;

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -7120,9 +7120,6 @@ declare module DevExpress.ui {
        */
       type?: 'custom' | 'localStorage' | 'sessionStorage';
     }
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
     export interface Summary {
       /**
        * [descr:dxDataGridOptions.summary.calculateCustomSummary]
@@ -11528,7 +11525,7 @@ declare module DevExpress.ui {
     };
   }
   /**
-   * [descr:dxFormButtonItem]
+   * @deprecated Use ButtonItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxFormButtonItem {
@@ -11570,7 +11567,7 @@ declare module DevExpress.ui {
     visibleIndex?: number;
   }
   /**
-   * [descr:dxFormEmptyItem]
+   * @deprecated Use EmptyItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxFormEmptyItem {
@@ -11600,7 +11597,7 @@ declare module DevExpress.ui {
     visibleIndex?: number;
   }
   /**
-   * [descr:dxFormGroupItem]
+   * @deprecated Use GroupItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxFormGroupItem {
@@ -11635,13 +11632,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxFormGroupItem.items]
      */
-    items?: Array<
-      | dxFormSimpleItem
-      | dxFormGroupItem
-      | dxFormTabbedItem
-      | dxFormEmptyItem
-      | dxFormButtonItem
-    >;
+    items?: Array<DevExpress.ui.dxForm.Item>;
     /**
      * [descr:dxFormGroupItem.name]
      */
@@ -11688,14 +11679,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxFormOptions.customizeItem]
      */
-    customizeItem?: (
-      item:
-        | dxFormSimpleItem
-        | dxFormGroupItem
-        | dxFormTabbedItem
-        | dxFormEmptyItem
-        | dxFormButtonItem
-    ) => void;
+    customizeItem?: (item: DevExpress.ui.dxForm.Item) => void;
     /**
      * [descr:dxFormOptions.formData]
      */
@@ -11703,13 +11687,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxFormOptions.items]
      */
-    items?: Array<
-      | dxFormSimpleItem
-      | dxFormGroupItem
-      | dxFormTabbedItem
-      | dxFormEmptyItem
-      | dxFormButtonItem
-    >;
+    items?: Array<DevExpress.ui.dxForm.Item>;
     /**
      * [descr:dxFormOptions.labelLocation]
      */
@@ -11774,7 +11752,7 @@ declare module DevExpress.ui {
     validationGroup?: string;
   }
   /**
-   * [descr:dxFormSimpleItem]
+   * @deprecated Use SimpleItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxFormSimpleItem {
@@ -11889,7 +11867,7 @@ declare module DevExpress.ui {
     visibleIndex?: number;
   }
   /**
-   * [descr:dxFormTabbedItem]
+   * @deprecated Use TabbedItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxFormTabbedItem {
@@ -11944,13 +11922,7 @@ declare module DevExpress.ui {
       /**
        * [descr:dxFormTabbedItem.tabs.items]
        */
-      items?: Array<
-        | dxFormSimpleItem
-        | dxFormGroupItem
-        | dxFormTabbedItem
-        | dxFormEmptyItem
-        | dxFormButtonItem
-      >;
+      items?: Array<DevExpress.ui.dxForm.Item>;
       /**
        * [descr:dxFormTabbedItem.tabs.tabTemplate]
        */
@@ -18359,7 +18331,7 @@ declare module DevExpress.ui {
     };
   }
   /**
-   * [descr:dxTabPanelItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxTabPanelItem extends dxMultiViewItem {
@@ -18396,7 +18368,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxTabPanelItem | any>
+      | Array<string | DevExpress.ui.dxTabPanel.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -18417,7 +18389,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxTabPanelOptions.items]
      */
-    items?: Array<string | dxTabPanelItem | any>;
+    items?: Array<string | DevExpress.ui.dxTabPanel.Item | any>;
     /**
      * [descr:dxTabPanelOptions.onTitleClick]
      */
@@ -19169,7 +19141,7 @@ declare module DevExpress.ui {
     export type Properties = dxToolbarOptions;
   }
   /**
-   * [descr:dxToolbarItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxToolbarItem extends CollectionWidgetItem {
@@ -19224,14 +19196,14 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxToolbarItem | any>
+      | Array<string | DevExpress.ui.dxToolbar.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
     /**
      * [descr:dxToolbarOptions.items]
      */
-    items?: Array<string | dxToolbarItem | any>;
+    items?: Array<string | DevExpress.ui.dxToolbar.Item | any>;
     /**
      * [descr:dxToolbarOptions.menuItemTemplate]
      */
@@ -20201,7 +20173,7 @@ declare module DevExpress.ui {
    */
   export type dxTreeListPaging = DevExpress.ui.dxTreeList.Paging;
   /**
-   * @deprecated 
+   * @deprecated Use DevExpress.ui.dxTreeList.RowObject instead
    */
   export type dxTreeListRowObject = DevExpress.ui.dxTreeList.RowObject;
   /**
@@ -22036,6 +22008,19 @@ declare module DevExpress.ui.dialog {
    */
   export function custom(options: CustomDialogOptions): any;
 }
+declare module DevExpress.ui.dxForm {
+  export type ButtonItem = dxFormButtonItem;
+  export type EmptyItem = dxFormEmptyItem;
+  export type GroupItem = dxFormGroupItem;
+  export type Item =
+    | SimpleItem
+    | GroupItem
+    | TabbedItem
+    | EmptyItem
+    | ButtonItem;
+  export type SimpleItem = dxFormSimpleItem;
+  export type TabbedItem = dxFormTabbedItem;
+}
 declare module DevExpress.ui.dxOverlay {
   /**
    * [descr:ui.dxOverlay.baseZIndex(zIndex)]
@@ -22044,6 +22029,12 @@ declare module DevExpress.ui.dxOverlay {
 }
 declare module DevExpress.ui.dxPivotGrid {
   export type Cell = dxPivotGridPivotGridCell;
+}
+declare module DevExpress.ui.dxTabPanel {
+  export type Item = dxTabPanelItem;
+}
+declare module DevExpress.ui.dxToolbar {
+  export type Item = dxToolbarItem;
 }
 declare module DevExpress.utils {
   /**

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2109,11 +2109,11 @@ declare module DevExpress.data {
     /**
      * [descr:PivotGridDataSource.fields()]
      */
-    fields(): Array<PivotGridDataSourceField>;
+    fields(): Array<DevExpress.data.PivotGridDataSource.Field>;
     /**
      * [descr:PivotGridDataSource.fields(fields)]
      */
-    fields(fields: Array<PivotGridDataSourceField>): void;
+    fields(fields: Array<DevExpress.data.PivotGridDataSource.Field>): void;
     /**
      * [descr:PivotGridDataSource.filter()]
      */
@@ -2128,7 +2128,7 @@ declare module DevExpress.data {
     getAreaFields(
       area: string,
       collectGroups: boolean
-    ): Array<PivotGridDataSourceField>;
+    ): Array<DevExpress.data.PivotGridDataSource.Field>;
     /**
      * [descr:PivotGridDataSource.getData()]
      */
@@ -2171,9 +2171,10 @@ declare module DevExpress.data {
     state(state: any): void;
   }
   /**
+   * @deprecated Use Field instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface PivotGridDataSourceField {
+  interface PivotGridDataSourceField {
     /**
      * [descr:PivotGridDataSourceOptions.fields.allowCrossGroupCalculation]
      */
@@ -2351,11 +2352,11 @@ declare module DevExpress.data {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface PivotGridDataSourceOptions {
+  interface PivotGridDataSourceOptions {
     /**
      * [descr:PivotGridDataSourceOptions.fields]
      */
-    fields?: Array<PivotGridDataSourceField>;
+    fields?: Array<DevExpress.data.PivotGridDataSource.Field>;
     /**
      * [descr:PivotGridDataSourceOptions.filter]
      */
@@ -2367,7 +2368,9 @@ declare module DevExpress.data {
     /**
      * [descr:PivotGridDataSourceOptions.onFieldsPrepared]
      */
-    onFieldsPrepared?: (fields: Array<PivotGridDataSourceField>) => void;
+    onFieldsPrepared?: (
+      fields: Array<DevExpress.data.PivotGridDataSource.Field>
+    ) => void;
     /**
      * [descr:PivotGridDataSourceOptions.onLoadError]
      */
@@ -2680,6 +2683,9 @@ declare module DevExpress.data {
     url?: string;
   }
 }
+declare module DevExpress.data.PivotGridDataSource {
+  export type Field = PivotGridDataSourceField;
+}
 declare module DevExpress.data.utils {
   /**
    * [descr:Utils.compileGetter(expr)]
@@ -2970,11 +2976,13 @@ declare module DevExpress.excelExporter {
      */
     to?: CellAddress;
   }
+  export type DataGridCell = ExcelDataGridCell;
   /**
    * [descr:ExcelDataGridCell]
+   * @deprecated [depNote:ExcelDataGridCell]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface ExcelDataGridCell {
+  interface ExcelDataGridCell {
     /**
      * [descr:ExcelDataGridCell.column]
      */
@@ -3081,16 +3089,16 @@ declare module DevExpress.excelExporter {
      * [descr:ExcelExportPivotGridProps.customizeCell]
      */
     customizeCell?: (options: {
-      pivotCell?: ExcelPivotGridCell;
+      pivotCell?: PivotGridCell;
       excelCell?: any;
     }) => void;
   }
   /**
    * [descr:ExcelPivotGridCell]
+   * @deprecated [depNote:ExcelPivotGridCell]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface ExcelPivotGridCell
-    extends DevExpress.ui.dxPivotGridPivotGridCell {
+  interface ExcelPivotGridCell extends DevExpress.ui.dxPivotGridPivotGridCell {
     /**
      * [descr:ExcelPivotGridCell.area]
      */
@@ -3116,6 +3124,7 @@ declare module DevExpress.excelExporter {
   export function exportPivotGrid(
     options: ExcelExportPivotGridProps
   ): DevExpress.core.utils.DxPromise<CellRange>;
+  export type PivotGridCell = ExcelPivotGridCell;
 }
 declare module DevExpress.exporter {
   /**
@@ -6046,7 +6055,7 @@ declare module DevExpress.ui {
       font?: DevExpress.exporter.ExcelFont;
       readonly value?: string | number | Date;
       numberFormat?: string;
-      gridCell?: DevExpress.excelExporter.ExcelDataGridCell;
+      gridCell?: DevExpress.excelExporter.DataGridCell;
     }
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
@@ -15089,17 +15098,17 @@ declare module DevExpress.ui {
       DevExpress.events.NativeEventInfo<dxPivotGrid> & {
         readonly area?: string;
         readonly cellElement?: DevExpress.core.DxElement;
-        readonly cell?: dxPivotGridPivotGridCell;
+        readonly cell?: Cell;
         readonly rowIndex?: number;
         readonly columnIndex?: number;
-        readonly columnFields?: Array<DevExpress.data.PivotGridDataSourceField>;
-        readonly rowFields?: Array<DevExpress.data.PivotGridDataSourceField>;
-        readonly dataFields?: Array<DevExpress.data.PivotGridDataSourceField>;
+        readonly columnFields?: Array<DevExpress.data.PivotGridDataSource.Field>;
+        readonly rowFields?: Array<DevExpress.data.PivotGridDataSource.Field>;
+        readonly dataFields?: Array<DevExpress.data.PivotGridDataSource.Field>;
       };
     export type CellPreparedEvent = DevExpress.events.EventInfo<dxPivotGrid> & {
       readonly area?: string;
       readonly cellElement?: DevExpress.core.DxElement;
-      readonly cell?: dxPivotGridPivotGridCell;
+      readonly cell?: Cell;
       readonly rowIndex?: number;
       readonly columnIndex?: number;
     };
@@ -15107,14 +15116,14 @@ declare module DevExpress.ui {
     export type ContextMenuPreparingEvent =
       DevExpress.events.EventInfo<dxPivotGrid> & {
         readonly area?: string;
-        readonly cell?: dxPivotGridPivotGridCell;
+        readonly cell?: Cell;
         readonly cellElement?: DevExpress.core.DxElement;
         readonly columnIndex?: number;
         readonly rowIndex?: number;
-        readonly dataFields?: Array<DevExpress.data.PivotGridDataSourceField>;
-        readonly rowFields?: Array<DevExpress.data.PivotGridDataSourceField>;
-        readonly columnFields?: Array<DevExpress.data.PivotGridDataSourceField>;
-        readonly field?: DevExpress.data.PivotGridDataSourceField;
+        readonly dataFields?: Array<DevExpress.data.PivotGridDataSource.Field>;
+        readonly rowFields?: Array<DevExpress.data.PivotGridDataSource.Field>;
+        readonly columnFields?: Array<DevExpress.data.PivotGridDataSource.Field>;
+        readonly field?: DevExpress.data.PivotGridDataSource.Field;
         items?: Array<any>;
       };
     export type DisposingEvent = DevExpress.events.EventInfo<dxPivotGrid>;
@@ -15167,7 +15176,7 @@ declare module DevExpress.ui {
     export type ContextMenuPreparingEvent =
       DevExpress.events.EventInfo<dxPivotGridFieldChooser> & {
         readonly area?: string;
-        readonly field?: DevExpress.data.PivotGridDataSourceField;
+        readonly field?: DevExpress.data.PivotGridDataSource.Field;
         readonly event?: DevExpress.events.DxEvent;
         items?: Array<any>;
       };
@@ -15701,9 +15710,10 @@ declare module DevExpress.ui {
   }
   /**
    * [descr:dxPivotGridPivotGridCell]
+   * @deprecated [depNote:dxPivotGridPivotGridCell]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface dxPivotGridPivotGridCell {
+  interface dxPivotGridPivotGridCell {
     /**
      * [descr:dxPivotGridPivotGridCell.columnPath]
      */
@@ -15749,7 +15759,7 @@ declare module DevExpress.ui {
    * [descr:dxPivotGridSummaryCell]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface dxPivotGridSummaryCell {
+  interface dxPivotGridSummaryCell {
     /**
      * [descr:dxPivotGridSummaryCell.child(direction, fieldValue)]
      */
@@ -15764,7 +15774,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxPivotGridSummaryCell.field(area)]
      */
-    field(area: string): DevExpress.data.PivotGridDataSourceField;
+    field(area: string): DevExpress.data.PivotGridDataSource.Field;
     /**
      * [descr:dxPivotGridSummaryCell.grandTotal()]
      */
@@ -15777,7 +15787,7 @@ declare module DevExpress.ui {
      * [descr:dxPivotGridSummaryCell.isPostProcessed(field)]
      */
     isPostProcessed(
-      field: DevExpress.data.PivotGridDataSourceField | string
+      field: DevExpress.data.PivotGridDataSource.Field | string
     ): boolean;
     /**
      * [descr:dxPivotGridSummaryCell.next(direction)]
@@ -15803,7 +15813,7 @@ declare module DevExpress.ui {
      * [descr:dxPivotGridSummaryCell.slice(field, value)]
      */
     slice(
-      field: DevExpress.data.PivotGridDataSourceField,
+      field: DevExpress.data.PivotGridDataSource.Field,
       value: number | string
     ): dxPivotGridSummaryCell;
     /**
@@ -15813,12 +15823,12 @@ declare module DevExpress.ui {
     /**
      * [descr:dxPivotGridSummaryCell.value(field)]
      */
-    value(field: DevExpress.data.PivotGridDataSourceField | string): any;
+    value(field: DevExpress.data.PivotGridDataSource.Field | string): any;
     /**
      * [descr:dxPivotGridSummaryCell.value(field, postProcessed)]
      */
     value(
-      field: DevExpress.data.PivotGridDataSourceField | string,
+      field: DevExpress.data.PivotGridDataSource.Field | string,
       postProcessed: boolean
     ): any;
     /**
@@ -22031,6 +22041,9 @@ declare module DevExpress.ui.dxOverlay {
    * [descr:ui.dxOverlay.baseZIndex(zIndex)]
    */
   export function baseZIndex(zIndex: number): void;
+}
+declare module DevExpress.ui.dxPivotGrid {
+  export type Cell = dxPivotGridPivotGridCell;
 }
 declare module DevExpress.utils {
   /**

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2350,6 +2350,7 @@ declare module DevExpress.data {
     wordWrapEnabled?: boolean;
   }
   /**
+   * @deprecated use Properties instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface PivotGridDataSourceOptions {
@@ -2685,6 +2686,7 @@ declare module DevExpress.data {
 }
 declare module DevExpress.data.PivotGridDataSource {
   export type Field = PivotGridDataSourceField;
+  export type Properties = PivotGridDataSourceOptions;
 }
 declare module DevExpress.data.utils {
   /**
@@ -3093,8 +3095,7 @@ declare module DevExpress.excelExporter {
     }) => void;
   }
   /**
-   * [descr:ExcelPivotGridCell]
-   * @deprecated [depNote:ExcelPivotGridCell]
+   * @deprecated Use PivotGridCell instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface ExcelPivotGridCell
@@ -15709,8 +15710,7 @@ declare module DevExpress.ui {
     wordWrapEnabled?: boolean;
   }
   /**
-   * [descr:dxPivotGridPivotGridCell]
-   * @deprecated [depNote:dxPivotGridPivotGridCell]
+   * @deprecated Use Cell instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxPivotGridPivotGridCell {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2174,7 +2174,7 @@ declare module DevExpress.data {
    * @deprecated Use Field instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  interface PivotGridDataSourceField {
+  export interface PivotGridDataSourceField {
     /**
      * [descr:PivotGridDataSourceOptions.fields.allowCrossGroupCalculation]
      */
@@ -2352,7 +2352,7 @@ declare module DevExpress.data {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  interface PivotGridDataSourceOptions {
+  export interface PivotGridDataSourceOptions {
     /**
      * [descr:PivotGridDataSourceOptions.fields]
      */
@@ -2978,11 +2978,10 @@ declare module DevExpress.excelExporter {
   }
   export type DataGridCell = ExcelDataGridCell;
   /**
-   * [descr:ExcelDataGridCell]
-   * @deprecated [depNote:ExcelDataGridCell]
+   * @deprecated Use DataGridCell instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  interface ExcelDataGridCell {
+  export interface ExcelDataGridCell {
     /**
      * [descr:ExcelDataGridCell.column]
      */
@@ -3098,7 +3097,8 @@ declare module DevExpress.excelExporter {
    * @deprecated [depNote:ExcelPivotGridCell]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  interface ExcelPivotGridCell extends DevExpress.ui.dxPivotGridPivotGridCell {
+  export interface ExcelPivotGridCell
+    extends DevExpress.ui.dxPivotGridPivotGridCell {
     /**
      * [descr:ExcelPivotGridCell.area]
      */
@@ -15713,7 +15713,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxPivotGridPivotGridCell]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  interface dxPivotGridPivotGridCell {
+  export interface dxPivotGridPivotGridCell {
     /**
      * [descr:dxPivotGridPivotGridCell.columnPath]
      */

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -4105,7 +4105,7 @@ declare module DevExpress.ui {
         DevExpress.ui.CollectionWidget.SelectionChangedInfo;
   }
   /**
-   * [descr:dxAccordionItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxAccordionItem extends CollectionWidgetItem {
@@ -4137,7 +4137,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxAccordionItem | any>
+      | Array<string | DevExpress.ui.dxAccordion.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -4180,7 +4180,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxAccordionOptions.items]
      */
-    items?: Array<string | dxAccordionItem | any>;
+    items?: Array<string | DevExpress.ui.dxAccordion.Item | any>;
     /**
      * [descr:dxAccordionOptions.multiple]
      */
@@ -4246,7 +4246,7 @@ declare module DevExpress.ui {
     export type Properties = dxActionSheetOptions;
   }
   /**
-   * [descr:dxActionSheetItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxActionSheetItem extends CollectionWidgetItem {
@@ -4285,14 +4285,14 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxActionSheetItem | any>
+      | Array<string | DevExpress.ui.dxActionSheet.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
     /**
      * [descr:dxActionSheetOptions.items]
      */
-    items?: Array<string | dxActionSheetItem | any>;
+    items?: Array<string | DevExpress.ui.dxActionSheet.Item | any>;
     /**
      * [descr:dxActionSheetOptions.onCancelClick]
      */
@@ -4422,7 +4422,7 @@ declare module DevExpress.ui {
     export type Properties = dxBoxOptions;
   }
   /**
-   * [descr:dxBoxItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxBoxItem extends CollectionWidgetItem {
@@ -4461,7 +4461,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxBoxItem | any>
+      | Array<string | DevExpress.ui.dxBox.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -4472,7 +4472,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxBoxOptions.items]
      */
-    items?: Array<string | dxBoxItem | any>;
+    items?: Array<string | DevExpress.ui.dxBox.Item | any>;
   }
   /**
    * [descr:dxButton]
@@ -4567,7 +4567,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxButtonGroupOptions.items]
      */
-    items?: Array<dxButtonGroupItem>;
+    items?: Array<DevExpress.ui.dxButtonGroup.Item>;
     /**
      * [descr:dxButtonGroupOptions.keyExpr]
      */
@@ -4938,7 +4938,7 @@ declare module DevExpress.ui {
     export type ShownEvent = DevExpress.events.EventInfo<dxContextMenu>;
   }
   /**
-   * [descr:dxContextMenuItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxContextMenuItem extends dxMenuBaseItem {
@@ -4964,14 +4964,14 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<dxContextMenuItem>
+      | Array<DevExpress.ui.dxContextMenu.Item>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
     /**
      * [descr:dxContextMenuOptions.items]
      */
-    items?: Array<dxContextMenuItem>;
+    items?: Array<DevExpress.ui.dxContextMenu.Item>;
     /**
      * [descr:dxContextMenuOptions.onHidden]
      */
@@ -7837,27 +7837,27 @@ declare module DevExpress.ui {
     /**
      * [descr:dxDiagram.getItemByKey(key)]
      */
-    getItemByKey(key: Object): dxDiagramItem;
+    getItemByKey(key: Object): DevExpress.ui.dxDiagram.Item;
     /**
      * [descr:dxDiagram.getItemById(id)]
      */
-    getItemById(id: string): dxDiagramItem;
+    getItemById(id: string): DevExpress.ui.dxDiagram.Item;
     /**
      * [descr:dxDiagram.getItems()]
      */
-    getItems(): Array<dxDiagramItem>;
+    getItems(): Array<DevExpress.ui.dxDiagram.Item>;
     /**
      * [descr:dxDiagram.getSelectedItems()]
      */
-    getSelectedItems(): Array<dxDiagramItem>;
+    getSelectedItems(): Array<DevExpress.ui.dxDiagram.Item>;
     /**
      * [descr:dxDiagram.setSelectedItems(items)]
      */
-    setSelectedItems(items: Array<dxDiagramItem>): void;
+    setSelectedItems(items: Array<DevExpress.ui.dxDiagram.Item>): void;
     /**
      * [descr:dxDiagram.scrollToItem(item)]
      */
-    scrollToItem(item: dxDiagramItem): void;
+    scrollToItem(item: DevExpress.ui.dxDiagram.Item): void;
     /**
      * [descr:dxDiagram.export()]
      */
@@ -7892,10 +7892,10 @@ declare module DevExpress.ui {
     export type InitializedEvent =
       DevExpress.events.InitializedEventInfo<dxDiagram>;
     export type ItemClickEvent = DevExpress.events.EventInfo<dxDiagram> & {
-      readonly item: dxDiagramItem;
+      readonly item: Item;
     };
     export type ItemDblClickEvent = DevExpress.events.EventInfo<dxDiagram> & {
-      readonly item: dxDiagramItem;
+      readonly item: Item;
     };
     export type OptionChangedEvent = DevExpress.events.EventInfo<dxDiagram> &
       DevExpress.events.ChangedOptionInfo;
@@ -7932,7 +7932,7 @@ declare module DevExpress.ui {
       };
     export type SelectionChangedEvent =
       DevExpress.events.EventInfo<dxDiagram> & {
-        readonly items: Array<dxDiagramItem>;
+        readonly items: Array<Item>;
       };
   }
   /**
@@ -8221,7 +8221,7 @@ declare module DevExpress.ui {
     shape?: dxDiagramShape;
   }
   /**
-   * [descr:dxDiagramItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxDiagramItem {
@@ -9972,7 +9972,7 @@ declare module DevExpress.ui {
       };
   }
   /**
-   * [descr:dxDropDownButtonItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxDropDownButtonItem extends dxListItem {
@@ -9999,7 +9999,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<dxDropDownButtonItem | any>
+      | Array<DevExpress.ui.dxDropDownButton.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -10049,7 +10049,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxDropDownButtonOptions.items]
      */
-    items?: Array<dxDropDownButtonItem | any>;
+    items?: Array<DevExpress.ui.dxDropDownButton.Item | any>;
     /**
      * [descr:dxDropDownButtonOptions.keyExpr]
      */
@@ -10413,7 +10413,7 @@ declare module DevExpress.ui {
      * [descr:dxFileManagerContextMenu.items]
      */
     items?: Array<
-      | dxFileManagerContextMenuItem
+      | DevExpress.ui.dxFileManager.ContextMenuItem
       | 'create'
       | 'upload'
       | 'refresh'
@@ -10425,7 +10425,7 @@ declare module DevExpress.ui {
     >;
   }
   /**
-   * [descr:dxFileManagerContextMenuItem]
+   * @deprecated Use ContexMenuItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxFileManagerContextMenuItem extends dxContextMenuItem {
@@ -10707,7 +10707,7 @@ declare module DevExpress.ui {
      * [descr:dxFileManagerToolbar.fileSelectionItems]
      */
     fileSelectionItems?: Array<
-      | dxFileManagerToolbarItem
+      | DevExpress.ui.dxFileManager.ToolbarItem
       | 'showNavPane'
       | 'create'
       | 'upload'
@@ -10725,7 +10725,7 @@ declare module DevExpress.ui {
      * [descr:dxFileManagerToolbar.items]
      */
     items?: Array<
-      | dxFileManagerToolbarItem
+      | DevExpress.ui.dxFileManager.ToolbarItem
       | 'showNavPane'
       | 'create'
       | 'upload'
@@ -10741,7 +10741,7 @@ declare module DevExpress.ui {
     >;
   }
   /**
-   * [descr:dxFileManagerToolbarItem]
+   * @deprecated Use ToolbarItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxFileManagerToolbarItem extends dxToolbarItem {
@@ -11999,7 +11999,7 @@ declare module DevExpress.ui {
       DevExpress.ui.CollectionWidget.SelectionChangedInfo;
   }
   /**
-   * [descr:dxGalleryItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxGalleryItem extends CollectionWidgetItem {
@@ -12030,7 +12030,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxGalleryItem | any>
+      | Array<string | DevExpress.ui.dxGallery.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -12049,7 +12049,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxGalleryOptions.items]
      */
-    items?: Array<string | dxGalleryItem | any>;
+    items?: Array<string | DevExpress.ui.dxGallery.Item | any>;
     /**
      * [descr:dxGalleryOptions.loop]
      */
@@ -12347,7 +12347,7 @@ declare module DevExpress.ui {
      * [descr:dxGanttContextMenu.items]
      */
     items?: Array<
-      | dxGanttContextMenuItem
+      | DevExpress.ui.dxGantt.ContextMenuItem
       | 'undo'
       | 'redo'
       | 'expandAll'
@@ -12362,7 +12362,7 @@ declare module DevExpress.ui {
     >;
   }
   /**
-   * [descr:dxGanttContextMenuItem]
+   * @deprecated Use ContextMenuItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxGanttContextMenuItem extends dxContextMenuItem {
@@ -12832,7 +12832,7 @@ declare module DevExpress.ui {
      * [descr:dxGanttToolbar.items]
      */
     items?: Array<
-      | dxGanttToolbarItem
+      | DevExpress.ui.dxGantt.ToolbarItem
       | 'separator'
       | 'undo'
       | 'redo'
@@ -12848,7 +12848,7 @@ declare module DevExpress.ui {
     >;
   }
   /**
-   * [descr:dxGanttToolbarItem]
+   * @deprecated Use ToolbarItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxGanttToolbarItem extends dxToolbarItem {
@@ -13248,7 +13248,7 @@ declare module DevExpress.ui {
      * [descr:dxHtmlEditorToolbar.items]
      */
     items?: Array<
-      | dxHtmlEditorToolbarItem
+      | DevExpress.ui.dxHtmlEditor.ToolbarItem
       | 'background'
       | 'bold'
       | 'color'
@@ -13292,7 +13292,7 @@ declare module DevExpress.ui {
     multiline?: boolean;
   }
   /**
-   * [descr:dxHtmlEditorToolbarItem]
+   * @deprecated Use ToolbarItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxHtmlEditorToolbarItem extends dxToolbarItem {
@@ -13589,7 +13589,7 @@ declare module DevExpress.ui {
       DevExpress.ui.CollectionWidget.SelectionChangedInfo;
   }
   /**
-   * [descr:dxListItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxListItem extends CollectionWidgetItem {
@@ -13638,7 +13638,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxListItem | any>
+      | Array<string | DevExpress.ui.dxList.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -13689,7 +13689,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxListOptions.items]
      */
-    items?: Array<string | dxListItem | any>;
+    items?: Array<string | DevExpress.ui.dxList.Item | any>;
     /**
      * [descr:dxListOptions.menuItems]
      */
@@ -14596,7 +14596,7 @@ declare module DevExpress.ui {
       | 'onHover';
   }
   /**
-   * [descr:dxMenuItem]
+   * @deprecated 
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxMenuItem extends dxMenuBaseItem {
@@ -14619,7 +14619,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<dxMenuItem>
+      | Array<DevExpress.ui.dxMenu.Item>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -14630,7 +14630,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxMenuOptions.items]
      */
-    items?: Array<dxMenuItem>;
+    items?: Array<DevExpress.ui.dxMenu.Item>;
     /**
      * [descr:dxMenuOptions.onSubmenuHidden]
      */
@@ -14716,7 +14716,7 @@ declare module DevExpress.ui {
         DevExpress.ui.CollectionWidget.SelectionChangedInfo;
   }
   /**
-   * [descr:dxMultiViewItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxMultiViewItem extends CollectionWidgetItem {}
@@ -14735,7 +14735,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxMultiViewItem | any>
+      | Array<string | DevExpress.ui.dxMultiView.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -14750,7 +14750,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxMultiViewOptions.items]
      */
-    items?: Array<string | dxMultiViewItem | any>;
+    items?: Array<string | DevExpress.ui.dxMultiView.Item | any>;
     /**
      * [descr:dxMultiViewOptions.loop]
      */
@@ -14794,7 +14794,7 @@ declare module DevExpress.ui {
       DevExpress.ui.CollectionWidget.SelectionChangedInfo;
   }
   /**
-   * [descr:dxNavBarItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxNavBarItem extends dxTabsItem {
@@ -16058,13 +16058,14 @@ declare module DevExpress.ui {
     /**
      * [descr:dxPopupOptions.toolbarItems]
      */
-    toolbarItems?: Array<dxPopupToolbarItem>;
+    toolbarItems?: Array<DevExpress.ui.dxPopup.ToolbarItem>;
     /**
      * [descr:dxPopupOptions.width]
      */
     width?: number | string | (() => number | string);
   }
   /**
+   * @deprecated Use ToolbarItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxPopupToolbarItem {
@@ -16407,7 +16408,7 @@ declare module DevExpress.ui {
     export type Properties = dxResponsiveBoxOptions;
   }
   /**
-   * [descr:dxResponsiveBoxItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxResponsiveBoxItem extends CollectionWidgetItem {
@@ -16477,7 +16478,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxResponsiveBoxItem | any>
+      | Array<string | DevExpress.ui.dxResponsiveBox.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -16488,7 +16489,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxResponsiveBoxOptions.items]
      */
-    items?: Array<string | dxResponsiveBoxItem | any>;
+    items?: Array<string | DevExpress.ui.dxResponsiveBox.Item | any>;
     /**
      * [descr:dxResponsiveBoxOptions.rows]
      */
@@ -17727,7 +17728,7 @@ declare module DevExpress.ui {
         DevExpress.ui.CollectionWidget.SelectionChangedInfo;
   }
   /**
-   * [descr:dxSlideOutItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxSlideOutItem extends CollectionWidgetItem {
@@ -17761,14 +17762,14 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxSlideOutItem | any>
+      | Array<string | DevExpress.ui.dxSlideOut.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
     /**
      * [descr:dxSlideOutOptions.items]
      */
-    items?: Array<string | dxSlideOutItem | any>;
+    items?: Array<string | DevExpress.ui.dxSlideOut.Item | any>;
     /**
      * [descr:dxSlideOutOptions.menuGroupTemplate]
      */
@@ -18452,7 +18453,7 @@ declare module DevExpress.ui {
       DevExpress.ui.CollectionWidget.SelectionChangedInfo;
   }
   /**
-   * [descr:dxTabsItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxTabsItem extends CollectionWidgetItem {
@@ -18476,7 +18477,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxTabsItem | any>
+      | Array<string | DevExpress.ui.dxTabs.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -18491,7 +18492,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxTabsOptions.items]
      */
-    items?: Array<string | dxTabsItem | any>;
+    items?: Array<string | DevExpress.ui.dxTabs.Item | any>;
     /**
      * [descr:dxTabsOptions.repaintChangesOnly]
      */
@@ -18947,7 +18948,7 @@ declare module DevExpress.ui {
     export type Properties = dxTileViewOptions;
   }
   /**
-   * [descr:dxTileViewItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxTileViewItem extends CollectionWidgetItem {
@@ -18983,7 +18984,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<string | dxTileViewItem | any>
+      | Array<string | DevExpress.ui.dxTileView.Item | any>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -19010,7 +19011,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxTileViewOptions.items]
      */
-    items?: Array<string | dxTileViewItem | any>;
+    items?: Array<string | DevExpress.ui.dxTileView.Item | any>;
     /**
      * [descr:dxTileViewOptions.showScrollbar]
      */
@@ -20347,7 +20348,7 @@ declare module DevExpress.ui {
     export type SelectionChangedEvent = DevExpress.events.EventInfo<dxTreeView>;
   }
   /**
-   * [descr:dxTreeViewItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxTreeViewItem extends CollectionWidgetItem {
@@ -20440,7 +20441,7 @@ declare module DevExpress.ui {
      */
     dataSource?:
       | string
-      | Array<dxTreeViewItem>
+      | Array<DevExpress.ui.dxTreeView.Item>
       | DevExpress.data.Store
       | DevExpress.data.DataSource
       | DevExpress.data.DataSourceOptions;
@@ -20471,7 +20472,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxTreeViewOptions.items]
      */
-    items?: Array<dxTreeViewItem>;
+    items?: Array<DevExpress.ui.dxTreeView.Item>;
     /**
      * [descr:dxTreeViewOptions.onItemClick]
      */
@@ -22006,8 +22007,30 @@ declare module DevExpress.ui.dialog {
    */
   export function custom(options: CustomDialogOptions): any;
 }
+declare module DevExpress.ui.dxAccordion {
+  export type Item = dxAccordionItem;
+}
+declare module DevExpress.ui.dxActionSheet {
+  export type Item = dxActionSheetItem;
+}
+declare module DevExpress.ui.dxBox {
+  export type Item = dxBoxItem;
+}
 declare module DevExpress.ui.dxButtonGroup {
   export type Item = dxButtonGroupItem;
+}
+declare module DevExpress.ui.dxContextMenu {
+  export type Item = dxContextMenuItem;
+}
+declare module DevExpress.ui.dxDiagram {
+  export type Item = dxDiagramItem;
+}
+declare module DevExpress.ui.dxDropDownButton {
+  export type Item = dxDropDownButtonItem;
+}
+declare module DevExpress.ui.dxFileManager {
+  export type ContextMenuItem = dxFileManagerContextMenuItem;
+  export type ToolbarItem = dxFileManagerToolbarItem;
 }
 declare module DevExpress.ui.dxForm {
   export type ButtonItem = dxFormButtonItem;
@@ -22022,6 +22045,28 @@ declare module DevExpress.ui.dxForm {
   export type SimpleItem = dxFormSimpleItem;
   export type TabbedItem = dxFormTabbedItem;
 }
+declare module DevExpress.ui.dxGallery {
+  export type Item = dxGalleryItem;
+}
+declare module DevExpress.ui.dxGantt {
+  export type ContextMenuItem = dxGanttContextMenuItem;
+  export type ToolbarItem = dxGanttToolbarItem;
+}
+declare module DevExpress.ui.dxHtmlEditor {
+  export type ToolbarItem = dxHtmlEditorToolbarItem;
+}
+declare module DevExpress.ui.dxList {
+  export type Item = dxListItem;
+}
+declare module DevExpress.ui.dxMenu {
+  export type Item = dxMenuItem;
+}
+declare module DevExpress.ui.dxMultiView {
+  export type Item = dxMultiViewItem;
+}
+declare module DevExpress.ui.dxNavBar {
+  export type Item = dxNavBarItem;
+}
 declare module DevExpress.ui.dxOverlay {
   /**
    * [descr:ui.dxOverlay.baseZIndex(zIndex)]
@@ -22031,11 +22076,29 @@ declare module DevExpress.ui.dxOverlay {
 declare module DevExpress.ui.dxPivotGrid {
   export type Cell = dxPivotGridPivotGridCell;
 }
+declare module DevExpress.ui.dxPopup {
+  export type ToolbarItem = dxPopupToolbarItem;
+}
+declare module DevExpress.ui.dxResponsiveBox {
+  export type Item = dxResponsiveBoxItem;
+}
+declare module DevExpress.ui.dxSlideOut {
+  export type Item = dxSlideOutItem;
+}
 declare module DevExpress.ui.dxTabPanel {
   export type Item = dxTabPanelItem;
 }
+declare module DevExpress.ui.dxTabs {
+  export type Item = dxTabsItem;
+}
+declare module DevExpress.ui.dxTileView {
+  export type Item = dxTileViewItem;
+}
 declare module DevExpress.ui.dxToolbar {
   export type Item = dxToolbarItem;
+}
+declare module DevExpress.ui.dxTreeView {
+  export type Item = dxTreeViewItem;
 }
 declare module DevExpress.utils {
   /**
@@ -22079,7 +22142,7 @@ declare module DevExpress.viz {
     value?: number;
   }
   /**
-   * [descr:BarGaugeLegendItem]
+   * @deprecated Use LegendItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface BarGaugeLegendItem extends BaseLegendItem {
@@ -24094,8 +24157,8 @@ declare module DevExpress.viz {
      * [descr:dxBarGaugeOptions.legend.customizeItems]
      */
     customizeItems?: (
-      items: Array<BarGaugeLegendItem>
-    ) => Array<BarGaugeLegendItem>;
+      items: Array<DevExpress.viz.dxBarGauge.LegendItem>
+    ) => Array<DevExpress.viz.dxBarGauge.LegendItem>;
     /**
      * [descr:dxBarGaugeOptions.legend.customizeText]
      */
@@ -24110,7 +24173,7 @@ declare module DevExpress.viz {
     markerTemplate?:
       | DevExpress.core.template
       | ((
-          legendItem: BarGaugeLegendItem,
+          legendItem: DevExpress.viz.dxBarGauge.LegendItem,
           element: SVGGElement
         ) => string | DevExpress.core.UserDefinedElement<SVGElement>);
     /**
@@ -28090,7 +28153,7 @@ declare module DevExpress.viz {
     /**
      * [descr:dxFunnel.getAllItems()]
      */
-    getAllItems(): Array<dxFunnelItem>;
+    getAllItems(): Array<DevExpress.viz.dxFunnel.Item>;
     getDataSource(): DevExpress.data.DataSource;
     /**
      * [descr:dxFunnel.hideTooltip()]
@@ -28109,7 +28172,7 @@ declare module DevExpress.viz {
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
     interface FunnelItemInfo {
-      readonly item: dxFunnelItem;
+      readonly item: Item;
     }
     export type HoverChangedEvent = DevExpress.events.EventInfo<dxFunnel> &
       FunnelItemInfo;
@@ -28128,7 +28191,7 @@ declare module DevExpress.viz {
       FunnelItemInfo;
   }
   /**
-   * [descr:dxFunnelItem]
+   * @deprecated Use Item instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface dxFunnelItem {
@@ -28181,20 +28244,20 @@ declare module DevExpress.viz {
      * [descr:dxFunnelOptions.legend.customizeHint]
      */
     customizeHint?: (itemInfo: {
-      item?: dxFunnelItem;
+      item?: DevExpress.viz.dxFunnel.Item;
       text?: string;
     }) => string;
     /**
      * [descr:dxFunnelOptions.legend.customizeItems]
      */
     customizeItems?: (
-      items: Array<FunnelLegendItem>
-    ) => Array<FunnelLegendItem>;
+      items: Array<DevExpress.viz.dxFunnel.LegendItem>
+    ) => Array<DevExpress.viz.dxFunnel.LegendItem>;
     /**
      * [descr:dxFunnelOptions.legend.customizeText]
      */
     customizeText?: (itemInfo: {
-      item?: dxFunnelItem;
+      item?: DevExpress.viz.dxFunnel.Item;
       text?: string;
     }) => string;
     /**
@@ -28203,7 +28266,7 @@ declare module DevExpress.viz {
     markerTemplate?:
       | DevExpress.core.template
       | ((
-          legendItem: FunnelLegendItem,
+          legendItem: DevExpress.viz.dxFunnel.LegendItem,
           element: SVGGElement
         ) => string | DevExpress.core.UserDefinedElement<SVGElement>);
     /**
@@ -28424,7 +28487,7 @@ declare module DevExpress.viz {
        * [descr:dxFunnelOptions.label.customizeText]
        */
       customizeText?: (itemInfo: {
-        item?: dxFunnelItem;
+        item?: DevExpress.viz.dxFunnel.Item;
         value?: number;
         valueText?: string;
         percent?: number;
@@ -28541,7 +28604,7 @@ declare module DevExpress.viz {
       | DevExpress.core.template
       | ((
           info: {
-            item?: dxFunnelItem;
+            item?: DevExpress.viz.dxFunnel.Item;
             value?: number;
             valueText?: string;
             percent?: number;
@@ -28553,7 +28616,7 @@ declare module DevExpress.viz {
      * [descr:dxFunnelOptions.tooltip.customizeTooltip]
      */
     customizeTooltip?: (info: {
-      item?: dxFunnelItem;
+      item?: DevExpress.viz.dxFunnel.Item;
       value?: number;
       valueText?: string;
       percent?: number;
@@ -28816,8 +28879,8 @@ declare module DevExpress.viz {
      * [descr:dxPieChartOptions.legend.customizeItems]
      */
     customizeItems?: (
-      items: Array<PieChartLegendItem>
-    ) => Array<PieChartLegendItem>;
+      items: Array<DevExpress.viz.dxPieChart.LegendItem>
+    ) => Array<DevExpress.viz.dxPieChart.LegendItem>;
     /**
      * [descr:dxPieChartOptions.legend.customizeText]
      */
@@ -28836,7 +28899,7 @@ declare module DevExpress.viz {
     markerTemplate?:
       | DevExpress.core.template
       | ((
-          legendItem: PieChartLegendItem,
+          legendItem: DevExpress.viz.dxPieChart.LegendItem,
           element: SVGGElement
         ) => string | DevExpress.core.UserDefinedElement<SVGElement>);
   }
@@ -32732,8 +32795,8 @@ declare module DevExpress.viz {
      * [descr:dxVectorMapOptions.legends.customizeItems]
      */
     customizeItems?: (
-      items: Array<VectorMapLegendItem>
-    ) => Array<VectorMapLegendItem>;
+      items: Array<DevExpress.viz.dxVectorMap.LegendItem>
+    ) => Array<DevExpress.viz.dxVectorMap.LegendItem>;
     /**
      * [descr:dxVectorMapOptions.legends.customizeText]
      */
@@ -32766,7 +32829,7 @@ declare module DevExpress.viz {
     markerTemplate?:
       | DevExpress.core.template
       | ((
-          legendItem: VectorMapLegendItem,
+          legendItem: DevExpress.viz.dxVectorMap.LegendItem,
           element: SVGGElement
         ) => string | DevExpress.core.UserDefinedElement<SVGElement>);
     /**
@@ -33205,14 +33268,14 @@ declare module DevExpress.viz {
     weight?: number;
   }
   /**
-   * [descr:FunnelLegendItem]
+   * @deprecated Use LegendItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface FunnelLegendItem extends BaseLegendItem {
     /**
      * [descr:FunnelLegendItem.item]
      */
-    item?: dxFunnelItem;
+    item?: DevExpress.viz.dxFunnel.Item;
   }
   /**
    * [descr:GaugeIndicator]
@@ -33343,7 +33406,7 @@ declare module DevExpress.viz {
     | 'Material'
     | 'Office';
   /**
-   * [descr:PieChartLegendItem]
+   * @deprecated Use LegendItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface PieChartLegendItem extends BaseLegendItem {
@@ -33492,7 +33555,7 @@ declare module DevExpress.viz {
     | 'week'
     | 'year';
   /**
-   * [descr:VectorMapLegendItem]
+   * @deprecated Use LegendItem instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface VectorMapLegendItem extends BaseLegendItem {
@@ -33594,6 +33657,22 @@ declare module DevExpress.viz {
         years?: number;
       }
     | TimeIntervalType;
+}
+declare module DevExpress.viz.dxBarGauge {
+  export type LegendItem = BarGaugeLegendItem;
+}
+declare module DevExpress.viz.dxFunnel {
+  /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+   */
+  export type Item = dxFunnelItem;
+  export type LegendItem = FunnelLegendItem;
+}
+declare module DevExpress.viz.dxPieChart {
+  export type LegendItem = PieChartLegendItem;
+}
+declare module DevExpress.viz.dxVectorMap {
+  export type LegendItem = VectorMapLegendItem;
 }
 declare module DevExpress.viz.map {
   /**


### PR DESCRIPTION
- component-name prefix removed from `Item` types
- `dxTreeListRowObject` renamed to `RowObject`
- `dxDataGridRowObject` renamed to `RowObject`
- dxDataGrid's `Summary` marked with `@public` tag
- `PivotGridDataSourceField` renamded to `Field`
- dxPivotGridDataSource's `ExcelDataGridCell` and `ExcelPivotGridCell` renamed to `DataGridCell` and `PivotGridCell`