### PR TITLE
HtmlEditor - Widget should not raise an error if it cannot find a relevant element when deleting an image (T1029874)

### DIFF
--- a/js/ui/html_editor/modules/resizing.js
+++ b/js/ui/html_editor/modules/resizing.js
@@ -160,7 +160,7 @@ export default class ResizingModule {
 
     _deleteImage() {
         if(this._isAllowedTarget(this._$target)) {
-            Quill.find(this._$target).deleteAt(0);
+            Quill.find(this._$target)?.deleteAt(0);
         }
     }
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/resizingModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/resizingModule.tests.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import Quill from 'devextreme-quill';
 
 import Resizing from 'ui/html_editor/modules/resizing';
 import devices from 'core/devices';
@@ -242,6 +243,30 @@ module('Resizing module', moduleConfig, () => {
 
             assert.strictEqual($(this.$element).find('img').length, 0, 'Image is removed');
         });
+    });
+
+    test('"Delete" keydown event should raise an error in case the target does not exists', function(assert) {
+        this.$element.prepend($(document.createTextNode('text')));
+        $(this.$element).dxHtmlEditor({
+            mediaResizing: {
+                enabled: true
+            }
+        });
+
+        this.options.enabled = true;
+        const $image = $(this.$element).find('img');
+        const findStub = sinon.stub(Quill, 'find');
+        let noError = true;
+        $image.trigger(clickEvent);
+
+        try {
+            $image.trigger($.Event('keydown', { key: 'Delete' }));
+        } catch(e) {
+            noError = false;
+        }
+
+        assert.ok(noError, 'Quill cannot find an image -> no error');
+        findStub.restore();
     });
 
 


### PR DESCRIPTION
(cherry picked from commit 254af94231fc6d3cac7616e33bad1eb837bc41db)
(cherry picked from commit 246c15dff16c686c021dc5588e454a820c1de521)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
