### PR TITLE
export: fix tests after Firefox update

### DIFF
--- a/testing/tests/DevExpress.exporter/excelCreator.tests.js
+++ b/testing/tests/DevExpress.exporter/excelCreator.tests.js
@@ -1,9 +1,11 @@
-const $ = require('jquery');
-const excelCreator = require('exporter').excel;
-const coreLocalization = require('localization/core');
+import $ from 'jquery';
+import { excel as excelCreator } from 'exporter';
+import coreLocalization from 'localization/core';
+import exportMocks from '../../helpers/exportMocks.js';
+import browser from 'core/utils/browser';
+
 const ExcelCreator = excelCreator.creator;
 const internals = excelCreator.__internals;
-const exportMocks = require('../../helpers/exportMocks.js');
 
 QUnit.module('Excel creator', {
     beforeEach: function() {
@@ -23,7 +25,7 @@ QUnit.test('Date time format converting', function(assert) {
         shortDate: '[$-9]M\\/d\\/yyyy',
         shortTime: '[$-9]H:mm AM/PM',
         shortDateShortTime: '[$-9]M\\/d\\/yyyy, H:mm AM/PM',
-        longDateLongTime: '[$-9]dddd, MMMM d, yyyy, H:mm:ss AM/PM',
+        longDateLongTime: `[$-9]dddd, MMMM d, yyyy${browser.mozilla ? ' \\a\\t' : ','} H:mm:ss AM/PM`,
         dayOfWeek: '[$-9]dddd',
         hour: '[$-9]HH',
         minute: '[$-9]H:mm:ss AM/PM',

--- a/testing/tests/DevExpress.exporter/jspdfParts/jspdf.dataGrid.tests.js
+++ b/testing/tests/DevExpress.exporter/jspdfParts/jspdf.dataGrid.tests.js
@@ -10,7 +10,6 @@ import { exportDataGrid } from 'pdf_exporter';
 import { initializeDxObjectAssign, clearDxObjectAssign } from '../commonParts/objectAssignHelper.js';
 
 import 'ui/data_grid';
-
 import 'generic_light.css!';
 
 QUnit.testStart(() => {
@@ -935,7 +934,7 @@ QUnit.module('Column data formats', moduleConfig, () => {
         { format: 'quarterAndYear', expectedPdfCellValue: 'Q4 2019' },
         { format: 'shortDate', expectedPdfCellValue: '10/9/2019' },
         { format: 'shortTime', expectedPdfCellValue: '9:09 AM' },
-        { format: 'longDateLongTime', expectedPdfCellValue: 'Wednesday, October 9, 2019, 9:09:09 AM' },
+        { format: 'longDateLongTime', expectedPdfCellValue: `Wednesday, October 9, 2019${browser.mozilla ? ' at' : ','} 9:09:09 AM` },
         { format: 'shortDateShortTime', expectedPdfCellValue: '10/9/2019, 9:09 AM' },
         { format: 'longDate', expectedPdfCellValue: 'Wednesday, October 9, 2019' },
         { format: 'longTime', expectedPdfCellValue: '9:09:09 AM' },

--- a/testing/tests/DevExpress.exporter/jspdfParts/jspdf.dataGrid.tests.js
+++ b/testing/tests/DevExpress.exporter/jspdfParts/jspdf.dataGrid.tests.js
@@ -8,6 +8,7 @@ import { LoadPanelTests } from '../commonParts/loadPanel.tests.js';
 import { JSPdfOptionTests } from './jspdf.options.tests.js';
 import { exportDataGrid } from 'pdf_exporter';
 import { initializeDxObjectAssign, clearDxObjectAssign } from '../commonParts/objectAssignHelper.js';
+import browser from 'core/utils/browser';
 
 import 'ui/data_grid';
 import 'generic_light.css!';


### PR DESCRIPTION
Firefox browser updated to v101.0.1, after that the funtion
`new Intl.DateTimeFormat('en-US', { timeZone: "UTC", weekday: "long", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "numeric", second: "numeric" }).format(date));`
returns the following result
`"Sunday, December 20, 2020 at 7:23:16 AM"`
In v100 it returns `"Sunday, December 20, 2020, 7:23:16 AM"`

In Chrome the same function call returns 
`"Sunday, December 20, 2020, 7:23:16 AM"`

A new format in Firefox corresponding also with
`new Intl.DateTimeFormat('en-US', { dateStyle: 'full', timeStyle: 'medium' }).format(date);`
it consistently works in Chrome and Firefox

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat