### PR TITLE
FileManager - Fix the getItems method invocation count after exception (T1085224)

### DIFF
--- a/js/ui/file_manager/ui.file_manager.item_list.details.js
+++ b/js/ui/file_manager/ui.file_manager.item_list.details.js
@@ -99,8 +99,7 @@ class FileManagerDetailsItemList extends FileManagerItemListBase {
             onContextMenuPreparing: this._onContextMenuPreparing.bind(this),
             onSelectionChanged: this._onFilesViewSelectionChanged.bind(this),
             onFocusedRowChanged: this._onFilesViewFocusedRowChanged.bind(this),
-            onOptionChanged: this._onFilesViewOptionChanged.bind(this),
-            onContentReady: () => this._refreshDeferred?.resolve()
+            onOptionChanged: this._onFilesViewOptionChanged.bind(this)
         });
     }
 

--- a/js/ui/file_manager/ui.file_manager.item_list.js
+++ b/js/ui/file_manager/ui.file_manager.item_list.js
@@ -39,7 +39,7 @@ class FileManagerItemListBase extends Widget {
             onFocusedItemChanged: this._createActionByOption('onFocusedItemChanged'),
             onSelectedItemOpened: this._createActionByOption('onSelectedItemOpened'),
             onContextMenuShowing: this._createActionByOption('onContextMenuShowing'),
-            onItemListContentReady: this._createActionByOption('onItemListContentReady')
+            onItemListDataLoaded: this._createActionByOption('onItemListDataLoaded')
         };
     }
 
@@ -82,7 +82,7 @@ class FileManagerItemListBase extends Widget {
             case 'onSelectionChanged':
             case 'onFocusedItemChanged':
             case 'onContextMenuShowing':
-            case 'onItemListContentReady':
+            case 'onItemListDataLoaded':
                 this._actions[name] = this._createActionByOption(name);
                 break;
             default:
@@ -103,7 +103,7 @@ class FileManagerItemListBase extends Widget {
                 this._parentDirectoryItemKey = parentDirectoryItem ? parentDirectoryItem.fileItem.key : null;
             })
             .always(() => {
-                this._onContentReady();
+                this._onDataLoaded();
             });
     }
 
@@ -133,12 +133,12 @@ class FileManagerItemListBase extends Widget {
         this._actions.onContextMenuShowing(e);
     }
 
