### PR TITLE
datagrid - adds tests for edit form in a new scrolling mode with newRowPosition

### DIFF
--- a/testing/helpers/dataGridHelper.js
+++ b/testing/helpers/dataGridHelper.js
@@ -26,3 +26,20 @@ export const createDataGrid = (options, $container) => {
     const dataGrid = dataGridElement.dxDataGrid('instance');
     return dataGrid;
 };
+
+export const isChildInsideParentViewport = (parentElement, childElement) => {
+    const $parent = $(parentElement);
+    const $child = $(childElement);
+    const parentInfo = $parent.offset();
+    const childInfo = $child.offset();
+    let result = false;
+
+    parentInfo.bottom = parentInfo.top + $parent.outerHeight();
+    childInfo.bottom = childInfo.top + $child.outerHeight();
+
+    result = (childInfo.top > parentInfo.top && childInfo.top < parentInfo.bottom)
+            || (childInfo.bottom > parentInfo.top && childInfo.bottom < parentInfo.bottom)
+            || (childInfo.top < parentInfo.top && childInfo.bottom > parentInfo.bottom);
+
+    return result;
+};

--- a/testing/helpers/dataGridHelper.js
+++ b/testing/helpers/dataGridHelper.js
@@ -26,20 +26,3 @@ export const createDataGrid = (options, $container) => {
     const dataGrid = dataGridElement.dxDataGrid('instance');
     return dataGrid;
 };
-
-export const isChildInsideParentViewport = (parentElement, childElement) => {
-    const $parent = $(parentElement);
-    const $child = $(childElement);
-    const parentInfo = $parent.offset();
-    const childInfo = $child.offset();
-    let result = false;
-
-    parentInfo.bottom = parentInfo.top + $parent.outerHeight();
-    childInfo.bottom = childInfo.top + $child.outerHeight();
-
-    result = (childInfo.top > parentInfo.top && childInfo.top < parentInfo.bottom)
-            || (childInfo.bottom > parentInfo.top && childInfo.bottom < parentInfo.bottom)
-            || (childInfo.top < parentInfo.top && childInfo.bottom > parentInfo.bottom);
-
-    return result;
-};

--- a/testing/helpers/wrappers/dataGridWrappers.js
+++ b/testing/helpers/wrappers/dataGridWrappers.js
@@ -275,6 +275,17 @@ export class RowsViewWrapper extends GridTableElement {
         return this._isInnerElementVisible($row, precision);
     }
 
+    isElementIntersectViewport($element) {
+        const rowsViewRect = this.getElement()[0].getBoundingClientRect();
+        const elementRect = $element[0].getBoundingClientRect();
+
+        const result = (elementRect.top > rowsViewRect.top && elementRect.top < rowsViewRect.bottom)
+            || (elementRect.bottom > rowsViewRect.top && elementRect.bottom < rowsViewRect.bottom)
+            || (elementRect.top <= rowsViewRect.top && elementRect.bottom >= rowsViewRect.bottom);
+
+        return result;
+    }
+
     _isInnerElementVisible($element, precision = 0) {
         const rowsViewRect = this.getContainer()[0].getBoundingClientRect();
         const elementRect = $element[0].getBoundingClientRect();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -48,7 +48,7 @@ import commonUtils from 'core/utils/common';
 import DataGridWrapper from '../../helpers/wrappers/dataGridWrappers.js';
 import 'ui/drop_down_box';
 import { CLICK_EVENT } from '../../helpers/grid/keyboardNavigationHelper.js';
-import { createDataGrid, baseModuleConfig } from '../../helpers/dataGridHelper.js';
+import { createDataGrid, baseModuleConfig, isChildInsideParentViewport } from '../../helpers/dataGridHelper.js';
 import { generateItems } from '../../helpers/dataGridMocks.js';
 import { getOuterHeight } from 'core/utils/size';
 
@@ -69,23 +69,6 @@ if('chrome' in window && devices.real().deviceType !== 'desktop') {
     // Chrome DevTools device emulation
     // Erase differences in user agent stylesheet
     $('head').append($('<style>').text('input[type=date] { padding: 1px 0; }'));
-}
-
-function isChildInsideParentViewport(parentElement, childElement) {
-    const $parent = $(parentElement);
-    const $child = $(childElement);
-    const parentInfo = $parent.offset();
-    const childInfo = $child.offset();
-    let result = false;
-
-    parentInfo.bottom = parentInfo.top + $parent.outerHeight();
-    childInfo.bottom = childInfo.top + $child.outerHeight();
-
-    result = (childInfo.top > parentInfo.top && childInfo.top < parentInfo.bottom)
-            || (childInfo.bottom > parentInfo.top && childInfo.bottom < parentInfo.bottom)
-            || (childInfo.top < parentInfo.top && childInfo.bottom > parentInfo.bottom);
-
-    return result;
 }
 
 QUnit.module('Initialization', baseModuleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -48,7 +48,7 @@ import commonUtils from 'core/utils/common';
 import DataGridWrapper from '../../helpers/wrappers/dataGridWrappers.js';
 import 'ui/drop_down_box';
 import { CLICK_EVENT } from '../../helpers/grid/keyboardNavigationHelper.js';
-import { createDataGrid, baseModuleConfig, isChildInsideParentViewport } from '../../helpers/dataGridHelper.js';
+import { createDataGrid, baseModuleConfig } from '../../helpers/dataGridHelper.js';
 import { generateItems } from '../../helpers/dataGridMocks.js';
 import { getOuterHeight } from 'core/utils/size';
 
@@ -6186,17 +6186,16 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
         // act
         dataGrid.addRow();
         const $virtualRowElement = $(dataGrid.element()).find('.dx-virtual-row');
-        const $rowsViewElement = $(dataGrid.element()).find('.dx-datagrid-rowsview');
         const visibleRows = dataGrid.getVisibleRows();
         const lastRowIndex = visibleRows.length - 1;
         const $lastRowElement = $(dataGrid.getRowElement(lastRowIndex));
 
         // assert
         assert.strictEqual($virtualRowElement.length, 1, 'only one virtual row is rendered');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement), 'virtual row is rendered outside viewport');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($virtualRowElement), 'virtual row is rendered outside viewport');
         assert.ok(visibleRows[lastRowIndex].isNewRow, 'last new row is rendered');
         assert.ok($lastRowElement.hasClass('dx-row-inserted'), 'last row is a new row');
