### PR TITLE
Scheduler - Disable page reloads in TestCafe tests

### DIFF
--- a/testing/testcafe/tests/scheduler/adaptive.weekView.ts
+++ b/testing/testcafe/tests/scheduler/adaptive.weekView.ts
@@ -1,9 +1,13 @@
-import createWidget from '../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../helpers/createWidget';
 import url from '../../helpers/getPageUrl';
 import Scheduler from '../../model/scheduler';
 
-fixture`Week view in adaptive mode`
-  .page(url(__dirname, '../container.html'));
+fixture.disablePageReloads`Week view in adaptive mode`
+  .page(url(__dirname, '../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const scheduler = new Scheduler('#container');
 

--- a/testing/testcafe/tests/scheduler/agenda/adaptive.ts
+++ b/testing/testcafe/tests/scheduler/agenda/adaptive.ts
@@ -1,8 +1,8 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 
-fixture`Agenda:adaptive`
+fixture.disablePageReloads`Agenda:adaptive`
   .page(url(__dirname, '../../container.html'));
 
 const createScheduler = async (groups: undefined | string[], rtlEnabled: boolean):
@@ -65,6 +65,9 @@ Promise<void> => {
     }).before(async () => createScheduler(testCase.groups, rtlEnabled))
       .after(async (t) => {
         await t.resizeWindow(1200, 800);
+        // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+        await t.wait(200);
+        await disposeWidgets();
       });
   });
 });

--- a/testing/testcafe/tests/scheduler/agenda/layout.ts
+++ b/testing/testcafe/tests/scheduler/agenda/layout.ts
@@ -1,10 +1,14 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import Scheduler from '../../../model/scheduler';
 import url from '../../../helpers/getPageUrl';
 
