### PR TITLE
Renovated Npm - Fix QUnit Build

### DIFF
--- a/build/gulp/transpile.js
+++ b/build/gulp/transpile.js
@@ -237,7 +237,7 @@ gulp.task('transpile-watch', gulp.series(
 
 gulp.task('transpile-tests', gulp.series('bundler-config', () =>
     gulp
-        .src(['testing/**/*.js'])
+        .src(['testing/**/*.js', "!testing/renovation-npm/**/*.js"])
         .pipe(babel(testsConfig))
         .pipe(gulp.dest('testing'))
 ));


### PR DESCRIPTION
Exclude renovated npm tests from transpilation task