### PR TITLE
DataGrid - The component returns undefined data when the Shift key is used for multiple selection in a certain scenario (T1092804)

### DIFF
--- a/js/ui/selection/selection.js
+++ b/js/ui/selection/selection.js
@@ -118,12 +118,14 @@ export default Class.inherit({
         let focusedItemNotInLoadedRange = false;
         let shiftFocusedItemNotInLoadedRange = false;
 
+        const itemIsNotInLoadedRange = (index) => index >= 0 && !items.filter(it => it.loadIndex === index).length;
+
         if(allowLoadByRange) {
             indexOffset = item.loadIndex - itemIndex;
             itemIndex = item.loadIndex;
-            focusedItemNotInLoadedRange = this._focusedItemIndex >= 0 && !items.filter(it => it.loadIndex === this._focusedItemIndex).length;
+            focusedItemNotInLoadedRange = itemIsNotInLoadedRange(this._focusedItemIndex);
             if(isDefined(this._shiftFocusedItemIndex)) {
-                shiftFocusedItemNotInLoadedRange = this._shiftFocusedItemIndex >= 0 && !items.filter(it => it.loadIndex === this._shiftFocusedItemIndex).length;
+                shiftFocusedItemNotInLoadedRange = itemIsNotInLoadedRange(this._shiftFocusedItemIndex);
             }
         }
 

--- a/js/ui/selection/selection.js
+++ b/js/ui/selection/selection.js
@@ -116,11 +116,15 @@ export default Class.inherit({
         const allowLoadByRange = this.options.allowLoadByRange?.();
         let indexOffset;
         let focusedItemNotInLoadedRange = false;
+        let shiftFocusedItemNotInLoadedRange = false;
 
         if(allowLoadByRange) {
             indexOffset = item.loadIndex - itemIndex;
             itemIndex = item.loadIndex;
             focusedItemNotInLoadedRange = this._focusedItemIndex >= 0 && !items.filter(it => it.loadIndex === this._focusedItemIndex).length;
+            if(isDefined(this._shiftFocusedItemIndex)) {
+                shiftFocusedItemNotInLoadedRange = this._shiftFocusedItemIndex >= 0 && !items.filter(it => it.loadIndex === this._shiftFocusedItemIndex).length;
+            }
         }
 
         if(!this.isSelectable() || !this.isDataItem(item)) {
@@ -133,7 +137,7 @@ export default Class.inherit({
         keys = keys || {};
 
         if(keys.shift && this.options.mode === 'multiple' && this._focusedItemIndex >= 0) {
-            if(focusedItemNotInLoadedRange) {
+            if(focusedItemNotInLoadedRange || shiftFocusedItemNotInLoadedRange) {
                 isSelectedItemsChanged = itemIndex !== this._shiftFocusedItemIndex || this._focusedItemIndex !== this._shiftFocusedItemIndex;
 
                 if(isSelectedItemsChanged) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -5491,6 +5491,54 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             // assert
             assert.deepEqual(dataGrid.getSelectedRowKeys(), [50, 55, 54, 53, 52, 51], 'selected keys with Shift');
         });
+
+        // T1092804
+        QUnit.test(`${scrollingMode} - Rows should be selected correctly with Shift on different pages`, function(assert) {
+            // arrange
+            const dataGrid = createDataGrid({
+                dataSource: Array(100).fill().map((x, i) => ({ id: i })),
+                keyExpr: 'id',
+                showBorders: true,
+                height: 500,
+                scrolling: {
+                    mode: scrollingMode.toLowerCase(),
+                    useNative: false
+                },
+                selection: {
+                    mode: 'multiple',
+                    showCheckBoxesMode: 'always'
+                }
+            });
+
+            this.clock.tick(300);
+
+            // act
+            $(dataGrid.element()).find('.dx-datagrid-rowsview .dx-checkbox:eq(1)').trigger('dxclick');
+            this.clock.tick(300);
+
+            dataGrid.getScrollable().scrollTo({ top: 1600 });
+            if(scrollingMode === 'Infinite') {
+                dataGrid.getScrollable().scrollTo({ top: 1600 });
+                this.clock.tick(300);
+                dataGrid.getScrollable().scrollTo({ top: 1600 });
+                this.clock.tick(300);
+            }
+            this.clock.tick(300);
+
+            const pointer1 = pointerMock($(dataGrid.element()).find('.dx-datagrid-rowsview .dx-checkbox:eq(2)'));
+            pointer1.start({ shiftKey: true }).down().up();
+            this.clock.tick(100);
+
+            const pointer2 = pointerMock($(dataGrid.element()).find('.dx-datagrid-rowsview .dx-checkbox:eq(3)'));
+            pointer2.start({ shiftKey: true }).down().up();
+
+            this.clock.tick(100);
+
+            // assert
+            const keys = dataGrid.getSelectedRowKeys();
+            assert.strictEqual(keys.length, 50, 'selected rows count');
+            assert.deepEqual(keys.sort((a, b) => a - b), Array(50).fill().map((x, i) => i + 1), 'selected rows keys');
+        });
     });
 
     QUnit.test('No redundant load calls with filter (T1063237)', function(assert) {


### PR DESCRIPTION
After selecting with shift pressed, in case current selected row is not in loaded range, the `changeItemSelectionWhenShiftKeyInVirtualPaging` method is called to load items. But it isn't called in case previous clicked row is not in loaded range, so I added it to the condition