### PR TITLE
Get rid of IE hacks: Utils - ReadyCallbacks

### DIFF
--- a/js/core/utils/ready_callbacks.js
+++ b/js/core/utils/ready_callbacks.js
@@ -14,8 +14,7 @@ const subscribeReady = callOnce(() => {
 const readyCallbacks = {
     add: callback => {
         const windowExists = hasWindow();
-        const isReady = domAdapter.getReadyState() !== 'loading';
-        if(windowExists && isReady) {
+        if(windowExists && domAdapter.getReadyState() !== 'loading') {
             callback();
         } else {
             callbacks.push(callback);

--- a/js/core/utils/ready_callbacks.js
+++ b/js/core/utils/ready_callbacks.js
@@ -4,11 +4,6 @@ import { hasWindow } from './window';
 import callOnce from './call_once';
 let callbacks = [];
 
-const isReady = () => {
-    // NOTE: we can't use document.readyState === "interactive" because of ie9/ie10 support
-    return domAdapter.getReadyState() === 'complete' || (domAdapter.getReadyState() !== 'loading' && !domAdapter.getDocumentElement().doScroll);
-};
-
 const subscribeReady = callOnce(() => {
     const removeListener = domAdapter.listen(domAdapter.getDocument(), 'DOMContentLoaded', () => {
         readyCallbacks.fire();
@@ -19,8 +14,8 @@ const subscribeReady = callOnce(() => {
 const readyCallbacks = {
     add: callback => {
         const windowExists = hasWindow();
-
-        if(windowExists && isReady()) {
+        const isReady = domAdapter.getReadyState() !== 'loading';
+        if(windowExists && isReady) {
             callback();
         } else {
             callbacks.push(callback);


### PR DESCRIPTION
Internet Explorer 9 and 10 have bugs where the 'interactive' state can be fired too early before the document has finished parsing.
Since we no longer support Internet Explorer,  we need only checking that `getReadyState()` returned value is not `loading`.