### PR TITLE
DataGrid: Fix clearing validation state of editors when a user modifies the value of an editor that has a defined setCellValue function (T1077720)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1113,14 +1113,15 @@ const EditingController = modules.ViewController.inherit((function() {
             const rowIndices = [oldRowIndex, rowIndex];
 
             this._beforeUpdateItems(rowIndices, rowIndex, oldRowIndex);
-            this._editRowFromOptionChangedCore(rowIndices, rowIndex, oldRowIndex);
+            this._editRowFromOptionChangedCore(rowIndices, rowIndex);
         },
 
-        _editRowFromOptionChangedCore: function(rowIndices, rowIndex, oldRowIndex) {
+        _editRowFromOptionChangedCore: function(rowIndices, rowIndex, preventRendering) {
             this._needFocusEditor = true;
             this._dataController.updateItems({
                 changeType: 'update',
-                rowIndices: rowIndices
+                rowIndices: rowIndices,
+                cancel: preventRendering
             });
         },
 

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -455,11 +455,13 @@ export const editingFormBasedModule = {
                     this.callBase.apply(this, arguments);
                 },
 
-                _editRowFromOptionChangedCore: function(rowIndices, rowIndex, oldRowIndex) {
-                    if(this.isPopupEditMode()) {
+                _editRowFromOptionChangedCore: function(rowIndices, rowIndex) {
+                    const isPopupEditMode = this.isPopupEditMode();
+
+                    this.callBase(rowIndices, rowIndex, isPopupEditMode);
+
+                    if(isPopupEditMode) {
                         this._showEditPopup(rowIndex);
-                    } else {
-                        this.callBase.apply(this, arguments);
                     }
                 }
             },

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -191,6 +191,7 @@ export const editingFormBasedModule = {
                     const row = this.component.getVisibleRows()[rowIndex];
                     const templateOptions = {
                         row: row,
+                        values: row.values,
                         rowType: row.rowType,
                         key: row.key,
                         rowIndex

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -441,6 +441,9 @@ const ValidatingController = modules.Controller.inherit((function() {
                     if(adapter) {
                         adapter.getValue = getValue;
                         adapter.validationRequestsCallbacks = [];
+                        adapter.bypass = () => {
+                            return parameters.row.isNewRow && !this._isValidationInProgress && !editingController.isCellModified(parameters);
+                        };
                     }
                 }
 
@@ -652,7 +655,7 @@ export const validatingModule = {
 
                 _validateEditFormAfterUpdate: function(row, isCustomSetCellValue) {
                     // T816256, T844143
-                    if(isCustomSetCellValue && this._editForm && !row.isNewRow) {
+                    if(isCustomSetCellValue && this._editForm) {
                         this._editForm.validate();
                     }
 


### PR DESCRIPTION
See https://devexpress.com/issue=T1077720