### PR TITLE
HtmlEditor: Fix component height when the placeholder is set (T1016472)

### DIFF
--- a/scss/widgets/base/_htmlEditor.scss
+++ b/scss/widgets/base/_htmlEditor.scss
@@ -308,6 +308,10 @@ $transparent-border: 1px solid transparent;
       z-index: -1;
       visibility: hidden;
     }
+
+    &[data-placeholder] > p {
+      height: 0.1px;
+    }
   }
 
   // stylelint-enable selector-class-pattern


### PR DESCRIPTION
Prev appearance:
Without content
![bfr_wo_text](https://user-images.githubusercontent.com/1554153/162161113-369e9da1-65c3-4d63-be2d-98cb88b9408c.png)

With content
![bfr_with_text](https://user-images.githubusercontent.com/1554153/162161144-a78997f8-0dc2-4eb4-b2c7-9ac6cbf9dfc0.png)

Current appearanceL
Without content
![aft_wo_text](https://user-images.githubusercontent.com/1554153/162161335-27746fc3-7c05-43a4-9028-17aea56ce5ec.png)

With content
![aft_with_text](https://user-images.githubusercontent.com/1554153/162161371-4f4fb737-f10a-43f6-ab21-bce8aed8d0fb.png)

