### PR TITLE
Add retry functionality to qunit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ project.lock.json
 yarn.lock
 RawLog.txt
 .DS_Store
+testing/CompletedSuites.txt

--- a/testing/runner/Tools/UIModelHelper.cs
+++ b/testing/runner/Tools/UIModelHelper.cs
@@ -53,10 +53,10 @@ namespace Runner.Tools
             return String.Format("~/testing/tests/{0}/{1}", catName, suiteName);
         }
 
-        public IEnumerable<Suite> GetAllSuites(bool deviceMode, string constellation, ISet<string> includeCategories, ISet<string> excludeCategories, int partIndex, int partCount)
+        public IEnumerable<Suite> GetAllSuites(bool deviceMode, string constellation, ISet<string> includeCategories, ISet<string> excludeCategories, ISet<string> excludeSuites, int partIndex, int partCount)
         {
-            var includesSpecified = includeCategories != null && includeCategories.Any();
-            var excludesSpecified = excludeCategories != null && excludeCategories.Any();
+            var includeCategoriesSpecified = includeCategories != null && includeCategories.Any();
+            var excludeCategoriesSpecified = excludeCategories != null && excludeCategories.Any();
 
             foreach (var cat in ReadCategories())
             {
@@ -66,22 +66,23 @@ namespace Runner.Tools
                 if (!String.IsNullOrEmpty(constellation) && cat.Constellation != constellation)
                     continue;
 
-                if (includesSpecified && !includeCategories.Contains(cat.Name))
+                if (includeCategoriesSpecified && !includeCategories.Contains(cat.Name))
                     continue;
 
                 if (cat.Explicit)
                 {
-                    if (!includesSpecified || !includeCategories.Contains(cat.Name))
+                    if (!includeCategoriesSpecified || !includeCategories.Contains(cat.Name))
                         continue;
                 }
 
-                if (excludesSpecified && excludeCategories.Contains(cat.Name))
+                if (excludeCategoriesSpecified && excludeCategories.Contains(cat.Name))
                     continue;
 
                 int index = 0;
                 foreach (var suite in ReadSuites(cat.Name)) {
                     if(partCount <= 1 || (index % partCount) == partIndex) {
-                        yield return suite;
+                        if (excludeSuites?.Contains(suite.FullName) != true)
+                            yield return suite;
 
                     }
                     index++;


### PR DESCRIPTION
This PR attempts to fix blinking tests by adding retry functionality to a runner. 

When we execute tests, runner writes passed fixtures to the `testing/CompletedSuites.txt`
If any of the tests fail, the runner starts one more time (up to **three** times), ignoring already passed fixtures, so it runs only failed fixtures.
In the worst case, this may slow down task execution time in case there's a real failing test after a dev commit, but it may increase the time for about 3-6 minutes (on my expectations)
In the best case, retries will hide blinking tests and allow developers to stop focusing on issues that do not relate directly to their work.