### PR TITLE
Refactor DataSource and Stores types

### DIFF
--- a/js/data/abstract_store.d.ts
+++ b/js/data/abstract_store.d.ts
@@ -3,16 +3,16 @@ import { DeepPartial } from '../core/index';
 import { FilterDescriptor, GroupDescriptor, LoadOptions } from './index';
 
 export type Options<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> = StoreOptions<TValue, TKey>;
+> = StoreOptions<TItem, TKey>;
 
 /**
  * @namespace DevExpress.data
  * @deprecated Use Options instead
  */
 export interface StoreOptions<
-    TValue = any,
+    TItem = any,
     TKey = any,
 > {
     /**
@@ -32,28 +32,28 @@ export interface StoreOptions<
      * @action
      * @public
      */
-    onInserted?: ((values: TValue, key: TKey) => void);
+    onInserted?: ((values: TItem, key: TKey) => void);
     /**
      * @docid
      * @type_function_param1 values:object
      * @action
      * @public
      */
-    onInserting?: ((values: TValue) => void);
+    onInserting?: ((values: TItem) => void);
     /**
      * @docid
      * @type_function_param2 loadOptions:LoadOptions
      * @action
      * @public
      */
-    onLoaded?: ((result: Array<TValue>, loadOptions: LoadOptions<TValue>) => void);
+    onLoaded?: ((result: Array<TItem>, loadOptions: LoadOptions<TItem>) => void);
     /**
      * @docid
      * @type_function_param1 loadOptions:LoadOptions
      * @action
      * @public
      */
-    onLoading?: ((loadOptions: LoadOptions<TValue>) => void);
+    onLoading?: ((loadOptions: LoadOptions<TItem>) => void);
     /**
      * @docid
      * @action
@@ -71,7 +71,7 @@ export interface StoreOptions<
      * @action
      * @public
      */
-    onPush?: ((changes: Array<TValue>) => void);
+    onPush?: ((changes: Array<TItem>) => void);
     /**
      * @docid
      * @type_function_param1 key:object|string|number
@@ -93,7 +93,7 @@ export interface StoreOptions<
      * @action
      * @public
      */
-    onUpdated?: ((key: TKey, values: TValue) => void);
+    onUpdated?: ((key: TKey, values: TItem) => void);
     /**
      * @docid
      * @type_function_param1 key:object|string|number
@@ -101,7 +101,7 @@ export interface StoreOptions<
      * @action
      * @public
      */
-    onUpdating?: ((key: TKey, values: TValue) => void);
+    onUpdating?: ((key: TKey, values: TItem) => void);
 }
 
 type EventName = 'loaded' | 'loading' | 'inserted' | 'inserting' | 'updated' | 'updating' | 'push' | 'removed' | 'removing' | 'modified' | 'modifying';
@@ -112,10 +112,10 @@ type EventName = 'loaded' | 'loading' | 'inserted' | 'inserting' | 'updated' | '
  * @namespace DevExpress.data
  */
 export default class Store<
-    TValue = any,
+    TItem = any,
     TKey = any,
 > {
-    constructor(options?: Options<TValue, TKey>)
+    constructor(options?: Options<TItem, TKey>)
     /**
      * @docid
      * @publicName byKey(key)
@@ -124,7 +124,7 @@ export default class Store<
      * @return Promise<any>
      * @public
      */
-    byKey(key: TKey, extraOptions?: LoadOptions<TValue>): DxPromise<TValue>;
+    byKey(key: TKey, extraOptions?: LoadOptions<TItem>): DxPromise<TItem>;
     /**
      * @docid
      * @publicName insert(values)
@@ -132,7 +132,7 @@ export default class Store<
      * @return Promise<any>
      * @public
      */
-    insert(values: TValue): DxPromise<TValue>;
+    insert(values: TItem): DxPromise<TItem>;
     /**
      * @docid
      * @publicName key()
@@ -146,14 +146,14 @@ export default class Store<
      * @return any|string|number
      * @public
      */
-    keyOf(obj: TValue): TKey;
+    keyOf(obj: TItem): TKey;
     /**
      * @docid
      * @publicName load()
      * @return Promise<any>
      * @public
      */
-    load(): DxPromise<Array<TValue>>;
+    load(): DxPromise<Array<TItem>>;
     /**
      * @docid
      * @publicName load(options)
@@ -161,7 +161,7 @@ export default class Store<
      * @return Promise<any>
      * @public
      */
-    load(options: LoadOptions<TValue>): DxPromise<Array<TValue>>;
+    load(options: LoadOptions<TItem>): DxPromise<Array<TItem>>;
     /**
      * @docid
      * @publicName off(eventName)
@@ -202,7 +202,7 @@ export default class Store<
      * @param1 changes:Array<any>
      * @public
      */
-    push(changes: Array<{ type: 'insert' | 'update' | 'remove'; data?: DeepPartial<TValue>; key?: TKey; index?: number }>): void;
+    push(changes: Array<{ type: 'insert' | 'update' | 'remove'; data?: DeepPartial<TItem>; key?: TKey; index?: number }>): void;
     /**
      * @docid
      * @publicName remove(key)
@@ -219,7 +219,7 @@ export default class Store<
      * @return Promise<number>
      * @public
      */
-    totalCount(obj: { filter?: FilterDescriptor | Array<FilterDescriptor>; group?: GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>> }): DxPromise<number>;
+    totalCount(obj: { filter?: FilterDescriptor | Array<FilterDescriptor>; group?: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>> }): DxPromise<number>;
     /**
      * @docid
      * @publicName update(key, values)
@@ -228,5 +228,5 @@ export default class Store<
      * @return Promise<any>
      * @public
      */
-    update(key: TKey, values: DeepPartial<TValue>): DxPromise<TValue>;
+    update(key: TKey, values: DeepPartial<TItem>): DxPromise<TItem>;
 }

--- a/js/data/abstract_store.d.ts
+++ b/js/data/abstract_store.d.ts
@@ -8,7 +8,10 @@ export type Options<
     TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
 > = StoreOptions<TValue, TKeyExpr, TKey>;
 
-/** @namespace DevExpress.data */
+/**
+ * @namespace DevExpress.data
+ * @deprecated Use Options instead
+ */
 export interface StoreOptions<
     TValue = any,
     TKeyExpr extends string | Array<string> = string | Array<string>,

--- a/js/data/abstract_store.d.ts
+++ b/js/data/abstract_store.d.ts
@@ -4,9 +4,8 @@ import { FilterDescriptor, GroupDescriptor, LoadOptions } from './index';
 
 export type Options<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> = StoreOptions<TValue, TKeyExpr, TKey>;
+    TKey = any,
+> = StoreOptions<TValue, TKey>;
 
 /**
  * @namespace DevExpress.data
@@ -14,8 +13,7 @@ export type Options<
  */
 export interface StoreOptions<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
