### PR TITLE
TestRunner - Update .Net version to 3.1

### DIFF
--- a/testing/runner/Controllers/MainController.cs
+++ b/testing/runner/Controllers/MainController.cs
@@ -18,10 +18,10 @@ namespace Runner.Controllers
         static readonly object IO_SYNC = new object();
 
         UIModelHelper _uiModelHelper;
-        IHostingEnvironment _env;
+        IWebHostEnvironment _env;
         RunFlags _runFlags;
 
-        public MainController(IHostingEnvironment env, RunFlags runFlags)
+        public MainController(IWebHostEnvironment env, RunFlags runFlags)
         {
             ConsoleHelper.Logger.SetWorkingFolder(env.ContentRootPath);
             _env = env;

--- a/testing/runner/Controllers/TestVectorMapDataController.cs
+++ b/testing/runner/Controllers/TestVectorMapDataController.cs
@@ -42,9 +42,9 @@ namespace Runner.Controllers
             }
         }
 
-        IHostingEnvironment _env;
+        IWebHostEnvironment _env;
 
-        public TestVectorMapDataController(IHostingEnvironment env)
+        public TestVectorMapDataController(IWebHostEnvironment env)
         {
             _env = env;
             ConsoleHelper.Logger.SetWorkingFolder(env.ContentRootPath);

--- a/testing/runner/Controllers/ThemesTestController.cs
+++ b/testing/runner/Controllers/ThemesTestController.cs
@@ -11,7 +11,7 @@ namespace Runner.Controllers
     [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
     public class ThemesTestController : Controller {
         string _bundlesPath;
-        public ThemesTestController(IHostingEnvironment env)
+        public ThemesTestController(IWebHostEnvironment env)
         {
             ConsoleHelper.Logger.SetWorkingFolder(env.ContentRootPath);
             _bundlesPath = Path.Combine(env.ContentRootPath, "scss", "bundles");

--- a/testing/runner/Program.cs
+++ b/testing/runner/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Newtonsoft.Json.Serialization;
@@ -37,12 +38,15 @@ namespace Runner
                             .AddMvcCore()
                             .AddViews()
                             .AddRazorViewEngine()
-                            .AddJsonFormatters()
-                            .AddJsonOptions(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver());
-
+                            .AddNewtonsoftJson(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver());
+                        services.AddMvc(options => options.EnableEndpointRouting = false).AddRazorRuntimeCompilation();
                         services.AddWebEncoders();
 
                         services.Configure<RazorViewEngineOptions>(options => options.ViewLocationExpanders.Add(new ViewLocationExpander()));
+                        services.Configure<KestrelServerOptions>(options =>
+                        {
+                            options.AllowSynchronousIO = true;
+                        });
 
                         services.AddSingleton(new RunFlags
                         {

--- a/testing/runner/Tools/UIModelHelper.cs
+++ b/testing/runner/Tools/UIModelHelper.cs
@@ -19,7 +19,7 @@ namespace Runner.Tools
         UrlHelper UrlHelper;
         string TestsRootPath;
 
-        public UIModelHelper(ActionContext actionContext, IHostingEnvironment env)
+        public UIModelHelper(ActionContext actionContext, IWebHostEnvironment env)
         {
             UrlHelper = new UrlHelper(actionContext);
             TestsRootPath = Path.Combine(env.ContentRootPath, "testing/tests");

--- a/testing/runner/runner.csproj
+++ b/testing/runner/runner.csproj
@@ -2,6 +2,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.22" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.22" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.1" />
@@ -9,7 +11,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <StartupObject>Runner.Program</StartupObject>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Update .Net version to 3.1 and fix the consequences of BC when switching from 2.1 to 3.1