### PR TITLE
Fix Gantt's Column type declaration

### DIFF
--- a/js/ui/gantt.d.ts
+++ b/js/ui/gantt.d.ts
@@ -249,7 +249,7 @@ export interface dxGanttOptions extends WidgetOptions<dxGantt> {
      * @default undefined
      * @public
      */
-    columns?: Array<dxGanttColumn | string>;
+    columns?: Array<Column | string>;
     /**
      * @docid
      * @default null
@@ -1537,9 +1537,12 @@ export type Properties = dxGanttOptions;
 export type Options = dxGanttOptions;
 
 /** @public */
-export type Column = dxGanttColumn;
+export type Column<TRowData = any, TKey = any> = dxGanttColumn<TRowData, TKey>;
 
-/** @namespace DevExpress.ui*/
+/**
+ * @namespace DevExpress.ui
+ * @deprecated Use the Column type instead
+ */
 export type dxGanttColumn<TRowData = any, TKey = any> = Skip<dxGanttColumnBlank<TRowData, TKey>, 'allowEditing' | 'allowFixing' | 'allowHiding' | 'allowReordering' | 'allowResizing' | 'allowSearch' | 'buttons' | 'columns' | 'editCellComponent' | 'editCellRender' | 'editCellTemplate' | 'editorOptions' | 'fixed' | 'fixedPosition' | 'formItem' | 'hidingPriority' | 'isBand' | 'lookup' | 'name' | 'ownerBand' | 'renderAsync' | 'setCellValue' | 'showEditorAlways' | 'showInColumnChooser' | 'type' | 'validationRules' | 'visible' >;
 
 /**

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -13708,7 +13708,10 @@ declare module DevExpress.ui {
     showTaskDetailsDialog(taskKey: any): void;
   }
   module dxGantt {
-    export type Column = dxGanttColumn;
+    export type Column<TRowData = any, TKey = any> = dxGanttColumn<
+      TRowData,
+      TKey
+    >;
     export type ContentReadyEvent = DevExpress.events.EventInfo<dxGantt>;
     export type ContextMenuPreparingEvent = DevExpress.events.Cancelable & {
       readonly component?: dxGantt;
@@ -13864,6 +13867,7 @@ declare module DevExpress.ui {
     };
   }
   /**
+   * @deprecated Use the Column type instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   export type dxGanttColumn<TRowData = any, TKey = any> = DevExpress.core.Skip<
@@ -14205,7 +14209,7 @@ declare module DevExpress.ui {
     /**
      * [descr:dxGanttOptions.columns]
      */
-    columns?: Array<dxGanttColumn | string>;
+    columns?: Array<DevExpress.ui.dxGantt.Column | string>;
     /**
      * [descr:dxGanttOptions.dependencies]
      */


### PR DESCRIPTION
- Add missing generic parameters to the `Column` type
- Remove usages of the internal `dxGanttColumn` type from public types