+    TKey = any,
 > {
     /**
      * @docid
@@ -24,10 +22,9 @@ export interface StoreOptions<
     errorHandler?: Function;
     /**
      * @docid
-     * @type string | Array<string>
      * @public
      */
-    key?: TKeyExpr;
+    key?: string | Array<string>;
     /**
      * @docid
      * @type_function_param1 values:object
@@ -114,12 +111,11 @@ type EventName = 'loaded' | 'loading' | 'inserted' | 'inserting' | 'updated' | '
  * @hidden
  * @namespace DevExpress.data
  */
-export default class Store
-<TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
+export default class Store<
+    TValue = any,
+    TKey = any,
 > {
-    constructor(options?: Options<TValue, TKeyExpr, TKey>)
+    constructor(options?: Options<TValue, TKey>)
     /**
      * @docid
      * @publicName byKey(key)
@@ -140,10 +136,9 @@ export default class Store
     /**
      * @docid
      * @publicName key()
-     * @return string | Array<string>
      * @public
      */
-    key(): TKeyExpr;
+    key(): string | Array<string>;
     /**
      * @docid
      * @publicName keyOf(obj)

--- a/js/data/array_store.d.ts
+++ b/js/data/array_store.d.ts
@@ -5,23 +5,23 @@ import { Query } from './query';
 
 /** @public */
 export type Options<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> = ArrayStoreOptions<TValue, TKey>;
+> = ArrayStoreOptions<TItem, TKey>;
 
 /**
  * @namespace DevExpress.data
  * @deprecated Use Options instead
  */
 export interface ArrayStoreOptions<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> extends StoreOptions<TValue, TKey> {
+> extends StoreOptions<TItem, TKey> {
     /**
      * @docid
      * @public
      */
-    data?: Array<TValue>;
+    data?: Array<TItem>;
 }
 /**
  * @docid
@@ -29,10 +29,10 @@ export interface ArrayStoreOptions<
  * @public
  */
 export default class ArrayStore<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> extends Store<TValue, TKey> {
-    constructor(options?: Options<TValue, TKey>)
+> extends Store<TItem, TKey> {
+    constructor(options?: Options<TItem, TKey>)
     /**
      * @docid
      * @publicName clear()

--- a/js/data/array_store.d.ts
+++ b/js/data/array_store.d.ts
@@ -6,9 +6,8 @@ import { Query } from './query';
 /** @public */
 export type Options<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> = ArrayStoreOptions<TValue, TKeyExpr, TKey>;
+    TKey = any,
+> = ArrayStoreOptions<TValue, TKey>;
 
 /**
  * @namespace DevExpress.data
@@ -16,9 +15,8 @@ export type Options<
  */
 export interface ArrayStoreOptions<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> extends StoreOptions<TValue, TKeyExpr, TKey> {
+    TKey = any,
+> extends StoreOptions<TValue, TKey> {
     /**
      * @docid
      * @public
@@ -32,10 +30,9 @@ export interface ArrayStoreOptions<
  */
 export default class ArrayStore<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> extends Store<TValue, TKeyExpr, TKey> {
-    constructor(options?: Options<TValue, TKeyExpr, TKey>)
+    TKey = any,
+> extends Store<TValue, TKey> {
+    constructor(options?: Options<TValue, TKey>)
     /**
      * @docid
      * @publicName clear()

--- a/js/data/custom_store.d.ts
+++ b/js/data/custom_store.d.ts
@@ -3,25 +3,25 @@ import Store, { Options as StoreOptions } from './abstract_store';
 
 /** @public */
 export type Options<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> = CustomStoreOptions<TValue, TKey>;
+> = CustomStoreOptions<TItem, TKey>;
 
 /**
  * @namespace DevExpress.data
  * @deprecated Use Options instead
  */
 export interface CustomStoreOptions<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> extends StoreOptions<TValue, TKey> {
+> extends StoreOptions<TItem, TKey> {
     /**
      * @docid
      * @type_function_param1 key:object|string|number
      * @type_function_return Promise<any>
      * @public
      */
-    byKey?: ((key: TKey) => PromiseLike<TValue>);
+    byKey?: ((key: TKey) => PromiseLike<TItem>);
     /**
      * @docid
      * @default true
@@ -34,14 +34,14 @@ export interface CustomStoreOptions<
      * @type_function_return Promise<any>
      * @public
      */
-    insert?: ((values: TValue) => PromiseLike<TValue>);
+    insert?: ((values: TItem) => PromiseLike<TItem>);
     /**
      * @docid
      * @type_function_param1 options:LoadOptions
      * @type_function_return Promise<any>|Array<any>
      * @public
      */
-    load: ((options: LoadOptions<TValue>) => PromiseLike<TValue> | Array<TValue>);
+    load: ((options: LoadOptions<TItem>) => PromiseLike<TItem> | Array<TItem>);
     /**
      * @docid
      * @default 'processed'
@@ -62,7 +62,7 @@ export interface CustomStoreOptions<
      * @type_function_return Promise<number>
      * @public
      */
-    totalCount?: ((loadOptions: { filter?: FilterDescriptor | Array<FilterDescriptor>; group?: GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>> }) => PromiseLike<number>);
+    totalCount?: ((loadOptions: { filter?: FilterDescriptor | Array<FilterDescriptor>; group?: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>> }) => PromiseLike<number>);
     /**
      * @docid
      * @type_function_param1 key:object|string|number
@@ -70,7 +70,7 @@ export interface CustomStoreOptions<
      * @type_function_return Promise<any>
      * @public
      */
-    update?: ((key: TKey, values: TValue) => PromiseLike<any>);
+    update?: ((key: TKey, values: TItem) => PromiseLike<any>);
     /**
      * @docid
      * @default undefined
@@ -84,10 +84,10 @@ export interface CustomStoreOptions<
  * @public
  */
 export default class CustomStore<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> extends Store<TValue, TKey> {
-    constructor(options?: Options<TValue, TKey>)
+> extends Store<TItem, TKey> {
+    constructor(options?: Options<TItem, TKey>)
     /**
      * @docid
      * @publicName clearRawDataCache()

--- a/js/data/custom_store.d.ts
+++ b/js/data/custom_store.d.ts
@@ -4,9 +4,8 @@ import Store, { Options as StoreOptions } from './abstract_store';
 /** @public */
 export type Options<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> = CustomStoreOptions<TValue, TKeyExpr, TKey>;
+    TKey = any,
+> = CustomStoreOptions<TValue, TKey>;
 
 /**
  * @namespace DevExpress.data
@@ -14,9 +13,8 @@ export type Options<
  */
 export interface CustomStoreOptions<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> extends StoreOptions<TValue, TKeyExpr, TKey> {
+    TKey = any,
+> extends StoreOptions<TValue, TKey> {
     /**
      * @docid
      * @type_function_param1 key:object|string|number
@@ -87,10 +85,9 @@ export interface CustomStoreOptions<
  */
 export default class CustomStore<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> extends Store<TValue, TKeyExpr, TKey> {
-    constructor(options?: Options<TValue, TKeyExpr, TKey>)
+    TKey = any,
+> extends Store<TValue, TKey> {
+    constructor(options?: Options<TValue, TKey>)
     /**
      * @docid
      * @publicName clearRawDataCache()

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -10,19 +10,20 @@ import { Options as ODataStoreOptions } from './odata/store';
 
 /** @public */
 export type Options<
-    TSourceValue = any,
-    TValue = TSourceValue,
-    TMappedValue = TValue,
+    TSourceItem = any,
+    TItem = TSourceItem,
+    TMappedItem = TItem,
     TKey = any,
-> = DataSourceOptions<TSourceValue, TValue, TMappedValue, TKey>;
+> = DataSourceOptions<TSourceItem, TItem, TMappedItem, TKey>;
 
 /**
  * @namespace DevExpress.data
  * @deprecated Use Options instead
  */
 export interface DataSourceOptions<
-    TSourceValue = any, TValue = TSourceValue,
-    TMappedValue = TValue,
+    TSourceItem = any,
+    TItem = TSourceItem,
+    TMappedItem = TItem,
     TKey = any,
 > {
     /**
@@ -46,14 +47,14 @@ export interface DataSourceOptions<
      * @type Group expression
      * @public
      */
-    group?: GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>>;
+    group?: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>;
     /**
      * @docid
      * @type_function_param1 dataItem:object
      * @type_function_return object
      * @public
      */
-    map?: ((dataItem: TSourceValue) => TMappedValue);
+    map?: ((dataItem: TSourceItem) => TMappedItem);
     /**
      * @docid
      * @type_function_param1 e:Object
@@ -61,7 +62,7 @@ export interface DataSourceOptions<
      * @action
      * @public
      */
-    onChanged?: ((e: { readonly changes?: Array<TMappedValue> }) => void);
+    onChanged?: ((e: { readonly changes?: Array<TMappedItem> }) => void);
     /**
      * @docid
      * @type_function_param1 error:Object
@@ -93,7 +94,7 @@ export interface DataSourceOptions<
      * @type_function_return Array<any>
      * @public
      */
-    postProcess?: ((data: Array<TMappedValue>) => Array<TValue>);
+    postProcess?: ((data: Array<TMappedItem>) => Array<TItem>);
     /**
      * @docid
      * @default undefined
@@ -134,36 +135,36 @@ export interface DataSourceOptions<
      * @type Select expression
      * @public
      */
-    select?: SelectDescriptor<TValue>;
+    select?: SelectDescriptor<TItem>;
     /**
      * @docid
      * @type Sort expression
      * @public
      */
-    sort?: SortDescriptor<TValue> | Array<SortDescriptor<TValue>>;
+    sort?: SortDescriptor<TItem> | Array<SortDescriptor<TItem>>;
     /**
      * @docid
      * @public
      * @type Store|StoreOptions|Array<any>
      */
-    store?: Array<TSourceValue> |
-        Store<TSourceValue, TKey> |
-        ArrayStoreOptions<TSourceValue, TKey> & { type: 'array' } |
-        LocalStoreOptions<TSourceValue, TKey> & { type: 'local' } |
-        ODataStoreOptions<TSourceValue, TKey> & { type: 'odata' } |
-        CustomStoreOptions<TSourceValue, TKey>;
+    store?: Array<TSourceItem> |
+        Store<TSourceItem, TKey> |
+        ArrayStoreOptions<TSourceItem, TKey> & { type: 'array' } |
+        LocalStoreOptions<TSourceItem, TKey> & { type: 'local' } |
+        ODataStoreOptions<TSourceItem, TKey> & { type: 'odata' } |
+        CustomStoreOptions<TSourceItem, TKey>;
 }
 /**
  * @docid
  * @public
  */
 export default class DataSource<
-    TValue = any,
+    TItem = any,
     TKey = any,
 > {
-    constructor(data: Array<TValue>);
-    constructor(options: CustomStoreOptions<TValue, TKey> | Options<any, TValue, any, TKey>);
-    constructor(store: Store<TValue, TKey>);
+    constructor(data: Array<TItem>);
+    constructor(options: CustomStoreOptions<TItem, TKey> | Options<any, TItem, any, TKey>);
+    constructor(store: Store<TItem, TKey>);
     constructor(url: string);
     /**
      * @docid
@@ -197,14 +198,14 @@ export default class DataSource<
      * @return object
      * @public
      */
-    group(): GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>>;
+    group(): GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>;
     /**
      * @docid
      * @publicName group(groupExpr)
      * @param1 groupExpr:object
      * @public
      */
-    group(groupExpr: GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>>): void;
+    group(groupExpr: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>): void;
     /**
      * @docid
      * @publicName isLastPage()
@@ -248,7 +249,7 @@ export default class DataSource<
      * @return object
      * @public
      */
-    loadOptions(): LoadOptions<TValue>;
+    loadOptions(): LoadOptions<TItem>;
     /**
      * @docid
      * @publicName off(eventName)
@@ -388,35 +389,35 @@ export default class DataSource<
      * @return any
      * @public
      */
-    select(): SelectDescriptor<TValue>;
+    select(): SelectDescriptor<TItem>;
     /**
      * @docid
      * @publicName select(expr)
      * @param1 expr:any
      * @public
      */
-    select(expr: SelectDescriptor<TValue>): void;
+    select(expr: SelectDescriptor<TItem>): void;
     /**
      * @docid
      * @publicName sort()
      * @return any
      * @public
      */
-    sort(): SortDescriptor<TValue> | Array<SortDescriptor<TValue>>;
+    sort(): SortDescriptor<TItem> | Array<SortDescriptor<TItem>>;
     /**
      * @docid
      * @publicName sort(sortExpr)
      * @param1 sortExpr:any
      * @public
      */
-    sort(sortExpr: SortDescriptor<TValue> | Array<SortDescriptor<TValue>>): void;
+    sort(sortExpr: SortDescriptor<TItem> | Array<SortDescriptor<TItem>>): void;
     /**
      * @docid
      * @publicName store()
      * @return object
      * @public
      */
-    store(): Store<TValue, TKey>;
+    store(): Store<TItem, TKey>;
     /**
      * @docid
      * @publicName totalCount()

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -435,7 +435,7 @@ export type DataSourceLike<TItem, TKey = any> =
     string |
     Array<TItem> |
     Store<TItem, TKey> |
-    Options<any, TItem, any, TKey> |
+    Options<any, any, TItem, TKey> |
     DataSource<TItem, TKey>;
 
 type EventName = 'changed' | 'loadError' | 'loadingChanged';

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -11,8 +11,8 @@ import { Options as ODataStoreOptions } from './odata/store';
 /** @public */
 export type Options<
     TStoreItem = any,
-    TItem = TStoreItem,
-    TMappedItem = TItem,
+    TMappedItem = TStoreItem,
+    TItem = TMappedItem,
     TKey = any,
 > = DataSourceOptions<TStoreItem, TItem, TMappedItem, TKey>;
 
@@ -22,8 +22,8 @@ export type Options<
  */
 export interface DataSourceOptions<
     TStoreItem = any,
-    TItem = TStoreItem,
-    TMappedItem = TItem,
+    TMappedItem = TStoreItem,
+    TItem = TMappedItem,
     TKey = any,
 > {
     /**

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -5,8 +5,8 @@ import { DxPromise } from '../core/utils/deferred';
 import Store from './abstract_store';
 import { Options as CustomStoreOptions } from './custom_store';
 import { Options as ArrayStoreOptions } from './array_store';
-import { LocalStoreOptions } from './local_store';
-import { ODataStoreOptions } from './odata/store';
+import { Options as LocalStoreOptions } from './local_store';
+import { Options as ODataStoreOptions } from './odata/store';
 
 /** @public */
 export type Options<

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -10,19 +10,19 @@ import { Options as ODataStoreOptions } from './odata/store';
 
 /** @public */
 export type Options<
-    TSourceItem = any,
-    TItem = TSourceItem,
+    TStoreItem = any,
+    TItem = TStoreItem,
     TMappedItem = TItem,
     TKey = any,
-> = DataSourceOptions<TSourceItem, TItem, TMappedItem, TKey>;
+> = DataSourceOptions<TStoreItem, TItem, TMappedItem, TKey>;
 
 /**
  * @namespace DevExpress.data
  * @deprecated Use Options instead
  */
 export interface DataSourceOptions<
-    TSourceItem = any,
-    TItem = TSourceItem,
+    TStoreItem = any,
+    TItem = TStoreItem,
     TMappedItem = TItem,
     TKey = any,
 > {
@@ -54,7 +54,7 @@ export interface DataSourceOptions<
      * @type_function_return object
      * @public
      */
-    map?: ((dataItem: TSourceItem) => TMappedItem);
+    map?: ((dataItem: TStoreItem) => TMappedItem);
     /**
      * @docid
      * @type_function_param1 e:Object
@@ -147,12 +147,12 @@ export interface DataSourceOptions<
      * @public
      * @type Store|StoreOptions|Array<any>
      */
-    store?: Array<TSourceItem> |
-        Store<TSourceItem, TKey> |
-        ArrayStoreOptions<TSourceItem, TKey> & { type: 'array' } |
-        LocalStoreOptions<TSourceItem, TKey> & { type: 'local' } |
-        ODataStoreOptions<TSourceItem, TKey> & { type: 'odata' } |
-        CustomStoreOptions<TSourceItem, TKey>;
+    store?: Array<TStoreItem> |
+        Store<TStoreItem, TKey> |
+        ArrayStoreOptions<TStoreItem, TKey> & { type: 'array' } |
+        LocalStoreOptions<TStoreItem, TKey> & { type: 'local' } |
+        ODataStoreOptions<TStoreItem, TKey> & { type: 'odata' } |
+        CustomStoreOptions<TStoreItem, TKey>;
 }
 /**
  * @docid

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -431,6 +431,11 @@ export default class DataSource<
  * @docid
  * @type Store|DataSource|DataSourceOptions|string|Array<any>
  * */
-export type DataSourceLike<TItem, TKey = any> = string | Array<TItem> | Store<TItem, TKey> | Options<any, TItem, any, TKey> | DataSource<TItem, TKey>;
+export type DataSourceLike<TItem, TKey = any> =
+    string |
+    Array<TItem> |
+    Store<TItem, TKey> |
+    Options<any, TItem, any, TKey> |
+    DataSource<TItem, TKey>;
 
 type EventName = 'changed' | 'loadError' | 'loadingChanged';

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -13,9 +13,8 @@ export type Options<
     TSourceValue = any,
     TValue = TSourceValue,
     TMappedValue = TValue,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> = DataSourceOptions<TSourceValue, TValue, TMappedValue, TKeyExpr, TKey>;
+    TKey = any,
+> = DataSourceOptions<TSourceValue, TValue, TMappedValue, TKey>;
 
 /**
  * @namespace DevExpress.data
@@ -24,8 +23,7 @@ export type Options<
 export interface DataSourceOptions<
     TSourceValue = any, TValue = TSourceValue,
     TMappedValue = TValue,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
+    TKey = any,
 > {
     /**
      * @docid
@@ -149,24 +147,23 @@ export interface DataSourceOptions<
      * @type Store|StoreOptions|Array<any>
      */
     store?: Array<TSourceValue> |
-        Store<TSourceValue, TKeyExpr, TKey> |
-        ArrayStoreOptions<TSourceValue, TKeyExpr, TKey> & { type: 'array' } |
-        LocalStoreOptions<TSourceValue, TKeyExpr, TKey> & { type: 'local' } |
-        ODataStoreOptions<TSourceValue, TKeyExpr, TKey> & { type: 'odata' } |
-        CustomStoreOptions<TSourceValue, TKeyExpr, TKey>;
+        Store<TSourceValue, TKey> |
+        ArrayStoreOptions<TSourceValue, TKey> & { type: 'array' } |
+        LocalStoreOptions<TSourceValue, TKey> & { type: 'local' } |
+        ODataStoreOptions<TSourceValue, TKey> & { type: 'odata' } |
+        CustomStoreOptions<TSourceValue, TKey>;
 }
 /**
  * @docid
  * @public
  */
-export default class DataSource
-<TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
+export default class DataSource<
+    TValue = any,
+    TKey = any,
 > {
     constructor(data: Array<TValue>);
-    constructor(options: CustomStoreOptions<TValue, TKeyExpr, TKey> | Options<any, TValue, any, TKeyExpr, TKey>);
-    constructor(store: Store<TValue, TKeyExpr, TKey>);
+    constructor(options: CustomStoreOptions<TValue, TKey> | Options<any, TValue, any, TKey>);
+    constructor(store: Store<TValue, TKey>);
     constructor(url: string);
     /**
      * @docid
@@ -235,10 +232,9 @@ export default class DataSource
     /**
      * @docid
      * @publicName key()
-     * @return string | Array<string>
      * @public
      */
-    key(): TKeyExpr;
+    key(): string | Array<string>;
     /**
      * @docid
      * @publicName load()
@@ -420,7 +416,7 @@ export default class DataSource
      * @return object
      * @public
      */
-    store(): Store<TValue, TKeyExpr, TKey>;
+    store(): Store<TValue, TKey>;
     /**
      * @docid
      * @publicName totalCount()
@@ -434,6 +430,6 @@ export default class DataSource
  * @docid
  * @type Store|DataSource|DataSourceOptions|string|Array<any>
  * */
-export type DataSourceLike<TItem, TKey = any> = string | Array<TItem> | Store<TItem, any, TKey> | Options<any, TItem, any, any, TKey> | DataSource<TItem, any, TKey>;
+export type DataSourceLike<TItem, TKey = any> = string | Array<TItem> | Store<TItem, TKey> | Options<any, TItem, any, TKey> | DataSource<TItem, TKey>;
 
 type EventName = 'changed' | 'loadError' | 'loadingChanged';

--- a/js/data/local_store.d.ts
+++ b/js/data/local_store.d.ts
@@ -4,18 +4,18 @@ import ArrayStore, {
 
 /** @public */
 export type Options<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> = LocalStoreOptions<TValue, TKey>;
+> = LocalStoreOptions<TItem, TKey>;
 
 /**
  * @namespace DevExpress.data
  * @deprecated Use Options instead
  */
 export interface LocalStoreOptions<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> extends ArrayStoreOptions<TValue, TKey> {
+> extends ArrayStoreOptions<TItem, TKey> {
     /**
      * @docid
      * @default 10000
@@ -40,10 +40,10 @@ export interface LocalStoreOptions<
  * @public
  */
 export default class LocalStore<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> extends ArrayStore<TValue, TKey> {
-    constructor(options?: Options<TValue, TKey>)
+> extends ArrayStore<TItem, TKey> {
+    constructor(options?: Options<TItem, TKey>)
     /**
      * @docid
      * @publicName clear()

--- a/js/data/local_store.d.ts
+++ b/js/data/local_store.d.ts
@@ -2,9 +2,19 @@ import ArrayStore, {
     ArrayStoreOptions,
 } from './array_store';
 
-/** @namespace DevExpress.data */
-export interface LocalStoreOptions
-<TValue = any,
+/** @public */
+export type Options<
+    TValue = any,
+    TKeyExpr extends string | Array<string> = string | Array<string>,
+    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
+> = LocalStoreOptions<TValue, TKeyExpr, TKey>;
+
+/**
+ * @namespace DevExpress.data
+ * @deprecated Use Options instead
+ */
+export interface LocalStoreOptions<
+    TValue = any,
     TKeyExpr extends string | Array<string> = string | Array<string>,
     TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
 > extends ArrayStoreOptions<TValue, TKeyExpr, TKey> {
@@ -36,7 +46,7 @@ export default class LocalStore
     TKeyExpr extends string | Array<string> = string | Array<string>,
     TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
 > extends ArrayStore<TValue, TKeyExpr, TKey> {
-    constructor(options?: LocalStoreOptions<TValue, TKeyExpr, TKey>)
+    constructor(options?: Options<TValue, TKeyExpr, TKey>)
     /**
      * @docid
      * @publicName clear()

--- a/js/data/local_store.d.ts
+++ b/js/data/local_store.d.ts
@@ -5,9 +5,8 @@ import ArrayStore, {
 /** @public */
 export type Options<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> = LocalStoreOptions<TValue, TKeyExpr, TKey>;
+    TKey = any,
+> = LocalStoreOptions<TValue, TKey>;
 
 /**
  * @namespace DevExpress.data
@@ -15,9 +14,8 @@ export type Options<
  */
 export interface LocalStoreOptions<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> extends ArrayStoreOptions<TValue, TKeyExpr, TKey> {
+    TKey = any,
+> extends ArrayStoreOptions<TValue, TKey> {
     /**
      * @docid
      * @default 10000
@@ -41,12 +39,11 @@ export interface LocalStoreOptions<
  * @inherits ArrayStore
  * @public
  */
-export default class LocalStore
-<TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> extends ArrayStore<TValue, TKeyExpr, TKey> {
-    constructor(options?: Options<TValue, TKeyExpr, TKey>)
+export default class LocalStore<
+    TValue = any,
+    TKey = any,
+> extends ArrayStore<TValue, TKey> {
+    constructor(options?: Options<TValue, TKey>)
     /**
      * @docid
      * @publicName clear()

--- a/js/data/odata/store.d.ts
+++ b/js/data/odata/store.d.ts
@@ -13,18 +13,18 @@ interface PromiseExtension<T> {
 
 /** @public */
 export type Options<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> = ODataStoreOptions<TValue, TKey>;
+> = ODataStoreOptions<TItem, TKey>;
 
 /**
  * @namespace DevExpress.data
  * @deprecated Use Options instead
  */
 export interface ODataStoreOptions<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> extends StoreOptions<TValue, TKey> {
+> extends StoreOptions<TItem, TKey> {
     /**
      * @docid
      * @type_function_param1_field5 params:object
@@ -76,7 +76,7 @@ export interface ODataStoreOptions<
      * @action
      * @public
      */
-    onLoading?: ((loadOptions: LoadOptions<TValue>) => void);
+    onLoading?: ((loadOptions: LoadOptions<TItem>) => void);
     /**
      * @docid
      * @public
@@ -102,11 +102,11 @@ export interface ODataStoreOptions<
  * @public
  */
 export default class ODataStore<
-    TValue = any,
+    TItem = any,
     TKey = any,
-> extends Store<TValue, TKey> {
-    constructor(options?: Options<TValue, TKey>)
-    byKey(key: TKey): DxPromise<TValue>;
+> extends Store<TItem, TKey> {
+    constructor(options?: Options<TItem, TKey>)
+    byKey(key: TKey): DxPromise<TItem>;
     /**
      * @docid
      * @publicName byKey(key, extraOptions)
@@ -114,7 +114,7 @@ export default class ODataStore<
      * @return Promise<any>
      * @public
      */
-    byKey(key: TKey, extraOptions: { expand?: string | Array<string>; select?: string | Array<string> }): DxPromise<TValue>;
+    byKey(key: TKey, extraOptions: { expand?: string | Array<string>; select?: string | Array<string> }): DxPromise<TItem>;
     /**
      * @docid
      * @publicName createQuery(loadOptions)
@@ -130,5 +130,5 @@ export default class ODataStore<
      * @return Promise<any>
      * @public
      */
-    insert(values: TValue): DxPromise<TValue> & PromiseExtension<TValue>;
+    insert(values: TItem): DxPromise<TItem> & PromiseExtension<TItem>;
 }

--- a/js/data/odata/store.d.ts
+++ b/js/data/odata/store.d.ts
@@ -1,5 +1,5 @@
 import { DxPromise } from '../../core/utils/deferred';
-import Store, { StoreOptions } from '../abstract_store';
+import Store, { Options as StoreOptions } from '../abstract_store';
 import { LoadOptions } from '../index';
 import { Query } from '../query';
 import { ODataRequestOptions } from './context';
@@ -11,9 +11,19 @@ interface PromiseExtension<T> {
     ): Promise<TResult1 | TResult2>;
 }
 
-/** @namespace DevExpress.data */
-export interface ODataStoreOptions
-<TValue = any,
+/** @public */
+export type Options<
+    TValue = any,
+    TKeyExpr extends string | Array<string> = string | Array<string>,
+    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
+> = ODataStoreOptions<TValue, TKeyExpr, TKey>;
+
+/**
+ * @namespace DevExpress.data
+ * @deprecated Use Options instead
+ */
+export interface ODataStoreOptions<
+    TValue = any,
     TKeyExpr extends string | Array<string> = string | Array<string>,
     TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
 > extends StoreOptions<TValue, TKeyExpr, TKey> {
@@ -98,7 +108,7 @@ export default class ODataStore
     TKeyExpr extends string | Array<string> = string | Array<string>,
     TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
 > extends Store<TValue, TKeyExpr, TKey> {
-    constructor(options?: ODataStoreOptions<TValue, TKeyExpr, TKey>)
+    constructor(options?: Options<TValue, TKeyExpr, TKey>)
     byKey(key: TKey): DxPromise<TValue>;
     /**
      * @docid

--- a/js/data/odata/store.d.ts
+++ b/js/data/odata/store.d.ts
@@ -14,9 +14,8 @@ interface PromiseExtension<T> {
 /** @public */
 export type Options<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> = ODataStoreOptions<TValue, TKeyExpr, TKey>;
+    TKey = any,
+> = ODataStoreOptions<TValue, TKey>;
 
 /**
  * @namespace DevExpress.data
@@ -24,9 +23,8 @@ export type Options<
  */
 export interface ODataStoreOptions<
     TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> extends StoreOptions<TValue, TKeyExpr, TKey> {
+    TKey = any,
+> extends StoreOptions<TValue, TKey> {
     /**
      * @docid
      * @type_function_param1_field5 params:object
@@ -103,12 +101,11 @@ export interface ODataStoreOptions<
  * @inherits Store
  * @public
  */
-export default class ODataStore
-<TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any,
-> extends Store<TValue, TKeyExpr, TKey> {
-    constructor(options?: Options<TValue, TKeyExpr, TKey>)
+export default class ODataStore<
+    TValue = any,
+    TKey = any,
+> extends Store<TValue, TKey> {
+    constructor(options?: Options<TValue, TKey>)
     byKey(key: TKey): DxPromise<TValue>;
     /**
      * @docid

--- a/js/ui/collection/ui.collection_widget.base.d.ts
+++ b/js/ui/collection/ui.collection_widget.base.d.ts
@@ -184,7 +184,7 @@ export default class CollectionWidget<
     TItem extends ItemLike = any,
     TKey = any,
 > extends Widget<TProperties> {
-    getDataSource(): DataSource<TItem, string | Array<string>, TKey>;
+    getDataSource(): DataSource<TItem, TKey>;
 }
 
 /**

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -2101,7 +2101,7 @@ export interface GridBase<TRowData = any, TKey = any> {
      * @public
      */
     getCombinedFilter(returnDataField: boolean): any;
-    getDataSource(): DataSource<TRowData, string | Array<string>, TKey>;
+    getDataSource(): DataSource<TRowData, TKey>;
     /**
      * @docid
      * @publicName getKeyByRowIndex(rowIndex)
@@ -4448,7 +4448,7 @@ declare class dxDataGrid<TRowData = any, TKey = any> extends Widget<dxDataGridOp
     getCellElement(rowIndex: number, visibleColumnIndex: number): DxElement | undefined;
     getCombinedFilter(): any;
     getCombinedFilter(returnDataField: boolean): any;
-    getDataSource(): DataSource<TRowData, string | Array<string>, TKey>;
+    getDataSource(): DataSource<TRowData, TKey>;
     getKeyByRowIndex(rowIndex: number): TKey | undefined;
     getRowElement(rowIndex: number): UserDefinedElementsArray | undefined;
     getRowIndexByKey(key: TKey): number;

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1143,7 +1143,7 @@ export default class dxTreeList<TRowData = any, TKey = any> extends Widget<dxTre
     getCellElement(rowIndex: number, visibleColumnIndex: number): DxElement | undefined;
     getCombinedFilter(): any;
     getCombinedFilter(returnDataField: boolean): any;
-    getDataSource(): DataSource<TRowData, string | Array<string>, TKey>;
+    getDataSource(): DataSource<TRowData, TKey>;
     getKeyByRowIndex(rowIndex: number): TKey | undefined;
     getRowElement(rowIndex: number): UserDefinedElementsArray | undefined;
     getRowIndexByKey(key: TKey): number;

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1599,11 +1599,8 @@ declare module DevExpress.data {
   /**
    * [descr:ArrayStore]
    */
-  export class ArrayStore<TValue = any, TKey = any> extends Store<
-    TValue,
-    TKey
-  > {
-    constructor(options?: DevExpress.data.ArrayStore.Options<TValue, TKey>);
+  export class ArrayStore<TItem = any, TKey = any> extends Store<TItem, TKey> {
+    constructor(options?: DevExpress.data.ArrayStore.Options<TItem, TKey>);
     /**
      * [descr:ArrayStore.clear()]
      */
@@ -1614,8 +1611,8 @@ declare module DevExpress.data {
     createQuery(): Query;
   }
   module ArrayStore {
-    export type Options<TValue = any, TKey = any> = ArrayStoreOptions<
-      TValue,
+    export type Options<TItem = any, TKey = any> = ArrayStoreOptions<
+      TItem,
       TKey
     >;
   }
@@ -1623,12 +1620,12 @@ declare module DevExpress.data {
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface ArrayStoreOptions<TValue = any, TKey = any>
-    extends DevExpress.data.Store.Options<TValue, TKey> {
+  export interface ArrayStoreOptions<TItem = any, TKey = any>
+    extends DevExpress.data.Store.Options<TItem, TKey> {
     /**
      * [descr:ArrayStoreOptions.data]
      */
-    data?: Array<TValue>;
+    data?: Array<TItem>;
   }
   /**
    * [descr:Utils.base64_encode(input)]
@@ -1643,19 +1640,16 @@ declare module DevExpress.data {
   /**
    * [descr:CustomStore]
    */
-  export class CustomStore<TValue = any, TKey = any> extends Store<
-    TValue,
-    TKey
-  > {
-    constructor(options?: DevExpress.data.CustomStore.Options<TValue, TKey>);
+  export class CustomStore<TItem = any, TKey = any> extends Store<TItem, TKey> {
+    constructor(options?: DevExpress.data.CustomStore.Options<TItem, TKey>);
     /**
      * [descr:CustomStore.clearRawDataCache()]
      */
     clearRawDataCache(): void;
   }
   module CustomStore {
-    export type Options<TValue = any, TKey = any> = CustomStoreOptions<
-      TValue,
+    export type Options<TItem = any, TKey = any> = CustomStoreOptions<
+      TItem,
       TKey
     >;
   }
@@ -1663,12 +1657,12 @@ declare module DevExpress.data {
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface CustomStoreOptions<TValue = any, TKey = any>
-    extends DevExpress.data.Store.Options<TValue, TKey> {
+  export interface CustomStoreOptions<TItem = any, TKey = any>
+    extends DevExpress.data.Store.Options<TItem, TKey> {
     /**
      * [descr:CustomStoreOptions.byKey]
      */
-    byKey?: (key: TKey) => PromiseLike<TValue>;
+    byKey?: (key: TKey) => PromiseLike<TItem>;
     /**
      * [descr:CustomStoreOptions.cacheRawData]
      */
@@ -1676,11 +1670,11 @@ declare module DevExpress.data {
     /**
      * [descr:CustomStoreOptions.insert]
      */
-    insert?: (values: TValue) => PromiseLike<TValue>;
+    insert?: (values: TItem) => PromiseLike<TItem>;
     /**
      * [descr:CustomStoreOptions.load]
      */
-    load: (options: LoadOptions<TValue>) => PromiseLike<TValue> | Array<TValue>;
+    load: (options: LoadOptions<TItem>) => PromiseLike<TItem> | Array<TItem>;
     /**
      * [descr:CustomStoreOptions.loadMode]
      */
@@ -1694,12 +1688,12 @@ declare module DevExpress.data {
      */
     totalCount?: (loadOptions: {
       filter?: FilterDescriptor | Array<FilterDescriptor>;
-      group?: GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>>;
+      group?: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>;
     }) => PromiseLike<number>;
     /**
      * [descr:CustomStoreOptions.update]
      */
-    update?: (key: TKey, values: TValue) => PromiseLike<any>;
+    update?: (key: TKey, values: TItem) => PromiseLike<any>;
     /**
      * [descr:CustomStoreOptions.useDefaultSearch]
      */
@@ -1708,14 +1702,14 @@ declare module DevExpress.data {
   /**
    * [descr:DataSource]
    */
-  export class DataSource<TValue = any, TKey = any> {
-    constructor(data: Array<TValue>);
+  export class DataSource<TItem = any, TKey = any> {
+    constructor(data: Array<TItem>);
     constructor(
       options:
-        | DevExpress.data.CustomStore.Options<TValue, TKey>
-        | DevExpress.data.DataSource.Options<any, TValue, any, TKey>
+        | DevExpress.data.CustomStore.Options<TItem, TKey>
+        | DevExpress.data.DataSource.Options<any, TItem, any, TKey>
     );
-    constructor(store: Store<TValue, TKey>);
+    constructor(store: Store<TItem, TKey>);
     constructor(url: string);
     /**
      * [descr:DataSource.cancel(operationId)]
@@ -1736,12 +1730,12 @@ declare module DevExpress.data {
     /**
      * [descr:DataSource.group()]
      */
-    group(): GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>>;
+    group(): GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>;
     /**
      * [descr:DataSource.group(groupExpr)]
      */
     group(
-      groupExpr: GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>>
+      groupExpr: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>
     ): void;
     /**
      * [descr:DataSource.isLastPage()]
@@ -1770,7 +1764,7 @@ declare module DevExpress.data {
     /**
      * [descr:DataSource.loadOptions()]
      */
-    loadOptions(): LoadOptions<TValue>;
+    loadOptions(): LoadOptions<TItem>;
     /**
      * [descr:DataSource.off(eventName)]
      */
@@ -1858,25 +1852,23 @@ declare module DevExpress.data {
     /**
      * [descr:DataSource.select()]
      */
-    select(): SelectDescriptor<TValue>;
+    select(): SelectDescriptor<TItem>;
     /**
      * [descr:DataSource.select(expr)]
      */
-    select(expr: SelectDescriptor<TValue>): void;
+    select(expr: SelectDescriptor<TItem>): void;
     /**
      * [descr:DataSource.sort()]
      */
-    sort(): SortDescriptor<TValue> | Array<SortDescriptor<TValue>>;
+    sort(): SortDescriptor<TItem> | Array<SortDescriptor<TItem>>;
     /**
      * [descr:DataSource.sort(sortExpr)]
      */
-    sort(
-      sortExpr: SortDescriptor<TValue> | Array<SortDescriptor<TValue>>
-    ): void;
+    sort(sortExpr: SortDescriptor<TItem> | Array<SortDescriptor<TItem>>): void;
     /**
      * [descr:DataSource.store()]
      */
-    store(): Store<TValue, TKey>;
+    store(): Store<TItem, TKey>;
     /**
      * [descr:DataSource.totalCount()]
      */
@@ -1898,20 +1890,20 @@ declare module DevExpress.data {
      */
     type EventName = 'changed' | 'loadError' | 'loadingChanged';
     export type Options<
-      TSourceValue = any,
-      TValue = TSourceValue,
-      TMappedValue = TValue,
+      TSourceItem = any,
+      TItem = TSourceItem,
+      TMappedItem = TItem,
       TKey = any
-    > = DataSourceOptions<TSourceValue, TValue, TMappedValue, TKey>;
+    > = DataSourceOptions<TSourceItem, TItem, TMappedItem, TKey>;
   }
   /**
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface DataSourceOptions<
-    TSourceValue = any,
-    TValue = TSourceValue,
-    TMappedValue = TValue,
+    TSourceItem = any,
+    TItem = TSourceItem,
+    TMappedItem = TItem,
     TKey = any
   > {
     /**
@@ -1929,15 +1921,15 @@ declare module DevExpress.data {
     /**
      * [descr:DataSourceOptions.group]
      */
-    group?: GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>>;
+    group?: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>;
     /**
      * [descr:DataSourceOptions.map]
      */
-    map?: (dataItem: TSourceValue) => TMappedValue;
+    map?: (dataItem: TSourceItem) => TMappedItem;
     /**
      * [descr:DataSourceOptions.onChanged]
      */
-    onChanged?: (e: { readonly changes?: Array<TMappedValue> }) => void;
+    onChanged?: (e: { readonly changes?: Array<TMappedItem> }) => void;
     /**
      * [descr:DataSourceOptions.onLoadError]
      */
@@ -1957,7 +1949,7 @@ declare module DevExpress.data {
     /**
      * [descr:DataSourceOptions.postProcess]
      */
-    postProcess?: (data: Array<TMappedValue>) => Array<TValue>;
+    postProcess?: (data: Array<TMappedItem>) => Array<TItem>;
     /**
      * [descr:DataSourceOptions.pushAggregationTimeout]
      */
@@ -1985,27 +1977,27 @@ declare module DevExpress.data {
     /**
      * [descr:DataSourceOptions.select]
      */
-    select?: SelectDescriptor<TValue>;
+    select?: SelectDescriptor<TItem>;
     /**
      * [descr:DataSourceOptions.sort]
      */
-    sort?: SortDescriptor<TValue> | Array<SortDescriptor<TValue>>;
+    sort?: SortDescriptor<TItem> | Array<SortDescriptor<TItem>>;
     /**
      * [descr:DataSourceOptions.store]
      */
     store?:
-      | Array<TSourceValue>
-      | Store<TSourceValue, TKey>
-      | (DevExpress.data.ArrayStore.Options<TSourceValue, TKey> & {
+      | Array<TSourceItem>
+      | Store<TSourceItem, TKey>
+      | (DevExpress.data.ArrayStore.Options<TSourceItem, TKey> & {
           type: 'array';
         })
-      | (DevExpress.data.LocalStore.Options<TSourceValue, TKey> & {
+      | (DevExpress.data.LocalStore.Options<TSourceItem, TKey> & {
           type: 'local';
         })
-      | (DevExpress.data.ODataStore.Options<TSourceValue, TKey> & {
+      | (DevExpress.data.ODataStore.Options<TSourceItem, TKey> & {
           type: 'odata';
         })
-      | DevExpress.data.CustomStore.Options<TSourceValue, TKey>;
+      | DevExpress.data.CustomStore.Options<TSourceItem, TKey>;
   }
   /**
    * [descr:EdmLiteral]
@@ -2132,19 +2124,19 @@ declare module DevExpress.data {
   /**
    * [descr:LocalStore]
    */
-  export class LocalStore<TValue = any, TKey = any> extends ArrayStore<
-    TValue,
+  export class LocalStore<TItem = any, TKey = any> extends ArrayStore<
+    TItem,
     TKey
   > {
-    constructor(options?: DevExpress.data.LocalStore.Options<TValue, TKey>);
+    constructor(options?: DevExpress.data.LocalStore.Options<TItem, TKey>);
     /**
      * [descr:LocalStore.clear()]
      */
     clear(): void;
   }
   module LocalStore {
-    export type Options<TValue = any, TKey = any> = LocalStoreOptions<
-      TValue,
+    export type Options<TItem = any, TKey = any> = LocalStoreOptions<
+      TItem,
       TKey
     >;
   }
@@ -2152,8 +2144,8 @@ declare module DevExpress.data {
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface LocalStoreOptions<TValue = any, TKey = any>
-    extends ArrayStoreOptions<TValue, TKey> {
+  export interface LocalStoreOptions<TItem = any, TKey = any>
+    extends ArrayStoreOptions<TItem, TKey> {
     /**
      * [descr:LocalStoreOptions.flushInterval]
      */
@@ -2270,12 +2262,9 @@ declare module DevExpress.data {
   /**
    * [descr:ODataStore]
    */
-  export class ODataStore<TValue = any, TKey = any> extends Store<
-    TValue,
-    TKey
-  > {
-    constructor(options?: DevExpress.data.ODataStore.Options<TValue, TKey>);
-    byKey(key: TKey): DevExpress.core.utils.DxPromise<TValue>;
+  export class ODataStore<TItem = any, TKey = any> extends Store<TItem, TKey> {
+    constructor(options?: DevExpress.data.ODataStore.Options<TItem, TKey>);
+    byKey(key: TKey): DevExpress.core.utils.DxPromise<TItem>;
     /**
      * [descr:ODataStore.byKey(key, extraOptions)]
      */
@@ -2285,7 +2274,7 @@ declare module DevExpress.data {
         expand?: string | Array<string>;
         select?: string | Array<string>;
       }
-    ): DevExpress.core.utils.DxPromise<TValue>;
+    ): DevExpress.core.utils.DxPromise<TItem>;
     /**
      * [descr:ODataStore.createQuery(loadOptions)]
      */
@@ -2299,13 +2288,13 @@ declare module DevExpress.data {
      * [descr:ODataStore.insert(values)]
      */
     insert(
-      values: TValue
-    ): DevExpress.core.utils.DxPromise<TValue> &
-      DevExpress.data.ODataStore.PromiseExtension<TValue>;
+      values: TItem
+    ): DevExpress.core.utils.DxPromise<TItem> &
+      DevExpress.data.ODataStore.PromiseExtension<TItem>;
   }
   module ODataStore {
-    export type Options<TValue = any, TKey = any> = ODataStoreOptions<
-      TValue,
+    export type Options<TItem = any, TKey = any> = ODataStoreOptions<
+      TItem,
       TKey
     >;
     /**
@@ -2331,8 +2320,8 @@ declare module DevExpress.data {
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface ODataStoreOptions<TValue = any, TKey = any>
-    extends DevExpress.data.Store.Options<TValue, TKey> {
+  export interface ODataStoreOptions<TItem = any, TKey = any>
+    extends DevExpress.data.Store.Options<TItem, TKey> {
     /**
      * [descr:ODataStoreOptions.beforeSend]
      */
@@ -2384,7 +2373,7 @@ declare module DevExpress.data {
     /**
      * [descr:ODataStoreOptions.onLoading]
      */
-    onLoading?: (loadOptions: LoadOptions<TValue>) => void;
+    onLoading?: (loadOptions: LoadOptions<TItem>) => void;
     /**
      * [descr:ODataStoreOptions.url]
      */
@@ -2908,19 +2897,19 @@ declare module DevExpress.data {
    * [descr:Store]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export class Store<TValue = any, TKey = any> {
-    constructor(options?: DevExpress.data.Store.Options<TValue, TKey>);
+  export class Store<TItem = any, TKey = any> {
+    constructor(options?: DevExpress.data.Store.Options<TItem, TKey>);
     /**
      * [descr:Store.byKey(key)]
      */
     byKey(
       key: TKey,
-      extraOptions?: LoadOptions<TValue>
-    ): DevExpress.core.utils.DxPromise<TValue>;
+      extraOptions?: LoadOptions<TItem>
+    ): DevExpress.core.utils.DxPromise<TItem>;
     /**
      * [descr:Store.insert(values)]
      */
-    insert(values: TValue): DevExpress.core.utils.DxPromise<TValue>;
+    insert(values: TItem): DevExpress.core.utils.DxPromise<TItem>;
     /**
      * [descr:Store.key()]
      */
@@ -2928,17 +2917,17 @@ declare module DevExpress.data {
     /**
      * [descr:Store.keyOf(obj)]
      */
-    keyOf(obj: TValue): TKey;
+    keyOf(obj: TItem): TKey;
     /**
      * [descr:Store.load()]
      */
-    load(): DevExpress.core.utils.DxPromise<Array<TValue>>;
+    load(): DevExpress.core.utils.DxPromise<Array<TItem>>;
     /**
      * [descr:Store.load(options)]
      */
     load(
-      options: LoadOptions<TValue>
-    ): DevExpress.core.utils.DxPromise<Array<TValue>>;
+      options: LoadOptions<TItem>
+    ): DevExpress.core.utils.DxPromise<Array<TItem>>;
     /**
      * [descr:Store.off(eventName)]
      */
@@ -2967,7 +2956,7 @@ declare module DevExpress.data {
     push(
       changes: Array<{
         type: 'insert' | 'update' | 'remove';
-        data?: DevExpress.core.DeepPartial<TValue>;
+        data?: DevExpress.core.DeepPartial<TItem>;
         key?: TKey;
         index?: number;
       }>
@@ -2981,15 +2970,15 @@ declare module DevExpress.data {
      */
     totalCount(obj: {
       filter?: FilterDescriptor | Array<FilterDescriptor>;
-      group?: GroupDescriptor<TValue> | Array<GroupDescriptor<TValue>>;
+      group?: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>;
     }): DevExpress.core.utils.DxPromise<number>;
     /**
      * [descr:Store.update(key, values)]
      */
     update(
       key: TKey,
-      values: DevExpress.core.DeepPartial<TValue>
-    ): DevExpress.core.utils.DxPromise<TValue>;
+      values: DevExpress.core.DeepPartial<TItem>
+    ): DevExpress.core.utils.DxPromise<TItem>;
   }
   module Store {
     /**
@@ -3010,13 +2999,13 @@ declare module DevExpress.data {
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
-    export type Options<TValue = any, TKey = any> = StoreOptions<TValue, TKey>;
+    export type Options<TItem = any, TKey = any> = StoreOptions<TItem, TKey>;
   }
   /**
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface StoreOptions<TValue = any, TKey = any> {
+  export interface StoreOptions<TItem = any, TKey = any> {
     /**
      * [descr:StoreOptions.errorHandler]
      */
@@ -3028,22 +3017,19 @@ declare module DevExpress.data {
     /**
      * [descr:StoreOptions.onInserted]
      */
-    onInserted?: (values: TValue, key: TKey) => void;
+    onInserted?: (values: TItem, key: TKey) => void;
     /**
      * [descr:StoreOptions.onInserting]
      */
-    onInserting?: (values: TValue) => void;
+    onInserting?: (values: TItem) => void;
     /**
      * [descr:StoreOptions.onLoaded]
      */
-    onLoaded?: (
-      result: Array<TValue>,
-      loadOptions: LoadOptions<TValue>
-    ) => void;
+    onLoaded?: (result: Array<TItem>, loadOptions: LoadOptions<TItem>) => void;
     /**
      * [descr:StoreOptions.onLoading]
      */
-    onLoading?: (loadOptions: LoadOptions<TValue>) => void;
+    onLoading?: (loadOptions: LoadOptions<TItem>) => void;
     /**
      * [descr:StoreOptions.onModified]
      */
@@ -3055,7 +3041,7 @@ declare module DevExpress.data {
     /**
      * [descr:StoreOptions.onPush]
      */
-    onPush?: (changes: Array<TValue>) => void;
+    onPush?: (changes: Array<TItem>) => void;
     /**
      * [descr:StoreOptions.onRemoved]
      */
@@ -3067,11 +3053,11 @@ declare module DevExpress.data {
     /**
      * [descr:StoreOptions.onUpdated]
      */
-    onUpdated?: (key: TKey, values: TValue) => void;
+    onUpdated?: (key: TKey, values: TItem) => void;
     /**
      * [descr:StoreOptions.onUpdating]
      */
-    onUpdating?: (key: TKey, values: TValue) => void;
+    onUpdating?: (key: TKey, values: TItem) => void;
   }
   /**
    * [descr:SummaryDescriptor]

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1883,7 +1883,7 @@ declare module DevExpress.data {
       | string
       | Array<TItem>
       | Store<TItem, TKey>
-      | Options<any, TItem, any, TKey>
+      | Options<any, any, TItem, TKey>
       | DataSource<TItem, TKey>;
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1599,14 +1599,11 @@ declare module DevExpress.data {
   /**
    * [descr:ArrayStore]
    */
-  export class ArrayStore<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends Store<TValue, TKeyExpr, TKey> {
-    constructor(
-      options?: DevExpress.data.ArrayStore.Options<TValue, TKeyExpr, TKey>
-    );
+  export class ArrayStore<TValue = any, TKey = any> extends Store<
+    TValue,
+    TKey
+  > {
+    constructor(options?: DevExpress.data.ArrayStore.Options<TValue, TKey>);
     /**
      * [descr:ArrayStore.clear()]
      */
@@ -1617,21 +1614,17 @@ declare module DevExpress.data {
     createQuery(): Query;
   }
   module ArrayStore {
-    export type Options<
-      TValue = any,
-      TKeyExpr extends string | Array<string> = string | Array<string>,
-      TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-    > = ArrayStoreOptions<TValue, TKeyExpr, TKey>;
+    export type Options<TValue = any, TKey = any> = ArrayStoreOptions<
+      TValue,
+      TKey
+    >;
   }
   /**
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface ArrayStoreOptions<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends DevExpress.data.Store.Options<TValue, TKeyExpr, TKey> {
+  export interface ArrayStoreOptions<TValue = any, TKey = any>
+    extends DevExpress.data.Store.Options<TValue, TKey> {
     /**
      * [descr:ArrayStoreOptions.data]
      */
@@ -1650,35 +1643,28 @@ declare module DevExpress.data {
   /**
    * [descr:CustomStore]
    */
-  export class CustomStore<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends Store<TValue, TKeyExpr, TKey> {
-    constructor(
-      options?: DevExpress.data.CustomStore.Options<TValue, TKeyExpr, TKey>
-    );
+  export class CustomStore<TValue = any, TKey = any> extends Store<
+    TValue,
+    TKey
+  > {
+    constructor(options?: DevExpress.data.CustomStore.Options<TValue, TKey>);
     /**
      * [descr:CustomStore.clearRawDataCache()]
      */
     clearRawDataCache(): void;
   }
   module CustomStore {
-    export type Options<
-      TValue = any,
-      TKeyExpr extends string | Array<string> = string | Array<string>,
-      TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-    > = CustomStoreOptions<TValue, TKeyExpr, TKey>;
+    export type Options<TValue = any, TKey = any> = CustomStoreOptions<
+      TValue,
+      TKey
+    >;
   }
   /**
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface CustomStoreOptions<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends DevExpress.data.Store.Options<TValue, TKeyExpr, TKey> {
+  export interface CustomStoreOptions<TValue = any, TKey = any>
+    extends DevExpress.data.Store.Options<TValue, TKey> {
     /**
      * [descr:CustomStoreOptions.byKey]
      */
@@ -1722,18 +1708,14 @@ declare module DevExpress.data {
   /**
    * [descr:DataSource]
    */
-  export class DataSource<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > {
+  export class DataSource<TValue = any, TKey = any> {
     constructor(data: Array<TValue>);
     constructor(
       options:
-        | DevExpress.data.CustomStore.Options<TValue, TKeyExpr, TKey>
-        | DevExpress.data.DataSource.Options<any, TValue, any, TKeyExpr, TKey>
+        | DevExpress.data.CustomStore.Options<TValue, TKey>
+        | DevExpress.data.DataSource.Options<any, TValue, any, TKey>
     );
-    constructor(store: Store<TValue, TKeyExpr, TKey>);
+    constructor(store: Store<TValue, TKey>);
     constructor(url: string);
     /**
      * [descr:DataSource.cancel(operationId)]
@@ -1780,7 +1762,7 @@ declare module DevExpress.data {
     /**
      * [descr:DataSource.key()]
      */
-    key(): TKeyExpr;
+    key(): string | Array<string>;
     /**
      * [descr:DataSource.load()]
      */
@@ -1894,7 +1876,7 @@ declare module DevExpress.data {
     /**
      * [descr:DataSource.store()]
      */
-    store(): Store<TValue, TKeyExpr, TKey>;
+    store(): Store<TValue, TKey>;
     /**
      * [descr:DataSource.totalCount()]
      */
@@ -1908,9 +1890,9 @@ declare module DevExpress.data {
     export type DataSourceLike<TItem, TKey = any> =
       | string
       | Array<TItem>
-      | Store<TItem, any, TKey>
-      | Options<any, TItem, any, any, TKey>
-      | DataSource<TItem, any, TKey>;
+      | Store<TItem, TKey>
+      | Options<any, TItem, any, TKey>
+      | DataSource<TItem, TKey>;
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
@@ -1919,9 +1901,8 @@ declare module DevExpress.data {
       TSourceValue = any,
       TValue = TSourceValue,
       TMappedValue = TValue,
-      TKeyExpr extends string | Array<string> = string | Array<string>,
-      TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-    > = DataSourceOptions<TSourceValue, TValue, TMappedValue, TKeyExpr, TKey>;
+      TKey = any
+    > = DataSourceOptions<TSourceValue, TValue, TMappedValue, TKey>;
   }
   /**
    * @deprecated Use Options instead
@@ -1931,8 +1912,7 @@ declare module DevExpress.data {
     TSourceValue = any,
     TValue = TSourceValue,
     TMappedValue = TValue,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
+    TKey = any
   > {
     /**
      * [descr:DataSourceOptions.customQueryParams]
@@ -2015,17 +1995,17 @@ declare module DevExpress.data {
      */
     store?:
       | Array<TSourceValue>
-      | Store<TSourceValue, TKeyExpr, TKey>
-      | (DevExpress.data.ArrayStore.Options<TSourceValue, TKeyExpr, TKey> & {
+      | Store<TSourceValue, TKey>
+      | (DevExpress.data.ArrayStore.Options<TSourceValue, TKey> & {
           type: 'array';
         })
-      | (DevExpress.data.LocalStore.Options<TSourceValue, TKeyExpr, TKey> & {
+      | (DevExpress.data.LocalStore.Options<TSourceValue, TKey> & {
           type: 'local';
         })
-      | (DevExpress.data.ODataStore.Options<TSourceValue, TKeyExpr, TKey> & {
+      | (DevExpress.data.ODataStore.Options<TSourceValue, TKey> & {
           type: 'odata';
         })
-      | DevExpress.data.CustomStore.Options<TSourceValue, TKeyExpr, TKey>;
+      | DevExpress.data.CustomStore.Options<TSourceValue, TKey>;
   }
   /**
    * [descr:EdmLiteral]
@@ -2152,35 +2132,28 @@ declare module DevExpress.data {
   /**
    * [descr:LocalStore]
    */
-  export class LocalStore<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends ArrayStore<TValue, TKeyExpr, TKey> {
-    constructor(
-      options?: DevExpress.data.LocalStore.Options<TValue, TKeyExpr, TKey>
-    );
+  export class LocalStore<TValue = any, TKey = any> extends ArrayStore<
+    TValue,
+    TKey
+  > {
+    constructor(options?: DevExpress.data.LocalStore.Options<TValue, TKey>);
     /**
      * [descr:LocalStore.clear()]
      */
     clear(): void;
   }
   module LocalStore {
-    export type Options<
-      TValue = any,
-      TKeyExpr extends string | Array<string> = string | Array<string>,
-      TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-    > = LocalStoreOptions<TValue, TKeyExpr, TKey>;
+    export type Options<TValue = any, TKey = any> = LocalStoreOptions<
+      TValue,
+      TKey
+    >;
   }
   /**
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface LocalStoreOptions<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends ArrayStoreOptions<TValue, TKeyExpr, TKey> {
+  export interface LocalStoreOptions<TValue = any, TKey = any>
+    extends ArrayStoreOptions<TValue, TKey> {
     /**
      * [descr:LocalStoreOptions.flushInterval]
      */
@@ -2297,14 +2270,11 @@ declare module DevExpress.data {
   /**
    * [descr:ODataStore]
    */
-  export class ODataStore<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends Store<TValue, TKeyExpr, TKey> {
-    constructor(
-      options?: DevExpress.data.ODataStore.Options<TValue, TKeyExpr, TKey>
-    );
+  export class ODataStore<TValue = any, TKey = any> extends Store<
+    TValue,
+    TKey
+  > {
+    constructor(options?: DevExpress.data.ODataStore.Options<TValue, TKey>);
     byKey(key: TKey): DevExpress.core.utils.DxPromise<TValue>;
     /**
      * [descr:ODataStore.byKey(key, extraOptions)]
@@ -2334,11 +2304,10 @@ declare module DevExpress.data {
       DevExpress.data.ODataStore.PromiseExtension<TValue>;
   }
   module ODataStore {
-    export type Options<
-      TValue = any,
-      TKeyExpr extends string | Array<string> = string | Array<string>,
-      TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-    > = ODataStoreOptions<TValue, TKeyExpr, TKey>;
+    export type Options<TValue = any, TKey = any> = ODataStoreOptions<
+      TValue,
+      TKey
+    >;
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
@@ -2362,11 +2331,8 @@ declare module DevExpress.data {
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface ODataStoreOptions<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends DevExpress.data.Store.Options<TValue, TKeyExpr, TKey> {
+  export interface ODataStoreOptions<TValue = any, TKey = any>
+    extends DevExpress.data.Store.Options<TValue, TKey> {
     /**
      * [descr:ODataStoreOptions.beforeSend]
      */
@@ -2942,14 +2908,8 @@ declare module DevExpress.data {
    * [descr:Store]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export class Store<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > {
-    constructor(
-      options?: DevExpress.data.Store.Options<TValue, TKeyExpr, TKey>
-    );
+  export class Store<TValue = any, TKey = any> {
+    constructor(options?: DevExpress.data.Store.Options<TValue, TKey>);
     /**
      * [descr:Store.byKey(key)]
      */
@@ -2964,7 +2924,7 @@ declare module DevExpress.data {
     /**
      * [descr:Store.key()]
      */
-    key(): TKeyExpr;
+    key(): string | Array<string>;
     /**
      * [descr:Store.keyOf(obj)]
      */
@@ -3050,21 +3010,13 @@ declare module DevExpress.data {
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
-    export type Options<
-      TValue = any,
-      TKeyExpr extends string | Array<string> = string | Array<string>,
-      TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-    > = StoreOptions<TValue, TKeyExpr, TKey>;
+    export type Options<TValue = any, TKey = any> = StoreOptions<TValue, TKey>;
   }
   /**
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface StoreOptions<
-    TValue = any,
-    TKeyExpr extends string | Array<string> = string | Array<string>,
-    TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > {
+  export interface StoreOptions<TValue = any, TKey = any> {
     /**
      * [descr:StoreOptions.errorHandler]
      */
@@ -3072,7 +3024,7 @@ declare module DevExpress.data {
     /**
      * [descr:StoreOptions.key]
      */
-    key?: TKeyExpr;
+    key?: string | Array<string>;
     /**
      * [descr:StoreOptions.onInserted]
      */
@@ -4274,11 +4226,7 @@ declare module DevExpress.ui {
     TItem extends DevExpress.ui.CollectionWidget.ItemLike = any,
     TKey = any
   > extends Widget<TProperties> {
-    getDataSource(): DevExpress.data.DataSource<
-      TItem,
-      string | Array<string>,
-      TKey
-    >;
+    getDataSource(): DevExpress.data.DataSource<TItem, TKey>;
   }
   module CollectionWidget {
     /**
@@ -5679,11 +5627,7 @@ declare module DevExpress.ui {
     ): DevExpress.core.DxElement | undefined;
     getCombinedFilter(): any;
     getCombinedFilter(returnDataField: boolean): any;
-    getDataSource(): DevExpress.data.DataSource<
-      TRowData,
-      string | Array<string>,
-      TKey
-    >;
+    getDataSource(): DevExpress.data.DataSource<TRowData, TKey>;
     getKeyByRowIndex(rowIndex: number): TKey | undefined;
     getRowElement(
       rowIndex: number
@@ -20727,11 +20671,7 @@ declare module DevExpress.ui {
     ): DevExpress.core.DxElement | undefined;
     getCombinedFilter(): any;
     getCombinedFilter(returnDataField: boolean): any;
-    getDataSource(): DevExpress.data.DataSource<
-      TRowData,
-      string | Array<string>,
-      TKey
-    >;
+    getDataSource(): DevExpress.data.DataSource<TRowData, TKey>;
     getKeyByRowIndex(rowIndex: number): TKey | undefined;
     getRowElement(
       rowIndex: number
@@ -22678,11 +22618,7 @@ declare module DevExpress.ui {
      * [descr:GridBase.getCombinedFilter(returnDataField)]
      */
     getCombinedFilter(returnDataField: boolean): any;
-    getDataSource(): DevExpress.data.DataSource<
-      TRowData,
-      string | Array<string>,
-      TKey
-    >;
+    getDataSource(): DevExpress.data.DataSource<TRowData, TKey>;
     /**
      * [descr:GridBase.getKeyByRowIndex(rowIndex)]
      */

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1891,8 +1891,8 @@ declare module DevExpress.data {
     type EventName = 'changed' | 'loadError' | 'loadingChanged';
     export type Options<
       TStoreItem = any,
-      TItem = TStoreItem,
-      TMappedItem = TItem,
+      TMappedItem = TStoreItem,
+      TItem = TMappedItem,
       TKey = any
     > = DataSourceOptions<TStoreItem, TItem, TMappedItem, TKey>;
   }
@@ -1902,8 +1902,8 @@ declare module DevExpress.data {
    */
   export interface DataSourceOptions<
     TStoreItem = any,
-    TItem = TStoreItem,
-    TMappedItem = TItem,
+    TMappedItem = TStoreItem,
+    TItem = TMappedItem,
     TKey = any
   > {
     /**

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -2019,8 +2019,12 @@ declare module DevExpress.data {
       | (DevExpress.data.ArrayStore.Options<TSourceValue, TKeyExpr, TKey> & {
           type: 'array';
         })
-      | (LocalStoreOptions<TSourceValue, TKeyExpr, TKey> & { type: 'local' })
-      | (ODataStoreOptions<TSourceValue, TKeyExpr, TKey> & { type: 'odata' })
+      | (DevExpress.data.LocalStore.Options<TSourceValue, TKeyExpr, TKey> & {
+          type: 'local';
+        })
+      | (DevExpress.data.ODataStore.Options<TSourceValue, TKeyExpr, TKey> & {
+          type: 'odata';
+        })
       | DevExpress.data.CustomStore.Options<TSourceValue, TKeyExpr, TKey>;
   }
   /**
@@ -2153,13 +2157,23 @@ declare module DevExpress.data {
     TKeyExpr extends string | Array<string> = string | Array<string>,
     TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
   > extends ArrayStore<TValue, TKeyExpr, TKey> {
-    constructor(options?: LocalStoreOptions<TValue, TKeyExpr, TKey>);
+    constructor(
+      options?: DevExpress.data.LocalStore.Options<TValue, TKeyExpr, TKey>
+    );
     /**
      * [descr:LocalStore.clear()]
      */
     clear(): void;
   }
+  module LocalStore {
+    export type Options<
+      TValue = any,
+      TKeyExpr extends string | Array<string> = string | Array<string>,
+      TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
+    > = LocalStoreOptions<TValue, TKeyExpr, TKey>;
+  }
   /**
+   * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface LocalStoreOptions<
@@ -2288,7 +2302,9 @@ declare module DevExpress.data {
     TKeyExpr extends string | Array<string> = string | Array<string>,
     TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
   > extends Store<TValue, TKeyExpr, TKey> {
-    constructor(options?: ODataStoreOptions<TValue, TKeyExpr, TKey>);
+    constructor(
+      options?: DevExpress.data.ODataStore.Options<TValue, TKeyExpr, TKey>
+    );
     byKey(key: TKey): DevExpress.core.utils.DxPromise<TValue>;
     /**
      * [descr:ODataStore.byKey(key, extraOptions)]
@@ -2318,6 +2334,11 @@ declare module DevExpress.data {
       DevExpress.data.ODataStore.PromiseExtension<TValue>;
   }
   module ODataStore {
+    export type Options<
+      TValue = any,
+      TKeyExpr extends string | Array<string> = string | Array<string>,
+      TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
+    > = ODataStoreOptions<TValue, TKeyExpr, TKey>;
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
@@ -2338,13 +2359,14 @@ declare module DevExpress.data {
     }
   }
   /**
+   * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface ODataStoreOptions<
     TValue = any,
     TKeyExpr extends string | Array<string> = string | Array<string>,
     TKey = TKeyExpr extends keyof TValue ? TValue[TKeyExpr] : any
-  > extends StoreOptions<TValue, TKeyExpr, TKey> {
+  > extends DevExpress.data.Store.Options<TValue, TKeyExpr, TKey> {
     /**
      * [descr:ODataStoreOptions.beforeSend]
      */
@@ -3035,6 +3057,7 @@ declare module DevExpress.data {
     > = StoreOptions<TValue, TKeyExpr, TKey>;
   }
   /**
+   * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface StoreOptions<

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1890,19 +1890,19 @@ declare module DevExpress.data {
      */
     type EventName = 'changed' | 'loadError' | 'loadingChanged';
     export type Options<
-      TSourceItem = any,
-      TItem = TSourceItem,
+      TStoreItem = any,
+      TItem = TStoreItem,
       TMappedItem = TItem,
       TKey = any
-    > = DataSourceOptions<TSourceItem, TItem, TMappedItem, TKey>;
+    > = DataSourceOptions<TStoreItem, TItem, TMappedItem, TKey>;
   }
   /**
    * @deprecated Use Options instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export interface DataSourceOptions<
-    TSourceItem = any,
-    TItem = TSourceItem,
+    TStoreItem = any,
+    TItem = TStoreItem,
     TMappedItem = TItem,
     TKey = any
   > {
@@ -1925,7 +1925,7 @@ declare module DevExpress.data {
     /**
      * [descr:DataSourceOptions.map]
      */
-    map?: (dataItem: TSourceItem) => TMappedItem;
+    map?: (dataItem: TStoreItem) => TMappedItem;
     /**
      * [descr:DataSourceOptions.onChanged]
      */
@@ -1986,18 +1986,18 @@ declare module DevExpress.data {
      * [descr:DataSourceOptions.store]
      */
     store?:
-      | Array<TSourceItem>
-      | Store<TSourceItem, TKey>
-      | (DevExpress.data.ArrayStore.Options<TSourceItem, TKey> & {
+      | Array<TStoreItem>
+      | Store<TStoreItem, TKey>
+      | (DevExpress.data.ArrayStore.Options<TStoreItem, TKey> & {
           type: 'array';
         })
-      | (DevExpress.data.LocalStore.Options<TSourceItem, TKey> & {
+      | (DevExpress.data.LocalStore.Options<TStoreItem, TKey> & {
           type: 'local';
         })
-      | (DevExpress.data.ODataStore.Options<TSourceItem, TKey> & {
+      | (DevExpress.data.ODataStore.Options<TStoreItem, TKey> & {
           type: 'odata';
         })
-      | DevExpress.data.CustomStore.Options<TSourceItem, TKey>;
+      | DevExpress.data.CustomStore.Options<TStoreItem, TKey>;
   }
   /**
    * [descr:EdmLiteral]


### PR DESCRIPTION
There're some renamings here:
1. `TValue` was renamed to `TItem` to remove false similarity to "key-value" words combination
2. `TSourceItem` was renamed to `TStoreItem` as it better describes actual type: DataSource accepts a store, not a source
3. I changed DataSource params order: `TStoreItem - TItem - TMappedItem` -> `TStoreItem - TMappedItem - TItem`. This matches to data-flow: it is taken from the store, can be mapped and post-processed after all.

The other changes are:
1. We decided to remove `TKeyExpr` as it has a little meaning but reduces readability a lot
2. I renamed remaining `LocalStore` and `ODataStore` Options types