-fixture`Agenda:layout`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Agenda:layout`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const data = [{
   text: 'Website Re-Design Plan',

--- a/testing/testcafe/tests/scheduler/agenda/switchingToAgenda.ts
+++ b/testing/testcafe/tests/scheduler/agenda/switchingToAgenda.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import Scheduler from '../../../model/scheduler';
 import url from '../../../helpers/getPageUrl';
 
-fixture`Agenda:view switching`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Agenda:view switching`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('View switching should work for empty agenda', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/appointmentForm.ts
+++ b/testing/testcafe/tests/scheduler/appointmentForm.ts
@@ -1,10 +1,14 @@
 import { Selector } from 'testcafe';
-import createWidget from '../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../helpers/createWidget';
 import url from '../../helpers/getPageUrl';
 import Scheduler from '../../model/scheduler';
 
-fixture`Appointment popup form`
-  .page(url(__dirname, '../container.html'));
+fixture.disablePageReloads`Appointment popup form`
+  .page(url(__dirname, '../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Subject and description fields should be empty after showing popup on empty cell', async (t) => {
   const APPOINTMENT_TEXT = 'Website Re-Design Plan';

--- a/testing/testcafe/tests/scheduler/appointmentForm/dataEditors.ts
+++ b/testing/testcafe/tests/scheduler/appointmentForm/dataEditors.ts
@@ -1,9 +1,13 @@
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Appointment popup form:date editors`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Appointment popup form:date editors`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Form\'s date editors should be pass numeric chars according by date mask', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/appointmentForm/showAppointmentPopup.ts
+++ b/testing/testcafe/tests/scheduler/appointmentForm/showAppointmentPopup.ts
@@ -1,10 +1,14 @@
 import { ClientFunction } from 'testcafe';
 import Scheduler from '../../../model/scheduler';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 
-fixture`Timeline Appointments`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Timeline Appointments`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const showAppointmentPopup = ClientFunction(() => {
   const instance = ($('#container') as any).dxScheduler('instance');

--- a/testing/testcafe/tests/scheduler/appointmentOverlapping/basic.ts
+++ b/testing/testcafe/tests/scheduler/appointmentOverlapping/basic.ts
@@ -1,10 +1,15 @@
 import { simpleData, allDayData } from './init/widget.data';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Appointment overlapping in Scheduler`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Appointment overlapping in Scheduler`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Multi-day appointment should not overlap other appointments when specific width is set, \'auto\' mode (T864456)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/appointments/resources.ts
+++ b/testing/testcafe/tests/scheduler/appointments/resources.ts
@@ -1,6 +1,6 @@
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 
 const dataSource = [{
   text: 'test-appt-1',
@@ -26,8 +26,12 @@ const priorityData = [{
   color: 'rgb(225, 142, 146)',
 }];
 
-fixture`Appointment resources`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Appointment resources`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Reosurce color should be correct if group is set in "views"', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/appointments/timelines.ts
+++ b/testing/testcafe/tests/scheduler/appointments/timelines.ts
@@ -1,9 +1,13 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 
-fixture`Timeline Appointments`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Timeline Appointments`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('all-day and ordinary appointments should overlap each other correctly in timeline views (T1017889)', async (t) => {
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);

--- a/testing/testcafe/tests/scheduler/deleteAppointments.ts
+++ b/testing/testcafe/tests/scheduler/deleteAppointments.ts
@@ -1,9 +1,13 @@
-import createWidget from '../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../helpers/createWidget';
 import url from '../../helpers/getPageUrl';
 import Scheduler from '../../model/scheduler';
 
-fixture`Delete appointments`
-  .page(url(__dirname, '../container.html'));
+fixture.disablePageReloads`Delete appointments`
+  .page(url(__dirname, '../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const scheduler = new Scheduler('#container');
 

--- a/testing/testcafe/tests/scheduler/dragAndDrop/T1017720.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/T1017720.ts
@@ -1,12 +1,16 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import { extend } from '../../../../../js/core/utils/extend';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`T1017720`
-  .page(url(__dirname, './pages/containerWithDnD.html'));
+fixture.disablePageReloads`T1017720`
+  .page(url(__dirname, './pages/containerWithDnD.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Drag-n-drop appointment above SVG element(T1017720)', async (t) => {
   const scheduler = new Scheduler('#scheduler');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/appointmentCollector.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/appointmentCollector.ts
@@ -1,12 +1,16 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import { appointmentCollectorData } from './init/widget.data';
 import createScheduler from './init/widget.setup';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Drag-and-drop behaviour for the appointment tooltip`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Drag-and-drop behaviour for the appointment tooltip`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Drag-n-drop between a scheduler table cell and the appointment tooltip', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/basic.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/basic.ts
@@ -1,10 +1,15 @@
 import { dataSource } from './init/widget.data';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Drag-and-drop appointments in the Scheduler basic views`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Drag-and-drop appointments in the Scheduler basic views`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 ['day', 'week', 'workWeek'].forEach((view) => test(`Drag-n-drop in the "${view}" view`, async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/dragAppointmentAfterResize.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/dragAppointmentAfterResize.ts
@@ -1,9 +1,14 @@
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Drag-n-drop appointment after resize(T835545)`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Drag-n-drop appointment after resize(T835545)`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 ['day', 'week', 'month', 'timelineDay', 'timelineWeek', 'timelineMonth'].forEach((view) => test(
   `After drag-n-drop appointment, size of appointment shouldn't change in the '${view}' view`, async (t) => {

--- a/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/base.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/base.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 import Scheduler from '../../../../model/scheduler';
 
-fixture`Outlook dragging base tests`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Outlook dragging base tests`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Basic drag-n-drop movements in groups', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/schedulerInContainer/schedulerInContainer.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/schedulerInContainer/schedulerInContainer.ts
@@ -1,11 +1,15 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 
-fixture`Outlook dragging, for case scheduler in container`
-  .page(url(__dirname, '../../../../container.html'));
+fixture.disablePageReloads`Outlook dragging, for case scheduler in container`
+  .page(url(__dirname, '../../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Dragging should be work right in case dxScheduler placed in dxTabPanel', async (t) => {
   const scheduler = new Scheduler('.dx-scheduler');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/schedulerInContainer/schedulerInTransformContainer.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/schedulerInContainer/schedulerInTransformContainer.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 
-fixture`Outlook dragging, for case scheduler in container with transform style`
-  .page(url(__dirname, './containerWithTransform.html'));
+fixture.disablePageReloads`Outlook dragging, for case scheduler in container with transform style`
+  .page(url(__dirname, './containerWithTransform.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Dragging should be work right in case dxScheduler placed in container with transform style', async (t) => {
   const scheduler = new Scheduler('.dx-scheduler');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/shiftedContainer.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/shiftedContainer.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 import Scheduler from '../../../../model/scheduler';
 
-fixture`Outlook dragging base tests in shifted container`
-  .page(url(__dirname, 'shiftedContainer.html'));
+fixture.disablePageReloads`Outlook dragging base tests in shifted container`
+  .page(url(__dirname, 'shiftedContainer.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Basic drag-n-drop movements in shifted container', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/timeline.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/timeline.ts
@@ -1,10 +1,15 @@
 import { dataSource } from './init/widget.data';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Drag-and-drop appointments in the Scheduler timeline views`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Drag-and-drop appointments in the Scheduler timeline views`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 ['timelineDay', 'timelineWeek', 'timelineWorkWeek'].forEach((view) => test(`Drag-n-drop in the "${view}" view`, async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/verticalGrouping.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/verticalGrouping.ts
@@ -1,10 +1,15 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Drag-and-drop appointments in the Scheduler with vertical grouping`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Drag-and-drop appointments in the Scheduler with vertical grouping`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Should drag appoinment to the previous day`s cell (T1025952)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/grouping/groupingByDate.ts
+++ b/testing/testcafe/tests/scheduler/grouping/groupingByDate.ts
@@ -1,10 +1,15 @@
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Drag-and-drop appointments into allDay panel in the grouped Scheduler `
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Drag-and-drop appointments into allDay panel in the grouped Scheduler `
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Drag-n-drop between dateTable and allDay panel, groupByDate=true', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/header/header.ts
+++ b/testing/testcafe/tests/scheduler/header/header.ts
@@ -1,10 +1,13 @@
-import { Selector } from 'testcafe';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Hotkeys for appointments update and navigation`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Hotkeys for appointments update and navigation`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('dateNavigator buttons should not be selected after clicking', async (t) => {
   const { toolbar } = new Scheduler('#container');
@@ -38,44 +41,6 @@ test('dateNavigator buttons should have "contained" styling mode with generic th
 
     .expect(toolbar.navigator.nextButton.hasClass('dx-button-mode-contained'))
     .ok();
-}).before(async () => createWidget('dxScheduler', {
-  currentView: 'day',
-  views: ['day'],
-  height: 580,
-}));
-
-fixture`Scheduler: Adaptive material theme layout`
-  .page(url(__dirname, '../../containerMaterial.html'));
-
-test('dateNavigator buttons should have "text" styling mode with material theme', async (t) => {
-  const { toolbar } = new Scheduler('#container');
-
-  await t
-    .expect(toolbar.navigator.prevButton.hasClass('dx-button-mode-text'))
-    .ok()
-
-    .expect(toolbar.navigator.caption.hasClass('dx-button-mode-text'))
-    .ok()
-
-    .expect(toolbar.navigator.nextButton.hasClass('dx-button-mode-text'))
-    .ok();
-}).before(async () => createWidget('dxScheduler', {
-  currentView: 'day',
-  views: ['day'],
-  height: 580,
-}));
-
-test('viewSwitcher dropdown button popup should have a specified class', async (t) => {
-  const { toolbar } = new Scheduler('#container');
-  const dropDownButton = toolbar.viewSwitcher.getDropDownButton();
-
-  const viewSwitcherDropDownButtonContent = '.dx-scheduler-view-switcher-dropdown-button-content';
-
-  await t
-    .click(dropDownButton.element)
-
-    .expect(Selector(viewSwitcherDropDownButtonContent).count)
-    .eql(1);
 }).before(async () => createWidget('dxScheduler', {
   currentView: 'day',
   views: ['day'],

--- a/testing/testcafe/tests/scheduler/header/material_theme.ts
+++ b/testing/testcafe/tests/scheduler/header/material_theme.ts
@@ -1,0 +1,46 @@
+import { Selector } from 'testcafe';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
+import url from '../../../helpers/getPageUrl';
+import Scheduler from '../../../model/scheduler';
+
+fixture.disablePageReloads`Scheduler: Adaptive material theme layout`
+  .page(url(__dirname, '../../containerMaterial.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
+
+test('dateNavigator buttons should have "text" styling mode with material theme', async (t) => {
+  const { toolbar } = new Scheduler('#container');
+
+  await t
+    .expect(toolbar.navigator.prevButton.hasClass('dx-button-mode-text'))
+    .ok()
+
+    .expect(toolbar.navigator.caption.hasClass('dx-button-mode-text'))
+    .ok()
+
+    .expect(toolbar.navigator.nextButton.hasClass('dx-button-mode-text'))
+    .ok();
+}).before(async () => createWidget('dxScheduler', {
+  currentView: 'day',
+  views: ['day'],
+  height: 580,
+}));
+
+test('viewSwitcher dropdown button popup should have a specified class', async (t) => {
+  const { toolbar } = new Scheduler('#container');
+  const dropDownButton = toolbar.viewSwitcher.getDropDownButton();
+
+  const viewSwitcherDropDownButtonContent = '.dx-scheduler-view-switcher-dropdown-button-content';
+
+  await t
+    .click(dropDownButton.element)
+
+    .expect(Selector(viewSwitcherDropDownButtonContent).count)
+    .eql(1);
+}).before(async () => createWidget('dxScheduler', {
+  currentView: 'day',
+  views: ['day'],
+  height: 580,
+}));

--- a/testing/testcafe/tests/scheduler/hotkeysBehaviour/hotkeysBehaviour.ts
+++ b/testing/testcafe/tests/scheduler/hotkeysBehaviour/hotkeysBehaviour.ts
@@ -1,11 +1,16 @@
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 import FocusableElement from '../../../model/internal/focusable';
 
-fixture`Hotkeys for appointments update and navigation`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Hotkeys for appointments update and navigation`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 ['week', 'month'].forEach((view) => {
   test(`Navigate between appointments in the "${view}" view (Tab/Shift+Tab)`, async (t) => {

--- a/testing/testcafe/tests/scheduler/layout/adaptive/generic/adaptive.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/generic/adaptive.ts
@@ -1,5 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 import {
@@ -11,7 +11,7 @@ import {
 } from '../../utils';
 import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
-fixture`Scheduler: Adaptive Generic theme layout`
+fixture.disablePageReloads`Scheduler: Adaptive Generic theme layout`
   .page(url(__dirname, '../../../../container.html'));
 
 const createScheduler = async (
@@ -51,6 +51,9 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 
   test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping is used`, async (t) => {
@@ -80,6 +83,9 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 
   test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping is used`, async (t) => {
@@ -109,5 +115,8 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/adaptive/generic/adaptiveRTL.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/generic/adaptiveRTL.ts
@@ -1,5 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 import {
@@ -11,7 +11,7 @@ import {
 } from '../../utils';
 import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
-fixture`Scheduler: Adaptive Generic theme layout in RTL`
+fixture.disablePageReloads`Scheduler: Adaptive Generic theme layout in RTL`
   .page(url(__dirname, '../../../../container.html'));
 
 const createScheduler = async (
@@ -58,6 +58,9 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 
   test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping and RTL are used`, async (t) => {
@@ -87,6 +90,9 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 
   test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping and RTL are used`, async (t) => {
@@ -116,5 +122,8 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/adaptive/material/adaptive.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/material/adaptive.ts
@@ -1,5 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 import {
@@ -11,7 +11,7 @@ import {
 } from '../../utils';
 import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
-fixture`Scheduler: Adaptive material theme layout`
+fixture.disablePageReloads`Scheduler: Adaptive material theme layout`
   .page(url(__dirname, '../../../../containerMaterial.html'));
 
 const createScheduler = async (
@@ -51,6 +51,9 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 
   test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping is used`, async (t) => {
@@ -80,6 +83,9 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 
   test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping is used`, async (t) => {
@@ -109,5 +115,8 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/adaptive/material/adaptiveRTL.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/material/adaptiveRTL.ts
@@ -1,5 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 import {
@@ -11,7 +11,7 @@ import {
 } from '../../utils';
 import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
-fixture`Scheduler: Adaptive Material theme layout in RTL`
+fixture.disablePageReloads`Scheduler: Adaptive Material theme layout in RTL`
   .page(url(__dirname, '../../../../containerMaterial.html'));
 
 const createScheduler = async (
@@ -58,6 +58,9 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 
   test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping and RTL are used`, async (t) => {
@@ -87,6 +90,9 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 
   test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping and RTL are used`, async (t) => {
@@ -119,5 +125,8 @@ const createScheduler = async (
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/adaptive/resize/browserResize.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/resize/browserResize.ts
@@ -1,10 +1,10 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
-fixture`Layout:BrowserResize`
+fixture.disablePageReloads`Layout:BrowserResize`
   .page(url(__dirname, '../../../../container.html'));
 
 const data = [{
@@ -145,5 +145,8 @@ const resourceDataSource = [{
     });
   }).after(async (t) => {
     await restoreBrowserSize(t);
+    // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+    await t.wait(200);
+    await disposeWidgets();
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/appointmentForm/allDay.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointmentForm/allDay.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../model/scheduler';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
-fixture`Layout:AppointmentForm:AllDay`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Layout:AppointmentForm:AllDay`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Start and end dates should be reflect the current day(appointment is already available case)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/layout/appointments/allDay/longAppointment.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/allDay/longAppointment.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../../model/scheduler';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 
-fixture`Layout:Appointments:AllDay`
-  .page(url(__dirname, '../../../../container.html'));
+fixture.disablePageReloads`Layout:Appointments:AllDay`
+  .page(url(__dirname, '../../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Long all day appointment should be render, if him ended on next view day in currentView: \'day\'(T1021963)', async (t) => {
   const { workSpace, toolbar } = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/layout/appointments/collector.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/collector.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 import Scheduler from '../../../../model/scheduler';
 
-fixture`Appointments collector`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Appointments collector`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Appointment collector has correct offset when adaptivityEnabled=true', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/layout/appointments/disable.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/disable.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../model/scheduler';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
-fixture`Layout:Appointments:disable`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Layout:Appointments:disable`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Appointment popup should be readOnly if appointment is disabled', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/layout/appointments/two-schedulers.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/two-schedulers.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../model/scheduler';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
-fixture`Layout:Appointments:two-schedulers`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Layout:Appointments:two-schedulers`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Appointment\'s dragging should be work properly, if on page placed two dxSchedulers(T1020820)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/layout/appointments/visible.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/visible.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../model/scheduler';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
-fixture`Layout:Appointments:visible`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Layout:Appointments:visible`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 [1, 0].forEach((maxAppointmentsPerCell) => {
   [true, false, undefined].forEach((visible) => {

--- a/testing/testcafe/tests/scheduler/layout/resources/base/generic.ts
+++ b/testing/testcafe/tests/scheduler/layout/resources/base/generic.ts
@@ -1,11 +1,15 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 import { createDataSetForScreenShotTests } from '../../utils';
 
-fixture`Scheduler: Generic theme layout`
-  .page(url(__dirname, '../../../../container.html'));
+fixture.disablePageReloads`Scheduler: Generic theme layout`
+  .page(url(__dirname, '../../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const createScheduler = async (view: string, resourcesValue?: unknown[]): Promise<void> => {
   await createWidget('dxScheduler', {

--- a/testing/testcafe/tests/scheduler/layout/resources/base/material.ts
+++ b/testing/testcafe/tests/scheduler/layout/resources/base/material.ts
@@ -1,11 +1,15 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import Scheduler from '../../../../../model/scheduler';
 import url from '../../../../../helpers/getPageUrl';
 import { createDataSetForScreenShotTests, resourceDataSource } from '../../utils';
 
-fixture`Scheduler: Material theme layout`
-  .page(url(__dirname, '../../../../containerMaterial.html'));
+fixture.disablePageReloads`Scheduler: Material theme layout`
+  .page(url(__dirname, '../../../../containerMaterial.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Scheduler should have correct height in month view (T927862)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/layout/resources/groups/generic.ts
+++ b/testing/testcafe/tests/scheduler/layout/resources/groups/generic.ts
@@ -1,10 +1,14 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import { createDataSetForScreenShotTests, resourceDataSource } from '../../utils';
 
-fixture`Scheduler: Generic theme layout`
-  .page(url(__dirname, '../../../../container.html'));
+fixture.disablePageReloads`Scheduler: Generic theme layout`
+  .page(url(__dirname, '../../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const createScheduler = async (view: string, groupOrientation: string): Promise<void> => {
   await createWidget('dxScheduler', {

--- a/testing/testcafe/tests/scheduler/layout/resources/groups/material.ts
+++ b/testing/testcafe/tests/scheduler/layout/resources/groups/material.ts
@@ -1,10 +1,14 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import { createDataSetForScreenShotTests, resourceDataSource } from '../../utils';
 
-fixture`Scheduler: Material theme layout`
-  .page(url(__dirname, '../../../../containerMaterial.html'));
+fixture.disablePageReloads`Scheduler: Material theme layout`
+  .page(url(__dirname, '../../../../containerMaterial.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const createScheduler = async (view: string, groupOrientation: string): Promise<void> => {
   await createWidget('dxScheduler', {

--- a/testing/testcafe/tests/scheduler/layout/templates/appointmentTemplate.ts
+++ b/testing/testcafe/tests/scheduler/layout/templates/appointmentTemplate.ts
@@ -1,11 +1,15 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../model/scheduler';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
-fixture`Layout:Templates:appointmentTemplate`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Layout:Templates:appointmentTemplate`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 ['day', 'workWeek', 'month', 'timelineDay', 'timelineWorkWeek', 'agenda'].forEach((currentView) => {
   test(`appointmentTemplate layout should be rendered right in '${currentView}'`, async (t) => {

--- a/testing/testcafe/tests/scheduler/layout/templates/cellTemplate.ts
+++ b/testing/testcafe/tests/scheduler/layout/templates/cellTemplate.ts
@@ -1,11 +1,15 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../model/scheduler';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
-fixture`Layout:Templates:CellTemplate`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Layout:Templates:CellTemplate`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 ['day', 'workWeek', 'month', 'timelineDay', 'timelineWorkWeek', 'timelineMonth'].forEach((currentView) => {
   test(`dataCellTemplate and dateCellTemplate layout should be rendered right in '${currentView}'`, async (t) => {

--- a/testing/testcafe/tests/scheduler/layout/templates/tooltipTemplate.ts
+++ b/testing/testcafe/tests/scheduler/layout/templates/tooltipTemplate.ts
@@ -1,11 +1,15 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../model/scheduler';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
-fixture`Layout:Templates:appointmentTooltipTemplate`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Layout:Templates:appointmentTooltipTemplate`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('appointmentTooltipTemplate layout should be rendered right', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/layout/views/crossScrolling.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/crossScrolling.ts
@@ -1,10 +1,14 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 import Scheduler from '../../../../model/scheduler';
 
-fixture`Scheduler: View with cross-scrolling`
-  .page(url(__dirname, '../../../container.html'));
+fixture.disablePageReloads`Scheduler: View with cross-scrolling`
+  .page(url(__dirname, '../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Scrollable synchronization should work after changing current date (T1027231)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/layout/views/intervalCount/viewsWithStartDate.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/intervalCount/viewsWithStartDate.ts
@@ -1,10 +1,14 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import Scheduler from '../../../../../model/scheduler';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 
-fixture`Layout: Views: IntervalCount with StartDate`
-  .page(url(__dirname, '../../../../container.html'));
+fixture.disablePageReloads`Layout: Views: IntervalCount with StartDate`
+  .page(url(__dirname, '../../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 [{
   view: 'timelineDay',

--- a/testing/testcafe/tests/scheduler/layout/views/timeline/month.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/timeline/month.ts
@@ -1,10 +1,14 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 import Scheduler from '../../../../../model/scheduler';
 
-fixture`Scheduler: Layout Views: Timeline Month`
-  .page(url(__dirname, '../../../../container.html'));
+fixture.disablePageReloads`Scheduler: Layout Views: Timeline Month`
+  .page(url(__dirname, '../../../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Header cells should be aligned with date-table cells in timeline-month when current date changes', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/month/longAppointments.ts
+++ b/testing/testcafe/tests/scheduler/month/longAppointments.ts
@@ -1,10 +1,14 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Scheduler: long appointments in month view`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Scheduler: long appointments in month view`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 [false, true].forEach((rtlEnabled) => {
   [

--- a/testing/testcafe/tests/scheduler/nativeScrolling.ts
+++ b/testing/testcafe/tests/scheduler/nativeScrolling.ts
@@ -1,10 +1,14 @@
 import { ClientFunction } from 'testcafe';
-import createWidget from '../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../helpers/createWidget';
 import url from '../../helpers/getPageUrl';
 import Scheduler from '../../model/scheduler';
 
-fixture`Scheduler: NativeScrolling`
-  .page(url(__dirname, '../container.html'));
+fixture.disablePageReloads`Scheduler: NativeScrolling`
+  .page(url(__dirname, '../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const createScheduler = async (options): Promise<void> => createWidget('dxScheduler', options, true);
 

--- a/testing/testcafe/tests/scheduler/navigator.ts
+++ b/testing/testcafe/tests/scheduler/navigator.ts
@@ -1,10 +1,14 @@
-import createWidget from '../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../helpers/createWidget';
 import Scheduler from '../../model/scheduler';
 import { extend } from '../../../../js/core/utils/extend';
 import url from '../../helpers/getPageUrl';
 
-fixture`Scheduler: Navigator`
-  .page(url(__dirname, '../container.html'));
+fixture.disablePageReloads`Scheduler: Navigator`
+  .page(url(__dirname, '../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const createScheduler = async (options = {}): Promise<void> => {
   await createWidget('dxScheduler', extend(options, {

--- a/testing/testcafe/tests/scheduler/recurrences/appointmentTooltip.timeZone.ts
+++ b/testing/testcafe/tests/scheduler/recurrences/appointmentTooltip.timeZone.ts
@@ -1,9 +1,13 @@
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Appointment tooltip with recurrence appointment and custom time zone`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Appointment tooltip with recurrence appointment and custom time zone`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Time in appointment tooltip should has valid value in case with recurrence appointment and custom time zone(T848058)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/recurrences/basic.ts
+++ b/testing/testcafe/tests/scheduler/recurrences/basic.ts
@@ -1,11 +1,16 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Rendering of the recurrence appointments in  Scheduler `
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Rendering of the recurrence appointments in  Scheduler `
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Drag-n-drop recurrence appointment between dateTable and allDay panel', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/resizeAppointments/basic.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/basic.ts
@@ -1,10 +1,15 @@
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Resize appointments in the Scheduler basic views`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Resize appointments in the Scheduler basic views`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 ['day', 'week', 'workWeek'].forEach((view) => test(`Resize in the "${view}" view`, async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/resizeAppointments/timeline.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/timeline.ts
@@ -1,10 +1,15 @@
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Resize appointments in the Scheduler basic views`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Resize appointments in the Scheduler basic views`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 ['timelineDay', 'timelineWeek', 'timelineWorkWeek'].forEach((view) => test(`Resize in the "${view}" view`, async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/resizeAppointments/verticalGrouping.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/verticalGrouping.ts
@@ -1,9 +1,14 @@
 import createScheduler from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 
-fixture`Resize appointments in the Scheduler with vertical groupping`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Resize appointments in the Scheduler with vertical groupping`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Should correctly calculate group resizing area (T1025952)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/tooltipBehaviour/tooltipBehavior.ts
+++ b/testing/testcafe/tests/scheduler/tooltipBehaviour/tooltipBehavior.ts
@@ -2,8 +2,9 @@ import dataSource from './init/widget.data';
 import { createScheduler, scroll } from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
+import { disposeWidgets } from '../../../helpers/createWidget';
 
-fixture`Appointment tooltip behavior during scrolling in the Scheduler (T755449)`
+fixture.disablePageReloads`Appointment tooltip behavior during scrolling in the Scheduler (T755449)`
   .page(url(__dirname, '../../container.html'));
 
 test('The tooltip of collector should not scroll page and immediately hide', async (t) => {
@@ -54,6 +55,9 @@ test('The tooltip of collector should not scroll page and immediately hide', asy
   }],
 })).after(async (t) => {
   await t.resizeWindow(1200, 800);
+  // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+  await t.wait(200);
+  await disposeWidgets();
 });
 
 test('The tooltip should not hide after automatic scrolling during an appointment click', async (t) => {
@@ -71,6 +75,9 @@ test('The tooltip should not hide after automatic scrolling during an appointmen
   dataSource,
 })).after(async (t) => {
   await t.resizeWindow(1200, 800);
+  // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+  await t.wait(200);
+  await disposeWidgets();
 });
 
 test('The tooltip should hide after manually scrolling in the browser', async (t) => {
@@ -92,4 +99,7 @@ test('The tooltip should hide after manually scrolling in the browser', async (t
   dataSource,
 })).after(async (t) => {
   await t.resizeWindow(1200, 800);
+  // WA due to the https://github.com/DevExpress/testcafe/issues/2230
+  await t.wait(200);
+  await disposeWidgets();
 });

--- a/testing/testcafe/tests/scheduler/virtualScrolling/appointments.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrolling/appointments.ts
@@ -1,11 +1,15 @@
 import { getStyleAttribute, setStyleAttribute } from '../../../helpers/domElement';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 import { scrollTo } from './utils';
 
-fixture`Scheduler: Virtual Scrolling`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Scheduler: Virtual Scrolling`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 test('Appointment should not repaint after scrolling if present on viewport', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/virtualScrolling/layout.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrolling/layout.ts
@@ -1,5 +1,5 @@
 import { createScreenshotsComparer, compareScreenshot } from 'devextreme-screenshot-comparer';
-import createWidget from '../../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
 import {
@@ -12,8 +12,12 @@ import {
   groupedByDateViews,
 } from './utils';
 
-fixture`Scheduler: Virtual Scrolling`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Scheduler: Virtual Scrolling`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const createScheduler = async (
   additionalProps: Record<string, unknown>,

--- a/testing/testcafe/tests/scheduler/virtualScrolling/zooming.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrolling/zooming.ts
@@ -11,7 +11,7 @@ import {
   scrollConfig,
 } from './utils';
 
-fixture`Scheduler: Virtual Scrolling with Zooming`
+fixture.disablePageReloads`Scheduler: Virtual Scrolling with Zooming`
   .page(url(__dirname, '../../container.html'));
 
 const createScheduler = async (

--- a/testing/testcafe/tests/scheduler/virtualScrollingCellSelection/bothDirectionsVirtualScrolling.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrollingCellSelection/bothDirectionsVirtualScrolling.ts
@@ -8,9 +8,14 @@ import {
   checkAllDayCellsWhenInViewport,
   checkAllDayCellsWhenNotInViewport,
 } from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 
-fixture`Scheduler: Cells Selection in Virtual Scrolling`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Scheduler: Cells Selection in Virtual Scrolling`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const scheduler = new Scheduler('#container');
 

--- a/testing/testcafe/tests/scheduler/virtualScrollingCellSelection/virtualScrollingCellSelection.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrollingCellSelection/virtualScrollingCellSelection.ts
@@ -10,9 +10,14 @@ import {
   checkAllDayCellsWhenInViewport,
   checkAllDayCellsWhenNotInViewport,
 } from './init/widget.setup';
+import { disposeWidgets } from '../../../helpers/createWidget';
 
-fixture`Scheduler: Cells Selection in Virtual Scrolling`
-  .page(url(__dirname, '../../container.html'));
+fixture.disablePageReloads`Scheduler: Cells Selection in Virtual Scrolling`
+  .page(url(__dirname, '../../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const scheduler = new Scheduler('#container');
 

--- a/testing/testcafe/tests/scheduler/workSpace.ts
+++ b/testing/testcafe/tests/scheduler/workSpace.ts
@@ -1,11 +1,15 @@
 import { ClientFunction } from 'testcafe';
-import createWidget from '../../helpers/createWidget';
+import createWidget, { disposeWidgets } from '../../helpers/createWidget';
 import Scheduler from '../../model/scheduler';
 import { extend } from '../../../../js/core/utils/extend';
 import url from '../../helpers/getPageUrl';
 
-fixture`Scheduler: Workspace`
-  .page(url(__dirname, '../container.html'));
+fixture.disablePageReloads`Scheduler: Workspace`
+  .page(url(__dirname, '../container.html'))
+  .afterEach(async (t) => {
+    await t.wait(200);
+    await disposeWidgets();
+  });
 
 const disableAnimation = ClientFunction(() => {
   (window as any).DevExpress.fx.off = true;


### PR DESCRIPTION
1. The private attribute `disablePageReloads` is used to speed up TestCafe tests by disabling page reloads.
2. Added removal of widgets after each test to create a clean testing environment (`disposeWidgets()`).