-        assert.ok(isChildInsideParentViewport($rowsViewElement, $lastRowElement), 'new row is in viewport');
+        assert.ok(dataGridWrapper.rowsView.isRowVisible($lastRowElement.index()), 'new row is in viewport');
     });
 
     QUnit.test('Virtual row should not be rendered in the viewport when the edit form is inserted in the first position with certain height and row count', function(assert) {
@@ -6239,15 +6238,14 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
         // act
         dataGrid.addRow();
         const $virtualRowElement = $(dataGrid.element()).find('.dx-virtual-row');
-        const $rowsViewElement = $(dataGrid.element()).find('.dx-datagrid-rowsview');
         visibleRows = dataGrid.getVisibleRows();
         const $firstRowElement = $(dataGrid.getRowElement(0));
 
         // assert
         assert.strictEqual($virtualRowElement.length, 1, 'only one virtual row is rendered');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement), 'virtual row is rendered outside viewport');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($virtualRowElement), 'virtual row is rendered outside viewport');
         assert.ok(visibleRows[0].isNewRow, 'first new row is rendered');
         assert.ok($firstRowElement.hasClass('dx-row-inserted'), 'first row is a new row');
-        assert.ok(isChildInsideParentViewport($rowsViewElement, $firstRowElement), 'new row is in viewport');
+        assert.ok(dataGridWrapper.rowsView.isRowVisible($firstRowElement.index()), 'new row is in viewport');
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -71,6 +71,23 @@ if('chrome' in window && devices.real().deviceType !== 'desktop') {
     $('head').append($('<style>').text('input[type=date] { padding: 1px 0; }'));
 }
 
