### PR TITLE
TreeList - state(null) does not restore the initial state of the following options: expandedRowKeys, focusedRowKey, and selectedRowKeys (T1049850)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.state_storing.js
+++ b/js/ui/grid_core/ui.grid_core.state_storing.js
@@ -172,9 +172,7 @@ export const stateStoringModule = {
                         exportController.selectionOnly(state.exportSelectionOnly);
                     }
 
-                    if(selectedRowKeys) {
-                        that.option('selectedRowKeys', selectedRowKeys);
-                    }
+                    that.option('selectedRowKeys', selectedRowKeys || []);
 
                     that.option('selectionFilter', selectionFilter);
 
@@ -182,9 +180,9 @@ export const stateStoringModule = {
                         that.option('pager').allowedPageSizes = allowedPageSizes;
                     }
 
-                    if(that.option('focusedRowEnabled') && state.focusedRowKey !== undefined) {
+                    if(that.option('focusedRowEnabled')) {
                         that.option('focusedRowIndex', -1);
-                        that.option('focusedRowKey', state.focusedRowKey);
+                        that.option('focusedRowKey', state.focusedRowKey || null);
                     }
 
                     that.component.endUpdate();

--- a/js/ui/grid_core/ui.grid_core.state_storing.js
+++ b/js/ui/grid_core/ui.grid_core.state_storing.js
@@ -172,7 +172,9 @@ export const stateStoringModule = {
                         exportController.selectionOnly(state.exportSelectionOnly);
                     }
 
-                    that.option('selectedRowKeys', selectedRowKeys || []);
+                    if(!that.option('selection.deferred')) {
+                        that.option('selectedRowKeys', selectedRowKeys || []);
+                    }
 
                     that.option('selectionFilter', selectionFilter);
 

--- a/js/ui/tree_list/ui.tree_list.state_storing.js
+++ b/js/ui/tree_list/ui.tree_list.state_storing.js
@@ -9,9 +9,7 @@ treeListCore.registerModule('stateStoring', extend(true, {}, stateStoringModule,
             stateStoring: {
                 applyState: function(state) {
                     origApplyState.apply(this, arguments);
-                    if(Object.prototype.hasOwnProperty.call(state, 'expandedRowKeys')) {
-                        this.option('expandedRowKeys', state.expandedRowKeys && state.expandedRowKeys.slice());
-                    }
+                    this.option('expandedRowKeys', state.expandedRowKeys ? state.expandedRowKeys.slice() : []);
                 }
             },
             data: {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
@@ -1611,6 +1611,7 @@ QUnit.module('State Storing with real controllers', {
             'filterPanel': {},
             'filterValue': null,
             'searchText': '',
+            'selectedRowKeys': [],
             'pageIndex': 0,
             'pageSize': 20
         };
@@ -1732,6 +1733,37 @@ QUnit.module('State Storing with real controllers', {
 
             // assert
             assert.equal(this.option('searchPanel.text'), '');
+        });
+
+        QUnit.test(`focusedRowKey should be cleared after calling state(${emptyState})`, function(assert) {
+            // arrange
+            this.setupDataGridModules({
+                dataSource: [{ id: 1 }, { id: 2 }],
+                keyExpr: 'id',
+                focusedRowEnabled: true,
+                focusedRowKey: 1
+            });
+
+            // act
+            this.state(emptyState);
+
+            // assert
+            assert.strictEqual(this.option('focusedRowKey'), null);
+        });
+
+        QUnit.test(`selectedRowKeys should be cleared after calling state(${emptyState})`, function(assert) {
+            // arrange
+            this.setupDataGridModules({
+                dataSource: [{ id: 1 }, { id: 2 }],
+                keyExpr: 'id',
+                selectedRowKeys: [1, 2],
+            });
+
+            // act
+            this.state(emptyState);
+
+            // assert
+            assert.deepEqual(this.option('selectedRowKeys'), []);
         });
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.treeList/stateStoring.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/stateStoring.tests.js
@@ -154,7 +154,8 @@ QUnit.module('State Storing', {
             expandedRowKeys: [1],
             pageIndex: 0,
             pageSize: 20,
-            searchText: ''
+            searchText: '',
+            selectedRowKeys: [],
         };
         let customSaveCallCount = 0;
 
@@ -225,6 +226,22 @@ QUnit.module('State Storing', {
         assert.deepEqual(expandedRowKeys, [], 'expandedRowKeys');
         assert.deepEqual(state.expandedRowKeys, [], 'expandedRowKeys has been updated in the state storage');
         assert.notStrictEqual(state.expandedRowKeys, this.option('expandedRowKeys'), 'expandedRowKeys has a different instance in the state storage');
+    });
+
+    [null, {}].forEach(emptyState => {
+        QUnit.test(`expandedRowKeys should be cleared after calling state(${emptyState})`, function(assert) {
+            // arrange
+            this.setupDataGridModules({
+                dataSource: [{ id: 1 }, { id: 2 }],
+                expandedRowKeys: [1]
+            });
+
+            // act
+            this.state(emptyState);
+
+            // assert
+            assert.deepEqual(this.option('expandedRowKeys'), []);
+        });
     });
 });
 


### PR DESCRIPTION
Changes similar to https://github.com/DevExpress/DevExtreme/pull/20257 for options:

- `expandedRowKeys`
- `focusedRowKey`
- `selectedRowKeys`