### PR TITLE
DropDownLists - Stop using composition events to detect IME input for Android devices (T1058956)

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -667,7 +667,6 @@ const DropDownList = DropDownEditor.inherit({
                     this._isTextCompositionInProgress(undefined);
                     this._searchHandler(e, this._searchValue());
                 });
-
             }
         }
     },

--- a/js/ui/drop_down_editor/ui.drop_down_list.js
+++ b/js/ui/drop_down_editor/ui.drop_down_list.js
@@ -31,6 +31,8 @@ const SEARCH_EVENT = 'input';
 
 const SEARCH_MODES = ['startswith', 'contains', 'endwith', 'notcontains'];
 
+const useCompositionEvents = devices.real().platform !== 'android';
+
 const DropDownList = DropDownEditor.inherit({
 
     _supportedKeys: function() {
@@ -659,11 +661,14 @@ const DropDownList = DropDownEditor.inherit({
 
         if(this._shouldRenderSearchEvent()) {
             eventsEngine.on(this._input(), this._getSearchEvent(), (e) => { this._searchHandler(e); });
-            eventsEngine.on(this._input(), this._getCompositionStartEvent(), () => { this._isTextCompositionInProgress(true); });
-            eventsEngine.on(this._input(), this._getCompositionEndEvent(), (e) => {
-                this._isTextCompositionInProgress(undefined);
-                this._searchHandler(e, this._searchValue());
-            });
+            if(useCompositionEvents) {
+                eventsEngine.on(this._input(), this._getCompositionStartEvent(), () => { this._isTextCompositionInProgress(true); });
+                eventsEngine.on(this._input(), this._getCompositionEndEvent(), (e) => {
+                    this._isTextCompositionInProgress(undefined);
+                    this._searchHandler(e, this._searchValue());
+                });
+
+            }
         }
     },
 
@@ -674,8 +679,10 @@ const DropDownList = DropDownEditor.inherit({
     _refreshEvents: function() {
         eventsEngine.off(this._input(), this._getSearchEvent());
         eventsEngine.off(this._input(), this._getSetFocusPolicyEvent());
-        eventsEngine.off(this._input(), this._getCompositionStartEvent());
-        eventsEngine.off(this._input(), this._getCompositionEndEvent());
+        if(useCompositionEvents) {
+            eventsEngine.off(this._input(), this._getCompositionStartEvent());
+            eventsEngine.off(this._input(), this._getCompositionEndEvent());
+        }
 
         this.callBase();
     },

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -711,14 +711,17 @@ QUnit.module('items & dataSource', moduleConfig, () => {
         });
 
         QUnit.test('should not search if composition is in progress (T1003899)', function(assert) {
-            const expectedResult = devices.real().platform === 'android' ? 0 : 2;
+            if(devices.real().platform === 'android') {
+                assert.expect(0);
+                return;
+            }
             this.$input.trigger($.Event('compositionstart'));
             this.keyboard.type('ㅇ');
             this.clock.tick(TIME_TO_WAIT);
             this.keyboard.type('ㅡ');
             this.clock.tick(TIME_TO_WAIT);
 
-            assert.strictEqual(this.getListItemsCount(), expectedResult, 'was no search');
+            assert.strictEqual(this.getListItemsCount(), 2, 'was no search');
         });
 
         QUnit.test('should not cancel search on input if composition is in progress', function(assert) {
@@ -731,7 +734,10 @@ QUnit.module('items & dataSource', moduleConfig, () => {
         });
 
         QUnit.test('should not get composite characters as search value when compositionend is raised because of next composition start', function(assert) {
-            const expectedResult = devices.real().platform === 'android' ? 0 : 1;
+            if(devices.real().platform === 'android') {
+                assert.expect(0);
+                return;
+            }
             this.$input.trigger($.Event('compositionstart'));
             this.keyboard.type('ㅏ');
             this.$input.trigger($.Event('compositionend'));
@@ -739,7 +745,7 @@ QUnit.module('items & dataSource', moduleConfig, () => {
             this.keyboard.type('ㅇ');
             this.clock.tick(TIME_TO_WAIT);
 
-            assert.strictEqual(this.getListItemsCount(), expectedResult, 'last input composite character is not in search value');
+            assert.strictEqual(this.getListItemsCount(), 1, 'last input composite character is not in search value');
         });
 
         QUnit.test('should search if composition is finished', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -711,13 +711,14 @@ QUnit.module('items & dataSource', moduleConfig, () => {
         });
 
         QUnit.test('should not search if composition is in progress (T1003899)', function(assert) {
+            const expectedResult = devices.real().platform === 'android' ? 0 : 2;
             this.$input.trigger($.Event('compositionstart'));
             this.keyboard.type('ㅇ');
             this.clock.tick(TIME_TO_WAIT);
             this.keyboard.type('ㅡ');
             this.clock.tick(TIME_TO_WAIT);
 
-            assert.strictEqual(this.getListItemsCount(), 2, 'was no search');
+            assert.strictEqual(this.getListItemsCount(), expectedResult, 'was no search');
         });
 
         QUnit.test('should not cancel search on input if composition is in progress', function(assert) {
@@ -730,6 +731,7 @@ QUnit.module('items & dataSource', moduleConfig, () => {
         });
 
         QUnit.test('should not get composite characters as search value when compositionend is raised because of next composition start', function(assert) {
+            const expectedResult = devices.real().platform === 'android' ? 0 : 1;
             this.$input.trigger($.Event('compositionstart'));
             this.keyboard.type('ㅏ');
             this.$input.trigger($.Event('compositionend'));
@@ -737,7 +739,7 @@ QUnit.module('items & dataSource', moduleConfig, () => {
             this.keyboard.type('ㅇ');
             this.clock.tick(TIME_TO_WAIT);
 
-            assert.strictEqual(this.getListItemsCount(), 1, 'last input composite character is not in search value');
+            assert.strictEqual(this.getListItemsCount(), expectedResult, 'last input composite character is not in search value');
         });
 
         QUnit.test('should search if composition is finished', function(assert) {


### PR DESCRIPTION

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
