### PR TITLE
Fix T1034877 - DataGrid - scrollByContent's default value is similar to ScrollView's scrollByContent

### DIFF
--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -958,6 +958,7 @@ export interface GridBaseScrolling {
      * @docid GridBaseOptions.scrolling.scrollByContent
      * @type boolean
      * @default true
+     * @default false [for](non-touch_devices)
      * @prevFileNamespace DevExpress.ui
      * @public
      */


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
