### PR TITLE
DataGrid - Focused row is not fully highlighted after editing if recalculateWhileEditing is enabled, rowRenderingMode is virtual, and useNative is false (T1072855)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -350,7 +350,7 @@ const FocusController = core.ViewController.inherit((function() {
                 }
             });
 
-            rowsView.scrollToElementVertically($mainRow);
+            $mainRow && rowsView.scrollToElementVertically($mainRow);
         },
         _clearPreviousFocusedRow: function($tableElement, focusedRowIndex) {
             const isNotMasterDetailFocusedRow = (_, focusedRow) => {

--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -331,19 +331,26 @@ const FocusController = core.ViewController.inherit((function() {
             const rowsView = that.getView('rowsView');
             let $tableElement;
 
+            let $mainRow;
+
             each(rowsView.getTableElements(), function(index, element) {
                 const isMainTable = index === 0;
                 $tableElement = $(element);
 
                 that._clearPreviousFocusedRow($tableElement, focusedRowIndex);
 
-                that._prepareFocusedRow({
+                const $row = that._prepareFocusedRow({
                     changedItem: change?.items?.[focusedRowIndex],
                     $tableElement: $tableElement,
                     focusedRowIndex: focusedRowIndex,
-                    isMainTable: isMainTable
                 });
+
+                if(isMainTable) {
+                    $mainRow = $row;
+                }
             });
+
+            rowsView.scrollToElementVertically($mainRow);
         },
         _clearPreviousFocusedRow: function($tableElement, focusedRowIndex) {
             const isNotMasterDetailFocusedRow = (_, focusedRow) => {
@@ -373,15 +380,11 @@ const FocusController = core.ViewController.inherit((function() {
             if(changedItem && (changedItem.rowType === 'data' || changedItem.rowType === 'group')) {
                 const focusedRowIndex = options.focusedRowIndex;
                 const $tableElement = options.$tableElement;
-                const isMainTable = options.isMainTable;
                 const tabIndex = this.option('tabindex') || 0;
                 const rowsView = this.getView('rowsView');
 
                 $row = $(rowsView._getRowElements($tableElement).eq(focusedRowIndex));
                 $row.addClass(ROW_FOCUSED_CLASS).attr('tabindex', tabIndex);
-                if(isMainTable) {
-                    rowsView.scrollToElementVertically($row);
-                }
             }
 
             return $row;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -3976,6 +3976,47 @@ QUnit.module('View\'s focus', {
             assert.strictEqual($focusedRowElement.attr('aria-rowindex'), '2', 'aria-rowindex');
         });
     });
+
+    QUnit.test('Fixed cells should be focused after navigating to focused row', function(assert) {
+        // arrange
+        this.dataGrid.option({
+            dataSource: [
+                { id: 1, name: 'name 1' },
+                { id: 2, name: 'name 2' },
+                { id: 3, name: 'name 3' },
+                { id: 4, name: 'name 4' },
+            ],
+            columns: [{
+                dataField: 'id',
+                fixed: true,
+            }, {
+                dataField: 'name',
+                fixed: false,
+            }],
+            height: 100,
+            keyExpr: 'id',
+            focusedRowEnabled: true,
+            scrolling: {
+                mode: 'virtual',
+            },
+        });
+        this.clock.tick(300);
+
+        // act
+        this.dataGrid.option('focusedRowIndex', 3);
+        this.clock.tick(100);
+
+        // assert
+        const row = this.dataGrid.getVisibleRows()[1];
+        assert.strictEqual(row.cells.length, 2);
+
+        row.cells.forEach((cell) => {
+            const $cell = $(cell.cellElement);
+            const $row = $cell.parent();
+
+            assert.ok($row.hasClass('dx-row-focused'));
+        });
+    });
 });
 
 QUnit.module('API methods', baseModuleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -4003,11 +4003,13 @@ QUnit.module('View\'s focus', {
         this.clock.tick(300);
 
         // act
-        this.dataGrid.option('focusedRowIndex', 3);
+        let rowIndex = this.dataGrid.getRowIndexByKey(4);
+        this.dataGrid.option('focusedRowIndex', rowIndex);
         this.clock.tick(100);
 
         // assert
-        const row = this.dataGrid.getVisibleRows()[1];
+        rowIndex = this.dataGrid.getRowIndexByKey(4);
+        const row = this.dataGrid.getVisibleRows()[rowIndex];
         assert.strictEqual(row.cells.length, 2);
 
         row.cells.forEach((cell) => {


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/21290