### PR TITLE
Export PDF TypeError: Cannot use 'in' operator to search for 'animation' in false (T985272)

### DIFF
--- a/js/exporter/exceljs/export.js
+++ b/js/exporter/exceljs/export.js
@@ -113,9 +113,11 @@ export const Export = {
         } = options;
 
         const internalComponent = component._getInternalInstance?.() || component;
-        const initialLoadPanelEnabledOption = internalComponent.option('loadPanel').enabled;
+        const initialLoadPanelEnabledOption = internalComponent.option('loadPanel') && internalComponent.option('loadPanel').enabled;
 
-        component.option('loadPanel.enabled', false);
+        if(initialLoadPanelEnabledOption) {
+            component.option('loadPanel.enabled', false);
+        }
 
         let exportLoadPanel;
         if(loadPanel.enabled && hasWindow()) {
@@ -186,7 +188,9 @@ export const Export = {
 
                 resolve(cellRange);
             }).always(() => {
-                component.option('loadPanel.enabled', initialLoadPanelEnabledOption);
+                if(initialLoadPanelEnabledOption) {
+                    component.option('loadPanel.enabled', initialLoadPanelEnabledOption);
+                }
 
                 if(loadPanel.enabled && hasWindow()) {
                     exportLoadPanel.dispose();

--- a/js/exporter/jspdf/export.js
+++ b/js/exporter/jspdf/export.js
@@ -75,9 +75,13 @@ export const Export = {
         } = options;
 
         const internalComponent = component._getInternalInstance?.() || component;
-        const initialLoadPanelEnabledOption = internalComponent.option('loadPanel').enabled;
+        const initialLoadPanelEnabledOption = internalComponent.option('loadPanel') && internalComponent.option('loadPanel').enabled;
 
-        component.option('loadPanel.enabled', false);
+
+        if(initialLoadPanelEnabledOption) {
+            component.option('loadPanel.enabled', false);
+        }
+
         let exportLoadPanel;
         if(loadPanel.enabled && hasWindow()) {
             const rowsView = component.getView('rowsView');
@@ -159,7 +163,9 @@ export const Export = {
 
                 resolve();
             }).always(() => {
-                component.option('loadPanel.enabled', initialLoadPanelEnabledOption);
+                if(initialLoadPanelEnabledOption) {
+                    component.option('loadPanel.enabled', initialLoadPanelEnabledOption);
+                }
 
                 if(loadPanel.enabled && hasWindow()) {
                     exportLoadPanel.dispose();

--- a/testing/tests/DevExpress.exporter/commonParts/loadPanel.tests.js
+++ b/testing/tests/DevExpress.exporter/commonParts/loadPanel.tests.js
@@ -18,7 +18,7 @@ const LoadPanelTests = {
         };
 
         const componentLoadPanel = `component.loadPanel: ${('loadPanel' in componentOptions) ? JSON.stringify(componentOptions.loadPanel) : 'not declared'}`;
-        QUnit.module('LoadPanel', moduleConfig, () => {
+        QUnit.module(`LoadPanel: ${componentLoadPanel}`, moduleConfig, () => {
             [
                 undefined,
                 { enabled: true },
@@ -34,7 +34,7 @@ const LoadPanelTests = {
                     showPane: false,
                 }
             ].forEach((loadPanelOptions) => {
-                QUnit.test(`${componentLoadPanel}, loadPanel: ${JSON.stringify(loadPanelOptions)}`, function(assert) {
+                QUnit.test(`loadPanel: ${JSON.stringify(loadPanelOptions)}`, function(assert) {
                     assert.expect(14);
                     const done = assert.async();
                     const component = getComponent(componentOptions);
@@ -91,7 +91,7 @@ const LoadPanelTests = {
                 });
             });
 
-            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: true }, $targetElement.height() > $window.height()`, function(assert) {
+            QUnit.test('loadPanel: { enabled: true }, $targetElement.height() > $window.height()', function(assert) {
                 assert.expect(10);
                 const done = assert.async();
                 const component = getComponent(componentOptions);
@@ -143,7 +143,7 @@ const LoadPanelTests = {
                 });
             });
 
-            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: true }, $targetElement.height() < $window.height()`, function(assert) {
+            QUnit.test('loadPanel: { enabled: true }, $targetElement.height() < $window.height()', function(assert) {
                 assert.expect(8);
                 const done = assert.async();
                 const component = getComponent(componentOptions);
@@ -188,7 +188,7 @@ const LoadPanelTests = {
                 });
             });
 
-            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: false }`, function(assert) {
+            QUnit.test('loadPanel: { enabled: false }', function(assert) {
                 assert.expect(5);
                 const done = assert.async();
                 const component = getComponent(componentOptions);
@@ -218,7 +218,7 @@ const LoadPanelTests = {
                 });
             });
 
-            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: true }, hasWindow(): false`, function(assert) {
+            QUnit.test('loadPanel: { enabled: true }, hasWindow(): false', function(assert) {
                 assert.expect(5);
                 const done = assert.async();
                 setWindow(undefined, false);
@@ -251,7 +251,7 @@ const LoadPanelTests = {
             });
 
             [{ type: 'default', expected: 'エクスポート...' }, { type: 'custom', expected: '!CUSTOM TEXT!' }].forEach((localizationText) => {
-                QUnit.test(`${componentLoadPanel}, ${localizationText.type} localization text, locale('ja')`, function(assert) {
+                QUnit.test(`${localizationText.type} localization text, locale('ja')`, function(assert) {
                     assert.expect(7);
                     const done = assert.async();
                     const locale = localization.locale();
@@ -306,7 +306,7 @@ const LoadPanelTests = {
                 });
             });
 
-            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: true }, use unical instance of exportLoadPanel for each exportDataGrid's function call`, function(assert) {
+            QUnit.test('loadPanel: { enabled: true }, use unical instance of exportLoadPanel for each exportDataGrid\'s function call', function(assert) {
                 const clock = sinon.useFakeTimers();
 
                 const $secondGrid = $('<div>');

--- a/testing/tests/DevExpress.exporter/commonParts/loadPanel.tests.js
+++ b/testing/tests/DevExpress.exporter/commonParts/loadPanel.tests.js
@@ -10,9 +10,15 @@ const EXPORT_LOAD_PANEL_CLASS = 'dx-export-loadpanel';
 
 const LoadPanelTests = {
     runTests(moduleConfig, exportFunc, getComponent, componentOptions, documentPropertyName) {
-        const componentLoadPanelEnabledOption = componentOptions.loadPanel.enabled === true;
+        const hasBuildInLoadPanel = (componentName) => {
+            if(componentName === 'dxDataGrid') {
+                return componentOptions.loadPanel && componentOptions.loadPanel.enabled === true ? 1 : 0;
+            }
+            return (componentOptions.loadPanel === undefined && !('loadPanel' in componentOptions)) || (componentOptions.loadPanel && componentOptions.loadPanel.enabled !== false) && componentOptions.loadPanel !== true ? 1 : 0;
+        };
 
-        QUnit.module(`LoadPanel: component.loadPanel.enabled: ${componentOptions.loadPanel.enabled}`, moduleConfig, () => {
+        const componentLoadPanel = `component.loadPanel: ${('loadPanel' in componentOptions) ? JSON.stringify(componentOptions.loadPanel) : 'not declared'}`;
+        QUnit.module('LoadPanel', moduleConfig, () => {
             [
                 undefined,
                 { enabled: true },
@@ -28,11 +34,11 @@ const LoadPanelTests = {
                     showPane: false,
                 }
             ].forEach((loadPanelOptions) => {
-                QUnit.test(`loadPanel: ${JSON.stringify(loadPanelOptions)}`, function(assert) {
+                QUnit.test(`${componentLoadPanel}, loadPanel: ${JSON.stringify(loadPanelOptions)}`, function(assert) {
                     assert.expect(14);
                     const done = assert.async();
                     const component = getComponent(componentOptions);
-                    const initialComponentLoadPanelEnabledValue = component.option('loadPanel').enabled;
+                    const initialComponentLoadPanelValue = component.option('loadPanel');
 
                     let initialOptions = loadPanelOptions;
                     if(!initialOptions) {
@@ -76,20 +82,20 @@ const LoadPanelTests = {
                         assert.strictEqual($exportLoadPanel.length, 0, 'export loadpanel not exist');
 
                         const $builtInLoadPanel = component.$element().find(`.${LOAD_PANEL_CLASS}`);
-                        assert.strictEqual($builtInLoadPanel.length, componentLoadPanelEnabledOption ? 1 : 0, 'builtin loadpanel exist');
+                        assert.strictEqual($builtInLoadPanel.length, hasBuildInLoadPanel(component.NAME) ? 1 : 0, 'builtin loadpanel exist');
 
-                        assert.strictEqual(component.option('loadPanel').enabled, initialComponentLoadPanelEnabledValue, 'component.loadPanel.enabled');
+                        assert.deepEqual(component.option('loadPanel'), initialComponentLoadPanelValue, 'component.loadPanel');
 
                         done();
                     });
                 });
             });
 
-            QUnit.test('loadPanel: { enabled: true }, $targetElement.height() > $window.height()', function(assert) {
+            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: true }, $targetElement.height() > $window.height()`, function(assert) {
                 assert.expect(10);
                 const done = assert.async();
                 const component = getComponent(componentOptions);
-                const initialComponentLoadPanelEnabledValue = component.option('loadPanel').enabled;
+                const initialComponentLoadPanelValue = component.option('loadPanel');
 
                 let isFirstCall = true;
                 let exportLoadPanel;
@@ -130,18 +136,18 @@ const LoadPanelTests = {
                     assert.strictEqual($exportLoadPanel.length, 0, 'export loadpanel not exist');
 
                     const $builtInLoadPanel = component.$element().find(`.${LOAD_PANEL_CLASS}`);
-                    assert.strictEqual($builtInLoadPanel.length, componentLoadPanelEnabledOption ? 1 : 0, 'builtin loadpanel exist');
-                    assert.strictEqual(component.option('loadPanel').enabled, initialComponentLoadPanelEnabledValue, 'component.loadPanel.enabled');
+                    assert.strictEqual($builtInLoadPanel.length, hasBuildInLoadPanel(component.NAME) ? 1 : 0, 'builtin loadpanel exist');
+                    assert.deepEqual(component.option('loadPanel'), initialComponentLoadPanelValue, 'component.loadPanel');
 
                     done();
                 });
             });
 
-            QUnit.test('loadPanel: { enabled: true }, $targetElement.height() < $window.height()', function(assert) {
+            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: true }, $targetElement.height() < $window.height()`, function(assert) {
                 assert.expect(8);
                 const done = assert.async();
                 const component = getComponent(componentOptions);
-                const initialComponentLoadPanelEnabledValue = component.option('loadPanel').enabled;
+                const initialComponentLoadPanelValue = component.option('loadPanel');
 
                 let isFirstCall = true;
                 let exportLoadPanel;
@@ -175,18 +181,18 @@ const LoadPanelTests = {
                     assert.strictEqual($exportLoadPanel.length, 0, 'export loadpanel not exist');
 
                     const $builtInLoadPanel = component.$element().find(`.${LOAD_PANEL_CLASS}`);
-                    assert.strictEqual($builtInLoadPanel.length, componentLoadPanelEnabledOption ? 1 : 0, 'builtin loadpanel exist');
-                    assert.strictEqual(component.option('loadPanel').enabled, initialComponentLoadPanelEnabledValue, 'component.loadPanel.enabled');
+                    assert.strictEqual($builtInLoadPanel.length, hasBuildInLoadPanel(component.NAME) ? 1 : 0, 'builtin loadpanel exist');
+                    assert.deepEqual(component.option('loadPanel'), initialComponentLoadPanelValue, 'component.loadPanel');
 
                     done();
                 });
             });
 
-            QUnit.test('loadPanel: { enabled: false }', function(assert) {
+            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: false }`, function(assert) {
                 assert.expect(5);
                 const done = assert.async();
                 const component = getComponent(componentOptions);
-                const initialComponentLoadPanelEnabledValue = component.option('loadPanel').enabled;
+                const initialComponentLoadPanelValue = component.option('loadPanel');
 
                 let isFirstCall = true;
 
@@ -205,19 +211,19 @@ const LoadPanelTests = {
                     assert.strictEqual($exportLoadPanel.length, 0, 'export loadpanel not exist');
 
                     const $builtInLoadPanel = component.$element().find(`.${LOAD_PANEL_CLASS}`);
-                    assert.strictEqual($builtInLoadPanel.length, componentLoadPanelEnabledOption ? 1 : 0, 'builtin loadpanel exist');
-                    assert.strictEqual(component.option('loadPanel').enabled, initialComponentLoadPanelEnabledValue, 'component.loadPanel.enabled');
+                    assert.strictEqual($builtInLoadPanel.length, hasBuildInLoadPanel(component.NAME) ? 1 : 0, 'builtin loadpanel exist');
+                    assert.deepEqual(component.option('loadPanel'), initialComponentLoadPanelValue, 'component.loadPanel');
 
                     done();
                 });
             });
 
-            QUnit.test('loadPanel: { enabled: true }, hasWindow(): false', function(assert) {
+            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: true }, hasWindow(): false`, function(assert) {
                 assert.expect(5);
                 const done = assert.async();
                 setWindow(undefined, false);
                 const component = getComponent(componentOptions);
-                const initialComponentLoadPanelEnabledValue = component.option('loadPanel').enabled;
+                const initialComponentLoadPanelValue = component.option('loadPanel');
 
                 let isFirstCall = true;
 
@@ -237,7 +243,7 @@ const LoadPanelTests = {
 
                     const $builtInLoadPanel = component.$element().find(`.${LOAD_PANEL_CLASS}`);
                     assert.strictEqual($builtInLoadPanel.length, 0, 'builtin loadpanel exist');
-                    assert.strictEqual(component.option('loadPanel').enabled, initialComponentLoadPanelEnabledValue, 'component.loadPanel.enabled');
+                    assert.deepEqual(component.option('loadPanel'), initialComponentLoadPanelValue, 'component.loadPanel');
 
                     setWindow(window);
                     done();
@@ -245,7 +251,7 @@ const LoadPanelTests = {
             });
 
             [{ type: 'default', expected: 'エクスポート...' }, { type: 'custom', expected: '!CUSTOM TEXT!' }].forEach((localizationText) => {
-                QUnit.test(`${localizationText.type} localization text, locale('ja')`, function(assert) {
+                QUnit.test(`${componentLoadPanel}, ${localizationText.type} localization text, locale('ja')`, function(assert) {
                     assert.expect(7);
                     const done = assert.async();
                     const locale = localization.locale();
@@ -264,7 +270,7 @@ const LoadPanelTests = {
                         localization.locale('ja');
 
                         const component = getComponent(componentOptions);
-                        const initialComponentLoadPanelEnabledValue = component.option('loadPanel').enabled;
+                        const initialComponentLoadPanelValue = component.option('loadPanel');
 
                         let isFirstCall = true;
                         let exportLoadPanel;
@@ -289,8 +295,8 @@ const LoadPanelTests = {
                             assert.strictEqual($exportLoadPanel.length, 0, 'export loadpanel not exist');
 
                             const $builtInLoadPanel = component.$element().find(`.${LOAD_PANEL_CLASS}`);
-                            assert.strictEqual($builtInLoadPanel.length, componentLoadPanelEnabledOption ? 1 : 0, 'builtin loadpanel exist');
-                            assert.strictEqual(component.option('loadPanel').enabled, initialComponentLoadPanelEnabledValue, 'component.loadPanel.enabled');
+                            assert.strictEqual($builtInLoadPanel.length, hasBuildInLoadPanel(component.NAME) ? 1 : 0, 'builtin loadpanel exist');
+                            assert.deepEqual(component.option('loadPanel'), initialComponentLoadPanelValue, 'component.loadPanel');
 
                             done();
                         });
@@ -300,7 +306,7 @@ const LoadPanelTests = {
                 });
             });
 
-            QUnit.test('loadPanel: { enabled: true }, use unical instance of exportLoadPanel for each exportDataGrid`s function call', function(assert) {
+            QUnit.test(`${componentLoadPanel}, loadPanel: { enabled: true }, use unical instance of exportLoadPanel for each exportDataGrid's function call`, function(assert) {
                 const clock = sinon.useFakeTimers();
 
                 const $secondGrid = $('<div>');
@@ -312,7 +318,7 @@ const LoadPanelTests = {
                 const component = getComponent(componentOptions);
                 const secondComponent = $secondGrid[component.NAME](componentOptions)[component.NAME]('instance');
 
-                const initialComponentLoadPanelEnabledValue = component.option('loadPanel').enabled;
+                const initialComponentLoadPanelValue = component.option('loadPanel');
 
                 clock.tick(300);
 
@@ -324,9 +330,9 @@ const LoadPanelTests = {
 
                 clock.tick(300);
 
-                assert.strictEqual($(`.${LOAD_PANEL_CLASS}`).not(`.${EXPORT_LOAD_PANEL_CLASS}`).length, componentLoadPanelEnabledOption ? 2 : 0, 'builtin loadpanel is turn off');
-                assert.strictEqual(component.option('loadPanel').enabled, initialComponentLoadPanelEnabledValue, 'component.loadPanel.enabled');
-                assert.strictEqual(secondComponent.option('loadPanel').enabled, initialComponentLoadPanelEnabledValue, 'component.loadPanel.enabled');
+                assert.strictEqual($(`.${LOAD_PANEL_CLASS}`).not(`.${EXPORT_LOAD_PANEL_CLASS}`).length, hasBuildInLoadPanel(component.NAME) ? 2 : 0, 'builtin loadpanel is turn off');
+                assert.deepEqual(component.option('loadPanel'), initialComponentLoadPanelValue, 'component.loadPanel');
+                assert.deepEqual(secondComponent.option('loadPanel'), initialComponentLoadPanelValue, 'component.loadPanel');
                 assert.strictEqual($(`.${LOAD_PANEL_CLASS}.${EXPORT_LOAD_PANEL_CLASS}`).length, 0, 'export loadpanel exist');
 
                 $secondGrid.remove();

--- a/testing/tests/DevExpress.exporter/exceljsParts/exceljs.dataGrid.tests.js
+++ b/testing/tests/DevExpress.exporter/exceljsParts/exceljs.dataGrid.tests.js
@@ -6545,21 +6545,27 @@ ExcelJSLocalizationFormatTests.runCurrencyTests([
     { value: 'SEK', expected: '$#,##0_);\\($#,##0\\)' } // NOT SUPPORTED in default
 ]);
 ExcelJSOptionTests.runTests(moduleConfig, exportDataGrid.__internals._getFullOptions, () => $('#dataGrid').dxDataGrid({}).dxDataGrid('instance'));
+
+
+[
+    { enabled: true },
+    { enabled: false },
+    { enabled: 'auto' },
+    {},
+    null,
+    undefined,
+    false,
+    true,
+].forEach((loadPanel) => {
+    LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
+        {
+            dataSource: [{ f1: 'f1_1' }],
+            loadPanel,
+            loadingTimeout: null
+        }, 'worksheet');
+});
 LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
     {
         dataSource: [{ f1: 'f1_1' }],
-        loadPanel: { enabled: true },
-        loadingTimeout: null
-    }, 'worksheet');
-LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
-    {
-        dataSource: [{ f1: 'f1_1' }],
-        loadPanel: { enabled: false },
-        loadingTimeout: null
-    }, 'worksheet');
-LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
-    {
-        dataSource: [{ f1: 'f1_1' }],
-        loadPanel: { enabled: 'auto' },
         loadingTimeout: null
     }, 'worksheet');

--- a/testing/tests/DevExpress.exporter/exceljsParts/exceljs.pivotGrid.tests.js
+++ b/testing/tests/DevExpress.exporter/exceljsParts/exceljs.pivotGrid.tests.js
@@ -6184,6 +6184,30 @@ ExcelJSLocalizationFormatTests.runPivotGridCurrencyTests([
     { value: 'SEK', expected: '$#,##0_);\\($#,##0\\)' } // NOT SUPPORTED in default
 ]);
 ExcelJSOptionTests.runTests(moduleConfig, exportPivotGrid.__internals._getFullOptions, () => $('#pivotGrid').dxPivotGrid({}).dxPivotGrid('instance'));
+
+
+[
+    { enabled: true },
+    { enabled: false },
+    {},
+    null,
+    false,
+    true,
+    undefined,
+].forEach((loadPanel) => {
+    LoadPanelTests.runTests(moduleConfig, exportPivotGrid, (options) => $('#pivotGrid').dxPivotGrid(options).dxPivotGrid('instance'),
+        {
+            fields: [
+                { area: 'row', dataField: 'row1', dataType: 'string' },
+                { area: 'column', dataField: 'col1', dataType: 'string' },
+                { area: 'data', summaryType: 'count', dataType: 'number' }
+            ],
+            store: [
+                { row1: 'A', col1: 'a' },
+            ],
+            loadPanel,
+        }, 'worksheet');
+});
 LoadPanelTests.runTests(moduleConfig, exportPivotGrid, (options) => $('#pivotGrid').dxPivotGrid(options).dxPivotGrid('instance'),
     {
         fields: [
@@ -6194,17 +6218,4 @@ LoadPanelTests.runTests(moduleConfig, exportPivotGrid, (options) => $('#pivotGri
         store: [
             { row1: 'A', col1: 'a' },
         ],
-        loadPanel: { enabled: true },
-    }, 'worksheet');
-LoadPanelTests.runTests(moduleConfig, exportPivotGrid, (options) => $('#pivotGrid').dxPivotGrid(options).dxPivotGrid('instance'),
-    {
-        fields: [
-            { area: 'row', dataField: 'row1', dataType: 'string' },
-            { area: 'column', dataField: 'col1', dataType: 'string' },
-            { area: 'data', summaryType: 'count', dataType: 'number' }
-        ],
-        store: [
-            { row1: 'A', col1: 'a' },
-        ],
-        loadPanel: { enabled: false },
     }, 'worksheet');

--- a/testing/tests/DevExpress.exporter/jspdfParts/jspdf.dataGrid.tests.js
+++ b/testing/tests/DevExpress.exporter/jspdfParts/jspdf.dataGrid.tests.js
@@ -4497,23 +4497,27 @@ QUnit.module('customizeCell', moduleConfig, () => {
 });
 
 JSPdfOptionTests.runTests(moduleConfig, exportDataGrid.__internals._getFullOptions, function() { return $('#dataGrid').dxDataGrid({}).dxDataGrid('instance'); });
-LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
-    {
-        dataSource: [{ f1: 'f1_1' }],
-        loadPanel: { enabled: true },
-        loadingTimeout: null
-    }, 'jsPDFDocument');
-LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
-    {
-        dataSource: [{ f1: 'f1_1' }],
-        loadPanel: { enabled: false },
-        loadingTimeout: null
-    }, 'jsPDFDocument');
-LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
-    {
-        dataSource: [{ f1: 'f1_1' }],
-        loadPanel: { enabled: 'auto' },
-        loadingTimeout: null
-    }, 'jsPDFDocument');
 
+[
+    { enabled: true },
+    { enabled: false },
+    { enabled: 'auto' },
+    {},
+    null,
+    undefined,
+    false,
+    true,
+].forEach((loadPanel) => {
+    LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
+        {
+            dataSource: [{ f1: 'f1_1' }],
+            loadPanel,
+            loadingTimeout: null
+        }, 'jsPDFDocument');
+});
+LoadPanelTests.runTests(moduleConfig, exportDataGrid, (options) => $('#dataGrid').dxDataGrid(options).dxDataGrid('instance'),
+    {
+        dataSource: [{ f1: 'f1_1' }],
+        loadingTimeout: null
+    }, 'jsPDFDocument');
 


### PR DESCRIPTION
The issue reproduces in v20.2.5. This version is discontinued. So we will not to fix there because it not a security fix. The customer uses WA and turn off the buildIn DataGrid.loadPanel manually. He uses 'false' value.

In newest versions we changed implementation and use our own loadPanel for export. This issue is not reproducing there, but we need additional check the follow configurations for DataGrid.loadPanel option

DataGrid.loadPanel
- is not declared
- { enabled: true },
- { enabled: false },
- { enabled: 'auto' },
 - {},
- null,
- undefined,
- false,
- true,
