### PR TITLE
Scheduler - Fixes for angular generator

### DIFF
--- a/js/renovation/ui/scheduler/props.ts
+++ b/js/renovation/ui/scheduler/props.ts
@@ -46,6 +46,12 @@ import { DataCellTemplateProps, DateTimeCellTemplateProps, ResourceCellTemplateP
 import { AppointmentTemplateProps, OverflowIndicatorTemplateProps } from './appointment/types';
 
 @ComponentBindings()
+export class ScrollingProps {
+  @OneWay()
+  mode?: 'standard' | 'virtual';
+}
+
+@ComponentBindings()
 export class ResourceProps {
   @OneWay()
   allowMultiple?: boolean;
@@ -197,12 +203,6 @@ export class AppointmentDraggingProps {
 
   @Event()
   onRemove?: ((e: AppointmentDraggingRemoveEvent) => void);
-}
-
-@ComponentBindings()
-export class ScrollingProps {
-  @OneWay()
-  mode?: 'standard' | 'virtual';
 }
 
 @ComponentBindings()

--- a/testing/renovation/platforms/declaration/scheduler.tsx
+++ b/testing/renovation/platforms/declaration/scheduler.tsx
@@ -3,13 +3,88 @@ import {
   Component, ComponentBindings, JSXComponent, InternalState, Effect,
 } from '@devextreme-generator/declarations';
 import React from 'react';
+import { SchedulerProps } from '../../../../js/renovation/ui/scheduler/props';
 import { Scheduler } from '../../../../js/renovation/ui/scheduler/scheduler';
 
 export const viewFunction = ({ componentProps }: App): JSX.Element => (
   <Scheduler
     id="container"
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    {...componentProps}
+    adaptivityEnabled={componentProps.adaptivityEnabled}
+    appointmentDragging={componentProps.appointmentDragging}
+    crossScrollingEnabled={componentProps.crossScrollingEnabled}
+    currentDate={componentProps.currentDate}
+    currentView={componentProps.currentView}
+    dataSource={componentProps.dataSource}
+    dateSerializationFormat={componentProps.dateSerializationFormat}
+    descriptionExpr={componentProps.descriptionExpr}
+    editing={componentProps.editing}
+    focusStateEnabled={componentProps.focusStateEnabled}
+    groupByDate={componentProps.groupByDate}
+    indicatorUpdateInterval={componentProps.indicatorUpdateInterval}
+    max={componentProps.max}
+    min={componentProps.min}
+    noDataText={componentProps.noDataText}
+    recurrenceEditMode={componentProps.recurrenceEditMode}
+    remoteFiltering={componentProps.remoteFiltering}
+    resources={componentProps.resources}
+    scrolling={componentProps.scrolling}
+    selectedCellData={componentProps.selectedCellData}
+    shadeUntilCurrentTime={componentProps.shadeUntilCurrentTime}
+    showAllDayPanel={componentProps.showAllDayPanel}
+    showCurrentTimeIndicator={componentProps.showCurrentTimeIndicator}
+    timeZone={componentProps.timeZone}
+    useDropDownViewSwitcher={componentProps.useDropDownViewSwitcher}
+    views={componentProps.views}
+    endDayHour={componentProps.endDayHour}
+    startDayHour={componentProps.startDayHour}
+    firstDayOfWeek={componentProps.firstDayOfWeek}
+    cellDuration={componentProps.cellDuration}
+    groups={componentProps.groups}
+    maxAppointmentsPerCell={componentProps.maxAppointmentsPerCell}
+    customizeDateNavigatorText={componentProps.customizeDateNavigatorText}
+    onAppointmentAdded={componentProps.onAppointmentAdded}
+    onAppointmentAdding={componentProps.onAppointmentAdding}
+    onAppointmentClick={componentProps.onAppointmentClick}
+    onAppointmentContextMenu={componentProps.onAppointmentContextMenu}
+    onAppointmentDblClick={componentProps.onAppointmentDblClick}
+    onAppointmentDeleted={componentProps.onAppointmentDeleted}
+    onAppointmentDeleting={componentProps.onAppointmentDeleting}
+    onAppointmentFormOpening={componentProps.onAppointmentFormOpening}
+    onAppointmentRendered={componentProps.onAppointmentRendered}
+    onAppointmentUpdated={componentProps.onAppointmentUpdated}
+    onAppointmentUpdating={componentProps.onAppointmentUpdating}
+    onCellClick={componentProps.onCellClick}
+    onCellContextMenu={componentProps.onCellContextMenu}
+    recurrenceExceptionExpr={componentProps.recurrenceExceptionExpr}
+    recurrenceRuleExpr={componentProps.recurrenceRuleExpr}
+    startDateExpr={componentProps.startDateExpr}
+    startDateTimeZoneExpr={componentProps.startDateTimeZoneExpr}
+    endDateExpr={componentProps.endDateExpr}
+    endDateTimeZoneExpr={componentProps.endDateTimeZoneExpr}
+    allDayExpr={componentProps.allDayExpr}
+    textExpr={componentProps.textExpr}
+    dataCellTemplate={componentProps.dataCellTemplate}
+    dateCellTemplate={componentProps.dateCellTemplate}
+    timeCellTemplate={componentProps.timeCellTemplate}
+    resourceCellTemplate={componentProps.resourceCellTemplate}
+    appointmentCollectorTemplate={componentProps.appointmentCollectorTemplate}
+    appointmentTemplate={componentProps.appointmentTemplate}
+    appointmentTooltipTemplate={componentProps.appointmentTooltipTemplate}
+    toolbar={componentProps.toolbar}
+    currentDateChange={componentProps.currentDateChange}
+    currentViewChange={componentProps.currentViewChange}
+    className={componentProps.className}
+    activeStateEnabled={componentProps.activeStateEnabled}
+    disabled={componentProps.disabled}
+    height={componentProps.height}
+    hint={componentProps.hint}
+    hoverStateEnabled={componentProps.hoverStateEnabled}
+    onClick={componentProps.onClick}
+    onKeyDown={componentProps.onKeyDown}
+    rtlEnabled={componentProps.rtlEnabled}
+    tabIndex={componentProps.tabIndex}
+    visible={componentProps.visible}
+    width={componentProps.width}
   />
 );
 
@@ -19,6 +94,7 @@ class AppProps { }
 @Component({
   defaultOptionRules: null,
   view: viewFunction,
+  jQuery: { register: true },
 })
 export class App extends JSXComponent<AppProps>() {
   @InternalState() options = {};
@@ -61,7 +137,10 @@ export class App extends JSXComponent<AppProps>() {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get componentProps(): any {
+  get componentProps(): Partial<
+  SchedulerProps &
+  { currentDateChange: (date: Date) => void } &
+  { currentViewChange: (view: string) => void }> {
     return {
       ...this.options,
       currentDate: this.currentDate,


### PR DESCRIPTION
1. Unspread scheduler props because spread operator doesn't work in Ng.
2. Make App as public component because it renders as ng-template.
3. Fix "ScrollingProps is used before initialization".