### PR TITLE
DataGrid: Fix the 'E1059 - The following column names are not unique:"buttons"' error occurs when a banded column's lookup option is updated and the command column 'buttons' is specified (T1046609)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -494,7 +494,7 @@ export const columnsControllerModule = {
             };
 
             function checkUserStateColumn(column, userStateColumn) {
-                return column && userStateColumn && (userStateColumn.name === column.name || !column.name) && (userStateColumn.dataField === column.dataField || column.name);
+                return column && userStateColumn && (userStateColumn.name === (column.name || column.dataField)) && (userStateColumn.dataField === column.dataField || column.name);
             }
 
             const applyUserState = function(that) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -9620,6 +9620,33 @@ QUnit.module('Customization of the command columns', {
         assert.deepEqual(this.columnOption('TestField3', 'lookup.dataSource'), [1, 2, 3], 'lookup datasource');
     });
 
+    // T1046609
+    QUnit.test('Update dataSource of the column lookup when command column is specified', function(assert) {
+        // arrange
+        this.applyOptions({
+            columns: [
+                { type: 'buttons', buttons: ['button1', 'button2'] },
+                {
+                    caption: 'Band Column 1', columns: [
+                        { dataField: 'TestField1', caption: 'Column 1', lookup: { dataSource: [] } },
+                        { dataField: 'TestField2', caption: 'Column 2' },
+                    ]
+                }
+            ]
+        });
+
+        try {
+            // act
+            this.columnOption('TestField1', 'lookup.dataSource', [1, 2, 3]);
+
+            // assert
+            assert.deepEqual(this.columnOption('TestField1', 'lookup.dataSource'), [1, 2, 3], 'lookup datasource');
+        } catch(e) {
+            // assert
+            assert.ok(false, 'exception');
+        }
+    });
+
     // T652910
     QUnit.test('Colspan of the band column should be correct when all child columns are hidden in a nested band column', function(assert) {
         // arrange


### PR DESCRIPTION
See https://devexpress.com/issue=T1046609