### PR TITLE
DataGrid - The "Cannot read properties of undefined (reading 'select')" error occurs on an attempt to change a cell's value with the Space button (T1034050)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -42,7 +42,7 @@ const REVERT_BUTTON_CLASS = 'dx-revert-button';
 
 const FAST_EDITING_DELETE_KEY = 'delete';
 
-const INTERACTIVE_ELEMENTS_SELECTOR = 'input:not([type=\'hidden\']), textarea, a, select, button, [tabindex], .dx-dropdowneditor-icon';
+const INTERACTIVE_ELEMENTS_SELECTOR = 'input:not([type=\'hidden\']), textarea, a, select, button, [tabindex], .dx-dropdowneditor-icon, .dx-checkbox';
 
 const EDIT_MODE_ROW = 'row';
 const EDIT_MODE_FORM = 'form';
@@ -1581,12 +1581,12 @@ const KeyboardNavigationController = core.ViewController.inherit({
         }
     },
     _editingCellHandler: function(eventArgs, editorValue) {
-        const $input = this._getFocusedCell().find('.dx-texteditor-input').eq(0);
+        const $input = this._getFocusedCell().find(INTERACTIVE_ELEMENTS_SELECTOR).eq(0);
         const keyDownEvent = createEvent(eventArgs, { type: 'keydown', target: $input.get(0) });
         const keyPressEvent = createEvent(eventArgs, { type: 'keypress', target: $input.get(0) });
         const inputEvent = createEvent(eventArgs, { type: 'input', target: $input.get(0) });
 
-        $input.get(0).select();
+        $input.get(0).select?.();
         eventsEngine.trigger($input, keyDownEvent);
 
         if(!keyDownEvent.isDefaultPrevented()) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardController.tests.js
@@ -368,6 +368,7 @@ QUnit.module('Keyboard controller', {
                     <td><textarea></textarea></td>
                     <td><a>Link<a/></td>
                     <td><select></select></td>
+                    <td><div class='dx-checkbox'></div></td>
                 </tr>`));
 
         const view = this.getView('rowsView');
@@ -408,6 +409,13 @@ QUnit.module('Keyboard controller', {
         callViewsRenderCompleted(this.component._views);
         this.clock.tick();
         assert.ok(navigationController._testInteractiveElement && navigationController._testInteractiveElement.is('select'), 'Interactive element is select');
+
+        // T1034050
+        // act, assert
+        navigationController.setFocusedCellPosition(0, 5);
+        callViewsRenderCompleted(this.component._views);
+        this.clock.tick();
+        assert.ok(navigationController._testInteractiveElement && navigationController._testInteractiveElement.is('.dx-checkbox'), 'Interactive element is select');
     });
 
     QUnit.testInActiveWindow('View is not focused when row is inline edited', function(assert) {


### PR DESCRIPTION
Ticket: https://devexpress.com/issue=T1034050

Cherry picks:

- https://github.com/DevExpress/DevExtreme/pull/19568
- https://github.com/DevExpress/DevExtreme/pull/19569

---

When editing action occurs, `.dx-texteditor-input` element was selected. But when editor is not `<input>`, for example checkbox, element wasn't found. 
I changed  `'.dx-texteditor-input'` to `INTERACTIVE_ELEMENTS_SELECTOR`