### PR TITLE
DataGridLight: Fix selection for angular and move logic to selectors

### DIFF
--- a/js/renovation/ui/grids/data_grid_light/__tests__/data_grid_light.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/__tests__/data_grid_light.test.tsx
@@ -175,7 +175,7 @@ describe('DataGridLight', () => {
       it('should return count of AllItems', () => {
         const plugins = new Plugins();
 
-        plugins.set(AllItems, [1, 2, 3]);
+        plugins.set(AllItems, generateData(3));
 
         expect(plugins.getValue(TotalCount)).toBe(3);
       });

--- a/js/renovation/ui/grids/data_grid_light/__tests__/data_grid_light.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/__tests__/data_grid_light.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import {
   DataGridLight, viewFunction as DataGridView, DataGridLightProps,
-  TotalCount, KeyExprPlugin, Items,
+  TotalCount, KeyExprPlugin, AllItems,
 } from '../data_grid_light';
 import { Widget } from '../../../common/widget';
 import { generateData, generateRows } from './test_data';
@@ -113,7 +113,7 @@ describe('DataGridLight', () => {
         });
 
         grid.updateDataSource();
-        expect(grid.plugins.getValue(Items)).toBe(dataSource);
+        expect(grid.plugins.getValue(AllItems)).toBe(dataSource);
       });
     });
 

--- a/js/renovation/ui/grids/data_grid_light/__tests__/data_grid_light.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/__tests__/data_grid_light.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { mount } from 'enzyme';
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { GetterExtender } from '../../../../utils/plugin/getter_extender';
+import { Plugins } from '../../../../utils/plugin/context';
+import { ValueSetter } from '../../../../utils/plugin/value_setter';
 import {
   DataGridLight, viewFunction as DataGridView, DataGridLightProps,
-  TotalCount, KeyExprPlugin, AllItems,
+  AllItems, Columns, KeyExprPlugin, VisibleColumns,
+  VisibleItems, VisibleRows, VisibleDataRows, TotalCount,
 } from '../data_grid_light';
 import { Widget } from '../../../common/widget';
 import { generateData, generateRows } from './test_data';
@@ -11,18 +15,42 @@ import { generateData, generateRows } from './test_data';
 describe('DataGridLight', () => {
   describe('View', () => {
     it('default render', () => {
-      const props = {
-        props: new DataGridLightProps(),
+      const props = new DataGridLightProps();
+      props.dataSource = [];
+      const viewModel = {
+        props,
         aria: { role: 'presentation' },
         classes: '',
         restAttributes: { 'rest-attributes': 'true' },
+        columns: [{ dataField: 'id' }],
+        keyExpr: 'id',
       } as Partial<DataGridLight>;
-      const tree = mount(<DataGridView {...props as any} /> as any);
+      const tree = mount(<DataGridView {...viewModel as any} /> as any);
 
       expect(tree.find(Widget).first().props()).toMatchObject({
         aria: { role: 'presentation' },
         classes: '',
         'rest-attributes': 'true',
+      });
+
+      expect(tree.find(ValueSetter).at(0).props()).toMatchObject({
+        type: AllItems, value: props.dataSource,
+      });
+      expect(tree.find(ValueSetter).at(1).props()).toMatchObject({
+        type: Columns, value: viewModel.columns,
+      });
+      expect(tree.find(ValueSetter).at(2).props()).toMatchObject({
+        type: KeyExprPlugin, value: viewModel.keyExpr,
+      });
+
+      expect(tree.find(GetterExtender).at(0).props()).toMatchObject({
+        type: VisibleColumns, order: -1, value: Columns,
+      });
+      expect(tree.find(GetterExtender).at(1).props()).toMatchObject({
+        type: VisibleItems, order: -1, value: AllItems,
+      });
+      expect(tree.find(GetterExtender).at(2).props()).toMatchObject({
+        type: VisibleRows, order: -1, value: VisibleDataRows,
       });
     });
 
@@ -84,39 +112,25 @@ describe('DataGridLight', () => {
         ]);
       });
     });
-  });
 
