### PR TITLE
TreeList - fix preserve arg in selectRows method

### DIFF
--- a/js/ui/tree_list/ui.tree_list.selection.js
+++ b/js/ui/tree_list/ui.tree_list.selection.js
@@ -177,7 +177,7 @@ treeListCore.registerModule('selection', extend(true, {}, selectionModule, {
                     const isRecursiveSelection = this.isRecursiveSelection();
                     const normalizedArgs = isRecursiveSelection && that._normalizeSelectionArgs({
                         keys: isDefined(value) ? value : []
-                    }, !isDeselect);
+                    }, preserve, !isDeselect);
 
                     if(normalizedArgs && !equalByValue(normalizedArgs.selectedRowKeys, selectedRowKeys)) {
                         that._isSelectionNormalizing = true;
@@ -337,11 +337,11 @@ treeListCore.registerModule('selection', extend(true, {}, selectionModule, {
                     });
                 },
 
-                _normalizeSelectedRowKeysCore: function(keys, args, isSelect) {
+                _normalizeSelectedRowKeysCore: function(keys, args, preserve, isSelect) {
                     const that = this;
 
                     keys.forEach(function(key) {
-                        if(that.isRowSelected(key) === isSelect) {
+                        if(preserve && that.isRowSelected(key) === isSelect) {
                             return;
                         }
 
@@ -363,7 +363,7 @@ treeListCore.registerModule('selection', extend(true, {}, selectionModule, {
                     });
                 },
 
-                _normalizeSelectionArgs: function(args, isSelect) {
+                _normalizeSelectionArgs: function(args, preserve, isSelect) {
                     let result;
                     const keys = Array.isArray(args.keys) ? args.keys : [args.keys];
                     const selectedRowKeys = this.option('selectedRowKeys') || [];
@@ -372,10 +372,10 @@ treeListCore.registerModule('selection', extend(true, {}, selectionModule, {
                         result = {
                             currentSelectedRowKeys: [],
                             currentDeselectedRowKeys: [],
-                            selectedRowKeys: selectedRowKeys.slice(0)
+                            selectedRowKeys: preserve ? selectedRowKeys.slice(0) : []
                         };
 
-                        this._normalizeSelectedRowKeysCore(keys, result, isSelect);
+                        this._normalizeSelectedRowKeysCore(keys, result, preserve, isSelect);
                     }
 
                     return result;

--- a/testing/tests/DevExpress.ui.widgets.treeList/selection.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/selection.tests.js
@@ -933,8 +933,8 @@ QUnit.module('Recursive selection', {
         // assert
         const items = this.dataController.items();
         assert.deepEqual(this.option('selectedRowKeys'), [3], 'selected row keys');
-        assert.ok(!items[0].isSelected, 'first item is not selected');
-        assert.ok(!items[1].isSelected, 'second item is not selected');
+        assert.notOk(items[0].isSelected, 'first item is not selected');
+        assert.notOk(items[1].isSelected, 'second item is not selected');
         assert.ok(items[2].isSelected, 'third item is selected');
     });
 

--- a/testing/tests/DevExpress.ui.widgets.treeList/selection.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/selection.tests.js
@@ -913,6 +913,31 @@ QUnit.module('Recursive selection', {
         assert.notOk(items[3].isSelected, 'fourth item isn\'t selected');
     });
 
+    QUnit.test('Selecting row with preserve = false', function(assert) {
+        // arrange
+        const $testElement = $('#treeList');
+
+        this.options.expandedRowKeys = [1];
+        this.options.dataSource = [
+            { id: 1, field1: 'test1' },
+            { id: 2, parentId: 1, field1: 'test2' },
+            { id: 3, parentId: 1, field1: 'test3' }
+        ],
+        this.setupTreeList();
+        this.rowsView.render($testElement);
+
+        // act
+        this.selectRows(2);
+        this.selectRows(3, false);
+
+        // assert
+        const items = this.dataController.items();
+        assert.deepEqual(this.option('selectedRowKeys'), [3], 'selected row keys');
+        assert.ok(!items[0].isSelected, 'first item is not selected');
+        assert.ok(!items[1].isSelected, 'second item is not selected');
+        assert.ok(items[2].isSelected, 'third item is selected');
+    });
+
     QUnit.test('Checking arguments of the \'onSelectionChanged\' event when select row', function(assert) {
     // arrange
         const selectionChangedArgs = [];


### PR DESCRIPTION
I added preverse arg to `_normalizeSelectionArgs` and `_normalizeSelectedRowKeysCore` methods of treeList. Previously they assumed that this arg is always `true`

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/19035
- https://github.com/DevExpress/DevExtreme/pull/19036