### PR TITLE
TS - fix promise resolving with multiple arguments (T1055063)

### DIFF
--- a/js/core/utils/deferred.d.ts
+++ b/js/core/utils/deferred.d.ts
@@ -22,7 +22,7 @@ declare class DeferredObj<T> {
 
 export function Deferred<T>(): DeferredObj<T>;
 
- // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unused-vars
 export interface PromiseType<T> { }
 /**
  * @docid
@@ -31,3 +31,11 @@ export interface PromiseType<T> { }
  */
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type DxPromise<T = void> = {} extends PromiseType<T> ? Promise<T> : PromiseType<T>;
+
+/** @namespace DevExpress.core.utils */
+export type DxExtendedPromise<T> = DxPromise<T> & {
+    then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T, extraParameters?: any) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+    ): PromiseLike<TResult1 | TResult2>;
+};

--- a/js/data/abstract_store.d.ts
+++ b/js/data/abstract_store.d.ts
@@ -1,4 +1,4 @@
-import { DxPromise } from '../core/utils/deferred';
+import { DxPromise, DxExtendedPromise } from '../core/utils/deferred';
 import { DeepPartial } from '../core/index';
 import { FilterDescriptor, GroupDescriptor, LoadOptions } from './index';
 
@@ -132,7 +132,7 @@ export default class Store<
      * @return Promise<any>
      * @public
      */
-    insert(values: TItem): DxPromise<TItem>;
+    insert(values: TItem): DxExtendedPromise<TItem>;
     /**
      * @docid
      * @publicName key()
@@ -153,7 +153,7 @@ export default class Store<
      * @return Promise<any>
      * @public
      */
-    load(): DxPromise<Array<TItem>>;
+    load(): DxExtendedPromise<Array<TItem>>;
     /**
      * @docid
      * @publicName load(options)
@@ -161,7 +161,7 @@ export default class Store<
      * @return Promise<any>
      * @public
      */
-    load(options: LoadOptions<TItem>): DxPromise<Array<TItem>>;
+    load(options: LoadOptions<TItem>): DxExtendedPromise<Array<TItem>>;
     /**
      * @docid
      * @publicName off(eventName)
@@ -226,5 +226,5 @@ export default class Store<
      * @return Promise<any>
      * @public
      */
-    update(key: TKey, values: DeepPartial<TItem>): DxPromise<TItem>;
+    update(key: TKey, values: DeepPartial<TItem>): DxExtendedPromise<TItem>;
 }

--- a/js/data/data_source.d.ts
+++ b/js/data/data_source.d.ts
@@ -8,7 +8,7 @@ import {
  Store,
  StoreOptions,
 } from './index';
-import { DxPromise } from '../core/utils/deferred';
+import { DxExtendedPromise } from '../core/utils/deferred';
 import { Options as CustomStoreOptions } from './custom_store';
 
 /** @public */
@@ -240,7 +240,7 @@ export default class DataSource<
      * @return Promise<any>
      * @public
      */
-    load(): DxPromise<any>;
+    load(): DxExtendedPromise<any>;
     /**
      * @docid
      * @publicName loadOptions()
@@ -328,7 +328,7 @@ export default class DataSource<
      * @return Promise<any>
      * @public
      */
-    reload(): DxPromise<any>;
+    reload(): DxExtendedPromise<any>;
     /**
      * @docid
      * @publicName requireTotalCount()

--- a/js/data/odata/store.d.ts
+++ b/js/data/odata/store.d.ts
@@ -4,13 +4,6 @@ import { LoadOptions } from '../index';
 import { Query } from '../query';
 import { ODataRequestOptions } from './context';
 
-interface PromiseExtension<T> {
-    then<TResult1 = T, TResult2 = never>(
-        onFulfilled?: ((value: T, extraParameters?: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
-        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
-    ): Promise<TResult1 | TResult2>;
-}
-
 /** @public */
 export type Options<
     TItem = any,
@@ -122,13 +115,4 @@ export default class ODataStore<
      * @public
      */
     createQuery(loadOptions?: { expand?: string | Array<string>; requireTotalCount?: boolean; customQueryParams?: any }): Query;
-
-    /**
-     * @docid
-     * @publicName insert(values)
-     * @param1 values:object
-     * @return Promise<any>
-     * @public
-     */
-    insert(values: TItem): DxPromise<TItem> & PromiseExtension<TItem>;
 }

--- a/testing/typescript/.eslintrc.js
+++ b/testing/typescript/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+    'overrides': [
+        {
+            'files': [
+                '*.ts',
+                '*.tsx'
+            ],
+            'rules': {
+                '@typescript-eslint/no-explicit-any': 'off',
+                '@typescript-eslint/no-floating-promises': 'off',
+                '@typescript-eslint/no-unused-vars': 'off',
+                '@typescript-eslint/no-unused-vars-experimental': 'off',
+                '@typescript-eslint/explicit-function-return-type': 'off',
+                '@typescript-eslint/explicit-module-boundary-types': 'off'
+            }
+        }
+    ]
+};

--- a/testing/typescript/consts.ts
+++ b/testing/typescript/consts.ts
@@ -1,0 +1,1 @@
+export const ANY = undefined as any;

--- a/testing/typescript/data/data_source.ts
+++ b/testing/typescript/data/data_source.ts
@@ -1,0 +1,9 @@
+import DataSource from '../../../js/data/data_source';
+import { ANY } from '../consts';
+
+export function promiseResolveAcceptsMultipleArguments() {
+  const callback: (a: any, b: any) => void = ANY;
+  const dataSource: DataSource = ANY;
+  dataSource.load().then(callback);
+  dataSource.reload().then(callback);
+}

