### PR TITLE
DataGrid: Fix the column edit button display after collapsing and expanding a grouped row (T1022630)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -2134,7 +2134,7 @@ export const editingModule = {
                 },
                 _updateItemsCore: function(change) {
                     this.callBase(change);
-                    this._updateEditRow(this.items());
+                    this._updateEditRow(this.items(true));
                 },
                 _applyChangeUpdate: function(change) {
                     this._updateEditRow(change.items);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -16654,6 +16654,65 @@ QUnit.module('Editing with scrolling', {
             assert.ok(rowsViewWrapper.getDataRow(0).isNewRow(), 'Row 0 is new in view');
             assert.ok(rowsViewWrapper.getDataRow(1).isNewRow(), 'Row 1 is new in view');
         });
+
+        // T1022630
+        QUnit.test(`scrolling.mode: ${rowRenderingMode}, scrolling.rowRenderingMode: ${rowRenderingMode} - The column edit button should not be displayed after collapsing and expanding a grouped row when the visible property is false`, function(assert) {
+            // arrange
+            const $testElement = $('#container');
+
+            this.options = $.extend(this.options, {
+                columns: [{ dataField: 'column1', groupIndex: 0 }, 'column2', {
+                    type: 'buttons',
+                    buttons: [{
+                        name: 'edit',
+                        icon: 'home',
+                        visible: function(e) {
+                            return !e.row.isEditing;
+                        }
+                    }]
+                }],
+                keyExpr: 'column2',
+                editing: {
+                    mode: 'row',
+                    allowUpdating: true
+                },
+                grouping: {
+                    autoExpandAll: true
+                },
+                scrolling: {
+                    mode: rowRenderingMode,
+                    rowRenderingMode: rowRenderingMode,
+                    rowPageSize: 5
+                }
+            });
+
+            this.setupDataGrid();
+            this.rowsView.render($testElement);
+
+            // assert
+            let $linkElements = $testElement.find('.dx-command-edit').first().find('.dx-link');
+            assert.strictEqual($linkElements.length, 1, 'link count');
+            assert.ok($linkElements.eq(0).hasClass('dx-link-edit'), 'the edit link');
+
+            // act
+            this.editRow(1);
+
+            // assert
+            $linkElements = $testElement.find('.dx-command-edit').first().find('.dx-link');
+            assert.strictEqual($linkElements.length, 2, 'link count');
+            assert.ok($linkElements.eq(0).hasClass('dx-link-save'), 'the save link');
+            assert.ok($linkElements.eq(1).hasClass('dx-link-cancel'), 'the cancel link');
+
+            // act
+            this.collapseRow(['Item101']);
+            this.expandRow(['Item101']);
+
+            // assert
+            $linkElements = $testElement.find('.dx-command-edit').first().find('.dx-link');
+            assert.strictEqual($linkElements.length, 2, 'link count');
+            assert.ok($linkElements.eq(0).hasClass('dx-link-save'), 'the save link');
+            assert.ok($linkElements.eq(1).hasClass('dx-link-cancel'), 'the cancel link');
+        });
     });
 
     QUnit.test('DataGrid should show error message on adding row if dataSource is not specified (T711831)', function(assert) {


### PR DESCRIPTION
See https://devexpress.com/issue=T1022630