### PR TITLE
TextArea - fix autoResize after window resize (T1037254) (#19730)

### DIFF
--- a/js/ui/text_area.js
+++ b/js/ui/text_area.js
@@ -241,6 +241,12 @@ const TextArea = TextBox.inherit({
         }
     },
 
+    _dimensionChanged: function() {
+        if(this.option('visible')) {
+            this._updateInputHeight();
+        }
+    },
+
     _optionChanged: function(args) {
         switch(args.name) {
             case 'autoResizeEnabled':

--- a/testing/tests/DevExpress.ui.widgets.editors/textArea.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textArea.tests.js
@@ -3,6 +3,7 @@ import pointerMock from '../../helpers/pointerMock.js';
 import nativePointerMock from '../../helpers/nativePointerMock.js';
 import keyboardMock from '../../helpers/keyboardMock.js';
 import devices from 'core/devices';
+import resizeCallbacks from 'core/utils/resize_callbacks';
 
 import 'generic_light.css!';
 import 'ui/text_area';
@@ -478,6 +479,22 @@ QUnit.module('the \'autoResizeEnabled\' option', () => {
         container.scrollTop(20);
         keyboardMock($input).type('\n\n');
         assert.strictEqual(container.scrollTop(), 20);
+    });
+
+    QUnit.test('widget is resized on window dimension changed', function(assert) {
+        const $element = $('#textarea').dxTextArea({
+            autoResizeEnabled: true
+        });
+
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+
+        $input.val('\n\n');
+        resizeCallbacks.fire();
+
+        const inputHeight = $input.outerHeight();
+        $input.height(0);
+
+        assert.equal(inputHeight, $input[0].scrollHeight, 'widget height is correct');
     });
 });
 


### PR DESCRIPTION
(cherry picked from commit ca19f3a9b4826a7d7a9bc0466284fc4f78e126bf)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
