### PR TITLE
Add concurrency, remove `push` from event triggers

### DIFF
--- a/.github/workflows/angular_tests.yml
+++ b/.github/workflows/angular_tests.yml
@@ -1,6 +1,10 @@
 name: Angular wrapper tests
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   test:

--- a/.github/workflows/bundlers_tests.yml
+++ b/.github/workflows/bundlers_tests.yml
@@ -1,6 +1,10 @@
 name: Bundlers tests
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   bundler-tests:

--- a/.github/workflows/demos_tests.yml
+++ b/.github/workflows/demos_tests.yml
@@ -1,9 +1,10 @@
 name: Demos visual tests
 
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request, workflow_dispatch]
 
 jobs:
   demos_build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   Renovation:

--- a/.github/workflows/qunit_tests-renovation.yml
+++ b/.github/workflows/qunit_tests-renovation.yml
@@ -1,6 +1,10 @@
 name: QUnit tests for renovation
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   qunit-tests:

--- a/.github/workflows/qunit_tests.yml
+++ b/.github/workflows/qunit_tests.yml
@@ -1,6 +1,10 @@
 name: QUnit tests
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   qunit-tests:

--- a/.github/workflows/renovation.yml
+++ b/.github/workflows/renovation.yml
@@ -1,6 +1,10 @@
 name: Renovation
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   jest-tests:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -1,6 +1,10 @@
 name: Styles tests
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   Tests:

--- a/.github/workflows/testcafe_tests.yml
+++ b/.github/workflows/testcafe_tests.yml
@@ -1,6 +1,10 @@
 name: TestCafe tests
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   testcafe:

--- a/.github/workflows/themebuilder_dart_tests.yml
+++ b/.github/workflows/themebuilder_dart_tests.yml
@@ -1,6 +1,10 @@
 name: Themebuilder and Styles tests
 
-on: [push, pull_request]
+concurrency:
+  group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+on: [pull_request]
 
 jobs:
   dart-test:


### PR DESCRIPTION
Workflows won't run after push now.

Workflows on PR's will run in `concurrent` mode. If you push several commits in a short period of time, then:
- pending actions for older commit will be replaced with the new ones,
- running actions will be cancelled and replaced with the new ones.