### PR TITLE
DataGrid - The mouse cursor is changed to 'hand' over a sorted column's header when sorting.mode is 'none' (T1032991)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.sorting_mixin.js
+++ b/js/ui/grid_core/ui.grid_core.sorting_mixin.js
@@ -26,7 +26,7 @@ export default {
 
             const isSortingAllowed = (sortingMode === 'single' || sortingMode === 'multiple') && column.allowSorting;
 
-            if(!isDefined(column.groupIndex) && isSortingAllowed) {
+            if(!isDefined(column.groupIndex) && (isSortingAllowed || isDefined(column.sortOrder))) {
                 ariaSortState = column.sortOrder === 'asc' ? 'ascending' : 'descending';
                 $sortIndicator = that.callBase(options)
                     .toggleClass(SORTUP_CLASS, column.sortOrder === 'asc')
@@ -41,7 +41,9 @@ export default {
                     $sortIndicator.addClass(SORT_INDEX_CLASS);
                 }
 
-                options.rootElement.addClass(that.addWidgetPrefix(HEADERS_ACTION_CLASS));
+                if(isSortingAllowed) {
+                    options.rootElement.addClass(that.addWidgetPrefix(HEADERS_ACTION_CLASS));
+                }
             }
 
             if(!isDefined(column.sortOrder)) {

--- a/js/ui/grid_core/ui.grid_core.sorting_mixin.js
+++ b/js/ui/grid_core/ui.grid_core.sorting_mixin.js
@@ -24,7 +24,7 @@ export default {
             rootElement.find('.' + SORT_CLASS).remove();
             !$indicatorsContainer.children().length && $indicatorsContainer.remove();
 
-            const isSortingAllowed = (sortingMode === 'single' || sortingMode === 'multiple') && column.allowSorting;
+            const isSortingAllowed = sortingMode !== 'none' && column.allowSorting;
 
             if(!isDefined(column.groupIndex) && (isSortingAllowed || isDefined(column.sortOrder))) {
                 ariaSortState = column.sortOrder === 'asc' ? 'ascending' : 'descending';
@@ -41,9 +41,7 @@ export default {
                     $sortIndicator.addClass(SORT_INDEX_CLASS);
                 }
 
-                if(isSortingAllowed) {
-                    options.rootElement.addClass(that.addWidgetPrefix(HEADERS_ACTION_CLASS));
-                }
+                options.rootElement.addClass(that.addWidgetPrefix(HEADERS_ACTION_CLASS));
             }
 
             if(!isDefined(column.sortOrder)) {

--- a/js/ui/grid_core/ui.grid_core.sorting_mixin.js
+++ b/js/ui/grid_core/ui.grid_core.sorting_mixin.js
@@ -41,7 +41,9 @@ export default {
                     $sortIndicator.addClass(SORT_INDEX_CLASS);
                 }
 
-                options.rootElement.addClass(that.addWidgetPrefix(HEADERS_ACTION_CLASS));
+                if(isSortingAllowed) {
+                    options.rootElement.addClass(that.addWidgetPrefix(HEADERS_ACTION_CLASS));
+                }
             }
 
             if(!isDefined(column.sortOrder)) {

--- a/js/ui/grid_core/ui.grid_core.sorting_mixin.js
+++ b/js/ui/grid_core/ui.grid_core.sorting_mixin.js
@@ -26,7 +26,7 @@ export default {
 
             const isSortingAllowed = (sortingMode === 'single' || sortingMode === 'multiple') && column.allowSorting;
 
-            if(!isDefined(column.groupIndex) && (isSortingAllowed || isDefined(column.sortOrder))) {
+            if(!isDefined(column.groupIndex) && isSortingAllowed) {
                 ariaSortState = column.sortOrder === 'asc' ? 'ascending' : 'descending';
                 $sortIndicator = that.callBase(options)
                     .toggleClass(SORTUP_CLASS, column.sortOrder === 'asc')

--- a/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
+++ b/js/ui/pivot_grid/ui.pivot_grid.field_chooser_base.js
@@ -155,7 +155,8 @@ const FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).
                     rootElement: $fieldElement,
                     column: {
                         alignment: that.option('rtlEnabled') ? 'right' : 'left',
-                        sortOrder: field.sortOrder === 'desc' ? 'desc' : 'asc'
+                        sortOrder: field.sortOrder === 'desc' ? 'desc' : 'asc',
+                        allowSorting: field.allowSorting
                     },
                     showColumnLines: showColumnLines
                 });
@@ -167,7 +168,8 @@ const FieldChooserBase = Widget.inherit(columnStateMixin).inherit(sortingMixin).
                 column: {
                     alignment: that.option('rtlEnabled') ? 'right' : 'left',
                     filterValues: mainGroupField.filterValues,
-                    allowFiltering: mainGroupField.allowFiltering && !field.groupIndex
+                    allowFiltering: mainGroupField.allowFiltering && !field.groupIndex,
+                    allowSorting: field.allowSorting
                 },
                 showColumnLines: showColumnLines
             });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsHeadersView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsHeadersView.tests.js
@@ -789,12 +789,12 @@ QUnit.module('Headers', {
         this.columnHeadersView.render(testElement);
 
         // assert
-        let sortElements = testElement.find('.' + 'dx-sort');
+        let sortElements = testElement.find('.dx-sort:not(.dx-sort-none)');
         assert.equal(sortElements.length, 0, 'sortElements count');
 
 
         let headerElement = testElement.find('td');
-        sortElements = testElement.find('.' + 'dx-sort');
+        sortElements = testElement.find('.dx-sort:not(.dx-sort-none)');
         assert.equal(sortElements.length, 0, 'not sorting');
         assert.equal(headerElement.attr('aria-sort'), 'none');
 
@@ -1132,14 +1132,14 @@ QUnit.module('Headers', {
         this.columnHeadersView.render(testElement);
 
         // assert
-        assert.equal(testElement.find('td').last().find('.' + 'dx-sort').length, 1);
+        assert.equal(testElement.find('td').last().find('.dx-sort:not(.dx-sort-none)').length, 1);
 
         // act
         testElement.find('td').last().trigger('dxclick');
 
         this.clock.tick();
         // assert
-        assert.strictEqual(testElement.find('td').last().find('.' + 'dx-sort').length, 0);
+        assert.strictEqual(testElement.find('td').last().find('.dx-sort:not(.dx-sort-none)').length, 0);
     });
 
     QUnit.test('Apply alignment for sorting', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
@@ -230,8 +230,9 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             loadingTimeout: null,
             columns: [
                 { dataField: 'field1', allowSorting: false },
-                { dataField: 'field2', allowSorting: false, sortOrder: 'asd' }, // T1032991
-                { dataField: 'field3' }],
+                { dataField: 'field2', allowSorting: false, sortOrder: 'asc' }, // T1032991
+                { dataField: 'field3' }
+            ],
             dataSource: []
         });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
@@ -228,20 +228,27 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         // act
         const dataGrid = createDataGrid({
             loadingTimeout: null,
-            columns: [{ dataField: 'field1', allowSorting: false }, { dataField: 'field2' }],
+            columns: [
+                { dataField: 'field1', allowSorting: false },
+                { dataField: 'field2', allowSorting: false, sortOrder: 'asd' }, // T1032991
+                { dataField: 'field3' }],
             dataSource: []
         });
 
+        const $grid = $(dataGrid.$element());
+
         // assert
-        assert.equal($(dataGrid.$element()).find('.dx-datagrid-drag-action').length, 0, 'no drag actions');
-        assert.equal($(dataGrid.$element()).find('.dx-datagrid-action').length, 1, 'one action');
-        assert.ok($(dataGrid.$element()).find('.dx-header-row > td').eq(1).hasClass('dx-datagrid-action'));
+        assert.equal($grid.find('.dx-datagrid-drag-action').length, 0, 'no drag actions');
+        assert.equal($grid.find('.dx-datagrid-action').length, 1, 'one action');
+        assert.notOk($grid.find('.dx-header-row > td').eq(0).hasClass('dx-datagrid-action'));
+        assert.notOk($grid.find('.dx-header-row > td').eq(1).hasClass('dx-datagrid-action'));
+        assert.ok($grid.find('.dx-header-row > td').eq(2).hasClass('dx-datagrid-action'));
 
         // act
         dataGrid.showColumnChooser();
 
         // assert
-        assert.equal($(dataGrid.$element()).find('.dx-datagrid-drag-action').length, 2, 'two drag actions for hiding columns');
+        assert.equal($(dataGrid.$element()).find('.dx-datagrid-drag-action').length, 3, 'two drag actions for hiding columns');
     });
 });
 


### PR DESCRIPTION
Ticket:  https://devexpress.com/issue=T1032991

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/19497
- https://github.com/DevExpress/DevExtreme/pull/19498

---

It was explicitly set that there is hand cursor if row is sorted, even if sorting is disabled. I added condition on adding "action" class.
