### PR TITLE
Temp W\A for DateViewRoller._itemHeight()

### DIFF
--- a/js/ui/date_box/ui.date_view_roller.js
+++ b/js/ui/date_box/ui.date_view_roller.js
@@ -1,4 +1,3 @@
-import { getHeight } from '../../core/utils/size';
 import $ from '../../core/renderer';
 import eventsEngine from '../../events/core/events_engine';
 import registerComponent from '../../core/component_registrator';
@@ -261,7 +260,9 @@ class DateViewRoller extends Scrollable {
     _itemHeight() {
         const $item = this._$items.first();
 
-        return getHeight($item);
+        // TODO: use getHeight instead of clientHeight after resolving the following:
+        // getHeight returns an incorrect value when a transform applied to an element;
+        return $item.get(0).clientHeight;
     }
 
     _toggleActive(state) {


### PR DESCRIPTION
This PR contains a temporary fix for the failed test:
`Rollers should be scrolled correctly when value is changed to 12/11/1925 using kbn and valueChangeEvent=keyup (T948310)`
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
