### PR TITLE
Events: fix `remove event` file location according to the documentation and fix firing `remove event` on disposing a node. (#20195)

### DIFF
--- a/js/animation/fx.js
+++ b/js/animation/fx.js
@@ -21,7 +21,7 @@ import {
 import { requestAnimationFrame, cancelAnimationFrame } from './frame';
 import { transitionEndEventName, transition } from '../core/utils/support';
 import positionUtils from './position';
-import { removeEvent } from '../core/remove_event';
+import { removeEvent } from '../events/remove';
 import { addNamespace } from '../events/utils/index';
 import { when, Deferred } from '../core/utils/deferred';
 const removeEventName = addNamespace(removeEvent, 'dxFX');

--- a/js/core/templates/bindable_template.js
+++ b/js/core/templates/bindable_template.js
@@ -1,7 +1,7 @@
 import $ from '../renderer';
 import { TemplateBase } from './template_base';
 import eventsEngine from '../../events/core/events_engine';
-import { removeEvent } from '../remove_event';
+import { removeEvent } from '../../events/remove';
 import { isPrimitive } from '../utils/type';
 
 const watchChanges = (function() {

--- a/js/core/utils/public_component.js
+++ b/js/core/utils/public_component.js
@@ -2,7 +2,7 @@ import { data as elementData } from '../../core/element_data';
 import eventsEngine from '../../events/core/events_engine';
 import WeakMap from '../polyfills/weak_map';
 import { isDefined } from './type';
-import { removeEvent } from '../remove_event';
+import { removeEvent } from '../../events/remove';
 
 const COMPONENT_NAMES_DATA_KEY = 'dxComponents';
 const ANONYMOUS_COMPONENT_DATA_KEY = 'dxPrivateComponent';

--- a/js/events/remove.js
+++ b/js/events/remove.js
@@ -1,7 +1,7 @@
-import $ from './renderer';
-import { beforeCleanData } from './element_data';
-import eventsEngine from '../events/core/events_engine';
-import registerEvent from '../events/core/event_registrator';
+import $ from '../core/renderer';
+import { beforeCleanData } from '../core/element_data';
+import eventsEngine from './core/events_engine';
+import registerEvent from './core/event_registrator';
 
 export const removeEvent = 'dxremove';
 const eventPropName = 'dxRemoveEvent';

--- a/js/events/utils/event_nodes_disposing.js
+++ b/js/events/utils/event_nodes_disposing.js
@@ -1,6 +1,5 @@
 import eventsEngine from '../core/events_engine';
-
-const REMOVE_EVENT_NAME = 'dxremove';
+import { removeEvent } from '../remove';
 
 function nodesByEvent(event) {
     return event && [
@@ -12,9 +11,9 @@ function nodesByEvent(event) {
 }
 
 export const subscribeNodesDisposing = (event, callback) => {
-    eventsEngine.one(nodesByEvent(event), REMOVE_EVENT_NAME, callback);
+    eventsEngine.one(nodesByEvent(event), removeEvent, callback);
 };
 
 export const unsubscribeNodesDisposing = (event, callback) => {
-    eventsEngine.off(nodesByEvent(event), REMOVE_EVENT_NAME, callback);
+    eventsEngine.off(nodesByEvent(event), removeEvent, callback);
 };

--- a/js/renovation/ui/form/_toDelete/ui.form.layout_manager.js
+++ b/js/renovation/ui/form/_toDelete/ui.form.layout_manager.js
@@ -13,7 +13,7 @@ import { each } from '../../core/utils/iterator';
 import { extend } from '../../core/utils/extend';
 import { inArray, normalizeIndexes } from '../../core/utils/array';
 import { compileGetter } from '../../core/utils/data';
-import { removeEvent } from '../../core/remove_event';
+import { removeEvent } from '../../events/remove';
 import { name as clickEventName } from '../../events/click';
 import errors from '../widget/ui.errors';
 import messageLocalization from '../../localization/message';

--- a/js/ui/form/ui.form.layout_manager.js
+++ b/js/ui/form/ui.form.layout_manager.js
@@ -10,7 +10,7 @@ import { each } from '../../core/utils/iterator';
 import { extend } from '../../core/utils/extend';
 import { normalizeIndexes } from '../../core/utils/array';
 import { compileGetter } from '../../core/utils/data';
-import { removeEvent } from '../../core/remove_event';
+import { removeEvent } from '../../events/remove';
 import messageLocalization from '../../localization/message';
 import { styleProp } from '../../core/utils/style';
 import Widget from '../widget/ui.widget';

--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -13,7 +13,7 @@ import { compileGetter } from '../../core/utils/data';
 import gridCoreUtils from './ui.grid_core.utils';
 import { ColumnsView } from './ui.grid_core.columns_view';
 import Scrollable from '../scroll_view/ui.scrollable';
-import { removeEvent } from '../../core/remove_event';
+import { removeEvent } from '../../events/remove';
 import messageLocalization from '../../localization/message';
 import browser from '../../core/utils/browser';
 import getScrollRtlBehavior from '../../core/utils/scroll_rtl_behavior';

--- a/testing/tests/DevExpress.ui.events/remove.tests.js
+++ b/testing/tests/DevExpress.ui.events/remove.tests.js
@@ -1,6 +1,6 @@
-const eventsEngine = require('events/core/events_engine');
-const $ = require('jquery');
-const { removeEvent } = require('core/remove_event');
+import $ from 'jquery';
+import eventsEngine from 'events/core/events_engine';
+import { removeEvent } from 'events/remove';
 
 QUnit.testStart(function() {
     const markup = '<div id="element"><div id="inner"></div></div>';


### PR DESCRIPTION
cherry picked from commit be917c35bb18c430c8dea40b8bbb69b4a297f52d