-  describe('Effects', () => {
-    describe('updateKeyExpr', () => {
-      it('should update keyExpr', () => {
+    describe('keyExpr', () => {
+      it('should return keyExpr prop', () => {
         const grid = new DataGridLight({
           keyExpr: 'some key',
         });
 
-        grid.updateKeyExpr();
-        expect(grid.plugins.getValue(KeyExprPlugin)).toEqual('some key');
+        expect(grid.keyExpr).toEqual('some key');
       });
 
-      it('should set keyExpr to null if user did not specified it', () => {
+      it('should return null if user did not specified it', () => {
         const grid = new DataGridLight({});
 
-        grid.updateKeyExpr();
-        expect(grid.plugins.getValue(KeyExprPlugin)).toEqual(null);
+        expect(grid.keyExpr).toEqual(null);
       });
     });
+  });
 
-    describe('updateDataSource', () => {
-      it('should update updateDataSource', () => {
-        const dataSource = [{ id: 1 }, { id: 2 }, { id: 3 }];
-        const grid = new DataGridLight({
-          dataSource,
-        });
-
-        grid.updateDataSource();
-        expect(grid.plugins.getValue(AllItems)).toBe(dataSource);
-      });
-    });
-
+  describe('Effects', () => {
     describe('updateVisibleRows', () => {
       const watchMock = jest.fn();
       const grid = new DataGridLight({});
@@ -133,115 +147,6 @@ describe('DataGridLight', () => {
         callback(data);
 
         expect(grid.visibleRows).toBe(data);
-      });
-    });
-
-    describe('updateVisibleRowsByVisibleItems', () => {
-      const watchMock = jest.fn();
-      const grid = new DataGridLight({});
-      grid.plugins = {
-        watch: watchMock,
-        getValue: () => generateRows(2),
-      } as any;
-
-      it('should update visibleRows by visibleItems', () => {
-        grid.updateVisibleRowsByVisibleItems();
-
-        const data = generateRows(2);
-
-        const callback = watchMock.mock.calls[0][1];
-        callback(data);
-
-        expect(grid.visibleRows).toMatchObject([
-          {
-            key: 0,
-            data: { id: 0 },
-            rowType: 'data',
-          }, {
-            key: 1,
-            data: { id: 1 },
-            rowType: 'data',
-          },
-        ]);
-      });
-
-      it('should not update visibleRows when it is undefined', () => {
-        grid.plugins.getValue = () => undefined;
-        grid.updateVisibleRowsByVisibleItems();
-
-        const callback = watchMock.mock.calls[0][1];
-        callback();
-
-        expect(grid.visibleRows).toMatchObject([]);
-      });
-    });
-
-    describe('setDataSourceToVisibleItems', () => {
-      const extendMock = jest.fn();
-      const dataSource = generateData(3);
-      const grid = new DataGridLight({
-        dataSource,
-      });
-      grid.plugins = {
-        extend: extendMock,
-      } as any;
-
-      it('should return dataSource', () => {
-        grid.setDataSourceToVisibleItems();
-
-        expect(extendMock.mock.calls[0][2]()).toBe(dataSource);
-      });
-    });
-
-    describe('setVisibleRowsByVisibleItems', () => {
-      const extendMock = jest.fn();
-      const dataSource = generateData(2);
-      const grid = new DataGridLight({
-        keyExpr: 'id',
-      });
-      grid.plugins = {
-        extend: extendMock,
-        getValue: () => dataSource,
-      } as any;
-
-      it('should return visibleRows', () => {
-        grid.setVisibleRowsByVisibleItems();
-
-        expect(extendMock.mock.calls[0][2]()).toMatchObject([
-          {
-            key: 0,
-            data: { id: 0 },
-            rowType: 'data',
-          }, {
-            key: 1,
-            data: { id: 1 },
-            rowType: 'data',
-          },
-        ]);
-      });
-
-      it('should return visibleRows when keyExpr is not set', () => {
-        grid.props.keyExpr = undefined;
-        grid.setVisibleRowsByVisibleItems();
-
-        expect(extendMock.mock.calls[0][2]()).toMatchObject([
-          {
-            key: { id: 0 },
-            data: { id: 0 },
-            rowType: 'data',
-          }, {
-            key: { id: 1 },
-            data: { id: 1 },
-            rowType: 'data',
-          },
-        ]);
-      });
-
-      it('should not return visibleRows when dataSource is not set', () => {
-        grid.plugins.getValue = () => undefined;
-        grid.setVisibleRowsByVisibleItems();
-
-        expect(extendMock.mock.calls[0][2]()).toMatchObject([]);
       });
     });
 
@@ -263,34 +168,56 @@ describe('DataGridLight', () => {
         expect(grid.visibleColumns).toBe(columns);
       });
     });
+  });
 
-    describe('setInitialColumnsToVisibleColumns', () => {
-      const extendMock = jest.fn();
-      const columns = ['id'];
-      const grid = new DataGridLight({
-        columns,
-      });
-      grid.plugins = {
-        extend: extendMock,
-      } as any;
+  describe('Selectors', () => {
+    describe('TotalCount', () => {
+      it('should return count of AllItems', () => {
+        const plugins = new Plugins();
 
-      it('should return columns', () => {
-        grid.setInitialColumnsToVisibleColumns();
+        plugins.set(AllItems, [1, 2, 3]);
 
-        expect(extendMock.mock.calls[0][2]()).toEqual([{ dataField: 'id' }]);
+        expect(plugins.getValue(TotalCount)).toBe(3);
       });
     });
 
-    describe('updateTotalCount', () => {
-      it('should be equal to dataSource\'s length', () => {
-        const dataSource = generateData(10);
-        const grid = new DataGridLight({
-          dataSource,
-        });
+    describe('VisibleDataRows', () => {
+      it('should wrap item into row object if keyExpr is defined', () => {
+        const plugins = new Plugins();
 
-        grid.updateTotalCount();
+        const data = generateData(2);
 
-        expect(grid.plugins.getValue(TotalCount)).toEqual(dataSource.length);
+        plugins.extend(VisibleItems, 0, () => data);
+        plugins.set(KeyExprPlugin, 'id');
+
+        expect(plugins.getValue(VisibleDataRows)).toEqual([{
+          rowType: 'data',
+          key: 0,
+          data: data[0],
+        }, {
+          rowType: 'data',
+          key: 1,
+          data: data[1],
+        }]);
+      });
+
+      it('should wrap item into row object if keyExpr is not defined', () => {
+        const plugins = new Plugins();
+
+        const data = generateData(2);
+
+        plugins.extend(VisibleItems, 0, () => data);
+        plugins.set(KeyExprPlugin, null);
+
+        expect(plugins.getValue(VisibleDataRows)).toEqual([{
+          rowType: 'data',
+          key: data[0],
+          data: data[0],
+        }, {
+          rowType: 'data',
+          key: data[1],
+          data: data[1],
+        }]);
       });
     });
   });

--- a/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
+++ b/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
@@ -117,13 +117,6 @@ export class DataGridLight extends JSXComponent(DataGridLightProps) {
   visibleColumns: ColumnInternal[] = [];
 
   @Effect()
-  updateVisibleRowsByVisibleItems(): () => void {
-    return this.plugins.watch(VisibleItems, () => {
-      this.visibleRows = this.plugins.getValue(VisibleRows) ?? [];
-    });
-  }
-
-  @Effect()
   updateVisibleRows(): () => void {
     return this.plugins.watch(VisibleRows, (visibleRows) => {
       this.visibleRows = visibleRows;

--- a/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
+++ b/js/renovation/ui/grids/data_grid_light/data_grid_light.tsx
@@ -5,8 +5,11 @@ import {
 } from '@devextreme-generator/declarations';
 
 import {
-  createValue, createGetter, Plugins, PluginsContext,
+  createValue, createGetter, Plugins, PluginsContext, createSelector,
 } from '../../../utils/plugin/context';
+import { ValueSetter } from '../../../utils/plugin/value_setter';
+import { GetterExtender } from '../../../utils/plugin/getter_extender';
+
 import { Widget } from '../../common/widget';
 import { BaseWidgetProps } from '../../common/base_props';
 
@@ -20,12 +23,27 @@ import { Footer } from './views/footer';
 
 import CLASSES from './classes';
 
+export const AllItems = createValue<RowData[]>();
 export const VisibleItems = createGetter<RowData[]>([]);
 export const VisibleRows = createGetter<Row[]>([]);
+
+export const Columns = createValue<ColumnInternal[]>();
 export const VisibleColumns = createGetter<ColumnInternal[]>([]);
-export const Items = createValue<RowData[]>();
+
 export const KeyExprPlugin = createValue<KeyExprInternal>();
-export const TotalCount = createValue<number>();
+export const TotalCount = createSelector<number>(
+  [AllItems],
+  (allItems: RowData[]) => allItems.length,
+);
+
+export const VisibleDataRows = createSelector<Row[]>(
+  [VisibleItems, KeyExprPlugin],
+  (visibleItems: RowData[], keyExpr: KeyExprInternal): Row[] => visibleItems.map((data) => ({
+    key: keyExpr ? data[keyExpr] : data,
+    data,
+    rowType: 'data',
+  })),
+);
 
 export const viewFunction = (viewModel: DataGridLight): JSX.Element => (
   <Widget // eslint-disable-line jsx-a11y/no-access-key
@@ -43,6 +61,13 @@ export const viewFunction = (viewModel: DataGridLight): JSX.Element => (
     width={viewModel.props.width}
     {...viewModel.restAttributes} // eslint-disable-line react/jsx-props-no-spreading
   >
+    <ValueSetter type={AllItems} value={viewModel.props.dataSource} />
+    <ValueSetter type={Columns} value={viewModel.columns} />
+    <ValueSetter type={KeyExprPlugin} value={viewModel.keyExpr} />
+    <GetterExtender type={VisibleColumns} order={-1} value={Columns} />
+    <GetterExtender type={VisibleItems} order={-1} value={AllItems} />
+    <GetterExtender type={VisibleRows} order={-1} value={VisibleDataRows} />
+
     <div className={`${CLASSES.dataGrid} ${CLASSES.gridBaseContainer}`} role="grid" aria-label="Data grid">
       <TableHeader columns={viewModel.visibleColumns} />
       <TableContent columns={viewModel.visibleColumns} dataSource={viewModel.visibleRows} />
@@ -92,11 +117,6 @@ export class DataGridLight extends JSXComponent(DataGridLightProps) {
   visibleColumns: ColumnInternal[] = [];
 
   @Effect()
-  updateTotalCount(): void {
-    this.plugins.set(TotalCount, this.props.dataSource.length);
-  }
-
-  @Effect()
   updateVisibleRowsByVisibleItems(): () => void {
     return this.plugins.watch(VisibleItems, () => {
       this.visibleRows = this.plugins.getValue(VisibleRows) ?? [];
@@ -111,41 +131,14 @@ export class DataGridLight extends JSXComponent(DataGridLightProps) {
   }
 
   @Effect()
-  setDataSourceToVisibleItems(): () => void {
-    return this.plugins.extend(VisibleItems, -1, () => this.props.dataSource);
-  }
-
-  @Effect()
-  setVisibleRowsByVisibleItems(): () => void {
-    return this.plugins.extend(VisibleRows, -1, () => {
-      const visibleItems = this.plugins.getValue(VisibleItems) ?? [];
-
-      return this.generateDataRows(visibleItems);
-    });
-  }
-
-  @Effect()
   updateVisibleColumns(): () => void {
     return this.plugins.watch(VisibleColumns, (columns) => {
       this.visibleColumns = columns;
     });
   }
 
-  @Effect()
-  setInitialColumnsToVisibleColumns(): () => void {
-    return this.plugins.extend(
-      VisibleColumns, -1, () => this.columns,
-    );
-  }
-
-  @Effect()
-  updateKeyExpr(): void {
-    this.plugins.set(KeyExprPlugin, this.props.keyExpr ?? null);
-  }
-
-  @Effect()
-  updateDataSource(): void {
-    this.plugins.set(Items, this.props.dataSource);
+  get keyExpr(): KeyExprInternal {
+    return this.props.keyExpr ?? null;
   }
 
   get columns(): ColumnInternal[] {
@@ -153,16 +146,6 @@ export class DataGridLight extends JSXComponent(DataGridLightProps) {
 
     return userColumns.map((userColumn) => ({
       dataField: userColumn,
-    }));
-  }
-
-  generateDataRows(visibleItems: RowData[]): Row[] {
-    const { keyExpr } = this.props;
-
-    return visibleItems.map((data) => ({
-      key: keyExpr ? data[keyExpr] : data,
-      data,
-      rowType: 'data',
     }));
   }
 }

--- a/js/renovation/ui/grids/data_grid_light/master_detail/__tests__/master_detail.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/master_detail/__tests__/master_detail.test.tsx
@@ -24,7 +24,7 @@ describe('Master Detail', () => {
       const tree = mount(<MasterDetailView {...viewProps as any} />);
 
       expect(tree.find(GetterExtender).at(0).props()).toEqual({
-        type: VisibleRows, order: 2, selector: AddMasterDetailRows,
+        type: VisibleRows, order: 2, value: AddMasterDetailRows,
       });
     });
   });

--- a/js/renovation/ui/grids/data_grid_light/master_detail/master_detail.tsx
+++ b/js/renovation/ui/grids/data_grid_light/master_detail/master_detail.tsx
@@ -53,7 +53,7 @@ export const AddMasterDetailRows = createSelector(
 
 export const viewFunction = (): JSX.Element => (
   <Fragment>
-    <GetterExtender type={VisibleRows} order={2} selector={AddMasterDetailRows} />
+    <GetterExtender type={VisibleRows} order={2} value={AddMasterDetailRows} />
   </Fragment>
 );
 

--- a/js/renovation/ui/grids/data_grid_light/paging/__tests__/paging.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/paging/__tests__/paging.test.tsx
@@ -39,7 +39,7 @@ describe('Paging', () => {
         type: SetPageSize, value: viewProps.setPageSize,
       });
       expect(tree.find(GetterExtender).at(0).props()).toEqual({
-        type: VisibleItems, order: 1, selector: CalculateVisibleItems,
+        type: VisibleItems, order: 1, value: CalculateVisibleItems,
       });
     });
   });

--- a/js/renovation/ui/grids/data_grid_light/paging/paging.tsx
+++ b/js/renovation/ui/grids/data_grid_light/paging/paging.tsx
@@ -21,7 +21,7 @@ export const viewFunction = (viewModel: Paging): JSX.Element => (
     <ValueSetter type={PagingEnabled} value={viewModel.props.enabled} />
     <ValueSetter type={SetPageIndex} value={viewModel.setPageIndex} />
     <ValueSetter type={SetPageSize} value={viewModel.setPageSize} />
-    <GetterExtender type={VisibleItems} order={1} selector={CalculateVisibleItems} />
+    <GetterExtender type={VisibleItems} order={1} value={CalculateVisibleItems} />
   </Fragment>
 );
 
@@ -39,7 +39,9 @@ export class PagingProps {
 
 @Component({
   defaultOptionRules: null,
-  jQuery: { register: true },
+  angular: {
+    innerComponent: false,
+  },
   view: viewFunction,
 })
 export class Paging extends JSXComponent(PagingProps) {

--- a/js/renovation/ui/grids/data_grid_light/selection/__tests__/plugins.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/__tests__/plugins.test.tsx
@@ -1,0 +1,260 @@
+import {
+  AddSelectionColumnToVisibleColumns,
+  AddSelectionToRowClasses,
+  AddSelectionToRowProperties,
+  AllowSelectAllValue,
+  ClearSelection,
+  IsSelected,
+  SelectableCount,
+  SelectableItems,
+  SelectAll,
+  SelectAllCheckboxTemplate,
+  SelectAllModeValue,
+  SelectedCount,
+  SelectedRowKeys,
+  SelectionCheckboxTemplate,
+  SelectionModeValue,
+  SetSelected,
+  SetSelectedRowKeys,
+  ToggleSelected,
+} from '../plugins';
+import {
+  AllItems, KeyExprPlugin, VisibleColumns, VisibleItems,
+} from '../../data_grid_light';
+import { Plugins } from '../../../../../utils/plugin/context';
+import { generateData } from '../../__tests__/test_data';
+
+describe('Selection', () => {
+  describe('Selectors', () => {
+    const plugins = new Plugins();
+    plugins.extend(VisibleColumns, -1, () => []);
+
+    const selectionCheckboxTemplate = jest.fn();
+    const selectAllCheckboxTemplate = jest.fn();
+
+    beforeEach(() => {
+      plugins.set(KeyExprPlugin, 'id');
+      plugins.set(SelectionModeValue, 'single');
+      plugins.set(AllowSelectAllValue, false);
+      plugins.set(SelectionCheckboxTemplate, selectionCheckboxTemplate);
+      plugins.set(SelectAllCheckboxTemplate, selectAllCheckboxTemplate);
+    });
+
+    describe('AddSelectionColumnToVisibleColumns', () => {
+      it('should add checkboxes column (mode: single)', () => {
+        plugins.set(SelectionModeValue, 'single');
+        plugins.set(AllowSelectAllValue, false);
+
+        expect(plugins.getValue(AddSelectionColumnToVisibleColumns)).toEqual([{
+          cellTemplate: selectionCheckboxTemplate,
+        }]);
+      });
+
+      it('should add checkboxes column and select all checkbox (mode: multilpe)', () => {
+        plugins.set(SelectionModeValue, 'multiple');
+        plugins.set(AllowSelectAllValue, true);
+
+        expect(plugins.getValue(AddSelectionColumnToVisibleColumns)).toEqual([{
+          cellTemplate: selectionCheckboxTemplate,
+          headerTemplate: selectAllCheckboxTemplate,
+        }]);
+      });
+
+      it('should not add checkboxes (mode: none)', () => {
+        plugins.set(SelectionModeValue, 'none');
+
+        expect(plugins.getValue(AddSelectionColumnToVisibleColumns)).toEqual([]);
+      });
+    });
+
+    describe('AddSelectionToRowProperties', () => {
+      it('should add aria-selected', () => {
+        plugins.set(SelectedRowKeys, [1]);
+
+        const attrGetter = plugins.getValue(AddSelectionToRowProperties)!;
+        expect(attrGetter({ data: { id: 1 }, rowType: 'data' })).toEqual({
+          'aria-selected': true,
+        });
+        expect(attrGetter({ data: { id: 2 }, rowType: 'data' })).toEqual({});
+      });
+    });
+
+    describe('AddSelectionToRowClasses', () => {
+      it('should add aria-selected', () => {
+        plugins.set(SelectedRowKeys, [1]);
+
+        const classesGetter = plugins.getValue(AddSelectionToRowClasses)!;
+        expect(classesGetter({ data: { id: 1 }, rowType: 'data' })).toEqual({
+          'dx-selection': true,
+        });
+        expect(classesGetter({ data: { id: 2 }, rowType: 'data' })).toEqual({});
+      });
+    });
+
+    describe('SelectedCount', () => {
+      it('should be selectedRowKeys count', () => {
+        plugins.set(SelectedRowKeys, [1, 2]);
+
+        expect(plugins.getValue(SelectedCount)).toBe(2);
+      });
+    });
+
+    describe('SelectableCount', () => {
+      it('should be selectableItems count', () => {
+        plugins.set(SelectableItems, generateData(5));
+
+        expect(plugins.getValue(SelectableCount)).toBe(5);
+      });
+    });
+  });
+
+  describe('Actions', () => {
+    const plugins = new Plugins();
+
+    beforeEach(() => {
+      plugins.set(KeyExprPlugin, 'id');
+      plugins.set(SelectionModeValue, 'single');
+      plugins.set(AllowSelectAllValue, false);
+    });
+
+    describe('ClearSelection', () => {
+      it('should clear selectedRowKeys', () => {
+        const setSelectedRowKeysMock = jest.fn();
+        plugins.set(SetSelectedRowKeys, setSelectedRowKeysMock);
+
+        plugins.callAction(ClearSelection);
+
+        expect(setSelectedRowKeysMock).toHaveBeenCalledWith([]);
+      });
+    });
+
+    describe('selectAll', () => {
+      const items = [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+      ];
+      const visibleItems = items.slice(2, 4);
+
+      plugins.set(AllItems, items);
+      const disposeVisibleItems = plugins.extend(VisibleItems, -1, () => visibleItems);
+
+      afterAll(() => {
+        disposeVisibleItems();
+      });
+
+      it('should work in "allPages" mode', () => {
+        const setSelectedRowKeysMock = jest.fn();
+        plugins.set(SelectAllModeValue, 'allPages');
+        plugins.set(SetSelectedRowKeys, setSelectedRowKeysMock);
+
+        plugins.callAction(SelectAll);
+
+        expect(setSelectedRowKeysMock).toHaveBeenCalledWith([1, 2, 3, 4]);
+      });
+
+      it('should work in "page" mode', () => {
+        const setSelectedRowKeysMock = jest.fn();
+        plugins.set(SelectAllModeValue, 'page');
+        plugins.set(SetSelectedRowKeys, setSelectedRowKeysMock);
+
+        plugins.callAction(SelectAll);
+
+        expect(setSelectedRowKeysMock).toHaveBeenCalledWith([3, 4]);
+      });
+    });
+
+    describe('IsSelected', () => {
+      it('should work', () => {
+        plugins.set(SelectedRowKeys, [2, 3]);
+
+        expect(plugins.callAction(IsSelected, { id: 1 })).toEqual(false);
+        expect(plugins.callAction(IsSelected, { id: 2 })).toEqual(true);
+        expect(plugins.callAction(IsSelected, { id: 3 })).toEqual(true);
+        expect(plugins.callAction(IsSelected, { id: 4 })).toEqual(false);
+      });
+    });
+
+    describe('SetSelected', () => {
+      beforeEach(() => {
+        plugins.set(SelectedRowKeys, []);
+        plugins.set(SetSelectedRowKeys, (keys) => {
+          plugins.set(SelectedRowKeys, keys);
+        });
+      });
+
+      it('should work with "multiple" mode', () => {
+        plugins.set(SelectionModeValue, 'multiple');
+
+        plugins.callAction(SetSelected, { id: 1 }, true);
+        plugins.callAction(SetSelected, { id: 2 }, true);
+        expect(plugins.getValue(SelectedRowKeys)).toEqual([1, 2]);
+
+        plugins.callAction(SetSelected, { id: 1 }, false);
+        expect(plugins.getValue(SelectedRowKeys)).toEqual([2]);
+      });
+
+      it('should work with "single" mode', () => {
+        plugins.set(SelectionModeValue, 'single');
+
+        plugins.callAction(SetSelected, { id: 1 }, true);
+        plugins.callAction(SetSelected, { id: 2 }, true);
+        expect(plugins.getValue(SelectedRowKeys)).toEqual([2]);
+
+        plugins.callAction(SetSelected, { id: 1 }, false);
+        expect(plugins.getValue(SelectedRowKeys)).toEqual([2]);
+      });
+    });
+
+    describe('ToggleSelected', () => {
+      beforeEach(() => {
+        plugins.set(SelectionModeValue, 'multiple');
+        plugins.set(SetSelectedRowKeys, (keys) => {
+          plugins.set(SelectedRowKeys, keys);
+        });
+      });
+
+      it('should select unselected item', () => {
+        plugins.set(SelectedRowKeys, []);
+        plugins.callAction(ToggleSelected, { id: 1 });
+        plugins.callAction(ToggleSelected, { id: 2 });
+        expect(plugins.getValue(SelectedRowKeys)).toEqual([1, 2]);
+      });
+
+      it('should unselect selected item', () => {
+        plugins.set(SelectedRowKeys, [1, 2]);
+
+        plugins.callAction(ToggleSelected, { id: 1 });
+        expect(plugins.getValue(SelectedRowKeys)).toEqual([2]);
+      });
+    });
+
+    describe('SelectableCount', () => {
+      const items = [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 },
+      ];
+      const visibleItems = items.slice(2, 4);
+
+      plugins.set(AllItems, items);
+      const disposeVisibleItems = plugins.extend(VisibleItems, -1, () => visibleItems);
+
+      afterAll(() => {
+        disposeVisibleItems();
+      });
+
+      it('should work in "allPages" mode', () => {
+        plugins.set(SelectAllModeValue, 'allPages');
+        expect(plugins.getValue(SelectableCount)).toEqual(4);
+      });
+
+      it('should work in "page" mode', () => {
+        plugins.set(SelectAllModeValue, 'page');
+        expect(plugins.getValue(SelectableCount)).toEqual(2);
+      });
+    });
+  });
+});

--- a/js/renovation/ui/grids/data_grid_light/selection/__tests__/select_checkbox.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/__tests__/select_checkbox.test.tsx
@@ -27,8 +27,7 @@ describe('SelectionCheckbox', () => {
           data: { id: 1 },
         });
 
-        const isSelected = (data: { id: number }) => data.id === 1;
-        checkbox.plugins.set(IsSelected, isSelected);
+        checkbox.plugins.set(IsSelected, (data) => data.id === 1);
         checkbox.updateIsSelected();
 
         expect(checkbox.isSelected).toEqual(true);

--- a/js/renovation/ui/grids/data_grid_light/selection/__tests__/selection.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/__tests__/selection.test.tsx
@@ -1,254 +1,106 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { Plugins } from '../../../../../utils/plugin/context';
 import {
-  ClearSelection, IsSelected, SelectableCount, SelectAll, SelectedCount, SetSelected,
+  ClearSelection, SelectAll, ToggleSelected,
 } from '../plugins';
 import {
   Selection, SelectionProps, viewFunction as SelectionView,
 } from '../selection';
-import {
-  AllItems, KeyExprPlugin, VisibleColumns, VisibleItems,
-} from '../../data_grid_light';
-import { RowClassesGetter, RowPropertiesGetter } from '../../widgets/row_base';
+import { SelectionCheckbox } from '../select_checkbox';
+import { GetterExtender } from '../../../../../utils/plugin/getter_extender';
+import { ValueSetter } from '../../../../../utils/plugin/value_setter';
+import { TemplateSetter } from '../../../../../utils/plugin/template_setter';
 import { RowClick } from '../../views/table_content';
+import { generateRows } from '../../__tests__/test_data';
 
 describe('Selection', () => {
   describe('View', () => {
-    it('should be empty', () => {
-      const tree = mount(<SelectionView />);
-      expect(tree.html()).toEqual('<div></div>');
+    it('should contain plugins', () => {
+      const viewProps = {
+        props: new SelectionProps(),
+      } as Partial<Selection>;
+      const tree = mount(<SelectionView {...viewProps as any} />);
+
+      expect(tree.find(GetterExtender)).toHaveLength(3);
+      expect(tree.find(ValueSetter)).toHaveLength(5);
+      expect(tree.find(TemplateSetter)).toHaveLength(2);
+    });
+
+    it('TemplateSetter should contain SelectionCheckbox inside template', () => {
+      const viewProps = {
+        props: new SelectionProps(),
+      } as Partial<Selection>;
+      const data = {};
+      const tree = mount(<SelectionView {...viewProps as any} />);
+      const {
+        template,
+      }: {
+        template: (props) => JSX.Element;
+      } = tree.find(TemplateSetter).first().props();
+
+      const templateTree = mount(template({ data }));
+
+      expect(templateTree.is(SelectionCheckbox)).toBe(true);
     });
   });
 
   describe('Effects', () => {
-    describe('watchKeyExpr', () => {
-      it('should update keyExpr', () => {
-        const selection = new Selection({});
-        selection.plugins.set(KeyExprPlugin, 'some someId');
-        selection.watchKeyExpr();
-
-        expect(selection.keyExpr).toEqual('some someId');
-      });
-    });
-
-    describe('addVisibleColumnsHandler', () => {
-      it('should add checkboxes column (mode: single)', () => {
-        const selection = new Selection({
-          mode: 'single',
-        });
-        selection.addVisibleColumnsHandler();
-
-        const visibleColumns = selection.plugins.getValue(VisibleColumns);
-        expect(visibleColumns).toMatchObject([{
-          cellTemplate: expect.any(Function),
-        }]);
-      });
-
-      it('should add checkboxes column and select all checkbox (mode: multilpe)', () => {
-        const selection = new Selection({
-          mode: 'multiple',
-          allowSelectAll: true,
-        });
-        selection.addVisibleColumnsHandler();
-
-        const visibleColumns = selection.plugins.getValue(VisibleColumns);
-        expect(visibleColumns).toMatchObject([{
-          cellTemplate: expect.any(Function),
-          headerTemplate: expect.any(Function),
-        }]);
-      });
-
-      it('should not add checkboxes (mode: none)', () => {
-        const selection = new Selection({
-          mode: 'none',
-        });
-        selection.addVisibleColumnsHandler();
-
-        const visibleColumns = selection.plugins.getValue(VisibleColumns);
-        expect(visibleColumns).toEqual([]);
-      });
-    });
-
-    describe('extendDataRowAttributes', () => {
-      it('should add aria-selected', () => {
-        const selection = new Selection({
-          selectedRowKeys: [1],
-        });
-        selection.keyExpr = 'someId';
-        selection.extendDataRowAttributes();
-
-        const attrGetter = selection.plugins.getValue(RowPropertiesGetter)!;
-        expect(attrGetter({ data: { someId: 1 }, rowType: 'data' })).toEqual({
-          'aria-selected': true,
-        });
-        expect(attrGetter({ data: { someId: 2 }, rowType: 'data' })).toEqual({});
-      });
-    });
-
-    describe('extendDataRowClasses', () => {
-      it('should add aria-selected', () => {
-        const selection = new Selection({
-          selectedRowKeys: [1],
-        });
-        selection.keyExpr = 'someId';
-        selection.extendDataRowClasses();
-
-        const classesGetter = selection.plugins.getValue(RowClassesGetter)!;
-        expect(classesGetter({ data: { someId: 1 }, rowType: 'data' })).toEqual({
-          'dx-selection': true,
-        });
-        expect(classesGetter({ data: { someId: 2 }, rowType: 'data' })).toEqual({});
-      });
-    });
-
     describe('setRowClickEvent', () => {
-      it('should invert selection', () => {
+      it('should call ToggleSelected on click', () => {
         const selection = new Selection(new SelectionProps());
-        selection.keyExpr = 'someId';
+        const toggleSelectedMock = jest.fn();
+        const testRow = generateRows(1)[0];
+        selection.plugins = new Plugins();
+        selection.plugins.set(ToggleSelected, toggleSelectedMock);
 
         selection.setRowClickEvent();
-        const invert = selection.plugins.getValue(RowClick)!;
+        const rowClickHandler = selection.plugins.getValue(RowClick)!;
 
-        expect(selection.props.selectedRowKeys).toEqual([]);
-        invert({ data: { someId: 1 }, rowType: 'data' });
-        expect(selection.props.selectedRowKeys).toEqual([1]);
-        invert({ data: { someId: 1 }, rowType: 'data' });
-        expect(selection.props.selectedRowKeys).toEqual([]);
-      });
-    });
+        rowClickHandler(testRow);
 
-    describe('addPluginMethods', () => {
-      it('should set methods', () => {
-        const selection = new Selection({});
-        selection.addPluginMethods();
-
-        expect(selection.plugins.getValue(SetSelected)).toBe(selection.setSelected);
-        expect(selection.plugins.getValue(IsSelected)).toBe(selection.isSelected);
-        expect(selection.plugins.getValue(ClearSelection)).toBe(selection.clearSelection);
-        expect(selection.plugins.getValue(SelectAll)).toBe(selection.selectAll);
-      });
-    });
-
-    describe('addPluginValues', () => {
-      it('should set methods', () => {
-        const selection = new Selection(new SelectionProps());
-        selection.addPluginValues();
-
-        expect(selection.plugins.getValue(SelectedCount)).toBe(0);
-        expect(selection.plugins.getValue(SelectableCount)).toBe(0);
+        expect(toggleSelectedMock).toHaveBeenCalledWith(testRow.data);
       });
     });
   });
 
   describe('Methods', () => {
     describe('clearSelection', () => {
-      it('should clear selectedRowKeys', () => {
-        const selection = new Selection({
-          selectedRowKeys: [1, 2, 3],
-        });
+      it('should call ClearSelection action', () => {
+        const selection = new Selection({});
+        const clearSelectionMock = jest.fn();
+
+        selection.plugins = new Plugins();
+        selection.plugins.set(ClearSelection, clearSelectionMock);
 
         selection.clearSelection();
-        expect(selection.props.selectedRowKeys).toHaveLength(0);
+
+        expect(clearSelectionMock).toHaveBeenCalled();
       });
     });
 
     describe('selectAll', () => {
-      const items = [
-        { someId: 1 },
-        { someId: 2 },
-        { someId: 3 },
-        { someId: 4 },
-      ];
-      const visibleItems = items.slice(1, 3);
+      it('should call SelectAll action', () => {
+        const selection = new Selection({});
+        const selectAllMock = jest.fn();
 
-      const selection = new Selection({});
-      selection.keyExpr = 'someId';
-      selection.plugins.set(AllItems, items);
-      selection.plugins.extend(VisibleItems, -1, () => visibleItems);
+        selection.plugins = new Plugins();
+        selection.plugins.set(SelectAll, selectAllMock);
 
-      it('should work in "allPages" mode', () => {
-        selection.props.selectAllMode = 'allPages';
         selection.selectAll();
 
-        expect(selection.props.selectedRowKeys).toEqual([1, 2, 3, 4]);
-      });
-
-      it('should work in "page" mode', () => {
-        selection.props.selectAllMode = 'page';
-        selection.selectAll();
-
-        expect(selection.props.selectedRowKeys).toEqual([2, 3]);
+        expect(selectAllMock).toHaveBeenCalled();
       });
     });
 
-    describe('isSelected', () => {
-      it('should work', () => {
-        const selection = new Selection({
-          selectedRowKeys: [2, 3],
-        });
-        selection.keyExpr = 'someId';
+    describe('setSelectedRoeKeys', () => {
+      it('should set selectedRowKeys', () => {
+        const selection = new Selection({});
+        const keys = [1, 2, 3];
 
-        expect(selection.isSelected({ someId: 1 })).toEqual(false);
-        expect(selection.isSelected({ someId: 2 })).toEqual(true);
-        expect(selection.isSelected({ someId: 3 })).toEqual(true);
-        expect(selection.isSelected({ someId: 4 })).toEqual(false);
-      });
-    });
+        selection.setSelectedRowKeys(keys);
 
-    describe('setSelected', () => {
-      it('should work with "multiple" mode', () => {
-        const selection = new Selection({
-          mode: 'multiple',
-          selectedRowKeys: [],
-        });
-        selection.keyExpr = 'someId';
-
-        selection.setSelected({ someId: 1 }, true);
-        selection.setSelected({ someId: 2 }, true);
-        expect(selection.props.selectedRowKeys).toEqual([1, 2]);
-
-        selection.setSelected({ someId: 1 }, false);
-        expect(selection.props.selectedRowKeys).toEqual([2]);
-      });
-
-      it('should work with "single" mode', () => {
-        const selection = new Selection({
-          mode: 'single',
-          selectedRowKeys: [],
-        });
-        selection.keyExpr = 'someId';
-
-        selection.setSelected({ someId: 1 }, true);
-        selection.setSelected({ someId: 2 }, true);
-        expect(selection.props.selectedRowKeys).toEqual([2]);
-
-        selection.setSelected({ someId: 2 }, false);
-        expect(selection.props.selectedRowKeys).toEqual([]);
-      });
-    });
-
-    describe('selectableCount', () => {
-      const items = [
-        { key: 1, data: { someId: 1 }, rowType: 'data' },
-        { key: 2, data: { someId: 2 }, rowType: 'data' },
-        { key: 3, data: { someId: 3 }, rowType: 'data' },
-        { key: 4, data: { someId: 4 }, rowType: 'data' },
-      ];
-      const visibleItems = items.slice(1, 3);
-
-      const selection = new Selection({});
-      selection.keyExpr = 'someId';
-      selection.plugins.set(AllItems, items);
-      selection.plugins.extend(VisibleItems, -1, () => visibleItems);
-
-      it('should work in "allPages" mode', () => {
-        selection.props.selectAllMode = 'allPages';
-        expect(selection.selectableCount()).toEqual(4);
-      });
-
-      it('should work in "page" mode', () => {
-        selection.props.selectAllMode = 'page';
-        expect(selection.selectableCount()).toEqual(2);
+        expect(selection.props.selectedRowKeys).toEqual(keys);
       });
     });
   });

--- a/js/renovation/ui/grids/data_grid_light/selection/__tests__/selection.test.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/__tests__/selection.test.tsx
@@ -7,7 +7,7 @@ import {
   Selection, SelectionProps, viewFunction as SelectionView,
 } from '../selection';
 import {
-  Items, KeyExprPlugin, VisibleColumns, VisibleItems,
+  AllItems, KeyExprPlugin, VisibleColumns, VisibleItems,
 } from '../../data_grid_light';
 import { RowClassesGetter, RowPropertiesGetter } from '../../widgets/row_base';
 import { RowClick } from '../../views/table_content';
@@ -163,7 +163,7 @@ describe('Selection', () => {
 
       const selection = new Selection({});
       selection.keyExpr = 'someId';
-      selection.plugins.set(Items, items);
+      selection.plugins.set(AllItems, items);
       selection.plugins.extend(VisibleItems, -1, () => visibleItems);
 
       it('should work in "allPages" mode', () => {
@@ -238,7 +238,7 @@ describe('Selection', () => {
 
       const selection = new Selection({});
       selection.keyExpr = 'someId';
-      selection.plugins.set(Items, items);
+      selection.plugins.set(AllItems, items);
       selection.plugins.extend(VisibleItems, -1, () => visibleItems);
 
       it('should work in "allPages" mode', () => {

--- a/js/renovation/ui/grids/data_grid_light/selection/plugins.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/plugins.tsx
@@ -1,9 +1,149 @@
-import { RowData } from '../types';
-import { createValue } from '../../../../utils/plugin/context';
+import type { JSXTemplate } from '@devextreme-generator/declarations';
+import type {
+  ColumnInternal, Key, Row, RowData, SelectAllMode, SelectionMode,
+} from '../types';
+import { createSelector, createValue } from '../../../../utils/plugin/context';
+import {
+  AllItems, KeyExprPlugin, VisibleColumns, VisibleItems,
+} from '../data_grid_light';
+import { createGetKey } from '../utils';
+import {
+  RowClassesGetter, RowClassesGetterType, RowPropertiesGetter, RowPropertiesGetterType,
+} from '../widgets/row_base';
+import CLASSES from '../classes';
 
-export const SetSelected = createValue<(data: RowData, value: boolean) => void>();
-export const IsSelected = createValue<(data: RowData) => boolean>();
-export const SelectAll = createValue<() => void>();
-export const ClearSelection = createValue<() => void>();
-export const SelectedCount = createValue<number>();
-export const SelectableCount = createValue<number>();
+const getKey = createGetKey('Selection');
+
+export const SelectionModeValue = createValue<SelectionMode>();
+export const AllowSelectAllValue = createValue<boolean>();
+
+export const SelectAllModeValue = createValue<SelectAllMode>();
+export const SelectedRowKeys = createValue<unknown[]>();
+export const SetSelectedRowKeys = createValue<(keys: unknown[]) => void>();
+
+export const SelectableItems = createSelector<RowData[]>(
+  [SelectAllModeValue, AllItems, VisibleItems],
+  (
+    selectAllModeValue: SelectAllMode, allItems: RowData[], visibleItems: RowData[],
+  ) => (
+    selectAllModeValue === 'allPages' ? allItems : visibleItems
+  ),
+);
+
+export const SelectableCount = createSelector<number>(
+  [SelectableItems],
+  (selectableItems: RowData[]) => selectableItems.length,
+);
+
+export const SelectedCount = createSelector<number>(
+  [SelectedRowKeys],
+  (selectedRowKeys: Key[]) => selectedRowKeys.length,
+);
+
+export const SetSelected = createSelector<(data: RowData, value: boolean) => void>(
+  [
+    SetSelectedRowKeys, SelectedRowKeys, SelectionModeValue, KeyExprPlugin,
+  ],
+(
+  setSelectedRowKeys, selectedRowKeys: Key[], selectionMode, keyExpr,
+) => (data: RowData, value: boolean): void => {
+  const key = getKey(data, keyExpr);
+
+  if (value) {
+    if (selectionMode === 'multiple') {
+      setSelectedRowKeys([
+        ...selectedRowKeys,
+        key,
+      ]);
+    } else {
+      setSelectedRowKeys([key]);
+    }
+  } else {
+    setSelectedRowKeys(
+      selectedRowKeys.filter((i) => i !== key),
+    );
+  }
+});
+
+export const IsSelected = createSelector<(data: RowData) => boolean>(
+  [SelectedRowKeys, KeyExprPlugin],
+(
+  selectedRowKeys: Key[], keyExpr,
+) => (data: RowData): boolean => selectedRowKeys.includes(getKey(data, keyExpr)));
+
+export const ToggleSelected = createSelector<(data: RowData) => void>(
+  [SetSelected, IsSelected],
+(setSelected, isSelected) => (data: RowData): void => {
+  const selected = isSelected(data);
+  setSelected(data, !selected);
+});
+
+export const SelectAll = createSelector<() => void>(
+  [SetSelectedRowKeys, SelectableItems, KeyExprPlugin],
+(setSelectedRowKeys, selectableItems: RowData[], keyExpr) => (): void => {
+  setSelectedRowKeys(selectableItems.map((item) => getKey(item, keyExpr)));
+});
+
+export const ClearSelection = createSelector<() => void>(
+  [SetSelectedRowKeys],
+(setSelectedRowKeys: (keys: Key[]) => void) => (): void => setSelectedRowKeys([]));
+
+export const SelectionCheckboxTemplate = createValue<JSXTemplate>();
+export const SelectAllCheckboxTemplate = createValue<JSXTemplate>();
+
+export const AddSelectionColumnToVisibleColumns = createSelector(
+  [
+    VisibleColumns,
+    SelectionModeValue,
+    AllowSelectAllValue,
+    SelectionCheckboxTemplate,
+    SelectAllCheckboxTemplate,
+  ],
+  (
+    visibleColumns: ColumnInternal[],
+    selectionMode,
+    allowSelectAll,
+    selectionCheckboxTemplate,
+    selectAllCheckboxTemplate,
+  ): ColumnInternal[] => {
+    if (selectionMode !== 'multiple') {
+      return visibleColumns;
+    }
+    const selectColumn: ColumnInternal = { cellTemplate: selectionCheckboxTemplate };
+
+    if (selectionMode === 'multiple' && allowSelectAll) {
+      selectColumn.headerTemplate = selectAllCheckboxTemplate;
+    }
+
+    return [
+      selectColumn,
+      ...visibleColumns,
+    ];
+  },
+);
+
+export const AddSelectionToRowProperties = createSelector(
+  [RowPropertiesGetter, IsSelected],
+  (base: RowPropertiesGetterType, isSelected) => (row: Row): Record<string, unknown> => {
+    if (row.rowType === 'data' && isSelected(row.data)) {
+      return {
+        ...base(row),
+        'aria-selected': true,
+      };
+    }
+    return base(row);
+  },
+);
+
+export const AddSelectionToRowClasses = createSelector(
+  [RowClassesGetter, IsSelected],
+  (base: RowClassesGetterType, isSelected) => (row: Row): Record<string, unknown> => {
+    if (row.rowType === 'data' && isSelected(row.data)) {
+      return {
+        ...base(row),
+        [CLASSES.selectedRow]: true,
+      };
+    }
+    return base(row);
+  },
+);

--- a/js/renovation/ui/grids/data_grid_light/selection/plugins.tsx
+++ b/js/renovation/ui/grids/data_grid_light/selection/plugins.tsx
@@ -106,7 +106,7 @@ export const AddSelectionColumnToVisibleColumns = createSelector(
     selectionCheckboxTemplate,
     selectAllCheckboxTemplate,
   ): ColumnInternal[] => {
-    if (selectionMode !== 'multiple') {
+    if (selectionMode === 'none') {
       return visibleColumns;
     }
     const selectColumn: ColumnInternal = { cellTemplate: selectionCheckboxTemplate };

--- a/js/renovation/ui/grids/data_grid_light/types.ts
+++ b/js/renovation/ui/grids/data_grid_light/types.ts
@@ -34,3 +34,6 @@ export interface ColumnInternal {
 
   cellContainerTemplate?: JSXTemplate<{ data: RowData }, 'data'>;
 }
+
+export type SelectionMode = 'multiple' | 'single' | 'none';
+export type SelectAllMode = 'allPages' | 'page';

--- a/js/renovation/ui/grids/data_grid_light/views/table_content.tsx
+++ b/js/renovation/ui/grids/data_grid_light/views/table_content.tsx
@@ -60,8 +60,9 @@ export class TableContent extends JSXComponent(TableContentProps) {
 
   @Effect()
   subscribeToRowClick(): () => void {
-    eventsEngine.on(this.divRef.current, clickEvent, `.${CLASSES.row}`, this.onRowClick);
-    return (): void => eventsEngine.off(this.divRef.current, clickEvent, this.onRowClick);
+    const onRowClick = this.onRowClick.bind(this);
+    eventsEngine.on(this.divRef.current, clickEvent, `.${CLASSES.row}`, onRowClick);
+    return (): void => eventsEngine.off(this.divRef.current, clickEvent, onRowClick);
   }
 
   onRowClick(e: Event): void {

--- a/js/renovation/ui/grids/data_grid_light/widgets/data_cell.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/data_cell.tsx
@@ -1,5 +1,5 @@
 import {
-  Component, JSXComponent, ComponentBindings, OneWay, JSXTemplate,
+  Component, JSXComponent, ComponentBindings, OneWay, JSXTemplate, Template,
 } from '@devextreme-generator/declarations';
 import { ColumnInternal, Row, RowData } from '../types';
 import { combineClasses } from '../../../../utils/combine_classes';
@@ -9,11 +9,13 @@ import CLASSES from '../classes';
 export const viewFunction = (viewModel: DataCell): JSX.Element => {
   const {
     cellText,
-    cellTemplate: CellTemplate,
-    cellContainerTemplate: CellContainerTemplate,
     classes,
   } = viewModel;
-  const { row } = viewModel.props;
+  const {
+    row,
+    cellTemplate: CellTemplate,
+    cellContainerTemplate: CellContainerTemplate,
+  } = viewModel.props;
   const cellContentTemplate = CellTemplate
     ? <CellTemplate data={row.data} />
     : cellText;
@@ -32,9 +34,7 @@ export const viewFunction = (viewModel: DataCell): JSX.Element => {
         </td>
       )
       : (
-        <CellContainerTemplate data={row.data}>
-          {cellContentTemplate}
-        </CellContainerTemplate>
+        <CellContainerTemplate data={row.data} />
       )
   );
 };
@@ -55,6 +55,12 @@ export class DataCellProps {
 
   @OneWay()
   column: ColumnInternal = {};
+
+  @Template()
+  cellTemplate?: JSXTemplate<{ data: RowData }, 'data'>;
+
+  @Template()
+  cellContainerTemplate?: JSXTemplate<{ data: RowData }, 'data'>;
 }
 
 @Component({
@@ -62,14 +68,6 @@ export class DataCellProps {
   view: viewFunction,
 })
 export class DataCell extends JSXComponent(DataCellProps) {
-  get cellTemplate(): JSXTemplate<{ data: RowData }, 'data'> | undefined {
-    return this.props.column.cellTemplate;
-  }
-
-  get cellContainerTemplate(): JSXTemplate<{ data: RowData }, 'data'> | undefined {
-    return this.props.column.cellContainerTemplate;
-  }
-
   get cellText(): string {
     const { dataField } = this.props.column;
     const value = dataField && this.props.row.data[dataField];

--- a/js/renovation/ui/grids/data_grid_light/widgets/data_row.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/data_row.tsx
@@ -27,6 +27,8 @@ export const viewFunction = (viewModel: DataRow): JSX.Element => {
               columnIndex={index}
               countColumn={columns.length}
               column={column}
+              cellTemplate={column.cellTemplate}
+              cellContainerTemplate={column.cellContainerTemplate}
               row={row}
             />
           ))}

--- a/js/renovation/ui/grids/data_grid_light/widgets/header_cell.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/header_cell.tsx
@@ -1,5 +1,5 @@
 import {
-  Component, JSXComponent, ComponentBindings, OneWay, JSXTemplate,
+  Component, JSXComponent, ComponentBindings, OneWay, JSXTemplate, Template,
 } from '@devextreme-generator/declarations';
 import { combineClasses } from '../../../../utils/combine_classes';
 
@@ -8,8 +8,7 @@ import CLASSES from '../classes';
 import { ColumnInternal } from '../types';
 
 export const viewFunction = ({
-  props: { column, columnIndex },
-  headerTemplate: HeaderTemplate,
+  props: { column, columnIndex, headerTemplate: HeaderTemplate },
   classes,
 }: HeaderCell): JSX.Element => (
   <td
@@ -39,6 +38,9 @@ export class HeaderCellProps {
 
   @OneWay()
   countColumn = 0;
+
+  @Template()
+  headerTemplate?: JSXTemplate;
 }
 
 @Component({
@@ -46,10 +48,6 @@ export class HeaderCellProps {
   view: viewFunction,
 })
 export class HeaderCell extends JSXComponent(HeaderCellProps) {
-  get headerTemplate(): JSXTemplate | undefined {
-    return this.props.column.headerTemplate;
-  }
-
   get classes(): string {
     const { columnIndex, countColumn } = this.props;
 

--- a/js/renovation/ui/grids/data_grid_light/widgets/header_row.tsx
+++ b/js/renovation/ui/grids/data_grid_light/widgets/header_row.tsx
@@ -13,6 +13,7 @@ export const viewFunction = (viewModel: HeaderRow): JSX.Element => (
         // eslint-disable-next-line react/no-array-index-key
         key={index}
         column={column}
+        headerTemplate={column.headerTemplate}
         countColumn={viewModel.props.columns.length}
         columnIndex={index}
       />

--- a/js/renovation/utils/plugin/__tests__/getter_extender.test.tsx
+++ b/js/renovation/utils/plugin/__tests__/getter_extender.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { GetterExtender, viewFunction as GetterExtenderView } from '../getter_extender';
-import { createGetter, createSelector, Plugins } from '../context';
+import {
+  createGetter, createSelector, createValue, Plugins,
+} from '../context';
 
 describe('GetterExtender', () => {
   const SomeGetter = createGetter(1);
@@ -22,13 +24,27 @@ describe('GetterExtender', () => {
 
   describe('Effects', () => {
     describe('updateComponentTypes', () => {
-      it('should subscribe to plugin', () => {
+      it('should subscribe to selector plugin', () => {
         const valueSetter = new GetterExtender({
           type: SomeGetter,
           order: 1,
           value: testSelector,
         });
         valueSetter.plugins = new Plugins();
+        valueSetter.updateExtender();
+
+        expect(valueSetter.plugins.getValue(SomeGetter)).toEqual('test');
+      });
+
+      it('should subscribe to value plugin', () => {
+        const SomeValue = createValue();
+        const valueSetter = new GetterExtender({
+          type: SomeGetter,
+          order: 1,
+          value: SomeValue,
+        });
+        valueSetter.plugins = new Plugins();
+        valueSetter.plugins.set(SomeValue, 'test');
         valueSetter.updateExtender();
 
         expect(valueSetter.plugins.getValue(SomeGetter)).toEqual('test');

--- a/js/renovation/utils/plugin/__tests__/getter_extender.test.tsx
+++ b/js/renovation/utils/plugin/__tests__/getter_extender.test.tsx
@@ -12,7 +12,7 @@ describe('GetterExtender', () => {
       const getterExtender = new GetterExtender({
         type: SomeGetter,
         order: 1,
-        selector: testSelector,
+        value: testSelector,
       });
 
       const tree = mount(<GetterExtenderView {...getterExtender as any} />);
@@ -26,7 +26,7 @@ describe('GetterExtender', () => {
         const valueSetter = new GetterExtender({
           type: SomeGetter,
           order: 1,
-          selector: testSelector,
+          value: testSelector,
         });
         valueSetter.plugins = new Plugins();
         valueSetter.updateExtender();

--- a/js/renovation/utils/plugin/__tests__/template_setter.test.tsx
+++ b/js/renovation/utils/plugin/__tests__/template_setter.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { TemplateSetter, viewFunction as TemplateSetterView } from '../template_setter';
+import { createValue, Plugins } from '../context';
+
+describe('ValueSetter', () => {
+  const SomeValue = createValue();
+
+  describe('View', () => {
+    it('should be empty', () => {
+      const templateSetter = new TemplateSetter({
+        type: SomeValue,
+        template: (): JSX.Element => <span />,
+      });
+
+      const tree = mount(<TemplateSetterView {...templateSetter as any} />);
+      expect(tree.html()).toEqual('<div></div>');
+    });
+  });
+
+  describe('Effects', () => {
+    describe('updateTemplate', () => {
+      it('should set template to plugin', () => {
+        const template = (): JSX.Element => <span />;
+        const valueSetter = new TemplateSetter({
+          type: SomeValue,
+          template,
+        });
+        valueSetter.plugins = new Plugins();
+
+        valueSetter.updateTemplate();
+
+        expect(valueSetter.plugins.getValue(SomeValue)).toEqual(template);
+      });
+    });
+  });
+});

--- a/js/renovation/utils/plugin/context.ts
+++ b/js/renovation/utils/plugin/context.ts
@@ -220,6 +220,10 @@ export class Plugins {
   }
 
   hasValue<T, S>(entity: PluginEntity<T, S>): boolean {
+    if (entity instanceof PluginGetter) {
+      return true;
+    }
+
     return entity.id in this.items;
   }
 

--- a/js/renovation/utils/plugin/context.ts
+++ b/js/renovation/utils/plugin/context.ts
@@ -235,7 +235,7 @@ export class Plugins {
       entity.deps.forEach((childEntity) => {
         const childSubscriptions = this.getSubscriptions(childEntity);
         childSubscriptions.push(() => {
-          this.update(entity);
+          this.update(entity, true);
         });
       });
     }
@@ -271,9 +271,11 @@ export class Plugins {
     }
   }
 
-  update<T, S>(entity: PluginEntity<T, S>): void {
+  update<T, S>(entity: PluginEntity<T, S>, force = false): void {
     if (entity instanceof PluginSelector) {
-      this.updateSelector(entity);
+      if (!this.hasValue(entity) || force) {
+        this.updateSelector(entity);
+      }
     }
   }
 

--- a/js/renovation/utils/plugin/getter_extender.tsx
+++ b/js/renovation/utils/plugin/getter_extender.tsx
@@ -4,7 +4,7 @@ import {
 } from '@devextreme-generator/declarations';
 
 import {
-  PluginsContext, Plugins, PluginGetter, PluginSelector,
+  PluginsContext, Plugins, PluginGetter, PluginSelector, PluginEntity,
 } from './context';
 
 export const viewFunction = (): JSX.Element => <div />;
@@ -15,21 +15,30 @@ export class GetterExtenderProps {
 
   @OneWay() order!: number;
 
-  @OneWay() selector!: PluginSelector<unknown>;
+  @OneWay() value!: PluginEntity<unknown>;
 }
 
 @Component({ defaultOptionRules: null, view: viewFunction })
-export class GetterExtender extends JSXComponent<GetterExtenderProps, 'type' | 'order' | 'selector'>(GetterExtenderProps) {
+export class GetterExtender extends JSXComponent<GetterExtenderProps, 'type' | 'order' | 'value'>(GetterExtenderProps) {
   @Consumer(PluginsContext)
   plugins!: Plugins;
 
   @Effect()
   updateExtender(): () => void {
+    const { value } = this.props;
+    if (value instanceof PluginSelector) {
+      return this.plugins.extend(
+        this.props.type,
+        this.props.order,
+        value.func,
+        value.deps,
+      );
+    }
     return this.plugins.extend(
       this.props.type,
       this.props.order,
-      this.props.selector.func,
-      this.props.selector.deps,
+      () => this.plugins.getValue(value),
+      [value],
     );
   }
 }

--- a/js/renovation/utils/plugin/template_setter.tsx
+++ b/js/renovation/utils/plugin/template_setter.tsx
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  JSXComponent, Component, ComponentBindings, OneWay, Effect, Template, Consumer, JSXTemplate,
+} from '@devextreme-generator/declarations';
+
+import {
+  Plugins, PluginEntity, PluginsContext,
+} from './context';
+
+@ComponentBindings()
+export class TemplateSetterProps {
+  @OneWay() type!: PluginEntity<unknown>;
+
+  @Template() template!: JSXTemplate<any>;
+}
+
+export const viewFunction = (): JSX.Element => <div />;
+
+@Component({ defaultOptionRules: null, view: viewFunction })
+export class TemplateSetter extends JSXComponent<TemplateSetterProps, 'type' | 'template'>(TemplateSetterProps) {
+  @Consumer(PluginsContext)
+  plugins!: Plugins;
+
+  @Effect()
+  updateTemplate(): void {
+    this.plugins.set(this.props.type, this.props.template);
+  }
+}

--- a/testing/testcafe/tests/renovation/data_grid_light/selection.ts
+++ b/testing/testcafe/tests/renovation/data_grid_light/selection.ts
@@ -2,7 +2,7 @@ import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import { Selector } from 'testcafe';
 import { multiPlatformTest, createWidget, updateComponentOptions } from '../../../helpers/multi-platform-test';
 
-const test = multiPlatformTest({ page: 'declaration/data_grid_light', platforms: ['react'] });
+const test = multiPlatformTest({ page: 'declaration/data_grid_light', platforms: ['react', 'angular'] });
 
 const defaultOptions = {
   columns: ['id', 'text'],


### PR DESCRIPTION
This PR contains the following changes:
1) Added TemplateSetter component that helps to avoid generating dynamic components in angular.
2) Supported passing any PluginEntity to GetterExtender.
3) Moved selection logic to selectors.
4) Replaced Effects in DataGridLight to ValueSetter and GetterExtender inside viewFunction.
5) Enabled selection testcafe tests for angular.