### PR TITLE
DataGrid - Editor is not rendered in a popup form if the infinite scrolling is used and when the column's renderAsync is set to true (T1050488)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -198,6 +198,7 @@ export const editingFormBasedModule = {
                         this._$popupContent = scrollable.$content();
 
                         formTemplate(this._$popupContent, templateOptions, { renderFormOnly: true });
+                        this._rowsView.renderDelayedTemplates();
                     };
                 },
 
@@ -287,7 +288,6 @@ export const editingFormBasedModule = {
                     this._rowsView.renderTemplate($container, template, cellOptions, !!$container.closest(getWindow().document).length).done(() => {
                         this._rowsView._updateCell($container, cellOptions);
                     });
-                    this._rowsView.renderDelayedTemplates();
                     return cellOptions;
                 },
 

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -287,6 +287,7 @@ export const editingFormBasedModule = {
                     this._rowsView.renderTemplate($container, template, cellOptions, !!$container.closest(getWindow().document).length).done(() => {
                         this._rowsView._updateCell($container, cellOptions);
                     });
+                    this._rowsView.renderDelayedTemplates();
                     return cellOptions;
                 },
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -3184,6 +3184,32 @@ QUnit.module('Editing', baseModuleConfig, () => {
         // assert
         assert.equal(idCallCount, 200, 'key call count after paging');
     });
+
+    QUnit.test('Popup should render editor if columns[].renderAsync option is true)', function(assert) {
+        createDataGrid({
+            dataSource: [
+                { id: 1, field1: 'test11', field2: 'test12' },
+            ],
+            columns: [{
+                dataField: 'field1',
+                renderAsync: true,
+                width: 100,
+            }],
+            editing: {
+                mode: 'popup',
+                allowUpdating: true,
+            },
+        });
+        this.clock.tick();
+
+        // act
+        $('.dx-link-edit').trigger('click');
+        this.clock.tick();
+
+        // assert
+        const $textBox = $('.dx-textbox');
+        assert.equal($textBox.length, 1);
+    });
 });
 
 QUnit.module('Validation with virtual scrolling and rendering', {


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/20512