+function isChildInsideParentViewport(parentElement, childElement) {
+    const $parent = $(parentElement);
+    const $child = $(childElement);
+    const parentInfo = $parent.offset();
+    const childInfo = $child.offset();
+    let result = false;
+
+    parentInfo.bottom = parentInfo.top + $parent.outerHeight();
+    childInfo.bottom = childInfo.top + $child.outerHeight();
+
+    result = (childInfo.top > parentInfo.top && childInfo.top < parentInfo.bottom)
+            || (childInfo.bottom > parentInfo.top && childInfo.bottom < parentInfo.bottom)
+            || (childInfo.top < parentInfo.top && childInfo.bottom > parentInfo.bottom);
+
+    return result;
+}
+
 QUnit.module('Initialization', baseModuleConfig, () => {
     QUnit.test('Accessibility columns id should not set for columns editors (T710132)', function(assert) {
         // arrange, act
@@ -6152,5 +6169,102 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
         // assert
         assert.ok(visibleRows[visibleRows.length - 1].isNewRow, 'last new row is rendered');
         assert.strictEqual($virtualRowElement.length, 1, 'only one virtual row is rendered');
+    });
+
+    QUnit.test('Virtual row should not be rendered in the viewport when the edit form is inserted in the last position with certain height and row count', function(assert) {
+        // arrange
+        const getData = function() {
+            const items = [];
+            for(let i = 0; i < 130; i++) {
+                items.push({
+                    id: i + 1,
+                    name: `name ${i + 1}`
+                });
+            }
+            return items;
+        };
+        const dataGrid = createDataGrid({
+            dataSource: getData(),
+            keyExpr: 'id',
+            editing: {
+                mode: 'form',
+                allowAdding: true,
+                newRowPosition: 'last',
+            },
+            height: 440,
+            scrolling: {
+                mode: 'virtual',
+                useNative: false
+            }
+        });
+
+        this.clock.tick(300);
+
+        // act
+        dataGrid.addRow();
+        const $virtualRowElement = $(dataGrid.element()).find('.dx-virtual-row');
+        const $rowsViewElement = $(dataGrid.element()).find('.dx-datagrid-rowsview');
+        const visibleRows = dataGrid.getVisibleRows();
+        const lastRowIndex = visibleRows.length - 1;
+        const $lastRowElement = $(dataGrid.getRowElement(lastRowIndex));
+
+        // assert
+        assert.strictEqual($virtualRowElement.length, 1, 'only one virtual row is rendered');
+        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement), 'virtual row is rendered outside viewport');
+        assert.ok(visibleRows[lastRowIndex].isNewRow, 'last new row is rendered');
+        assert.ok($lastRowElement.hasClass('dx-row-inserted'), 'last row is a new row');
+        assert.ok(isChildInsideParentViewport($rowsViewElement, $lastRowElement), 'new row is in viewport');
+    });
+
+    QUnit.test('Virtual row should not be rendered in the viewport when the edit form is inserted in the first position with certain height and row count', function(assert) {
+        // arrange
+        const getData = function() {
+            const items = [];
+            for(let i = 0; i < 130; i++) {
+                items.push({
+                    id: i + 1,
+                    name: `name ${i + 1}`
+                });
+            }
+            return items;
+        };
+        const dataGrid = createDataGrid({
+            dataSource: getData(),
+            keyExpr: 'id',
+            editing: {
+                mode: 'form',
+                allowAdding: true,
+                newRowPosition: 'first',
+            },
+            height: 440,
+            scrolling: {
+                mode: 'virtual',
+                useNative: false
+            }
+        });
+
+        this.clock.tick(300);
+
+        // act
+        dataGrid.getScrollable().scrollTo({ top: 4100 });
+        let visibleRows = dataGrid.getVisibleRows();
+        const lastRowIndex = visibleRows.length - 1;
+
+        // assert
+        assert.strictEqual(visibleRows[lastRowIndex].key, 130, 'last row is rendered');
+
+        // act
+        dataGrid.addRow();
+        const $virtualRowElement = $(dataGrid.element()).find('.dx-virtual-row');
+        const $rowsViewElement = $(dataGrid.element()).find('.dx-datagrid-rowsview');
+        visibleRows = dataGrid.getVisibleRows();
+        const $firstRowElement = $(dataGrid.getRowElement(0));
+
+        // assert
+        assert.strictEqual($virtualRowElement.length, 1, 'only one virtual row is rendered');
+        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement), 'virtual row is rendered outside viewport');
+        assert.ok(visibleRows[0].isNewRow, 'first new row is rendered');
+        assert.ok($firstRowElement.hasClass('dx-row-inserted'), 'first row is a new row');
+        assert.ok(isChildInsideParentViewport($rowsViewElement, $firstRowElement), 'new row is in viewport');
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -5,7 +5,7 @@ import ArrayStore from 'data/array_store';
 import { DataSource } from 'data/data_source/data_source';
 import pointerEvents from 'events/pointer';
 import DataGridWrapper from '../../helpers/wrappers/dataGridWrappers.js';
-import { createDataGrid, baseModuleConfig, isChildInsideParentViewport } from '../../helpers/dataGridHelper.js';
+import { createDataGrid, baseModuleConfig } from '../../helpers/dataGridHelper.js';
 import $ from 'jquery';
 
 
@@ -4397,12 +4397,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         this.clock.tick(300);
-        const $rowsViewElement = $(dataGrid.element()).find('.dx-datagrid-rowsview');
         let $virtualRowElement = $(dataGrid.element()).find('.dx-virtual-row');
 
         // assert
         assert.strictEqual($virtualRowElement.length, 1, 'virtual row is rendered initially');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement), 'virtual row is rendered outside viewport initially');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($virtualRowElement), 'virtual row is rendered outside viewport initially');
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 1000 });
@@ -4410,7 +4409,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // assert
         assert.strictEqual($virtualRowElement.length, 1, 'virtual row is rendered after scrolling to bottom');
-        assert.ok(isChildInsideParentViewport($rowsViewElement, $virtualRowElement), 'virtual row is rendered inside viewport after scrolling to bottom');
+        assert.ok(dataGridWrapper.rowsView.isElementIntersectViewport($virtualRowElement), 'virtual row is rendered inside viewport after scrolling to bottom');
 
         // act
         this.clock.tick(300);
