### PR TITLE
HtmlEditor - reset formDialog popup options after the cell or table properties form was shown (T1038636)

### DIFF
--- a/js/ui/html_editor/utils/toolbar_helper.js
+++ b/js/ui/html_editor/utils/toolbar_helper.js
@@ -126,6 +126,17 @@ function prepareShowFormProperties(module, type) {
 
         let formInstance;
 
+        const resetDialogOptions = () => {
+            module.editorInstance.formDialogOption({
+                contentTemplate: savedDialogOptions.contentTemplate,
+                title: savedDialogOptions.title,
+                minHeight: savedDialogOptions.minHeight || 0,
+                minWidth: savedDialogOptions.minWidth || 0,
+                maxWidth: savedDialogOptions.maxWidth || 'none',
+                onHidden: null
+            });
+        };
+
         module.editorInstance.formDialogOption({
             'contentTemplate': (container) => {
                 const $content = $('<div>').appendTo(container);
@@ -139,17 +150,7 @@ function prepareShowFormProperties(module, type) {
             title: localizationMessage.format(`dxHtmlEditor-${type}Properties`),
             minHeight: MIN_HEIGHT,
             minWidth: Math.min(800, getWidth(getWindow()) * 0.9 - 1),
-            maxWidth: getWidth(getWindow()) * 0.9,
-            onHiding: () => {
-                module.editorInstance.formDialogOption({
-                    contentTemplate: savedDialogOptions.contentTemplate,
-                    title: savedDialogOptions.title,
-                    minHeight: savedDialogOptions.minHeight || 0,
-                    minWidth: savedDialogOptions.minWidth || 0,
-                    maxWidth: savedDialogOptions.maxWidth || 'none',
-                    onHiding: null
-                });
-            }
+            maxWidth: getWidth(getWindow()) * 0.9
         });
 
         const promise = module.editorInstance.showFormDialog();
@@ -158,11 +159,13 @@ function prepareShowFormProperties(module, type) {
             module.saveValueChangeEvent(event);
             tablePropertiesFormConfig.applyHandler(formInstance);
             formInstance.dispose();
+            resetDialogOptions();
         });
 
         promise.fail(() => {
             module.quill.focus();
             formInstance.dispose();
+            resetDialogOptions();
         });
     };
 }

--- a/js/ui/html_editor/utils/toolbar_helper.js
+++ b/js/ui/html_editor/utils/toolbar_helper.js
@@ -126,6 +126,7 @@ function prepareShowFormProperties(module, type) {
         const tablePropertiesFormConfig = getFormConfigConstructor(type)(module, { $element, formats, tableBlot, rowBlot });
 
         const { contentTemplate, title, minHeight, minWidth, maxWidth } = module.editorInstance._formDialog._popup.option();
+        const savedOptions = { contentTemplate, title, minHeight, minWidth, maxWidth };
 
         let formInstance;
 
@@ -152,14 +153,14 @@ function prepareShowFormProperties(module, type) {
             tablePropertiesFormConfig.applyHandler(formInstance);
             formInstance.dispose();
         }).then(() => {
-            resetFormDialogOptions(module.editorInstance, { contentTemplate, title, minHeight, minWidth, maxWidth });
+            resetFormDialogOptions(module.editorInstance, savedOptions);
         });
 
         promise.fail(() => {
             module.quill.focus();
             formInstance.dispose();
         }).then(() => {
-            resetFormDialogOptions(module.editorInstance, { contentTemplate, title, minHeight, minWidth, maxWidth });
+            resetFormDialogOptions(module.editorInstance, savedOptions);
         });
     };
 }

--- a/js/ui/html_editor/utils/toolbar_helper.js
+++ b/js/ui/html_editor/utils/toolbar_helper.js
@@ -104,13 +104,13 @@ function getFormatHandlers(module) {
     };
 }
 
