### PR TITLE
Add sideEffect modules validation (T1054272)

### DIFF
--- a/build/gulp/transpile.js
+++ b/build/gulp/transpile.js
@@ -164,7 +164,7 @@ const transpileEsm = (dist) => gulp.series.apply(gulp, [
             if (chunk.isNull())
                 return callback(null, chunk);
             searchSideEffectModules(chunk.path, sideEffectModulesSet); 
-            callback(null, chunk);
+            callback();
         })),
     () => gulp
         .src(esmTranspileSrc)

--- a/build/gulp/transpile.js
+++ b/build/gulp/transpile.js
@@ -160,11 +160,11 @@ const transpileEsm = (dist) => gulp.series.apply(gulp, [
     ]),
     () => gulp
         .src(esmTranspileSrc)
-        .pipe(flatMap((stream, file) => {
-            // NOTE: flatmap thinks that the 'js/viz/vector_map.utils' folder is a file.
-            if(file.extname === '.utils') return stream;
-            searchSideEffectModules(file.path, sideEffectModulesSet);          
-            return stream;
+        .pipe(through2.obj((chunk, enc, callback) => {
+            if (chunk.isNull())
+                return callback(null, chunk);
+            searchSideEffectModules(chunk.path, sideEffectModulesSet); 
+            callback(null, chunk);
         })),
     () => gulp
         .src(esmTranspileSrc)

--- a/build/gulp/transpile.js
+++ b/build/gulp/transpile.js
@@ -55,7 +55,12 @@ const generatedTs = [
 
 const bundlesSrc = ['js/bundles/**/*.js'];
 
-const sideEffectModulesSet = new Set();
+const sideEffectModulesSet = new Set([
+    path.join(srcDir, '/localization/globalize/currency'),
+    path.join(srcDir, '/localization/globalize/date'),
+    path.join(srcDir, '/localization/globalize/message'),
+    path.join(srcDir, '/localization/globalize/number')
+]);
 
 const searchSideEffectModules = (filePath, modules) => {
     const content = fs.readFileSync(filePath);


### PR DESCRIPTION
All modules in DevExtreme package have property `side Effects` with `false` value. But we use several modules in our components for side effects only. For example, `import './ui.data_grid.editing';` in `ui.data_grid.js`. It leads  to skipping modules by `tree shaking`. 