### PR TITLE
Fix react warning

### DIFF
--- a/js/renovation/ui/pager/__tests__/resizable_container.test.tsx
+++ b/js/renovation/ui/pager/__tests__/resizable_container.test.tsx
@@ -107,14 +107,14 @@ describe('resizable-container', () => {
 
     describe('UpdateChildProps', () => {
       describe('contentAttributes', () => {
-        it('should merge rest attributes with pager props', () => {
+        it('should merge rest attributes with know pager props exclude react twoWay defaultPageSize and defaultPageIndex', () => {
           const resizableContainer = new ResizableContainer({
-            pagerProps: { prop1: 'value1' },
+            pagerProps: { defaultPageSize: 5, defaultIndex: 5, infoText: true },
           } as any);
 
-          expect(resizableContainer.contentAttributes).toEqual({
+          expect(resizableContainer.contentAttributes).toMatchObject({
             'rest-attributes': 'restAttributes',
-            prop1: 'value1',
+            infoText: true,
           });
         });
       });

--- a/js/renovation/ui/pager/__tests__/resizable_container.test.tsx
+++ b/js/renovation/ui/pager/__tests__/resizable_container.test.tsx
@@ -11,6 +11,7 @@ import {
   calculateAdaptivityProps,
 } from '../resizable_container';
 import resizeCallbacks from '../../../../core/utils/resize_callbacks';
+import { InternalPagerProps } from '../common/pager_props';
 
 jest.mock('../../../utils/get_computed_style');
 jest.mock('../../../../core/utils/resize_callbacks');
@@ -52,7 +53,7 @@ describe('resizable-container', () => {
           pagerPropsProp2: 'pagerPropsProp2',
           pageIndexChange: jest.fn(),
           pageSizeChange: jest.fn(),
-        },
+        } as Partial<InternalPagerProps>,
         props: {
           contentTemplate,
         } as any,

--- a/js/renovation/ui/pager/resizable_container.tsx
+++ b/js/renovation/ui/pager/resizable_container.tsx
@@ -106,8 +106,60 @@ export class ResizableContainer extends JSXComponent<ResizableContainerProps, 'p
     }
   }
 
-  get contentAttributes(): Record<string, unknown> & Pick<InternalPagerProps, 'pageIndexChange' | 'pageSizeChange'> {
-    return { ...this.restAttributes, ...this.props.pagerProps };
+  get contentAttributes(): Record<string, unknown> & InternalPagerProps {
+    // Without destructing in react defaultPageSize and defaultPageIndex from this.props.pagerProps
+    // added to contentAttributes after added to Widget.restAttributes
+    // and way to the following error:
+    // React does not recognize the `defaultPageSize` prop on a DOM element.
+    const {
+      pageSize,
+      pageIndex,
+      pageIndexChange,
+      pageSizeChange,
+      gridCompatibility,
+      className,
+      showInfo,
+      infoText,
+      lightModeEnabled,
+      displayMode,
+      maxPagesCount,
+      pageCount,
+      pagesCountText,
+      visible,
+      hasKnownLastPage,
+      pagesNavigatorVisible,
+      showPageSizes,
+      pageSizes,
+      rtlEnabled,
+      showNavigationButtons,
+      totalCount,
+      onKeyDown,
+    } = this.props.pagerProps;
+    return {
+      ...this.restAttributes,
+      pageSize,
+      pageIndex,
+      pageIndexChange,
+      pageSizeChange,
+      gridCompatibility,
+      className,
+      showInfo,
+      infoText,
+      lightModeEnabled,
+      displayMode,
+      maxPagesCount,
+      pageCount,
+      pagesCountText,
+      visible,
+      hasKnownLastPage,
+      pagesNavigatorVisible,
+      showPageSizes,
+      pageSizes,
+      rtlEnabled,
+      showNavigationButtons,
+      totalCount,
+      onKeyDown,
+    };
   }
 
   updateAdaptivityProps(): void {
@@ -118,8 +170,8 @@ export class ResizableContainer extends JSXComponent<ResizableContainerProps, 'p
       pages: this.pagesRef.current,
     });
     if (isDefined(this.actualAdaptivityProps)
-    && (this.actualAdaptivityProps.infoTextVisible !== this.infoTextVisible
-      || this.actualAdaptivityProps.isLargeDisplayMode !== this.isLargeDisplayMode)) {
+      && (this.actualAdaptivityProps.infoTextVisible !== this.infoTextVisible
+        || this.actualAdaptivityProps.isLargeDisplayMode !== this.isLargeDisplayMode)) {
       return;
     }
     const isEmpty = !isDefined(this.elementsWidth);


### PR DESCRIPTION
Warning: React does not recognize the `defaultPageSize` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `defaultpagesize` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by ForwardRef(widget))
    in ConfigProvider (created by ForwardRef(widget))
    in ForwardRef(widget) (created by PagerContent)
    in PagerContent (created by ResizableContainer)
    in ResizableContainer (created by Pager)
    in Pager (created by App)
    in App

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
