### PR TITLE
DataGrid - A row becomes invisible after text selection if row dragging and column fixing are enabled (T1035340)

### DIFF
--- a/js/ui/draggable.js
+++ b/js/ui/draggable.js
@@ -600,11 +600,11 @@ const Draggable = DOMComponent.inherit({
     _dragStartHandler: function(e) {
         const $element = this._getDraggableElement(e);
 
-        if(this._$sourceElement) {
-            return;
-        }
         if(!this._isValidElement(e, $element)) {
             e.cancel = true;
+            return;
+        }
+        if(this._$sourceElement) {
             return;
         }
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowDragging.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowDragging.integration.tests.js
@@ -12,6 +12,7 @@ import $ from 'jquery';
 import DataGrid from 'ui/data_grid';
 import pointerMock from '../../helpers/pointerMock.js';
 import { createDataGrid, baseModuleConfig } from '../../helpers/dataGridHelper.js';
+import CustomStore from 'data/custom_store';
 
 
 QUnit.module('Row dragging', baseModuleConfig, () => {
@@ -68,5 +69,59 @@ QUnit.module('Row dragging', baseModuleConfig, () => {
                 }
             });
         }
+    });
+
+    QUnit.test('Row reordering should work when columnFixed is enabled', function(assert) {
+        $('#qunit-fixture').attr('id', 'qunit-fixture-visible');
+        // arrange
+        const tasks = [{ id: 1 }, { id: 2 }, { id: 3 }];
+        const tasksStore = new CustomStore({
+            key: 'id',
+            load: function(loadOptions) {
+                const d = $.Deferred();
+                setTimeout(() => {
+                    d.resolve(tasks);
+                });
+                return d;
+            },
+            update: function(key, values) {},
+            totalCount: function() {
+                return tasks.length;
+            }
+        });
+
+        const dataGrid = createDataGrid({
+            dataSource: tasksStore,
+            remoteOperations: true,
+            rowDragging: {
+                allowReordering: true,
+                dropFeedbackMode: 'push',
+                onReorder: function(e) {
+                    const visibleRows = e.component.getVisibleRows();
+                    const newOrderIndex = visibleRows[e.toIndex].data.OrderIndex;
+                    const d = $.Deferred();
+
+                    tasksStore.update(e.itemData.ID, { OrderIndex: newOrderIndex }).then(function() {
+                        e.component.refresh().then(d.resolve, d.reject);
+                    }, d.reject);
+
+                    e.promise = d.promise();
+                }
+            },
+            columnFixing: {
+                enabled: true
+            }
+        });
+
+        this.clock.tick(1000);
+
+        // act
+        pointerMock(dataGrid.getCellElement(0, 0)).start().down().move(0, 1).up();
+        this.clock.tick(1000);
+        pointerMock(dataGrid.getCellElement(1, 1)).start().down().move(0, 1).up();
+        this.clock.tick(1000);
+
+        // assert
+        assert.notOk($('.dx-sortable-source-hidden').length, 'no dx-sortable-source-hidden elements after dragging');
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowDragging.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowDragging.integration.tests.js
@@ -72,7 +72,6 @@ QUnit.module('Row dragging', baseModuleConfig, () => {
     });
 
     QUnit.test('Row reordering should work when columnFixed is enabled', function(assert) {
-        $('#qunit-fixture').attr('id', 'qunit-fixture-visible');
         // arrange
         const tasks = [{ id: 1 }, { id: 2 }, { id: 3 }];
         const tasksStore = new CustomStore({


### PR DESCRIPTION
Cherry picks: 

- https://github.com/DevExpress/DevExtreme/pull/19698
- https://github.com/DevExpress/DevExtreme/pull/19699

---

Reproduced only when column fixing is enabled and dataSource is remote.

Row become invisible after dragging another row because it was saved in `this._$sourceElement`, and then got class `dx-sortable-source-hidden`.

Before it was checked that if `this._$sourceElement` is not null, then `_dragStartHandler` should do nothing. I thought it meant "Do not start drag if there is already `_$sourceElement`". Adding `e.cancel = true` [here (click)](https://github.com/DevExpress/DevExtreme/pull/19670/files#diff-986ccb5e4b9c9f65e79bd598977909c6586f790b0013b9ef7a567b1843d5bd29L603-L605) solved the problem, but tests in sortable failed.

Then I researched why `this._$sourceElement` wasn't cleared to `null`, as it supposed to. The problem was in syncing between `_sortable` and `_sortableFixed` in datagrid's row_dragging module. So I decided to move this property to option: `this._$sourceElement` -> `this.option('_$sourceElement')`, so that it could be synced in `onOptionChanged`. It solved the problem, but tests failed.

Then I moved checking `this._isValidElement(e, $element)` higher then checking `this._$sourceElement` and it worked