### PR TITLE
DataGridLight - improvements

### DIFF
--- a/js/renovation/ui/grids/data_grid_light/__tests__/data_grid_light.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/__tests__/data_grid_light.test.tsx
@@ -96,6 +96,13 @@ describe('DataGridLight', () => {
         grid.updateKeyExpr();
         expect(grid.plugins.getValue(KeyExprPlugin)).toEqual('some key');
       });
+
+      it('should set keyExpr to null if user did not specified it', () => {
+        const grid = new DataGridLight({});
+
+        grid.updateKeyExpr();
+        expect(grid.plugins.getValue(KeyExprPlugin)).toEqual(null);
+      });
     });
 
     describe('updateDataSource', () => {

--- a/js/renovation/ui/grids/data_grid_light/__tests__/utils.test.ts
+++ b/js/renovation/ui/grids/data_grid_light/__tests__/utils.test.ts
@@ -1,0 +1,30 @@
+import { createGetKey } from '../utils';
+
+describe('getKey', () => {
+  const getKey = createGetKey('(Module name)');
+
+  it('should throw E1042 if keyExpr is missing', () => {
+    expect(() => getKey({}, null))
+      .toThrowErrorMatchingInlineSnapshot(`
+"E1042 - (Module name) requires the key field to be specified. See:
+http://js.devexpress.com/error/%VERSION%/E1042"
+`);
+  });
+
+  it('should return undefined if keyExpr was not initialized via plugins', () => {
+    expect(getKey({}, undefined)).toEqual(undefined);
+  });
+
+  it('should throw E1046 if data object does not have key', () => {
+    expect(() => getKey({}, 'id'))
+      .toThrowErrorMatchingInlineSnapshot(`
+"E1046 - The 'id' key field is not found in data objects. See:
+http://js.devexpress.com/error/%VERSION%/E1046"
+`);
+  });
+
+  it('return key', () => {
+    const key = getKey({ id: '123' }, 'id');
+    expect(key).toEqual('123');
+  });
+});

--- a/js/renovation/ui/grids/data_grid_light/__tests__/utils.test.ts
+++ b/js/renovation/ui/grids/data_grid_light/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
-import { createGetKey } from '../utils';
+import { Row } from '../types';
+import { createGetKey, getReactRowKey } from '../utils';
 
 describe('getKey', () => {
   const getKey = createGetKey('(Module name)');
@@ -26,5 +27,36 @@ http://js.devexpress.com/error/%VERSION%/E1046"
   it('return key', () => {
     const key = getKey({ id: '123' }, 'id');
     expect(key).toEqual('123');
+  });
+});
+
+describe('getReactRowKey', () => {
+  it('should return key with row key and row type', () => {
+    const row: Row = {
+      data: {},
+      key: 'someKey',
+      rowType: 'data',
+    };
+
+    expect(getReactRowKey(row, 11)).toEqual('data_someKey');
+  });
+
+  it('should return index if no key', () => {
+    const row: Row = {
+      data: {},
+      rowType: 'data',
+    };
+
+    expect(getReactRowKey(row, 11)).toEqual('11');
+  });
+
+  it('should index if key is complex', () => {
+    const row: Row = {
+      data: {},
+      key: {},
+      rowType: 'data',
+    };
+
+    expect(getReactRowKey(row, 11)).toEqual('11');
   });
 });

--- a/js/renovation/ui/grids/data_grid_light/classes.ts
+++ b/js/renovation/ui/grids/data_grid_light/classes.ts
@@ -1,0 +1,39 @@
+export default {
+  dataGrid: 'dx-datagrid',
+  gridBaseContainer: 'dx-gridbase-container',
+  rowsView: 'dx-datagrid-rowsview',
+  noWrap: 'dx-datagrid-nowrap',
+  content: 'dx-datagrid-content',
+  headers: 'dx-datagrid-headers',
+  afterHeaders: 'dx-datagrid-after-headers',
+  scrollContainer: 'dx-datagrid-scroll-container',
+
+  firstChild: 'dx-first-child',
+  lastChild: 'dx-last-child',
+
+  row: 'dx-row',
+  dataRow: 'dx-data-row',
+  headerRow: 'dx-header-row',
+  masterDetailRow: 'dx-master-detail-row',
+
+  pager: 'dx-datagrid-pager',
+
+  checkboxSize: 'dx-datagrid-checkbox-size',
+  selectCheckbox: 'dx-select-checkbox',
+  selectedRow: 'dx-selection',
+
+  columnLines: 'dx-column-lines',
+  textContent: 'dx-datagrid-text-content',
+  textContentAlignmentLeft: 'dx-text-content-alignment-left',
+  action: 'dx-datagrid-action',
+  cellFocusDisabled: 'dx-cell-focus-disabled',
+  groupSpace: 'dx-datagrid-group-space',
+
+  table: 'dx-datagrid-table',
+  fixedTable: 'dx-datagrid-table-fixed',
+
+  commandExpand: 'dx-command-expand',
+  expand: 'dx-datagrid-expand',
+  groupOpened: 'dx-datagrid-group-opened',
+  groupClosed: 'dx-datagrid-group-closed',
+};

--- a/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
+++ b/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
@@ -11,7 +11,7 @@ import { Widget } from '../../common/widget';
 import { BaseWidgetProps } from '../../common/base_props';
 
 import type {
-  Column, ColumnUserConfig, KeyExpr, RowData, Row, KeyExprUserConfig,
+  ColumnInternal, Column, KeyExprInternal, RowData, Row, KeyExpr,
 } from './types';
 
 import { TableContent } from './views/table_content';
@@ -22,9 +22,9 @@ import CLASSES from './classes';
 
 export const VisibleItems = createGetter<RowData[]>([]);
 export const VisibleRows = createGetter<Row[]>([]);
-export const VisibleColumns = createGetter<Column[]>([]);
+export const VisibleColumns = createGetter<ColumnInternal[]>([]);
 export const Items = createValue<RowData[]>();
-export const KeyExprPlugin = createValue<KeyExpr>();
+export const KeyExprPlugin = createValue<KeyExprInternal>();
 export const TotalCount = createValue<number>();
 
 export const viewFunction = (viewModel: DataGridLight): JSX.Element => (
@@ -58,10 +58,10 @@ export class DataGridLightProps extends BaseWidgetProps {
   dataSource: RowData[] = [];
 
   @OneWay()
-  keyExpr?: KeyExprUserConfig;
+  keyExpr?: KeyExpr;
 
   @OneWay()
-  columns: ColumnUserConfig[] = [];
+  columns: Column[] = [];
 
   @Slot()
   children?: JSX.Element | JSX.Element[];
@@ -89,7 +89,7 @@ export class DataGridLight extends JSXComponent(DataGridLightProps) {
   visibleRows: Row[] = [];
 
   @InternalState()
-  visibleColumns: Column[] = [];
+  visibleColumns: ColumnInternal[] = [];
 
   @Effect()
   updateTotalCount(): void {
@@ -148,7 +148,7 @@ export class DataGridLight extends JSXComponent(DataGridLightProps) {
     this.plugins.set(Items, this.props.dataSource);
   }
 
-  get columns(): Column[] {
+  get columns(): ColumnInternal[] {
     const userColumns = this.props.columns;
 
     return userColumns.map((userColumn) => ({

--- a/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
+++ b/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
@@ -11,7 +11,7 @@ import { Widget } from '../../common/widget';
 import { BaseWidgetProps } from '../../common/base_props';
 
 import type {
-  Column, ColumnUserConfig, KeyExpr, RowData, Row,
+  Column, ColumnUserConfig, KeyExpr, RowData, Row, KeyExprUserConfig,
 } from './types';
 
 import { TableContent } from './views/table_content';
@@ -58,7 +58,7 @@ export class DataGridLightProps extends BaseWidgetProps {
   dataSource: RowData[] = [];
 
   @OneWay()
-  keyExpr?: KeyExpr;
+  keyExpr?: KeyExprUserConfig;
 
   @OneWay()
   columns: ColumnUserConfig[] = [];
@@ -140,7 +140,7 @@ export class DataGridLight extends JSXComponent(DataGridLightProps) {
 
   @Effect()
   updateKeyExpr(): void {
-    this.plugins.set(KeyExprPlugin, this.props.keyExpr);
+    this.plugins.set(KeyExprPlugin, this.props.keyExpr ?? null);
   }
 
   @Effect()

--- a/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
+++ b/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
@@ -18,6 +18,8 @@ import { TableContent } from './views/table_content';
 import { TableHeader } from './views/table_header';
 import { Footer } from './views/footer';
 
+import CLASSES from './classes';
+
 export const VisibleItems = createGetter<RowData[]>([]);
 export const VisibleRows = createGetter<Row[]>([]);
 export const VisibleColumns = createGetter<Column[]>([]);
@@ -41,7 +43,7 @@ export const viewFunction = (viewModel: DataGridLight): JSX.Element => (
     width={viewModel.props.width}
     {...viewModel.restAttributes} // eslint-disable-line react/jsx-props-no-spreading
   >
-    <div className="dx-datagrid dx-gridbase-container" role="grid" aria-label="Data grid">
+    <div className={`${CLASSES.dataGrid} ${CLASSES.gridBaseContainer}`} role="grid" aria-label="Data grid">
       <TableHeader columns={viewModel.visibleColumns} />
       <TableContent columns={viewModel.visibleColumns} dataSource={viewModel.visibleRows} />
       <Footer />

--- a/js/renovation/ui/grids/data_grid_light/master_detail/expand_column.tsx
+++ b/js/renovation/ui/grids/data_grid_light/master_detail/expand_column.tsx
@@ -10,12 +10,14 @@ import eventsEngine from '../../../../../events/core/events_engine';
 import { name as clickEvent } from '../../../../../events/click';
 import { KeyExprPlugin } from '../data_grid_light';
 
+import CLASSES from '../classes';
+
 export const viewFunction = (viewModel: ExpandColumn): JSX.Element => (
   <td
     ref={viewModel.cellRef}
-    className="dx-command-expand dx-datagrid-group-space dx-datagrid-expand"
+    className={`${CLASSES.commandExpand} ${CLASSES.groupSpace} ${CLASSES.expand}`}
   >
-    <div className={viewModel.isExpanded ? 'dx-datagrid-group-opened' : 'dx-datagrid-group-closed'} />
+    <div className={viewModel.isExpanded ? CLASSES.groupOpened : CLASSES.groupClosed} />
   </td>
 );
 

--- a/js/renovation/ui/grids/data_grid_light/master_detail/expand_column.tsx
+++ b/js/renovation/ui/grids/data_grid_light/master_detail/expand_column.tsx
@@ -9,8 +9,11 @@ import { IsExpanded, SetExpanded } from './plugins';
 import eventsEngine from '../../../../../events/core/events_engine';
 import { name as clickEvent } from '../../../../../events/click';
 import { KeyExprPlugin } from '../data_grid_light';
+import { createGetKey } from '../utils';
 
 import CLASSES from '../classes';
+
+const getKey = createGetKey('Master-Detail');
 
 export const viewFunction = (viewModel: ExpandColumn): JSX.Element => (
   <td
@@ -39,7 +42,7 @@ export class ExpandColumn extends JSXComponent<ExpandColumnProps, 'data'>(Expand
   plugins: Plugins = new Plugins();
 
   @InternalState()
-  keyExpr: KeyExpr = '';
+  keyExpr?: KeyExpr;
 
   @InternalState()
   isExpanded = false;
@@ -54,7 +57,7 @@ export class ExpandColumn extends JSXComponent<ExpandColumnProps, 'data'>(Expand
   @Effect()
   updateIsExpanded(): () => void {
     return this.plugins.watch(IsExpanded, (isExpanded) => {
-      this.isExpanded = isExpanded(this.props.data[this.keyExpr]);
+      this.isExpanded = isExpanded(getKey(this.props.data, this.keyExpr));
     });
   }
 
@@ -68,7 +71,7 @@ export class ExpandColumn extends JSXComponent<ExpandColumnProps, 'data'>(Expand
     const target = e.target as Element;
 
     if (target.closest('.dx-datagrid-expand')) {
-      this.toggleExpanded(this.props.data[this.keyExpr]);
+      this.toggleExpanded(getKey(this.props.data, this.keyExpr));
     }
   }
 

--- a/js/renovation/ui/grids/data_grid_light/master_detail/expand_column.tsx
+++ b/js/renovation/ui/grids/data_grid_light/master_detail/expand_column.tsx
@@ -4,7 +4,7 @@ import {
 } from '@devextreme-generator/declarations';
 import { Plugins, PluginsContext } from '../../../../utils/plugin/context';
 
-import { Key, KeyExpr, RowData } from '../types';
+import { Key, KeyExprInternal, RowData } from '../types';
 import { IsExpanded, SetExpanded } from './plugins';
 import eventsEngine from '../../../../../events/core/events_engine';
 import { name as clickEvent } from '../../../../../events/click';
@@ -42,7 +42,7 @@ export class ExpandColumn extends JSXComponent<ExpandColumnProps, 'data'>(Expand
   plugins: Plugins = new Plugins();
 
   @InternalState()
-  keyExpr?: KeyExpr;
+  keyExpr?: KeyExprInternal;
 
   @InternalState()
   isExpanded = false;

--- a/js/renovation/ui/grids/data_grid_light/master_detail/master_detail.tsx
+++ b/js/renovation/ui/grids/data_grid_light/master_detail/master_detail.tsx
@@ -18,7 +18,7 @@ import {
   VisibleRows, VisibleColumns,
 } from '../data_grid_light';
 import {
-  Row, Key, Column, RowTemplateProps,
+  Row, Key, ColumnInternal, RowTemplateProps,
 } from '../types';
 import { GetterExtender } from '../../../../utils/plugin/getter_extender';
 
@@ -63,7 +63,7 @@ export class MasterDetail extends JSXComponent<MasterDetailProps, 'template'>(Ma
   addVisibleColumnsHandler(): (() => void) | undefined {
     if (this.props.enabled) {
       return this.plugins.extend(VisibleColumns, 1, (columns) => {
-        const expandColumn: Column = {
+        const expandColumn: ColumnInternal = {
           headerCssClass: `${CLASSES.commandExpand} ${CLASSES.groupSpace}`,
           cellContainerTemplate: ExpandColumn,
         };

--- a/js/renovation/ui/grids/data_grid_light/master_detail/master_detail.tsx
+++ b/js/renovation/ui/grids/data_grid_light/master_detail/master_detail.tsx
@@ -26,6 +26,8 @@ import { ExpandColumn } from './expand_column';
 import { SetExpanded, IsExpanded, MasterDetailTemplate } from './plugins';
 import { MasterDetailRow } from './master_detail_row';
 
+import CLASSES from '../classes';
+
 export const viewFunction = (viewModel: MasterDetail): JSX.Element => (
   <Fragment>
     <GetterExtender type={VisibleRows} order={2} func={viewModel.processVisibleRows} />
@@ -62,7 +64,7 @@ export class MasterDetail extends JSXComponent<MasterDetailProps, 'template'>(Ma
     if (this.props.enabled) {
       return this.plugins.extend(VisibleColumns, 1, (columns) => {
         const expandColumn: Column = {
-          headerCssClass: 'dx-command-expand dx-datagrid-group-space',
+          headerCssClass: `${CLASSES.commandExpand} ${CLASSES.groupSpace}`,
           cellContainerTemplate: ExpandColumn,
         };
 

--- a/js/renovation/ui/grids/data_grid_light/master_detail/master_detail_row.tsx
+++ b/js/renovation/ui/grids/data_grid_light/master_detail/master_detail_row.tsx
@@ -13,6 +13,7 @@ import { Row, RowTemplateProps } from '../types';
 import { RowBase, RowClassesGetter } from '../widgets/row_base';
 import { MasterDetailTemplate } from './plugins';
 import { VisibleColumns } from '../data_grid_light';
+import CLASSES from '../classes';
 
 export const viewFunction = (viewModel: MasterDetailRow): JSX.Element => {
   const { masterDetailRowTemplate: MasterDetailRowTemplate, colSpan } = viewModel;
@@ -81,7 +82,7 @@ export class MasterDetailRow extends JSXComponent(MasterDetailRowProps) {
         if (row.rowType === 'detail') {
           return {
             ...base(row),
-            'dx-master-detail-row': true,
+            [CLASSES.masterDetailRow]: true,
           };
         }
         return base(row);

--- a/js/renovation/ui/grids/data_grid_light/pager/__tests__/pager.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/pager/__tests__/pager.test.tsx
@@ -59,23 +59,24 @@ describe('Pager', () => {
       });
 
       it('should be calculated when auto', () => {
-        const grid = new Pager({
+        const pager = new Pager({
           allowedPageSizes: 'auto',
         });
 
-        grid.plugins.set(PageSize, 20);
+        pager.plugins.set(PageSize, 20);
+        pager.updatePageSize();
 
-        expect(grid.allowedPageSizes).toEqual([10, 20, 40]);
+        expect(pager.allowedPageSizes).toEqual([10, 20, 40]);
       });
 
       it('should be empty when auto and pageSize is all', () => {
-        const grid = new Pager({
+        const pager = new Pager({
           allowedPageSizes: 'auto',
         });
 
-        grid.plugins.set(PageSize, 'all');
+        pager.plugins.set(PageSize, 'all');
 
-        expect(grid.allowedPageSizes).toEqual([]);
+        expect(pager.allowedPageSizes).toEqual([]);
       });
     });
   });

--- a/js/renovation/ui/grids/data_grid_light/pager/pager.tsx
+++ b/js/renovation/ui/grids/data_grid_light/pager/pager.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /* eslint-disable max-classes-per-file */
 import {
-  Component, JSXComponent, ComponentBindings, OneWay, Consumer,
+  Component, JSXComponent, ComponentBindings, OneWay, Consumer, InternalState, Effect,
 } from '@devextreme-generator/declarations';
 import { PlaceholderExtender } from '../../../../utils/plugin/placeholder_extender';
 
@@ -87,25 +87,31 @@ export class Pager extends JSXComponent(PagerProps) {
   @Consumer(PluginsContext)
   plugins = new Plugins();
 
-  onPageSizeChange(pageSize: number): void {
-    const setPageSize = this.plugins.getValue(SetPageSize);
-    if (!setPageSize) {
-      return;
-    }
+  @InternalState()
+  pageSize: number | 'all' = 'all';
 
+  @Effect()
+  updatePageSize(): () => void {
+    return this.plugins.watch(PageSize, (pageSize) => {
+      this.pageSize = pageSize;
+    });
+  }
+
+  onPageSizeChange(pageSize: number): void {
     if (pageSize === 0) {
-      setPageSize('all');
+      this.plugins.callAction(SetPageSize, 'all');
     } else {
-      setPageSize(pageSize);
+      this.plugins.callAction(SetPageSize, pageSize);
     }
   }
 
   onPageIndexChange(pageIndex: number): void {
-    this.plugins.getValue(SetPageIndex)?.(pageIndex);
+    this.plugins.callAction(SetPageIndex, pageIndex);
   }
 
   get allowedPageSizes(): (number | 'all')[] {
-    const pageSize = this.plugins.getValue(PageSize) ?? 'all';
+    // eslint-disable-next-line prefer-destructuring
+    const pageSize = this.pageSize;
 
     if (this.props.allowedPageSizes === 'auto') {
       if (pageSize === 'all') {

--- a/js/renovation/ui/grids/data_grid_light/pager/pager.tsx
+++ b/js/renovation/ui/grids/data_grid_light/pager/pager.tsx
@@ -15,7 +15,7 @@ import { TotalCount } from '../data_grid_light';
 import { FooterPlaceholder } from '../views/footer';
 import { Plugins, PluginsContext } from '../../../../utils/plugin/context';
 
-const DATAGRID_PAGER_CLASS = 'dx-datagrid-pager';
+import CLASSES from '../classes';
 
 export const viewFunction = ({
   allowedPageSizes, onPageIndexChange, onPageSizeChange,
@@ -29,7 +29,7 @@ export const viewFunction = ({
     deps={[PageIndex, PageSize, TotalCount, PageCount]}
     template={({ deps }): JSX.Element => (
       <PagerContent
-        className={DATAGRID_PAGER_CLASS}
+        className={CLASSES.pager}
         pageSizes={allowedPageSizes}
         displayMode={displayMode}
         infoText={infoText}

--- a/js/renovation/ui/grids/data_grid_light/selection/select_all_checkbox.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/select_all_checkbox.tsx
@@ -10,9 +10,11 @@ import {
   ClearSelection, SelectableCount, SelectAll, SelectedCount,
 } from './plugins';
 
+import CLASSES from '../classes';
+
 export const viewFunction = (viewModel: SelectAllCheckbox): JSX.Element => (
   <CheckBox
-    className="dx-select-checkbox dx-datagrid-checkbox-size"
+    className={`${CLASSES.selectCheckbox} ${CLASSES.checkboxSize}`}
     value={viewModel.value}
     valueChange={viewModel.onValueChange}
   />

--- a/js/renovation/ui/grids/data_grid_light/selection/select_checkbox.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/select_checkbox.tsx
@@ -4,13 +4,15 @@ import {
 } from '@devextreme-generator/declarations';
 import { Plugins, PluginsContext } from '../../../../utils/plugin/context';
 
+import CLASSES from '../classes';
+
 import { CheckBox } from '../../../editors/check_box/check_box';
 import { RowData } from '../types';
 import { IsSelected, SetSelected } from './plugins';
 
 export const viewFunction = (viewModel: SelectionCheckbox): JSX.Element => (
   <CheckBox
-    className="dx-select-checkbox dx-datagrid-checkbox-size"
+    className={`${CLASSES.selectCheckbox} ${CLASSES.checkboxSize}`}
     value={viewModel.isSelected}
     valueChange={viewModel.setSelected}
   />

--- a/js/renovation/ui/grids/data_grid_light/selection/selection.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/selection.tsx
@@ -21,6 +21,9 @@ import {
   ClearSelection, IsSelected, SelectableCount, SelectAll, SelectedCount, SetSelected,
 } from './plugins';
 import CLASSES from '../classes';
+import { createGetKey } from '../utils';
+
+const getKey = createGetKey('Selection');
 
 export const viewFunction = (): JSX.Element => <div />;
 
@@ -48,7 +51,7 @@ export class Selection extends JSXComponent(SelectionProps) {
   plugins = new Plugins();
 
   @InternalState()
-  keyExpr: KeyExpr = '';
+  keyExpr?: KeyExpr;
 
   @Effect()
   watchKeyExpr(): () => void {
@@ -132,7 +135,7 @@ export class Selection extends JSXComponent(SelectionProps) {
   @Method()
   selectAll(): void {
     const items = this.getAllItems();
-    this.props.selectedRowKeys = items.map((item) => item[this.keyExpr]);
+    this.props.selectedRowKeys = items.map((item) => getKey(item, this.keyExpr));
   }
 
   @Method()
@@ -141,22 +144,24 @@ export class Selection extends JSXComponent(SelectionProps) {
   }
 
   isSelected(data: RowData): boolean {
-    return this.props.selectedRowKeys.includes(data[this.keyExpr]);
+    return this.props.selectedRowKeys.includes(getKey(data, this.keyExpr));
   }
 
   setSelected(data: RowData, value: boolean): void {
+    const key = getKey(data, this.keyExpr);
+
     if (value) {
       if (this.props.mode === 'multiple') {
         this.props.selectedRowKeys = [
           ...this.props.selectedRowKeys,
-          data[this.keyExpr],
+          key,
         ];
       } else {
-        this.props.selectedRowKeys = [data[this.keyExpr]];
+        this.props.selectedRowKeys = [key];
       }
     } else {
       this.props.selectedRowKeys = this.props.selectedRowKeys
-        .filter((i) => i !== data[this.keyExpr]);
+        .filter((i) => i !== key);
     }
   }
 

--- a/js/renovation/ui/grids/data_grid_light/selection/selection.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/selection.tsx
@@ -13,7 +13,7 @@ import {
   KeyExprPlugin, VisibleColumns, VisibleItems, Items,
 } from '../data_grid_light';
 import {
-  Column, KeyExpr, RowData, Key,
+  ColumnInternal, KeyExprInternal, RowData, Key,
 } from '../types';
 import { RowClassesGetter, RowPropertiesGetter } from '../widgets/row_base';
 import { RowClick } from '../views/table_content';
@@ -51,7 +51,7 @@ export class Selection extends JSXComponent(SelectionProps) {
   plugins = new Plugins();
 
   @InternalState()
-  keyExpr?: KeyExpr;
+  keyExpr?: KeyExprInternal;
 
   @Effect()
   watchKeyExpr(): () => void {
@@ -64,7 +64,7 @@ export class Selection extends JSXComponent(SelectionProps) {
   addVisibleColumnsHandler(): (() => void) | undefined {
     if (this.props.mode !== 'none') {
       return this.plugins.extend(VisibleColumns, 2, (columns) => {
-        const selectColumn: Column = { cellTemplate: SelectionCheckbox };
+        const selectColumn: ColumnInternal = { cellTemplate: SelectionCheckbox };
 
         if (this.props.mode === 'multiple' && this.props.allowSelectAll) {
           selectColumn.headerTemplate = SelectAllCheckbox;

--- a/js/renovation/ui/grids/data_grid_light/selection/selection.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/selection.tsx
@@ -20,6 +20,7 @@ import { RowClick } from '../views/table_content';
 import {
   ClearSelection, IsSelected, SelectableCount, SelectAll, SelectedCount, SetSelected,
 } from './plugins';
+import CLASSES from '../classes';
 
 export const viewFunction = (): JSX.Element => <div />;
 
@@ -113,7 +114,7 @@ export class Selection extends JSXComponent(SelectionProps) {
         if (row.rowType === 'data' && this.isSelected(row.data)) {
           return {
             ...base(row),
-            'dx-selection': true,
+            [CLASSES.selectedRow]: true,
           };
         }
         return base(row);

--- a/js/renovation/ui/grids/data_grid_light/types.ts
+++ b/js/renovation/ui/grids/data_grid_light/types.ts
@@ -4,9 +4,9 @@
 import { JSXTemplate } from '@devextreme-generator/declarations';
 
 export type RowData = Record<string, unknown>;
-export type ColumnUserConfig = string;
-export type KeyExprUserConfig = string;
-export type KeyExpr = KeyExprUserConfig | null;
+export type Column = string;
+export type KeyExpr = string;
+export type KeyExprInternal = KeyExpr | null;
 export type Key = unknown;
 export interface Row {
   key?: Key;
@@ -23,7 +23,7 @@ export interface RowTemplateProps {
   rowIndex: number;
 }
 
-export interface Column {
+export interface ColumnInternal {
   dataField?: string;
 
   headerCssClass?: string;

--- a/js/renovation/ui/grids/data_grid_light/types.ts
+++ b/js/renovation/ui/grids/data_grid_light/types.ts
@@ -5,7 +5,8 @@ import { JSXTemplate } from '@devextreme-generator/declarations';
 
 export type RowData = Record<string, unknown>;
 export type ColumnUserConfig = string;
-export type KeyExpr = string;
+export type KeyExprUserConfig = string;
+export type KeyExpr = KeyExprUserConfig | null;
 export type Key = unknown;
 export interface Row {
   key?: Key;

--- a/js/renovation/ui/grids/data_grid_light/utils.ts
+++ b/js/renovation/ui/grids/data_grid_light/utils.ts
@@ -1,5 +1,8 @@
-import { RowData, Key, KeyExpr } from './types';
+import {
+  RowData, Key, KeyExpr, Row,
+} from './types';
 import errors from '../../../../ui/widget/ui.errors';
+import { isString, isNumeric } from '../../../../core/utils/type';
 
 export const createGetKey = (featureName: string) => (
   rowData: RowData,
@@ -21,4 +24,12 @@ export const createGetKey = (featureName: string) => (
   }
 
   return rowData[keyExpr];
+};
+
+export const getReactRowKey = (row: Row, index: number): string => {
+  if (!row.key || !(isNumeric(row.key) || isString(row.key))) {
+    return `${index}`;
+  }
+
+  return `${row.rowType}_${row.key}`;
 };

--- a/js/renovation/ui/grids/data_grid_light/utils.ts
+++ b/js/renovation/ui/grids/data_grid_light/utils.ts
@@ -1,12 +1,12 @@
 import {
-  RowData, Key, KeyExpr, Row,
+  RowData, Key, KeyExprInternal, Row,
 } from './types';
 import errors from '../../../../ui/widget/ui.errors';
 import { isString, isNumeric } from '../../../../core/utils/type';
 
 export const createGetKey = (featureName: string) => (
   rowData: RowData,
-  keyExpr: KeyExpr | undefined,
+  keyExpr: KeyExprInternal | undefined,
 ): Key => {
   if (keyExpr === undefined) {
     // keyExpr wasn't updated on effect

--- a/js/renovation/ui/grids/data_grid_light/utils.ts
+++ b/js/renovation/ui/grids/data_grid_light/utils.ts
@@ -1,0 +1,24 @@
+import { RowData, Key, KeyExpr } from './types';
+import errors from '../../../../ui/widget/ui.errors';
+
+export const createGetKey = (featureName: string) => (
+  rowData: RowData,
+  keyExpr: KeyExpr | undefined,
+): Key => {
+  if (keyExpr === undefined) {
+    // keyExpr wasn't updated on effect
+    return undefined;
+  }
+
+  if (keyExpr === null) {
+    // keyExpr was not specified in config
+    throw errors.Error('E1042', featureName);
+  }
+
+  if (!(keyExpr in rowData)) {
+    // no keyExpr field in data object
+    throw errors.Error('E1046', keyExpr);
+  }
+
+  return rowData[keyExpr];
+};

--- a/js/renovation/ui/grids/data_grid_light/views/__tests__/table_content.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/views/__tests__/table_content.test.tsx
@@ -17,7 +17,7 @@ describe('TableContent', () => {
         columns,
       });
 
-      const tree = mount(<TableContentView {...tableContent as any} />);
+      const tree = mount(<TableContentView rows={tableContent.rows} {...tableContent as any} />);
 
       expect(tree.find('table').exists()).toBe(true);
       expect(tree.find('tr').length).toBe(1);
@@ -38,7 +38,7 @@ describe('TableContent', () => {
         columns,
       });
 
-      const tree = mount(<TableContentView {...tableContent as any} />);
+      const tree = mount(<TableContentView rows={tableContent.rows} {...tableContent as any} />);
 
       expect(tree.find('table').exists()).toBe(true);
       expect(tree.find('tr').length).toBe(1);

--- a/js/renovation/ui/grids/data_grid_light/views/__tests__/table_content.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/views/__tests__/table_content.test.tsx
@@ -4,13 +4,13 @@ import {
   emit, fakeClickEvent, clear, EVENT,
 } from '../../../../../test_utils/events_mock';
 import { RowClick, TableContent, viewFunction as TableContentView } from '../table_content';
-import { Row, Column } from '../../types';
+import { Row, ColumnInternal } from '../../types';
 
 describe('TableContent', () => {
   describe('View', () => {
     it('default render', () => {
       const rows: Row[] = [{ data: { id: 1, field: 'test' }, key: 1, rowType: 'data' }];
-      const columns: Column[] = [{ dataField: 'id' }, { dataField: 'field' }];
+      const columns: ColumnInternal[] = [{ dataField: 'id' }, { dataField: 'field' }];
 
       const tableContent = new TableContent({
         dataSource: rows,
@@ -31,7 +31,7 @@ describe('TableContent', () => {
         rowType: 'data',
         template: () => <tr className="myRow"><td>Test</td></tr>,
       }];
-      const columns: Column[] = [{ dataField: 'id' }, { dataField: 'field' }];
+      const columns: ColumnInternal[] = [{ dataField: 'id' }, { dataField: 'field' }];
 
       const tableContent = new TableContent({
         dataSource: rows,

--- a/js/renovation/ui/grids/data_grid_light/views/table_content.tsx
+++ b/js/renovation/ui/grids/data_grid_light/views/table_content.tsx
@@ -12,6 +12,7 @@ import {
 import eventsEngine from '../../../../../events/core/events_engine';
 import { name as clickEvent } from '../../../../../events/click';
 import CLASSES from '../classes';
+import { getReactRowKey } from '../utils';
 
 export const viewFunction = (viewModel: TableContent): JSX.Element => (
   <div className={`${CLASSES.rowsView} ${CLASSES.noWrap} ${CLASSES.afterHeaders}`} role="presentation">
@@ -19,12 +20,11 @@ export const viewFunction = (viewModel: TableContent): JSX.Element => (
       <Table>
         <Fragment>
           {
-          viewModel.props.dataSource.map((item, rowIndex) => (
+          viewModel.rows.map((item) => (
             <DataRow
-              // eslint-disable-next-line react/no-array-index-key
-              key={rowIndex}
+              key={item.reactKey}
               row={item}
-              rowIndex={rowIndex}
+              rowIndex={item.index}
               columns={viewModel.props.columns}
             />
           ))
@@ -70,5 +70,13 @@ export class TableContent extends JSXComponent(TableContentProps) {
     if (index >= 0) {
       this.plugins.callAction(RowClick, this.props.dataSource[index]);
     }
+  }
+
+  get rows(): (Row & { index: number; reactKey: string })[] {
+    return this.props.dataSource.map((row, index) => ({
+      ...row,
+      index,
+      reactKey: getReactRowKey(row, index),
+    }));
   }
 }

--- a/js/renovation/ui/grids/data_grid_light/views/table_content.tsx
+++ b/js/renovation/ui/grids/data_grid_light/views/table_content.tsx
@@ -5,7 +5,7 @@ import {
 
 import { Table } from '../widgets/table';
 import { DataRow } from '../widgets/data_row';
-import { Column, Row } from '../types';
+import { ColumnInternal, Row } from '../types';
 import {
   createValue, Plugins, PluginsContext,
 } from '../../../../utils/plugin/context';
@@ -43,7 +43,7 @@ export class TableContentProps {
   dataSource: Row[] = [];
 
   @OneWay()
-  columns: Column[] = [];
+  columns: ColumnInternal[] = [];
 }
 
 @Component({

--- a/js/renovation/ui/grids/data_grid_light/views/table_content.tsx
+++ b/js/renovation/ui/grids/data_grid_light/views/table_content.tsx
@@ -11,10 +11,11 @@ import {
 } from '../../../../utils/plugin/context';
 import eventsEngine from '../../../../../events/core/events_engine';
 import { name as clickEvent } from '../../../../../events/click';
+import CLASSES from '../classes';
 
 export const viewFunction = (viewModel: TableContent): JSX.Element => (
-  <div className="dx-datagrid-rowsview dx-datagrid-nowrap dx-datagrid-after-headers" role="presentation">
-    <div ref={viewModel.divRef} className="dx-datagrid-content">
+  <div className={`${CLASSES.rowsView} ${CLASSES.noWrap} ${CLASSES.afterHeaders}`} role="presentation">
+    <div ref={viewModel.divRef} className={`${CLASSES.content}`}>
       <Table>
         <Fragment>
           {
@@ -59,12 +60,12 @@ export class TableContent extends JSXComponent(TableContentProps) {
 
   @Effect()
   subscribeToRowClick(): () => void {
-    eventsEngine.on(this.divRef.current, clickEvent, '.dx-row', this.onRowClick);
+    eventsEngine.on(this.divRef.current, clickEvent, `.${CLASSES.row}`, this.onRowClick);
     return (): void => eventsEngine.off(this.divRef.current, clickEvent, this.onRowClick);
   }
 
   onRowClick(e: Event): void {
-    const allRows = this.divRef.current!.getElementsByClassName('dx-row');
+    const allRows = this.divRef.current!.getElementsByClassName(CLASSES.row);
     const index = Array.from(allRows).indexOf(e.currentTarget as Element);
     if (index >= 0) {
       this.plugins.callAction(RowClick, this.props.dataSource[index]);

--- a/js/renovation/ui/grids/data_grid_light/views/table_header.tsx
+++ b/js/renovation/ui/grids/data_grid_light/views/table_header.tsx
@@ -5,10 +5,11 @@ import {
 import { Table } from '../widgets/table';
 import { HeaderRow } from '../widgets/header_row';
 import { Column } from '../types';
+import CLASSES from '../classes';
 
 export const viewFunction = (viewModel: TableHeader): JSX.Element => (
-  <div className="dx-datagrid-headers dx-datagrid-nowrap" role="presentation">
-    <div className="dx-datagrid-content dx-datagrid-scroll-container" role="presentation">
+  <div className={`${CLASSES.headers} ${CLASSES.noWrap}`} role="presentation">
+    <div className={`${CLASSES.content} ${CLASSES.scrollContainer}`} role="presentation">
       <Table>
         <HeaderRow columns={viewModel.props.columns} />
       </Table>

--- a/js/renovation/ui/grids/data_grid_light/views/table_header.tsx
+++ b/js/renovation/ui/grids/data_grid_light/views/table_header.tsx
@@ -4,7 +4,7 @@ import {
 
 import { Table } from '../widgets/table';
 import { HeaderRow } from '../widgets/header_row';
-import { Column } from '../types';
+import { ColumnInternal } from '../types';
 import CLASSES from '../classes';
 
 export const viewFunction = (viewModel: TableHeader): JSX.Element => (
@@ -20,7 +20,7 @@ export const viewFunction = (viewModel: TableHeader): JSX.Element => (
 @ComponentBindings()
 export class TableHeaderProps {
   @OneWay()
-  columns: Column[] = [];
+  columns: ColumnInternal[] = [];
 }
 
 @Component({

--- a/js/renovation/ui/grids/data_grid_light/widgets/data_cell.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/data_cell.tsx
@@ -1,7 +1,7 @@
 import {
   Component, JSXComponent, ComponentBindings, OneWay, JSXTemplate,
 } from '@devextreme-generator/declarations';
-import { Column, Row, RowData } from '../types';
+import { ColumnInternal, Row, RowData } from '../types';
 import { combineClasses } from '../../../../utils/combine_classes';
 
 import CLASSES from '../classes';
@@ -54,7 +54,7 @@ export class DataCellProps {
   countColumn = 0;
 
   @OneWay()
-  column: Column = {};
+  column: ColumnInternal = {};
 }
 
 @Component({

--- a/js/renovation/ui/grids/data_grid_light/widgets/data_cell.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/data_cell.tsx
@@ -4,6 +4,8 @@ import {
 import { Column, Row, RowData } from '../types';
 import { combineClasses } from '../../../../utils/combine_classes';
 
+import CLASSES from '../classes';
+
 export const viewFunction = (viewModel: DataCell): JSX.Element => {
   const {
     cellText,
@@ -78,8 +80,8 @@ export class DataCell extends JSXComponent(DataCellProps) {
     const { columnIndex, countColumn } = this.props;
 
     const classesMap = {
-      'dx-first-child': columnIndex === 0,
-      'dx-last-child': columnIndex === countColumn - 1,
+      [CLASSES.firstChild]: columnIndex === 0,
+      [CLASSES.lastChild]: columnIndex === countColumn - 1,
     };
 
     return combineClasses(classesMap);

--- a/js/renovation/ui/grids/data_grid_light/widgets/data_row.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/data_row.tsx
@@ -5,6 +5,7 @@ import { Plugins, PluginsContext } from '../../../../utils/plugin/context';
 import { Column, Row, RowTemplateProps } from '../types';
 import { DataCell } from './data_cell';
 import { RowBase, RowClassesGetter } from './row_base';
+import CLASSES from '../classes';
 
 export const viewFunction = (viewModel: DataRow): JSX.Element => {
   const { rowTemplate: RowTemplate } = viewModel;
@@ -69,7 +70,7 @@ export class DataRow extends JSXComponent(DataRowProps) {
         if (row.rowType === 'data') {
           return {
             ...base(row),
-            'dx-data-row': true,
+            [CLASSES.dataRow]: true,
           };
         }
         return base(row);

--- a/js/renovation/ui/grids/data_grid_light/widgets/data_row.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/data_row.tsx
@@ -2,7 +2,7 @@ import {
   Component, JSXComponent, ComponentBindings, OneWay, Effect, Consumer, JSXTemplate,
 } from '@devextreme-generator/declarations';
 import { Plugins, PluginsContext } from '../../../../utils/plugin/context';
-import { Column, Row, RowTemplateProps } from '../types';
+import { ColumnInternal, Row, RowTemplateProps } from '../types';
 import { DataCell } from './data_cell';
 import { RowBase, RowClassesGetter } from './row_base';
 import CLASSES from '../classes';
@@ -47,7 +47,7 @@ export class DataRowProps {
   rowIndex = 0;
 
   @OneWay()
-  columns: Column[] = [];
+  columns: ColumnInternal[] = [];
 }
 
 @Component({

--- a/js/renovation/ui/grids/data_grid_light/widgets/header_cell.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/header_cell.tsx
@@ -5,7 +5,7 @@ import { combineClasses } from '../../../../utils/combine_classes';
 
 import CLASSES from '../classes';
 
-import { Column } from '../types';
+import { ColumnInternal } from '../types';
 
 export const viewFunction = ({
   props: { column, columnIndex },
@@ -18,7 +18,7 @@ export const viewFunction = ({
     // TODO uncomment after https://trello.com/c/kVXfSWI7
     // aria-colindex={index + 1}
     id={`dx-col-${columnIndex + 1}`}
-    aria-label={`Column ${column.dataField}`}
+    aria-label={`ColumnInternal ${column.dataField}`}
     className={classes}
     aria-sort="none"
     tabIndex={0}
@@ -32,7 +32,7 @@ export const viewFunction = ({
 @ComponentBindings()
 export class HeaderCellProps {
   @OneWay()
-  column: Column = {};
+  column: ColumnInternal = {};
 
   @OneWay()
   columnIndex = 0;

--- a/js/renovation/ui/grids/data_grid_light/widgets/header_cell.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/header_cell.tsx
@@ -3,6 +3,8 @@ import {
 } from '@devextreme-generator/declarations';
 import { combineClasses } from '../../../../utils/combine_classes';
 
+import CLASSES from '../classes';
+
 import { Column } from '../types';
 
 export const viewFunction = ({
@@ -21,7 +23,7 @@ export const viewFunction = ({
     aria-sort="none"
     tabIndex={0}
   >
-    <div className="dx-datagrid-text-content dx-text-content-alignment-left" role="presentation">
+    <div className={`${CLASSES.textContent} ${CLASSES.textContentAlignmentLeft}`} role="presentation">
       {HeaderTemplate ? <HeaderTemplate /> : column.dataField}
     </div>
   </td>
@@ -52,10 +54,10 @@ export class HeaderCell extends JSXComponent(HeaderCellProps) {
     const { columnIndex, countColumn } = this.props;
 
     const classesMap = {
-      'dx-datagrid-action': true,
-      'dx-cell-focus-disabled': true,
-      'dx-first-child': columnIndex === 0,
-      'dx-last-child': columnIndex === countColumn - 1,
+      [CLASSES.action]: true,
+      [CLASSES.cellFocusDisabled]: true,
+      [CLASSES.firstChild]: columnIndex === 0,
+      [CLASSES.lastChild]: columnIndex === countColumn - 1,
     };
 
     if (this.props.column.headerCssClass) {

--- a/js/renovation/ui/grids/data_grid_light/widgets/header_row.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/header_row.tsx
@@ -1,7 +1,7 @@
 import {
   Component, JSXComponent, ComponentBindings, OneWay,
 } from '@devextreme-generator/declarations';
-import { Column } from '../types';
+import { ColumnInternal } from '../types';
 import { HeaderCell } from './header_cell';
 
 import CLASSES from '../classes';
@@ -23,7 +23,7 @@ export const viewFunction = (viewModel: HeaderRow): JSX.Element => (
 @ComponentBindings()
 export class HeaderRowProps {
   @OneWay()
-  columns: Column[] = [];
+  columns: ColumnInternal[] = [];
 }
 
 @Component({

--- a/js/renovation/ui/grids/data_grid_light/widgets/header_row.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/header_row.tsx
@@ -4,8 +4,10 @@ import {
 import { Column } from '../types';
 import { HeaderCell } from './header_cell';
 
+import CLASSES from '../classes';
+
 export const viewFunction = (viewModel: HeaderRow): JSX.Element => (
-  <tr className="dx-row dx-column-lines dx-header-row" role="row">
+  <tr className={`${CLASSES.row} ${CLASSES.columnLines} ${CLASSES.headerRow}`} role="row">
     {viewModel.props.columns.map((column, index) => (
       <HeaderCell
         // eslint-disable-next-line react/no-array-index-key

--- a/js/renovation/ui/grids/data_grid_light/widgets/row_base.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/row_base.tsx
@@ -4,6 +4,7 @@ import {
 import { combineClasses } from '../../../../utils/combine_classes';
 import { createGetter, PluginsContext, Plugins } from '../../../../utils/plugin/context';
 import { Row } from '../types';
+import CLASSES from '../classes';
 
 export type RowPropertiesGetterType = (row: Row) => Record<string, unknown>;
 export const RowPropertiesGetter = createGetter<RowPropertiesGetterType>(() => ({}));
@@ -44,8 +45,8 @@ export class RowBase extends JSXComponent(RowBaseProps) {
 
   get cssClasses(): string {
     return combineClasses({
-      'dx-row': true,
-      'dx-column-lines': true,
+      [CLASSES.row]: true,
+      [CLASSES.columnLines]: true,
       ...this.additionalClasses,
     });
   }

--- a/js/renovation/ui/grids/data_grid_light/widgets/table.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/table.tsx
@@ -1,9 +1,10 @@
 import {
   Component, JSXComponent, ComponentBindings, Slot,
 } from '@devextreme-generator/declarations';
+import CLASSES from '../classes';
 
 export const viewFunction = (viewModel: Table): JSX.Element => (
-  <table className="dx-datagrid-table dx-datagrid-table-fixed" role="presentation">
+  <table className={`${CLASSES.table} ${CLASSES.fixedTable}`} role="presentation">
     <tbody role="presentation">
       {viewModel.props.children}
     </tbody>


### PR DESCRIPTION
Better review this PR commit-by-commit

Changes:

### moved class names constants to `classes.ts`.

Maybe in future we will separate this file to `<module>/classes.ts`

### added `getKey` function

It will throw correct errors if `keyExpr` doesn't exist. In future it will be useful to get complex keys

This function needs to be able to differ when keyExpr wasn't yet initialized (cause plugins set keyExpr in effect), so I added `null` type to keyExpr

- `null` means that user didn't specified keyExpr in config and widget should throw error
- `undefined` means that key wasn't initialized yet

### used row key as react key

removed `// eslint-disable-next-line react/no-array-index-key`

I created function `getReactRowKey`, it combines row's type and key to create react key (because master-detail row and data row have same key)

### fixed using `getValue()` in pager

changed to `.watch()`