### PR TITLE
Number localization: fix parsing when '-' is used in prefix stub or '0'/'#' is used in suffix stub (T1061646) (#20988)

### DIFF
--- a/js/localization/ldml/number.js
+++ b/js/localization/ldml/number.js
@@ -7,8 +7,13 @@ const MAXIMUM_NUMBER_LENGTH = 15;
 
 function getGroupSizes(formatString) {
     return formatString.split(',').slice(1).map(function(str) {
-        return str.split('').filter(function(char) {
-            return char === '#' || char === '0';
+        let singleQuotesLeft = 0;
+        return str.split('').filter(function(char, index) {
+            singleQuotesLeft += char === '\'';
+
+            const isDigit = char === '#' || char === '0';
+            const isInStub = singleQuotesLeft % 2;
+            return isDigit && !isInStub;
         }).length;
     });
 }

--- a/js/localization/number.js
+++ b/js/localization/number.js
@@ -242,19 +242,19 @@ const numberLocalization = dependencyInjector({
 
         let negativeEtalon = this.format(-1, format).replace(digitalRegExp, '1');
         specialCharacters.forEach(char => {
-            negativeEtalon = negativeEtalon.replace(char, `\\${char}`);
+            negativeEtalon = negativeEtalon.replaceAll(char, `\\${char}`);
         });
-        negativeEtalon = negativeEtalon.replace(' ', '\\s');
-        negativeEtalon = negativeEtalon.replace('1', '.+');
+        negativeEtalon = negativeEtalon.replaceAll(' ', '\\s');
+        negativeEtalon = negativeEtalon.replaceAll('1', '.+');
 
         return new RegExp(negativeEtalon, 'g');
     },
 
     getSign: function(text, format) {
-        if(text.replace(/[^0-9-]/g, '').charAt(0) === '-') {
-            return -1;
-        }
         if(!format) {
+            if(text.replace(/[^0-9-]/g, '').charAt(0) === '-') {
+                return -1;
+            }
             return 1;
         }
 

--- a/js/localization/number.js
+++ b/js/localization/number.js
@@ -242,7 +242,7 @@ const numberLocalization = dependencyInjector({
 
         let negativeEtalon = this.format(-1, format).replace(digitalRegExp, '1');
         specialCharacters.forEach(char => {
-            negativeEtalon = negativeEtalon.replace(new RegExp(char, 'g'), `\\${char}`);
+            negativeEtalon = negativeEtalon.replace(new RegExp('\\' + char, 'g'), `\\${char}`);
         });
         negativeEtalon = negativeEtalon.replace(/ /g, '\\s');
         negativeEtalon = negativeEtalon.replace(/1/g, '.+');

--- a/js/localization/number.js
+++ b/js/localization/number.js
@@ -242,10 +242,10 @@ const numberLocalization = dependencyInjector({
 
         let negativeEtalon = this.format(-1, format).replace(digitalRegExp, '1');
         specialCharacters.forEach(char => {
-            negativeEtalon = negativeEtalon.replaceAll(char, `\\${char}`);
+            negativeEtalon = negativeEtalon.replace(new RegExp(char, 'g'), `\\${char}`);
         });
-        negativeEtalon = negativeEtalon.replaceAll(' ', '\\s');
-        negativeEtalon = negativeEtalon.replaceAll('1', '.+');
+        negativeEtalon = negativeEtalon.replace(/ /g, '\\s');
+        negativeEtalon = negativeEtalon.replace(/1/g, '.+');
 
         return new RegExp(negativeEtalon, 'g');
     },

--- a/testing/tests/DevExpress.localization/sharedParts/localization.shared.js
+++ b/testing/tests/DevExpress.localization/sharedParts/localization.shared.js
@@ -663,7 +663,6 @@ module.exports = function() {
         QUnit.test('parse different positive and negative parts', function(assert) {
             assert.equal(localization.parseNumber('(10)', '#0;(#0)'), -10);
             assert.equal(localization.parseNumber('-10'), -10);
-            assert.equal(localization.parseNumber('-10', '#0;(#0)'), -10);
         });
 
         QUnit.test('parse different positive and negative parts with groups', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -269,7 +269,7 @@ QUnit.module('format: sign and minus button', moduleConfig, () => {
             value: -14500.55
         });
 
-        this.keyboard.caret(6).type('a').change();
+        this.keyboard.caret(20).type('a').change();
         assert.strictEqual(this.input.val(), '$*/\\?||(?)^   & [({14500.55])}', 'value is correct');
         assert.strictEqual(this.instance.option('value'), -14500.55, 'value is correct');
     });
@@ -2205,7 +2205,10 @@ QUnit.module('stubs', moduleConfig, function() {
         { format: '\'0\'1 0,###.##', expectedText: '-01 1,234.56', expectedValue: -1234.56 },
         { format: '0,###.## \'#\'1', expectedText: '1,234.56 #1', expectedValue: 1234.56 },
         { format: '0,###.## \'#\'1', expectedText: '-1,234.56 #1', expectedValue: -1234.56 },
-        { format: '0,###.##;abc(0,###.##)', expectedText: 'abc(1,234.56)', expectedValue: -1234.56 }
+        { format: '0,###.##;abc(0,###.##)', expectedText: 'abc(1,234.56)', expectedValue: -1234.56 },
+        { format: '#,##0\'.\'\'0\'\'0\'', expectedText: '1,234.00', expectedValue: 1234 },
+        { format: '\'-\'#,###.00', expectedText: '-1.00', expectedValue: 1 },
+        { format: '\'-\'#,###.00', expectedText: '--1.00', expectedValue: -1 },
     ].forEach(({ format, expectedText, expectedValue }) => {
         QUnit.test(`widget should correctly apply format="${format}", value="${expectedValue}"`, function(assert) {
             this.instance.option({


### PR DESCRIPTION
…

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
