### PR TITLE
update dependency minimist to 1.2.6 [security]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,7 @@
         "looks-same": "^7.2.3",
         "map-stream": "0.0.7",
         "merge-stream": "^2.0.0",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "mustache": "4.0.1",
         "nconf": "^0.10.0",
         "normalize-path": "^3.0.0",
@@ -18886,9 +18886,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -44260,9 +44260,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "looks-same": "^7.2.3",
     "map-stream": "0.0.7",
     "merge-stream": "^2.0.0",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.6",
     "mustache": "4.0.1",
     "nconf": "^0.10.0",
     "normalize-path": "^3.0.0",


### PR DESCRIPTION
Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).

https://github.com/advisories/GHSA-xvch-5gv4-984h