### PR TITLE
TreeList: Fix value of a node's aria-selected attribute after collapsing the node when recursive selection enabled (T1085491)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.selection.js
+++ b/js/ui/grid_core/ui.grid_core.selection.js
@@ -802,7 +802,7 @@ export const selectionModule = {
                     const $row = this.callBase(row);
 
                     if(row) {
-                        const isSelected = !!row.isSelected;
+                        const isSelected = row.isSelected;
                         if(isSelected) {
                             $row.addClass(ROW_SELECTION_CLASS);
                         }

--- a/testing/tests/DevExpress.ui.widgets.treeList/selection.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/selection.tests.js
@@ -1657,5 +1657,36 @@ QUnit.module('Recursive selection', {
         assert.deepEqual(this.option('selectedRowKeys'), [0], 'selected row keys');
         assert.ok(items[0].isSelected, 'first item is selected');
     });
+
+    // T1085491
+    QUnit.test('The aria-selected attribute of the parent node should be in an indeterminate state after select child node -> collapse parent node', function(assert) {
+        // arrange
+        const $testElement = $('#treeList');
+
+        this.options.dataSource = [
+            { id: 1, field1: 'test1' },
+            { id: 2, parentId: 1, field1: 'test2' },
+            { id: 3, parentId: 1, field1: 'test3' },
+        ];
+        this.options.expandedRowKeys = [1];
+        this.setupTreeList();
+        this.rowsView.render($testElement);
+
+        // act
+        this.selectRows([3]);
+
+        // assert
+        let items = this.dataController.items();
+        assert.strictEqual(items[0].isSelected, undefined, 'selection state of the first item is indeterminate');
+        assert.strictEqual($(this.rowsView.getRowElement(0)).attr('aria-selected'), 'undefined', 'aria-selected attr with \'undefined\' value');
+
+        // act
+        this.collapseRow(1);
+
+        // assert
+        items = this.dataController.items();
+        assert.strictEqual(items[0].isSelected, undefined, 'selection state of the first item is indeterminate');
+        assert.strictEqual($(this.rowsView.getRowElement(0)).attr('aria-selected'), 'undefined', 'aria-selected attr with \'undefined\' value');
+    });
 });
 


### PR DESCRIPTION
See https://devexpress.com/issue=T1085491