### PR TITLE
Remove @pseudo and @extends tag

### DIFF
--- a/js/core/dom_component.js
+++ b/js/core/dom_component.js
@@ -323,16 +323,6 @@ const DOMComponent = Component.inherit({
         return extend(this.callBase(), { context });
     },
 
-    /**
-    * @pseudo Action
-    * @section Utils
-    * @type function
-    * @default null
-    * @type_function_param1 e:object
-    * @type_function_param1_field1 component:this
-    * @type_function_param1_field2 element:DxElement
-    * @type_function_param1_field3 model:object
-    **/
     _defaultActionArgs() {
         const $element = this.$element();
         const model = this._modelByElement($element);

--- a/js/ui/collection/ui.collection_widget.edit.js
+++ b/js/ui/collection/ui.collection_widget.edit.js
@@ -72,10 +72,14 @@ const CollectionWidget = BaseCollectionWidget.inherit({
             onSelectionChanged: null,
 
             /**
+            * @section Utils
+            * @default null
             * @name CollectionWidgetOptions.onItemReordered
-            * @extends Action
             * @type function(e)
             * @type_function_param1 e:object
+            * @type_function_param1_field1 component:this
+            * @type_function_param1_field2 element:DxElement
+            * @type_function_param1_field3 model:object
             * @type_function_param1_field4 itemData:object
             * @type_function_param1_field5 itemElement:DxElement
             * @type_function_param1_field6 itemIndex:number | object
@@ -87,10 +91,15 @@ const CollectionWidget = BaseCollectionWidget.inherit({
             onItemReordered: null,
 
             /**
+            * @section Utils
+            * @default null
             * @name CollectionWidgetOptions.onItemDeleting
-            * @extends Action
             * @type function(e)
             * @type_function_param1 e:object
+            * @type_function_param1 e:object
+            * @type_function_param1_field1 component:this
+            * @type_function_param1_field2 element:DxElement
+            * @type_function_param1_field3 model:object
             * @type_function_param1_field4 itemData:object
             * @type_function_param1_field5 itemElement:DxElement
             * @type_function_param1_field6 itemIndex:number | object
@@ -101,10 +110,15 @@ const CollectionWidget = BaseCollectionWidget.inherit({
             onItemDeleting: null,
 
             /**
+            * @section Utils
+            * @default null
             * @name CollectionWidgetOptions.onItemDeleted
-            * @extends Action
             * @type function(e)
             * @type_function_param1 e:object
+            * @type_function_param1 e:object
+            * @type_function_param1_field1 component:this
+            * @type_function_param1_field2 element:DxElement
+            * @type_function_param1_field3 model:object
             * @type_function_param1_field4 itemData:object
             * @type_function_param1_field5 itemElement:DxElement
             * @type_function_param1_field6 itemIndex:number | object

--- a/js/ui/collection/ui.collection_widget.edit.js
+++ b/js/ui/collection/ui.collection_widget.edit.js
@@ -96,7 +96,6 @@ const CollectionWidget = BaseCollectionWidget.inherit({
             * @name CollectionWidgetOptions.onItemDeleting
             * @type function(e)
             * @type_function_param1 e:object
-            * @type_function_param1 e:object
             * @type_function_param1_field1 component:this
             * @type_function_param1_field2 element:DxElement
             * @type_function_param1_field3 model:object
@@ -114,7 +113,6 @@ const CollectionWidget = BaseCollectionWidget.inherit({
             * @default null
             * @name CollectionWidgetOptions.onItemDeleted
             * @type function(e)
-            * @type_function_param1 e:object
             * @type_function_param1 e:object
             * @type_function_param1_field1 component:this
             * @type_function_param1_field2 element:DxElement

--- a/js/ui/draggable.js
+++ b/js/ui/draggable.js
@@ -258,11 +258,16 @@ const Draggable = DOMComponent.inherit({
             onDragEnd: null,
             onDragEnter: null,
             onDragLeave: null,
+
             /**
+             * @section Utils
+             * @default null
              * @name dxDraggableOptions.onDrop
              * @type function(e)
-             * @extends Action
              * @type_function_param1 e:object
+             * @type_function_param1_field1 component:this
+             * @type_function_param1_field2 element:DxElement
+             * @type_function_param1_field3 model:object
              * @type_function_param1_field4 event:event
              * @type_function_param1_field5 itemData:any
              * @type_function_param1_field6 itemElement:DxElement

--- a/js/ui/form.d.ts
+++ b/js/ui/form.d.ts
@@ -111,7 +111,7 @@ export interface dxFormOptions extends WidgetOptions<dxForm> {
     colCount?: number | 'auto';
     /**
      * @docid
-     * @extends ColCountResponsibleType
+     * @type object
      * @inherits ColCountResponsible
      * @default undefined
      * @public
@@ -488,7 +488,7 @@ export interface dxFormGroupItem {
     colCount?: number;
     /**
      * @docid
-     * @extends ColCountResponsibleType
+     * @type object
      * @inherits ColCountResponsible
      * @default undefined
      * @public
@@ -748,7 +748,7 @@ export interface dxFormTabbedItem {
       colCount?: number;
       /**
        * @docid
-       * @extends ColCountResponsibleType
+       * @type object
        * @inherits ColCountResponsible
        * @default undefined
        */

--- a/js/ui/form/ui.form.js
+++ b/js/ui/form/ui.form.js
@@ -86,10 +86,6 @@ const Form = Widget.inherit({
 
             screenByWidth: defaultScreenFactorFunc,
 
-            /**
-            * @pseudo ColCountResponsibleType
-            * @type object
-            */
             colCountByScreen: undefined,
 
             labelLocation: 'left',

--- a/js/ui/map.d.ts
+++ b/js/ui/map.d.ts
@@ -105,8 +105,8 @@ export interface dxMapOptions extends WidgetOptions<dxMap> {
      */
     autoAdjust?: boolean;
     /**
+     * @type Object|string|Array<number>
      * @docid
-     * @extends MapLocationType
      * @fires dxMapOptions.onOptionChanged
      * @inherits MapLocation
      * @public
@@ -171,8 +171,8 @@ export interface dxMapOptions extends WidgetOptions<dxMap> {
        */
       iconSrc?: string;
       /**
+       * @type Object|string|Array<number>
        * @docid
-       * @extends MapLocationType
        * @inherits MapLocation
        */
       location?: any | string | Array<number>;
@@ -291,7 +291,6 @@ export interface dxMapOptions extends WidgetOptions<dxMap> {
       color?: string;
       /**
        * @docid
-       * @extends MapLocationType
        * @inherits MapLocation
        * @type Array<object>
        */

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -85,10 +85,6 @@ const Map = Widget.inherit({
             },
 
             /**
-            * @pseudo MapLocationType
-            * @type Object|string|Array<number>
-            */
-            /**
             * @name MapLocation
             * @hidden
             */

--- a/js/ui/popover.js
+++ b/js/ui/popover.js
@@ -171,22 +171,40 @@ const Popover = Popup.inherit({
             resizeEnabled: false,
 
             /**
+            * @section Utils
+            * @type function
+            * @default null
+            * @type_function_param1 e:object
+            * @type_function_param1_field1 component:this
+            * @type_function_param1_field2 element:DxElement
+            * @type_function_param1_field3 model:object
             * @name dxPopoverOptions.onResizeStart
-            * @extends Action
             * @action
             * @hidden
             */
 
             /**
+            * @section Utils
+            * @type function
+            * @default null
+            * @type_function_param1 e:object
+            * @type_function_param1_field1 component:this
+            * @type_function_param1_field2 element:DxElement
+            * @type_function_param1_field3 model:object
             * @name dxPopoverOptions.onResize
-            * @extends Action
             * @action
             * @hidden
             */
 
             /**
+            * @section Utils
+            * @type function
+            * @default null
+            * @type_function_param1 e:object
+            * @type_function_param1_field1 component:this
+            * @type_function_param1_field2 element:DxElement
+            * @type_function_param1_field3 model:object
             * @name dxPopoverOptions.onResizeEnd
-            * @extends Action
             * @action
             * @hidden
             */

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -442,7 +442,8 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     endDateTimeZoneExpr?: string;
     /**
      * @docid
-     * @extends EndDayHour
+     * @type number
+     * @default 24
      * @public
      */
     endDayHour?: number;
@@ -810,7 +811,8 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     startDateTimeZoneExpr?: string;
     /**
      * @docid
-     * @extends StartDayHour
+     * @type number
+     * @default 0
      * @public
      */
     startDayHour?: number;
@@ -886,7 +888,8 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       dateCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
-       * @extends EndDayHour
+       * @type number
+       * @default 24
        */
       endDayHour?: number;
       /**
@@ -938,7 +941,8 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       startDate?: Date | number | string;
       /**
        * @docid
-       * @extends StartDayHour
+       * @type number
+       * @default 0
        */
       startDayHour?: number;
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -468,7 +468,8 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     groupByDate?: boolean;
     /**
      * @docid
-     * @extends Groups
+     * @type Array<string>
+     * @default []
      * @public
      */
     groups?: Array<string>;
@@ -910,7 +911,8 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       groupOrientation?: 'horizontal' | 'vertical';
       /**
        * @docid
-       * @extends Groups
+       * @type Array<string>
+       * @default []
        */
       groups?: Array<string>;
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -323,7 +323,14 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
     /**
      * @docid
-     * @extends AppointmentTooltipTemplate
+     * @type template|function
+     * @default "appointmentTooltip"
+     * @type_function_param1 model:object
+     * @type_function_param1_field1 appointmentData:object
+     * @type_function_param1_field2 targetedAppointmentData:object
+     * @type_function_param2 itemIndex:number
+     * @type_function_param3 contentElement:DxElement
+     * @type_function_return string|Element|jQuery
      * @public
      */
     appointmentTooltipTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
@@ -884,7 +891,14 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
-       * @extends AppointmentTooltipTemplate
+       * @type template|function
+       * @default "appointmentTooltip"
+       * @type_function_param1 model:object
+       * @type_function_param1_field1 appointmentData:object
+       * @type_function_param1_field2 targetedAppointmentData:object
+       * @type_function_param2 itemIndex:number
+       * @type_function_param3 contentElement:DxElement
+       * @type_function_return string|Element|jQuery
        */
       appointmentTooltipTemplate?: template | ((model: AppointmentTooltipTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -209,7 +209,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     /**
      * @docid
      * @default "appointmentCollector"
-     * @extends AppointmentCollectorTemplate
+     * @type template|function
+     * @type_function_param1 data:object
+     * @type_function_param1_field1 appointmentCount:number
+     * @type_function_param1_field2 isCompact:boolean
+     * @type_function_param2 collectorElement:DxElement
+     * @type_function_return string|Element|jQuery
      * @public
      */
     appointmentCollectorTemplate?: template | ((data: AppointmentCollectorTemplateData, collectorElement: DxElement) => string | UserDefinedElement);
@@ -894,7 +899,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       /**
        * @docid
        * @default "appointmentCollector"
-       * @extends AppointmentCollectorTemplate
+       * @type template|function
+       * @type_function_param1 data:object
+       * @type_function_param1_field1 appointmentCount:number
+       * @type_function_param1_field2 isCompact:boolean
+       * @type_function_param2 collectorElement:DxElement
+       * @type_function_return string|Element|jQuery
        */
       appointmentCollectorTemplate?: template | ((data: AppointmentCollectorTemplateData, collectorElement: DxElement) => string | UserDefinedElement);
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -322,7 +322,8 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     appointmentTooltipTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
     /**
      * @docid
-     * @extends CellDuration
+     * @type number
+     * @default 30
      * @public
      */
     cellDuration?: number;
@@ -874,7 +875,8 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       appointmentTooltipTemplate?: template | ((model: AppointmentTooltipTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
-       * @extends CellDuration
+       * @type number
+       * @default 30
        */
       cellDuration?: number;
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -740,7 +740,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     remoteFiltering?: boolean;
     /**
      * @docid
-     * @extends ResourceCellTemplate
+     * @type template|function
+     * @default null
+     * @type_function_param1 itemData:object
+     * @type_function_param2 itemIndex:number
+     * @type_function_param3 itemElement:DxElement
+     * @type_function_return string|Element|jQuery
      * @public
      */
     resourceCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
@@ -988,7 +993,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       name?: string;
       /**
        * @docid
-       * @extends ResourceCellTemplate
+       * @type template|function
+       * @default null
+       * @type_function_param1 itemData:object
+       * @type_function_param2 itemIndex:number
+       * @type_function_param3 itemElement:DxElement
+       * @type_function_return string|Element|jQuery
        */
       resourceCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -375,7 +375,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     customizeDateNavigatorText?: ((info: DateNavigatorTextInfo) => string);
     /**
      * @docid
-     * @extends DataCellTemplate
+     * @type template|function
+     * @default null
+     * @type_function_param1 itemData:object
+     * @type_function_param2 itemIndex:number
+     * @type_function_param3 itemElement:DxElement
+     * @type_function_return string|Element|jQuery
      * @public
      */
     dataCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
@@ -914,7 +919,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       cellDuration?: number;
       /**
        * @docid
-       * @extends DataCellTemplate
+       * @type template|function
+       * @default null
+       * @type_function_param1 itemData:object
+       * @type_function_param2 itemIndex:number
+       * @type_function_param3 itemElement:DxElement
+       * @type_function_return string|Element|jQuery
        */
       dataCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -209,7 +209,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     /**
      * @docid
      * @default "appointmentCollector"
-     * @type template|function
      * @type_function_param1 data:object
      * @type_function_param1_field1 appointmentCount:number
      * @type_function_param1_field2 isCompact:boolean
@@ -315,7 +314,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     };
     /**
      * @docid
-     * @type template|function
      * @default "item"
      * @type_function_param1 model:object
      * @type_function_param1_field1 appointmentData:object
@@ -328,7 +326,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
     /**
      * @docid
-     * @type template|function
      * @default "appointmentTooltip"
      * @type_function_param1 model:object
      * @type_function_param1_field1 appointmentData:object
@@ -380,7 +377,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     customizeDateNavigatorText?: ((info: DateNavigatorTextInfo) => string);
     /**
      * @docid
-     * @type template|function
      * @default null
      * @type_function_param1 itemData:object
      * @type_function_param2 itemIndex:number
@@ -398,7 +394,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     dataSource?: string | Array<Appointment> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
-     * @type template|function
      * @default null
      * @type_function_param1 itemData:object
      * @type_function_param2 itemIndex:number
@@ -745,7 +740,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     remoteFiltering?: boolean;
     /**
      * @docid
-     * @type template|function
      * @default null
      * @type_function_param1 itemData:object
      * @type_function_param2 itemIndex:number
@@ -860,7 +854,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     textExpr?: string;
     /**
      * @docid
-     * @type template|function
      * @default null
      * @type_function_param1 itemData:object
      * @type_function_param2 itemIndex:number
@@ -899,7 +892,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       /**
        * @docid
        * @default "appointmentCollector"
-       * @type template|function
        * @type_function_param1 data:object
        * @type_function_param1_field1 appointmentCount:number
        * @type_function_param1_field2 isCompact:boolean
@@ -909,7 +901,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       appointmentCollectorTemplate?: template | ((data: AppointmentCollectorTemplateData, collectorElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
-       * @type template|function
        * @default "item"
        * @type_function_param1 model:object
        * @type_function_param1_field1 appointmentData:object
@@ -921,7 +912,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
-       * @type template|function
        * @default "appointmentTooltip"
        * @type_function_param1 model:object
        * @type_function_param1_field1 appointmentData:object
@@ -939,7 +929,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       cellDuration?: number;
       /**
        * @docid
-       * @type template|function
        * @default null
        * @type_function_param1 itemData:object
        * @type_function_param2 itemIndex:number
@@ -949,7 +938,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       dataCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
-       * @type template|function
        * @default null
        * @type_function_param1 itemData:object
        * @type_function_param2 itemIndex:number
@@ -1003,7 +991,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       name?: string;
       /**
        * @docid
-       * @type template|function
        * @default null
        * @type_function_param1 itemData:object
        * @type_function_param2 itemIndex:number
@@ -1024,7 +1011,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       startDayHour?: number;
       /**
        * @docid
-       * @type template|function
        * @default null
        * @type_function_param1 itemData:object
        * @type_function_param2 itemIndex:number

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -388,7 +388,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     dataSource?: string | Array<Appointment> | Store | DataSource | DataSourceOptions;
     /**
      * @docid
-     * @extends DateCellTemplate
+     * @type template|function
+     * @default null
+     * @type_function_param1 itemData:object
+     * @type_function_param2 itemIndex:number
+     * @type_function_param3 itemElement:DxElement
+     * @type_function_return string|Element|jQuery
      * @public
      */
     dateCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
@@ -914,7 +919,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       dataCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
-       * @extends DateCellTemplate
+       * @type template|function
+       * @default null
+       * @type_function_param1 itemData:object
+       * @type_function_param2 itemIndex:number
+       * @type_function_param3 itemElement:DxElement
+       * @type_function_return string|Element|jQuery
        */
       dateCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -209,11 +209,9 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     /**
      * @docid
      * @default "appointmentCollector"
-     * @type_function_param1 data:object
      * @type_function_param1_field1 appointmentCount:number
      * @type_function_param1_field2 isCompact:boolean
      * @type_function_param2 collectorElement:DxElement
-     * @type_function_return string|Element|jQuery
      * @public
      */
     appointmentCollectorTemplate?: template | ((data: AppointmentCollectorTemplateData, collectorElement: DxElement) => string | UserDefinedElement);
@@ -315,24 +313,20 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     /**
      * @docid
      * @default "item"
-     * @type_function_param1 model:object
      * @type_function_param1_field1 appointmentData:object
      * @type_function_param1_field2 targetedAppointmentData:object
      * @type_function_param2 itemIndex:number
      * @type_function_param3 contentElement:DxElement
-     * @type_function_return string|Element|jQuery
      * @public
      */
     appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
     /**
      * @docid
      * @default "appointmentTooltip"
-     * @type_function_param1 model:object
      * @type_function_param1_field1 appointmentData:object
      * @type_function_param1_field2 targetedAppointmentData:object
      * @type_function_param2 itemIndex:number
      * @type_function_param3 contentElement:DxElement
-     * @type_function_return string|Element|jQuery
      * @public
      */
     appointmentTooltipTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
@@ -381,7 +375,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @type_function_param1 itemData:object
      * @type_function_param2 itemIndex:number
      * @type_function_param3 itemElement:DxElement
-     * @type_function_return string|Element|jQuery
      * @public
      */
     dataCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
@@ -398,7 +391,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @type_function_param1 itemData:object
      * @type_function_param2 itemIndex:number
      * @type_function_param3 itemElement:DxElement
-     * @type_function_return string|Element|jQuery
      * @public
      */
     dateCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
@@ -744,7 +736,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @type_function_param1 itemData:object
      * @type_function_param2 itemIndex:number
      * @type_function_param3 itemElement:DxElement
-     * @type_function_return string|Element|jQuery
      * @public
      */
     resourceCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
@@ -858,7 +849,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @type_function_param1 itemData:object
      * @type_function_param2 itemIndex:number
      * @type_function_param3 itemElement:DxElement
-     * @type_function_return string|Element|jQuery
      * @public
      */
     timeCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
@@ -892,33 +882,27 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       /**
        * @docid
        * @default "appointmentCollector"
-       * @type_function_param1 data:object
        * @type_function_param1_field1 appointmentCount:number
        * @type_function_param1_field2 isCompact:boolean
        * @type_function_param2 collectorElement:DxElement
-       * @type_function_return string|Element|jQuery
        */
       appointmentCollectorTemplate?: template | ((data: AppointmentCollectorTemplateData, collectorElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
        * @default "item"
-       * @type_function_param1 model:object
        * @type_function_param1_field1 appointmentData:object
        * @type_function_param1_field2 targetedAppointmentData:object
        * @type_function_param2 itemIndex:number
        * @type_function_param3 contentElement:DxElement
-       * @type_function_return string|Element|jQuery
        */
       appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
        * @default "appointmentTooltip"
-       * @type_function_param1 model:object
        * @type_function_param1_field1 appointmentData:object
        * @type_function_param1_field2 targetedAppointmentData:object
        * @type_function_param2 itemIndex:number
        * @type_function_param3 contentElement:DxElement
-       * @type_function_return string|Element|jQuery
        */
       appointmentTooltipTemplate?: template | ((model: AppointmentTooltipTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
       /**
@@ -933,7 +917,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
        * @type_function_param1 itemData:object
        * @type_function_param2 itemIndex:number
        * @type_function_param3 itemElement:DxElement
-       * @type_function_return string|Element|jQuery
        */
       dataCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**
@@ -942,7 +925,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
        * @type_function_param1 itemData:object
        * @type_function_param2 itemIndex:number
        * @type_function_param3 itemElement:DxElement
-       * @type_function_return string|Element|jQuery
        */
       dateCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**
@@ -995,7 +977,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
        * @type_function_param1 itemData:object
        * @type_function_param2 itemIndex:number
        * @type_function_param3 itemElement:DxElement
-       * @type_function_return string|Element|jQuery
        */
       resourceCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**
@@ -1015,7 +996,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
        * @type_function_param1 itemData:object
        * @type_function_param2 itemIndex:number
        * @type_function_param3 itemElement:DxElement
-       * @type_function_return string|Element|jQuery
        */
       timeCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -310,7 +310,14 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     };
     /**
      * @docid
-     * @extends AppointmentTemplate
+     * @type template|function
+     * @default "item"
+     * @type_function_param1 model:object
+     * @type_function_param1_field1 appointmentData:object
+     * @type_function_param1_field2 targetedAppointmentData:object
+     * @type_function_param2 itemIndex:number
+     * @type_function_param3 contentElement:DxElement
+     * @type_function_return string|Element|jQuery
      * @public
      */
     appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
@@ -865,7 +872,14 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       appointmentCollectorTemplate?: template | ((data: AppointmentCollectorTemplateData, collectorElement: DxElement) => string | UserDefinedElement);
       /**
        * @docid
-       * @extends AppointmentTemplate
+       * @type template|function
+       * @default "item"
+       * @type_function_param1 model:object
+       * @type_function_param1_field1 appointmentData:object
+       * @type_function_param1_field2 targetedAppointmentData:object
+       * @type_function_param2 itemIndex:number
+       * @type_function_param3 contentElement:DxElement
+       * @type_function_return string|Element|jQuery
        */
       appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
       /**

--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -850,7 +850,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     textExpr?: string;
     /**
      * @docid
-     * @extends TimeCellTemplate
+     * @type template|function
+     * @default null
+     * @type_function_param1 itemData:object
+     * @type_function_param2 itemIndex:number
+     * @type_function_param3 itemElement:DxElement
+     * @type_function_return string|Element|jQuery
      * @public
      */
     timeCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
@@ -999,7 +1004,12 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       startDayHour?: number;
       /**
        * @docid
-       * @extends TimeCellTemplate
+       * @type template|function
+       * @default null
+       * @type_function_param1 itemData:object
+       * @type_function_param2 itemIndex:number
+       * @type_function_param3 itemElement:DxElement
+       * @type_function_return string|Element|jQuery
        */
       timeCellTemplate?: template | ((itemData: any, itemIndex: number, itemElement: DxElement) => string | UserDefinedElement);
       /**

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -145,17 +145,6 @@ class Scheduler extends Widget {
     _getDefaultOptions() {
         const defaultOptions = extend(super._getDefaultOptions(), {
 
-            /**
-                * @pseudo AppointmentCollectorTemplate
-                * @type template|function
-                * @default "appointmentCollector"
-                * @type_function_param1 data:object
-                * @type_function_param1_field1 appointmentCount:number
-                * @type_function_param1_field2 isCompact:boolean
-                * @type_function_param2 collectorElement:DxElement
-                * @type_function_return string|Element|jQuery
-                */
-
             views: ['day', 'week'],
             currentView: 'day', // TODO: should we calculate currentView if views array contains only one item, for example 'month'?
             currentDate: dateUtils.trimTime(new Date()),

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -144,17 +144,6 @@ const RECURRENCE_EDITING_MODE = {
 class Scheduler extends Widget {
     _getDefaultOptions() {
         const defaultOptions = extend(super._getDefaultOptions(), {
-            /**
-                * @pseudo StartDayHour
-                * @type number
-                * @default 0
-                */
-
-            /**
-                * @pseudo EndDayHour
-                * @type number
-                * @default 24
-                */
 
             /**
                 * @pseudo Groups

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -147,18 +147,6 @@ class Scheduler extends Widget {
 
 
             /**
-                * @pseudo AppointmentTemplate
-                * @type template|function
-                * @default "item"
-                * @type_function_param1 model:object
-                * @type_function_param1_field1 appointmentData:object
-                * @type_function_param1_field2 targetedAppointmentData:object
-                * @type_function_param2 itemIndex:number
-                * @type_function_param3 contentElement:DxElement
-                * @type_function_return string|Element|jQuery
-                */
-
-            /**
                 * @pseudo AppointmentTooltipTemplate
                 * @type template|function
                 * @default "appointmentTooltip"

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -146,16 +146,6 @@ class Scheduler extends Widget {
         const defaultOptions = extend(super._getDefaultOptions(), {
 
             /**
-                * @pseudo DataCellTemplate
-                * @type template|function
-                * @default null
-                * @type_function_param1 itemData:object
-                * @type_function_param2 itemIndex:number
-                * @type_function_param3 itemElement:DxElement
-                * @type_function_return string|Element|jQuery
-                */
-
-            /**
                 * @pseudo TimeCellTemplate
                 * @type template|function
                 * @default null

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -145,17 +145,6 @@ class Scheduler extends Widget {
     _getDefaultOptions() {
         const defaultOptions = extend(super._getDefaultOptions(), {
 
-
-            /**
-                * @pseudo DateCellTemplate
-                * @type template|function
-                * @default null
-                * @type_function_param1 itemData:object
-                * @type_function_param2 itemIndex:number
-                * @type_function_param3 itemElement:DxElement
-                * @type_function_return string|Element|jQuery
-                */
-
             /**
                 * @pseudo DataCellTemplate
                 * @type template|function

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -147,18 +147,6 @@ class Scheduler extends Widget {
 
 
             /**
-                * @pseudo AppointmentTooltipTemplate
-                * @type template|function
-                * @default "appointmentTooltip"
-                * @type_function_param1 model:object
-                * @type_function_param1_field1 appointmentData:object
-                * @type_function_param1_field2 targetedAppointmentData:object
-                * @type_function_param2 itemIndex:number
-                * @type_function_param3 contentElement:DxElement
-                * @type_function_return string|Element|jQuery
-                */
-
-            /**
                 * @pseudo DateCellTemplate
                 * @type template|function
                 * @default null

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -146,12 +146,6 @@ class Scheduler extends Widget {
         const defaultOptions = extend(super._getDefaultOptions(), {
 
             /**
-                * @pseudo Groups
-                * @type Array<string>
-                * @default []
-                */
-
-            /**
                 * @pseudo CellDuration
                 * @type number
                 * @default 30

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -145,11 +145,6 @@ class Scheduler extends Widget {
     _getDefaultOptions() {
         const defaultOptions = extend(super._getDefaultOptions(), {
 
-            /**
-                * @pseudo CellDuration
-                * @type number
-                * @default 30
-                */
 
             /**
                 * @pseudo AppointmentTemplate

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -146,16 +146,6 @@ class Scheduler extends Widget {
         const defaultOptions = extend(super._getDefaultOptions(), {
 
             /**
-                * @pseudo ResourceCellTemplate
-                * @type template|function
-                * @default null
-                * @type_function_param1 itemData:object
-                * @type_function_param2 itemIndex:number
-                * @type_function_param3 itemElement:DxElement
-                * @type_function_return string|Element|jQuery
-                */
-
-            /**
                 * @pseudo AppointmentCollectorTemplate
                 * @type template|function
                 * @default "appointmentCollector"

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -146,16 +146,6 @@ class Scheduler extends Widget {
         const defaultOptions = extend(super._getDefaultOptions(), {
 
             /**
-                * @pseudo TimeCellTemplate
-                * @type template|function
-                * @default null
-                * @type_function_param1 itemData:object
-                * @type_function_param2 itemIndex:number
-                * @type_function_param3 itemElement:DxElement
-                * @type_function_return string|Element|jQuery
-                */
-
-            /**
                 * @pseudo ResourceCellTemplate
                 * @type template|function
                 * @default null

--- a/js/ui/select_box.d.ts
+++ b/js/ui/select_box.d.ts
@@ -123,9 +123,13 @@ export interface dxSelectBoxOptions<TComponent> extends dxDropDownListOptions<TC
      */
     fieldTemplate?: template | ((selectedItem: any, fieldElement: DxElement) => string | UserDefinedElement);
     /**
+     * @section Utils
+     * @type function
      * @docid
-     * @extends Action
      * @type_function_param1 e:object
+     * @type_function_param1_field1 component:this
+     * @type_function_param1_field2 element:DxElement
+     * @type_function_param1_field3 model:object
      * @type_function_param1_field4 text:string
      * @type_function_param1_field5 customItem:string|object|Promise<any>
      * @type_function_param1_field1 component:this

--- a/js/ui/sortable.js
+++ b/js/ui/sortable.js
@@ -79,10 +79,14 @@ const Sortable = Draggable.inherit({
             onRemove: null,
             onReorder: null,
             /**
+             * @section Utils
+             * @default null
              * @name dxSortableOptions.onPlaceholderPrepared
              * @type function(e)
-             * @extends Action
              * @type_function_param1 e:object
+             * @type_function_param1_field1 component:this
+             * @type_function_param1_field2 element:DxElement
+             * @type_function_param1_field3 model:object
              * @type_function_param1_field4 event:event
              * @type_function_param1_field5 cancel:boolean
              * @type_function_param1_field6 itemData:any

--- a/js/ui/validator.d.ts
+++ b/js/ui/validator.d.ts
@@ -107,7 +107,6 @@ export interface dxValidatorOptions extends DOMComponentOptions<dxValidator> {
 /**
  * @docid
  * @inherits DOMComponent
- * @extension
  * @module ui/validator
  * @export default
  * @namespace DevExpress.ui

--- a/js/ui/validator.d.ts
+++ b/js/ui/validator.d.ts
@@ -107,6 +107,7 @@ export interface dxValidatorOptions extends DOMComponentOptions<dxValidator> {
 /**
  * @docid
  * @inherits DOMComponent
+ * @extension
  * @module ui/validator
  * @export default
  * @namespace DevExpress.ui

--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -55,16 +55,28 @@ const Widget = DOMComponent.inherit({
             accessKey: undefined,
 
             /**
+            * @section Utils
+            * @type function
+            * @default null
+            * @type_function_param1 e:object
+            * @type_function_param1_field1 component:this
+            * @type_function_param1_field2 element:DxElement
+            * @type_function_param1_field3 model:object
             * @name WidgetOptions.onFocusIn
-            * @extends Action
             * @action
             * @hidden
             */
             onFocusIn: null,
 
             /**
+            * @section Utils
+            * @type function
+            * @default null
+            * @type_function_param1 e:object
+            * @type_function_param1_field1 component:this
+            * @type_function_param1_field2 element:DxElement
+            * @type_function_param1_field3 model:object
             * @name WidgetOptions.onFocusOut
-            * @extends Action
             * @action
             * @hidden
             */

--- a/js/viz/bar_gauge.d.ts
+++ b/js/viz/bar_gauge.d.ts
@@ -252,7 +252,7 @@ export interface dxBarGaugeOptions extends BaseWidgetOptions<dxBarGauge> {
     onTooltipShown?: ((e: TooltipShownEvent) => void);
     /**
      * @docid
-     * @extends CommonVizPalette
+     * @default "Material"
      * @type Array<string>|Enums.VizPalette
      * @public
      */

--- a/js/viz/bar_gauge.d.ts
+++ b/js/viz/bar_gauge.d.ts
@@ -196,7 +196,8 @@ export interface dxBarGaugeOptions extends BaseWidgetOptions<dxBarGauge> {
       font?: Font;
       /**
        * @docid
-       * @extends CommonVizFormat
+       * @type format
+       * @default undefined
        */
       format?: Format;
       /**
@@ -328,7 +329,8 @@ export interface dxBarGaugeLegend extends BaseLegend {
     customizeText?: ((arg: { item?: BarGaugeBarInfo; text?: string }) => string);
     /**
      * @docid dxBarGaugeOptions.legend.itemTextFormat
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     itemTextFormat?: Format;

--- a/js/viz/bar_gauge.d.ts
+++ b/js/viz/bar_gauge.d.ts
@@ -196,7 +196,7 @@ export interface dxBarGaugeOptions extends BaseWidgetOptions<dxBarGauge> {
       font?: Font;
       /**
        * @docid
-       * @type format
+       * @type Format
        * @default undefined
        */
       format?: Format;
@@ -329,7 +329,7 @@ export interface dxBarGaugeLegend extends BaseLegend {
     customizeText?: ((arg: { item?: BarGaugeBarInfo; text?: string }) => string);
     /**
      * @docid dxBarGaugeOptions.legend.itemTextFormat
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */

--- a/js/viz/chart.d.ts
+++ b/js/viz/chart.d.ts
@@ -709,7 +709,8 @@ export interface dxChartOptions extends BaseChartOptions<dxChart> {
           font?: Font;
           /**
            * @docid
-           * @extends CommonVizFormat
+           * @type format
+           * @default undefined
            */
           format?: Format;
           /**
@@ -760,7 +761,8 @@ export interface dxChartOptions extends BaseChartOptions<dxChart> {
         font?: Font;
         /**
          * @docid
-         * @extends CommonVizFormat
+         * @type format
+         * @default undefined
          */
         format?: Format;
         /**
@@ -815,7 +817,8 @@ export interface dxChartOptions extends BaseChartOptions<dxChart> {
           font?: Font;
           /**
            * @docid
-           * @extends CommonVizFormat
+           * @type format
+           * @default undefined
            */
           format?: Format;
           /**
@@ -1510,7 +1513,8 @@ export interface dxChartArgumentAxisLabel extends dxChartCommonAxisSettingsLabel
     customizeText?: ((argument: { value?: Date | number | string; valueText?: string }) => string);
     /**
      * @docid dxChartOptions.argumentAxis.label.format
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     format?: Format;
@@ -2583,7 +2587,8 @@ export interface dxChartValueAxisLabel extends dxChartCommonAxisSettingsLabel {
     customizeText?: ((axisValue: { value?: Date | number | string; valueText?: string }) => string);
     /**
      * @docid dxChartOptions.valueAxis.label.format
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     format?: Format;
@@ -3668,7 +3673,8 @@ export interface dxChartSeriesTypesCommonSeriesLabel {
     alignment?: 'center' | 'left' | 'right';
     /**
      * @docid dxChartSeriesTypes.CommonSeries.label.argumentFormat
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     argumentFormat?: Format;
@@ -3747,7 +3753,8 @@ export interface dxChartSeriesTypesCommonSeriesLabel {
     font?: Font;
     /**
      * @docid dxChartSeriesTypes.CommonSeries.label.format
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     format?: Format;

--- a/js/viz/chart.d.ts
+++ b/js/viz/chart.d.ts
@@ -709,7 +709,7 @@ export interface dxChartOptions extends BaseChartOptions<dxChart> {
           font?: Font;
           /**
            * @docid
-           * @type format
+           * @type Format
            * @default undefined
            */
           format?: Format;
@@ -761,7 +761,7 @@ export interface dxChartOptions extends BaseChartOptions<dxChart> {
         font?: Font;
         /**
          * @docid
-         * @type format
+         * @type Format
          * @default undefined
          */
         format?: Format;
@@ -817,7 +817,7 @@ export interface dxChartOptions extends BaseChartOptions<dxChart> {
           font?: Font;
           /**
            * @docid
-           * @type format
+           * @type Format
            * @default undefined
            */
           format?: Format;
@@ -1513,7 +1513,7 @@ export interface dxChartArgumentAxisLabel extends dxChartCommonAxisSettingsLabel
     customizeText?: ((argument: { value?: Date | number | string; valueText?: string }) => string);
     /**
      * @docid dxChartOptions.argumentAxis.label.format
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */
@@ -2587,7 +2587,7 @@ export interface dxChartValueAxisLabel extends dxChartCommonAxisSettingsLabel {
     customizeText?: ((axisValue: { value?: Date | number | string; valueText?: string }) => string);
     /**
      * @docid dxChartOptions.valueAxis.label.format
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */
@@ -3673,7 +3673,7 @@ export interface dxChartSeriesTypesCommonSeriesLabel {
     alignment?: 'center' | 'left' | 'right';
     /**
      * @docid dxChartSeriesTypes.CommonSeries.label.argumentFormat
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */
@@ -3753,7 +3753,7 @@ export interface dxChartSeriesTypesCommonSeriesLabel {
     font?: Font;
     /**
      * @docid dxChartSeriesTypes.CommonSeries.label.format
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */

--- a/js/viz/chart_components/base_chart.d.ts
+++ b/js/viz/chart_components/base_chart.d.ts
@@ -194,7 +194,7 @@ export interface BaseChartOptions<TComponent> extends BaseWidgetOptions<TCompone
     onTooltipShown?: ((e: EventInfo<TComponent> & TooltipInfo) => void);
     /**
      * @docid
-     * @extends CommonVizPalette
+     * @default "Material"
      * @type Array<string>|Enums.VizPalette
      * @public
      */

--- a/js/viz/chart_components/base_chart.d.ts
+++ b/js/viz/chart_components/base_chart.d.ts
@@ -106,7 +106,8 @@ export interface BaseChartOptions<TComponent> extends BaseWidgetOptions<TCompone
     customizePoint?: ((pointInfo: any) => dxChartSeriesTypesCommonSeriesPoint);
     /**
      * @docid BaseChartOptions.dataSource
-     * @extends CommonVizDataSource
+     * @type Array<any>|Store|DataSource|DataSourceOptions|string
+     * @notUsedInTheme
      * @public
      */
     dataSource?: Array<any> | Store | DataSource | DataSourceOptions | string;

--- a/js/viz/chart_components/base_chart.d.ts
+++ b/js/viz/chart_components/base_chart.d.ts
@@ -271,7 +271,8 @@ export interface BaseChartLegend extends BaseLegend {
 export interface BaseChartTooltip extends BaseWidgetTooltip {
     /**
      * @docid BaseChartOptions.tooltip.argumentFormat
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     argumentFormat?: Format;

--- a/js/viz/chart_components/base_chart.d.ts
+++ b/js/viz/chart_components/base_chart.d.ts
@@ -272,7 +272,7 @@ export interface BaseChartLegend extends BaseLegend {
 export interface BaseChartTooltip extends BaseWidgetTooltip {
     /**
      * @docid BaseChartOptions.tooltip.argumentFormat
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */

--- a/js/viz/common.d.ts
+++ b/js/viz/common.d.ts
@@ -199,7 +199,7 @@ export interface BaseLegend {
        * @default '#232323' &prop(color)
        * @default 18 &prop(size)
        * @default 200 &prop(weight)
-       * @extends CommonVizLightFontFamily
+       * @default "'Segoe UI Light', 'Helvetica Neue Light', 'Segoe UI', 'Helvetica Neue', 'Trebuchet MS', Verdana, sans-serif" &prop(family)
        */
       font?: Font;
       /**
@@ -247,7 +247,7 @@ export interface BaseLegend {
          * @default '#232323' &prop(color)
          * @default 14 &prop(size)
          * @default 200 &prop(weight)
-         * @extends CommonVizLightFontFamily
+         * @default "'Segoe UI Light', 'Helvetica Neue Light', 'Segoe UI', 'Helvetica Neue', 'Trebuchet MS', Verdana, sans-serif" &prop(family)
          */
         font?: Font;
         /**

--- a/js/viz/core/base_widget.d.ts
+++ b/js/viz/core/base_widget.d.ts
@@ -514,7 +514,7 @@ export interface BaseWidgetTooltip {
     font?: Font;
     /**
      * @docid BaseWidgetOptions.tooltip.format
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */

--- a/js/viz/core/base_widget.d.ts
+++ b/js/viz/core/base_widget.d.ts
@@ -333,7 +333,7 @@ export interface BaseWidgetTitle {
      * @default '#232323' &prop(color)
      * @default 28 &prop(size)
      * @default 200 &prop(weight)
-     * @extends CommonVizLightFontFamily
+     * @default "'Segoe UI Light', 'Helvetica Neue Light', 'Segoe UI', 'Helvetica Neue', 'Trebuchet MS', Verdana, sans-serif" &prop(family)
      * @public
      */
     font?: Font;
@@ -387,7 +387,7 @@ export interface BaseWidgetTitle {
        * @default '#232323' &prop(color)
        * @default 16 &prop(size)
        * @default 200 &prop(weight)
-       * @extends CommonVizLightFontFamily
+       * @default "'Segoe UI Light', 'Helvetica Neue Light', 'Segoe UI', 'Helvetica Neue', 'Trebuchet MS', Verdana, sans-serif" &prop(family)
        */
       font?: Font;
       /**

--- a/js/viz/core/base_widget.d.ts
+++ b/js/viz/core/base_widget.d.ts
@@ -514,7 +514,8 @@ export interface BaseWidgetTooltip {
     font?: Font;
     /**
      * @docid BaseWidgetOptions.tooltip.format
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     format?: Format;

--- a/js/viz/docs/docBaseWidget.js
+++ b/js/viz/docs/docBaseWidget.js
@@ -1,10 +1,4 @@
 /**
-* @pseudo CommonVizFormat
-* @type format
-* @default undefined
-*/
-
-/**
 * @pseudo CommonVizLightFontFamily
 * @default "'Segoe UI Light', 'Helvetica Neue Light', 'Segoe UI', 'Helvetica Neue', 'Trebuchet MS', Verdana, sans-serif" &prop(family)
 */

--- a/js/viz/docs/docBaseWidget.js
+++ b/js/viz/docs/docBaseWidget.js
@@ -1,5 +1,0 @@
-/**
-* @pseudo CommonVizPalette
-* @type Array<string>|Enums.VizPalette
-* @default "Material"
-*/

--- a/js/viz/docs/docBaseWidget.js
+++ b/js/viz/docs/docBaseWidget.js
@@ -1,10 +1,4 @@
 /**
-* @pseudo CommonVizDataSource
-* @type Array<any>|Store|DataSource|DataSourceOptions|string
-* @notUsedInTheme
-*/
-
-/**
 * @pseudo CommonVizPalette
 * @type Array<string>|Enums.VizPalette
 * @default "Material"

--- a/js/viz/docs/docBaseWidget.js
+++ b/js/viz/docs/docBaseWidget.js
@@ -1,9 +1,4 @@
 /**
-* @pseudo CommonVizLightFontFamily
-* @default "'Segoe UI Light', 'Helvetica Neue Light', 'Segoe UI', 'Helvetica Neue', 'Trebuchet MS', Verdana, sans-serif" &prop(family)
-*/
-
-/**
 * @pseudo CommonVizDataSource
 * @type Array<any>|Store|DataSource|DataSourceOptions|string
 * @notUsedInTheme

--- a/js/viz/funnel.d.ts
+++ b/js/viz/funnel.d.ts
@@ -377,7 +377,7 @@ export interface dxFunnelOptions extends BaseWidgetOptions<dxFunnel> {
       font?: Font;
       /**
        * @docid
-       * @type format
+       * @type Format
        * @default undefined
        */
       format?: Format;

--- a/js/viz/funnel.d.ts
+++ b/js/viz/funnel.d.ts
@@ -153,7 +153,8 @@ export interface dxFunnelOptions extends BaseWidgetOptions<dxFunnel> {
     colorField?: string;
     /**
      * @docid
-     * @extends CommonVizDataSource
+     * @type Array<any>|Store|DataSource|DataSourceOptions|string
+     * @notUsedInTheme
      * @public
      */
     dataSource?: Array<any> | Store | DataSource | DataSourceOptions | string;

--- a/js/viz/funnel.d.ts
+++ b/js/viz/funnel.d.ts
@@ -376,7 +376,8 @@ export interface dxFunnelOptions extends BaseWidgetOptions<dxFunnel> {
       font?: Font;
       /**
        * @docid
-       * @extends CommonVizFormat
+       * @type format
+       * @default undefined
        */
       format?: Format;
       /**

--- a/js/viz/funnel.d.ts
+++ b/js/viz/funnel.d.ts
@@ -496,7 +496,7 @@ export interface dxFunnelOptions extends BaseWidgetOptions<dxFunnel> {
     onSelectionChanged?: ((e: SelectionChangedEvent) => void);
     /**
      * @docid
-     * @extends CommonVizPalette
+     * @default "Material"
      * @type Array<string>|Enums.VizPalette
      * @public
      */

--- a/js/viz/gauges/base_gauge.d.ts
+++ b/js/viz/gauges/base_gauge.d.ts
@@ -335,7 +335,7 @@ export interface BaseGaugeScaleLabel {
     font?: Font;
     /**
      * @docid BaseGaugeOptions.scale.label.format
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */
@@ -565,7 +565,7 @@ export interface CommonIndicator {
       font?: Font;
       /**
        * @docid
-       * @type format
+       * @type Format
        * @default undefined
        * @propertyOf circularRangeBar,linearRangeBar,circularTextCloud,linearTextCloud
        */

--- a/js/viz/gauges/base_gauge.d.ts
+++ b/js/viz/gauges/base_gauge.d.ts
@@ -335,7 +335,8 @@ export interface BaseGaugeScaleLabel {
     font?: Font;
     /**
      * @docid BaseGaugeOptions.scale.label.format
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     format?: Format;
@@ -564,7 +565,8 @@ export interface CommonIndicator {
       font?: Font;
       /**
        * @docid
-       * @extends CommonVizFormat
+       * @type format
+       * @default undefined
        * @propertyOf circularRangeBar,linearRangeBar,circularTextCloud,linearTextCloud
        */
       format?: Format;

--- a/js/viz/gauges/base_gauge.d.ts
+++ b/js/viz/gauges/base_gauge.d.ts
@@ -158,7 +158,7 @@ export interface BaseGaugeRangeContainer {
     offset?: number;
     /**
      * @docid BaseGaugeOptions.rangeContainer.palette
-     * @extends CommonVizPalette
+     * @default "Material"
      * @type Array<string>|Enums.VizPalette
      * @public
      */
@@ -500,7 +500,7 @@ export interface CommonIndicator {
     offset?: number;
     /**
      * @docid
-     * @extends CommonVizPalette
+     * @default "Material"
      * @type Array<string>|Enums.VizPalette
      * @public
      */

--- a/js/viz/pie_chart.d.ts
+++ b/js/viz/pie_chart.d.ts
@@ -607,7 +607,7 @@ export interface dxPieChartSeriesTypesCommonPieChartSeries {
     label?: {
       /**
        * @docid dxPieChartSeriesTypes.CommonPieChartSeries.label.argumentFormat
-       * @type format
+       * @type Format
        * @default undefined
        */
       argumentFormat?: Format;
@@ -677,7 +677,7 @@ export interface dxPieChartSeriesTypesCommonPieChartSeries {
       font?: Font;
       /**
        * @docid dxPieChartSeriesTypes.CommonPieChartSeries.label.format
-       * @type format
+       * @type Format
        * @default undefined
        */
       format?: Format;

--- a/js/viz/pie_chart.d.ts
+++ b/js/viz/pie_chart.d.ts
@@ -227,7 +227,7 @@ export interface dxPieChartOptions extends BaseChartOptions<dxPieChart> {
     onLegendClick?: ((e: LegendClickEvent) => void) | string;
     /**
      * @docid
-     * @extends CommonVizPalette
+     * @default "Material"
      * @type Array<string>|Enums.VizPalette
      * @public
      */

--- a/js/viz/pie_chart.d.ts
+++ b/js/viz/pie_chart.d.ts
@@ -607,7 +607,8 @@ export interface dxPieChartSeriesTypesCommonPieChartSeries {
     label?: {
       /**
        * @docid dxPieChartSeriesTypes.CommonPieChartSeries.label.argumentFormat
-       * @extends CommonVizFormat
+       * @type format
+       * @default undefined
        */
       argumentFormat?: Format;
       /**
@@ -676,7 +677,8 @@ export interface dxPieChartSeriesTypesCommonPieChartSeries {
       font?: Font;
       /**
        * @docid dxPieChartSeriesTypes.CommonPieChartSeries.label.format
-       * @extends CommonVizFormat
+       * @type format
+       * @default undefined
        */
       format?: Format;
       /**

--- a/js/viz/polar_chart.d.ts
+++ b/js/viz/polar_chart.d.ts
@@ -641,7 +641,8 @@ export interface dxPolarChartArgumentAxisLabel extends dxPolarChartCommonAxisSet
     customizeText?: ((argument: { value?: Date | number | string; valueText?: string }) => string);
     /**
      * @docid dxPolarChartOptions.argumentAxis.label.format
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     format?: Format;
@@ -1270,7 +1271,8 @@ export interface dxPolarChartValueAxisLabel extends dxPolarChartCommonAxisSettin
     customizeText?: ((axisValue: { value?: Date | number | string; valueText?: string }) => string);
     /**
      * @docid dxPolarChartOptions.valueAxis.label.format
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     format?: Format;
@@ -1845,7 +1847,8 @@ export interface dxPolarChartSeriesTypesCommonPolarChartSeries {
 export interface dxPolarChartSeriesTypesCommonPolarChartSeriesLabel {
     /**
      * @docid dxPolarChartSeriesTypes.CommonPolarChartSeries.label.argumentFormat
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     argumentFormat?: Format;
@@ -1924,7 +1927,8 @@ export interface dxPolarChartSeriesTypesCommonPolarChartSeriesLabel {
     font?: Font;
     /**
      * @docid dxPolarChartSeriesTypes.CommonPolarChartSeries.label.format
-     * @extends CommonVizFormat
+     * @type format
+     * @default undefined
      * @public
      */
     format?: Format;

--- a/js/viz/polar_chart.d.ts
+++ b/js/viz/polar_chart.d.ts
@@ -641,7 +641,7 @@ export interface dxPolarChartArgumentAxisLabel extends dxPolarChartCommonAxisSet
     customizeText?: ((argument: { value?: Date | number | string; valueText?: string }) => string);
     /**
      * @docid dxPolarChartOptions.argumentAxis.label.format
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */
@@ -1271,7 +1271,7 @@ export interface dxPolarChartValueAxisLabel extends dxPolarChartCommonAxisSettin
     customizeText?: ((axisValue: { value?: Date | number | string; valueText?: string }) => string);
     /**
      * @docid dxPolarChartOptions.valueAxis.label.format
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */
@@ -1847,7 +1847,7 @@ export interface dxPolarChartSeriesTypesCommonPolarChartSeries {
 export interface dxPolarChartSeriesTypesCommonPolarChartSeriesLabel {
     /**
      * @docid dxPolarChartSeriesTypes.CommonPolarChartSeries.label.argumentFormat
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */
@@ -1927,7 +1927,7 @@ export interface dxPolarChartSeriesTypesCommonPolarChartSeriesLabel {
     font?: Font;
     /**
      * @docid dxPolarChartSeriesTypes.CommonPolarChartSeries.label.format
-     * @type format
+     * @type Format
      * @default undefined
      * @public
      */

--- a/js/viz/range_selector.d.ts
+++ b/js/viz/range_selector.d.ts
@@ -302,7 +302,8 @@ export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelecto
     containerBackgroundColor?: string;
     /**
      * @docid
-     * @extends CommonVizDataSource
+     * @type Array<any>|Store|DataSource|DataSourceOptions|string
+     * @notUsedInTheme
      * @public
      */
     dataSource?: Array<any> | Store | DataSource | DataSourceOptions | string;

--- a/js/viz/range_selector.d.ts
+++ b/js/viz/range_selector.d.ts
@@ -441,7 +441,7 @@ export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelecto
         font?: Font;
         /**
          * @docid
-         * @type format
+         * @type Format
          * @default undefined
          */
         format?: Format;
@@ -491,7 +491,7 @@ export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelecto
           customizeText?: ((markerValue: { value?: Date | number; valueText?: string }) => string);
           /**
            * @docid
-           * @type format
+           * @type Format
            * @default undefined
            */
           format?: Format;
@@ -717,7 +717,7 @@ export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelecto
       font?: Font;
       /**
        * @docid
-       * @type format
+       * @type Format
        * @default undefined
        */
       format?: Format;

--- a/js/viz/range_selector.d.ts
+++ b/js/viz/range_selector.d.ts
@@ -440,7 +440,8 @@ export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelecto
         font?: Font;
         /**
          * @docid
-         * @extends CommonVizFormat
+         * @type format
+         * @default undefined
          */
         format?: Format;
         /**
@@ -489,7 +490,8 @@ export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelecto
           customizeText?: ((markerValue: { value?: Date | number; valueText?: string }) => string);
           /**
            * @docid
-           * @extends CommonVizFormat
+           * @type format
+           * @default undefined
            */
           format?: Format;
         };
@@ -714,7 +716,8 @@ export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelecto
       font?: Font;
       /**
        * @docid
-       * @extends CommonVizFormat
+       * @type format
+       * @default undefined
        */
       format?: Format;
       /**

--- a/js/viz/range_selector.d.ts
+++ b/js/viz/range_selector.d.ts
@@ -217,7 +217,7 @@ export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelecto
       negativesAsZeroes?: boolean;
       /**
        * @docid
-       * @extends CommonVizPalette
+       * @default "Material"
        * @type Array<string>|Enums.VizPalette
        */
       palette?: Array<string> | PaletteType;

--- a/js/viz/sankey.d.ts
+++ b/js/viz/sankey.d.ts
@@ -483,7 +483,7 @@ export interface dxSankeyOptions extends BaseWidgetOptions<dxSankey> {
     onNodeHoverChanged?: ((e: NodeHoverEvent) => void);
     /**
      * @docid
-     * @extends CommonVizPalette
+     * @default "Material"
      * @type Array<string>|Enums.VizPalette
      * @public
      */

--- a/js/viz/sankey.d.ts
+++ b/js/viz/sankey.d.ts
@@ -112,7 +112,8 @@ export interface dxSankeyOptions extends BaseWidgetOptions<dxSankey> {
     alignment?: 'bottom' | 'center' | 'top' | Array<'bottom' | 'center' | 'top'>;
     /**
      * @docid
-     * @extends CommonVizDataSource
+     * @type Array<any>|Store|DataSource|DataSourceOptions|string
+     * @notUsedInTheme
      * @public
      */
     dataSource?: Array<any> | Store | DataSource | DataSourceOptions | string;

--- a/js/viz/sparkline.d.ts
+++ b/js/viz/sparkline.d.ts
@@ -75,7 +75,8 @@ export interface dxSparklineOptions extends BaseSparklineOptions<dxSparkline> {
     barPositiveColor?: string;
     /**
      * @docid
-     * @extends CommonVizDataSource
+     * @type Array<any>|Store|DataSource|DataSourceOptions|string
+     * @notUsedInTheme
      * @public
      */
     dataSource?: Array<any> | Store | DataSource | DataSourceOptions | string;

--- a/js/viz/tree_map.d.ts
+++ b/js/viz/tree_map.d.ts
@@ -125,7 +125,7 @@ export interface dxTreeMapOptions extends BaseWidgetOptions<dxTreeMap> {
       colorizeGroups?: boolean;
       /**
        * @docid
-       * @extends CommonVizPalette
+       * @default "Material"
        * @type Array<string>|Enums.VizPalette
        */
       palette?: Array<string> | PaletteType;

--- a/js/viz/tree_map.d.ts
+++ b/js/viz/tree_map.d.ts
@@ -149,7 +149,8 @@ export interface dxTreeMapOptions extends BaseWidgetOptions<dxTreeMap> {
     };
     /**
      * @docid
-     * @extends CommonVizDataSource
+     * @type Array<any>|Store|DataSource|DataSourceOptions|string
+     * @notUsedInTheme
      * @public
      */
     dataSource?: Array<any> | Store | DataSource | DataSourceOptions | string;

--- a/js/viz/vector_map.d.ts
+++ b/js/viz/vector_map.d.ts
@@ -435,7 +435,7 @@ export interface dxVectorMapOptions extends BaseWidgetOptions<dxVectorMap> {
       opacity?: number;
       /**
        * @docid
-       * @extends CommonVizPalette
+       * @default "Material"
        * @type Array<string>|Enums.VizPalette
        */
       palette?: Array<string> | PaletteType;

--- a/js/viz/vector_map.d.ts
+++ b/js/viz/vector_map.d.ts
@@ -364,7 +364,6 @@ export interface dxVectorMapOptions extends BaseWidgetOptions<dxVectorMap> {
       /**
        * @docid
        * @type object|Store|DataSource|DataSourceOptions|string|Array<any>
-       * @type Array<any>|Store|DataSource|DataSourceOptions|string
        * @notUsedInTheme
        */
       dataSource?: any | Store | DataSource | DataSourceOptions | string;

--- a/js/viz/vector_map.d.ts
+++ b/js/viz/vector_map.d.ts
@@ -364,7 +364,8 @@ export interface dxVectorMapOptions extends BaseWidgetOptions<dxVectorMap> {
       /**
        * @docid
        * @type object|Store|DataSource|DataSourceOptions|string|Array<any>
-       * @extends CommonVizDataSource
+       * @type Array<any>|Store|DataSource|DataSourceOptions|string
+       * @notUsedInTheme
        */
       dataSource?: any | Store | DataSource | DataSourceOptions | string;
       /**


### PR DESCRIPTION
https://trello.com/c/jcyQ0lw1/993-remove-pseudo-tags

Notes:
- change `@type format` to `@type Format` - first one failed validatie-ts task and ts type is specified as Format.
- when @type has less info than ts type - I deleted @type (mostly was `@type function` and ts type that says what it accept and return)