@@ -4418,8 +4417,8 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // assert
         assert.strictEqual($virtualRowElement.length, 2, 'virtual rows are rendered after timeout scrolling to bottom');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(0)), 'top virtual row is rendered outside viewport after timeout scrolling to bottom');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(1)), 'bottom virtual row is rendered outside viewport after timeout scrolling to bottom');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(0))), 'top virtual row is rendered outside viewport after timeout scrolling to bottom');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(1))), 'bottom virtual row is rendered outside viewport after timeout scrolling to bottom');
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 500 });
@@ -4427,8 +4426,8 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // assert
         assert.strictEqual($virtualRowElement.length, 2, 'virtual rows are rendered after scrolling to top');
-        assert.ok(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(0)), 'top virtual row is rendered inside viewport after scrolling to top');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(1)), 'bottom virtual row is rendered outside viewport after scrolling to top');
+        assert.ok(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(0))), 'top virtual row is rendered inside viewport after scrolling to top');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(1))), 'bottom virtual row is rendered outside viewport after scrolling to top');
 
         // act
         this.clock.tick(300);
@@ -4436,8 +4435,8 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // assert
         assert.strictEqual($virtualRowElement.length, 2, 'virtual rows are rendered after timeout scrolling to top');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(0)), 'top virtual row is rendered outside viewport after timeout scrolling to top');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(1)), 'bottom virtual row is rendered outside viewport after timeout scrolling to top');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(0))), 'top virtual row is rendered outside viewport after timeout scrolling to top');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(1))), 'bottom virtual row is rendered outside viewport after timeout scrolling to top');
     });
 
     QUnit.test('Rows should be rendered properly when renderAsync = false', function(assert) {
@@ -4465,12 +4464,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         this.clock.tick(300);
-        const $rowsViewElement = $(dataGrid.element()).find('.dx-datagrid-rowsview');
         let $virtualRowElement = $(dataGrid.element()).find('.dx-virtual-row');
 
         // assert
         assert.strictEqual($virtualRowElement.length, 1, 'virtual row is rendered initially');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement), 'virtual row is rendered outside viewport initially');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($virtualRowElement), 'virtual row is rendered outside viewport initially');
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 1000 });
@@ -4478,8 +4476,8 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // assert
         assert.strictEqual($virtualRowElement.length, 2, 'virtual rows are rendered after scrolling to bottom');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(0)), 'top virtual row is rendered outside viewport after scrolling to bottom');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(1)), 'bottom virtual row is rendered outside viewport after scrolling to bottom');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(0))), 'top virtual row is rendered outside viewport after scrolling to bottom');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(1))), 'bottom virtual row is rendered outside viewport after scrolling to bottom');
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 500 });
@@ -4487,8 +4485,8 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // assert
         assert.strictEqual($virtualRowElement.length, 2, 'virtual rows are rendered after scrolling to top');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(0)), 'top virtual row is rendered outside viewport after scrolling to top');
-        assert.notOk(isChildInsideParentViewport($rowsViewElement, $virtualRowElement.get(1)), 'bottom virtual row is rendered outside viewport after scrolling to top');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(0))), 'top virtual row is rendered outside viewport after scrolling to top');
+        assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(1))), 'bottom virtual row is rendered outside viewport after scrolling to top');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -5,7 +5,7 @@ import ArrayStore from 'data/array_store';
 import { DataSource } from 'data/data_source/data_source';
 import pointerEvents from 'events/pointer';
 import DataGridWrapper from '../../helpers/wrappers/dataGridWrappers.js';
-import { createDataGrid, baseModuleConfig } from '../../helpers/dataGridHelper.js';
+import { createDataGrid, baseModuleConfig, isChildInsideParentViewport } from '../../helpers/dataGridHelper.js';
 import $ from 'jquery';
 
 
@@ -4371,23 +4371,6 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         }, 300);
     });
-
-    function isChildInsideParentViewport(parentElement, childElement) {
-        const $parent = $(parentElement);
-        const $child = $(childElement);
-        const parentInfo = $parent.offset();
-        const childInfo = $child.offset();
-        let result = false;
-
-        parentInfo.bottom = parentInfo.top + $parent.outerHeight();
-        childInfo.bottom = childInfo.top + $child.outerHeight();
-
-        result = (childInfo.top > parentInfo.top && childInfo.top < parentInfo.bottom)
-                || (childInfo.bottom > parentInfo.top && childInfo.bottom < parentInfo.bottom)
-                || (childInfo.top < parentInfo.top && childInfo.bottom > parentInfo.bottom);
-
-        return result;
-    }
 
     QUnit.test('Rows should be rendered properly when renderAsync = true', function(assert) {
         // arrange


### PR DESCRIPTION
The issue was fixed in #19600. This pull request adds corresponding tests.