### PR TITLE
DataGrid: Fix applying the 'editing.changes' option for editable row in popup and form editing modes (T1089969)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_controller.js
+++ b/js/ui/grid_core/ui.grid_core.data_controller.js
@@ -701,6 +701,7 @@ export const dataControllerModule = {
                     const changeTypes = [];
                     const items = [];
                     const newIndexByKey = {};
+                    const isLiveUpdate = change?.isLiveUpdate ?? true;
 
                     function getRowKey(row) {
                         if(row) {
@@ -747,7 +748,7 @@ export const dataControllerModule = {
                                 const index = change.index;
                                 const newItem = change.data;
                                 const oldItem = change.oldItem;
-                                const changedColumnIndices = this._partialUpdateRow(oldItem, newItem, index, true);
+                                const changedColumnIndices = this._partialUpdateRow(oldItem, newItem, index, isLiveUpdate);
 
                                 rowIndices.push(index);
                                 changeTypes.push('update');

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -486,7 +486,8 @@ const EditingController = modules.ViewController.inherit((function() {
             this._processInsertChanges(args.value);
 
             dataController.updateItems({
-                repaintChangesOnly: true
+                repaintChangesOnly: true,
+                isLiveUpdate: false
             });
         },
 

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -9,6 +9,7 @@ import Button from '../button';
 import devices from '../../core/devices';
 import Form from '../form';
 import { Deferred } from '../../core/utils/deferred';
+import { equalByValue } from '../../core/utils/common';
 import Scrollable from '../scroll_view/ui.scrollable';
 import Popup from '../popup';
 import {
@@ -95,10 +96,13 @@ export const editingFormBasedModule = {
                 },
 
                 _handleDataChanged: function(args) {
-                    const editForm = this._editForm;
+                    if(this.isPopupEditMode()) {
+                        const editRowKey = this.option('editing.editRowKey');
+                        const hasEditRow = args?.items?.some((item) => equalByValue(item.key, editRowKey));
 
-                    if(args.changeType === 'refresh' && this.isPopupEditMode() && editForm?.option('visible')) {
-                        this._repaintEditPopup();
+                        if(args.changeType === 'refresh' || hasEditRow) {
+                            this._repaintEditPopup();
+                        }
                     }
 
                     this.callBase.apply(this, arguments);
@@ -449,6 +453,14 @@ export const editingFormBasedModule = {
                     if(this._editingController.isFormEditMode()) {
                         item.rowType = 'detail';
                     }
+                },
+
+                _getChangedColumnIndices: function(oldItem, newItem, visibleRowIndex, isLiveUpdate) {
+                    if(isLiveUpdate === false && newItem.isEditing && this._editingController.isFormEditMode()) {
+                        return;
+                    }
+
+                    return this.callBase.apply(this, arguments);
                 }
             }
         },


### PR DESCRIPTION
See https://devexpress.com/issue=T1089969