### PR TITLE
DataGrid - Selection of a row stored in local storage is missing when using stateStoring and the scrolling mode is set to 'virtual' (T1092443)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.selection.js
+++ b/js/ui/grid_core/ui.grid_core.selection.js
@@ -253,6 +253,7 @@ const SelectionController = gridCore.Controller.inherit((function() {
             const selectionFilter = that._selection.selectionFilter();
             const dataController = that._dataController;
             const items = dataController.items(true);
+            const visibleItems = dataController.items();
 
             if(!items) {
                 return;
@@ -260,6 +261,7 @@ const SelectionController = gridCore.Controller.inherit((function() {
 
             const isSelectionWithCheckboxes = that.isSelectionWithCheckboxes();
             const changedItemIndexes = that.getChangedItemIndexes(items);
+            const visibleChangedItemIndexes = that.getChangedItemIndexes(visibleItems);
 
             that._updateCheckboxesState({
                 selectedItemKeys: args.selectedItemKeys,
@@ -271,7 +273,7 @@ const SelectionController = gridCore.Controller.inherit((function() {
             if(changedItemIndexes.length || (isSelectionWithCheckboxes !== that.isSelectionWithCheckboxes())) {
                 dataController.updateItems({
                     changeType: 'updateSelection',
-                    itemIndexes: changedItemIndexes
+                    itemIndexes: visibleChangedItemIndexes
                 });
             }
 

--- a/js/ui/grid_core/ui.grid_core.selection.js
+++ b/js/ui/grid_core/ui.grid_core.selection.js
@@ -252,7 +252,7 @@ const SelectionController = gridCore.Controller.inherit((function() {
             const isDeferredMode = that.option('selection.deferred');
             const selectionFilter = that._selection.selectionFilter();
             const dataController = that._dataController;
-            const items = dataController.items();
+            const items = dataController.items(true);
 
             if(!items) {
                 return;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -141,9 +141,12 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         this.clock.tick();
+        const scrollable = dataGrid.getScrollable();
 
         // act
         dataGrid.navigateToRow(100);
+        this.clock.tick();
+        $(scrollable.container()).trigger('scroll');
         this.clock.tick();
 
         // assert

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -115,6 +115,43 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         assert.ok(getHeight(dataGrid.$element().find('.dx-virtual-row').first().children().first()) <= scrollTop, 'scrollTop should be less than or equal to virtual row height');
     });
 
+    // T1092443
+    QUnit.test('Virtual scrolling should work with stateStoring and selection', function(assert) {
+        // arrange
+        const dataSource = [...Array(100).keys()].map(i => ({ id: i + 1 }));
+
+        const dataGrid = createDataGrid({
+            height: 440,
+            stateStoring: {
+                enabled: true,
+                type: 'custom',
+                customLoad: function() {
+                    return {
+                        selectedRowKeys: [100],
+                        pageIndex: 4,
+                    };
+                },
+                customSave: function() {}
+            },
+            keyExpr: 'id',
+            scrolling: {
+                mode: 'virtual',
+            },
+            dataSource,
+        });
+
+        this.clock.tick();
+
+        // act
+        dataGrid.navigateToRow(100);
+        this.clock.tick();
+
+        // assert
+        assert.deepEqual(dataGrid.getSelectedRowKeys(), [100], 'selectedRowKeys is actual');
+        assert.deepEqual(dataGrid.getVisibleRows().slice(-1)[0].isSelected, true, 'last row is selected');
+        assert.ok(dataGrid.getVisibleRows().slice(0, -1).every(row => row.isSelected === false), 'other rows are not selected');
+    });
+
     // T916093
     ['standard', 'virtual', 'infinite'].forEach(scrollingMode => {
         QUnit.test(`LoadPanel should be shown during export (scrolling.mode = ${scrollingMode})`, function(assert) {


### PR DESCRIPTION
When row's `isSelected` is changed and row is not rendered (i.e. it is in `dataController.items(true)`, but not in `dataController.items()`), state of the row is not updated