### PR TITLE
DataGrid - The Add row buttons is not displayed if allowAdding option is set to true in code (T1085151)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.header_panel.js
+++ b/js/ui/grid_core/ui.grid_core.header_panel.js
@@ -96,7 +96,7 @@ const HeaderPanel = ColumnsView.inherit({
                 if(isDefined(defaultButtonsByNames[button.name])) {
                     button = extend(true, {}, defaultButtonsByNames[button.name], button);
                 } else if(DEFAULT_TOOLBAR_ITEM_NAMES.includes(button.name)) {
-                    button.visible = false;
+                    button = { ...button, visible: false };
                 }
             }
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerPanel.tests.js
@@ -907,6 +907,10 @@ QUnit.module('Draw buttons in header panel', {
         $.each($toolbarItemElements, (_, toolbarItemElement) => {
             assert.ok($(toolbarItemElement).hasClass('dx-state-invisible'), 'button is hidden');
         });
+
+        this.options.toolbar.items.forEach(item => {
+            assert.strictEqual(item.visible, undefined, 'visible option should not be changed in user props');
+        });
     });
 
     QUnit.test('Toolbar item with custom name should be visible', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerPanel.tests.js
@@ -908,6 +908,7 @@ QUnit.module('Draw buttons in header panel', {
             assert.ok($(toolbarItemElement).hasClass('dx-state-invisible'), 'button is hidden');
         });
 
+        // T1085151
         this.options.toolbar.items.forEach(item => {
             assert.strictEqual(item.visible, undefined, 'visible option should not be changed in user props');
         });


### PR DESCRIPTION
Because of mutating setting prop `visible` in case default button is not available, `visible: false` was set to `toolbar.items[].visible: false` and was hidden even default button gets available.