--- a/testing/typescript/data/stores.ts
+++ b/testing/typescript/data/stores.ts
@@ -1,12 +1,11 @@
 /* eslint-disable no-new */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars-experimental */
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import $ from 'jquery';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import CustomStore from '../../../js/data/custom_store';
+import { Store } from '../../../js/data';
+import { ANY } from '../consts';
 
 export async function infersTItemFromComplexLoadResult() {
   const store = new CustomStore({
@@ -27,7 +26,7 @@ export async function infersTItemFromComplexLoadResult() {
 
 export function loadAcceptsAjaxResult() {
   new CustomStore({
-    load: (): JQueryXHR => $.ajax({
+    load: () => $.ajax({
       url: 'url', cache: false, dataType: 'json', data: 'data',
     }),
   });
@@ -45,4 +44,14 @@ export function loadAcceptsPromiseOfObject() {
     // eslint-disable-next-line @typescript-eslint/ban-types
     load: () => new Promise<object>(undefined),
   });
+}
+
+export function promiseThenAcceptsMultipleArguments() {
+  const callback: (a: any, b: any) => void = ANY;
+
+  const store: Store = ANY;
+  store.load().then(callback);
+  store.load(ANY).then(callback);
+  store.insert(ANY).then(callback);
+  store.update(ANY, ANY).then(callback);
 }

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1556,6 +1556,24 @@ declare module DevExpress.core {
 }
 declare module DevExpress.core.utils {
   /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
+   */
+  export type DxExtendedPromise<T> = DxPromise<T> & {
+    then<TResult1 = T, TResult2 = never>(
+      onFulfilled?:
+        | ((
+            value: T,
+            extraParameters?: any
+          ) => TResult1 | PromiseLike<TResult1>)
+        | undefined
+        | null,
+      onRejected?:
+        | ((reason: any) => TResult2 | PromiseLike<TResult2>)
+        | undefined
+        | null
+    ): PromiseLike<TResult1 | TResult2>;
+  };
+  /**
    * [descr:DxPromise]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
@@ -1760,7 +1778,7 @@ declare module DevExpress.data {
     /**
      * [descr:DataSource.load()]
      */
-    load(): DevExpress.core.utils.DxPromise<any>;
+    load(): DevExpress.core.utils.DxExtendedPromise<any>;
     /**
      * [descr:DataSource.loadOptions()]
      */
@@ -1816,7 +1834,7 @@ declare module DevExpress.data {
     /**
      * [descr:DataSource.reload()]
      */
-    reload(): DevExpress.core.utils.DxPromise<any>;
+    reload(): DevExpress.core.utils.DxExtendedPromise<any>;
     /**
      * [descr:DataSource.requireTotalCount()]
      */
@@ -2305,38 +2323,12 @@ declare module DevExpress.data {
       requireTotalCount?: boolean;
       customQueryParams?: any;
     }): Query;
-
-    /**
-     * [descr:ODataStore.insert(values)]
-     */
-    insert(
-      values: TItem
-    ): DevExpress.core.utils.DxPromise<TItem> &
-      DevExpress.data.ODataStore.PromiseExtension<TItem>;
   }
   module ODataStore {
     export type Options<TItem = any, TKey = any> = ODataStoreOptions<
       TItem,
       TKey
     >;
-    /**
-     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-     */
-    interface PromiseExtension<T> {
-      then<TResult1 = T, TResult2 = never>(
-        onFulfilled?:
-          | ((
-              value: T,
-              extraParameters?: T
-            ) => TResult1 | PromiseLike<TResult1>)
-          | undefined
-          | null,
-        onRejected?:
-          | ((reason: any) => TResult2 | PromiseLike<TResult2>)
-          | undefined
-          | null
-      ): Promise<TResult1 | TResult2>;
-    }
   }
   /**
    * @deprecated Use Options instead
@@ -2931,7 +2923,7 @@ declare module DevExpress.data {
     /**
      * [descr:Store.insert(values)]
      */
-    insert(values: TItem): DevExpress.core.utils.DxPromise<TItem>;
+    insert(values: TItem): DevExpress.core.utils.DxExtendedPromise<TItem>;
     /**
      * [descr:Store.key()]
      */
@@ -2943,13 +2935,13 @@ declare module DevExpress.data {
     /**
      * [descr:Store.load()]
      */
-    load(): DevExpress.core.utils.DxPromise<Array<TItem>>;
+    load(): DevExpress.core.utils.DxExtendedPromise<Array<TItem>>;
     /**
      * [descr:Store.load(options)]
      */
     load(
       options: LoadOptions<TItem>
-    ): DevExpress.core.utils.DxPromise<Array<TItem>>;
+    ): DevExpress.core.utils.DxExtendedPromise<Array<TItem>>;
     /**
      * [descr:Store.off(eventName)]
      */
@@ -3000,7 +2992,7 @@ declare module DevExpress.data {
     update(
       key: TKey,
       values: DevExpress.core.DeepPartial<TItem>
-    ): DevExpress.core.utils.DxPromise<TItem>;
+    ): DevExpress.core.utils.DxExtendedPromise<TItem>;
   }
   module Store {
     /**


### PR DESCRIPTION
Allowed to use an additional argument when resolving promises (method then) for data store methods (load, insert, update). Based on PR 'Remove JQuery types away from modules (#16638)' by @IlyaKhD