### PR TITLE
DataGrid - fix number column's parseValue

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -981,7 +981,7 @@ export const columnsControllerModule = {
 
                 if(isNumeric(parsedValue)) {
                     const formattedValue = numberLocalization.format(parsedValue, format);
-                    const formattedValueWithDefaultFormat = numberLocalization.format(parsedValue);
+                    const formattedValueWithDefaultFormat = numberLocalization.format(parsedValue, 'decimal');
 
                     if(formattedValue === text || formattedValueWithDefaultFormat === text) {
                         return parsedValue;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -13,6 +13,10 @@ import ajaxMock from '../../helpers/ajaxMock.js';
 
 import 'ui/data_grid';
 
+import 'localization/globalize/currency';
+import 'localization/globalize/number';
+import { locale } from 'localization/core';
+
 QUnit.testDone(function() {
     ajaxMock.clear();
 });
@@ -84,6 +88,8 @@ const processColumnsForCompare = function(columns, parameterNames, ignoreParamet
 };
 
 const setupModule = function(moduleNames) {
+    locale('en');
+
     executeAsyncMock.setup();
 
     dataGridMocks.setupDataGridModules(this, ['columns', 'data', 'selection', 'editing', 'editingRowBased', 'filterRow', 'masterDetail'].concat(moduleNames || []), {


### PR DESCRIPTION
I have used `numberLocalization.format(parsedValue)` to stringify numbers without special format. I assumed that with no `format` arg it will be `decimal` by default because of this lines: https://github.com/DevExpress/DevExtreme/blob/21_2/js/localization/number.js#L282-L284

But it seems that this function is overloaded and `format` set to another, so `12000` will be `12,000`.

I explicitly set format to be `decimal` and added import with that overloading to test