### PR TITLE
Fix DataSource's store prop typings

### DIFF
--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -1,12 +1,15 @@
 import {
- FilterDescriptor, GroupDescriptor, SelectDescriptor, SortDescriptor, LoadOptions, SearchOperation,
+ FilterDescriptor,
+ GroupDescriptor,
+ LoadOptions,
+ SearchOperation,
+ SelectDescriptor,
+ SortDescriptor,
+ Store,
+ StoreOptions,
 } from './index';
 import { DxPromise } from '../core/utils/deferred';
-import Store from './abstract_store';
 import { Options as CustomStoreOptions } from './custom_store';
-import { Options as ArrayStoreOptions } from './array_store';
-import { Options as LocalStoreOptions } from './local_store';
-import { Options as ODataStoreOptions } from './odata/store';
 
 /** @public */
 export type Options<
@@ -147,12 +150,7 @@ export interface DataSourceOptions<
      * @public
      * @type Store|StoreOptions|Array<any>
      */
-    store?: Array<TStoreItem> |
-        Store<TStoreItem, TKey> |
-        ArrayStoreOptions<TStoreItem, TKey> & { type: 'array' } |
-        LocalStoreOptions<TStoreItem, TKey> & { type: 'local' } |
-        ODataStoreOptions<TStoreItem, TKey> & { type: 'odata' } |
-        CustomStoreOptions<TStoreItem, TKey>;
+    store?: Array<TStoreItem> | Store<TStoreItem, TKey> | StoreOptions<TStoreItem, TKey>;
 }
 /**
  * @docid

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -460,10 +460,7 @@ export type DataSourceLike<TItem, TKey = any> =
     sort?: SortDescriptor<TItem> | Array<SortDescriptor<TItem>>;
     store?: Array<TStoreItem> |
         Store<TStoreItem, any> |
-        ArrayStoreOptions<TStoreItem, any> & { type: 'array' } |
-        LocalStoreOptions<TStoreItem, any> & { type: 'local' } |
-        ODataStoreOptions<TStoreItem, any> & { type: 'odata' } |
-        CustomStoreOptions<TStoreItem, any>;
+        StoreOptions<TStoreItem, any>;
 }
 
 type EventName = 'changed' | 'loadError' | 'loadingChanged';

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -434,7 +434,7 @@ export type DataSourceLike<TItem, TKey = any> =
     DataSourceOptionsStub<any, any, TItem> |
     DataSource<TItem, TKey>;
 
-    interface DataSourceOptionsStub<
+interface DataSourceOptionsStub<
     TStoreItem = any,
     TMappedItem = TStoreItem,
     TItem = TMappedItem,
@@ -458,9 +458,7 @@ export type DataSourceLike<TItem, TKey = any> =
     searchValue?: any;
     select?: SelectDescriptor<TItem>;
     sort?: SortDescriptor<TItem> | Array<SortDescriptor<TItem>>;
-    store?: Array<TStoreItem> |
-        Store<TStoreItem, any> |
-        StoreOptions<TStoreItem, any>;
+    store?: Array<TStoreItem> | Store<TStoreItem, any> | StoreOptions<TStoreItem, any>;
 }
 
 type EventName = 'changed' | 'loadError' | 'loadingChanged';

--- a/js/data/index.d.ts
+++ b/js/data/index.d.ts
@@ -153,14 +153,20 @@ export type SummaryDescriptor<T> = KeySelector<T> | BaseGroupDescriptor<T> & {
     userData?: any;
 }
 
-/** @public */
+/**
+ * @public
+ * @namespace DevExpress.data.utils
+ */
 export type Store<TItem = any, TKey = any> =
     CustomStore<TItem, TKey> |
     ArrayStore<TItem, TKey> |
     LocalStore<TItem, TKey> |
     ODataStore<TItem, TKey>;
 
-/** @public */
+/**
+ * @public
+ * @namespace DevExpress.data.utils
+ */
 export type StoreOptions<TItem = any, TKey = any> =
     CustomStoreOptions<TItem, TKey> |
     ArrayStoreOptions<TItem, TKey> & { type: 'array' } |

--- a/js/data/index.d.ts
+++ b/js/data/index.d.ts
@@ -1,3 +1,8 @@
+import CustomStore, { Options as CustomStoreOptions } from './custom_store';
+import ArrayStore, { Options as ArrayStoreOptions } from './array_store';
+import LocalStore, { Options as LocalStoreOptions } from './local_store';
+import ODataStore, { Options as ODataStoreOptions } from './odata/store';
+
 /**
  * @docid
  * @public
@@ -147,3 +152,17 @@ export type SummaryDescriptor<T> = KeySelector<T> | BaseGroupDescriptor<T> & {
      */
     userData?: any;
 }
