### PR TITLE
dxScheduler - fix deprecation of scrollToTime method (#19185)

### DIFF
--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -1104,7 +1104,7 @@ export default class dxScheduler extends Widget {
      * @param1 hours:Number
      * @param2 minutes:Number
      * @param3 date:Date|undefined
-     * @deprecated
+     * @deprecated dxScheduler.scrollTo
      * @public
      */
     scrollToTime(hours: number, minutes: number, date?: Date): void;

--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -2099,6 +2099,7 @@ class Scheduler extends Widget {
     }
 
     scrollToTime(hours, minutes, date) {
+        errors.log('W0002', 'dxScheduler', 'scrollToTime', '21.1', 'Use the "scrollTo" method instead');
         this._workSpace.scrollToTime(hours, minutes, date);
     }
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/scrollToTime.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/scrollToTime.tests.js
@@ -109,8 +109,8 @@ QUnit.module('Scrolling to time', () => {
 
                 scheduler.instance.scrollToTime(12, 0, new Date(2015, 1, 16));
 
-                assert.equal(errors.log.callCount, 1, 'warning has been called once');
-                assert.equal(errors.log.getCall(0).args[0], 'W1008', 'warning has correct error id');
+                assert.equal(errors.log.callCount, 2, 'warning has been called once');
+                assert.equal(errors.log.getCall(1).args[0], 'W1008', 'warning has correct error id');
             });
 
             QUnit.test('Check scrolling to time for timeline view', function(assert) {
@@ -214,6 +214,23 @@ QUnit.module('Scrolling to time', () => {
                     scheduler.instance._workSpace.getCoordinatesByDate(new Date(2015, 1, 11, 9, 5)).left - scrollLeft - offset,
                     1.001,
                     'scrollBy was called with right distance',
+                );
+            });
+
+            QUnit.test('scrollToTime should throw a deprecation warning', function(assert) {
+                const scheduler = createWrapper({
+                    views: ['day'],
+                    currentView: 'day',
+                    currentDate: new Date(2021, 8, 9),
+                });
+
+                scheduler.instance.scrollToTime(10, 0);
+
+                assert.equal(errors.log.callCount, 1, 'warning has been called once');
+                assert.deepEqual(
+                    errors.log.getCall(0).args,
+                    ['W0002', 'dxScheduler', 'scrollToTime', '21.1', 'Use the "scrollTo" method instead'],
+                    'Deprecation warning is correct',
                 );
             });
         });


### PR DESCRIPTION
(cherry picked from commit f693a7e7d11fe9090a76c2b1a3cd56842135b14b)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
