### PR TITLE
Fix T1034877 - DataGrid - scrollByContent's default value is similar to ScrollView's scrollByContent

### DIFF
--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -1765,6 +1765,7 @@ export interface ScrollingBase {
     /**
      * @docid GridBaseOptions.scrolling.scrollByContent
      * @default true
+     * @default false [for](non-touch_devices)
      * @public
      */
     scrollByContent?: boolean;

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -1765,7 +1765,7 @@ export interface ScrollingBase {
     /**
      * @docid GridBaseOptions.scrolling.scrollByContent
      * @default true
-     * @default false [for](non-touch_devices)
+     * @default false &for(non-touch_devices)
      * @public
      */
     scrollByContent?: boolean;


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
