### PR TITLE
DataGrid - Columns are overlapped when the grouping feature and fixed columns are used if the type for one column is set to 'groupExpand' (T1075560)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -1404,6 +1404,7 @@ export const columnsControllerModule = {
                     const firstGroupColumn = expandColumns.filter((column) => column.groupIndex === 0)[0];
                     const isFixedFirstGroupColumn = firstGroupColumn && firstGroupColumn.fixed;
                     const isColumnFixing = this._isColumnFixing();
+                    const rtlEnabled = this.option('rtlEnabled');
 
                     if(expandColumns.length) {
                         expandColumn = this.columnOption('command:expand');
@@ -1416,6 +1417,7 @@ export const columnsControllerModule = {
                             cellTemplate: !isDefined(column.groupIndex) ? column.cellTemplate : null,
                             headerCellTemplate: null,
                             fixed: !isDefined(column.groupIndex) || !isFixedFirstGroupColumn ? isColumnFixing : true,
+                            fixedPosition: rtlEnabled ? 'right' : 'left',
                         }, expandColumn, {
                             index: column.index,
                             type: column.type || GROUP_COMMAND_COLUMN_NAME

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -6534,6 +6534,17 @@ QUnit.module('Sorting/Grouping', { beforeEach: setupModule, afterEach: teardownM
         assert.strictEqual(expandColumns[0].groupIndex, 0);
         assert.strictEqual(expandColumns[0].headerCellTemplate, null);
     });
+
+    // T1075560
+    QUnit.test('Expand columns should not have fixedPosition right', function(assert) {
+        // arrange
+        this.applyOptions({ columns: [{ dataField: 'field', groupIndex: 0, fixed: true, fixedPosition: 'right' }] });
+
+        // act, assert
+        const expandColumns = this.columnsController.getExpandColumns();
+        assert.strictEqual(expandColumns.length, 1, 'count expand column');
+        assert.strictEqual(expandColumns[0].fixedPosition, 'left');
+    });
 });
 
 QUnit.module('ParseValue', { beforeEach: setupModule, afterEach: teardownModule }, () => {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -6536,14 +6536,25 @@ QUnit.module('Sorting/Grouping', { beforeEach: setupModule, afterEach: teardownM
     });
 
     // T1075560
-    QUnit.test('Expand columns should not have fixedPosition right', function(assert) {
-        // arrange
-        this.applyOptions({ columns: [{ dataField: 'field', groupIndex: 0, fixed: true, fixedPosition: 'right' }] });
+    QUnit.test('Fixed position of expand columns should be identical to RTL', function(assert) {
+        [true, false].forEach((rtlEnabled) => {
+            ['left', 'right'].forEach((initialFixedPosition) => {
+                this.applyOptions({
+                    columns: [{
+                        dataField: 'field', groupIndex: 0, fixed: true, fixedPosition: initialFixedPosition
+                    }],
+                    rtlEnabled,
+                });
 
-        // act, assert
-        const expandColumns = this.columnsController.getExpandColumns();
-        assert.strictEqual(expandColumns.length, 1, 'count expand column');
-        assert.strictEqual(expandColumns[0].fixedPosition, 'left');
+                // assert
+                const expandColumns = this.columnsController.getExpandColumns();
+                const properFixedPosition = rtlEnabled ? 'right' : 'left';
+
+                assert.strictEqual(expandColumns.length, 1, 'count expand column');
+                assert.strictEqual(expandColumns[0].fixedPosition, properFixedPosition, `rtl: ${rtlEnabled}, initialFixedPosition: ${initialFixedPosition}`);
+            });
+        });
+
     });
 });
 


### PR DESCRIPTION
If column with `fixedPosition: 'right'` was grouped, expand column also had `fixedPosition: 'right'`. Because of it in [_getFixedColumnsCore](https://github.com/pomahtri/devextreme/blob/DataGrid_fixed_position_with_grouping/21_1/js/ui/grid_core/ui.grid_core.columns_controller.js#L1321) beginning of the transparent column was wrong.

I added setting `fixedPosition: left` to expand columns 