### PR TITLE
Call cleanData only for node with widget created by knockout integrtaion (T1081028) (#21508)

### DIFF
--- a/js/integration/knockout/clean_node.js
+++ b/js/integration/knockout/clean_node.js
@@ -2,6 +2,7 @@ import { afterCleanData, strategyChanging, cleanData } from '../../core/element_
 // eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
 import { compare as compareVersion } from '../../core/utils/version';
+import { getClosestNodeWithKoCreation } from './utils';
 
 if(ko) {
     const originalKOCleanExternalData = ko.utils.domNodeDisposal.cleanExternalData;
@@ -26,8 +27,10 @@ if(ko) {
 
         ko.utils.domNodeDisposal.cleanExternalData = function(node) {
             node.cleanedByKo = true;
-            if(!node.cleanedByJquery) {
-                cleanData([node]);
+            if(getClosestNodeWithKoCreation(node)) {
+                if(!node.cleanedByJquery) {
+                    cleanData([node]);
+                }
             }
         };
     };

--- a/js/integration/knockout/utils.js
+++ b/js/integration/knockout/utils.js
@@ -1,11 +1,22 @@
 
 // eslint-disable-next-line no-restricted-imports
 import ko from 'knockout';
+import $ from '../../core/renderer';
 
 export const getClosestNodeWithContext = (node) => {
     const context = ko.contextFor(node);
     if(!context && node.parentNode) {
         return getClosestNodeWithContext(node.parentNode);
+    }
+
+    return node;
+};
+export const getClosestNodeWithKoCreation = (node) => {
+    const $el = $(node);
+    const data = $el.data();
+    const hasFlag = data && data['dxKoCreation'];
+    if(!hasFlag && node.parentNode) {
+        return getClosestNodeWithKoCreation(node.parentNode);
     }
 
     return node;

--- a/testing/tests/DevExpress.knockout/cleanNode.tests.js
+++ b/testing/tests/DevExpress.knockout/cleanNode.tests.js
@@ -9,6 +9,7 @@ const FIXTURE_ELEMENT = $('#qunit-fixture');
 const setTestData = function($element) {
     dataUtils.data($element.get(0), '__test_key__', { key: 'value' });
     ko.utils.domData.set($element.get(0), '__test_key__', { key: 'value ' });
+    dataUtils.data($element.get(0), 'dxKoCreation', true);
 };
 
 const hasKOTestData = function($element) {
@@ -141,7 +142,6 @@ if($.fn.jquery[0] !== '1') {
             dataUtils.data($(this)[0], 'dxTestData', true);
             ko.utils.domData.set(this, 'dxTestData', true);
         });
-
         const cleanDataLog = [];
         const dataUtilsStrategy = dataUtils.getDataStrategy();
         const originalCleanData = dataUtilsStrategy.cleanData;


### PR DESCRIPTION
Сheck dxKoCreation data exists not only for the current node but all parents to detect widget creation using knockout integration

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
