### PR TITLE
DataGrid - The "Cannot read properties of undefined (reading 'column')" error is thrown when right-clicking a row (T1084959)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.context_menu.js
+++ b/js/ui/grid_core/ui.grid_core.context_menu.js
@@ -49,7 +49,7 @@ const ContextMenuController = modules.ViewController.inherit({
                     rowIndex: rowIndex,
                     row: view._getRows()[rowIndex],
                     columnIndex: columnIndex,
-                    column: rowOptions?.cells?.[columnIndex].column
+                    column: rowOptions?.cells?.[columnIndex]?.column
                 };
 
                 options.items = view.getContextMenuItems && view.getContextMenuItems(options);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/contextMenuView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/contextMenuView.tests.js
@@ -282,6 +282,41 @@ QUnit.module('Context menu with rowsView', {
         assert.strictEqual(contextMenuOptions.column.dataField, 'Column2', 'dataField');
     });
 
+    // T1084959
+    QUnit.test('Context menu should work if `cells` is empty array', function(assert) {
+        // arrange
+        const $testElement = $('#secondContainer');
+
+        this.options = {
+            dataRowTemplate: function(container, options) {
+                const data = options.data;
+                $(container).append('<tr class=\'main-row\'>' +
+                            '<td class=\'click-me\'>CLICK ME</td>' +
+                        '</tr>' +
+                        '<tr class=\'notes-row\'>' +
+                            '<td><div>' + data.id + '</div></td>' +
+                        '</tr>');
+            }
+        };
+
+        this.items = [
+            { data: { id: 1 }, values: [1], rowType: 'data', dataIndex: 0, cells: [] },
+            { data: { id: 2 }, values: [2], rowType: 'data', dataIndex: 1, cells: [] },
+        ];
+
+        this.columns = [{ dataField: 'Column1' }];
+
+        this.setupDataGrid();
+        this.rowsView.render($testElement);
+        this.contextMenuView.render($testElement);
+
+        // act
+        $('.click-me').eq(1).trigger('contextmenu');
+
+        // assert
+        assert.ok(true, 'no error thrown');
+    });
+
     // T403458
     QUnit.test('Context menu with option onContextMenuPreparing when no data and scrollbar', function(assert) {
     // arrange


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
