### PR TITLE
scrollable: subscribe to mouseenter, mouseleave event instead of usind dxhover events

### DIFF
--- a/js/renovation/ui/scroll_view/__tests__/scroll_view.test.tsx
+++ b/js/renovation/ui/scroll_view/__tests__/scroll_view.test.tsx
@@ -83,7 +83,7 @@ describe('ScrollView', () => {
         rtlEnabled: true,
         disabled: true,
         focusStateEnabled: false,
-        hoverStateEnabled: !useNativeScrolling,
+        hoverStateEnabled: false,
         tabIndex: 0,
         visible: true,
       };

--- a/js/renovation/ui/scroll_view/__tests__/scrollable.test.tsx
+++ b/js/renovation/ui/scroll_view/__tests__/scrollable.test.tsx
@@ -83,7 +83,7 @@ describe('Scrollable', () => {
         rtlEnabled: true,
         disabled: true,
         focusStateEnabled: false,
-        hoverStateEnabled: !useNativeScrolling,
+        hoverStateEnabled: false,
         tabIndex: 0,
         visible: true,
       };

--- a/js/renovation/ui/scroll_view/common/consts.ts
+++ b/js/renovation/ui/scroll_view/common/consts.ts
@@ -45,6 +45,13 @@ export const TopPocketState = {
   STATE_PULLED: 5,
 };
 
+export const ShowScrollbarMode = {
+  HOVER: 'onHover',
+  ALWAYS: 'always',
+  NEVER: 'never',
+  SCROLL: 'onScroll',
+};
+
 export const KEY_CODES = {
   PAGE_UP: 'pageUp',
   PAGE_DOWN: 'pageDown',

--- a/js/renovation/ui/scroll_view/common/scrollbar_props.ts
+++ b/js/renovation/ui/scroll_view/common/scrollbar_props.ts
@@ -5,9 +5,7 @@ import {
 
 @ComponentBindings()
 export class ScrollbarProps {
-  @OneWay() activeStateEnabled?: boolean = false;
-
-  @OneWay() hoverStateEnabled?: boolean;
+  @OneWay() direction: 'vertical' | 'horizontal' = 'vertical';
 
   @OneWay() containerHasSizes = false;
 
@@ -15,9 +13,7 @@ export class ScrollbarProps {
 
   @OneWay() contentSize = 0;
 
-  @OneWay() isScrollableHovered = false;
-
-  @OneWay() forceVisibility = false;
+  @OneWay() visible = false;
 
   @OneWay() scrollLocation = 0;
 

--- a/js/renovation/ui/scroll_view/scrollbar/__tests__/animated_scrollbar.test.tsx
+++ b/js/renovation/ui/scroll_view/scrollbar/__tests__/animated_scrollbar.test.tsx
@@ -32,6 +32,7 @@ describe('AnimatedScrollbar', () => {
     const viewModel = mount<AnimatedScrollbar>(<AnimatedScrollbar {...props} />);
 
     expect({ ...viewModel.props() }).toEqual({
+      direction: 'vertical',
       bottomPocketSize: 0,
       containerHasSizes: false,
       containerSize: 0,

--- a/js/renovation/ui/scroll_view/scrollbar/__tests__/animated_scrollbar.test.tsx
+++ b/js/renovation/ui/scroll_view/scrollbar/__tests__/animated_scrollbar.test.tsx
@@ -32,14 +32,12 @@ describe('AnimatedScrollbar', () => {
     const viewModel = mount<AnimatedScrollbar>(<AnimatedScrollbar {...props} />);
 
     expect({ ...viewModel.props() }).toEqual({
-      activeStateEnabled: false,
       bottomPocketSize: 0,
       containerHasSizes: false,
       containerSize: 0,
       contentPaddingBottom: 0,
       contentSize: 0,
-      forceVisibility: false,
-      isScrollableHovered: false,
+      visible: false,
       maxOffset: 0,
       minOffset: 0,
       scrollLocation: 0,
@@ -52,8 +50,6 @@ describe('AnimatedScrollbar', () => {
     { name: 'moveTo', calledWith: ['arg1'] },
     { name: 'isScrollbar', calledWith: ['arg1'] },
     { name: 'isThumb', calledWith: ['arg1'] },
-    { name: 'show', calledWith: [] },
-    { name: 'hide', calledWith: [] },
   ]).describe('Method: %o', (methodInfo) => {
     it(`${methodInfo.name}() method should call according scrollbar method`, () => {
       const viewModel = new AnimatedScrollbar({});
@@ -235,11 +231,9 @@ describe('Handlers', () => {
               const scrollbar = mount(AnimatedScrollbarComponent(viewModel as any));
 
               const initHandler = jest.fn();
-              const hideHandler = jest.fn();
               (viewModel as any).scrollbarRef = {
                 current: {
                   initHandler,
-                  hide: hideHandler,
                   isScrollbar: jest.fn(() => targetClass === 'dx-scrollable-scrollbar'),
                   isThumb: jest.fn(() => targetClass === 'dx-scrollable-scroll'),
                 },
@@ -251,7 +245,6 @@ describe('Handlers', () => {
 
               viewModel.initHandler(event, crossThumbScrolling, 30);
 
-              expect(hideHandler).toHaveBeenCalledTimes(1);
               expect(viewModel.pendingBounceAnimator).toEqual(false);
               expect(viewModel.pendingInertiaAnimator).toEqual(false);
               expect(viewModel.stopped).toEqual(true);
@@ -268,13 +261,15 @@ describe('Handlers', () => {
 
                 expectedThumbScrolling = isScrollbarClicked || (scrollByThumb && targetClass === 'dx-scrollable-scroll');
                 expectedCrossThumbScrolling = !expectedThumbScrolling && crossThumbScrolling;
+
+                expect(initHandler).toHaveBeenCalledTimes(1);
+                expect(initHandler).toHaveBeenCalledWith(event, expectedThumbScrolling, 30);
+              } else {
+                expect(initHandler).toHaveBeenCalledTimes(0);
               }
 
               expect(viewModel.thumbScrolling).toEqual(expectedThumbScrolling);
               expect(viewModel.crossThumbScrolling).toEqual(expectedCrossThumbScrolling);
-
-              expect(initHandler).toHaveBeenCalledTimes(1);
-              expect(initHandler).toHaveBeenCalledWith(event, expectedThumbScrolling, 30);
             });
         });
       });

--- a/js/renovation/ui/scroll_view/scrollbar/__tests__/scrollbar.test.tsx
+++ b/js/renovation/ui/scroll_view/scrollbar/__tests__/scrollbar.test.tsx
@@ -14,7 +14,7 @@ import {
   THUMB_MIN_SIZE,
 } from '../scrollbar';
 
-import { DIRECTION_HORIZONTAL, DIRECTION_VERTICAL } from '../../common/consts';
+import { DIRECTION_HORIZONTAL, DIRECTION_VERTICAL, ShowScrollbarMode } from '../../common/consts';
 
 import {
   optionValues,
@@ -36,12 +36,10 @@ describe('Scrollbar', () => {
     const viewModel = mount<Scrollbar>(<Scrollbar {...props} />);
 
     expect({ ...viewModel.props() }).toEqual({
-      activeStateEnabled: false,
       containerHasSizes: false,
       containerSize: 0,
       contentSize: 0,
-      forceVisibility: false,
-      isScrollableHovered: false,
+      visible: false,
       maxOffset: 0,
       minOffset: 0,
       scrollLocation: 0,
@@ -51,18 +49,6 @@ describe('Scrollbar', () => {
   describe('Classes', () => {
     each([DIRECTION_HORIZONTAL, DIRECTION_VERTICAL]).describe('Direction: %o', (direction) => {
       each(optionValues.showScrollbar).describe('ShowScrollbar: %o', (showScrollbar) => {
-        it('hoverStart, hoverEnd handlers should update hovered state only for onHover mode', () => {
-          const viewModel = new Scrollbar({ direction, showScrollbar }) as any;
-
-          expect(viewModel.hovered).toBe(false);
-
-          viewModel.hoverInHandler();
-          expect(viewModel.hovered).toBe(showScrollbar === 'onHover');
-
-          viewModel.hoverOutHandler();
-          expect(viewModel.hovered).toBe(false);
-        });
-
         each([
           { scrollLocation: 50.145623, expectedTranslate: -25.0728115 },
           { scrollLocation: 0, expectedTranslate: 0 },
@@ -82,22 +68,22 @@ describe('Scrollbar', () => {
 
             const scrollbar = mount(ScrollbarComponent(viewModel));
 
-            let expectedScrollTransform = '';
+            let expectedThumbTransform = '';
 
             if (showScrollbar === 'never') {
-              expectedScrollTransform = 'none';
+              expectedThumbTransform = 'none';
             } else {
               if (direction === DIRECTION_HORIZONTAL) {
-                expectedScrollTransform = `translate(${expectedTranslate}px, 0px)`;
+                expectedThumbTransform = `translate(${expectedTranslate}px, 0px)`;
               }
               if (direction === DIRECTION_VERTICAL) {
-                expectedScrollTransform = `translate(0px, ${expectedTranslate}px)`;
+                expectedThumbTransform = `translate(0px, ${expectedTranslate}px)`;
               }
             }
 
             const thumbElement = scrollbar.find('.dx-scrollable-scroll');
 
-            expect(thumbElement.prop('style')).toHaveProperty('transform', expectedScrollTransform);
+            expect(thumbElement.prop('style')).toHaveProperty('transform', expectedThumbTransform);
             expect(thumbElement.prop('style')).toHaveProperty(direction === 'vertical' ? 'height' : 'width', 50);
             expect(thumbElement.prop('style')).not.toHaveProperty(direction === 'vertical' ? 'width' : 'height');
           });
@@ -112,54 +98,51 @@ describe('Scrollbar', () => {
             const scrollbar = mount(ScrollbarComponent(viewModel));
 
             if (needHoverableClass) {
-              expect(viewModel.cssClasses).toEqual(expect.stringMatching('dx-scrollbar-hoverable'));
+              expect(viewModel.scrollbarClasses).toEqual(expect.stringMatching('dx-scrollbar-hoverable'));
               expect(scrollbar.find('.dx-scrollbar-hoverable').length).toBe(1);
             } else {
-              expect(viewModel.cssClasses).toEqual(expect.not.stringMatching('dx-scrollbar-hoverable'));
+              expect(viewModel.scrollbarClasses).toEqual(expect.not.stringMatching('dx-scrollbar-hoverable'));
               expect(scrollbar.find('.dx-scrollbar-hoverable').length).toBe(0);
             }
           });
         });
 
-        each([10, 0, -100]).describe('containerToContentRatio: %o', (maxOffset) => {
-          each([true, false]).describe('visibility: %o', (visibility) => {
-            each([true, false]).describe('isScrollableHovered: %o', (isScrollableHovered) => {
-              each([true, false]).describe('hovered: %o', (hovered) => {
-                each([true, false, undefined]).describe('ShowOnScrollByWheel: %o', (showOnScrollByWheel) => {
-                  each([10, 15, 20]).describe('containerSize: %o', (containerSize) => {
-                    it('scroll visibility', () => {
-                      const viewModel = new Scrollbar({
-                        direction,
-                        showScrollbar,
-                        isScrollableHovered,
-                        containerSize,
-                        maxOffset,
-                      });
-
-                      viewModel.visibility = visibility;
-                      viewModel.showOnScrollByWheel = showOnScrollByWheel;
-                      viewModel.hovered = hovered;
-
-                      const expectedScrollbarVisibility = showScrollbar !== 'never' && -maxOffset > 0 && containerSize > 15;
-
-                      expect(viewModel.isVisible).toEqual(expectedScrollbarVisibility);
-
-                      let expectedScrollVisibility: boolean | undefined = undefined;
-
-                      if (!expectedScrollbarVisibility) {
-                        expectedScrollVisibility = false;
-                      } else if (showScrollbar === 'onHover') {
-                        expectedScrollVisibility = visibility || isScrollableHovered || hovered;
-                      } else if (showScrollbar === 'always') {
-                        expectedScrollVisibility = true;
-                      } else {
-                        expectedScrollVisibility = visibility || !!showOnScrollByWheel;
-                      }
-
-                      expect(viewModel.scrollClasses).toEqual(expectedScrollVisibility
-                        ? expect.not.stringMatching('dx-state-invisible')
-                        : expect.stringMatching('dx-state-invisible'));
+        each([0, -100]).describe('maxOffset: %o', (maxOffset) => {
+          each([10, 15, 20]).describe('containerSize: %o', (containerSize) => {
+            each([true, false]).describe('visibility: %o', (visibility) => {
+              each([true, false]).describe('visible: %o', (visible) => {
+                each([true, false]).describe('hovered: %o', (hovered) => {
+                  it('scroll visibility', () => {
+                    const viewModel = new Scrollbar({
+                      direction,
+                      showScrollbar,
+                      visible,
+                      containerSize,
+                      maxOffset,
                     });
+
+                    viewModel.visibility = visibility;
+                    viewModel.hovered = hovered;
+
+                    const isScrollbarVisible = showScrollbar !== 'never' && maxOffset !== 0 && containerSize >= 15;
+
+                    expect(viewModel.hidden).toEqual(!isScrollbarVisible);
+
+                    let expectedThumbVisibility: boolean | undefined = undefined;
+
+                    if (!isScrollbarVisible) {
+                      expectedThumbVisibility = false;
+                    } else if (showScrollbar === 'onHover') {
+                      expectedThumbVisibility = visibility || visible || hovered;
+                    } else if (showScrollbar === 'always') {
+                      expectedThumbVisibility = true;
+                    } else {
+                      expectedThumbVisibility = visibility || visible;
+                    }
+
+                    expect(viewModel.thumbClasses).toEqual(expectedThumbVisibility
+                      ? expect.not.stringMatching('dx-state-invisible')
+                      : expect.stringMatching('dx-state-invisible'));
                   });
                 });
               });
@@ -175,40 +158,100 @@ describe('Scrollbar', () => {
 
     it('should subscribe to pointerDown event', () => {
       const scrollbar = new Scrollbar({ direction: 'vertical' });
-      scrollbar.scrollRef = { current: {} as HTMLElement } as RefObject;
-      scrollbar.expand = jest.fn();
-
-      scrollbar.pointerDownEffect();
-      emit('dxpointerdown');
-
-      expect(scrollbar.expand).toHaveBeenCalledTimes(1);
-    });
-
-    it('Down & Up effects should add & remove scroll active class', () => {
-      const scrollbar = new Scrollbar({ direction: 'vertical' });
-      scrollbar.scrollRef = { current: {} as HTMLElement } as RefObject;
+      scrollbar.thumbRef = { current: {} as HTMLElement } as RefObject;
+      scrollbar.expanded = false;
 
       scrollbar.pointerDownEffect();
       emit('dxpointerdown');
 
       expect(scrollbar.expanded).toEqual(true);
-      expect(scrollbar.cssClasses).toEqual(expect.stringMatching('dx-scrollable-scrollbar-active'));
+    });
+
+    it('Down & Up effects should add & remove scroll active class', () => {
+      const scrollbar = new Scrollbar({ direction: 'vertical' });
+      scrollbar.thumbRef = { current: {} as HTMLElement } as RefObject;
+
+      scrollbar.pointerDownEffect();
+      emit('dxpointerdown');
+
+      expect(scrollbar.expanded).toEqual(true);
+      expect(scrollbar.scrollbarClasses).toEqual(expect.stringMatching('dx-scrollable-scrollbar-active'));
 
       scrollbar.pointerUpEffect();
       emit('dxpointerup');
 
       expect(scrollbar.expanded).toEqual(false);
-      expect(scrollbar.cssClasses).toEqual(expect.not.stringMatching('dx-scrollable-scrollbar-active'));
+      expect(scrollbar.scrollbarClasses).toEqual(expect.not.stringMatching('dx-scrollable-scrollbar-active'));
     });
 
     it('should subscribe to pointerUp event', () => {
       const scrollbar = new Scrollbar({ direction: 'vertical' });
-      scrollbar.collapse = jest.fn();
+      scrollbar.expanded = true;
 
       scrollbar.pointerUpEffect();
       emit('dxpointerup');
 
-      expect(scrollbar.collapse).toHaveBeenCalledTimes(1);
+      expect(scrollbar.expanded).toEqual(false);
+    });
+
+    it('should subscribe to mouseenter event if showScrollbar mode is onHover', () => {
+      const viewModel = new Scrollbar({
+        direction: 'vertical',
+        showScrollbar: 'onHover',
+      });
+      viewModel.scrollbarRef = { current: {} } as RefObject;
+      viewModel.hovered = false;
+
+      viewModel.mouseEnterEffect();
+      emit('mouseenter');
+
+      expect(viewModel.hovered).toEqual(true);
+    });
+
+    each([ShowScrollbarMode.SCROLL, ShowScrollbarMode.NEVER, ShowScrollbarMode.ALWAYS]).describe('ShowScrollbar: %o', (showScrollbar) => {
+      it(`should not subscribe to mouseenter event if showScrollbar mode is ${showScrollbar}`, () => {
+        const viewModel = new Scrollbar({
+          direction: 'vertical',
+          showScrollbar,
+        });
+        viewModel.scrollbarRef = { current: {} } as RefObject;
+        viewModel.hovered = false;
+
+        viewModel.mouseEnterEffect();
+        emit('mouseenter');
+
+        expect(viewModel.hovered).toEqual(false);
+      });
+    });
+
+    it('should subscribe to mouseleave event if showScrollbar mode is onHover', () => {
+      const viewModel = new Scrollbar({
+        direction: 'vertical',
+        showScrollbar: 'onHover',
+      });
+      viewModel.scrollbarRef = { current: {} } as RefObject;
+      viewModel.hovered = true;
+
+      viewModel.mouseLeaveEffect();
+      emit('mouseleave');
+
+      expect(viewModel.hovered).toEqual(false);
+    });
+
+    each([ShowScrollbarMode.SCROLL, ShowScrollbarMode.NEVER, ShowScrollbarMode.ALWAYS]).describe('ShowScrollbar: %o', (showScrollbar) => {
+      it(`should not subscribe to mouseleave event if showScrollbar mode is ${showScrollbar}`, () => {
+        const viewModel = new Scrollbar({
+          direction: 'vertical',
+          showScrollbar,
+        });
+        viewModel.scrollbarRef = { current: {} } as RefObject;
+        viewModel.hovered = true;
+
+        viewModel.mouseLeaveEffect();
+        emit('mouseleave');
+
+        expect(viewModel.hovered).toEqual(true);
+      });
     });
   });
 
@@ -489,17 +532,13 @@ describe('Scrollbar', () => {
   describe('Handlers', () => {
     each([DIRECTION_HORIZONTAL, DIRECTION_VERTICAL]).describe('Direction: %o', (direction) => {
       test.each(getPermutations([
-        optionValues.isDxWheelEvent,
         [true, false],
         optionValues.scrollByThumb,
         ['dx-scrollable-scroll', 'dx-scrollable-scrollbar'],
         optionValues.showScrollbar,
       ]))('initHandler(event, thumbScrolling, offset), isDxWheelEvent: %o, thumbScrolling: %o, scrollByThumb: %o, targetClass: %, showScrollbar: %o',
-        (isDxWheelEvent, thumbScrolling, scrollByThumb, targetClass, showScrollbar) => {
+        (thumbScrolling, scrollByThumb, targetClass, showScrollbar) => {
           const event = { ...defaultEvent, originalEvent: {} } as any;
-          if (isDxWheelEvent) {
-            event.originalEvent.type = 'dxmousewheel';
-          }
 
           const viewModel = new Scrollbar({
             direction,
@@ -518,62 +557,15 @@ describe('Scrollbar', () => {
 
           const isScrollbarClicked = targetClass !== 'dx-scrollable-scroll' && scrollByThumb;
 
-          let expectedShowOnScrollByWheel: boolean | undefined = undefined;
-          let expectedExpandedValue = false;
-
-          if (isDxWheelEvent || !isScrollbarClicked) {
-            expect(viewModel.moveToMouseLocation).toBeCalledTimes(0);
-          } else {
+          if (isScrollbarClicked) {
             expect(viewModel.moveToMouseLocation).toBeCalledTimes(1);
             expect(viewModel.moveToMouseLocation).toHaveBeenCalledWith(event, 30);
-          }
-
-          if (isDxWheelEvent) {
-            if (showScrollbar === 'onScroll') {
-              expectedShowOnScrollByWheel = true;
-            }
           } else {
-            expectedShowOnScrollByWheel = undefined;
-            if (thumbScrolling) {
-              expectedExpandedValue = true;
-            }
+            expect(viewModel.moveToMouseLocation).toBeCalledTimes(0);
           }
 
-          expect(viewModel.showOnScrollByWheel).toEqual(expectedShowOnScrollByWheel);
-          expect(viewModel.expanded).toEqual(expectedExpandedValue);
+          expect(viewModel.expanded).toEqual(!!thumbScrolling);
         });
-
-      test.each(optionValues.showScrollbar)('change visibility scrollbar on hide(), showScrollbar: %o,', (showScrollbar) => {
-        jest.clearAllTimers();
-        jest.useFakeTimers();
-
-        const viewModel = new Scrollbar({
-          direction,
-          showScrollbar,
-        } as ScrollbarPropsType);
-        viewModel.showOnScrollByWheel = true;
-        viewModel.visibility = true;
-
-        viewModel.hide();
-
-        viewModel.visibility = false;
-        if (showScrollbar === 'onScroll') {
-          expect(setTimeout).toHaveBeenCalledTimes(1);
-          expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 500);
-        }
-
-        jest.runOnlyPendingTimers();
-
-        if (showScrollbar === 'onScroll') {
-          expect(viewModel.showOnScrollByWheel).toEqual(undefined);
-          expect(viewModel.hideScrollbarTimer === undefined).toBe(false);
-        } else {
-          expect(viewModel.showOnScrollByWheel).toEqual(true);
-        }
-
-        viewModel.disposeHideScrollbarTimer()();
-        expect(viewModel.hideScrollbarTimer).toBe(undefined);
-      });
 
       each([true, false]).describe('thumbScrolling: %o', (thumbScrolling) => {
         each([true, false]).describe('inRange: %o', (inRangeMockValue) => {

--- a/js/renovation/ui/scroll_view/scrollbar/__tests__/scrollbar.test.tsx
+++ b/js/renovation/ui/scroll_view/scrollbar/__tests__/scrollbar.test.tsx
@@ -36,6 +36,7 @@ describe('Scrollbar', () => {
     const viewModel = mount<Scrollbar>(<Scrollbar {...props} />);
 
     expect({ ...viewModel.props() }).toEqual({
+      direction: 'vertical',
       containerHasSizes: false,
       containerSize: 0,
       contentSize: 0,

--- a/js/renovation/ui/scroll_view/scrollbar/animated_scrollbar.tsx
+++ b/js/renovation/ui/scroll_view/scrollbar/animated_scrollbar.tsx
@@ -40,7 +40,7 @@ export const viewFunction = (viewModel: AnimatedScrollbar): JSX.Element => {
       contentSize, containerSize,
       showScrollbar, scrollByThumb, bounceEnabled,
       scrollLocation, scrollLocationChange,
-      isScrollableHovered, rtlEnabled,
+      visible, rtlEnabled,
       containerHasSizes,
       minOffset, maxOffset,
     },
@@ -53,7 +53,7 @@ export const viewFunction = (viewModel: AnimatedScrollbar): JSX.Element => {
       contentSize={contentSize}
       containerSize={containerSize}
       containerHasSizes={containerHasSizes}
-      isScrollableHovered={isScrollableHovered}
+      visible={visible}
       minOffset={minOffset}
       maxOffset={maxOffset}
       scrollLocation={scrollLocation}
@@ -69,7 +69,7 @@ export const viewFunction = (viewModel: AnimatedScrollbar): JSX.Element => {
 
 type AnimatedScrollbarPropsType = AnimatedScrollbarProps
 & Pick<BaseWidgetProps, 'rtlEnabled'>
-& Pick<ScrollableSimulatedProps, 'direction' | 'pullDownEnabled' | 'reachBottomEnabled' | 'forceGeneratePockets'
+& Pick<ScrollableSimulatedProps, 'pullDownEnabled' | 'reachBottomEnabled' | 'forceGeneratePockets'
 | 'inertiaEnabled' | 'showScrollbar' | 'scrollByThumb' | 'bounceEnabled' | 'scrollLocationChange'>;
 
 @Component({
@@ -140,7 +140,6 @@ export class AnimatedScrollbar extends JSXComponent<AnimatedScrollbarPropsType>(
     crossThumbScrolling: boolean,
     offset: number,
   ): void {
-    this.scrollbarRef.current!.hide();
     this.cancel();
 
     this.refreshing = false;
@@ -148,23 +147,8 @@ export class AnimatedScrollbar extends JSXComponent<AnimatedScrollbarPropsType>(
 
     if (!isDxMouseWheelEvent(event.originalEvent)) {
       this.calcThumbScrolling(event, crossThumbScrolling);
+      this.scrollbarRef.current!.initHandler(event, this.thumbScrolling, offset);
     }
-
-    this.scrollbarRef.current!.initHandler(event, this.thumbScrolling, offset);
-
-    // if (this.thumbScrolling) {
-    //   this.needRiseEnd = true;
-    // }
-  }
-
-  @Method()
-  show(): void {
-    this.scrollbarRef.current!.show();
-  }
-
-  @Method()
-  hide(): void {
-    this.scrollbarRef.current!.hide();
   }
 
   @Method()
@@ -231,7 +215,6 @@ export class AnimatedScrollbar extends JSXComponent<AnimatedScrollbarPropsType>(
   risePullDown(): void {
     if (
       this.props.forceGeneratePockets
-      // && !this.props.scrolling
       && this.needRiseEnd
       && this.inRange
       && !(this.pendingBounceAnimator || this.pendingInertiaAnimator)
@@ -260,7 +243,6 @@ export class AnimatedScrollbar extends JSXComponent<AnimatedScrollbarPropsType>(
     ) {
       this.needRiseEnd = false;
       this.wasRelease = false;
-      this.hide();
 
       this.props.onUnlock?.();
 

--- a/js/renovation/ui/scroll_view/scrollbar/scrollbar.tsx
+++ b/js/renovation/ui/scroll_view/scrollbar/scrollbar.tsx
@@ -9,24 +9,23 @@ import {
   Mutable,
 } from '@devextreme-generator/declarations';
 
-import { Widget } from '../../common/widget';
 import { combineClasses } from '../../../utils/combine_classes';
-import { DisposeEffectReturn, EffectReturn } from '../../../utils/effect_return';
+import { EffectReturn } from '../../../utils/effect_return';
 import domAdapter from '../../../../core/dom_adapter';
-import { isDefined } from '../../../../core/utils/type';
-import { isDxMouseWheelEvent } from '../../../../events/utils/index';
 import {
   DIRECTION_HORIZONTAL, SCROLLABLE_SCROLLBAR_CLASS,
   SCROLLABLE_SCROLL_CLASS,
   SCROLLABLE_SCROLL_CONTENT_CLASS,
-  HIDE_SCROLLBAR_TIMEOUT,
   SCROLLABLE_SCROLLBAR_ACTIVE_CLASS,
   HOVER_ENABLED_STATE,
+  ShowScrollbarMode,
 } from '../common/consts';
 
 import {
   subscribeToDXPointerDownEvent,
   subscribeToDXPointerUpEvent,
+  subscribeToMouseEnterEvent,
+  subscribeToMouseLeaveEvent,
 } from '../../../utils/subscribe_to_event';
 
 import { BaseWidgetProps } from '../../common/base_props';
@@ -34,7 +33,6 @@ import { inRange } from '../../../../core/utils/math';
 import { DxMouseEvent } from '../common/types';
 import { clampIntoRange } from '../utils/clamp_into_range';
 import { ScrollbarProps } from '../common/scrollbar_props';
-import { ScrollableProps } from '../common/scrollable_props';
 import { ScrollableSimulatedProps } from '../common/simulated_strategy_props';
 
 const OUT_BOUNDS_ACCELERATION = 0.5;
@@ -42,32 +40,20 @@ export const THUMB_MIN_SIZE = 15;
 
 export const viewFunction = (viewModel: Scrollbar): JSX.Element => {
   const {
-    cssClasses, scrollStyles, scrollRef, scrollbarRef, hoverStateEnabled,
-    hoverInHandler, hoverOutHandler, isVisible,
-    props: { activeStateEnabled },
+    scrollbarRef, thumbRef, scrollbarClasses, thumbClasses, thumbStyles,
   } = viewModel;
 
   return (
-    <Widget
-      rootElementRef={scrollbarRef}
-      classes={cssClasses}
-      activeStateEnabled={activeStateEnabled}
-      hoverStateEnabled={hoverStateEnabled}
-      focusStateEnabled
-      visible={isVisible}
-      onHoverStart={hoverInHandler}
-      onHoverEnd={hoverOutHandler}
-    >
-      <div className={viewModel.scrollClasses} style={scrollStyles} ref={scrollRef}>
+    <div className={scrollbarClasses} ref={scrollbarRef}>
+      <div className={thumbClasses} style={thumbStyles} ref={thumbRef}>
         <div className={SCROLLABLE_SCROLL_CONTENT_CLASS} />
       </div>
-    </Widget>
+    </div>
   );
 };
 
 export type ScrollbarPropsType = ScrollbarProps
 & Pick<BaseWidgetProps, 'rtlEnabled'>
-& Pick<ScrollableProps, 'direction'>
 & Pick<ScrollableSimulatedProps, 'bounceEnabled' | 'showScrollbar' | 'scrollByThumb' | 'scrollLocationChange'>;
 
 @Component({
@@ -80,10 +66,6 @@ export class Scrollbar extends JSXComponent<ScrollbarPropsType>() {
 
   @Mutable() prevScrollLocation = 0;
 
-  @Mutable() hideScrollbarTimer?: unknown;
-
-  @InternalState() showOnScrollByWheel?: boolean;
-
   @InternalState() hovered = false;
 
   @InternalState() expanded = false;
@@ -92,16 +74,50 @@ export class Scrollbar extends JSXComponent<ScrollbarPropsType>() {
 
   @Ref() scrollbarRef!: RefObject<HTMLDivElement>;
 
-  @Ref() scrollRef!: RefObject<HTMLDivElement>;
+  @Ref() thumbRef!: RefObject<HTMLDivElement>;
 
   @Effect()
   pointerDownEffect(): EffectReturn {
-    return subscribeToDXPointerDownEvent(this.scrollRef.current, () => { this.expand(); });
+    return subscribeToDXPointerDownEvent(
+      this.thumbRef.current, () => {
+        this.expanded = true;
+      },
+    );
   }
 
   @Effect()
   pointerUpEffect(): EffectReturn {
-    return subscribeToDXPointerUpEvent(domAdapter.getDocument(), () => { this.collapse(); });
+    return subscribeToDXPointerUpEvent(
+      domAdapter.getDocument(), () => {
+        this.expanded = false;
+      },
+    );
+  }
+
+  @Effect()
+  mouseEnterEffect(): EffectReturn {
+    if (this.isHoverMode) {
+      return subscribeToMouseEnterEvent(
+        this.scrollbarRef.current, () => {
+          this.hovered = true;
+        },
+      );
+    }
+
+    return undefined;
+  }
+
+  @Effect()
+  mouseLeaveEffect(): EffectReturn {
+    if (this.isHoverMode) {
+      return subscribeToMouseLeaveEvent(
+        this.scrollbarRef.current, () => {
+          this.hovered = false;
+        },
+      );
+    }
+
+    return undefined;
   }
 
   @Method()
@@ -116,34 +132,11 @@ export class Scrollbar extends JSXComponent<ScrollbarPropsType>() {
   }
 
   @Method()
-  show(): void {
-    this.visibility = true;
-  }
-
-  @Method()
-  hide(): void {
-    this.visibility = false;
-
-    if (isDefined(this.showOnScrollByWheel) && this.props.showScrollbar === 'onScroll') {
-      this.hideScrollbarTimer = setTimeout(() => {
-        this.showOnScrollByWheel = undefined;
-      }, HIDE_SCROLLBAR_TIMEOUT);
-    }
-  }
-
-  @Method()
   initHandler(
     event: DxMouseEvent,
     thumbScrolling: boolean,
     offset: number,
   ): void {
-    if (isDxMouseWheelEvent(event.originalEvent)) {
-      if (this.props.showScrollbar === 'onScroll') {
-        this.showOnScrollByWheel = true;
-      }
-      return;
-    }
-
     const { target } = event.originalEvent;
     const scrollbarClicked = this.props.scrollByThumb && this.isScrollbar(target);
 
@@ -152,7 +145,7 @@ export class Scrollbar extends JSXComponent<ScrollbarPropsType>() {
     }
 
     if (thumbScrolling) {
-      this.expand();
+      this.expanded = true;
     }
   }
 
@@ -170,11 +163,6 @@ export class Scrollbar extends JSXComponent<ScrollbarPropsType>() {
     }
 
     this.scrollStep(resultDelta, minOffset, maxOffset);
-  }
-
-  @Effect({ run: 'once' })
-  disposeHideScrollbarTimer(): DisposeEffectReturn {
-    return (): void => this.clearHideScrollbarTimer();
   }
 
   @Method()
@@ -230,11 +218,6 @@ export class Scrollbar extends JSXComponent<ScrollbarPropsType>() {
     return this.props.direction === DIRECTION_HORIZONTAL;
   }
 
-  clearHideScrollbarTimer(): void {
-    clearTimeout(this.hideScrollbarTimer as number);
-    this.hideScrollbarTimer = undefined;
-  }
-
   moveToMouseLocation(event: DxMouseEvent, offset: number): void {
     const mouseLocation = event[`page${this.axis.toUpperCase()}`] - offset;
     const delta = mouseLocation / this.containerToContentRatio - this.props.containerSize / 2;
@@ -264,48 +247,25 @@ export class Scrollbar extends JSXComponent<ScrollbarPropsType>() {
     return 1;
   }
 
-  expand(): void {
-    this.expanded = true;
-  }
-
-  collapse(): void {
-    this.expanded = false;
-  }
-
-  hoverInHandler(): void {
-    if (this.props.showScrollbar === 'onHover') {
-      this.hovered = true;
-    }
-  }
-
-  hoverOutHandler(): void {
-    if (this.props.showScrollbar === 'onHover') {
-      this.hovered = false;
-    }
-  }
-
-  get cssClasses(): string {
+  get scrollbarClasses(): string {
     const classesMap = {
       [SCROLLABLE_SCROLLBAR_CLASS]: true,
       [`dx-scrollbar-${this.props.direction}`]: true,
-      [SCROLLABLE_SCROLLBAR_ACTIVE_CLASS]: !!this.expanded,
-      [HOVER_ENABLED_STATE]: !!this.hoverStateEnabled,
+      [SCROLLABLE_SCROLLBAR_ACTIVE_CLASS]: this.expanded,
+      [HOVER_ENABLED_STATE]: this.isExpandable,
+      'dx-state-invisible': this.hidden,
     };
     return combineClasses(classesMap);
   }
 
-  get scrollStyles(): { [key: string]: string | number } {
+  get thumbStyles(): { [key: string]: string | number } {
     return {
       [this.dimension]: this.scrollSize || THUMB_MIN_SIZE, // TODO: remove ||
-      transform: this.scrollTransform,
+      transform: this.isNeverMode ? 'none' : this.thumbTransform,
     };
   }
 
-  get scrollTransform(): string {
-    if (this.props.showScrollbar === 'never') {
-      return 'none';
-    }
-
+  get thumbTransform(): string {
     const translateValue = -this.props.scrollLocation * this.scrollRatio;
 
     if (this.isHorizontal) {
@@ -315,36 +275,44 @@ export class Scrollbar extends JSXComponent<ScrollbarPropsType>() {
     return `translate(0px, ${translateValue}px)`;
   }
 
-  get scrollClasses(): string {
+  get thumbClasses(): string {
     return combineClasses({
       [SCROLLABLE_SCROLL_CLASS]: true,
-      'dx-state-invisible': !this.visible,
+      'dx-state-invisible': !this.isThumbVisible,
     });
   }
 
-  get isVisible(): boolean {
-    return this.props.showScrollbar !== 'never' && -this.props.maxOffset > 0 && this.props.containerSize > 15;
+  get hidden(): boolean {
+    return this.isNeverMode || this.props.maxOffset === 0 || this.props.containerSize < 15;
   }
 
-  get visible(): boolean {
-    const { showScrollbar, forceVisibility } = this.props;
-
-    if (!this.isVisible) {
+  get isThumbVisible(): boolean {
+    if (this.hidden) {
       return false;
     }
-    if (showScrollbar === 'onHover') {
-      return this.visibility || this.props.isScrollableHovered || this.hovered;
+    if (this.isHoverMode) {
+      return this.props.visible || this.visibility || this.hovered;
     }
-    if (showScrollbar === 'always') {
+    if (this.isAlwaysMode) {
       return true;
     }
 
-    return forceVisibility || this.visibility || !!this.showOnScrollByWheel;
+    return this.props.visible || this.visibility;
   }
 
-  get hoverStateEnabled(): boolean {
-    const { showScrollbar, scrollByThumb } = this.props;
+  get isExpandable(): boolean {
+    return (this.isHoverMode || this.isAlwaysMode) && this.props.scrollByThumb;
+  }
 
-    return (showScrollbar === 'onHover' || showScrollbar === 'always') && scrollByThumb;
+  get isHoverMode(): boolean {
+    return this.props.showScrollbar === ShowScrollbarMode.HOVER;
+  }
+
+  get isAlwaysMode(): boolean {
+    return this.props.showScrollbar === ShowScrollbarMode.ALWAYS;
+  }
+
+  get isNeverMode(): boolean {
+    return this.props.showScrollbar === ShowScrollbarMode.NEVER;
   }
 }

--- a/js/renovation/ui/scroll_view/scrollbar/scrollbar.tsx
+++ b/js/renovation/ui/scroll_view/scrollbar/scrollbar.tsx
@@ -40,11 +40,11 @@ export const THUMB_MIN_SIZE = 15;
 
 export const viewFunction = (viewModel: Scrollbar): JSX.Element => {
   const {
-    scrollbarRef, thumbRef, scrollbarClasses, thumbClasses, thumbStyles,
+    scrollbarRef, thumbRef, scrollbarClasses, thumbClasses, thumbStyles, hidden,
   } = viewModel;
 
   return (
-    <div className={scrollbarClasses} ref={scrollbarRef}>
+    <div className={scrollbarClasses} ref={scrollbarRef} hidden={hidden}>
       <div className={thumbClasses} style={thumbStyles} ref={thumbRef}>
         <div className={SCROLLABLE_SCROLL_CONTENT_CLASS} />
       </div>

--- a/js/renovation/ui/scroll_view/strategy/__tests__/native.test.tsx
+++ b/js/renovation/ui/scroll_view/strategy/__tests__/native.test.tsx
@@ -1083,22 +1083,6 @@ describe('Methods', () => {
         if (isHorizontal) {
           expect(viewModel.hScrollLocation).toEqual(-4);
         }
-
-        expect(viewModel.needForceScrollbarsVisibility).toEqual(true);
-
-        expect(viewModel.hideScrollbarTimer === undefined).toBe(false);
-
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 500);
-
-        expect(viewModel.needForceScrollbarsVisibility).toEqual(true);
-
-        jest.runOnlyPendingTimers();
-
-        expect(viewModel.needForceScrollbarsVisibility).toEqual(false);
-
-        viewModel.disposeHideScrollbarTimer()();
-        expect(viewModel.hideScrollbarTimer).toBe(undefined);
       });
     });
   });
@@ -1158,11 +1142,11 @@ describe('Scrollbar integration', () => {
         contentSize: 0,
         maxOffset: -0,
         scrollLocation: 0,
-        forceVisibility: false,
+        visible: false,
         showScrollbar: 'onScroll',
       };
-      const vScrollbarClasses = 'dx-widget dx-scrollable-scrollbar dx-scrollbar-vertical dx-state-invisible';
-      const hScrollbarClasses = 'dx-widget dx-scrollable-scrollbar dx-scrollbar-horizontal dx-state-invisible';
+      const vScrollbarClasses = 'dx-scrollable-scrollbar dx-scrollbar-vertical dx-state-invisible';
+      const hScrollbarClasses = 'dx-scrollable-scrollbar dx-scrollbar-horizontal dx-state-invisible';
 
       if (helper.isBoth) {
         expect(scrollbars.length).toEqual(2);

--- a/js/renovation/ui/scroll_view/strategy/__tests__/native_test_helper.ts
+++ b/js/renovation/ui/scroll_view/strategy/__tests__/native_test_helper.ts
@@ -198,8 +198,8 @@ class ScrollableTestHelper {
       const scrollbar = scrollbarRef.instance();
       scrollbar.scrollbarRef = React.createRef();
       scrollbar.scrollbarRef.current = scrollbarRef.getDOMNode();
-      scrollbar.scrollRef = React.createRef();
-      scrollbar.scrollRef.current = scrollbarRef.find('.dx-scrollable-scroll').getDOMNode();
+      scrollbar.thumbRef = React.createRef();
+      scrollbar.thumbRef.current = scrollbarRef.find('.dx-scrollable-scroll').getDOMNode();
 
       Object.assign(scrollbar, {
         props: {

--- a/js/renovation/ui/scroll_view/strategy/__tests__/simulated.test.tsx
+++ b/js/renovation/ui/scroll_view/strategy/__tests__/simulated.test.tsx
@@ -12,6 +12,7 @@ import {
   DIRECTION_BOTH,
   TopPocketState,
   HOVER_ENABLED_STATE,
+  ShowScrollbarMode,
 } from '../../common/consts';
 
 import devices from '../../../../../core/devices';
@@ -242,14 +243,14 @@ describe('Simulated > Render', () => {
         const scrollbars = helper.getScrollbars();
         const commonOptions = {
           scrollByThumb: true,
-          isScrollableHovered: false,
+          visible: false,
           bounceEnabled: true,
           showScrollbar,
         };
 
         const isHoverable = showScrollbar === 'onHover' || showScrollbar === 'always';
-        const vScrollbarClasses = `dx-widget dx-scrollable-scrollbar dx-scrollbar-vertical ${isHoverable ? `${HOVER_ENABLED_STATE} ` : ''}dx-state-invisible`;
-        const hScrollbarClasses = `dx-widget dx-scrollable-scrollbar dx-scrollbar-horizontal ${isHoverable ? `${HOVER_ENABLED_STATE} ` : ''}dx-state-invisible`;
+        const vScrollbarClasses = `dx-scrollable-scrollbar dx-scrollbar-vertical ${isHoverable ? `${HOVER_ENABLED_STATE} ` : ''}dx-state-invisible`;
+        const hScrollbarClasses = `dx-scrollable-scrollbar dx-scrollbar-horizontal ${isHoverable ? `${HOVER_ENABLED_STATE} ` : ''}dx-state-invisible`;
 
         if (helper.isBoth) {
           expect(scrollbars.length).toEqual(2);
@@ -331,6 +332,62 @@ describe('Simulated > Behavior', () => {
         } else {
           expect(viewModel.locked).toEqual(false);
         }
+      });
+    });
+
+    it('should subscribe to mouseenter event if showScrollbar mode is onHover', () => {
+      const helper = new ScrollableTestHelper({
+        direction: 'vertical',
+        showScrollbar: 'onHover',
+      });
+      helper.viewModel.hovered = false;
+
+      helper.viewModel.mouseEnterEffect();
+      emit('mouseenter');
+
+      expect(helper.viewModel.hovered).toEqual(true);
+    });
+
+    each([ShowScrollbarMode.SCROLL, ShowScrollbarMode.NEVER, ShowScrollbarMode.ALWAYS]).describe('ShowScrollbar: %o', (showScrollbar) => {
+      it(`should not subscribe to mouseenter event if showScrollbar mode is ${showScrollbar}`, () => {
+        const helper = new ScrollableTestHelper({
+          direction: 'vertical',
+          showScrollbar,
+        });
+        helper.viewModel.hovered = false;
+
+        helper.viewModel.mouseEnterEffect();
+        emit('mouseenter');
+
+        expect(helper.viewModel.hovered).toEqual(false);
+      });
+    });
+
+    it('should subscribe to mouseleave event if showScrollbar mode is onHover', () => {
+      const helper = new ScrollableTestHelper({
+        direction: 'vertical',
+        showScrollbar: 'onHover',
+      });
+      helper.viewModel.hovered = true;
+
+      helper.viewModel.mouseLeaveEffect();
+      emit('mouseleave');
+
+      expect(helper.viewModel.hovered).toEqual(false);
+    });
+
+    each([ShowScrollbarMode.SCROLL, ShowScrollbarMode.NEVER, ShowScrollbarMode.ALWAYS]).describe('ShowScrollbar: %o', (showScrollbar) => {
+      it(`should not subscribe to mouseleave event if showScrollbar mode is ${showScrollbar}`, () => {
+        const helper = new ScrollableTestHelper({
+          direction: 'vertical',
+          showScrollbar,
+        });
+        helper.viewModel.hovered = true;
+
+        helper.viewModel.mouseLeaveEffect();
+        emit('mouseleave');
+
+        expect(helper.viewModel.hovered).toEqual(true);
       });
     });
 
@@ -997,20 +1054,6 @@ describe('Simulated > Behavior', () => {
             }
           });
         });
-      });
-    });
-
-    each(['always', 'onHover', 'never', 'onScroll']).describe('HoverEffect params. showScrollbar: %o', (showScrollbar) => {
-      it('hoverStart, hoverEnd handlers should update hovered state only for onHover mode', () => {
-        const viewModel = new Scrollable({ direction: DIRECTION_HORIZONTAL, showScrollbar }) as any;
-
-        expect(viewModel.hovered).toBe(false);
-
-        viewModel.hoverInHandler();
-        expect(viewModel.hovered).toBe(showScrollbar === 'onHover');
-
-        viewModel.hoverOutHandler();
-        expect(viewModel.hovered).toBe(false);
       });
     });
   });

--- a/js/renovation/ui/scroll_view/strategy/__tests__/simulated_test_helper.ts
+++ b/js/renovation/ui/scroll_view/strategy/__tests__/simulated_test_helper.ts
@@ -240,8 +240,8 @@ class ScrollableTestHelper {
       scrollbar.scrollbarRef = React.createRef();
       scrollbar.scrollbarRef.current = scrollbars.at(index).getDOMNode();
 
-      scrollbar.scrollRef = React.createRef();
-      scrollbar.scrollRef.current = scrollbars.at(index).find('.dx-scrollable-scroll').getDOMNode();
+      scrollbar.thumbRef = React.createRef();
+      scrollbar.thumbRef.current = scrollbars.at(index).find('.dx-scrollable-scroll').getDOMNode();
 
       Object.assign(animatedScrollbar, {
         props: {

--- a/js/renovation/ui/scroll_view/strategy/native.tsx
+++ b/js/renovation/ui/scroll_view/strategy/native.tsx
@@ -37,7 +37,6 @@ import {
   ScrollOffset, ScrollableDirection, DxMouseEvent,
   DxMouseWheelEvent,
 } from '../common/types';
-import resizeObserverSingleton from '../../../../core/resize_observer';
 
 import { isDxMouseWheelEvent } from '../../../../events/utils/index';
 
@@ -63,6 +62,7 @@ import { isVisible } from '../utils/is_element_visible';
 import { ScrollableNativeProps } from '../common/native_strategy_props';
 import { allowedDirection } from '../utils/get_allowed_direction';
 import { getScrollTopMax } from '../utils/get_scroll_top_max';
+import { subscribeToResize } from '../utils/subscribe_to_resize';
 
 export const viewFunction = (viewModel: ScrollableNative): JSX.Element => {
   const {
@@ -430,26 +430,20 @@ export class ScrollableNative extends JSXComponent<ScrollableNativeProps>() {
 
   @Effect({ run: 'once' })
   /* istanbul ignore next */
-  containerResizeObserver(): DisposeEffectReturn {
-    const containerEl = this.containerRef.current;
-
-    resizeObserverSingleton.observe(containerEl, ({ target }) => {
-      this.setContainerDimensions(target);
-    });
-
-    return (): void => { resizeObserverSingleton.unobserve(containerEl); };
+  subscribeContainerToResize(): EffectReturn {
+    return subscribeToResize(
+      this.containerRef.current,
+      (element: HTMLDivElement) => { this.setContainerDimensions(element); },
+    );
   }
 
   @Effect({ run: 'once' })
   /* istanbul ignore next */
-  contentResizeObserver(): DisposeEffectReturn {
-    const contentEl = this.contentRef.current;
-
-    resizeObserverSingleton.observe(contentEl, ({ target }) => {
-      this.setContentDimensions(target);
-    });
-
-    return (): void => { resizeObserverSingleton.unobserve(contentEl); };
+  subscribeContentToResize(): EffectReturn {
+    return subscribeToResize(
+      this.contentRef.current,
+      (element: HTMLDivElement) => { this.setContentDimensions(element); },
+    );
   }
 
   scrollByLocation(location: ScrollOffset): void {

--- a/js/renovation/ui/scroll_view/strategy/native.tsx
+++ b/js/renovation/ui/scroll_view/strategy/native.tsx
@@ -64,14 +64,12 @@ import { ScrollableNativeProps } from '../common/native_strategy_props';
 import { allowedDirection } from '../utils/get_allowed_direction';
 import { getScrollTopMax } from '../utils/get_scroll_top_max';
 
-const HIDE_SCROLLBAR_TIMEOUT = 500;
-
 export const viewFunction = (viewModel: ScrollableNative): JSX.Element => {
   const {
     cssClasses, wrapperRef, contentRef, containerRef, topPocketRef, bottomPocketRef, direction,
     hScrollbarRef, vScrollbarRef,
     contentClientWidth, containerClientWidth, contentClientHeight, containerClientHeight,
-    updateHandleInternal, needForceScrollbarsVisibility,
+    updateHandleInternal, scrolling,
     scrollableRef, isLoadPanelVisible, topPocketState,
     pullDownTranslateTop, pullDownIconAngle, pullDownOpacity,
     topPocketHeight, contentStyles, scrollViewContentRef, contentTranslateTop,
@@ -158,7 +156,7 @@ export const viewFunction = (viewModel: ScrollableNative): JSX.Element => {
           containerSize={containerClientWidth}
           maxOffset={hScrollOffsetMax}
           scrollLocation={hScrollLocation}
-          forceVisibility={needForceScrollbarsVisibility}
+          visible={scrolling}
         />
       )}
       { needRenderScrollbars && showScrollbar !== 'never' && useSimulatedScrollbar && direction.isVertical && (
@@ -170,7 +168,7 @@ export const viewFunction = (viewModel: ScrollableNative): JSX.Element => {
           containerSize={containerClientHeight}
           maxOffset={vScrollOffsetMax}
           scrollLocation={vScrollLocation}
-          forceVisibility={needForceScrollbarsVisibility}
+          visible={scrolling}
         />
       )}
     </Widget>
@@ -230,7 +228,7 @@ export class ScrollableNative extends JSXComponent<ScrollableNativeProps>() {
 
   @InternalState() bottomPocketHeight = 0;
 
-  @InternalState() needForceScrollbarsVisibility = false;
+  @InternalState() scrolling = false;
 
   @InternalState() topPocketState = TopPocketState.STATE_RELEASED;
 
@@ -356,11 +354,6 @@ export class ScrollableNative extends JSXComponent<ScrollableNativeProps>() {
     }
 
     this.containerRef.current![this.fullScrollInactiveProp] = 0;
-  }
-
-  @Effect({ run: 'once' })
-  disposeHideScrollbarTimer(): DisposeEffectReturn {
-    return (): void => this.clearHideScrollbarTimer();
   }
 
   @Effect()
@@ -510,7 +503,9 @@ export class ScrollableNative extends JSXComponent<ScrollableNativeProps>() {
     this.eventForUserAction = event;
 
     if (this.props.useSimulatedScrollbar) {
+      this.scrolling = true;
       this.syncScrollbarsWithContent();
+      this.scrolling = false;
     }
 
     this.props.onScroll?.(this.getEventArgs());
@@ -628,19 +623,6 @@ export class ScrollableNative extends JSXComponent<ScrollableNativeProps>() {
 
     this.hScrollLocation = -left;
     this.vScrollLocation = -top;
-
-    this.needForceScrollbarsVisibility = true;
-
-    this.clearHideScrollbarTimer();
-
-    this.hideScrollbarTimer = setTimeout(() => {
-      this.needForceScrollbarsVisibility = false;
-    }, HIDE_SCROLLBAR_TIMEOUT);
-  }
-
-  clearHideScrollbarTimer(): void {
-    clearTimeout(this.hideScrollbarTimer as number);
-    this.hideScrollbarTimer = undefined;
   }
 
   getInitEventData(): {

--- a/js/renovation/ui/scroll_view/strategy/simulated.tsx
+++ b/js/renovation/ui/scroll_view/strategy/simulated.tsx
@@ -37,7 +37,6 @@ import {
 import { isDefined } from '../../../../core/utils/type';
 import { ScrollableSimulatedProps } from '../common/simulated_strategy_props';
 import eventsEngine from '../../../../events/core/events_engine';
-import resizeObserverSingleton from '../../../../core/resize_observer';
 
 import {
   ScrollDirection,
@@ -85,6 +84,7 @@ import { isVisible } from '../utils/is_element_visible';
 import { getTranslateValues } from '../utils/get_translate_values';
 import { clampIntoRange } from '../utils/clamp_into_range';
 import { allowedDirection } from '../utils/get_allowed_direction';
+import { subscribeToResize } from '../utils/subscribe_to_resize';
 
 export const viewFunction = (viewModel: ScrollableSimulated): JSX.Element => {
   const {
@@ -536,58 +536,38 @@ export class ScrollableSimulated extends JSXComponent<ScrollableSimulatedProps>(
 
   @Effect({ run: 'once' })
   /* istanbul ignore next */
-  topPocketResizeObserver(): DisposeEffectReturn | undefined {
-    if (!this.props.forceGeneratePockets) {
-      return undefined;
-    }
-
-    const topPocketEl = this.topPocketRef.current;
-
-    resizeObserverSingleton.observe(topPocketEl, ({ target }) => {
-      this.setTopPocketDimensions(target);
-    });
-
-    return (): void => { resizeObserverSingleton.unobserve(topPocketEl); };
+  subscribeTopPocketToResize(): EffectReturn {
+    return subscribeToResize(
+      this.topPocketRef.current,
+      (element: HTMLDivElement) => { this.setTopPocketDimensions(element); },
+    );
   }
 
   @Effect({ run: 'once' })
   /* istanbul ignore next */
-  bottomPocketResizeObserver(): DisposeEffectReturn | undefined {
-    if (!this.props.forceGeneratePockets) {
-      return undefined;
-    }
-
-    const bottomPocketEl = this.bottomPocketRef.current;
-
-    resizeObserverSingleton.observe(bottomPocketEl, ({ target }) => {
-      this.setBottomPocketDimensions(target);
-    });
-
-    return (): void => { resizeObserverSingleton.unobserve(bottomPocketEl); };
+  subscribeBottomPocketToResize(): EffectReturn {
+    return subscribeToResize(
+      this.bottomPocketRef.current,
+      (element: HTMLDivElement) => { this.setBottomPocketDimensions(element); },
+    );
   }
 
   @Effect({ run: 'once' })
   /* istanbul ignore next */
-  containerResizeObserver(): DisposeEffectReturn {
-    const containerEl = this.containerRef.current;
-
-    resizeObserverSingleton.observe(containerEl, ({ target }) => {
-      this.setContainerDimensions(target);
-    });
-
-    return (): void => { resizeObserverSingleton.unobserve(containerEl); };
+  subscribeContainerToResize(): EffectReturn {
+    return subscribeToResize(
+      this.containerRef.current,
+      (element: HTMLDivElement) => { this.setContainerDimensions(element); },
+    );
   }
 
   @Effect({ run: 'once' })
   /* istanbul ignore next */
-  contentResizeObserver(): DisposeEffectReturn {
-    const contentEl = this.content();
-
-    resizeObserverSingleton.observe(contentEl, ({ target }) => {
-      this.setContentDimensions(target);
-    });
-
-    return (): void => { resizeObserverSingleton.unobserve(contentEl); };
+  subscribeContentToResize(): EffectReturn {
+    return subscribeToResize(
+      this.content(),
+      (element: HTMLDivElement) => { this.setContentDimensions(element); },
+    );
   }
 
   // if delete this effect we need to wait changing size inside resizeObservable

--- a/js/renovation/ui/scroll_view/utils/__tests__/subscribe_to_event.test.tsx
+++ b/js/renovation/ui/scroll_view/utils/__tests__/subscribe_to_event.test.tsx
@@ -1,0 +1,114 @@
+import { DisposeEffectReturn } from '../../../../utils/effect_return';
+import resizeObserverSingleton from '../../../../../core/resize_observer';
+import { getWindow, setWindow } from '../../../../../core/utils/window';
+
+import { subscribeToResize } from '../subscribe_to_resize';
+
+jest.mock('../../../../../core/resize_observer', () => ({
+  ...jest.requireActual('../../../../../core/resize_observer'),
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+}));
+
+describe('subscribeToResize', () => {
+  afterEach(() => { jest.clearAllMocks(); });
+
+  it('should not initialize resizeObservable on element if element is not defined', () => {
+    const observeHandler = jest.fn();
+    resizeObserverSingleton.observe = observeHandler;
+
+    subscribeToResize(null, () => {});
+
+    expect(observeHandler).toBeCalledTimes(0);
+  });
+
+  it('should not initialize resizeObservable on element if window is not defined', () => {
+    const originalWindow = getWindow();
+
+    try {
+      setWindow({}, false);
+
+      const observeHandler = jest.fn();
+      const resizeHandler = jest.fn();
+      resizeObserverSingleton.observe = observeHandler;
+
+      const element = {
+        clientWidth: 10,
+        clientHeight: 15,
+      } as HTMLDivElement;
+
+      subscribeToResize(element, resizeHandler);
+
+      expect(observeHandler).toBeCalledTimes(0);
+    } finally {
+      setWindow(originalWindow, true);
+    }
+  });
+
+  it('resize effect should return undefined value if window is not defined', () => {
+    const originalWindow = getWindow();
+
+    try {
+      setWindow({}, false);
+
+      const handler = jest.fn();
+      const unobserveHandler = jest.fn();
+      resizeObserverSingleton.unobserve = unobserveHandler;
+
+      const element = {
+        clientWidth: 10,
+        clientHeight: 15,
+      } as HTMLDivElement;
+
+      const unsubscribeFn = subscribeToResize(element, handler);
+
+      expect(unsubscribeFn).toEqual(undefined);
+      expect(unobserveHandler).toBeCalledTimes(0);
+    } finally {
+      setWindow(originalWindow, true);
+    }
+  });
+
+  it('should observe element changing, hasWindow: true', () => {
+    const observeHandler = jest.fn();
+    const resizeHandler = jest.fn();
+    resizeObserverSingleton.observe = observeHandler;
+
+    const element = {
+      clientWidth: 10,
+      clientHeight: 15,
+    } as HTMLDivElement;
+
+    subscribeToResize(element, resizeHandler);
+
+    expect(observeHandler).toBeCalledTimes(1);
+    expect(observeHandler.mock.calls[0][0]).toEqual(element);
+
+    const target = {
+      clientWidth: 20,
+      clientHeight: 30,
+    };
+    const entry = { target };
+    observeHandler.mock.calls[0][1](entry);
+    expect(resizeHandler).toBeCalledTimes(1);
+    expect(resizeHandler).toBeCalledWith(target);
+  });
+
+  it('should unobserve element changing on unsubsribe from effect, hasWindow: true', () => {
+    const handler = jest.fn();
+    const unobserveHandler = jest.fn();
+    resizeObserverSingleton.unobserve = unobserveHandler;
+
+    const element = {
+      clientWidth: 10,
+      clientHeight: 15,
+    } as HTMLDivElement;
+
+    const unsubscribeFn = subscribeToResize(element, handler);
+
+    (unsubscribeFn as DisposeEffectReturn)();
+
+    expect(unobserveHandler).toBeCalledTimes(1);
+    expect(unobserveHandler).toBeCalledWith(element);
+  });
+});

--- a/js/renovation/ui/scroll_view/utils/subscribe_to_resize.ts
+++ b/js/renovation/ui/scroll_view/utils/subscribe_to_resize.ts
@@ -1,0 +1,21 @@
+import resizeObserverSingleton from '../../../../core/resize_observer';
+import { EffectReturn } from '../../../utils/effect_return';
+import { hasWindow } from '../../../../core/utils/window';
+
+export function subscribeToResize(
+  element: HTMLDivElement | undefined | null,
+  handler: (el: HTMLDivElement) => void,
+): EffectReturn {
+  if (hasWindow() && element) {
+    resizeObserverSingleton.observe(
+      element,
+      ({ target }) => { handler(target); },
+    );
+
+    return (): void => {
+      resizeObserverSingleton.unobserve(element);
+    };
+  }
+
+  return undefined;
+}

--- a/js/renovation/utils/__tests__/subscribe_to_event.test.ts
+++ b/js/renovation/utils/__tests__/subscribe_to_event.test.ts
@@ -15,6 +15,8 @@ import {
   subscribeToDXPointerDownEvent,
   subscribeToDXPointerUpEvent,
   subscribeToKeyDownEvent,
+  subscribeToMouseEnterEvent,
+  subscribeToMouseLeaveEvent,
 } from '../subscribe_to_event';
 
 describe('subscribeToEvent', () => {
@@ -33,6 +35,8 @@ describe('subscribeToEvent', () => {
     { name: EVENT.pointerDown, subscribeFn: subscribeToDXPointerDownEvent },
     { name: EVENT.pointerUp, subscribeFn: subscribeToDXPointerUpEvent },
     { name: 'keydown', subscribeFn: subscribeToKeyDownEvent },
+    { name: 'mouseenter', subscribeFn: subscribeToMouseEnterEvent },
+    { name: 'mouseleave', subscribeFn: subscribeToMouseLeaveEvent },
   ]).describe('event: %o', (event) => {
     it(`should not subscribe to ${event.name} event without handler`, () => {
       event.subscribeFn(element, null);

--- a/js/renovation/utils/subscribe_to_event.ts
+++ b/js/renovation/utils/subscribe_to_event.ts
@@ -32,4 +32,7 @@ export const subscribeToDXScrollCancelEvent = subscribeToEvent(scrollEvents.canc
 export const subscribeToDXPointerDownEvent = subscribeToEvent(pointerEvents.down);
 export const subscribeToDXPointerUpEvent = subscribeToEvent(pointerEvents.up);
 
+export const subscribeToMouseEnterEvent = subscribeToEvent('mouseenter');
+export const subscribeToMouseLeaveEvent = subscribeToEvent('mouseleave');
+
 export const subscribeToKeyDownEvent = subscribeToEvent('keydown');

--- a/scss/widgets/base/_scrollable.scss
+++ b/scss/widgets/base/_scrollable.scss
@@ -172,6 +172,7 @@
 
 .dx-scrollable-scroll {
   position: relative;
+  box-sizing: border-box;
   background-color: #888; /* NOTE: fallback for rgba non-supporting */
   background-color: rgba(0, 0, 0, 0.5);
   -webkit-transform: translate(0, 0); // stylelint-disable-line property-no-vendor-prefix


### PR DESCRIPTION
- subscribe to mouseenter, mouseleave event instead of usind dxhover events
- avoid using timeouts for hiding scrollbars in both strategies 
- avoid using widget functionality for scrollbars