### PR TITLE
Make DataGrid specific types public

### DIFF
--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -1638,7 +1638,7 @@ export interface EditingBase<TRowData = any, TKey = any> {
 
 /**
  * @docid
- * @namespace DevExpress.ui
+ * @namespace DevExpress.ui.dxDataGrid
  */
 export interface DataChange<TRowData = any, TKey = any> {
     /**

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4180,19 +4180,18 @@ type DefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChoo
 
 /**
  * @public
- * @docid
+ * @docid dxDataGridToolbarItem
  * @inherits dxToolbarItem
- * @namespace DevExpress.ui
  */
 export type ToolbarItem = dxToolbarItem & {
   /**
-   * @docid
+   * @docid dxDataGridToolbarItem.name
    * @type Enums.DataGridToolbarItem|string
    * @public
    */
   name?: DefaultToolbarItemName | string;
   /**
-   * @docid
+   * @docid dxDataGridToolbarItem.location
    * @type Enums.ToolbarItemLocation
    * @default 'after'
    * @public
@@ -4202,26 +4201,25 @@ export type ToolbarItem = dxToolbarItem & {
 
 /**
  * @public
- * @docid
+ * @docid dxDataGridToolbar
  * @type object
- * @namespace DevExpress.ui
  */
 export type Toolbar = {
   /**
-   * @docid
+   * @docid dxDataGridToolbar.items
    * @type Array<ToolbarItem,Enums.DataGridToolbarItem>
    * @public
    */
   items?: Array<DefaultToolbarItemName | ToolbarItem>;
   /**
-   * @docid
+   * @docid dxDataGridToolbar.visible
    * @type boolean
    * @default undefined
    * @public
    */
   visible?: boolean;
   /**
-   * @docid
+   * @docid dxDataGridToolbar.disabled
    * @type boolean
    * @default false
    * @public

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4179,6 +4179,9 @@ export type SummaryTexts = {
 
 type DefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'exportButton' | 'groupPanel' | 'revertButton' | 'saveButton' | 'searchPanel';
 
+export type dxDataGridToolbar = Toolbar;
+export type dxDataGridToolbarItem = ToolbarItem;
+
 /**
  * @docid dxDataGridToolbarItem
  * @inherits dxToolbarItem

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4180,11 +4180,11 @@ export type SummaryTexts = {
 type DefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'exportButton' | 'groupPanel' | 'revertButton' | 'saveButton' | 'searchPanel';
 
 /**
- * @public
  * @docid dxDataGridToolbarItem
  * @inherits dxToolbarItem
+ * @namespace DevExpress.ui.dxDataGrid
  */
-export type ToolbarItem = dxToolbarItem & {
+export interface ToolbarItem extends dxToolbarItem {
   /**
    * @docid dxDataGridToolbarItem.name
    * @type Enums.DataGridToolbarItem|string
@@ -4198,12 +4198,13 @@ export type ToolbarItem = dxToolbarItem & {
    * @public
    */
   location?: 'after' | 'before' | 'center';
-};
+}
 
 /**
  * @public
  * @docid dxDataGridToolbar
  * @type object
+ * @namespace DevExpress.ui.dxDataGrid
  */
 export type Toolbar = {
   /**

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -3734,7 +3734,8 @@ export interface dxDataGridOptions<TRowData = any, TKey = any> extends GridBaseO
     toolbar?: Toolbar;
 }
 
-export interface ExcelCellInfo<TRowData = any, TKey = any> {
+/** @public */
+export type ExcelCellInfo<TRowData = any, TKey = any> = {
   readonly component: dxDataGrid<TRowData, TKey>;
   horizontalAlignment?: 'center' | 'centerContinuous' | 'distributed' | 'fill' | 'general' | 'justify' | 'left' | 'right';
   verticalAlignment?: 'bottom' | 'center' | 'distributed' | 'justify' | 'top';
@@ -3746,7 +3747,7 @@ export interface ExcelCellInfo<TRowData = any, TKey = any> {
   readonly value?: string | number | Date;
   numberFormat?: string;
   gridCell?: ExcelCell;
-}
+};
 
 /** @public */
 export type Export<TRowData = any, TKey = any> = {
@@ -3814,7 +3815,8 @@ export type Export<TRowData = any, TKey = any> = {
   texts?: ExportTexts;
 };
 
-export interface ExportTexts {
+/** @public */
+export type ExportTexts = {
   /**
    * @docid dxDataGridOptions.export.texts.exportAll
    * @default "Export all data"
@@ -3830,9 +3832,10 @@ export interface ExportTexts {
    * @default "Export"
    */
   exportTo?: string;
-}
+};
 
-export interface GroupPanel {
+/** @public */
+export type GroupPanel = {
   /**
    * @docid dxDataGridOptions.groupPanel.allowColumnDragging
    * @default true
@@ -3849,9 +3852,10 @@ export interface GroupPanel {
    * @default false
    */
   visible?: boolean | 'auto';
-}
+};
 
-export interface Grouping {
+/** @public */
+export type Grouping = {
   /**
    * @docid dxDataGridOptions.grouping.allowCollapsing
    * @default true
@@ -3879,9 +3883,10 @@ export interface Grouping {
    * @type object
    */
   texts?: GroupingTexts;
-}
+};
 
-export interface GroupingTexts {
+/** @public */
+export type GroupingTexts = {
   /**
    * @docid dxDataGridOptions.grouping.texts.groupByThisColumn
    * @default "Group by This Column"
@@ -3907,9 +3912,10 @@ export interface GroupingTexts {
    * @default "Ungroup All"
    */
   ungroupAll?: string;
-}
+};
 
-export interface MasterDetail<TRowData = any, TKey = any> {
+/** @public */
+export type MasterDetail<TRowData = any, TKey = any> = {
   /**
    * @docid dxDataGridOptions.masterDetail.autoExpandAll
    * @default false
@@ -3928,7 +3934,7 @@ export interface MasterDetail<TRowData = any, TKey = any> {
    * @type_function_param2_field3 watch:function
    */
   template?: template | ((detailElement: DxElement, detailInfo: MasterDetailTemplateData<TRowData, TKey>) => any);
-}
+};
 
 export interface dxDataGridSortByGroupSummaryInfoItem {
     /**
@@ -3950,17 +3956,18 @@ export interface dxDataGridSortByGroupSummaryInfoItem {
     summaryItem?: string | number;
 }
 
-export interface CustomSummaryInfo<TRowData = any, TKey = any> {
+/** @public */
+export type CustomSummaryInfo<TRowData = any, TKey = any> = {
   readonly component: dxDataGrid<TRowData, TKey>;
   readonly name?: string;
   readonly summaryProcess: string;
   readonly value?: any;
   totalValue?: any;
   readonly groupIndex?: number;
-}
+};
 
 /** @public */
-export interface Summary<TRowData = any, TKey = any> {
+export type Summary<TRowData = any, TKey = any> = {
   /**
    * @docid dxDataGridOptions.summary.calculateCustomSummary
    * @type_function_param1 options:object
@@ -3999,14 +4006,16 @@ export interface Summary<TRowData = any, TKey = any> {
    * @default undefined
    */
   totalItems?: Array<SummaryTotalItem>;
-}
+};
 
-export interface SummaryItemTextInfo {
+/** @public */
+export type SummaryItemTextInfo = {
   readonly value?: string | number | Date;
   readonly valueText: string;
-}
+};
 
-export interface SummaryGroupItem {
+/** @public */
+export type SummaryGroupItem = {
     /**
      * @docid dxDataGridOptions.summary.groupItems.alignByColumn
      * @default false
@@ -4059,9 +4068,10 @@ export interface SummaryGroupItem {
      * @default undefined
      */
     valueFormat?: Format;
-}
+};
 
-export interface SummaryTotalItem {
+/** @public */
+export type SummaryTotalItem = {
   /**
    * @docid dxDataGridOptions.summary.totalItems.alignment
    * @type Enums.HorizontalAlignment
@@ -4115,9 +4125,10 @@ export interface SummaryTotalItem {
    * @default undefined
    */
   valueFormat?: Format;
-}
+};
 
-export interface SummaryTexts {
+/** @public */
+export type SummaryTexts = {
     /**
      * @docid dxDataGridOptions.summary.texts.avg
      * @default "Avg={0}"
@@ -4163,16 +4174,17 @@ export interface SummaryTexts {
      * @default "Sum of {1} is {0}"
      */
     sumOtherColumn?: string;
-}
+};
 
 type DefaultToolbarItem = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'exportButton' | 'groupPanel' | 'revertButton' | 'saveButton' | 'searchPanel';
 
 /**
+ * @public
  * @docid
  * @inherits dxToolbarItem
  * @namespace DevExpress.ui
  */
-export interface ToolbarItem extends dxToolbarItem {
+export type ToolbarItem = dxToolbarItem & {
   /**
    * @docid
    * @type Enums.DataGridToolbarItem|string
@@ -4186,14 +4198,15 @@ export interface ToolbarItem extends dxToolbarItem {
    * @public
    */
   location?: 'after' | 'before' | 'center';
-}
+};
 
 /**
+ * @public
  * @docid
  * @type object
  * @namespace DevExpress.ui
  */
-export interface Toolbar {
+export type Toolbar = {
   /**
    * @docid
    * @type Array<ToolbarItem,Enums.DataGridToolbarItem>
@@ -4214,7 +4227,7 @@ export interface Toolbar {
    * @public
    */
   disabled?: boolean;
-}
+};
 
 /**
  * @public
@@ -4714,7 +4727,7 @@ export type dxDataGridRowObject<TRowData = any, TKey = any> = Row<TRowData, TKey
  * @docid dxDataGridRowObject
  * @type object
  */
-export interface Row<TRowData = any, TKey = any> {
+export type Row<TRowData = any, TKey = any> = {
     /**
      * @docid dxDataGridRowObject.data
      * @public
@@ -4765,7 +4778,7 @@ export interface Row<TRowData = any, TKey = any> {
      * @public
      */
     readonly values: Array<any>;
-}
+};
 
 /** @public */
 export type ExplicitTypes<TRowData, TKey> = {
@@ -4784,6 +4797,7 @@ export type ExplicitTypes<TRowData, TKey> = {
   ColumnHeaderCellTemplateData: ColumnHeaderCellTemplateData<TRowData, TKey>;
   ContentReadyEvent: ContentReadyEvent<TRowData, TKey>;
   ContextMenuPreparingEvent: ContextMenuPreparingEvent<TRowData, TKey>;
+  CustomSummaryInfo: CustomSummaryInfo<TRowData, TKey>;
   DataErrorOccurredEvent: DataErrorOccurredEvent<TRowData, TKey>;
   DataRowTemplateData: DataRowTemplateData<TRowData, TKey>;
   DisposingEvent: DisposingEvent<TRowData, TKey>;
@@ -4793,18 +4807,24 @@ export type ExplicitTypes<TRowData, TKey> = {
   EditingStartEvent: EditingStartEvent<TRowData, TKey>;
   EditorPreparedEvent: EditorPreparedEvent<TRowData, TKey>;
   EditorPreparingEvent: EditorPreparingEvent<TRowData, TKey>;
+  ExcelCellInfo: ExcelCellInfo<TRowData, TKey>;
   Export: Export<TRowData, TKey>;
   ExportedEvent: ExportedEvent<TRowData, TKey>;
   ExportingEvent: ExportingEvent<TRowData, TKey>;
+  ExportTexts: ExportTexts;
   FileSavingEvent: FileSavingEvent<TRowData, TKey>;
   FocusedCellChangedEvent: FocusedCellChangedEvent<TRowData, TKey>;
   FocusedCellChangingEvent: FocusedCellChangingEvent<TRowData, TKey>;
   FocusedRowChangedEvent: FocusedRowChangedEvent<TRowData, TKey>;
   FocusedRowChangingEvent: FocusedRowChangingEvent<TRowData, TKey>;
   GroupData: GroupData<TRowData>;
+  Grouping: Grouping;
+  GroupingTexts: GroupingTexts;
+  GroupPanel: GroupPanel;
   InitializedEvent: InitializedEvent<TRowData, TKey>;
   InitNewRowEvent: InitNewRowEvent<TRowData, TKey>;
   KeyDownEvent: KeyDownEvent<TRowData, TKey>;
+  MasterDetail: MasterDetail<TRowData, TKey>;
   MasterDetailTemplateData: MasterDetailTemplateData<TRowData, TKey>;
   OptionChangedEvent: OptionChangedEvent<TRowData, TKey>;
   Properties: Properties<TRowData, TKey>;
@@ -4838,6 +4858,12 @@ export type ExplicitTypes<TRowData, TKey> = {
   Selection: Selection;
   SelectionChangedEvent: SelectionChangedEvent<TRowData, TKey>;
   Summary: Summary<TRowData, TKey>;
+  SummaryGroupItem: SummaryGroupItem;
+  SummaryItemTextInfo: SummaryItemTextInfo;
+  SummaryTexts: SummaryTexts;
+  SummaryTotalItem: SummaryTotalItem;
+  Toolbar: Toolbar;
+  ToolbarItem: ToolbarItem;
   ToolbarPreparingEvent: ToolbarPreparingEvent<TRowData, TKey>;
 };
 

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4176,7 +4176,7 @@ export type SummaryTexts = {
     sumOtherColumn?: string;
 };
 
-type DefaultToolbarItem = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'exportButton' | 'groupPanel' | 'revertButton' | 'saveButton' | 'searchPanel';
+type DefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'exportButton' | 'groupPanel' | 'revertButton' | 'saveButton' | 'searchPanel';
 
 /**
  * @public
@@ -4190,7 +4190,7 @@ export type ToolbarItem = dxToolbarItem & {
    * @type Enums.DataGridToolbarItem|string
    * @public
    */
-  name?: DefaultToolbarItem | string;
+  name?: DefaultToolbarItemName | string;
   /**
    * @docid
    * @type Enums.ToolbarItemLocation
@@ -4212,7 +4212,7 @@ export type Toolbar = {
    * @type Array<ToolbarItem,Enums.DataGridToolbarItem>
    * @public
    */
-  items?: Array<DefaultToolbarItem | ToolbarItem>;
+  items?: Array<DefaultToolbarItemName | ToolbarItem>;
   /**
    * @docid
    * @type boolean

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -3728,6 +3728,7 @@ export interface dxDataGridOptions<TRowData = any, TKey = any> extends GridBaseO
     summary?: Summary<TRowData, TKey>;
     /**
      * @docid
+     * @type dxDataGridToolbar
      * @default undefined
      * @public
      */
@@ -4207,7 +4208,7 @@ export type ToolbarItem = dxToolbarItem & {
 export type Toolbar = {
   /**
    * @docid dxDataGridToolbar.items
-   * @type Array<ToolbarItem,Enums.DataGridToolbarItem>
+   * @type Array<dxDataGridToolbarItem,Enums.DataGridToolbarItem>
    * @public
    */
   items?: Array<DefaultToolbarItemName | ToolbarItem>;

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -4785,6 +4785,7 @@ export type ExplicitTypes<TRowData, TKey> = {
   ContentReadyEvent: ContentReadyEvent<TRowData, TKey>;
   ContextMenuPreparingEvent: ContextMenuPreparingEvent<TRowData, TKey>;
   DataErrorOccurredEvent: DataErrorOccurredEvent<TRowData, TKey>;
+  DataRowTemplateData: DataRowTemplateData<TRowData, TKey>;
   DisposingEvent: DisposingEvent<TRowData, TKey>;
   EditCanceledEvent: EditCanceledEvent<TRowData, TKey>;
   EditCancelingEvent: EditCancelingEvent<TRowData, TKey>;
@@ -4800,6 +4801,7 @@ export type ExplicitTypes<TRowData, TKey> = {
   FocusedCellChangingEvent: FocusedCellChangingEvent<TRowData, TKey>;
   FocusedRowChangedEvent: FocusedRowChangedEvent<TRowData, TKey>;
   FocusedRowChangingEvent: FocusedRowChangingEvent<TRowData, TKey>;
+  GroupData: GroupData<TRowData>;
   InitializedEvent: InitializedEvent<TRowData, TKey>;
   InitNewRowEvent: InitNewRowEvent<TRowData, TKey>;
   KeyDownEvent: KeyDownEvent<TRowData, TKey>;
@@ -4827,7 +4829,6 @@ export type ExplicitTypes<TRowData, TKey> = {
   RowRemovedEvent: RowRemovedEvent<TRowData, TKey>;
   RowRemovingEvent: RowRemovingEvent<TRowData, TKey>;
   RowTemplateData: RowTemplateData<TRowData, TKey>;
-  DataRowTemplateData: DataRowTemplateData<TRowData, TKey>;
   RowUpdatedEvent: RowUpdatedEvent<TRowData, TKey>;
   RowUpdatingEvent: RowUpdatingEvent<TRowData, TKey>;
   RowValidatingEvent: RowValidatingEvent<TRowData, TKey>;
@@ -4838,7 +4839,6 @@ export type ExplicitTypes<TRowData, TKey> = {
   SelectionChangedEvent: SelectionChangedEvent<TRowData, TKey>;
   Summary: Summary<TRowData, TKey>;
   ToolbarPreparingEvent: ToolbarPreparingEvent<TRowData, TKey>;
-  GroupData: GroupData<TRowData>;
 };
 
 /** @public */

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -3731,7 +3731,7 @@ export interface dxDataGridOptions<TRowData = any, TKey = any> extends GridBaseO
      * @default undefined
      * @public
      */
-    toolbar?: dxDataGridToolbar;
+    toolbar?: Toolbar;
 }
 
 export interface ExcelCellInfo<TRowData = any, TKey = any> {
@@ -4165,20 +4165,20 @@ export interface SummaryTexts {
     sumOtherColumn?: string;
 }
 
-type dxDataGridDefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'exportButton' | 'groupPanel' | 'revertButton' | 'saveButton' | 'searchPanel';
+type DefaultToolbarItem = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'exportButton' | 'groupPanel' | 'revertButton' | 'saveButton' | 'searchPanel';
 
 /**
  * @docid
  * @inherits dxToolbarItem
  * @namespace DevExpress.ui
  */
-export interface dxDataGridToolbarItem extends dxToolbarItem {
+export interface ToolbarItem extends dxToolbarItem {
   /**
    * @docid
    * @type Enums.DataGridToolbarItem|string
    * @public
    */
-  name?: dxDataGridDefaultToolbarItemName | string;
+  name?: DefaultToolbarItem | string;
   /**
    * @docid
    * @type Enums.ToolbarItemLocation
@@ -4193,13 +4193,13 @@ export interface dxDataGridToolbarItem extends dxToolbarItem {
  * @type object
  * @namespace DevExpress.ui
  */
-export interface dxDataGridToolbar {
+export interface Toolbar {
   /**
    * @docid
-   * @type Array<dxDataGridToolbarItem,Enums.DataGridToolbarItem>
+   * @type Array<ToolbarItem,Enums.DataGridToolbarItem>
    * @public
    */
-  items?: Array<dxDataGridDefaultToolbarItemName | dxDataGridToolbarItem>;
+  items?: Array<DefaultToolbarItem | ToolbarItem>;
   /**
    * @docid
    * @type boolean

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1382,7 +1382,7 @@ export type dxTreeListNode<TRowData = any, TKey = any> = Node<TRowData, TKey>;
  * @docid dxTreeListNode
  * @type object
  */
-export interface Node<TRowData = any, TKey = any> {
+export type Node<TRowData = any, TKey = any> = {
     /**
      * @docid dxTreeListNode.children
      * @type  Array<dxTreeListNode>
@@ -1420,7 +1420,7 @@ export interface Node<TRowData = any, TKey = any> {
      * @public
      */
     visible?: boolean;
-}
+};
 
 /**
  * @namespace DevExpress.ui
@@ -1433,7 +1433,7 @@ export type dxTreeListRowObject<TRowData = any, TKey = any> = Row<TRowData, TKey
  * @docid dxTreeListRowObject
  * @type object
  */
-export interface Row<TRowData = any, TKey = any> {
+export type Row<TRowData = any, TKey = any> = {
     /**
      * @docid dxTreeListRowObject.isEditing
      * @public
@@ -1490,7 +1490,7 @@ export interface Row<TRowData = any, TKey = any> {
      * @public
      */
     readonly data: TRowData;
-}
+};
 
 /** @public */
 export type ExplicitTypes<TRowData, TKey> = {

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1180,9 +1180,9 @@ export default class dxTreeList<TRowData = any, TKey = any> extends Widget<dxTre
 type DefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'revertButton' | 'saveButton' | 'searchPanel';
 
 /**
- * @public
  * @docid dxTreeListToolbarItem
  * @inherits dxToolbarItem
+ * @namespace DevExpress.ui.dxTreeList
  */
 export interface ToolbarItem extends dxToolbarItem {
     /**
@@ -1204,8 +1204,9 @@ export interface ToolbarItem extends dxToolbarItem {
  * @public
  * @docid dxTreeListToolbar
  * @type object
+ * @namespace DevExpress.ui.dxTreeList
  */
-export interface Toolbar {
+export type Toolbar = {
     /**
      * @docid dxTreeListToolbar.items
      * @type Array<dxTreeListToolbarItem,Enums.TreeListToolbarItem>
@@ -1226,7 +1227,7 @@ export interface Toolbar {
      * @public
      */
     disabled?: boolean;
-}
+};
 
 /**
  * @public

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -847,7 +847,7 @@ export interface dxTreeListOptions<TRowData = any, TKey = any> extends GridBaseO
      * @default undefined
      * @public
      */
-    toolbar?: dxTreeListToolbar;
+    toolbar?: Toolbar;
 }
 
 /**
@@ -1176,22 +1176,22 @@ export default class dxTreeList<TRowData = any, TKey = any> extends Widget<dxTre
     updateDimensions(): void;
 }
 
-type dxTreeListDefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'revertButton' | 'saveButton' | 'searchPanel';
+type DefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'revertButton' | 'saveButton' | 'searchPanel';
 
 /**
- * @docid
+ * @public
+ * @docid dxTreeListToolbarItem
  * @inherits dxToolbarItem
- * @namespace DevExpress.ui
  */
-export interface dxTreeListToolbarItem extends dxToolbarItem {
+export interface ToolbarItem extends dxToolbarItem {
     /**
-     * @docid
+     * @docid dxTreeListToolbarItem.name
      * @type Enums.TreeListToolbarItem|string
      * @public
      */
-    name?: dxTreeListDefaultToolbarItemName | string;
+    name?: DefaultToolbarItemName | string;
     /**
-     * @docid
+     * @docid dxTreeListToolbarItem.location
      * @type Enums.ToolbarItemLocation
      * @default 'after'
      * @public
@@ -1200,26 +1200,26 @@ export interface dxTreeListToolbarItem extends dxToolbarItem {
 }
 
 /**
- * @docid
+ * @public
+ * @docid dxTreeListToolbar
  * @type object
- * @namespace DevExpress.ui
  */
-export interface dxTreeListToolbar {
+export interface Toolbar {
     /**
-     * @docid
-     * @type Array<dxTreeListToolbarItem,Enums.TreeListToolbarItem>
+     * @docid dxTreeListToolbar.items
+     * @type Array<ToolbarItem,Enums.TreeListToolbarItem>
      * @public
      */
-    items?: (dxTreeListDefaultToolbarItemName | dxTreeListToolbarItem)[];
+    items?: (DefaultToolbarItemName | ToolbarItem)[];
     /**
-     * @docid
+     * @docid dxTreeListToolbar.visible
      * @type boolean
      * @default undefined
      * @public
      */
     visible?: boolean;
     /**
-     * @docid
+     * @docid dxTreeListToolbar.disabled
      * @type boolean
      * @default false
      * @public

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -844,6 +844,7 @@ export interface dxTreeListOptions<TRowData = any, TKey = any> extends GridBaseO
     selection?: Selection;
     /**
      * @docid
+     * @type dxTreeListToolbar
      * @default undefined
      * @public
      */
@@ -1207,7 +1208,7 @@ export interface ToolbarItem extends dxToolbarItem {
 export interface Toolbar {
     /**
      * @docid dxTreeListToolbar.items
-     * @type Array<ToolbarItem,Enums.TreeListToolbarItem>
+     * @type Array<dxTreeListToolbarItem,Enums.TreeListToolbarItem>
      * @public
      */
     items?: (DefaultToolbarItemName | ToolbarItem)[];
@@ -1550,6 +1551,8 @@ export type ExplicitTypes<TRowData, TKey> = {
   Scrolling: Scrolling;
   Selection: Selection;
   SelectionChangedEvent: SelectionChangedEvent<TRowData, TKey>;
+  Toolbar: Toolbar;
+  ToolbarItem: ToolbarItem;
   ToolbarPreparingEvent: ToolbarPreparingEvent<TRowData, TKey>;
 };
 

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -1178,6 +1178,8 @@ export default class dxTreeList<TRowData = any, TKey = any> extends Widget<dxTre
 }
 
 type DefaultToolbarItemName = 'addRowButton' | 'applyFilterButton' | 'columnChooserButton' | 'revertButton' | 'saveButton' | 'searchPanel';
+export type dxTreeListToolbar = Toolbar;
+export type dxTreeListToolbarItem = ToolbarItem;
 
 /**
  * @docid dxTreeListToolbarItem

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -21015,6 +21015,8 @@ declare module DevExpress.ui {
       Scrolling: Scrolling;
       Selection: Selection;
       SelectionChangedEvent: SelectionChangedEvent<TRowData, TKey>;
+      Toolbar: Toolbar;
+      ToolbarItem: ToolbarItem;
       ToolbarPreparingEvent: ToolbarPreparingEvent<TRowData, TKey>;
     };
     export type FocusedCellChangedEvent<

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -6304,6 +6304,18 @@ declare module DevExpress.ui {
       readonly isSelected?: boolean;
       readonly isExpanded?: boolean;
     };
+    /**
+     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+     */
+    type DefaultToolbarItem =
+      | 'addRowButton'
+      | 'applyFilterButton'
+      | 'columnChooserButton'
+      | 'exportButton'
+      | 'groupPanel'
+      | 'revertButton'
+      | 'saveButton'
+      | 'searchPanel';
     export type DisposingEvent<
       TRowData = any,
       TKey = any
@@ -6336,18 +6348,6 @@ declare module DevExpress.ui {
       readonly fromIndex: number;
       readonly fromData?: any;
     }
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    type dxDataGridDefaultToolbarItemName =
-      | 'addRowButton'
-      | 'applyFilterButton'
-      | 'columnChooserButton'
-      | 'exportButton'
-      | 'groupPanel'
-      | 'revertButton'
-      | 'saveButton'
-      | 'searchPanel';
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
@@ -8466,7 +8466,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxDataGridOptions.toolbar]
      */
-    toolbar?: dxDataGridToolbar;
+    toolbar?: Toolbar;
   }
   /**
    * @deprecated Use DevExpress.ui.dxDataGrid.Scrolling instead
@@ -8476,41 +8476,6 @@ declare module DevExpress.ui {
    * @deprecated Use DevExpress.ui.dxDataGrid.Selection instead
    */
   export type dxDataGridSelection = DevExpress.ui.dxDataGrid.Selection;
-  /**
-   * [descr:dxDataGridToolbar]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-   */
-  export interface dxDataGridToolbar {
-    /**
-     * [descr:dxDataGridToolbar.items]
-     */
-    items?: Array<
-      | DevExpress.ui.dxDataGrid.dxDataGridDefaultToolbarItemName
-      | dxDataGridToolbarItem
-    >;
-    /**
-     * [descr:dxDataGridToolbar.visible]
-     */
-    visible?: boolean;
-    /**
-     * [descr:dxDataGridToolbar.disabled]
-     */
-    disabled?: boolean;
-  }
-  /**
-   * [descr:dxDataGridToolbarItem]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-   */
-  export interface dxDataGridToolbarItem extends dxToolbarItem {
-    /**
-     * [descr:dxDataGridToolbarItem.name]
-     */
-    name?: DevExpress.ui.dxDataGrid.dxDataGridDefaultToolbarItemName | string;
-    /**
-     * [descr:dxDataGridToolbarItem.location]
-     */
-    location?: 'after' | 'before' | 'center';
-  }
   /**
    * [descr:dxDateBox]
    */
@@ -23427,6 +23392,38 @@ declare module DevExpress.ui {
      */
     static initialized(callback: Function): void;
     static isMaterial(theme: string): boolean;
+  }
+  /**
+   * [descr:Toolbar]
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+   */
+  export interface Toolbar {
+    /**
+     * [descr:Toolbar.items]
+     */
+    items?: Array<DevExpress.ui.dxDataGrid.DefaultToolbarItem | ToolbarItem>;
+    /**
+     * [descr:Toolbar.visible]
+     */
+    visible?: boolean;
+    /**
+     * [descr:Toolbar.disabled]
+     */
+    disabled?: boolean;
+  }
+  /**
+   * [descr:ToolbarItem]
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+   */
+  export interface ToolbarItem extends dxToolbarItem {
+    /**
+     * [descr:ToolbarItem.name]
+     */
+    name?: DevExpress.ui.dxDataGrid.DefaultToolbarItem | string;
+    /**
+     * [descr:ToolbarItem.location]
+     */
+    location?: 'after' | 'before' | 'center';
   }
   export interface ValidationCallbackData {
     value?: string | number;

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -6362,6 +6362,14 @@ declare module DevExpress.ui {
        */
       summaryItem?: string | number;
     }
+    /**
+     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+     */
+    export type dxDataGridToolbar = Toolbar;
+    /**
+     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+     */
+    export type dxDataGridToolbarItem = ToolbarItem;
     export type EditCanceledEvent<
       TRowData = any,
       TKey = any
@@ -20826,6 +20834,14 @@ declare module DevExpress.ui {
       TRowData = any,
       TKey = any
     > = DevExpress.events.EventInfo<dxTreeList<TRowData, TKey>>;
+    /**
+     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+     */
+    export type dxTreeListToolbar = Toolbar;
+    /**
+     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+     */
+    export type dxTreeListToolbarItem = ToolbarItem;
     export type EditCanceledEvent<
       TRowData = any,
       TKey = any

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -6304,7 +6304,7 @@ declare module DevExpress.ui {
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
-    type DefaultToolbarItem =
+    type DefaultToolbarItemName =
       | 'addRowButton'
       | 'applyFilterButton'
       | 'columnChooserButton'
@@ -23380,7 +23380,9 @@ declare module DevExpress.ui {
     /**
      * [descr:Toolbar.items]
      */
-    items?: Array<DevExpress.ui.dxDataGrid.DefaultToolbarItem | ToolbarItem>;
+    items?: Array<
+      DevExpress.ui.dxDataGrid.DefaultToolbarItemName | ToolbarItem
+    >;
     /**
      * [descr:Toolbar.visible]
      */
@@ -23397,7 +23399,7 @@ declare module DevExpress.ui {
     /**
      * [descr:ToolbarItem.name]
      */
-    name?: DevExpress.ui.dxDataGrid.DefaultToolbarItem | string;
+    name?: DevExpress.ui.dxDataGrid.DefaultToolbarItemName | string;
     /**
      * [descr:ToolbarItem.location]
      */

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -8044,6 +8044,36 @@ declare module DevExpress.ui {
        */
       valueFormat?: Format;
     };
+    /**
+     * [descr:dxDataGridToolbar]
+     */
+    export type Toolbar = {
+      /**
+       * [descr:dxDataGridToolbar.items]
+       */
+      items?: Array<DefaultToolbarItemName | ToolbarItem>;
+      /**
+       * [descr:dxDataGridToolbar.visible]
+       */
+      visible?: boolean;
+      /**
+       * [descr:dxDataGridToolbar.disabled]
+       */
+      disabled?: boolean;
+    };
+    /**
+     * [descr:dxDataGridToolbarItem]
+     */
+    export type ToolbarItem = dxToolbarItem & {
+      /**
+       * [descr:dxDataGridToolbarItem.name]
+       */
+      name?: DefaultToolbarItemName | string;
+      /**
+       * [descr:dxDataGridToolbarItem.location]
+       */
+      location?: 'after' | 'before' | 'center';
+    };
     export type ToolbarPreparingEvent<
       TRowData = any,
       TKey = any
@@ -8446,7 +8476,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxDataGridOptions.toolbar]
      */
-    toolbar?: Toolbar;
+    toolbar?: DevExpress.ui.dxDataGrid.Toolbar;
   }
   /**
    * @deprecated Use DevExpress.ui.dxDataGrid.Scrolling instead
@@ -20812,20 +20842,20 @@ declare module DevExpress.ui {
       TKey = any
     > = DevExpress.events.EventInfo<dxTreeList<TRowData, TKey>> &
       DevExpress.ui.dxDataGrid.DataErrorOccurredInfo;
-    export type DisposingEvent<
-      TRowData = any,
-      TKey = any
-    > = DevExpress.events.EventInfo<dxTreeList<TRowData, TKey>>;
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
-    type dxTreeListDefaultToolbarItemName =
+    type DefaultToolbarItemName =
       | 'addRowButton'
       | 'applyFilterButton'
       | 'columnChooserButton'
       | 'revertButton'
       | 'saveButton'
       | 'searchPanel';
+    export type DisposingEvent<
+      TRowData = any,
+      TKey = any
+    > = DevExpress.events.EventInfo<dxTreeList<TRowData, TKey>>;
     export type EditCanceledEvent<
       TRowData = any,
       TKey = any
@@ -21349,6 +21379,36 @@ declare module DevExpress.ui {
       TKey = any
     > = DevExpress.events.EventInfo<dxTreeList<TRowData, TKey>> &
       DevExpress.ui.dxDataGrid.SelectionChangedInfo<TRowData, TKey>;
+    /**
+     * [descr:dxTreeListToolbar]
+     */
+    export interface Toolbar {
+      /**
+       * [descr:dxTreeListToolbar.items]
+       */
+      items?: (DefaultToolbarItemName | ToolbarItem)[];
+      /**
+       * [descr:dxTreeListToolbar.visible]
+       */
+      visible?: boolean;
+      /**
+       * [descr:dxTreeListToolbar.disabled]
+       */
+      disabled?: boolean;
+    }
+    /**
+     * [descr:dxTreeListToolbarItem]
+     */
+    export interface ToolbarItem extends dxToolbarItem {
+      /**
+       * [descr:dxTreeListToolbarItem.name]
+       */
+      name?: DefaultToolbarItemName | string;
+      /**
+       * [descr:dxTreeListToolbarItem.location]
+       */
+      location?: 'after' | 'before' | 'center';
+    }
     export type ToolbarPreparingEvent<
       TRowData = any,
       TKey = any
@@ -21675,7 +21735,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxTreeListOptions.toolbar]
      */
-    toolbar?: dxTreeListToolbar;
+    toolbar?: DevExpress.ui.dxTreeList.Toolbar;
   }
   /**
    * @deprecated 
@@ -21689,41 +21749,6 @@ declare module DevExpress.ui {
    * @deprecated Use DevExpress.ui.dxTreeList.Selection instead
    */
   export type dxTreeListSelection = DevExpress.ui.dxTreeList.Selection;
-  /**
-   * [descr:dxTreeListToolbar]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-   */
-  export interface dxTreeListToolbar {
-    /**
-     * [descr:dxTreeListToolbar.items]
-     */
-    items?: (
-      | DevExpress.ui.dxTreeList.dxTreeListDefaultToolbarItemName
-      | dxTreeListToolbarItem
-    )[];
-    /**
-     * [descr:dxTreeListToolbar.visible]
-     */
-    visible?: boolean;
-    /**
-     * [descr:dxTreeListToolbar.disabled]
-     */
-    disabled?: boolean;
-  }
-  /**
-   * [descr:dxTreeListToolbarItem]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-   */
-  export interface dxTreeListToolbarItem extends dxToolbarItem {
-    /**
-     * [descr:dxTreeListToolbarItem.name]
-     */
-    name?: DevExpress.ui.dxTreeList.dxTreeListDefaultToolbarItemName | string;
-    /**
-     * [descr:dxTreeListToolbarItem.location]
-     */
-    location?: 'after' | 'before' | 'center';
-  }
   /**
    * [descr:dxTreeView]
    */
@@ -23373,38 +23398,6 @@ declare module DevExpress.ui {
     static initialized(callback: Function): void;
     static isMaterial(theme: string): boolean;
   }
-  /**
-   * [descr:Toolbar]
-   */
-  export type Toolbar = {
-    /**
-     * [descr:Toolbar.items]
-     */
-    items?: Array<
-      DevExpress.ui.dxDataGrid.DefaultToolbarItemName | ToolbarItem
-    >;
-    /**
-     * [descr:Toolbar.visible]
-     */
-    visible?: boolean;
-    /**
-     * [descr:Toolbar.disabled]
-     */
-    disabled?: boolean;
-  };
-  /**
-   * [descr:ToolbarItem]
-   */
-  export type ToolbarItem = dxToolbarItem & {
-    /**
-     * [descr:ToolbarItem.name]
-     */
-    name?: DevExpress.ui.dxDataGrid.DefaultToolbarItemName | string;
-    /**
-     * [descr:ToolbarItem.location]
-     */
-    location?: 'after' | 'before' | 'center';
-  };
   export interface ValidationCallbackData {
     value?: string | number;
     rule: any;

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -4452,32 +4452,6 @@ declare module DevExpress.ui {
     validationCallback?: (options: ValidationCallbackData) => boolean;
   }
   /**
-   * [descr:DataChange]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-   */
-  export interface DataChange<TRowData = any, TKey = any> {
-    /**
-     * [descr:DataChange.key]
-     */
-    key: TKey;
-    /**
-     * [descr:DataChange.type]
-     */
-    type: 'insert' | 'update' | 'remove';
-    /**
-     * [descr:DataChange.data]
-     */
-    data: DevExpress.core.DeepPartial<TRowData>;
-    /**
-     * [descr:DataChange.insertAfterKey]
-     */
-    insertAfterKey?: TKey;
-    /**
-     * [descr:DataChange.insertBeforeKey]
-     */
-    insertBeforeKey?: TKey;
-  }
-  /**
    * [descr:DataExpressionMixin]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
@@ -23578,6 +23552,34 @@ declare module DevExpress.ui.dxButtonGroup {
 }
 declare module DevExpress.ui.dxContextMenu {
   export type Item = dxContextMenuItem;
+}
+declare module DevExpress.ui.dxDataGrid {
+  /**
+   * [descr:DataChange]
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+   */
+  export interface DataChange<TRowData = any, TKey = any> {
+    /**
+     * [descr:DataChange.key]
+     */
+    key: TKey;
+    /**
+     * [descr:DataChange.type]
+     */
+    type: 'insert' | 'update' | 'remove';
+    /**
+     * [descr:DataChange.data]
+     */
+    data: DevExpress.core.DeepPartial<TRowData>;
+    /**
+     * [descr:DataChange.insertAfterKey]
+     */
+    insertAfterKey?: TKey;
+    /**
+     * [descr:DataChange.insertBeforeKey]
+     */
+    insertBeforeKey?: TKey;
+  }
 }
 declare module DevExpress.ui.dxDiagram {
   export type Item = dxDiagramItem;

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -6266,17 +6266,14 @@ declare module DevExpress.ui {
       readonly rowIndex: number;
       readonly row?: Row<TRowData, TKey>;
     };
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface CustomSummaryInfo<TRowData = any, TKey = any> {
+    export type CustomSummaryInfo<TRowData = any, TKey = any> = {
       readonly component: dxDataGrid<TRowData, TKey>;
       readonly name?: string;
       readonly summaryProcess: string;
       readonly value?: any;
       totalValue?: any;
       readonly groupIndex?: number;
-    }
+    };
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
@@ -6563,10 +6560,7 @@ declare module DevExpress.ui {
       readonly dataField?: string;
       readonly row?: Row<TRowData, TKey>;
     };
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface ExcelCellInfo<TRowData = any, TKey = any> {
+    export type ExcelCellInfo<TRowData = any, TKey = any> = {
       readonly component: dxDataGrid<TRowData, TKey>;
       horizontalAlignment?:
         | 'center'
@@ -6610,7 +6604,7 @@ declare module DevExpress.ui {
       readonly value?: string | number | Date;
       numberFormat?: string;
       gridCell?: DevExpress.excelExporter.DataGridCell;
-    }
+    };
     export type ExplicitTypes<TRowData, TKey> = {
       AdaptiveDetailRowPreparingEvent: AdaptiveDetailRowPreparingEvent<
         TRowData,
@@ -6633,6 +6627,7 @@ declare module DevExpress.ui {
       >;
       ContentReadyEvent: ContentReadyEvent<TRowData, TKey>;
       ContextMenuPreparingEvent: ContextMenuPreparingEvent<TRowData, TKey>;
+      CustomSummaryInfo: CustomSummaryInfo<TRowData, TKey>;
       DataErrorOccurredEvent: DataErrorOccurredEvent<TRowData, TKey>;
       DataRowTemplateData: DataRowTemplateData<TRowData, TKey>;
       DisposingEvent: DisposingEvent<TRowData, TKey>;
@@ -6642,18 +6637,24 @@ declare module DevExpress.ui {
       EditingStartEvent: EditingStartEvent<TRowData, TKey>;
       EditorPreparedEvent: EditorPreparedEvent<TRowData, TKey>;
       EditorPreparingEvent: EditorPreparingEvent<TRowData, TKey>;
+      ExcelCellInfo: ExcelCellInfo<TRowData, TKey>;
       Export: Export<TRowData, TKey>;
       ExportedEvent: ExportedEvent<TRowData, TKey>;
       ExportingEvent: ExportingEvent<TRowData, TKey>;
+      ExportTexts: ExportTexts;
       FileSavingEvent: FileSavingEvent<TRowData, TKey>;
       FocusedCellChangedEvent: FocusedCellChangedEvent<TRowData, TKey>;
       FocusedCellChangingEvent: FocusedCellChangingEvent<TRowData, TKey>;
       FocusedRowChangedEvent: FocusedRowChangedEvent<TRowData, TKey>;
       FocusedRowChangingEvent: FocusedRowChangingEvent<TRowData, TKey>;
       GroupData: GroupData<TRowData>;
+      Grouping: Grouping;
+      GroupingTexts: GroupingTexts;
+      GroupPanel: GroupPanel;
       InitializedEvent: InitializedEvent<TRowData, TKey>;
       InitNewRowEvent: InitNewRowEvent<TRowData, TKey>;
       KeyDownEvent: KeyDownEvent<TRowData, TKey>;
+      MasterDetail: MasterDetail<TRowData, TKey>;
       MasterDetailTemplateData: MasterDetailTemplateData<TRowData, TKey>;
       OptionChangedEvent: OptionChangedEvent<TRowData, TKey>;
       Properties: Properties<TRowData, TKey>;
@@ -6687,6 +6688,12 @@ declare module DevExpress.ui {
       Selection: Selection;
       SelectionChangedEvent: SelectionChangedEvent<TRowData, TKey>;
       Summary: Summary<TRowData, TKey>;
+      SummaryGroupItem: SummaryGroupItem;
+      SummaryItemTextInfo: SummaryItemTextInfo;
+      SummaryTexts: SummaryTexts;
+      SummaryTotalItem: SummaryTotalItem;
+      Toolbar: Toolbar;
+      ToolbarItem: ToolbarItem;
       ToolbarPreparingEvent: ToolbarPreparingEvent<TRowData, TKey>;
     };
     export type Export<TRowData = any, TKey = any> = {
@@ -6744,10 +6751,7 @@ declare module DevExpress.ui {
       DevExpress.events.EventInfo<dxDataGrid<TRowData, TKey>> & {
         fileName?: string;
       };
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface ExportTexts {
+    export type ExportTexts = {
       /**
        * [descr:dxDataGridOptions.export.texts.exportAll]
        */
@@ -6760,7 +6764,7 @@ declare module DevExpress.ui {
        * [descr:dxDataGridOptions.export.texts.exportTo]
        */
       exportTo?: string;
-    }
+    };
     export type FileSavingEvent<
       TRowData = any,
       TKey = any
@@ -6977,10 +6981,7 @@ declare module DevExpress.ui {
        */
       isContinuationOnNextPage?: boolean;
     };
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface Grouping {
+    export type Grouping = {
       /**
        * [descr:dxDataGridOptions.grouping.allowCollapsing]
        */
@@ -7001,11 +7002,8 @@ declare module DevExpress.ui {
        * [descr:dxDataGridOptions.grouping.texts]
        */
       texts?: GroupingTexts;
-    }
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface GroupingTexts {
+    };
+    export type GroupingTexts = {
       /**
        * [descr:dxDataGridOptions.grouping.texts.groupByThisColumn]
        */
@@ -7026,15 +7024,12 @@ declare module DevExpress.ui {
        * [descr:dxDataGridOptions.grouping.texts.ungroupAll]
        */
       ungroupAll?: string;
-    }
+    };
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
     type GroupKey = any[];
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface GroupPanel {
+    export type GroupPanel = {
       /**
        * [descr:dxDataGridOptions.groupPanel.allowColumnDragging]
        */
@@ -7047,7 +7042,7 @@ declare module DevExpress.ui {
        * [descr:dxDataGridOptions.groupPanel.visible]
        */
       visible?: boolean | 'auto';
-    }
+    };
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
      */
@@ -7176,10 +7171,7 @@ declare module DevExpress.ui {
        */
       width?: number;
     }
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface MasterDetail<TRowData = any, TKey = any> {
+    export type MasterDetail<TRowData = any, TKey = any> = {
       /**
        * [descr:dxDataGridOptions.masterDetail.autoExpandAll]
        */
@@ -7197,7 +7189,7 @@ declare module DevExpress.ui {
             detailElement: DevExpress.core.DxElement,
             detailInfo: MasterDetailTemplateData<TRowData, TKey>
           ) => any);
-    }
+    };
     export type MasterDetailTemplateData<TRowData = any, TKey = any> = {
       readonly key: TKey;
       readonly data: TRowData;
@@ -7272,7 +7264,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxDataGridRowObject]
      */
-    export interface Row<TRowData = any, TKey = any> {
+    export type Row<TRowData = any, TKey = any> = {
       /**
        * [descr:dxDataGridRowObject.data]
        */
@@ -7313,7 +7305,7 @@ declare module DevExpress.ui {
        * [descr:dxDataGridRowObject.values]
        */
       readonly values: Array<any>;
-    }
+    };
     export type RowClickEvent<
       TRowData = any,
       TKey = any
@@ -7898,7 +7890,7 @@ declare module DevExpress.ui {
        */
       type?: 'custom' | 'localStorage' | 'sessionStorage';
     }
-    export interface Summary<TRowData = any, TKey = any> {
+    export type Summary<TRowData = any, TKey = any> = {
       /**
        * [descr:dxDataGridOptions.summary.calculateCustomSummary]
        */
@@ -7925,11 +7917,8 @@ declare module DevExpress.ui {
        * [descr:dxDataGridOptions.summary.totalItems]
        */
       totalItems?: Array<SummaryTotalItem>;
-    }
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface SummaryGroupItem {
+    };
+    export type SummaryGroupItem = {
       /**
        * [descr:dxDataGridOptions.summary.groupItems.alignByColumn]
        */
@@ -7970,18 +7959,12 @@ declare module DevExpress.ui {
        * [descr:dxDataGridOptions.summary.groupItems.valueFormat]
        */
       valueFormat?: Format;
-    }
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface SummaryItemTextInfo {
+    };
+    export type SummaryItemTextInfo = {
       readonly value?: string | number | Date;
       readonly valueText: string;
-    }
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface SummaryTexts {
+    };
+    export type SummaryTexts = {
       /**
        * [descr:dxDataGridOptions.summary.texts.avg]
        */
@@ -8018,11 +8001,8 @@ declare module DevExpress.ui {
        * [descr:dxDataGridOptions.summary.texts.sumOtherColumn]
        */
       sumOtherColumn?: string;
-    }
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    export interface SummaryTotalItem {
+    };
+    export type SummaryTotalItem = {
       /**
        * [descr:dxDataGridOptions.summary.totalItems.alignment]
        */
@@ -8063,7 +8043,7 @@ declare module DevExpress.ui {
        * [descr:dxDataGridOptions.summary.totalItems.valueFormat]
        */
       valueFormat?: Format;
-    }
+    };
     export type ToolbarPreparingEvent<
       TRowData = any,
       TKey = any
@@ -21065,7 +21045,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxTreeListNode]
      */
-    export interface Node<TRowData = any, TKey = any> {
+    export type Node<TRowData = any, TKey = any> = {
       /**
        * [descr:dxTreeListNode.children]
        */
@@ -21094,7 +21074,7 @@ declare module DevExpress.ui {
        * [descr:dxTreeListNode.visible]
        */
       visible?: boolean;
-    }
+    };
     export type NodesInitializedEvent<
       TRowData = any,
       TKey = any
@@ -21122,7 +21102,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxTreeListRowObject]
      */
-    export interface Row<TRowData = any, TKey = any> {
+    export type Row<TRowData = any, TKey = any> = {
       /**
        * [descr:dxTreeListRowObject.isEditing]
        */
@@ -21167,7 +21147,7 @@ declare module DevExpress.ui {
        * [descr:dxTreeListRowObject.data]
        */
       readonly data: TRowData;
-    }
+    };
     export type RowClickEvent<
       TRowData = any,
       TKey = any
@@ -23395,9 +23375,8 @@ declare module DevExpress.ui {
   }
   /**
    * [descr:Toolbar]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface Toolbar {
+  export type Toolbar = {
     /**
      * [descr:Toolbar.items]
      */
@@ -23410,12 +23389,11 @@ declare module DevExpress.ui {
      * [descr:Toolbar.disabled]
      */
     disabled?: boolean;
-  }
+  };
   /**
    * [descr:ToolbarItem]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export interface ToolbarItem extends dxToolbarItem {
+  export type ToolbarItem = dxToolbarItem & {
     /**
      * [descr:ToolbarItem.name]
      */
@@ -23424,7 +23402,7 @@ declare module DevExpress.ui {
      * [descr:ToolbarItem.location]
      */
     location?: 'after' | 'before' | 'center';
-  }
+  };
   export interface ValidationCallbackData {
     value?: string | number;
     rule: any;

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -6634,6 +6634,7 @@ declare module DevExpress.ui {
       ContentReadyEvent: ContentReadyEvent<TRowData, TKey>;
       ContextMenuPreparingEvent: ContextMenuPreparingEvent<TRowData, TKey>;
       DataErrorOccurredEvent: DataErrorOccurredEvent<TRowData, TKey>;
+      DataRowTemplateData: DataRowTemplateData<TRowData, TKey>;
       DisposingEvent: DisposingEvent<TRowData, TKey>;
       EditCanceledEvent: EditCanceledEvent<TRowData, TKey>;
       EditCancelingEvent: EditCancelingEvent<TRowData, TKey>;
@@ -6649,6 +6650,7 @@ declare module DevExpress.ui {
       FocusedCellChangingEvent: FocusedCellChangingEvent<TRowData, TKey>;
       FocusedRowChangedEvent: FocusedRowChangedEvent<TRowData, TKey>;
       FocusedRowChangingEvent: FocusedRowChangingEvent<TRowData, TKey>;
+      GroupData: GroupData<TRowData>;
       InitializedEvent: InitializedEvent<TRowData, TKey>;
       InitNewRowEvent: InitNewRowEvent<TRowData, TKey>;
       KeyDownEvent: KeyDownEvent<TRowData, TKey>;
@@ -6676,7 +6678,6 @@ declare module DevExpress.ui {
       RowRemovedEvent: RowRemovedEvent<TRowData, TKey>;
       RowRemovingEvent: RowRemovingEvent<TRowData, TKey>;
       RowTemplateData: RowTemplateData<TRowData, TKey>;
-      DataRowTemplateData: DataRowTemplateData<TRowData, TKey>;
       RowUpdatedEvent: RowUpdatedEvent<TRowData, TKey>;
       RowUpdatingEvent: RowUpdatingEvent<TRowData, TKey>;
       RowValidatingEvent: RowValidatingEvent<TRowData, TKey>;
@@ -6687,7 +6688,6 @@ declare module DevExpress.ui {
       SelectionChangedEvent: SelectionChangedEvent<TRowData, TKey>;
       Summary: Summary<TRowData, TKey>;
       ToolbarPreparingEvent: ToolbarPreparingEvent<TRowData, TKey>;
-      GroupData: GroupData<TRowData>;
     };
     export type Export<TRowData = any, TKey = any> = {
       /**

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -8044,36 +8044,6 @@ declare module DevExpress.ui {
        */
       valueFormat?: Format;
     };
-    /**
-     * [descr:dxDataGridToolbar]
-     */
-    export type Toolbar = {
-      /**
-       * [descr:dxDataGridToolbar.items]
-       */
-      items?: Array<DefaultToolbarItemName | ToolbarItem>;
-      /**
-       * [descr:dxDataGridToolbar.visible]
-       */
-      visible?: boolean;
-      /**
-       * [descr:dxDataGridToolbar.disabled]
-       */
-      disabled?: boolean;
-    };
-    /**
-     * [descr:dxDataGridToolbarItem]
-     */
-    export type ToolbarItem = dxToolbarItem & {
-      /**
-       * [descr:dxDataGridToolbarItem.name]
-       */
-      name?: DefaultToolbarItemName | string;
-      /**
-       * [descr:dxDataGridToolbarItem.location]
-       */
-      location?: 'after' | 'before' | 'center';
-    };
     export type ToolbarPreparingEvent<
       TRowData = any,
       TKey = any
@@ -21381,36 +21351,6 @@ declare module DevExpress.ui {
       TKey = any
     > = DevExpress.events.EventInfo<dxTreeList<TRowData, TKey>> &
       DevExpress.ui.dxDataGrid.SelectionChangedInfo<TRowData, TKey>;
-    /**
-     * [descr:dxTreeListToolbar]
-     */
-    export interface Toolbar {
-      /**
-       * [descr:dxTreeListToolbar.items]
-       */
-      items?: (DefaultToolbarItemName | ToolbarItem)[];
-      /**
-       * [descr:dxTreeListToolbar.visible]
-       */
-      visible?: boolean;
-      /**
-       * [descr:dxTreeListToolbar.disabled]
-       */
-      disabled?: boolean;
-    }
-    /**
-     * [descr:dxTreeListToolbarItem]
-     */
-    export interface ToolbarItem extends dxToolbarItem {
-      /**
-       * [descr:dxTreeListToolbarItem.name]
-       */
-      name?: DefaultToolbarItemName | string;
-      /**
-       * [descr:dxTreeListToolbarItem.location]
-       */
-      location?: 'after' | 'before' | 'center';
-    }
     export type ToolbarPreparingEvent<
       TRowData = any,
       TKey = any
@@ -23552,6 +23492,37 @@ declare module DevExpress.ui.dxDataGrid {
      */
     insertBeforeKey?: TKey;
   }
+  /**
+   * [descr:dxDataGridToolbar]
+   */
+  export type Toolbar = {
+    /**
+     * [descr:dxDataGridToolbar.items]
+     */
+    items?: Array<DefaultToolbarItemName | ToolbarItem>;
+    /**
+     * [descr:dxDataGridToolbar.visible]
+     */
+    visible?: boolean;
+    /**
+     * [descr:dxDataGridToolbar.disabled]
+     */
+    disabled?: boolean;
+  };
+  /**
+   * [descr:dxDataGridToolbarItem]
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+   */
+  export interface ToolbarItem extends dxToolbarItem {
+    /**
+     * [descr:dxDataGridToolbarItem.name]
+     */
+    name?: DefaultToolbarItemName | string;
+    /**
+     * [descr:dxDataGridToolbarItem.location]
+     */
+    location?: 'after' | 'before' | 'center';
+  }
 }
 declare module DevExpress.ui.dxDiagram {
   export type Item = dxDiagramItem;
@@ -23628,6 +23599,39 @@ declare module DevExpress.ui.dxTileView {
 }
 declare module DevExpress.ui.dxToolbar {
   export type Item = dxToolbarItem;
+}
+declare module DevExpress.ui.dxTreeList {
+  /**
+   * [descr:dxTreeListToolbar]
+   */
+  export type Toolbar = {
+    /**
+     * [descr:dxTreeListToolbar.items]
+     */
+    items?: (DefaultToolbarItemName | ToolbarItem)[];
+    /**
+     * [descr:dxTreeListToolbar.visible]
+     */
+    visible?: boolean;
+    /**
+     * [descr:dxTreeListToolbar.disabled]
+     */
+    disabled?: boolean;
+  };
+  /**
+   * [descr:dxTreeListToolbarItem]
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+   */
+  export interface ToolbarItem extends dxToolbarItem {
+    /**
+     * [descr:dxTreeListToolbarItem.name]
+     */
+    name?: DefaultToolbarItemName | string;
+    /**
+     * [descr:dxTreeListToolbarItem.location]
+     */
+    location?: 'after' | 'before' | 'center';
+  }
 }
 declare module DevExpress.ui.dxTreeView {
   export type Item = dxTreeViewItem;


### PR DESCRIPTION
It's better to review commit by commit. 
There is a couple of small fixes, and the main commit that consists of same-type changes:

```diff
+/** @public */
+export type Foo = {
-export interface Foo {
...
+};
-}
```

`@public` tag added to remove warning message in the production build. `interface` is changed to `type` to follow our typing conventions.

Note that `DataChange`, `Toolbar` and `ToolbarItem` were added in v21.2, so we can move\rename them before v21.2.3 published