### PR TITLE
Execute workflows only when pushing to the 21_2 branch

### DIFF
--- a/.github/workflows/devextreme_npm_tests.yml
+++ b/.github/workflows/devextreme_npm_tests.yml
@@ -4,7 +4,10 @@ concurrency:
   group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [21_2]
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,10 @@ concurrency:
   group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [21_2]
 
 jobs:
   Renovation:

--- a/.github/workflows/qunit_tests-additional-renovation.yml
+++ b/.github/workflows/qunit_tests-additional-renovation.yml
@@ -4,7 +4,10 @@ concurrency:
   group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [21_2]
 
 jobs:
   build:

--- a/.github/workflows/qunit_tests-renovation.yml
+++ b/.github/workflows/qunit_tests-renovation.yml
@@ -4,7 +4,10 @@ concurrency:
   group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [21_2]
 
 jobs:
   build:

--- a/.github/workflows/renovation.yml
+++ b/.github/workflows/renovation.yml
@@ -4,7 +4,10 @@ concurrency:
   group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [21_2]
 
 jobs:
   jest-tests:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -4,7 +4,10 @@ concurrency:
   group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [21_2]
 
 jobs:
   Tests:

--- a/.github/workflows/testcafe_tests.yml
+++ b/.github/workflows/testcafe_tests.yml
@@ -4,7 +4,10 @@ concurrency:
   group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [21_2]
 
 jobs:
   testcafe:

--- a/.github/workflows/themebuilder_dart_tests.yml
+++ b/.github/workflows/themebuilder_dart_tests.yml
@@ -4,7 +4,10 @@ concurrency:
   group: wf-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [21_2]
 
 jobs:
   dart-test:


### PR DESCRIPTION
This prevents workflow runs on Renovate.Bot branches