### PR TITLE
DataGrid: Fix applying the 'editing.changes' option for editable row in popup and form editing modes (T1089969)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_controller.js
+++ b/js/ui/grid_core/ui.grid_core.data_controller.js
@@ -745,6 +745,7 @@ export const dataControllerModule = {
                     const changeTypes = [];
                     const items = [];
                     const newIndexByKey = {};
+                    const isLiveUpdate = change?.isLiveUpdate ?? true;
 
                     function getRowKey(row) {
                         if(row) {
@@ -791,7 +792,7 @@ export const dataControllerModule = {
                                 const index = change.index;
                                 const newItem = change.data;
                                 const oldItem = change.oldItem;
-                                const changedColumnIndices = this._partialUpdateRow(oldItem, newItem, index, true);
+                                const changedColumnIndices = this._partialUpdateRow(oldItem, newItem, index, isLiveUpdate);
 
                                 rowIndices.push(index);
                                 changeTypes.push('update');

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -520,7 +520,8 @@ const EditingController = modules.ViewController.inherit((function() {
             this._processInsertChanges(args.value);
 
             dataController.updateItems({
-                repaintChangesOnly: true
+                repaintChangesOnly: true,
+                isLiveUpdate: false
             });
         },
 

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -9,6 +9,7 @@ import Button from '../button';
 import devices from '../../core/devices';
 import Form from '../form';
 import { Deferred } from '../../core/utils/deferred';
+import { equalByValue } from '../../core/utils/common';
 import Scrollable from '../scroll_view/ui.scrollable';
 import Popup from '../popup';
 import {
@@ -95,10 +96,13 @@ export const editingFormBasedModule = {
                 },
 
                 _handleDataChanged: function(args) {
-                    const editForm = this._editForm;
+                    if(this.isPopupEditMode()) {
+                        const editRowKey = this.option('editing.editRowKey');
+                        const hasEditRow = args?.items?.some((item) => equalByValue(item.key, editRowKey));
 
-                    if(args.changeType === 'refresh' && this.isPopupEditMode() && editForm?.option('visible')) {
-                        this._repaintEditPopup();
+                        if(args.changeType === 'refresh' || hasEditRow) {
+                            this._repaintEditPopup();
+                        }
                     }
 
                     this.callBase.apply(this, arguments);
@@ -468,6 +472,14 @@ export const editingFormBasedModule = {
                     if(this._editingController.isFormEditMode()) {
                         item.rowType = 'detail';
                     }
+                },
+
+                _getChangedColumnIndices: function(oldItem, newItem, visibleRowIndex, isLiveUpdate) {
+                    if(isLiveUpdate === false && newItem.isEditing && this._editingController.isFormEditMode()) {
+                        return;
+                    }
+
+                    return this.callBase.apply(this, arguments);
                 }
             }
         },

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -6608,6 +6608,49 @@ QUnit.module('Editing state', baseModuleConfig, () => {
     });
 
     ['Row', 'Form', 'Popup', 'Cell', 'Batch'].forEach(editMode => {
+        // T1089969
+        QUnit.test(`${editMode} - Changing editing.changes option should update the values of the edited cells`, function(assert) {
+            // arrange
+            const dataGrid = $('#dataGrid').dxDataGrid({
+                dataSource: [{ id: 1, field: 'field' }],
+                keyExpr: 'id',
+                columns: ['field'],
+                editing: {
+                    allowUpdating: true,
+                    mode: editMode.toLowerCase()
+                },
+                loadingTimeout: null,
+            }).dxDataGrid('instance');
+
+            // act
+            if(editMode === 'Batch' || editMode === 'Cell') {
+                dataGrid.editCell(0, 0);
+            } else {
+                dataGrid.editRow(0);
+            }
+            this.clock.tick();
+
+            // assert
+            switch(editMode) {
+                case 'Batch':
+                case 'Cell':
+                    assert.ok($(dataGrid.getRowElement(0)).children().first().hasClass('dx-editor-cell'), 'cell is editing');
+                    break;
+                case 'Popup':
+                    assert.ok($('.dx-datagrid-edit-popup').is(':visible'), 'edit popup is visible');
+                    break;
+                default:
+                    assert.ok($(dataGrid.getRowElement(0)).hasClass('dx-edit-row'), 'row is editing');
+            }
+
+            // act
+            dataGrid.option('editing.changes', [{ type: 'update', key: 1, data: { field: 'test' } }]);
+
+            // assert
+            const cellValue = $(dataGrid.getCellElement(0, 0)).find('.dx-texteditor-input').val();
+            assert.strictEqual(cellValue, 'test', 'cell value');
+        });
+
         ['changes', 'editRowKey', 'editColumnName'].forEach(editingOption => {
             QUnit.test(`${editMode} - Changing the editing.${editingOption} option should not raise the onToolbarPreparing event (T949025)`, function(assert) {
                 // arrange


### PR DESCRIPTION
See https://devexpress.com/issue=T1089969