### PR TITLE
Git rid of unused localizeNode method

### DIFF
--- a/js/localization/message.js
+++ b/js/localization/message.js
@@ -1,7 +1,5 @@
-import $ from '../core/renderer';
 import dependencyInjector from '../core/utils/dependency_injector';
 import { extend } from '../core/utils/extend';
-import { each } from '../core/utils/iterator';
 import { format as stringFormat } from '../core/utils/string';
 import { humanize } from '../core/utils/inflector';
 import coreLocalization from './core';
@@ -50,36 +48,6 @@ const messageLocalization = dependencyInjector({
             }
 
             return prefix + (result || defaultResult);
-        });
-    },
-
-    localizeNode: function(node) {
-        const that = this;
-
-        $(node).each((index, nodeItem) => {
-            if(!nodeItem.nodeType) {
-                return;
-            }
-
-            if(nodeItem.nodeType === 3) {
-                nodeItem.nodeValue = that.localizeString(nodeItem.nodeValue);
-            } else {
-                if(!$(nodeItem).is('iframe')) { // T199912
-                    each(nodeItem.attributes || [], (index, attr) => {
-                        if(typeof attr.value === 'string') {
-                            const localizedValue = that.localizeString(attr.value);
-
-                            if(attr.value !== localizedValue) {
-                                attr.value = localizedValue;
-                            }
-                        }
-                    });
-
-                    $(nodeItem).contents().each((index, node) => {
-                        that.localizeNode(node);
-                    });
-                }
-            }
         });
     },
 

--- a/testing/tests/DevExpress.localization/sharedParts/localization.shared.js
+++ b/testing/tests/DevExpress.localization/sharedParts/localization.shared.js
@@ -40,7 +40,6 @@ module.exports = function() {
         checkModules('localization.message', messageLocalization, [
             'setup',
             'localizeString',
-            'localizeNode',
             'getMessagesByLocales',
             'getFormatter',
             'format',
@@ -567,25 +566,6 @@ module.exports = function() {
             assert.equal(localized, toLocalize);
         });
 
-        QUnit.test('localizeNode', function(assert) {
-            const $node = $(
-                '<div data=\'@Loading\'>' +
-                    '   @Loading' +
-                    '   <div data=\'@Loading\' class=\'inner\'>' +
-                    '       @Loading' +
-                    '   </div>' +
-                    '</div>');
-            const $contents = $node.contents();
-
-            messageLocalization.localizeNode($node);
-
-            assert.equal($node.attr('data'), 'Loading...');
-
-            assert.equal($.trim($contents.eq(0).text()), 'Loading...');
-            assert.equal($contents.eq(1).attr('data'), 'Loading...');
-            assert.equal($.trim($contents.eq(1).text()), 'Loading...');
-        });
-
         QUnit.test('getDictionary', function(assert) {
             localization.loadMessages({
                 'en': {
@@ -601,61 +581,6 @@ module.exports = function() {
             assert.equal(messageLocalization.getDictionary(true)['freshAddedKey'], undefined);
             assert.equal(messageLocalization.getDictionary()['unknownKey'], 'Unknown key');
             assert.equal(messageLocalization.getDictionary(true)['unknownKey'], 'Unknown key');
-        });
-
-        QUnit.test('T199912: Application crashes if it has iframe and jquery version is 1.11.x', function(assert) {
-            const $node = $('<iframe data=\'@Loading\'></iframe>');
-
-            messageLocalization.localizeNode($node);
-            assert.equal($node.attr('data'), '@Loading', 'T199912: Don\'t touch iframes');
-        });
-
-        QUnit.test('B239384: Application crushes if opening in IE with flash-specific tags', function(assert) {
-            assert.expect(0);
-
-            const html = '\
-            <object name="_dp_swf_engine" width="1" height="1" align="middle" id="_dp_swf_engine" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" style="width: 1px; height: 1px;">\
-                <param name="_cx" value="5080">\
-                <param name="_cy" value="5080">\
-                <param name="FlashVars" value="">\
-                <param name="Movie" value="">\
-                <param name="Src" value="">\
-                <param name="WMode" value="Transparent">\
-                <param name="Play" value="-1">\
-                <param name="Loop" value="-1">\
-                <param name="Quality" value="High">\
-                <param name="SAlign" value="">\
-                <param name="Menu" value="-1">\
-                <param name="Base" value="">\
-                <param name="AllowScriptAccess" value="always">\
-                <param name="Scale" value="ShowAll">\
-                <param name="DeviceFont" value="0">\
-                <param name="EmbedMovie" value="0">\
-                <param name="BGColor" value="">\
-                <param name="SWRemote" value="">\
-                <param name="MovieData" value="">\
-                <param name="SeamlessTabbing" value="1">\
-                <param name="Profile" value="0">\
-                <param name="ProfileAddress" value="">\
-                <param name="ProfilePort" value="0">\
-                <param name="AllowNetworking" value="all">\
-                <param name="AllowFullScreen" value="false">\
-                <param name="AllowFullScreenInteractive" value="">\
-                <param name="IsDependent" value="61">\
-                <param name="movie" value="">\
-                <param name="quality" value="high">\
-                <param name="wmode" value="transparent">\
-                <param name="allowScriptAccess" value="always">\
-            </object>';
-            messageLocalization.localizeNode($(html));
-        });
-
-        QUnit.test('input attr \'type\' was not localized (Q588810)', function(assert) {
-            const $node = $('<input type=\'text\'></input>');
-
-            messageLocalization.localizeNode($node);
-
-            assert.equal($node.attr('type'), 'text');
         });
     });
 


### PR DESCRIPTION
It is an atavism of a SPA Framework. Is not used now.
There was the last renderer import in localization modules.