+
+/** @public */
+export type Store<TItem = any, TKey = any> =
+    CustomStore<TItem, TKey> |
+    ArrayStore<TItem, TKey> |
+    LocalStore<TItem, TKey> |
+    ODataStore<TItem, TKey>;
+
+/** @public */
+export type StoreOptions<TItem = any, TKey = any> =
+    CustomStoreOptions<TItem, TKey> |
+    ArrayStoreOptions<TItem, TKey> & { type: 'array' } |
+    LocalStoreOptions<TItem, TKey> & { type: 'local' } |
+    ODataStoreOptions<TItem, TKey> & { type: 'odata' };

--- a/js/ui/pivot_grid/data_source.d.ts
+++ b/js/ui/pivot_grid/data_source.d.ts
@@ -2,9 +2,10 @@ import {
     DxPromise,
 } from '../../core/utils/deferred';
 
-import Store, {
-    Options as StoreOptions,
-} from '../../data/abstract_store';
+import {
+    Store,
+    StoreOptions,
+} from '../../data/index';
 
 import DataSource from '../../data/data_source';
 
@@ -196,7 +197,7 @@ export interface PivotGridDataSourceOptions {
      * @docid
      * @public
      */
-    store?: Store | StoreOptions | XmlaStore | XmlaStoreOptions | Array<{
+    store?: Store | StoreOptions | XmlaStore | (XmlaStoreOptions & { type: 'xmla' }) | Array<{
       /**
        * @docid
        * @type Enums.PivotGridStoreType

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1909,16 +1909,7 @@ declare module DevExpress.data {
       store?:
         | Array<TStoreItem>
         | Store<TStoreItem, any>
-        | (DevExpress.data.ArrayStore.Options<TStoreItem, any> & {
-            type: 'array';
-          })
-        | (DevExpress.data.LocalStore.Options<TStoreItem, any> & {
-            type: 'local';
-          })
-        | (DevExpress.data.ODataStore.Options<TStoreItem, any> & {
-            type: 'odata';
-          })
-        | DevExpress.data.CustomStore.Options<TStoreItem, any>;
+        | StoreOptions<TStoreItem, any>;
     }
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
@@ -2023,16 +2014,7 @@ declare module DevExpress.data {
     store?:
       | Array<TStoreItem>
       | Store<TStoreItem, TKey>
-      | (DevExpress.data.ArrayStore.Options<TStoreItem, TKey> & {
-          type: 'array';
-        })
-      | (DevExpress.data.LocalStore.Options<TStoreItem, TKey> & {
-          type: 'local';
-        })
-      | (DevExpress.data.ODataStore.Options<TStoreItem, TKey> & {
-          type: 'odata';
-        })
-      | DevExpress.data.CustomStore.Options<TStoreItem, TKey>;
+      | StoreOptions<TStoreItem, TKey>;
   }
   /**
    * [descr:EdmLiteral]
@@ -2776,9 +2758,9 @@ declare module DevExpress.data {
      */
     store?:
       | Store
-      | DevExpress.data.Store.Options
+      | StoreOptions
       | XmlaStore
-      | XmlaStoreOptions
+      | (XmlaStoreOptions & { type: 'xmla' })
       | Array<{
           /**
            * [descr:PivotGridDataSourceOptions.store.type]
@@ -2927,65 +2909,112 @@ declare module DevExpress.data {
    * [descr:SortDescriptor]
    */
   export type SortDescriptor<T> = GroupDescriptor<T>;
+  export type Store<TItem = any, TKey = any> =
+    | CustomStore<TItem, TKey>
+    | ArrayStore<TItem, TKey>
+    | LocalStore<TItem, TKey>
+    | ODataStore<TItem, TKey>;
   /**
-   * [descr:Store]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+   * @docid
+   * @hidden
+   * @namespace DevExpress.data
    */
   export class Store<TItem = any, TKey = any> {
     constructor(options?: DevExpress.data.Store.Options<TItem, TKey>);
     /**
-     * [descr:Store.byKey(key)]
+     * @docid
+     * @publicName byKey(key)
+     * @param1 key:object|string|number
+     * @param2 extraOptions:LoadOptions
+     * @return Promise<any>
+     * @public
      */
     byKey(
       key: TKey,
       extraOptions?: LoadOptions<TItem>
     ): DevExpress.core.utils.DxPromise<TItem>;
     /**
-     * [descr:Store.insert(values)]
+     * @docid
+     * @publicName insert(values)
+     * @param1 values:object
+     * @return Promise<any>
+     * @public
      */
     insert(values: TItem): DevExpress.core.utils.DxPromise<TItem>;
     /**
-     * [descr:Store.key()]
+     * @docid
+     * @publicName key()
+     * @public
      */
     key(): string | Array<string>;
     /**
-     * [descr:Store.keyOf(obj)]
+     * @docid
+     * @publicName keyOf(obj)
+     * @param1 obj:object
+     * @return any|string|number
+     * @public
      */
     keyOf(obj: TItem): TKey;
     /**
-     * [descr:Store.load()]
+     * @docid
+     * @publicName load()
+     * @return Promise<any>
+     * @public
      */
     load(): DevExpress.core.utils.DxPromise<Array<TItem>>;
     /**
-     * [descr:Store.load(options)]
+     * @docid
+     * @publicName load(options)
+     * @param1 options:LoadOptions
+     * @return Promise<any>
+     * @public
      */
     load(
       options: LoadOptions<TItem>
     ): DevExpress.core.utils.DxPromise<Array<TItem>>;
     /**
-     * [descr:Store.off(eventName)]
+     * @docid
+     * @publicName off(eventName)
+     * @param1 eventName:string
+     * @return this
+     * @public
      */
     off(eventName: DevExpress.data.Store.EventName): this;
     /**
-     * [descr:Store.off(eventName, eventHandler)]
+     * @docid
+     * @publicName off(eventName, eventHandler)
+     * @param1 eventName:string
+     * @return this
+     * @public
      */
     off(
       eventName: DevExpress.data.Store.EventName,
       eventHandler: Function
     ): this;
     /**
-     * [descr:Store.on(eventName, eventHandler)]
+     * @docid
+     * @publicName on(eventName, eventHandler)
+     * @param1 eventName:string
+     * @return this
+     * @public
      */
     on(
       eventName: DevExpress.data.Store.EventName,
       eventHandler: Function
     ): this;
     /**
-     * [descr:Store.on(events)]
+     * @docid
+     * @publicName on(events)
+     * @param1 events:object
+     * @return this
+     * @public
      */
     on(events: { [key in DevExpress.data.Store.EventName]?: Function }): this;
     /**
-     * [descr:Store.push(changes)]
+     * @docid
+     * @publicName push(changes)
+     * @param1 changes:Array<any>
+     * @public
      */
     push(
       changes: Array<{
@@ -2996,18 +3025,32 @@ declare module DevExpress.data {
       }>
     ): void;
     /**
-     * [descr:Store.remove(key)]
+     * @docid
+     * @publicName remove(key)
+     * @param1 key:object|string|number
+     * @return Promise<void>
+     * @public
      */
     remove(key: TKey): DevExpress.core.utils.DxPromise<void>;
     /**
-     * [descr:Store.totalCount(options)]
+     * @docid
+     * @publicName totalCount(options)
+     * @param1_field1 filter:object
+     * @param1_field2 group:object
+     * @return Promise<number>
+     * @public
      */
     totalCount(obj: {
       filter?: FilterDescriptor | Array<FilterDescriptor>;
       group?: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>;
     }): DevExpress.core.utils.DxPromise<number>;
     /**
-     * [descr:Store.update(key, values)]
+     * @docid
+     * @publicName update(key, values)
+     * @param1 key:object|string|number
+     * @param2 values:object
+     * @return Promise<any>
+     * @public
      */
     update(
       key: TKey,
@@ -3093,6 +3136,12 @@ declare module DevExpress.data {
      */
     onUpdating?: (key: TKey, values: TItem) => void;
   }
+  /** @public */
+  export type StoreOptions<TItem = any, TKey = any> =
+    | DevExpress.data.CustomStore.Options<TItem, TKey>
+    | (DevExpress.data.ArrayStore.Options<TItem, TKey> & { type: 'array' })
+    | (DevExpress.data.LocalStore.Options<TItem, TKey> & { type: 'local' })
+    | (DevExpress.data.ODataStore.Options<TItem, TKey> & { type: 'odata' });
   /**
    * [descr:SummaryDescriptor]
    */

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1703,7 +1703,7 @@ declare module DevExpress.data {
         | DevExpress.data.CustomStore.Options<TItem, TKey>
         | DevExpress.data.DataSource.Options<any, any, TItem, TKey>
     );
-    constructor(store: Store<TItem, TKey>);
+    constructor(store: DevExpress.data.utils.Store<TItem, TKey>);
     constructor(url: string);
     /**
      * [descr:DataSource.cancel(operationId)]
@@ -1862,7 +1862,7 @@ declare module DevExpress.data {
     /**
      * [descr:DataSource.store()]
      */
-    store(): Store<TItem, TKey>;
+    store(): DevExpress.data.utils.Store<TItem, TKey>;
     /**
      * [descr:DataSource.totalCount()]
      */
@@ -1876,7 +1876,7 @@ declare module DevExpress.data {
     export type DataSourceLike<TItem, TKey = any> =
       | string
       | Array<TItem>
-      | Store<TItem, TKey>
+      | DevExpress.data.utils.Store<TItem, TKey>
       | DataSourceOptionsStub<any, any, TItem>
       | DataSource<TItem, TKey>;
     /**
@@ -1908,8 +1908,8 @@ declare module DevExpress.data {
       sort?: SortDescriptor<TItem> | Array<SortDescriptor<TItem>>;
       store?:
         | Array<TStoreItem>
-        | Store<TStoreItem, any>
-        | StoreOptions<TStoreItem, any>;
+        | DevExpress.data.utils.Store<TStoreItem, any>
+        | DevExpress.data.utils.StoreOptions<TStoreItem, any>;
     }
     /**
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
@@ -2013,8 +2013,8 @@ declare module DevExpress.data {
      */
     store?:
       | Array<TStoreItem>
-      | Store<TStoreItem, TKey>
-      | StoreOptions<TStoreItem, TKey>;
+      | DevExpress.data.utils.Store<TStoreItem, TKey>
+      | DevExpress.data.utils.StoreOptions<TStoreItem, TKey>;
   }
   /**
    * [descr:EdmLiteral]
@@ -2757,8 +2757,8 @@ declare module DevExpress.data {
      * [descr:PivotGridDataSourceOptions.store]
      */
     store?:
-      | Store
-      | StoreOptions
+      | DevExpress.data.utils.Store
+      | DevExpress.data.utils.StoreOptions
       | XmlaStore
       | (XmlaStoreOptions & { type: 'xmla' })
       | Array<{
@@ -2909,112 +2909,65 @@ declare module DevExpress.data {
    * [descr:SortDescriptor]
    */
   export type SortDescriptor<T> = GroupDescriptor<T>;
-  export type Store<TItem = any, TKey = any> =
-    | CustomStore<TItem, TKey>
-    | ArrayStore<TItem, TKey>
-    | LocalStore<TItem, TKey>
-    | ODataStore<TItem, TKey>;
   /**
-   * @docid
-   * @hidden
-   * @namespace DevExpress.data
+   * [descr:Store]
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export class Store<TItem = any, TKey = any> {
     constructor(options?: DevExpress.data.Store.Options<TItem, TKey>);
     /**
-     * @docid
-     * @publicName byKey(key)
-     * @param1 key:object|string|number
-     * @param2 extraOptions:LoadOptions
-     * @return Promise<any>
-     * @public
+     * [descr:Store.byKey(key)]
      */
     byKey(
       key: TKey,
       extraOptions?: LoadOptions<TItem>
     ): DevExpress.core.utils.DxPromise<TItem>;
     /**
-     * @docid
-     * @publicName insert(values)
-     * @param1 values:object
-     * @return Promise<any>
-     * @public
+     * [descr:Store.insert(values)]
      */
     insert(values: TItem): DevExpress.core.utils.DxPromise<TItem>;
     /**
-     * @docid
-     * @publicName key()
-     * @public
+     * [descr:Store.key()]
      */
     key(): string | Array<string>;
     /**
-     * @docid
-     * @publicName keyOf(obj)
-     * @param1 obj:object
-     * @return any|string|number
-     * @public
+     * [descr:Store.keyOf(obj)]
      */
     keyOf(obj: TItem): TKey;
     /**
-     * @docid
-     * @publicName load()
-     * @return Promise<any>
-     * @public
+     * [descr:Store.load()]
      */
     load(): DevExpress.core.utils.DxPromise<Array<TItem>>;
     /**
-     * @docid
-     * @publicName load(options)
-     * @param1 options:LoadOptions
-     * @return Promise<any>
-     * @public
+     * [descr:Store.load(options)]
      */
     load(
       options: LoadOptions<TItem>
     ): DevExpress.core.utils.DxPromise<Array<TItem>>;
     /**
-     * @docid
-     * @publicName off(eventName)
-     * @param1 eventName:string
-     * @return this
-     * @public
+     * [descr:Store.off(eventName)]
      */
     off(eventName: DevExpress.data.Store.EventName): this;
     /**
-     * @docid
-     * @publicName off(eventName, eventHandler)
-     * @param1 eventName:string
-     * @return this
-     * @public
+     * [descr:Store.off(eventName, eventHandler)]
      */
     off(
       eventName: DevExpress.data.Store.EventName,
       eventHandler: Function
     ): this;
     /**
-     * @docid
-     * @publicName on(eventName, eventHandler)
-     * @param1 eventName:string
-     * @return this
-     * @public
+     * [descr:Store.on(eventName, eventHandler)]
      */
     on(
       eventName: DevExpress.data.Store.EventName,
       eventHandler: Function
     ): this;
     /**
-     * @docid
-     * @publicName on(events)
-     * @param1 events:object
-     * @return this
-     * @public
+     * [descr:Store.on(events)]
      */
     on(events: { [key in DevExpress.data.Store.EventName]?: Function }): this;
     /**
-     * @docid
-     * @publicName push(changes)
-     * @param1 changes:Array<any>
-     * @public
+     * [descr:Store.push(changes)]
      */
     push(
       changes: Array<{
@@ -3025,32 +2978,18 @@ declare module DevExpress.data {
       }>
     ): void;
     /**
-     * @docid
-     * @publicName remove(key)
-     * @param1 key:object|string|number
-     * @return Promise<void>
-     * @public
+     * [descr:Store.remove(key)]
      */
     remove(key: TKey): DevExpress.core.utils.DxPromise<void>;
     /**
-     * @docid
-     * @publicName totalCount(options)
-     * @param1_field1 filter:object
-     * @param1_field2 group:object
-     * @return Promise<number>
-     * @public
+     * [descr:Store.totalCount(options)]
      */
     totalCount(obj: {
       filter?: FilterDescriptor | Array<FilterDescriptor>;
       group?: GroupDescriptor<TItem> | Array<GroupDescriptor<TItem>>;
     }): DevExpress.core.utils.DxPromise<number>;
     /**
-     * @docid
-     * @publicName update(key, values)
-     * @param1 key:object|string|number
-     * @param2 values:object
-     * @return Promise<any>
-     * @public
+     * [descr:Store.update(key, values)]
      */
     update(
       key: TKey,
@@ -3136,12 +3075,6 @@ declare module DevExpress.data {
      */
     onUpdating?: (key: TKey, values: TItem) => void;
   }
-  /** @public */
-  export type StoreOptions<TItem = any, TKey = any> =
-    | DevExpress.data.CustomStore.Options<TItem, TKey>
-    | (DevExpress.data.ArrayStore.Options<TItem, TKey> & { type: 'array' })
-    | (DevExpress.data.LocalStore.Options<TItem, TKey> & { type: 'local' })
-    | (DevExpress.data.ODataStore.Options<TItem, TKey> & { type: 'odata' });
   /**
    * [descr:SummaryDescriptor]
    */
@@ -3197,6 +3130,16 @@ declare module DevExpress.data.utils {
    * [descr:Utils.compileSetter(expr)]
    */
   export function compileSetter(expr: string | Array<string>): Function;
+  export type Store<TItem = any, TKey = any> =
+    | CustomStore<TItem, TKey>
+    | ArrayStore<TItem, TKey>
+    | LocalStore<TItem, TKey>
+    | ODataStore<TItem, TKey>;
+  export type StoreOptions<TItem = any, TKey = any> =
+    | DevExpress.data.CustomStore.Options<TItem, TKey>
+    | (DevExpress.data.ArrayStore.Options<TItem, TKey> & { type: 'array' })
+    | (DevExpress.data.LocalStore.Options<TItem, TKey> & { type: 'local' })
+    | (DevExpress.data.ODataStore.Options<TItem, TKey> & { type: 'odata' });
 }
 declare module DevExpress.data.utils.odata {
   /**


### PR DESCRIPTION
## Description
This removes using internal abstract store class from public types. I've added `Store` - a union of all available stores. As it has the same name as abstract `Store` I have to move it to the `DevExpress.data.utils` namespace (any better ideas?). The same for the `StoreOptions`

Besides hiding internal type, this fixes issue with narrowing store type: https://github.com/DevExpress/DevExtreme/issues/17885#issuecomment-1002101219

## Cherry-picks
- #20807