### PR TITLE
dxScheduler - Embed Toolbar into Scheduler

### DIFF
--- a/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
+++ b/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
@@ -59,7 +59,7 @@ describe('Scheduler', () => {
         accessKey: 'A',
         activeStateEnabled: true,
         disabled: true,
-        focusStateEnabled: true,
+        focusStateEnabled: false,
         height: 100,
         hint: 'hint',
         hoverStateEnabled: true,

--- a/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
+++ b/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
@@ -49,7 +49,7 @@ describe('Scheduler', () => {
       />,
     );
 
-    it('should be rendered', () => {
+    it('should render correct markup and pass correct props to the toolbar', () => {
       const tree = renderComponent({});
 
       expect(tree.is(Widget)).toBe(true);

--- a/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
+++ b/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
@@ -120,8 +120,13 @@ describe('Scheduler', () => {
         ],
         customizeDateNavigatorText: () => {},
       };
+      const setCurrentDate = () => {};
+      const setCurrentView = () => {};
+      const startViewDate = new Date(2021, 1, 1);
 
-      const tree = renderComponent({ props });
+      const tree = renderComponent({
+        props, setCurrentView, setCurrentDate, startViewDate,
+      });
       const schedulerToolbar = tree.find(SchedulerToolbar);
 
       expect(schedulerToolbar.exists())
@@ -139,6 +144,9 @@ describe('Scheduler', () => {
           currentView: props.currentView,
           useDropDownViewSwitcher: props.useDropDownViewSwitcher,
           customizationFunction: props.customizeDateNavigatorText,
+          onCurrentViewUpdate: setCurrentView,
+          onCurrentDateUpdate: setCurrentDate,
+          startViewDate,
         });
     });
   });

--- a/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
+++ b/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
@@ -122,22 +122,15 @@ describe('Scheduler', () => {
       };
 
       const tree = renderComponent({ props });
-
       const schedulerToolbar = tree.find(SchedulerToolbar);
-
-      const {
-        currentDate,
-        intervalCount,
-        firstDayOfWeek,
-      } = defaultCurrentViewConfig;
 
       expect(schedulerToolbar.exists())
         .toBe(true);
       expect(schedulerToolbar.props())
         .toEqual({
-          currentDate,
-          intervalCount,
-          firstDayOfWeek,
+          currentDate: defaultCurrentViewConfig.currentDate,
+          intervalCount: defaultCurrentViewConfig.intervalCount,
+          firstDayOfWeek: defaultCurrentViewConfig.firstDayOfWeek,
 
           items: props.toolbar,
           min: props.min,

--- a/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
+++ b/js/renovation/ui/scheduler/__tests__/scheduler.test.tsx
@@ -375,7 +375,7 @@ describe('Scheduler', () => {
       });
 
       describe('startViewDate', () => {
-        it('should return passed currentDate', () => {
+        it('should return correct startViewDate if view is day', () => {
           const scheduler = new Scheduler({
             ...new SchedulerProps(),
             currentDate: new Date(2021, 1, 1),
@@ -385,25 +385,15 @@ describe('Scheduler', () => {
             .toBe(new Date(2021, 1, 1).getTime());
         });
 
-        it('should return startViewDate from viewDataProvider', () => {
+        it('should return correct startViewDate if view is week', () => {
           const scheduler = new Scheduler({
             ...new SchedulerProps(),
-          });
-
-          const viewDataProvider = new ViewDataProvider('week') as any;
-          viewDataProvider.getStartViewDate = () => new Date(2021, 1, 1);
-          const cellsMetaData = {
-            dateTableCellsMeta: [],
-            allDayPanelCellsMeta: [],
-          };
-
-          scheduler.onViewRendered({
-            viewDataProvider,
-            cellsMetaData,
+            currentDate: new Date(2021, 7, 19),
+            currentView: 'week',
           });
 
           expect(scheduler.startViewDate.getTime())
-            .toBe(new Date(2021, 1, 1).getTime());
+            .toBe(new Date(2021, 7, 15).getTime());
         });
       });
     });

--- a/js/renovation/ui/scheduler/header/__tests__/header.test.tsx
+++ b/js/renovation/ui/scheduler/header/__tests__/header.test.tsx
@@ -17,7 +17,7 @@ describe('Scheduler Toolbar', () => {
     );
 
     it('should render and pass', () => {
-      const toolbar = render({ items: 'items' });
+      const toolbar = render({ items: 'items' }).childAt(0);
 
       expect(toolbar.is(Toolbar)).toBe(true);
       expect(toolbar.prop('items')).toEqual('items');
@@ -221,6 +221,42 @@ describe('Scheduler Toolbar', () => {
           const toolbar = createToolbar({ currentView: 'timelineMonth' });
 
           expect(toolbar.step).toBe('month');
+        });
+      });
+
+      describe('Displayed date', () => {
+        it('should retun correct displayed date for week view', () => {
+          const toolbar = createToolbar({
+            currentDate: new Date(2021, 4, 7),
+            currentView: 'week',
+            views: {
+              type: 'week',
+              intervalCount: 3,
+              startDate: new Date(2021, 4, 5),
+            },
+          });
+
+          expect(toolbar.displayedDate.getTime())
+            .toBe(new Date(2021, 4, 7).getTime());
+        });
+
+        it('should retun startViewDate props', () => {
+          const toolbar = createToolbar({
+            startViewDate: new Date(2021, 5, 10),
+          });
+
+          expect(toolbar.displayedDate.getTime())
+            .toBe(new Date(2021, 5, 10).getTime());
+        });
+
+        it('should retun next week of startViewDate if view is month', () => {
+          const toolbar = createToolbar({
+            currentView: 'month',
+            startViewDate: new Date(2021, 5, 10),
+          });
+
+          expect(toolbar.displayedDate.getTime())
+            .toBe(new Date(2021, 5, 17).getTime());
         });
       });
 

--- a/js/renovation/ui/scheduler/header/__tests__/header.test.tsx
+++ b/js/renovation/ui/scheduler/header/__tests__/header.test.tsx
@@ -17,8 +17,10 @@ describe('Scheduler Toolbar', () => {
     );
 
     it('should render and pass', () => {
-      const toolbar = render({ items: 'items' }).childAt(0);
+      const tree = render({ items: 'items' });
+      const toolbar = tree.childAt(0);
 
+      expect(tree.hasClass(HEADER_CLASS)).toBe(true);
       expect(toolbar.is(Toolbar)).toBe(true);
       expect(toolbar.prop('items')).toEqual('items');
     });
@@ -235,15 +237,6 @@ describe('Scheduler Toolbar', () => {
 
           expect(toolbar.displayedDate.getTime())
             .toBe(new Date(2021, 4, 4).getTime());
-        });
-
-        it('should retun startViewDate props', () => {
-          const toolbar = createToolbar({
-            startViewDate: new Date(2021, 5, 10),
-          });
-
-          expect(toolbar.displayedDate.getTime())
-            .toBe(new Date(2021, 5, 10).getTime());
         });
 
         it('should retun next week of startViewDate if view is month', () => {

--- a/js/renovation/ui/scheduler/header/__tests__/header.test.tsx
+++ b/js/renovation/ui/scheduler/header/__tests__/header.test.tsx
@@ -225,7 +225,7 @@ describe('Scheduler Toolbar', () => {
       });
 
       describe('Displayed date', () => {
-        it('should retun correct displayed date for week view', () => {
+        it('should retun correct displayed date if view is week', () => {
           const toolbar = createToolbar({
             currentDate: new Date(2021, 4, 7),
             currentView: 'week',

--- a/js/renovation/ui/scheduler/header/__tests__/header.test.tsx
+++ b/js/renovation/ui/scheduler/header/__tests__/header.test.tsx
@@ -30,6 +30,7 @@ describe('Scheduler Toolbar', () => {
       currentView: 'day',
       views: ['day', 'week'],
       currentDate: new Date(2021, 7, 7),
+      startViewDate: new Date(2021, 7, 7),
       items: [
         {
           defaultElement: 'dateNavigator',
@@ -184,6 +185,7 @@ describe('Scheduler Toolbar', () => {
         'week', 'workWeek',
       ],
       currentDate: new Date(2021, 7, 7),
+      startViewDate: new Date(2021, 7, 7),
       items: [
         {
           defaultElement: 'dateNavigator',
@@ -225,19 +227,14 @@ describe('Scheduler Toolbar', () => {
       });
 
       describe('Displayed date', () => {
-        it('should retun correct displayed date if view is week', () => {
+        it('should retun correct displayed date', () => {
           const toolbar = createToolbar({
             currentDate: new Date(2021, 4, 7),
-            currentView: 'week',
-            views: {
-              type: 'week',
-              intervalCount: 3,
-              startDate: new Date(2021, 4, 5),
-            },
+            startViewDate: new Date(2021, 4, 4),
           });
 
           expect(toolbar.displayedDate.getTime())
-            .toBe(new Date(2021, 4, 7).getTime());
+            .toBe(new Date(2021, 4, 4).getTime());
         });
 
         it('should retun startViewDate props', () => {
@@ -383,7 +380,7 @@ describe('Scheduler Toolbar', () => {
             expect(previousButton.items![0].icon).toBe('chevronprev');
           });
 
-          it('should return correct dateNavigator calendat button text', () => {
+          it('should return correct dateNavigator calendar button text', () => {
             const toolbar = createToolbar();
 
             const previousButton = toolbar.items[0].options as ToolbarButtonGroupProps;

--- a/js/renovation/ui/scheduler/header/header.tsx
+++ b/js/renovation/ui/scheduler/header/header.tsx
@@ -15,12 +15,11 @@ import '../../../../ui/drop_down_button';
 
 import dateUtils from '../../../../core/utils/date';
 import {
-  getCaption,
+  getCaption, nextWeek,
   getStep, getViewName,
   getNextIntervalDate,
-  getViewType, nextWeek,
 } from '../../../../ui/scheduler/header/utils';
-import { formToolbarItem, formatViews } from './utils';
+import { formToolbarItem, formatViews, isMonthView } from './utils';
 
 import type { DateNavigatorTextInfo } from '../../../../ui/scheduler';
 import {
@@ -83,7 +82,7 @@ export default class SchedulerToolbar extends JSXComponent<SchedulerToolbarProps
   get displayedDate(): Date {
     const startViewDate = new Date(this.props.startViewDate);
 
-    if (this.isMonth()) {
+    if (isMonthView(this.props.currentView)) {
       return nextWeek(startViewDate);
     }
 
@@ -116,11 +115,6 @@ export default class SchedulerToolbar extends JSXComponent<SchedulerToolbarProps
 
   get selectedView(): string {
     return getViewName(this.props.currentView) as string;
-  }
-
-  isMonth(): boolean {
-    const { currentView } = this.props;
-    return getViewType(currentView) as string === 'month';
   }
 
   setCurrentView(view: ItemView): void {

--- a/js/renovation/ui/scheduler/header/header.tsx
+++ b/js/renovation/ui/scheduler/header/header.tsx
@@ -18,6 +18,7 @@ import {
   getCaption,
   getStep, getViewName,
   getNextIntervalDate,
+  getViewType, nextWeek,
 } from '../../../../ui/scheduler/header/utils';
 import { formToolbarItem, formatViews } from './utils';
 
@@ -34,7 +35,13 @@ import { ToolbarItem } from '../../toolbar/toolbar_props';
 const { trimTime } = dateUtils;
 
 export const viewFunction = (viewModel: SchedulerToolbar): JSX.Element => (
-  <Toolbar items={viewModel.items} />
+  <div
+    className="dx-scheduler-header"
+  >
+    <Toolbar
+      items={viewModel.items}
+    />
+  </div>
 );
 
 @ComponentBindings()
@@ -48,6 +55,8 @@ export class SchedulerToolbarBaseProps {
   @OneWay() currentDate: Date = new Date();
 
   @Event() onCurrentDateUpdate!: (date: Date) => void;
+
+  @OneWay() startViewDate?: Date;
 
   @OneWay() intervalCount = 1;
 
@@ -71,13 +80,27 @@ export default class SchedulerToolbar extends JSXComponent<SchedulerToolbarProps
     return getStep(this.props.currentView) as string;
   }
 
+  get displayedDate(): Date {
+    if (this.props.startViewDate) {
+      const startViewDate = new Date(this.props.startViewDate);
+
+      if (this.isMonth()) {
+        return nextWeek(startViewDate);
+      }
+
+      return startViewDate;
+    }
+
+    return new Date(this.props.currentDate);
+  }
+
   get caption(): DateNavigatorTextInfo {
     const options = {
       step: this.step,
       intervalCount: this.props.intervalCount,
       firstDayOfWeek: this.props.firstDayOfWeek,
       agendaDuration: this.props.agendaDuration,
-      date: this.props.currentDate,
+      date: this.displayedDate,
     };
 
     return getCaption(
@@ -97,6 +120,11 @@ export default class SchedulerToolbar extends JSXComponent<SchedulerToolbarProps
 
   get selectedView(): string {
     return getViewName(this.props.currentView) as string;
+  }
+
+  isMonth(): boolean {
+    const { currentView } = this.props;
+    return getViewType(currentView) as string === 'month';
   }
 
   setCurrentView(view: ItemView): void {

--- a/js/renovation/ui/scheduler/header/header.tsx
+++ b/js/renovation/ui/scheduler/header/header.tsx
@@ -81,17 +81,13 @@ export default class SchedulerToolbar extends JSXComponent<SchedulerToolbarProps
   }
 
   get displayedDate(): Date {
-    if (this.props.startViewDate) {
-      const startViewDate = new Date(this.props.startViewDate);
+    const startViewDate = new Date(this.props.startViewDate);
 
-      if (this.isMonth()) {
-        return nextWeek(startViewDate);
-      }
-
-      return startViewDate;
+    if (this.isMonth()) {
+      return nextWeek(startViewDate);
     }
 
-    return new Date(this.props.currentDate);
+    return startViewDate;
   }
 
   get caption(): DateNavigatorTextInfo {

--- a/js/renovation/ui/scheduler/header/header.tsx
+++ b/js/renovation/ui/scheduler/header/header.tsx
@@ -52,11 +52,11 @@ export class SchedulerToolbarBaseProps {
 
   @Event() onCurrentViewUpdate!: (view: string | ViewType) => void;
 
-  @OneWay() currentDate: Date = new Date();
+  @OneWay() currentDate!: Date;
 
   @Event() onCurrentDateUpdate!: (date: Date) => void;
 
-  @OneWay() startViewDate?: Date;
+  @OneWay() startViewDate!: Date;
 
   @OneWay() intervalCount = 1;
 
@@ -73,7 +73,7 @@ export type SchedulerToolbarProps = SchedulerToolbarBaseProps
 & Pick<SchedulerProps, 'currentView' | 'min' | 'max' | 'useDropDownViewSwitcher'>;
 
 @Component({ view: viewFunction })
-export default class SchedulerToolbar extends JSXComponent<SchedulerToolbarProps, 'items' | 'views' | 'onCurrentViewUpdate' | 'onCurrentDateUpdate'>() {
+export default class SchedulerToolbar extends JSXComponent<SchedulerToolbarProps, 'items' | 'views' | 'onCurrentViewUpdate' | 'currentDate' | 'onCurrentDateUpdate' | 'startViewDate'>() {
   cssClass = 'dx-scheduler-header';
 
   get step(): string {

--- a/js/renovation/ui/scheduler/header/utils.ts
+++ b/js/renovation/ui/scheduler/header/utils.ts
@@ -8,7 +8,10 @@ import { ToolbarItem } from '../../toolbar/toolbar_props';
 import { ViewProps } from '../props';
 import { SchedulerToolbarItem } from './props';
 
-import { validateViews, getViewName, getViewText } from '../../../../ui/scheduler/header/utils';
+import {
+  validateViews, getViewName,
+  getViewText, getViewType,
+} from '../../../../ui/scheduler/header/utils';
 
 const DEFAULT_ELEMENT = 'defaultElement';
 const VIEW_SWITCHER = 'viewSwitcher';
@@ -66,3 +69,5 @@ export const formatViews = (views: (ViewType | ViewProps)[]): ItemView[] => {
     return { text, name };
   });
 };
+
+export const isMonthView = (currentView: string): boolean => getViewType(currentView) as string === 'month';

--- a/js/renovation/ui/scheduler/scheduler.tsx
+++ b/js/renovation/ui/scheduler/scheduler.tsx
@@ -186,17 +186,9 @@ export class Scheduler extends JSXComponent(SchedulerProps) {
     return this.instance.getEndViewDate();
   }
 
-  get startViewDate(): Date {
-    if (this.viewDataProvider) {
-      return this.viewDataProvider.getStartViewDate();
-    }
-
-    return this.currentViewConfig.currentDate;
-  }
-
   @Method()
   getStartViewDate(): Date {
-    return this.startViewDate;
+    return this.instance.getStartViewDate();
   }
 
   @Method()
@@ -249,5 +241,13 @@ export class Scheduler extends JSXComponent(SchedulerProps) {
 
   setCurrentDate(date: Date): void {
     this.props.currentDate = date;
+  }
+
+  get startViewDate(): Date {
+    if (this.viewDataProvider) {
+      return this.viewDataProvider.getStartViewDate();
+    }
+
+    return this.currentViewConfig.currentDate;
   }
 }

--- a/js/renovation/ui/scheduler/scheduler.tsx
+++ b/js/renovation/ui/scheduler/scheduler.tsx
@@ -19,6 +19,7 @@ import { CurrentViewConfigType } from './workspaces/props';
 import { CellsMetaData, ViewDataProviderType, ViewMetaData } from './workspaces/types';
 import { WorkSpace } from './workspaces/base/work_space';
 import SchedulerToolbar from './header/header';
+import { getViewDataGeneratorByViewType } from '../../../ui/scheduler/workspaces/view_model/utils';
 
 export const viewFunction = ({
   restAttributes,
@@ -157,11 +158,27 @@ export class Scheduler extends JSXComponent(SchedulerProps) {
   }
 
   get startViewDate(): Date {
-    if (this.viewDataProvider) {
-      return this.viewDataProvider.getStartViewDate();
-    }
+    const type = this.props.currentView;
+    const {
+      currentDate,
+      startDayHour,
+      startDate,
+      intervalCount,
+      firstDayOfWeek,
+    } = this.currentViewConfig;
 
-    return this.currentViewConfig.currentDate;
+    const options = {
+      currentDate,
+      startDayHour,
+      startDate,
+      intervalCount,
+      firstDayOfWeek,
+    };
+
+    const viewDataGenerator = getViewDataGeneratorByViewType(type);
+    const startViewDate = viewDataGenerator.getStartViewDate(options) as Date;
+
+    return startViewDate;
   }
 
   @Method()

--- a/js/renovation/ui/scheduler/scheduler.tsx
+++ b/js/renovation/ui/scheduler/scheduler.tsx
@@ -18,16 +18,19 @@ import { getCurrentViewConfig, getCurrentViewProps } from './model/views';
 import { CurrentViewConfigType } from './workspaces/props';
 import { CellsMetaData, ViewDataProviderType, ViewMetaData } from './workspaces/types';
 import { WorkSpace } from './workspaces/base/work_space';
+import SchedulerToolbar from './header/header';
 
 export const viewFunction = ({
   restAttributes,
   currentViewConfig,
   onViewRendered,
+  setCurrentDate,
+  setCurrentView,
+  startViewDate,
   props: {
     accessKey,
     activeStateEnabled,
     disabled,
-    focusStateEnabled,
     height,
     hint,
     hoverStateEnabled,
@@ -36,6 +39,13 @@ export const viewFunction = ({
     visible,
     width,
     className,
+    toolbar: toolbarItems,
+    views,
+    currentView,
+    useDropDownViewSwitcher,
+    customizeDateNavigatorText,
+    min,
+    max,
   },
 }: Scheduler): JSX.Element => {
   const {
@@ -68,7 +78,7 @@ export const viewFunction = ({
       accessKey={accessKey}
       activeStateEnabled={activeStateEnabled}
       disabled={disabled}
-      focusStateEnabled={focusStateEnabled}
+      focusStateEnabled={false}// TODO: waiting for a toolbar wrapper rerender fix
       height={height}
       hint={hint}
       hoverStateEnabled={hoverStateEnabled}
@@ -80,6 +90,21 @@ export const viewFunction = ({
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...restAttributes}
     >
+      <SchedulerToolbar
+        items={toolbarItems}
+        views={views}
+        currentView={currentView}
+        onCurrentViewUpdate={setCurrentView}
+        currentDate={currentDate}
+        onCurrentDateUpdate={setCurrentDate}
+        startViewDate={startViewDate}
+        min={min}
+        max={max}
+        intervalCount={intervalCount}
+        firstDayOfWeek={firstDayOfWeek}
+        useDropDownViewSwitcher={useDropDownViewSwitcher}
+        customizationFunction={customizeDateNavigatorText}
+      />
       <WorkSpace
         firstDayOfWeek={firstDayOfWeek}
         startDayHour={startDayHour}
@@ -161,9 +186,17 @@ export class Scheduler extends JSXComponent(SchedulerProps) {
     return this.instance.getEndViewDate();
   }
 
+  get startViewDate(): Date {
+    if (this.viewDataProvider) {
+      return this.viewDataProvider.getStartViewDate();
+    }
+
+    return this.currentViewConfig.currentDate;
+  }
+
   @Method()
   getStartViewDate(): Date {
-    return this.instance.getStartViewDate();
+    return this.startViewDate;
   }
 
   @Method()
@@ -208,5 +241,13 @@ export class Scheduler extends JSXComponent(SchedulerProps) {
   onViewRendered(viewMetaData: ViewMetaData): void {
     this.viewDataProvider = viewMetaData.viewDataProvider;
     this.cellsMetaData = viewMetaData.cellsMetaData;
+  }
+
+  setCurrentView(view: string): void {
+    this.props.currentView = view;
+  }
+
+  setCurrentDate(date: Date): void {
+    this.props.currentDate = date;
   }
 }

--- a/js/renovation/ui/scheduler/scheduler.tsx
+++ b/js/renovation/ui/scheduler/scheduler.tsx
@@ -156,6 +156,14 @@ export class Scheduler extends JSXComponent(SchedulerProps) {
     return getCurrentViewConfig(this.currentViewProps, this.props);
   }
 
+  get startViewDate(): Date {
+    if (this.viewDataProvider) {
+      return this.viewDataProvider.getStartViewDate();
+    }
+
+    return this.currentViewConfig.currentDate;
+  }
+
   @Method()
   getComponentInstance(): dxScheduler {
     return this.instance;
@@ -241,13 +249,5 @@ export class Scheduler extends JSXComponent(SchedulerProps) {
 
   setCurrentDate(date: Date): void {
     this.props.currentDate = date;
-  }
-
-  get startViewDate(): Date {
-    if (this.viewDataProvider) {
-      return this.viewDataProvider.getStartViewDate();
-    }
-
-    return this.currentViewConfig.currentDate;
   }
 }

--- a/js/renovation/ui/scheduler/workspaces/types.d.ts
+++ b/js/renovation/ui/scheduler/workspaces/types.d.ts
@@ -157,6 +157,7 @@ export interface ViewDataProviderType {
   getRowCount: (config: CountGenerationConfig) => number;
   update: (options: unknown, isGenerateNewData: boolean) => void;
   getGroupPanelData: (options: unknown) => GroupPanelData;
+  getStartViewDate: () => Date;
 }
 
 export interface CellsMetaData {

--- a/js/ui/scheduler/workspaces/view_model/utils.js
+++ b/js/ui/scheduler/workspaces/view_model/utils.js
@@ -1,0 +1,27 @@
+import { VIEWS } from '../../constants';
+import { ViewDataGenerator } from './view_data_generator';
+import { ViewDataGeneratorDay } from './view_data_generator_day';
+import { ViewDataGeneratorMonth } from './view_data_generator_month';
+import { ViewDataGeneratorTimelineMonth } from './view_data_generator_timeline_month';
+import { ViewDataGeneratorWeek } from './view_data_generator_week';
+import { ViewDataGeneratorWorkWeek } from './view_data_generator_work_week';
+
+export const getViewDataGeneratorByViewType = (viewType) => {
+    switch(viewType) {
+        case VIEWS.MONTH:
+            return new ViewDataGeneratorMonth();
+        case VIEWS.TIMELINE_MONTH:
+            return new ViewDataGeneratorTimelineMonth();
+        case VIEWS.DAY:
+        case VIEWS.TIMELINE_DAY:
+            return new ViewDataGeneratorDay();
+        case VIEWS.WEEK:
+        case VIEWS.TIMELINE_WEEK:
+            return new ViewDataGeneratorWeek();
+        case VIEWS.WORK_WEEK:
+        case VIEWS.TIMELINE_WORK_WEEK:
+            return new ViewDataGeneratorWorkWeek();
+        default:
+            return new ViewDataGenerator();
+    }
+};

--- a/js/ui/scheduler/workspaces/view_model/view_data_generator.js
+++ b/js/ui/scheduler/workspaces/view_model/view_data_generator.js
@@ -22,6 +22,10 @@ export class ViewDataGenerator {
 
     get tableAllDay() { return false; }
 
+    getStartViewDate(options) {
+        return this._calculateStartViewDate(options);
+    }
+
     getCompleteViewDataMap(options) {
         const {
             groups,

--- a/js/ui/scheduler/workspaces/view_model/view_data_provider.js
+++ b/js/ui/scheduler/workspaces/view_model/view_data_provider.js
@@ -1,38 +1,11 @@
 import dateUtils from '../../../../core/utils/date';
 import { getGroupPanelData } from '../../../../renovation/ui/scheduler/view_model/group_panel/utils';
 import { isGroupingByDate, isHorizontalGroupingApplied, isVerticalGroupingApplied } from '../../../../renovation/ui/scheduler/workspaces/utils';
-import { VIEWS } from '../../constants';
 import { calculateIsGroupedAllDayPanel } from '../../../../renovation/ui/scheduler/view_model/to_test/views/utils/base';
 import { DateHeaderDataGenerator } from './date_header_data_generator';
 import { GroupedDataMapProvider } from './grouped_data_map_provider';
 import { TimePanelDataGenerator } from './time_panel_data_generator';
-import { ViewDataGenerator } from './view_data_generator';
-import { ViewDataGeneratorDay } from './view_data_generator_day';
-import { ViewDataGeneratorMonth } from './view_data_generator_month';
-import { ViewDataGeneratorTimelineMonth } from './view_data_generator_timeline_month';
-import { ViewDataGeneratorWeek } from './view_data_generator_week';
-import { ViewDataGeneratorWorkWeek } from './view_data_generator_work_week';
-
-const getViewDataGeneratorByViewType = (viewType) => {
-    switch(viewType) {
-        case VIEWS.MONTH:
-            return new ViewDataGeneratorMonth();
-        case VIEWS.TIMELINE_MONTH:
-            return new ViewDataGeneratorTimelineMonth();
-        case VIEWS.DAY:
-        case VIEWS.TIMELINE_DAY:
-            return new ViewDataGeneratorDay();
-        case VIEWS.WEEK:
-        case VIEWS.TIMELINE_WEEK:
-            return new ViewDataGeneratorWeek();
-        case VIEWS.WORK_WEEK:
-        case VIEWS.TIMELINE_WORK_WEEK:
-            return new ViewDataGeneratorWorkWeek();
-        default:
-            return new ViewDataGenerator();
-
-    }
-};
+import { getViewDataGeneratorByViewType } from './utils';
 
 export default class ViewDataProvider {
     constructor(viewType) {


### PR DESCRIPTION
```ts
import React from 'react';
import { useState } from 'react';
import Scheduler from './artifacts/react/renovation/ui/scheduler/scheduler';

function App() {
    const [currentView, setCurrentView] = useState('week');
    const [currentDate, setCurrentDate] = useState(new Date(2021, 4, 7));

    return (
        <Scheduler
            currentView={currentView}
            currentViewChange={view => setCurrentView(view)}
            currentDate={currentDate}
            currentDateChange={date => setCurrentDate(date as Date)}
            views={[
                'day',
                {
                    type: 'week',
                    intervalCount: 3,
                    startDate: new Date(2021, 4, 5),
                },
                'month'
            ]}
        ></Scheduler>
    )
};

export default App;
```