### PR TITLE
Dart test: install packages using "dart pub" instead of deprecated "pub" command

### DIFF
--- a/.github/workflows/themebuilder_dart_tests.yml
+++ b/.github/workflows/themebuilder_dart_tests.yml
@@ -29,7 +29,7 @@ jobs:
       uses: dart-lang/setup-dart@v1
 
     - name: Install dart packages
-      run: pub get
+      run: dart pub get
       working-directory: ./themebuilder-scss/dart-compiler
 
     - name: Run npm install


### PR DESCRIPTION
https://github.com/Dart-Code/Dart-Code/issues/3545