-    _raiseItemListContentReady() {
-        this._actions.onItemListContentReady();
+    _raiseItemListDataLoaded() {
+        this._actions.onItemListDataLoaded();
     }
 
-    _onContentReady() {
-        this._raiseItemListContentReady();
+    _onDataLoaded() {
+        this._raiseItemListDataLoaded();
         this._refreshDeferred?.resolve();
     }
 

--- a/js/ui/file_manager/ui.file_manager.item_list.js
+++ b/js/ui/file_manager/ui.file_manager.item_list.js
@@ -38,7 +38,8 @@ class FileManagerItemListBase extends Widget {
             onSelectionChanged: this._createActionByOption('onSelectionChanged'),
             onFocusedItemChanged: this._createActionByOption('onFocusedItemChanged'),
             onSelectedItemOpened: this._createActionByOption('onSelectedItemOpened'),
-            onContextMenuShowing: this._createActionByOption('onContextMenuShowing')
+            onContextMenuShowing: this._createActionByOption('onContextMenuShowing'),
+            onItemListContentReady: this._createActionByOption('onItemListContentReady')
         };
     }
 
@@ -81,6 +82,7 @@ class FileManagerItemListBase extends Widget {
             case 'onSelectionChanged':
             case 'onFocusedItemChanged':
             case 'onContextMenuShowing':
+            case 'onItemListContentReady':
                 this._actions[name] = this._createActionByOption(name);
                 break;
             default:
@@ -89,16 +91,20 @@ class FileManagerItemListBase extends Widget {
     }
 
     _getItems() {
-        return this._getItemsInternal().done(itemInfos => {
-            this._itemCount = itemInfos.length;
-            if(this._itemCount === 0) {
-                this._resetFocus();
-            }
+        return this._getItemsInternal()
+            .done(itemInfos => {
+                this._itemCount = itemInfos.length;
+                if(this._itemCount === 0) {
+                    this._resetFocus();
+                }
 
-            const parentDirectoryItem = this._findParentDirectoryItem(itemInfos);
-            this._hasParentDirectoryItem = !!parentDirectoryItem;
-            this._parentDirectoryItemKey = parentDirectoryItem ? parentDirectoryItem.fileItem.key : null;
-        });
+                const parentDirectoryItem = this._findParentDirectoryItem(itemInfos);
+                this._hasParentDirectoryItem = !!parentDirectoryItem;
+                this._parentDirectoryItemKey = parentDirectoryItem ? parentDirectoryItem.fileItem.key : null;
+            })
+            .always(() => {
+                this._onContentReady();
+            });
     }
 
     _getItemsInternal() {
@@ -125,6 +131,15 @@ class FileManagerItemListBase extends Widget {
 
     _raiseContextMenuShowing(e) {
         this._actions.onContextMenuShowing(e);
+    }
+
+    _raiseItemListContentReady() {
+        this._actions.onItemListContentReady();
+    }
+
+    _onContentReady() {
+        this._raiseItemListContentReady();
+        this._refreshDeferred?.resolve();
     }
 
     _tryRaiseSelectionChanged({ selectedItemInfos, selectedItems, selectedItemKeys, currentSelectedItemKeys, currentDeselectedItemKeys }) {

--- a/js/ui/file_manager/ui.file_manager.item_list.thumbnails.js
+++ b/js/ui/file_manager/ui.file_manager.item_list.thumbnails.js
@@ -45,8 +45,7 @@ class FileManagerThumbnailsItemList extends FileManagerItemListBase {
             itemThumbnailTemplate: this._getItemThumbnailContainer.bind(this),
             getTooltipText: this._getTooltipText.bind(this),
             onSelectionChanged: this._onItemListSelectionChanged.bind(this),
-            onFocusedItemChanged: this._onItemListFocusedItemChanged.bind(this),
-            onContentReady: () => this._refreshDeferred?.resolve()
+            onFocusedItemChanged: this._onItemListFocusedItemChanged.bind(this)
         });
     }
 

--- a/js/ui/file_manager/ui.file_manager.js
+++ b/js/ui/file_manager/ui.file_manager.js
@@ -49,6 +49,7 @@ class FileManager extends Widget {
         super._init();
         this._providerUpdateDeferred = null;
         this._lockCurrentPathProcessing = false;
+        this._wasRendered = false;
 
         this._controller = new FileItemsController({
             currentPath: this.option('currentPath'),
@@ -80,7 +81,11 @@ class FileManager extends Widget {
 
         this.$element().addClass(FILE_MANAGER_CLASS);
 
-        this._prepareToLoad();
+        if(this._wasRendered) {
+            this._prepareToLoad();
+        } else {
+            this._wasRendered = true;
+        }
         this._createNotificationControl();
 
         this._initCommandManager();
@@ -180,7 +185,7 @@ class FileManager extends Widget {
             getDirectories: this.getDirectories.bind(this),
             getCurrentDirectory: this._getCurrentDirectory.bind(this),
             onDirectoryClick: ({ itemData }) => this._setCurrentDirectory(itemData),
-            onFilesTreeViewContentReady: () => this._tryUnlockController(VIEW_AREAS.folders)
+            onItemListDataLoaded: () => this._tryUnlockController(VIEW_AREAS.folders)
         });
 
         this._filesTreeView.updateCurrentDirectory();
@@ -202,7 +207,7 @@ class FileManager extends Widget {
             onFocusedItemChanged: this._onItemViewFocusedItemChanged.bind(this),
             onSelectedItemOpened: this._onSelectedItemOpened.bind(this),
             onContextMenuShowing: e => this._onContextMenuShowing(VIEW_AREAS.items, e),
-            onItemListContentReady: () => this._tryUnlockController(VIEW_AREAS.items),
+            onItemListItemsLoaded: () => this._tryUnlockController(VIEW_AREAS.items),
             getItemThumbnail: this._getItemThumbnailInfo.bind(this),
             customizeDetailColumns: this.option('customizeDetailColumns'),
             detailColumns: this.option('itemView.details.columns')
@@ -299,13 +304,13 @@ class FileManager extends Widget {
     _tryUnlockController(area) {
         this._loadedWidgets.push(area);
         if(this._isAllWidgetsLoaded()) {
-            this._controller.unlock();
+            this._controller.endSingleLoad();
         }
     }
 
     _prepareToLoad() {
         this._loadedWidgets = [];
-        this._controller.lock();
+        this._controller.startSingleLoad();
     }
 
     _updateToolbar(selectedItems) {

--- a/js/ui/file_manager/ui.file_manager.js
+++ b/js/ui/file_manager/ui.file_manager.js
@@ -74,11 +74,13 @@ class FileManager extends Widget {
         this._lockSelectionProcessing = false;
         this._lockFocusedItemProcessing = false;
         this._itemKeyToFocus = undefined;
+        this._loadedWidgets = [];
 
         this._commandManager = new FileManagerCommandManager(this.option('permissions'));
 
         this.$element().addClass(FILE_MANAGER_CLASS);
 
+        this._prepareToLoad();
         this._createNotificationControl();
 
         this._initCommandManager();
@@ -177,7 +179,8 @@ class FileManager extends Widget {
             contextMenu: this._filesTreeViewContextMenu,
             getDirectories: this.getDirectories.bind(this),
             getCurrentDirectory: this._getCurrentDirectory.bind(this),
-            onDirectoryClick: ({ itemData }) => this._setCurrentDirectory(itemData)
+            onDirectoryClick: ({ itemData }) => this._setCurrentDirectory(itemData),
+            onFilesTreeViewContentReady: () => this._tryUnlockController(VIEW_AREAS.folders)
         });
 
         this._filesTreeView.updateCurrentDirectory();
@@ -199,6 +202,7 @@ class FileManager extends Widget {
             onFocusedItemChanged: this._onItemViewFocusedItemChanged.bind(this),
             onSelectedItemOpened: this._onSelectedItemOpened.bind(this),
             onContextMenuShowing: e => this._onContextMenuShowing(VIEW_AREAS.items, e),
+            onItemListContentReady: () => this._tryUnlockController(VIEW_AREAS.items),
             getItemThumbnail: this._getItemThumbnailInfo.bind(this),
             customizeDetailColumns: this.option('customizeDetailColumns'),
             detailColumns: this.option('itemView.details.columns')
@@ -281,8 +285,27 @@ class FileManager extends Widget {
     }
 
     _refreshAndShowProgress() {
+        this._prepareToLoad();
         return when(this._notificationControl.tryShowProgressPanel(), this._controller.refresh())
             .then(() => this._filesTreeView.refresh());
+    }
+
+    _isAllWidgetsLoaded() {
+        return this._loadedWidgets.length === 2 &&
+            this._loadedWidgets.indexOf(VIEW_AREAS.folders) !== -1 &&
+            this._loadedWidgets.indexOf(VIEW_AREAS.items) !== -1;
+    }
+
+    _tryUnlockController(area) {
+        this._loadedWidgets.push(area);
+        if(this._isAllWidgetsLoaded()) {
+            this._controller.unlock();
+        }
+    }
+
+    _prepareToLoad() {
+        this._loadedWidgets = [];
+        this._controller.lock();
     }
 
     _updateToolbar(selectedItems) {

--- a/js/ui/file_manager/ui.file_manager.js
+++ b/js/ui/file_manager/ui.file_manager.js
@@ -185,7 +185,7 @@ class FileManager extends Widget {
             getDirectories: this.getDirectories.bind(this),
             getCurrentDirectory: this._getCurrentDirectory.bind(this),
             onDirectoryClick: ({ itemData }) => this._setCurrentDirectory(itemData),
-            onItemListDataLoaded: () => this._tryUnlockController(VIEW_AREAS.folders)
+            onItemListDataLoaded: () => this._tryEndLoading(VIEW_AREAS.folders)
         });
 
         this._filesTreeView.updateCurrentDirectory();
@@ -207,7 +207,7 @@ class FileManager extends Widget {
             onFocusedItemChanged: this._onItemViewFocusedItemChanged.bind(this),
             onSelectedItemOpened: this._onSelectedItemOpened.bind(this),
             onContextMenuShowing: e => this._onContextMenuShowing(VIEW_AREAS.items, e),
-            onItemListItemsLoaded: () => this._tryUnlockController(VIEW_AREAS.items),
+            onItemListItemsLoaded: () => this._tryEndLoading(VIEW_AREAS.items),
             getItemThumbnail: this._getItemThumbnailInfo.bind(this),
             customizeDetailColumns: this.option('customizeDetailColumns'),
             detailColumns: this.option('itemView.details.columns')
@@ -301,7 +301,7 @@ class FileManager extends Widget {
             this._loadedWidgets.indexOf(VIEW_AREAS.items) !== -1;
     }
 
-    _tryUnlockController(area) {
+    _tryEndLoading(area) {
         this._loadedWidgets.push(area);
         if(this._isAllWidgetsLoaded()) {
             this._controller.endSingleLoad();

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
@@ -1352,16 +1352,6 @@ QUnit.module('Navigation operations', moduleConfig, () => {
         const optionChangedSpy = sinon.spy();
         const objectProvider = new ObjectFileSystemProvider({ data: createTestFileSystem() });
         const customProvider = new CustomFileSystemProvider({
-            getItems1: function(parentDirectory) {
-                return new Promise((resolve, reject) => {
-                    if(parentDirectory.key === 'Folder 2') {
-                        const error = new FileSystemError(42, parentDirectory, 'Custom text');
-                        reject(error);
-                    } else {
-                        objectProvider.getItems(parentDirectory).then(result => resolve(result));
-                    }
-                });
-            },
             getItems: function(parentDirectory) {
                 const deferred = new Deferred();
                 if(parentDirectory.key === 'Folder 2') {
@@ -1425,5 +1415,121 @@ QUnit.module('Navigation operations', moduleConfig, () => {
         assert.strictEqual(this.wrapper.getBreadcrumbsPath(), 'Files', 'Breadcrumbs has correct path');
         assert.strictEqual(this.fileManager.getCurrentDirectory().key, '', 'Current directory is the target one');
         assert.strictEqual(this.wrapper.getFocusedItemText(), 'Files', 'NavPane current folder text is correct');
+    });
+
+    test('getItems must be invoked only once in case of exception (T1085224)', function(assert) {
+        const customProvider = new CustomFileSystemProvider({
+            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
+        });
+        const getItemsSpy = sinon.spy(customProvider, 'getItems');
+        this.fileManager.option({
+            fileSystemProvider: customProvider
+        });
+        this.clock.tick(800);
+
+        assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
+    });
+
+    test('only one notification must be shown in case of getItems exception (T1085224)', function(assert) {
+        const provider = new CustomFileSystemProvider({
+            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
+        });
+
+        this.fileManager.option('fileSystemProvider', provider);
+        this.clock.tick(400);
+
+        const infos = this.progressPanelWrapper.getInfos();
+        assert.strictEqual(infos.length, 1, 'There is one notification on panel');
+
+        assert.strictEqual(infos[0].common.commonText, 'The directory cannot be opened', 'Title is correct');
+
+        const details = infos[0].details;
+        assert.strictEqual(details.length, 1, 'Notification has one details section');
+
+        assert.strictEqual(details[0].commonText, '', 'Common text is correct');
+        assert.strictEqual(details[0].errorText, 'Custom text', 'Error text is correct');
+    });
+
+    test('getItems must be invoked only once in case of exception after refresh (T1085224)', function(assert) {
+        const customProvider = new CustomFileSystemProvider({
+            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
+        });
+        const getItemsSpy = sinon.spy(customProvider, 'getItems');
+        this.fileManager.option({
+            fileSystemProvider: customProvider
+        });
+        this.clock.tick(800);
+
+        getItemsSpy.reset();
+        this.wrapper.getToolbarRefreshButton().trigger('dxclick');
+        this.clock.tick(800);
+
+        assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
+    });
+
+    test('only one notification must be shown in case of getItems exception after refresh (T1085224)', function(assert) {
+        const provider = new CustomFileSystemProvider({
+            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
+        });
+
+        this.fileManager.option('fileSystemProvider', provider);
+        this.clock.tick(400);
+
+        this.progressPanelWrapper.getInfos()[0].common.$closeButton.trigger('dxclick');
+        this.clock.tick(400);
+
+        let infos = this.progressPanelWrapper.getInfos();
+        assert.strictEqual(infos.length, 0, 'There are no notifications on panel');
+
+        this.wrapper.getToolbarRefreshButton().trigger('dxclick');
+        this.clock.tick(700);
+
+        infos = this.progressPanelWrapper.getInfos();
+        assert.strictEqual(infos.length, 1, 'There is one notification on panel');
+
+        assert.strictEqual(infos[0].common.commonText, 'The directory cannot be opened', 'Title is correct');
+
+        const details = infos[0].details;
+        assert.strictEqual(details.length, 1, 'Notification has one details section');
+
+        assert.strictEqual(details[0].commonText, '', 'Common text is correct');
+        assert.strictEqual(details[0].errorText, 'Custom text', 'Error text is correct');
+    });
+
+    test('getItems must be invoked only once in case of exception detailsView (T1085224)', function(assert) {
+        const customProvider = new CustomFileSystemProvider({
+            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
+        });
+        const getItemsSpy = sinon.spy(customProvider, 'getItems');
+        this.fileManager.option({
+            itemView: { mode: 'details' },
+            fileSystemProvider: customProvider
+        });
+        this.clock.tick(800);
+
+        assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
+    });
+
+    test('only one notification must be shown in case of getItems exception detailsView (T1085224)', function(assert) {
+        const provider = new CustomFileSystemProvider({
+            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
+        });
+
+        this.fileManager.option({
+            itemView: { mode: 'details' },
+            fileSystemProvider: provider
+        });
+        this.clock.tick(800);
+
+        const infos = this.progressPanelWrapper.getInfos();
+        assert.strictEqual(infos.length, 1, 'There is one notification on panel');
+
+        assert.strictEqual(infos[0].common.commonText, 'The directory cannot be opened', 'Title is correct');
+
+        const details = infos[0].details;
+        assert.strictEqual(details.length, 1, 'Notification has one details section');
+
+        assert.strictEqual(details[0].commonText, '', 'Common text is correct');
+        assert.strictEqual(details[0].errorText, 'Custom text', 'Error text is correct');
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
@@ -11,6 +11,7 @@ import fx from 'animation/fx';
 import { FileManagerWrapper, FileManagerBreadcrumbsWrapper, FileManagerProgressPanelWrapper, createTestFileSystem } from '../../../helpers/fileManagerHelpers.js';
 import SlowFileProvider from '../../../helpers/fileManager/file_provider.slow.js';
 import { Deferred } from 'core/utils/deferred';
+import { extend } from 'core/utils/extend';
 
 const moduleConfig = {
 
@@ -50,6 +51,40 @@ const moduleConfig = {
         fx.off = false;
     }
 
+};
+
+const moduleConfig_T1085224 = {
+    beforeEach: function() {
+        this.clock = sinon.useFakeTimers();
+        fx.off = true;
+        this.$element = $('#fileManager');
+        this.wrapper = new FileManagerWrapper(this.$element);
+        this.progressPanelWrapper = new FileManagerProgressPanelWrapper(this.$element);
+        this.clock.tick(400);
+    },
+    afterEach: function() {
+        this.clock.tick(5000);
+        this.clock.restore();
+        fx.off = false;
+    }
+};
+
+const createFileManager_T1085224 = (context, useThumbnailViewMode, extOptions) => {
+    const provider = new CustomFileSystemProvider({
+        getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
+    });
+    const getItemsSpy = sinon.spy(provider, 'getItems');
+    const viewMode = useThumbnailViewMode ? 'thumbnails' : 'details';
+    extOptions = extOptions || {};
+    const options = extend({
+        fileSystemProvider: provider,
+        itemView: {
+            mode: viewMode
+        }
+    }, extOptions);
+    const fileManager = $('#fileManager').dxFileManager(options).dxFileManager('instance');
+    context.clock.tick(400);
+    return { fileManager, getItemsSpy };
 };
 
 const createBreadcrumbs = (context, controller) => {
@@ -1416,50 +1451,11 @@ QUnit.module('Navigation operations', moduleConfig, () => {
         assert.strictEqual(this.fileManager.getCurrentDirectory().key, '', 'Current directory is the target one');
         assert.strictEqual(this.wrapper.getFocusedItemText(), 'Files', 'NavPane current folder text is correct');
     });
+});
 
-    test('getItems must be invoked only once in case of exception (T1085224)', function(assert) {
-        const customProvider = new CustomFileSystemProvider({
-            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
-        });
-        const getItemsSpy = sinon.spy(customProvider, 'getItems');
-        this.fileManager.option({
-            fileSystemProvider: customProvider
-        });
-        this.clock.tick(800);
-
-        assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
-    });
-
-    test('only one notification must be shown in case of getItems exception (T1085224)', function(assert) {
-        const provider = new CustomFileSystemProvider({
-            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
-        });
-
-        this.fileManager.option('fileSystemProvider', provider);
-        this.clock.tick(400);
-
-        const infos = this.progressPanelWrapper.getInfos();
-        assert.strictEqual(infos.length, 1, 'There is one notification on panel');
-
-        assert.strictEqual(infos[0].common.commonText, 'The directory cannot be opened', 'Title is correct');
-
-        const details = infos[0].details;
-        assert.strictEqual(details.length, 1, 'Notification has one details section');
-
-        assert.strictEqual(details[0].commonText, '', 'Common text is correct');
-        assert.strictEqual(details[0].errorText, 'Custom text', 'Error text is correct');
-    });
-
-    test('getItems must be invoked only once in case of exception after refresh (T1085224)', function(assert) {
-        const customProvider = new CustomFileSystemProvider({
-            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
-        });
-        const getItemsSpy = sinon.spy(customProvider, 'getItems');
-        this.fileManager.option({
-            fileSystemProvider: customProvider
-        });
-        this.clock.tick(800);
-
+QUnit.module('initial navigation with error (T1085224)', moduleConfig_T1085224, () => {
+    test('getItems must be invoked only once in case of exception after refresh thumbanilsView (T1085224)', function(assert) {
+        const { getItemsSpy } = createFileManager_T1085224(this, true);
         getItemsSpy.reset();
         this.wrapper.getToolbarRefreshButton().trigger('dxclick');
         this.clock.tick(800);
@@ -1467,13 +1463,17 @@ QUnit.module('Navigation operations', moduleConfig, () => {
         assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
     });
 
-    test('only one notification must be shown in case of getItems exception after refresh (T1085224)', function(assert) {
-        const provider = new CustomFileSystemProvider({
-            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
-        });
+    test('getItems must be invoked only once in case of exception after refresh detailsView (T1085224)', function(assert) {
+        const { getItemsSpy } = createFileManager_T1085224(this);
+        getItemsSpy.reset();
+        this.wrapper.getToolbarRefreshButton().trigger('dxclick');
+        this.clock.tick(800);
 
-        this.fileManager.option('fileSystemProvider', provider);
-        this.clock.tick(400);
+        assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
+    });
+
+    test('only one notification must be shown in case of getItems exception after refresh thumbnailsView (T1085224)', function(assert) {
+        createFileManager_T1085224(this, true);
 
         this.progressPanelWrapper.getInfos()[0].common.$closeButton.trigger('dxclick');
         this.clock.tick(400);
@@ -1496,30 +1496,42 @@ QUnit.module('Navigation operations', moduleConfig, () => {
         assert.strictEqual(details[0].errorText, 'Custom text', 'Error text is correct');
     });
 
-    test('getItems must be invoked only once in case of exception detailsView (T1085224)', function(assert) {
-        const customProvider = new CustomFileSystemProvider({
-            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
-        });
-        const getItemsSpy = sinon.spy(customProvider, 'getItems');
-        this.fileManager.option({
-            itemView: { mode: 'details' },
-            fileSystemProvider: customProvider
-        });
-        this.clock.tick(800);
+    test('only one notification must be shown in case of getItems exception after refresh detailsView (T1085224)', function(assert) {
+        createFileManager_T1085224(this, true);
 
+        this.progressPanelWrapper.getInfos()[0].common.$closeButton.trigger('dxclick');
+        this.clock.tick(400);
+
+        let infos = this.progressPanelWrapper.getInfos();
+        assert.strictEqual(infos.length, 0, 'There are no notifications on panel');
+
+        this.wrapper.getToolbarRefreshButton().trigger('dxclick');
+        this.clock.tick(700);
+
+        infos = this.progressPanelWrapper.getInfos();
+        assert.strictEqual(infos.length, 1, 'There is one notification on panel');
+
+        assert.strictEqual(infos[0].common.commonText, 'The directory cannot be opened', 'Title is correct');
+
+        const details = infos[0].details;
+        assert.strictEqual(details.length, 1, 'Notification has one details section');
+
+        assert.strictEqual(details[0].commonText, '', 'Common text is correct');
+        assert.strictEqual(details[0].errorText, 'Custom text', 'Error text is correct');
+    });
+
+    test('getItems must be invoked only once in case of exception thumbnailsView (T1085224)', function(assert) {
+        const { getItemsSpy } = createFileManager_T1085224(this, true);
         assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
     });
 
-    test('only one notification must be shown in case of getItems exception detailsView (T1085224)', function(assert) {
-        const provider = new CustomFileSystemProvider({
-            getItems: () => { throw new FileSystemError(42, null, 'Custom text'); }
-        });
+    test('getItems must be invoked only once in case of exception detailsView (T1085224)', function(assert) {
+        const { getItemsSpy } = createFileManager_T1085224(this);
+        assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
+    });
 
-        this.fileManager.option({
-            itemView: { mode: 'details' },
-            fileSystemProvider: provider
-        });
-        this.clock.tick(800);
+    test('only one notification must be shown in case of getItems exception thumbnailsView (T1085224)', function(assert) {
+        createFileManager_T1085224(this, true);
 
         const infos = this.progressPanelWrapper.getInfos();
         assert.strictEqual(infos.length, 1, 'There is one notification on panel');
@@ -1531,5 +1543,30 @@ QUnit.module('Navigation operations', moduleConfig, () => {
 
         assert.strictEqual(details[0].commonText, '', 'Common text is correct');
         assert.strictEqual(details[0].errorText, 'Custom text', 'Error text is correct');
+    });
+
+    test('only one notification must be shown in case of getItems exception detailsView (T1085224)', function(assert) {
+        createFileManager_T1085224(this);
+
+        const infos = this.progressPanelWrapper.getInfos();
+        assert.strictEqual(infos.length, 1, 'There is one notification on panel');
+
+        assert.strictEqual(infos[0].common.commonText, 'The directory cannot be opened', 'Title is correct');
+
+        const details = infos[0].details;
+        assert.strictEqual(details.length, 1, 'Notification has one details section');
+
+        assert.strictEqual(details[0].commonText, '', 'Common text is correct');
+        assert.strictEqual(details[0].errorText, 'Custom text', 'Error text is correct');
+    });
+
+    test('getItems must be invoked only once in case of exception thumbnailsView (provider+path) (T1085224)', function(assert) {
+        const { getItemsSpy } = createFileManager_T1085224(this, true, { currentPath: 'somePath' });
+        assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
+    });
+
+    test('getItems must be invoked only once in case of exception detailsView (provider+path) (T1085224)', function(assert) {
+        const { getItemsSpy } = createFileManager_T1085224(this, false, { currentPath: 'somePath' });
+        assert.strictEqual(getItemsSpy.callCount, 1, 'getItems function must be called once');
     });
 });


### PR DESCRIPTION
…n (T1085224)

# Conflicts:
#	js/ui/file_manager/file_items_controller.js

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
