### PR TITLE
DataGrid - toolbar.disabled and toolbar.visible options

### DIFF
--- a/js/renovation/ui/grids/data_grid/common/data_grid_props.tsx
+++ b/js/renovation/ui/grids/data_grid/common/data_grid_props.tsx
@@ -1178,6 +1178,10 @@ export interface DataGridToolbarItem extends dxToolbarItem {
 @ComponentBindings()
 export class DataGridToolbar {
   @OneWay() items?: (DataGridDefaultToolbarItemName | DataGridToolbarItem)[];
+
+  @OneWay() visible?: boolean = true;
+
+  @OneWay() disabled?: boolean = false;
 }
 
 @ComponentBindings()

--- a/js/renovation/ui/grids/data_grid/common/data_grid_props.tsx
+++ b/js/renovation/ui/grids/data_grid/common/data_grid_props.tsx
@@ -1179,9 +1179,9 @@ export interface DataGridToolbarItem extends dxToolbarItem {
 export class DataGridToolbar {
   @OneWay() items?: (DataGridDefaultToolbarItemName | DataGridToolbarItem)[];
 
-  @OneWay() visible?: boolean = true;
+  @OneWay() visible?: boolean;
 
-  @OneWay() disabled?: boolean = false;
+  @OneWay() disabled?: boolean;
 }
 
 @ComponentBindings()
@@ -1552,7 +1552,10 @@ export class DataGridProps extends BaseWidgetProps /* implements Options */ {
     falseText: messageLocalization.format('dxDataGrid-falseText'),
   };
 
-  @OneWay() toolbar?: DataGridToolbar;
+  @OneWay() toolbar?: DataGridToolbar = {
+    visible: true,
+    disabled: false,
+  };
 
   @TwoWay() filterValue?: string | any[] | ((...args: any[]) => any) | null = null;
 

--- a/js/renovation/ui/grids/data_grid/common/data_grid_props.tsx
+++ b/js/renovation/ui/grids/data_grid/common/data_grid_props.tsx
@@ -1552,10 +1552,7 @@ export class DataGridProps extends BaseWidgetProps /* implements Options */ {
     falseText: messageLocalization.format('dxDataGrid-falseText'),
   };
 
-  @OneWay() toolbar?: DataGridToolbar = {
-    visible: true,
-    disabled: false,
-  };
+  @OneWay() toolbar?: DataGridToolbar;
 
   @TwoWay() filterValue?: string | any[] | ((...args: any[]) => any) | null = null;
 

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4158,14 +4158,14 @@ export interface dxDataGridToolbar {
   /**
    * @docid
    * @type boolean
-   * @default true
+   * @default undefined
    * @public
    */
   visible?: boolean;
   /**
    * @docid
    * @type boolean
-   * @default false
+   * @default undefined
    * @public
    */
   disabled?: boolean;

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4155,6 +4155,20 @@ export interface dxDataGridToolbar {
    * @public
    */
   items?: Array<dxDataGridDefaultToolbarItemName | dxDataGridToolbarItem>;
+  /**
+   * @docid
+   * @type boolean
+   * @default true
+   * @public
+   */
+  visible?: boolean;
+  /**
+   * @docid
+   * @type boolean
+   * @default false
+   * @public
+   */
+  disabled?: boolean;
 }
 
 /**

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4165,7 +4165,7 @@ export interface dxDataGridToolbar {
   /**
    * @docid
    * @type boolean
-   * @default undefined
+   * @default false
    * @public
    */
   disabled?: boolean;

--- a/js/ui/grid_core/ui.grid_core.header_panel.js
+++ b/js/ui/grid_core/ui.grid_core.header_panel.js
@@ -35,8 +35,8 @@ const HeaderPanel = ColumnsView.inherit({
         const options = {
             toolbarOptions: {
                 items: this._getToolbarItems(),
-                visible: userToolbarOptions && userToolbarOptions.visible,
-                disabled: userToolbarOptions && userToolbarOptions.disabled,
+                visible: userToolbarOptions?.visible,
+                disabled: userToolbarOptions?.disabled,
                 onItemRendered: function(e) {
                     const itemRenderedCallback = e.itemData.onItemRendered;
 
@@ -47,14 +47,14 @@ const HeaderPanel = ColumnsView.inherit({
             }
         };
 
-        const userItems = userToolbarOptions.items;
+        const userItems = userToolbarOptions?.items;
         options.toolbarOptions.items = this._normalizeToolbarItems(options.toolbarOptions.items, userItems);
 
         this.executeAction('onToolbarPreparing', options);
 
         if(options.toolbarOptions && !isDefined(options.toolbarOptions.visible)) {
             const toolbarItems = options.toolbarOptions.items;
-            options.toolbarOptions.visible = !!(toolbarItems && toolbarItems.length);
+            options.toolbarOptions.visible = !!(toolbarItems?.length);
         }
 
         return options.toolbarOptions;

--- a/js/ui/grid_core/ui.grid_core.header_panel.js
+++ b/js/ui/grid_core/ui.grid_core.header_panel.js
@@ -33,6 +33,8 @@ const HeaderPanel = ColumnsView.inherit({
         const options = {
             toolbarOptions: {
                 items: this._getToolbarItems(),
+                visible: this.option('toolbar.visible'),
+                disabled: this.option('toolbar.disabled'),
                 onItemRendered: function(e) {
                     const itemRenderedCallback = e.itemData.onItemRendered;
 
@@ -161,18 +163,28 @@ const HeaderPanel = ColumnsView.inherit({
             const parts = getPathParts(args.fullName);
             const optionName = args.fullName.replace(/^toolbar\./, '');
 
-            if(parts.length <= 2) {
-                // toolbar and toolbar.items case
+            if(parts.length === 1) {
+                // `toolbar` case
                 const toolbarOptions = this._getToolbarOptions();
                 this._toolbar.option(toolbarOptions);
-            } else if(parts.length === 3) {
-                // toolbar.items[i] case
-                const normalizedItem = this._normalizeToolbarItems(this._getToolbarItems(), args.value);
-                this._toolbar.option(optionName, normalizedItem);
-            } else if(parts.length >= 4) {
-                // toolbar.items[i].prop case
+            } else if(parts[1] === 'items') {
+                if(parts.length === 2) {
+                    // `toolbar.items` case
+                    const toolbarOptions = this._getToolbarOptions();
+                    this._toolbar.option('items', toolbarOptions.items);
+                } else if(parts.length === 3) {
+                    // `toolbar.items[i]` case
+                    const normalizedItem = this._normalizeToolbarItems(this._getToolbarItems(), args.value);
+                    this._toolbar.option(optionName, normalizedItem);
+                } else if(parts.length >= 4) {
+                    // `toolbar.items[i].prop` case
+                    this._toolbar.option(optionName, args.value);
+                }
+            } else {
+                // `toolbar.visible`, `toolbar.disabled` case
                 this._toolbar.option(optionName, args.value);
             }
+
         }
         this.callBase(args);
     },
@@ -187,6 +199,10 @@ const HeaderPanel = ColumnsView.inherit({
 export const headerPanelModule = {
     defaultOptions: function() {
         return {
+            toolbar: {
+                visible: true,
+                disabled: false
+            }
         };
     },
     views: {

--- a/js/ui/grid_core/ui.grid_core.header_panel.js
+++ b/js/ui/grid_core/ui.grid_core.header_panel.js
@@ -167,32 +167,34 @@ const HeaderPanel = ColumnsView.inherit({
             this._invalidate();
             args.handled = true;
         }
-        if(args.name === 'toolbar' && this._toolbar) {
-            const parts = getPathParts(args.fullName);
-            const optionName = args.fullName.replace(/^toolbar\./, '');
+        if(args.name === 'toolbar') {
+            args.handled = true;
+            if(this._toolbar) {
+                const parts = getPathParts(args.fullName);
+                const optionName = args.fullName.replace(/^toolbar\./, '');
 
-            if(parts.length === 1) {
-                // `toolbar` case
-                const toolbarOptions = this._getToolbarOptions();
-                this._toolbar.option(toolbarOptions);
-            } else if(parts[1] === 'items') {
-                if(parts.length === 2) {
-                    // `toolbar.items` case
+                if(parts.length === 1) {
+                    // `toolbar` case
                     const toolbarOptions = this._getToolbarOptions();
-                    this._toolbar.option('items', toolbarOptions.items);
-                } else if(parts.length === 3) {
-                    // `toolbar.items[i]` case
-                    const normalizedItem = this._normalizeToolbarItems(this._getToolbarItems(), args.value);
-                    this._toolbar.option(optionName, normalizedItem);
-                } else if(parts.length >= 4) {
-                    // `toolbar.items[i].prop` case
+                    this._toolbar.option(toolbarOptions);
+                } else if(parts[1] === 'items') {
+                    if(parts.length === 2) {
+                        // `toolbar.items` case
+                        const toolbarOptions = this._getToolbarOptions();
+                        this._toolbar.option('items', toolbarOptions.items);
+                    } else if(parts.length === 3) {
+                        // `toolbar.items[i]` case
+                        const normalizedItem = this._normalizeToolbarItems(this._getToolbarItems(), args.value);
+                        this._toolbar.option(optionName, normalizedItem);
+                    } else if(parts.length >= 4) {
+                        // `toolbar.items[i].prop` case
+                        this._toolbar.option(optionName, args.value);
+                    }
+                } else {
+                    // `toolbar.visible`, `toolbar.disabled` case
                     this._toolbar.option(optionName, args.value);
                 }
-            } else {
-                // `toolbar.visible`, `toolbar.disabled` case
-                this._toolbar.option(optionName, args.value);
             }
-
         }
         this.callBase(args);
     },

--- a/js/ui/grid_core/ui.grid_core.header_panel.js
+++ b/js/ui/grid_core/ui.grid_core.header_panel.js
@@ -163,7 +163,7 @@ const HeaderPanel = ColumnsView.inherit({
             this._invalidate();
             args.handled = true;
         }
-        if(args.name === 'toolbar') {
+        if(args.name === 'toolbar' && this._toolbar) {
             const parts = getPathParts(args.fullName);
             const optionName = args.fullName.replace(/^toolbar\./, '');
 

--- a/js/ui/grid_core/ui.grid_core.header_panel.js
+++ b/js/ui/grid_core/ui.grid_core.header_panel.js
@@ -51,6 +51,10 @@ const HeaderPanel = ColumnsView.inherit({
         this.executeAction('onToolbarPreparing', options);
 
         if(options.toolbarOptions) {
+            if(!isDefined(options.toolbarOptions.visible)) {
+                options.toolbarOptions.visible = true;
+            }
+
             const toolbarItems = options.toolbarOptions.items;
             options.toolbarOptions.visible = !!(
                 options.toolbarOptions.visible &&

--- a/js/ui/grid_core/ui.grid_core.header_panel.js
+++ b/js/ui/grid_core/ui.grid_core.header_panel.js
@@ -50,9 +50,13 @@ const HeaderPanel = ColumnsView.inherit({
 
         this.executeAction('onToolbarPreparing', options);
 
-        if(options.toolbarOptions && !isDefined(options.toolbarOptions.visible)) {
+        if(options.toolbarOptions) {
             const toolbarItems = options.toolbarOptions.items;
-            options.toolbarOptions.visible = !!(toolbarItems && toolbarItems.length);
+            options.toolbarOptions.visible = !!(
+                options.toolbarOptions.visible &&
+                toolbarItems &&
+                toolbarItems.length
+            );
         }
 
         return options.toolbarOptions;

--- a/js/ui/grid_core/ui.grid_core.header_panel.js
+++ b/js/ui/grid_core/ui.grid_core.header_panel.js
@@ -30,11 +30,13 @@ const HeaderPanel = ColumnsView.inherit({
     },
 
     _getToolbarOptions: function() {
+        const userToolbarOptions = this.option('toolbar');
+
         const options = {
             toolbarOptions: {
                 items: this._getToolbarItems(),
-                visible: this.option('toolbar.visible'),
-                disabled: this.option('toolbar.disabled'),
+                visible: userToolbarOptions && userToolbarOptions.visible,
+                disabled: userToolbarOptions && userToolbarOptions.disabled,
                 onItemRendered: function(e) {
                     const itemRenderedCallback = e.itemData.onItemRendered;
 
@@ -45,22 +47,14 @@ const HeaderPanel = ColumnsView.inherit({
             }
         };
 
-        const userItems = this.option('toolbar.items');
+        const userItems = userToolbarOptions.items;
         options.toolbarOptions.items = this._normalizeToolbarItems(options.toolbarOptions.items, userItems);
 
         this.executeAction('onToolbarPreparing', options);
 
-        if(options.toolbarOptions) {
-            if(!isDefined(options.toolbarOptions.visible)) {
-                options.toolbarOptions.visible = true;
-            }
-
+        if(options.toolbarOptions && !isDefined(options.toolbarOptions.visible)) {
             const toolbarItems = options.toolbarOptions.items;
-            options.toolbarOptions.visible = !!(
-                options.toolbarOptions.visible &&
-                toolbarItems &&
-                toolbarItems.length
-            );
+            options.toolbarOptions.visible = !!(toolbarItems && toolbarItems.length);
         }
 
         return options.toolbarOptions;
@@ -209,10 +203,6 @@ const HeaderPanel = ColumnsView.inherit({
 export const headerPanelModule = {
     defaultOptions: function() {
         return {
-            toolbar: {
-                visible: true,
-                disabled: false
-            }
         };
     },
     views: {

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1206,14 +1206,14 @@ export interface dxTreeListToolbarItem extends dxToolbarItem {
     /**
      * @docid
      * @type boolean
-     * @default true
+     * @default undefined
      * @public
      */
     visible?: boolean;
     /**
      * @docid
      * @type boolean
-     * @default false
+     * @default undefined
      * @public
      */
     disabled?: boolean;

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1203,6 +1203,20 @@ export interface dxTreeListToolbarItem extends dxToolbarItem {
      * @public
      */
     name?: dxTreeListDefaultToolbarItemName | string;
+    /**
+     * @docid
+     * @type boolean
+     * @default true
+     * @public
+     */
+    visible?: boolean;
+    /**
+     * @docid
+     * @type boolean
+     * @default false
+     * @public
+     */
+    disabled?: boolean;
 }
 
 /**

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -2574,6 +2574,38 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         const selectBoxDisabled = $selectBoxDisabled.dxSelectBox('instance');
         assert.equal(selectBoxDisabled.option('value'), 'item2', 'selectbox state saved');
     });
+
+    QUnit.test('Change toolbar.visible and toolbar.disabled options', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            loadingTimeout: null,
+            dataSource: [{ field1: 1, field2: 2 }],
+            columnChooser: {
+                enabled: true
+            },
+            toolbar: {
+                visible: true
+            }
+        });
+
+        const $toolbar = dataGrid.$element().find('.dx-toolbar');
+
+        // assert
+        assert.notOk($toolbar.hasClass('dx-state-invisible'), 'toolbar is shown');
+        assert.notOk($toolbar.hasClass('dx-state-disabled'), 'toolbar is not disabled');
+
+        // act
+        dataGrid.option('toolbar.visible', false);
+
+        // assert
+        assert.ok($toolbar.hasClass('dx-state-invisible'), 'toolbar is hidden');
+
+        // act
+        dataGrid.option('toolbar.disabled', true);
+
+        // assert
+        assert.ok($toolbar.hasClass('dx-state-disabled'), 'toolbar is disabled');
+    });
 });
 
 QUnit.module('API methods', baseModuleConfig, () => {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -8016,6 +8016,14 @@ declare module DevExpress.ui {
       | DevExpress.ui.dxDataGrid.dxDataGridDefaultToolbarItemName
       | dxDataGridToolbarItem
     >;
+    /**
+     * [descr:dxDataGridToolbar.visible]
+     */
+    visible?: boolean;
+    /**
+     * [descr:dxDataGridToolbar.disabled]
+     */
+    disabled?: boolean;
   }
   /**
    * [descr:dxDataGridToolbarItem]
@@ -20592,6 +20600,14 @@ declare module DevExpress.ui {
      * [descr:dxTreeListToolbarItem.name]
      */
     name?: DevExpress.ui.dxTreeList.dxTreeListDefaultToolbarItemName | string;
+    /**
+     * [descr:dxTreeListToolbarItem.visible]
+     */
+    visible?: boolean;
+    /**
+     * [descr:dxTreeListToolbarItem.disabled]
+     */
+    disabled?: boolean;
   }
   /**
    * [descr:dxTreeView]


### PR DESCRIPTION
I added options `toolbar.disabled` and `toolbar.visible`, they are similar to DxToolbar's one.

- `toolbar.disabled` by default is `undefined`, cause it has default definition in DxToolbar. But I wrote to doccomments that default is `false`, cause behavior is the same.
- `toolbar.visible` by default is `undefined`
  - if it's `undefined`, visibility depends on predefined or custom buttons existance. 
  - if it's `true`, it's always visible (even if there's no buttons in toolbar)
  - if it's `false`, it's always invisible (even if there are some buttons in toolbar)