### PR TITLE
Sortable - The drop indicator is displayed incorrectly after scrolling when dragging an item from another Sortable (T1035958)

### DIFF
--- a/js/ui/sortable.js
+++ b/js/ui/sortable.js
@@ -764,7 +764,7 @@ const Sortable = Draggable.inherit({
         return left;
     },
 
-    _movePlaceholder: function(_isFromHandler) {
+    _movePlaceholder: function() {
         const that = this;
         const $placeholderElement = that._$placeholderElement || that._createPlaceholder();
         if(!$placeholderElement) {

--- a/js/ui/sortable.js
+++ b/js/ui/sortable.js
@@ -160,11 +160,6 @@ const Sortable = Draggable.inherit({
         this.option('fromIndexOffset', this.option('offset'));
     },
 
-    _dragEndHandler: function() {
-        this.callBase.apply(this, arguments);
-        this._unsubscribeFromSourceScroll();
-    },
-
     _subscribeToSourceScroll: function(e) {
         const $scrollable = this._getScrollable($(e.target));
         if($scrollable) {
@@ -247,10 +242,10 @@ const Sortable = Draggable.inherit({
         }
     },
 
-    _dragLeaveHandler: function(e) {
+    _dragLeaveHandler: function() {
         this.callBase.apply(this, arguments);
 
-        this._unsubscribeFromSourceScroll(e);
+        this._unsubscribeFromSourceScroll();
     },
 
     dragEnter: function() {
@@ -290,6 +285,9 @@ const Sortable = Draggable.inherit({
     },
 
     dragEnd: function(sourceEvent) {
+        sourceEvent.fromComponent._unsubscribeFromSourceScroll();
+        sourceEvent.toComponent._unsubscribeFromSourceScroll();
+
         const $sourceElement = this._getSourceElement();
         const sourceDraggable = this._getSourceDraggable();
         const isSourceDraggable = sourceDraggable.NAME !== this.NAME;

--- a/js/ui/sortable.js
+++ b/js/ui/sortable.js
@@ -285,8 +285,8 @@ const Sortable = Draggable.inherit({
     },
 
     dragEnd: function(sourceEvent) {
-        sourceEvent.fromComponent._unsubscribeFromSourceScroll();
-        sourceEvent.toComponent._unsubscribeFromSourceScroll();
+        sourceEvent.fromComponent._unsubscribeFromSourceScroll?.();
+        sourceEvent.toComponent._unsubscribeFromSourceScroll?.();
 
         const $sourceElement = this._getSourceElement();
         const sourceDraggable = this._getSourceDraggable();

--- a/js/ui/sortable.js
+++ b/js/ui/sortable.js
@@ -192,14 +192,17 @@ const Sortable = Draggable.inherit({
                 if(e.target[scrollProp] !== sourceScrollableInfo[scrollProp]) {
                     const scrollBy = e.target[scrollProp] - sourceScrollableInfo[scrollProp];
                     this._correctItemPoints(scrollBy);
+                    this._movePlaceholder();
                     sourceScrollableInfo[scrollProp] = e.target[scrollProp];
                 }
             });
         }
     },
 
-    _dragEnterHandler: function() {
+    _dragEnterHandler: function(e) {
         this.callBase.apply(this, arguments);
+
+        this._subscribeToSourceScroll(e);
 
         if(this === this._getSourceDraggable()) {
             return;
@@ -242,6 +245,12 @@ const Sortable = Draggable.inherit({
                 }
             }
         }
+    },
+
+    _dragLeaveHandler: function(e) {
+        this.callBase.apply(this, arguments);
+
+        this._unsubscribeFromSourceScroll(e);
     },
 
     dragEnter: function() {
@@ -755,9 +764,13 @@ const Sortable = Draggable.inherit({
         return left;
     },
 
-    _movePlaceholder: function() {
+    _movePlaceholder: function(_isFromHandler) {
         const that = this;
         const $placeholderElement = that._$placeholderElement || that._createPlaceholder();
+        if(!$placeholderElement) {
+            return;
+        }
+
         const items = that._getItems();
         const toIndex = that.option('toIndex');
         const isVerticalOrientation = that._isVerticalOrientation();

--- a/testing/tests/DevExpress.ui.widgets/sortable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/sortable.tests.js
@@ -3076,8 +3076,8 @@ QUnit.module('Dragging between sortables with scroll', {
         };
 
         this.createSortable = (options) => {
-            this.$elements.forEach(($element) => {
-                this.createOneSortable(options, $element);
+            return this.$elements.map(($element) => {
+                return this.createOneSortable(options, $element);
             });
         };
     },
@@ -3138,6 +3138,45 @@ QUnit.module('Dragging between sortables with scroll', {
         assert.equal(this.$elements[1].children().length, 11, 'children count');
         assert.equal(onRemove.callCount, 1, 'onRemove call count');
         assert.equal(onAdd.callCount, 1, 'onAdd call count');
+    });
+
+    QUnit.test('Dragging between two sortables with scroll should update itemPoints (T1035958)', function(assert) {
+        // arrange
+        const done = assert.async();
+        let scrollTimes = 0;
+
+        const sortable = this.createSortable({
+            filter: '.draggable',
+            group: 'shared',
+            moveItemOnDrop: true,
+        });
+
+        $('.draggable').width(280);
+        this.$elements[0].width(280);
+        this.$elements[1].width(280);
+        this.$elements[1].height(280);
+
+        $('#bothScrolls2').css('top', 0);
+        $('#bothScrolls2').css('left', 300);
+
+        this.$scrolls[1].on('scroll', () => {
+            // assert
+            const itemPoints = sortable[1].option('itemPoints');
+
+            if(scrollTimes === 0) {
+                // first scroll event, itemPoints must be the same
+                assert.equal(itemPoints[1].top, 50);
+            } else if(scrollTimes === 1) {
+                // second scroll event, itemPoints must be the same
+                assert.equal(itemPoints[1].top, 49);
+                done();
+            }
+
+            scrollTimes++;
+        });
+
+        // act
+        pointerMock(this.$elements[0].children().eq(0)).start().down().move(300, 200).move(0, 50);
     });
 
     // T872379
@@ -3782,7 +3821,6 @@ QUnit.module('autoscroll', getModuleConfigForTestsWithScroll('#itemsWithScroll',
             done();
         });
     });
-
 });
 
 // T971119


### PR DESCRIPTION
`_subscribeToSourceScroll` was called only in `_dragStartHandler`. That means that scrollable was updating only for one-component dragging. In order to update `itemPoints` in cross-component dragging, I added `_subscribeToSourceScroll` in `_dragEnterHandler`