### PR TITLE
DataGrid: Fix the "TypeError: Cannot read properties of undefined (reading 'key')" error occurs on an attempt to add a new record if newRowPosition is 'pageTop' or 'pageBottom' (T1048652)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -799,10 +799,12 @@ const EditingController = modules.ViewController.inherit((function() {
                 case LAST_NEW_ROW_POSITION:
                     break;
                 case PAGE_TOP_NEW_ROW_POSITION:
-                    change.insertBeforeKey = allItems[0].key;
-                    break;
                 case PAGE_BOTTOM_NEW_ROW_POSITION:
-                    change.insertAfterKey = allItems[allItems.length - 1].key;
+                    if(allItems.length) {
+                        const itemIndex = newRowPosition === PAGE_TOP_NEW_ROW_POSITION ? 0 : allItems.length - 1;
+
+                        change[itemIndex === 0 ? 'insertBeforeKey' : 'insertAfterKey'] = allItems[itemIndex].key;
+                    }
                     break;
                 default: {
                     const isViewportBottom = newRowPosition === VIEWPORT_BOTTOM_NEW_ROW_POSITION;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -20547,6 +20547,66 @@ QUnit.module('Editing - new row position', {
                 assert.strictEqual(rows.length, isVirtualScrolling ? 9 : 11, 'row count');
                 assert.ok(rows[isVirtualScrolling ? 0 : 1].isNewRow, 'new row');
             });
+
+            QUnit.test('newRowPosition = pageBottom when there are no items', function(assert) {
+                // arrange
+                const $testElement = $('#container').height(200);
+
+                this.options.height = 200;
+                this.options.dataSource.store.data = [];
+                this.options.editing.newRowPosition = 'pageBottom';
+                this.setupModules();
+                this.clock.tick();
+                this.rowsView.render($testElement);
+                this.rowsView.height(200);
+                this.rowsView.resize();
+                this.clock.tick();
+
+                // assert
+                let rows = this.getVisibleRows();
+                assert.strictEqual(this.pageIndex(), 0, 'pageIndex');
+                assert.strictEqual(rows.length, 0, 'row count');
+
+                // act
+                this.addRow();
+                this.clock.tick();
+
+                // assert
+                rows = this.getVisibleRows();
+                assert.strictEqual(this.pageIndex(), 0, 'pageIndex');
+                assert.strictEqual(rows.length, 1, 'row count');
+                assert.ok(rows[0].isNewRow, 'new row');
+            });
+
+            QUnit.test('newRowPosition = pageTop when there are no items', function(assert) {
+                // arrange
+                const $testElement = $('#container').height(200);
+
+                this.options.height = 200;
+                this.options.dataSource.store.data = [];
+                this.options.editing.newRowPosition = 'pageTop';
+                this.setupModules();
+                this.clock.tick();
+                this.rowsView.render($testElement);
+                this.rowsView.height(200);
+                this.rowsView.resize();
+                this.clock.tick();
+
+                // assert
+                let rows = this.getVisibleRows();
+                assert.strictEqual(this.pageIndex(), 0, 'pageIndex');
+                assert.strictEqual(rows.length, 0, 'row count');
+
+                // act
+                this.addRow();
+                this.clock.tick();
+
+                // assert
+                rows = this.getVisibleRows();
+                assert.strictEqual(this.pageIndex(), 0, 'pageIndex');
+                assert.strictEqual(rows.length, 1, 'row count');
+                assert.ok(rows[0].isNewRow, 'new row');
+            });
         });
     });
 });


### PR DESCRIPTION
See https://devexpress.com/issue=T1048652