### PR TITLE
Use devextreme-internal-tools ^7.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "cssom": "^0.4.4",
         "del": "^2.2.2",
         "devextreme-cldr-data": "^1.0.2",
-        "devextreme-internal-tools": "^7.5.0",
+        "devextreme-internal-tools": "^7.6.0",
         "devextreme-screenshot-comparer": "^2.0.9",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.2",
@@ -8160,9 +8160,9 @@
       "dev": true
     },
     "node_modules/devextreme-internal-tools": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-7.5.0.tgz",
-      "integrity": "sha512-zWdsMbNsd5AhHxk/XxMJ3Mq/36lx7qksIj9TYCGoptJf+PLqZvu47Yr3dJAon3ekegFeiep7EEjGgTzmn2HAJw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-7.6.0.tgz",
+      "integrity": "sha512-UR99YRBO54pBxZE4TGABO8zSFoyB/xUNi9TYRqYVpqnyORLymsKolXBw9Ho/Aqha6ATOPVAjh0TXysYWhQndKg==",
       "dev": true,
       "dependencies": {
         "prettier": "2.3.2",
@@ -37668,9 +37668,9 @@
       "dev": true
     },
     "devextreme-internal-tools": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-7.5.0.tgz",
-      "integrity": "sha512-zWdsMbNsd5AhHxk/XxMJ3Mq/36lx7qksIj9TYCGoptJf+PLqZvu47Yr3dJAon3ekegFeiep7EEjGgTzmn2HAJw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-7.6.0.tgz",
+      "integrity": "sha512-UR99YRBO54pBxZE4TGABO8zSFoyB/xUNi9TYRqYVpqnyORLymsKolXBw9Ho/Aqha6ATOPVAjh0TXysYWhQndKg==",
       "dev": true,
       "requires": {
         "prettier": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "cssom": "^0.4.4",
     "del": "^2.2.2",
     "devextreme-cldr-data": "^1.0.2",
-    "devextreme-internal-tools": "^7.5.0",
+    "devextreme-internal-tools": "^7.6.0",
     "devextreme-screenshot-comparer": "^2.0.9",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",


### PR DESCRIPTION
devextreme-internal-tools 7.6.0 handle unknown type properly, while devextreme-internal-tools 7.5 fails on unknown.
