### PR TITLE
DataGrid - fix export.texts

### DIFF
--- a/js/ui/data_grid/ui.data_grid.export.js
+++ b/js/ui/data_grid/ui.data_grid.export.js
@@ -738,7 +738,7 @@ dataGridCore.registerModule('export', {
                             icon: DATAGRID_EXPORT_ICON,
                             displayExpr: 'text',
                             items: items,
-                            hint: 'Export',
+                            hint: this.option('export.texts.exportTo'),
                             elementAttr: {
                                 class: DATAGRID_EXPORT_BUTTON_CLASS
                             },

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
@@ -2253,6 +2253,35 @@ QUnit.module('Export menu', {
         assert.equal($button.first().attr('title'), 'Export', 'hint of button');
     });
 
+    QUnit.test('export.texts options are used', function(assert) {
+        // arrange
+        this.setupModules({
+            'export': {
+                enabled: true,
+                allowExportSelectedData: true,
+                texts: {
+                    exportAll: 'exportAll',
+                    exportSelectedRows: 'exportSelectedRows',
+                    exportTo: 'exportTo',
+                }
+            }
+        }, true);
+
+        const $container = $('#container');
+
+        this.headerPanel.render($container);
+
+        const $button = $container.find('.dx-datagrid-export-button');
+        $button.find('.dx-button').trigger('click');
+        const $exportAllButton = $('.dx-datagrid-export-menu .dx-item:eq(0)');
+        const $exportSelectedRows = $('.dx-datagrid-export-menu .dx-item:eq(1)');
+
+        // assert
+        assert.equal($button.attr('title'), 'exportTo', 'exportTo');
+        assert.equal($exportAllButton.attr('title'), 'exportAll', 'exportAll');
+        assert.equal($exportSelectedRows.attr('title'), 'exportSelectedRows', 'exportSelectedRows');
+    });
+
     QUnit.test('Search panel should be replaced after export button', function(assert) {
         this.setupModules({
             'export': {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
@@ -2272,7 +2272,7 @@ QUnit.module('Export menu', {
         this.headerPanel.render($container);
 
         const $button = $container.find('.dx-datagrid-export-button');
-        $button.find('.dx-button').trigger('click');
+        $button.find('.dx-button').trigger('dxclick');
         const $exportAllButton = $('.dx-datagrid-export-menu .dx-item:eq(0)');
         const $exportSelectedRows = $('.dx-datagrid-export-menu .dx-item:eq(1)');
 


### PR DESCRIPTION
I forgot to use the `export.texts.exportTo` option in previous changes of export UI