### PR TITLE
DataGrid - typing - revert intersect (T1037095)

### DIFF
--- a/js/renovation/ui/grids/data_grid/data_grid.tsx
+++ b/js/renovation/ui/grids/data_grid/data_grid.tsx
@@ -441,12 +441,12 @@ export class DataGrid extends JSXComponent(DataGridProps) implements DataGridFor
   }
 
   @Method()
-  getSelectedRowKeys(): any[] | DxPromise<any> {
+  getSelectedRowKeys(): any[] & DxPromise<any> {
     return this.instance?.getSelectedRowKeys();
   }
 
   @Method()
-  getSelectedRowsData(): any[] | DxPromise<any> {
+  getSelectedRowsData(): any[] & DxPromise<any> {
     return this.instance?.getSelectedRowsData();
   }
 

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4353,14 +4353,14 @@ declare class dxDataGrid<TRowData = any, TKey = any> extends Widget<dxDataGridOp
     /**
      * @docid
      * @publicName getSelectedRowKeys()
-     * @return Array<any> & Promise<any>
+     * @return Array<any> | Promise<any>
      * @public
      */
     getSelectedRowKeys(): Array<TKey> & DxPromise<Array<TKey>>;
     /**
      * @docid
      * @publicName getSelectedRowsData()
-     * @return Array<any> & Promise<any>
+     * @return Array<any> | Promise<any>
      * @public
      */
     getSelectedRowsData(): Array<TRowData> & DxPromise<Array<TRowData>>;

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4353,17 +4353,17 @@ declare class dxDataGrid<TRowData = any, TKey = any> extends Widget<dxDataGridOp
     /**
      * @docid
      * @publicName getSelectedRowKeys()
-     * @return Array<any> | Promise<any>
+     * @return Array<any> & Promise<any>
      * @public
      */
-    getSelectedRowKeys(): Array<TKey> | DxPromise<Array<TKey>>;
+    getSelectedRowKeys(): Array<TKey> & DxPromise<Array<TKey>>;
     /**
      * @docid
      * @publicName getSelectedRowsData()
-     * @return Array<any> | Promise<any>
+     * @return Array<any> & Promise<any>
      * @public
      */
-    getSelectedRowsData(): Array<TRowData> | DxPromise<Array<TRowData>>;
+    getSelectedRowsData(): Array<TRowData> & DxPromise<Array<TRowData>>;
     /**
      * @docid
      * @publicName getTotalSummaryValue(summaryItemName)

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -5568,15 +5568,13 @@ declare module DevExpress.ui {
     /**
      * [descr:dxDataGrid.getSelectedRowKeys()]
      */
-    getSelectedRowKeys():
-      | Array<TKey>
-      | DevExpress.core.utils.DxPromise<Array<TKey>>;
+    getSelectedRowKeys(): Array<TKey> &
+      DevExpress.core.utils.DxPromise<Array<TKey>>;
     /**
      * [descr:dxDataGrid.getSelectedRowsData()]
      */
-    getSelectedRowsData():
-      | Array<TRowData>
-      | DevExpress.core.utils.DxPromise<Array<TRowData>>;
+    getSelectedRowsData(): Array<TRowData> &
+      DevExpress.core.utils.DxPromise<Array<TRowData>>;
     /**
      * [descr:dxDataGrid.getTotalSummaryValue(summaryItemName)]
      */


### PR DESCRIPTION
Reverting some changes from https://github.com/DevExpress/DevExtreme/pull/19464

---

I thought that intersection was typo, but it was by design. If there was union, users would need to check current type everytime. It's wrong conceptually, but preferable for users, cause they know in compile time whether it's promise or array.