### PR TITLE
DataGrid: Remove unstable test

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -8404,35 +8404,6 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
         assert.strictEqual(this.dataController.items()[4].rowType, 'data', 'row 4 is detail');
     });
 
-    QUnit.test('delete row with confirmDelete and confirmDeleteMessage is not empty', function(assert) {
-    // arrange
-        let removeHandlerCallCount = 0;
-        const dataSource = new DataSource({
-            key: 'id',
-            load: () => [{ id: 1 }],
-            totalCount: () => 1,
-            remove: () => ++removeHandlerCallCount
-        });
-
-        this.dataController.setDataSource(dataSource);
-        dataSource.load();
-
-        // act
-        this.editingController.deleteRow(0);
-
-        // assert
-        assert.equal(removeHandlerCallCount, 0, 'row is not deleted');
-
-        // arrange
-        this.options.editing.confirmDelete = false;
-
-        // act
-        this.editingController.deleteRow(0);
-
-        // assert
-        assert.equal(removeHandlerCallCount, 1, 'row is deleted');
-    });
-
     QUnit.test('delete row with confirmDelete and confirmDeleteMessage is empty', function(assert) {
     // arrange
         let removeHandlerCallCount = 0;


### PR DESCRIPTION
This test renders confirmation message with animation in dataController test that is wrong. The similar test exists in editing tests.