### PR TITLE
Add a workflow that forces failed renovate[bot] PR checks every hour

### DIFF
--- a/.github/actions/force-renovate-workflow/action.yml
+++ b/.github/actions/force-renovate-workflow/action.yml
@@ -1,0 +1,48 @@
+name: "Force Renovate Workflow"
+
+runs:
+  using: "composite"
+  steps:
+    - name: execute
+      shell: bash
+      run: |
+        paginate () { # "method" "URL" "items getter"
+          local result="[]"
+          local page=0
+          while true
+          do
+
+            ((page++))
+            local value=$(echo $(curl -s -X $1 $2 -H "Accept: application/vnd.github.v3+json" -G -H "Authorization: Bearer ${{github.token}}" -d per_page=100 -d page=$page) | jq $3)
+            if [ $(echo $value | jq -r ". | length") == 0 ]; then
+
+              echo $result
+              return 0
+
+            fi
+            result=$(echo '{"a": '$result', "b": '$value'}' | jq '.a + .b')
+
+          done
+
+          echo "exit"
+          echo $result
+        }
+
+        all_requests=$(paginate GET "https://api.github.com/repos/${{github.repository}}/pulls?state=open")
+        renovate_request_refs=$(echo $all_requests | jq 'map(select(.user.login | contains("renovate"))) | .[] | .head.ref')
+
+        for request_ref in $(echo $renovate_request_refs | jq -r .); do
+
+          all_checks=$(paginate GET "https://api.github.com/repos/${{github.repository}}/commits/$request_ref/check-runs" .check_runs)
+          failed_checks=$(echo $all_checks | jq 'map(select((.conclusion != null) and (.conclusion | contains("failure"))))')
+
+          for check_id in $(echo $failed_checks | jq -r .[].check_suite.id); do
+
+            curl -s -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: Bearer ${{github.token}}" \
+              "https://api.github.com/repos/${{github.repository}}/check-suites/${check_id}/rerequest"
+
+          done
+
+        done

--- a/.github/workflows/renovate_force.yml
+++ b/.github/workflows/renovate_force.yml
@@ -1,0 +1,13 @@
+name: Force renovate workflows
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */1 * * *'
+
+jobs:
+  execute:
+    runs-on: shr-ubuntu-c5-docker-cpu0d5ram1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/force-renovate-workflow

--- a/build/pre-commit/validate-workflows.js
+++ b/build/pre-commit/validate-workflows.js
@@ -5,7 +5,8 @@ const { readFileSync } = require('fs');
 const chalks = require('./chalks');
 
 const exceptions = [
-    '.github/workflows/renovate_autoapprove.yml'
+    '.github/workflows/renovate_autoapprove.yml',
+    '.github/workflows/renovate_force.yml'
 ]
 
 module.exports = (results) => {


### PR DESCRIPTION
About the `force-renovate-workflow` action:
- the `paginate()` method iterates through pages of responses to GitHub API calls and returns a single JSON string;
- the script works as follows:
    - request all open PRs,
    - filter PRs by user: user name should contain the `renovate` string,
    - iterate through PR base refs and find failed check runs,
    - for each failed check run, get the parent suite and force it;
- workflow runs every hour, or by the `workflow_dispatch` event