### PR TITLE
DataGrid: Fix clearing validation state of editors when a user modifies the value of an editor that has a defined setCellValue function (T1077720)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1113,14 +1113,15 @@ const EditingController = modules.ViewController.inherit((function() {
             const rowIndices = [oldRowIndex, rowIndex];
 
             this._beforeUpdateItems(rowIndices, rowIndex, oldRowIndex);
-            this._editRowFromOptionChangedCore(rowIndices, rowIndex, oldRowIndex);
+            this._editRowFromOptionChangedCore(rowIndices, rowIndex);
         },
 
-        _editRowFromOptionChangedCore: function(rowIndices, rowIndex, oldRowIndex) {
+        _editRowFromOptionChangedCore: function(rowIndices, rowIndex, preventRendering) {
             this._needFocusEditor = true;
             this._dataController.updateItems({
                 changeType: 'update',
-                rowIndices: rowIndices
+                rowIndices: rowIndices,
+                cancel: preventRendering
             });
         },
 

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -453,11 +453,13 @@ export const editingFormBasedModule = {
                     this.callBase.apply(this, arguments);
                 },
 
-                _editRowFromOptionChangedCore: function(rowIndices, rowIndex, oldRowIndex) {
-                    if(this.isPopupEditMode()) {
+                _editRowFromOptionChangedCore: function(rowIndices, rowIndex) {
+                    const isPopupEditMode = this.isPopupEditMode();
+
+                    this.callBase(rowIndices, rowIndex, isPopupEditMode);
+
+                    if(isPopupEditMode) {
                         this._showEditPopup(rowIndex);
-                    } else {
-                        this.callBase.apply(this, arguments);
                     }
                 }
             },

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -189,6 +189,7 @@ export const editingFormBasedModule = {
                     const row = this.component.getVisibleRows()[rowIndex];
                     const templateOptions = {
                         row: row,
+                        values: row.values,
                         rowType: row.rowType,
                         key: row.key,
                         rowIndex

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -441,6 +441,9 @@ const ValidatingController = modules.Controller.inherit((function() {
                     if(adapter) {
                         adapter.getValue = getValue;
                         adapter.validationRequestsCallbacks = [];
+                        adapter.bypass = () => {
+                            return parameters.row.isNewRow && !this._isValidationInProgress && !editingController.isCellModified(parameters);
+                        };
                     }
                 }
 
@@ -652,7 +655,7 @@ export const validatingModule = {
 
                 _validateEditFormAfterUpdate: function(row, isCustomSetCellValue) {
                     // T816256, T844143
-                    if(isCustomSetCellValue && this._editForm && !row.isNewRow) {
+                    if(isCustomSetCellValue && this._editForm) {
                         this._editForm.validate();
                     }
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -15601,6 +15601,94 @@ QUnit.module('Editing with validation', {
             assert.strictEqual(newRowCount, 1, 'single new row after saving');
         });
     });
+
+    // T1077720
+    ['cell', 'batch', 'row', 'form', 'popup'].forEach((mode) => {
+        QUnit.test(`The ${mode} edit mode - Validation state of editors should not be cleared cleared when a user modifies the value of an editor that has a defined setCellValue function`, function(assert) {
+            // arrange
+            fx.off = true;
+
+            try {
+                const rowsView = this.rowsView;
+                const $testElement = $('#container');
+                const getCellText = (rowIndex, columnIndex) => {
+                    const $cellElement = $(this.getCellElement(rowIndex, columnIndex));
+                    const $inputElement = $cellElement.find('.dx-texteditor-input');
+
+                    return $inputElement.length ? $inputElement.val() : $cellElement.text();
+                };
+                const isValidCell = (rowIndex, columnIndex) => {
+                    if(mode === 'popup' || mode === 'form') {
+                        return !$(this.getCellElement(rowIndex, columnIndex)).find('.dx-invalid').length;
+                    }
+
+                    return !$(this.getCellElement(rowIndex, columnIndex)).hasClass('dx-datagrid-invalid');
+                };
+
+                this.options.columns = [];
+                const gridConfig = {
+                    dataSource: [{ a: 'test1', b: 'test2' }],
+                    editing: {
+                        mode,
+                        allowAdding: true
+                    },
+                    columns: [
+                        {
+                            dataField: 'a',
+                            setCellValue: function(newData, value) {
+                                this.defaultSetCellValue(newData, value);
+                            },
+                            validationRules: [{ type: 'required' }]
+                        },
+                        {
+                            dataField: 'b',
+                            setCellValue: function(newData, value) {
+                                this.defaultSetCellValue(newData, value);
+                            },
+                            validationRules: [{ type: 'required' }]
+                        }
+                    ]
+                };
+
+                rowsView.render($testElement);
+                this.applyOptions(gridConfig);
+
+                const onInitNewRow = function(e) {
+                    e.data.a = 'test';
+                };
+                this.option('onInitNewRow', onInitNewRow);
+
+                // act
+                this.addRow();
+                this.clock.tick();
+
+                // assert
+                const newRow = this.getVisibleRows()[0];
+                assert.ok(newRow.isNewRow, 'new row');
+
+                // act
+                this.cellValue(0, 0, '');
+                this.clock.tick();
+
+                // assert
+                assert.strictEqual(getCellText(0, 0), '', 'text of the first cell');
+                assert.notOk(isValidCell(0, 0), 'first cell is not valid');
+                assert.ok(isValidCell(0, 1), 'second cell is valid');
+
+                // act
+                this.cellValue(0, 1, '123');
+                this.clock.tick();
+
+                // assert
+                assert.strictEqual(getCellText(0, 0), '', 'text of the first cell');
+                assert.notOk(isValidCell(0, 0), 'first cell is not valid');
+                assert.strictEqual(getCellText(0, 1), '123', 'text of the second cell');
+                assert.ok(isValidCell(0, 1), 'second cell is valid');
+            } finally {
+                fx.off = false;
+            }
+        });
+    });
 });
 
 QUnit.module('Editing with real dataController with grouping, masterDetail', {


### PR DESCRIPTION
See https://devexpress.com/issue=T1077720