### PR TITLE
DataSource: delete _delayedLoadTask on disposing

### DIFF
--- a/js/data/data_source/data_source.js
+++ b/js/data/data_source/data_source.js
@@ -158,12 +158,12 @@ export const DataSource = Class.inherit({
         this._eventsStrategy.dispose();
         clearTimeout(this._aggregationTimeoutId);
 
+        this._delayedLoadTask?.abort();
+        this._operationManager.cancelAll();
+
         delete this._store;
         delete this._items;
-
-        this._delayedLoadTask?.abort();
-
-        this._operationManager.cancelAll();
+        delete this._delayedLoadTask;
 
         this._disposed = true;
     },

--- a/testing/tests/DevExpress.data/dataSource.tests.js
+++ b/testing/tests/DevExpress.data/dataSource.tests.js
@@ -1320,6 +1320,26 @@ QUnit.test('items should be deleted on dataSource disposing(T1045202)', function
     });
 });
 
+QUnit.test('_dalayedLoadTask should be deleted on dataSource disposing(T1045202)', function(assert) {
+    this.clock = sinon.useFakeTimers();
+    const source = new DataSource({
+        store: TEN_NUMBERS,
+    });
+
+    source.on('customizeStoreLoadOptions', function(options) {
+        options.delay = 5;
+    });
+
+    source.load();
+    this.clock.tick(4);
+
+    assert.notEqual(source._delayedLoadTask, undefined);
+    source.dispose();
+    assert.equal(source._delayedLoadTask, undefined);
+
+    this.clock.restore();
+});
+
 QUnit.module('Changing store load options', moduleConfig);
 
 QUnit.test('sort', function(assert) {


### PR DESCRIPTION
When `dataSource` loads data with delay (`loadOperation.delay` ), `_items` value saved by a chain of links starting with `_delayedLoadTask`. 
In this case it is not enough to delete only `_items` at `dataSource.dispose`, but  it needs to delete `_delayedLoadTask` too.