### PR TITLE
ResizeObserver integration: refactoring

### DIFF
--- a/js/core/resize_observer.js
+++ b/js/core/resize_observer.js
@@ -1,40 +1,49 @@
+import { noop } from './utils/common';
 import { getWindow, hasWindow } from './utils/window';
 const window = getWindow();
 
-const ResizeObserver = (function() {
+const ResizeObserverNoWindowMock = {
+    observe: noop,
+    unobserve: noop,
+    disconnect: noop
+};
+
+const ResizeObserverSingletonFactory = (function() {
     let instance;
 
-    function ResizeObserver(options) {
+    function ResizeObserverSingleton() {
         if(!hasWindow()) {
-            return;
+            return ResizeObserverNoWindowMock;
         }
 
-        if(instance) {
-            return instance;
-        }
-
-        this._observer = new window.ResizeObserver((...args) => {
-            const shouldSkip = options.shouldSkipCallback?.(...args);
-            if(!shouldSkip) {
-                options.callback(...args);
-            }
+        this._callbacksMap = new Map();
+        this._observer = new window.ResizeObserver((entries) => {
+            entries.forEach(entry => {
+                this._callbacksMap.get(entry.target)?.(entry);
+            });
         });
-        return instance = this;
     }
 
-    ResizeObserver.prototype.observe = function(element) {
-        this._observer?.observe(element);
+    ResizeObserverSingleton.getInstance = function() {
+        return instance ?? (instance = new ResizeObserverSingleton());
     };
 
-    ResizeObserver.prototype.unobserve = function(element) {
-        this._observer?.unobserve(element);
+    ResizeObserverSingleton.prototype.observe = function(element, callback) {
+        this._callbacksMap.set(element, callback);
+        this._observer.observe(element);
     };
 
-    ResizeObserver.prototype.disconnect = function() {
-        this._observer?.disconnect();
+    ResizeObserverSingleton.prototype.unobserve = function(element) {
+        this._callbacksMap.delete(element);
+        this._observer.unobserve(element);
     };
 
-    return ResizeObserver;
+    ResizeObserverSingleton.prototype.disconnect = function() {
+        this._callbacksMap.clear();
+        this._observer.disconnect();
+    };
+
+    return ResizeObserverSingleton;
 })();
 
-export default ResizeObserver;
+export default ResizeObserverSingletonFactory;

--- a/js/core/resize_observer.js
+++ b/js/core/resize_observer.js
@@ -2,7 +2,7 @@ import { noop } from './utils/common';
 import { getWindow, hasWindow } from './utils/window';
 const window = getWindow();
 
-const ResizeObserverNoWindowMock = {
+const ResizeObserverMock = {
     observe: noop,
     unobserve: noop,
     disconnect: noop
@@ -10,8 +10,8 @@ const ResizeObserverNoWindowMock = {
 
 class ResizeObserverSingleton {
     constructor() {
-        if(!hasWindow()) {
-            return ResizeObserverNoWindowMock;
+        if(!hasWindow() || !window.ResizeObserver) {
+            return ResizeObserverMock;
         }
 
         this._callbacksMap = new Map();

--- a/js/core/resize_observer.js
+++ b/js/core/resize_observer.js
@@ -8,10 +8,8 @@ const ResizeObserverNoWindowMock = {
     disconnect: noop
 };
 
-const ResizeObserverSingletonFactory = (function() {
-    let instance;
-
-    function ResizeObserverSingleton() {
+class ResizeObserverSingleton {
+    constructor() {
         if(!hasWindow()) {
             return ResizeObserverNoWindowMock;
         }
@@ -24,26 +22,26 @@ const ResizeObserverSingletonFactory = (function() {
         });
     }
 
-    ResizeObserverSingleton.getInstance = function() {
-        return instance ?? (instance = new ResizeObserverSingleton());
-    };
-
-    ResizeObserverSingleton.prototype.observe = function(element, callback) {
+    observe(element, callback) {
         this._callbacksMap.set(element, callback);
         this._observer.observe(element);
-    };
+    }
 
-    ResizeObserverSingleton.prototype.unobserve = function(element) {
+    unobserve(element) {
         this._callbacksMap.delete(element);
         this._observer.unobserve(element);
-    };
+    }
 
-    ResizeObserverSingleton.prototype.disconnect = function() {
+    disconnect() {
         this._callbacksMap.clear();
         this._observer.disconnect();
-    };
+    }
+}
 
-    return ResizeObserverSingleton;
-})();
+const resizeObserverSingleton = new ResizeObserverSingleton();
 
-export default ResizeObserverSingletonFactory;
+///#DEBUG
+resizeObserverSingleton.ResizeObserverSingleton = ResizeObserverSingleton;
+///#ENDDEBUG
+
+export default resizeObserverSingleton;

--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -354,37 +354,30 @@ const Overlay = Widget.inherit({
         };
     },
 
-    _areContentDimensionsRendered: function(entries) {
-        const contentBox = entries[0].contentBoxSize?.[0];
+    _areContentDimensionsRendered: function(entry) {
+        const contentBox = entry.contentBoxSize?.[0];
         if(contentBox) {
             return parseInt(contentBox.inlineSize, 10) === this._renderedDimensions?.width
                     && parseInt(contentBox.blockSize, 10) === this._renderedDimensions?.height;
         }
 
-        const contentRect = entries[0].contentRect;
+        const contentRect = entry.contentRect;
         return parseInt(contentRect.width, 10) === this._renderedDimensions?.width
                 && parseInt(contentRect.height, 10) === this._renderedDimensions?.height;
     },
 
-    _resizeObserverCallback(entries) {
-        entries.forEach(entry => {
-            if(entry.target === this._$content.get(0)) {
-                this._renderGeometry({ shouldOnlyReposition: true });
-            }
-        });
+    _contentResizeHandler: function(entry) {
+        if(!this._shouldSkipContentResize(entry)) {
+            this._renderGeometry({ shouldOnlyReposition: true });
+        }
     },
 
     _updateResizeCallbackSkipCondition() {
         const doesShowAnimationChangeDimensions = this._doesShowAnimationChangeDimensions();
 
-        this._shouldSkipResizeObserverCallback = (entries) => {
-            for(let i = 0; i < entries.length; ++i) {
-                const entry = entries[i];
-                if(entry.target === this._$content.get(0)) {
-                    return doesShowAnimationChangeDimensions && this._showAnimationProcessing
-                        || this._areContentDimensionsRendered(entries);
-                }
-            }
+        this._shouldSkipContentResize = (entry) => {
+            return doesShowAnimationChangeDimensions && this._showAnimationProcessing
+                || this._areContentDimensionsRendered(entry);
         };
     },
 
@@ -404,7 +397,7 @@ const Overlay = Widget.inherit({
 
         const contentElement = this._$content.get(0);
         if(shouldObserve) {
-            this._resizeObserver.observe(contentElement);
+            this._resizeObserver.observe(contentElement, (entry) => { this._contentResizeHandler(entry); });
         } else {
             this._resizeObserver.unobserve(contentElement);
         }

--- a/js/ui/overlay/ui.overlay.js
+++ b/js/ui/overlay/ui.overlay.js
@@ -34,6 +34,7 @@ import swatch from '../widget/swatch_container';
 import Widget from '../widget/ui.widget';
 import browser from '../../core/utils/browser';
 import * as zIndexPool from './z_index';
+import resizeObserverSingleton from '../../core/resize_observer';
 const ready = readyCallbacks.add;
 const window = getWindow();
 const viewPortChanged = changeCallback;
@@ -397,9 +398,9 @@ const Overlay = Widget.inherit({
 
         const contentElement = this._$content.get(0);
         if(shouldObserve) {
-            this._resizeObserver.observe(contentElement, (entry) => { this._contentResizeHandler(entry); });
+            resizeObserverSingleton.observe(contentElement, (entry) => { this._contentResizeHandler(entry); });
         } else {
-            this._resizeObserver.unobserve(contentElement);
+            resizeObserverSingleton.unobserve(contentElement);
         }
     },
 
@@ -1409,6 +1410,7 @@ const Overlay = Widget.inherit({
 
         this._renderVisibility(false);
         this._stopShowTimer();
+        this._observeContentResize(false);
 
         this._cleanFocusState();
     },

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -8,7 +8,7 @@ import { extend } from '../../core/utils/extend';
 import { focusable as focusableSelector } from './selectors';
 import { inArray } from '../../core/utils/array';
 import { isPlainObject, isDefined } from '../../core/utils/type';
-import ResizeObserver from '../../core/resize_observer';
+import ResizeObserverSingleton from '../../core/resize_observer';
 import devices from '../../core/devices';
 import { compare as compareVersions } from '../../core/utils/version';
 
@@ -102,14 +102,8 @@ const Widget = DOMComponent.inherit({
             return;
         }
 
-        this._resizeObserver = new ResizeObserver({
-            callback: (entries) => { this._resizeObserverCallback(entries); },
-            shouldSkipCallback: (entries) => this._shouldSkipResizeObserverCallback(entries)
-        });
+        this._resizeObserver = new ResizeObserverSingleton();
     },
-
-    _resizeObserverCallback: noop,
-    _shouldSkipResizeObserverCallback: noop,
 
     _innerWidgetOptionChanged: function(innerWidget, args) {
         const options = Widget.getOptionsFromContainer(args);

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -102,7 +102,7 @@ const Widget = DOMComponent.inherit({
             return;
         }
 
-        this._resizeObserver = new ResizeObserverSingleton();
+        this._resizeObserver = ResizeObserverSingleton.getInstance();
     },
 
     _innerWidgetOptionChanged: function(innerWidget, args) {

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -8,7 +8,6 @@ import { extend } from '../../core/utils/extend';
 import { focusable as focusableSelector } from './selectors';
 import { inArray } from '../../core/utils/array';
 import { isPlainObject, isDefined } from '../../core/utils/type';
-import ResizeObserverSingleton from '../../core/resize_observer';
 import devices from '../../core/devices';
 import { compare as compareVersions } from '../../core/utils/version';
 
@@ -94,15 +93,6 @@ const Widget = DOMComponent.inherit({
     _init() {
         this.callBase();
         this._initContentReadyAction();
-        this._initResizeObserver();
-    },
-
-    _initResizeObserver: function() {
-        if(!this.option('useResizeObserver')) {
-            return;
-        }
-
-        this._resizeObserver = ResizeObserverSingleton.getInstance();
     },
 
     _innerWidgetOptionChanged: function(innerWidget, args) {
@@ -168,8 +158,6 @@ const Widget = DOMComponent.inherit({
     _fireContentReadyAction: deferRenderer(function() { return this._contentReadyAction(); }),
 
     _dispose() {
-        this._resizeObserver?.disconnect();
-        this._resizeObserver = null;
         this._contentReadyAction = null;
         this._detachKeyboardEvents();
 

--- a/testing/tests/DevExpress.core/resizeObserver.tests.js
+++ b/testing/tests/DevExpress.core/resizeObserver.tests.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
-import ResizeObserverSingleton from 'core/resize_observer';
+import resizeObserverSingleton from 'core/resize_observer';
+
 import { getWindow, setWindow } from 'core/utils/window';
 const window = getWindow();
 
@@ -14,12 +15,11 @@ QUnit.testStart(function() {
 QUnit.module('Resize observer', () => {
     QUnit.test('should not raise any error if there is no window', function(assert) {
         setWindow(window, false);
-        let observer;
 
         try {
             const element = $('#root').get(0);
 
-            observer = new ResizeObserverSingleton();
+            const observer = new resizeObserverSingleton.ResizeObserverSingleton();
             observer.observe(element, () => {});
             observer.unobserve(element);
             observer.disconnect();
@@ -34,7 +34,7 @@ QUnit.module('Resize observer', () => {
 
     QUnit.module('base functionality', {
         beforeEach: function() {
-            this.observer = ResizeObserverSingleton.getInstance();
+            this.observer = resizeObserverSingleton;
             this.$element = $('#root');
             this.element = this.$element.get(0);
         },
@@ -43,10 +43,6 @@ QUnit.module('Resize observer', () => {
             this.$element.width(200);
         }
     }, () => {
-        QUnit.testInActiveWindow('there is only one ResizeObserverSingleton instance', function(assert) {
-            assert.strictEqual(ResizeObserverSingleton.getInstance(), this.observer, 'instances are the same');
-        });
-
         QUnit.testInActiveWindow('callback should be raised after observable element resize', function(assert) {
             const resizeHandled = assert.async();
             const callback = () => {

--- a/testing/tests/DevExpress.core/resizeObserver.tests.js
+++ b/testing/tests/DevExpress.core/resizeObserver.tests.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import ResizeObserver from 'core/resize_observer';
+import ResizeObserverSingleton from 'core/resize_observer';
 import { getWindow, setWindow } from 'core/utils/window';
 const window = getWindow();
 
@@ -12,92 +12,65 @@ QUnit.testStart(function() {
 });
 
 QUnit.module('Resize observer', () => {
-    QUnit.test('initialization should not raise any error if there is no window', function(assert) {
+    QUnit.test('should not raise any error if there is no window', function(assert) {
         setWindow(window, false);
         let observer;
 
         try {
-            observer = new ResizeObserver();
+            const element = $('#root').get(0);
+
+            observer = new ResizeObserverSingleton();
+            observer.observe(element, () => {});
+            observer.unobserve(element);
+            observer.disconnect();
 
             assert.ok(true, 'no errors were raised');
         } catch(e) {
             assert.ok(false, `error: ${e.message}`);
         } finally {
             setWindow(window, true);
-            observer.disconnect();
         }
     });
 
-    let callback;
-    let shouldSkipCallback;
     QUnit.module('base functionality', {
         beforeEach: function() {
-            this.observer = new ResizeObserver({
-                callback: () => { callback(); },
-                shouldSkipCallback: () => shouldSkipCallback()
-            });
+            this.observer = ResizeObserverSingleton.getInstance();
             this.$element = $('#root');
+            this.element = this.$element.get(0);
         },
         afterEach: function() {
             this.observer.disconnect();
             this.$element.width(200);
         }
     }, () => {
-        QUnit.testInActiveWindow('there is only one ResizeObserver instance', function(assert) {
-            assert.strictEqual(new ResizeObserver(), this.observer, 'instances are the same');
-        });
-
-        QUnit.testInActiveWindow('should call passed "shouldSkipCallback" function before callback', function(assert) {
-            const resizeHandled = assert.async();
-            shouldSkipCallback = sinon.stub();
-            callback = () => {
-                assert.strictEqual(shouldSkipCallback.callCount, 1, 'shouldSkipCallback is called before callback call');
-                resizeHandled();
-            };
-
-            this.observer.observe(this.$element.get(0));
+        QUnit.testInActiveWindow('there is only one ResizeObserverSingleton instance', function(assert) {
+            assert.strictEqual(ResizeObserverSingleton.getInstance(), this.observer, 'instances are the same');
         });
 
         QUnit.testInActiveWindow('callback should be raised after observable element resize', function(assert) {
             const resizeHandled = assert.async();
-            callback = () => {
+            const callback = () => {
                 assert.ok(true, 'observer callback is called');
                 resizeHandled();
             };
 
-            this.observer.observe(this.$element.get(0));
+            this.observer.observe(this.element, callback);
             this.$element.width(50);
         });
 
         QUnit.testInActiveWindow('callback should not be raised after element is unobserved', function(assert) {
             const done = assert.async();
 
-            callback = () => {
+            const callback = () => {
                 assert.ok(false, 'observer callback was called after unobserve');
             };
 
-            this.observer.observe(this.$element.get(0));
-            this.observer.unobserve(this.$element.get(0));
+            this.observer.observe(this.element, callback);
+            this.observer.unobserve(this.element);
 
             setTimeout(() => {
                 assert.ok(true, 'no callbacks were called');
                 done();
-            }, TIME_TO_WAIT);
-        });
-
-        QUnit.testInActiveWindow('should not call "callback" if "shouldSkipCallback" returns true', function(assert) {
-            const done = assert.async();
-            shouldSkipCallback = sinon.stub().returns(true);
-            callback = sinon.stub();
-
-            this.observer.observe(this.$element.get(0));
-
-            setTimeout(() => {
-                this.$element.width(50);
-                setTimeout(() => {
-                    assert.strictEqual(callback.callCount, 0, 'callback was not called');
-                    done();
-                }, TIME_TO_WAIT);
             }, TIME_TO_WAIT);
         });
     });


### PR DESCRIPTION
Now component should make `import resizeObserverSingleton from 'core/resize_observer';` to get access to resize observer single instance.

Inheritors should add callbacks this way: `resizeObserverSingleton.observe(element, callback)`.
Callback receives the single parameter - [ResizeObserverEntry](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry).

Only one callback for an element is supported now.

It's important to unobserve appropriate elements on component dispose.
