### PR TITLE
DataGrid - TypeError when DataGrid's data source is empty and focusedRowEnabled is set to true (T1090672)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -2034,7 +2034,9 @@ export const columnsControllerModule = {
                                 that._columns.push(group.selector);
                             });
                             each(sortParameters, function(index, sort) {
-                                that._columns.push(sort.selector);
+                                if(!isFunction(sort.selector)) {
+                                    that._columns.push(sort.selector);
+                                }
                             });
                             assignColumns(that, createColumnsFromOptions(that, that._columns));
                         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -1540,6 +1540,21 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.strictEqual(dataGrid.getVisibleRows().length, 0, 'no rows');
     });
 
+    // T1090672
+    QUnit.test('Initialization with empty dataSource without columns with focusedRowEnabled should not cause exception', function(assert) {
+        // arrange
+        createDataGrid({
+            keyExpr: 'id',
+            dataSource: [],
+            focusedRowEnabled: true,
+        });
+
+        this.clock.tick(100);
+
+        // assert
+        assert.ok(true, 'no errors');
+    });
+
 });
 QUnit.module('Virtual row rendering', baseModuleConfig, () => {
     // T809900


### PR DESCRIPTION
After setting 'focusedRowEnabled', dataGrid adds sorting by indices, setting `.selector` as function. In case there are no columns, dataGrid adds this selector as column and tries to set name to it, but failed, cause `Function.name` is readonly

I added checking that selector is not function