### PR TITLE
Lock version for 'cheerio' package to '1.0.0-rc.10'

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,10 +24,6 @@
     },
     "packageRules": [
         {
-            "matchPackagePatterns": [ "enzyme" ],
-            "enabled": false
-        },
-        {
             "matchPackagePatterns": [ "*" ],
             "matchUpdateTypes": [ "minor", "patch" ],
             "automerge": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "babel-plugin-transform-object-assign": "^6.22.0",
         "babel-preset-env": "^1.6.1",
         "bootstrap": "^4.3.1",
+        "cheerio": "1.0.0-rc.10",
         "cldr-core": "latest",
         "cldr-numbers-full": "latest",
         "cldrjs": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "bootstrap": "^4.3.1",
+    "cheerio": "1.0.0-rc.10",
     "cldr-core": "latest",
     "cldr-numbers-full": "latest",
     "cldrjs": "^0.5.0",


### PR DESCRIPTION
The package 'cheerio@1.0.0-rc.10' has been updated to 'cheerio@1.0.0-rc.11' and started pulling a new 'htmlparser2@8.0.1' which uses 'typescript@^4.6' in types, and we can't do that

The problem occurs at the stage of lint renovation
https://github.com/DevExpress/DevExtreme/runs/6831029796?check_suite_focus=true