-function resetFormDialogOptions(editorInstance, savedOptions) {
+function resetFormDialogOptions(editorInstance, { contentTemplate, title, minHeight, minWidth, maxWidth }) {
     editorInstance.formDialogOption({
-        contentTemplate: savedOptions.contentTemplate,
-        title: savedOptions.title,
-        minHeight: savedOptions.minHeight || 0,
-        minWidth: savedOptions.minWidth || 0,
-        maxWidth: savedOptions.maxWidth || 'none',
+        contentTemplate,
+        title,
+        minHeight: minHeight ?? 0,
+        minWidth: minWidth ?? 0,
+        maxWidth: maxWidth ?? 'none'
     });
 }
 
@@ -125,14 +125,7 @@ function prepareShowFormProperties(module, type) {
 
         const tablePropertiesFormConfig = getFormConfigConstructor(type)(module, { $element, formats, tableBlot, rowBlot });
 
-        const formDialogPopupOptions = module.editorInstance._formDialog._popup.option() ?? {};
-        const savedDialogOptions = {
-            contentTemplate: formDialogPopupOptions.contentTemplate,
-            title: formDialogPopupOptions.title,
-            minHeight: formDialogPopupOptions.minHeight,
-            minWidth: formDialogPopupOptions.minWidth,
-            maxWidth: formDialogPopupOptions.maxWidth
-        };
+        const { contentTemplate, title, minHeight, minWidth, maxWidth } = module.editorInstance._formDialog._popup.option();
 
         let formInstance;
 
@@ -159,14 +152,14 @@ function prepareShowFormProperties(module, type) {
             tablePropertiesFormConfig.applyHandler(formInstance);
             formInstance.dispose();
         }).then(() => {
-            resetFormDialogOptions(module.editorInstance, savedDialogOptions);
+            resetFormDialogOptions(module.editorInstance, { contentTemplate, title, minHeight, minWidth, maxWidth });
         });
 
         promise.fail(() => {
             module.quill.focus();
             formInstance.dispose();
         }).then(() => {
-            resetFormDialogOptions(module.editorInstance, savedDialogOptions);
+            resetFormDialogOptions(module.editorInstance, { contentTemplate, title, minHeight, minWidth, maxWidth });
         });
     };
 }

--- a/js/ui/html_editor/utils/toolbar_helper.js
+++ b/js/ui/html_editor/utils/toolbar_helper.js
@@ -104,6 +104,16 @@ function getFormatHandlers(module) {
     };
 }
 
+function resetFormDialogOptions(editorInstance, savedOptions) {
+    editorInstance.formDialogOption({
+        contentTemplate: savedOptions.contentTemplate,
+        title: savedOptions.title,
+        minHeight: savedOptions.minHeight || 0,
+        minWidth: savedOptions.minWidth || 0,
+        maxWidth: savedOptions.maxWidth || 'none',
+    });
+}
+
 function prepareShowFormProperties(module, type) {
     return ($element) => {
         if(!$element?.length) {
@@ -148,22 +158,15 @@ function prepareShowFormProperties(module, type) {
             module.saveValueChangeEvent(event);
             tablePropertiesFormConfig.applyHandler(formInstance);
             formInstance.dispose();
+        }).then(() => {
+            resetFormDialogOptions(module.editorInstance, savedDialogOptions);
         });
 
         promise.fail(() => {
             module.quill.focus();
             formInstance.dispose();
-        });
-
-        promise.always(() => {
-            module.editorInstance.formDialogOption({
-                contentTemplate: savedDialogOptions.contentTemplate,
-                title: savedDialogOptions.title,
-                minHeight: savedDialogOptions.minHeight || 0,
-                minWidth: savedDialogOptions.minWidth || 0,
-                maxWidth: savedDialogOptions.maxWidth || 'none',
-                onHidden: null
-            });
+        }).then(() => {
+            resetFormDialogOptions(module.editorInstance, savedDialogOptions);
         });
     };
 }

