### PR TITLE
DataGrid - width becomes incorrect on an attempt to expand a detail row if an error row is visible in the first record (T1058684)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_view.js
+++ b/js/ui/grid_core/ui.grid_core.columns_view.js
@@ -32,6 +32,7 @@ const ROW_CLASS = 'dx-row';
 const GROUP_ROW_CLASS = 'dx-group-row';
 const DETAIL_ROW_CLASS = 'dx-master-detail-row';
 const FILTER_ROW_CLASS = 'filter-row';
+const ERROR_ROW_CLASS = 'dx-error-row';
 const CELL_UPDATED_ANIMATION_CLASS = 'cell-updated-animation';
 
 const HIDDEN_COLUMNS_WIDTH = '0.0001px';
@@ -903,7 +904,7 @@ export const ColumnsView = modules.View.inherit(columnStateMixin).inherit({
             for(let i = 0; i < $rows.length; i++) {
                 const $row = $rows.eq(i);
                 const isRowVisible = $row.get(0).style.display !== 'none' && !$row.hasClass('dx-state-invisible');
-                if(!$row.is('.' + GROUP_ROW_CLASS) && !$row.is('.' + DETAIL_ROW_CLASS) && isRowVisible) {
+                if(!$row.is('.' + GROUP_ROW_CLASS) && !$row.is('.' + DETAIL_ROW_CLASS) && !$row.is('.' + ERROR_ROW_CLASS) && isRowVisible) {
                     $cells = $row.children('td');
                     break;
                 }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsView.tests.js
@@ -99,6 +99,14 @@ QUnit.module('API methods', {
         assert.deepEqual(this.columnsView.getColumnWidths(), this.widths);
     });
 
+    QUnit.test('Get column widths with error row (editForm) (T1058684)', function(assert) {
+        // arrange
+        this.columnsView.element().find('table').prepend($('<tr class="dx-error-row"><td></td><td></td></tr><tr><td></td><td></td><td></td><td></td><td></td></tr>'));
+
+        // act, assert
+        assert.deepEqual(this.columnsView.getColumnWidths(), this.widths);
+    });
+
     QUnit.test('Set column widths', function(assert) {
         // arrange
         const that = this;


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/20825