--- a/js/ui/html_editor/utils/toolbar_helper.js
+++ b/js/ui/html_editor/utils/toolbar_helper.js
@@ -126,17 +126,6 @@ function prepareShowFormProperties(module, type) {
 
         let formInstance;
 
-        const resetDialogOptions = () => {
-            module.editorInstance.formDialogOption({
-                contentTemplate: savedDialogOptions.contentTemplate,
-                title: savedDialogOptions.title,
-                minHeight: savedDialogOptions.minHeight || 0,
-                minWidth: savedDialogOptions.minWidth || 0,
-                maxWidth: savedDialogOptions.maxWidth || 'none',
-                onHidden: null
-            });
-        };
-
         module.editorInstance.formDialogOption({
             'contentTemplate': (container) => {
                 const $content = $('<div>').appendTo(container);
@@ -159,13 +148,22 @@ function prepareShowFormProperties(module, type) {
             module.saveValueChangeEvent(event);
             tablePropertiesFormConfig.applyHandler(formInstance);
             formInstance.dispose();
-            resetDialogOptions();
         });
 
         promise.fail(() => {
             module.quill.focus();
             formInstance.dispose();
-            resetDialogOptions();
+        });
+
+        promise.always(() => {
+            module.editorInstance.formDialogOption({
+                contentTemplate: savedDialogOptions.contentTemplate,
+                title: savedDialogOptions.title,
+                minHeight: savedDialogOptions.minHeight || 0,
+                minWidth: savedDialogOptions.minWidth || 0,
+                maxWidth: savedDialogOptions.maxWidth || 'none',
+                onHidden: null
+            });
         });
     };
 }

--- a/js/ui/html_editor/utils/toolbar_helper.js
+++ b/js/ui/html_editor/utils/toolbar_helper.js
@@ -115,6 +115,15 @@ function prepareShowFormProperties(module, type) {
 
         const tablePropertiesFormConfig = getFormConfigConstructor(type)(module, { $element, formats, tableBlot, rowBlot });
 
+        const formDialogPopupInstance = module.editorInstance._formDialog._popup;
+        const savedDialogOptions = {
+            contentTemplate: formDialogPopupInstance.option('contentTemplate'),
+            title: formDialogPopupInstance.option('title'),
+            minHeight: formDialogPopupInstance.option('minHeight'),
+            minWidth: formDialogPopupInstance.option('minWidth'),
+            maxWidth: formDialogPopupInstance.option('maxWidth')
+        };
+
         let formInstance;
 
         module.editorInstance.formDialogOption({
@@ -130,7 +139,17 @@ function prepareShowFormProperties(module, type) {
             title: localizationMessage.format(`dxHtmlEditor-${type}Properties`),
             minHeight: MIN_HEIGHT,
             minWidth: Math.min(800, getWidth(getWindow()) * 0.9 - 1),
-            maxWidth: getWidth(getWindow()) * 0.9
+            maxWidth: getWidth(getWindow()) * 0.9,
+            onHiding: () => {
+                module.editorInstance.formDialogOption({
+                    contentTemplate: savedDialogOptions.contentTemplate,
+                    title: savedDialogOptions.title,
+                    minHeight: savedDialogOptions.minHeight || 0,
+                    minWidth: savedDialogOptions.minWidth || 0,
+                    maxWidth: savedDialogOptions.maxWidth || 'none',
+                    onHidden: null
+                });
+            }
         });
 
         const promise = module.editorInstance.showFormDialog();

--- a/js/ui/html_editor/utils/toolbar_helper.js
+++ b/js/ui/html_editor/utils/toolbar_helper.js
@@ -115,13 +115,13 @@ function prepareShowFormProperties(module, type) {
 
         const tablePropertiesFormConfig = getFormConfigConstructor(type)(module, { $element, formats, tableBlot, rowBlot });
 
-        const formDialogPopupInstance = module.editorInstance._formDialog._popup;
+        const formDialogPopupOptions = module.editorInstance._formDialog._popup.option() ?? {};
         const savedDialogOptions = {
-            contentTemplate: formDialogPopupInstance.option('contentTemplate'),
-            title: formDialogPopupInstance.option('title'),
-            minHeight: formDialogPopupInstance.option('minHeight'),
-            minWidth: formDialogPopupInstance.option('minWidth'),
-            maxWidth: formDialogPopupInstance.option('maxWidth')
+            contentTemplate: formDialogPopupOptions.contentTemplate,
+            title: formDialogPopupOptions.title,
+            minHeight: formDialogPopupOptions.minHeight,
+            minWidth: formDialogPopupOptions.minWidth,
+            maxWidth: formDialogPopupOptions.maxWidth
         };
 
         let formInstance;
@@ -147,7 +147,7 @@ function prepareShowFormProperties(module, type) {
                     minHeight: savedDialogOptions.minHeight || 0,
                     minWidth: savedDialogOptions.minWidth || 0,
                     maxWidth: savedDialogOptions.maxWidth || 'none',
-                    onHidden: null
+                    onHiding: null
                 });
             }
         });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/tableProperties.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/tableProperties.tests.js
@@ -3,6 +3,9 @@ import 'ui/html_editor';
 
 import { getFormatHandlers } from 'ui/html_editor/utils/toolbar_helper';
 
+const FORM_CLASS = 'dx-formdialog-form';
+const FIELD_ITEM_CLASS = 'dx-field-item';
+
 const showCellPropertiesForm = (instance, $cellElement) => {
     showForm(instance, $cellElement, 'cellProperties');
 };
@@ -264,6 +267,33 @@ module('Table properties forms', {
             assert.strictEqual($form.length, 1);
             assert.ok($form.eq(0).is(':visible'));
             assert.ok($scrollView.length, 'Form should be in the ScrollView');
+        });
+
+        test('Cell Form can not update other form dialogs', function(assert) {
+            this.createWidget();
+
+            const $tableElement = this.$element.find('table').eq(0);
+            const $targetCell = $tableElement.find('td').eq(6);
+
+            this.quillInstance.setSelection(50, 1);
+
+            showCellPropertiesForm(this.instance, $targetCell);
+
+            this.clock.tick();
+
+            const formInstance = this.getFormInstance();
+
+            this.applyFormChanges(formInstance);
+
+            const contextMenuModule = this.instance.getModule('tableContextMenu');
+            const formatHelpers = getFormatHandlers(contextMenuModule);
+            formatHelpers['link'](this.$element);
+
+            this.clock.tick();
+
+            const formItemsCount = $(`.${FORM_CLASS} .${FIELD_ITEM_CLASS}`).length;
+
+            assert.equal(formItemsCount, 3, '3 form items are rendered');
         });
 
         test('show cell form start values', function(assert) {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
