### PR TITLE
Scheduler: fix incorrect behavior of dragging appointments between two schedulers with async DataSource (T1094033). Cherry-pick to 21_2

### DIFF
--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -2386,6 +2386,10 @@ class Scheduler extends Widget {
         validateDayHours(startDayHour, endDayHour);
     }
 
+    _getDragBehavior() {
+        return this._workSpace.dragBehavior;
+    }
+
     /**
         * @name dxScheduler.registerKeyHandler
         * @publicName registerKeyHandler(key, handler)

--- a/js/ui/scheduler/utils/isSchedulerComponent.js
+++ b/js/ui/scheduler/utils/isSchedulerComponent.js
@@ -1,0 +1,5 @@
+const schedulerComponentName = 'dxScheduler';
+
+export function isSchedulerComponent(component) {
+    return component.NAME === schedulerComponentName;
+}

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
@@ -984,7 +984,17 @@ class SchedulerWorkSpace extends WidgetObserver {
 
         eventsEngine.on(element, DragEventNames.ENTER, DRAG_AND_DROP_SELECTOR, { checkDropTarget: onCheckDropTarget }, onDragEnter);
         eventsEngine.on(element, DragEventNames.LEAVE, removeClasses);
-        eventsEngine.on(element, DragEventNames.DROP, DRAG_AND_DROP_SELECTOR, removeClasses);
+        eventsEngine.on(element, DragEventNames.DROP, DRAG_AND_DROP_SELECTOR, () => {
+            if(!this.dragBehavior?.dragBetweenComponentsPromise) {
+                this.dragBehavior.removeDroppableClasses();
+                return;
+            }
+
+            this.dragBehavior.dragBetweenComponentsPromise?.then(() => {
+                this.dragBehavior.removeDroppableClasses();
+            });
+        });
+
     }
 
     _attachPointerEvents(element) {

--- a/testing/testcafe/model/scheduler/appointment/index.ts
+++ b/testing/testcafe/model/scheduler/appointment/index.ts
@@ -16,6 +16,7 @@ const CLASS = {
     body: 'dx-scheduler-appointment-body',
     tail: 'dx-scheduler-appointment-tail',
   },
+  draggableSource: 'dx-draggable-source',
 };
 
 export default class Appointment {
@@ -38,6 +39,8 @@ export default class Appointment {
   isReducedBody: Promise<boolean>;
 
   isReducedTail: Promise<boolean>;
+
+  isDraggableSource: Promise<boolean>;
 
   constructor(scheduler: Selector, index = 0, title?: string) {
     const element = scheduler.find(`.${CLASS.appointment}`);
@@ -68,6 +71,7 @@ export default class Appointment {
     this.isReducedHead = this.element.hasClass(CLASS.reduced.head);
     this.isReducedBody = this.element.hasClass(CLASS.reduced.body);
     this.isReducedTail = this.element.hasClass(CLASS.reduced.tail);
+    this.isDraggableSource = this.element.hasClass(CLASS.draggableSource);
   }
 
   getColor(): Promise<string> {

--- a/testing/testcafe/model/scheduler/index.ts
+++ b/testing/testcafe/model/scheduler/index.ts
@@ -15,6 +15,7 @@ export const CLASS = {
   allDayTableCell: 'dx-scheduler-all-day-table-cell',
   focusedCell: 'dx-scheduler-focused-cell',
   selectedCell: 'dx-state-focused',
+  droppableCell: 'dx-scheduler-date-table-droppable-cell',
   dateTableRow: 'dx-scheduler-date-table-row',
   dateTableScrollable: 'dx-scheduler-date-table-scrollable',
   headerPanelCell: 'dx-scheduler-header-panel-cell',
@@ -119,6 +120,12 @@ export default class Scheduler extends Widget {
     const cells = isAllDay ? this.allDayTableCells : this.dateTableCells;
 
     return cells.filter(`.${CLASS.selectedCell}`);
+  }
+
+  getDroppableCell(isAllDay = false): Selector {
+    const cells = isAllDay ? this.allDayTableCells : this.dateTableCells;
+
+    return cells.filter(`.${CLASS.droppableCell}`);
   }
 
   getAppointment(title: string, index = 0): Appointment {

--- a/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/dragAppointmentWithDataSource.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/dragAppointmentWithDataSource.ts
@@ -1,0 +1,121 @@
+import { ClientFunction } from 'testcafe';
+import url from '../../../../helpers/getPageUrl';
+import Scheduler from '../../../../model/scheduler';
+import createWidget from '../../../../helpers/createWidget';
+
+interface TestAppointment {
+  id: number;
+  text: string;
+  startDate: Date;
+  endDate: Date;
+}
+
+const FIRST_SCHEDULER_SELECTOR = '#scheduler-first';
+const SECOND_SCHEDULER_SELECTOR = '#scheduler-second';
+const EXPECTED_APPOINTMENT_TIME = '12:00 AM - 1:00 AM';
+
+const TEST_APPOINTMENT = {
+  id: 10,
+  text: 'My appointment',
+  startDate: new Date(2021, 3, 28, 1),
+  endDate: new Date(2021, 3, 28, 2),
+};
+
+const getBaseSchedulerOptions = (currentDate) => ({
+  currentDate,
+  currentView: 'workWeek',
+  width: 600,
+  appointmentDragging: {
+    group: 'testDragGroup',
+    onRemove(e) {
+      e.component.deleteAppointment(e.itemData);
+    },
+    onAdd(e) {
+      e.component.addAppointment(e.itemData);
+    },
+  },
+});
+
+const createSchedulerWithRemoteDataSource = async (
+  options: any,
+  selector: string,
+  appointments: TestAppointment[],
+): Promise<void> => {
+  await ClientFunction(() => {
+    class DataSourceMock {
+      key = 'id';
+
+      private data: TestAppointment[];
+
+      constructor(initialData: TestAppointment[] = []) {
+        this.data = initialData;
+      }
+
+      load = () => Promise.resolve(this.data);
+
+      insert = (value) => {
+        this.data = [...this.data, value];
+        return Promise.resolve();
+      };
+
+      update = (key, value) => {
+        this.data = this.data.map((item) => {
+          if (item.id === key) {
+            return value;
+          }
+          return item;
+        });
+        return Promise.resolve();
+      };
+
+      remove = (id) => {
+        this.data = this.data.filter((item) => item.id !== id);
+        return Promise.resolve();
+      };
+    }
+
+    ($(selector) as any).dxScheduler({
+      ...options,
+      dataSource: new DataSourceMock(appointments),
+    });
+  }, { dependencies: { selector, options, appointments } })();
+};
+
+fixture`Drag-n-drop appointments between two schedulers with async DataSource (T1094033)`
+  .page(url(__dirname, '../pages/containerForTwoSchedulers.html'));
+
+test('Should set correct start and end dates in drag&dropped appointment', async (t) => {
+  const firstScheduler = new Scheduler(FIRST_SCHEDULER_SELECTOR);
+  const secondScheduler = new Scheduler(SECOND_SCHEDULER_SELECTOR);
+
+  const appointmentToMoveElement = firstScheduler
+    .getAppointment(TEST_APPOINTMENT.text)
+    .element();
+  const cellToMoveElement = secondScheduler
+    .getDateTableCell(0, 0);
+
+  await t.dragToElement(appointmentToMoveElement, cellToMoveElement, { speed: 0.1 });
+
+  const movedAppointmentTime = await secondScheduler
+    .getAppointment(TEST_APPOINTMENT.text)
+    .date
+    .time;
+
+  await t.expect(movedAppointmentTime).eql(EXPECTED_APPOINTMENT_TIME);
+}).before(async () => {
+  await createSchedulerWithRemoteDataSource(
+    getBaseSchedulerOptions(new Date(2021, 3, 26)),
+    FIRST_SCHEDULER_SELECTOR,
+    [TEST_APPOINTMENT],
+  );
+
+  await createWidget(
+    'dxScheduler',
+    {
+      ...getBaseSchedulerOptions(new Date(2021, 4, 26)),
+      dataSource: [],
+    },
+    false,
+    SECOND_SCHEDULER_SELECTOR,
+  );
+});

--- a/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/removeDroppableCellClass.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/removeDroppableCellClass.ts
@@ -1,0 +1,77 @@
+import url from '../../../../helpers/getPageUrl';
+import Scheduler from '../../../../model/scheduler';
+import createWidget from '../../../../helpers/createWidget';
+
+const FIRST_SCHEDULER_SELECTOR = '#scheduler-first';
+const SECOND_SCHEDULER_SELECTOR = '#scheduler-second';
+const METHODS_TO_CANCEL = [
+  'onDragStart',
+  'onDragMove',
+  'onDragEnd',
+  'onRemove',
+  'onAdd',
+];
+
+const TEST_APPOINTMENT = {
+  id: 10,
+  text: 'My appointment',
+  startDate: new Date(2021, 3, 28, 1),
+  endDate: new Date(2021, 3, 28, 2),
+};
+
+const getSchedulerOptions = (dataSource, currentDate, cancelMethodName) => ({
+  dataSource,
+  currentDate,
+  currentView: 'workWeek',
+  width: 600,
+  appointmentDragging: {
+    group: 'testDragGroup',
+    onRemove(e) {
+      e.component.deleteAppointment(e.itemData);
+    },
+    onAdd(e) {
+      e.component.addAppointment(e.itemData);
+    },
+    [cancelMethodName]: (e) => {
+      e.cancel = true;
+    },
+  },
+});
+
+fixture`Cancel drag-n-drop when dragging an appointment from one scheduler to another`
+  .page(url(__dirname, '../pages/containerForTwoSchedulers.html'));
+
+METHODS_TO_CANCEL.forEach((methodName) => {
+  test(`Should remove drag-n-drop classes if event was canceled in method ${methodName}`, async (t) => {
+    const firstScheduler = new Scheduler(FIRST_SCHEDULER_SELECTOR);
+    const secondScheduler = new Scheduler(SECOND_SCHEDULER_SELECTOR);
+
+    const appointmentToMoveElement = firstScheduler
+      .getAppointment(TEST_APPOINTMENT.text)
+      .element();
+    const cellToMoveElement = secondScheduler
+      .getDateTableCell(0, 0);
+
+    await t.dragToElement(appointmentToMoveElement, cellToMoveElement, { speed: 0.1 });
+
+    const droppableCellExistsInFirstScheduler = await firstScheduler.getDroppableCell().exists;
+    const droppableCellExistsInSecondScheduler = await secondScheduler.getDroppableCell().exists;
+
+    await t.expect(droppableCellExistsInFirstScheduler).notOk('Droppable cell class was not removed from the first scheduler.');
+    await t.expect(droppableCellExistsInSecondScheduler).notOk('Droppable cell class was not removed from the second scheduler.');
+  }).before(async () => {
+    await createWidget(
+      'dxScheduler',
+      getSchedulerOptions([TEST_APPOINTMENT], new Date(2021, 3, 26), methodName),
+      false,
+      FIRST_SCHEDULER_SELECTOR,
+    );
+
+    await createWidget(
+      'dxScheduler',
+      getSchedulerOptions([], new Date(2021, 4, 26), methodName),
+      false,
+      SECOND_SCHEDULER_SELECTOR,
+    );
+  });
+});

--- a/testing/testcafe/tests/scheduler/dragAndDrop/insideScheduler/removeDroppableCellClass.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/insideScheduler/removeDroppableCellClass.ts
@@ -1,0 +1,60 @@
+import url from '../../../../helpers/getPageUrl';
+import createWidget from '../../../../helpers/createWidget';
+import Scheduler from '../../../../model/scheduler';
+
+fixture`Cancel drag-n-drop when dragging an appointment inside the scheduler`
+  .page(url(__dirname, '../../../container.html'));
+
+const METHODS_TO_CANCEL = [
+  'onDragStart',
+  'onDragMove',
+  'onDragEnd',
+];
+const SCHEDULER_SELECTOR = '#container';
+
+const TEST_APPOINTMENT = {
+  id: 10,
+  text: 'My appointment',
+  startDate: new Date(2021, 3, 28, 1),
+  endDate: new Date(2021, 3, 28, 2),
+};
+
+const getSchedulerOptions = () => ({
+  dataSource: [TEST_APPOINTMENT],
+  currentDate: new Date(2021, 3, 28),
+  currentView: 'workWeek',
+  width: 600,
+});
+
+METHODS_TO_CANCEL.forEach((methodName) => {
+  test(`Should remove drag-n-drop classes if event was canceled in method ${methodName}`, async (t) => {
+    const scheduler = new Scheduler(SCHEDULER_SELECTOR);
+
+    const appointmentToMoveElement = scheduler
+      .getAppointment(TEST_APPOINTMENT.text)
+      .element();
+    const cellToMoveElement = scheduler
+      .getDateTableCell(1, 0);
+
+    await t.dragToElement(appointmentToMoveElement, cellToMoveElement, { speed: 0.1 });
+
+    const droppableCellExists = await scheduler
+      .getDroppableCell()
+      .exists;
+    const appointmentIsDraggableSource = await scheduler
+      .getAppointment(TEST_APPOINTMENT.text)
+      .isDraggableSource;
+
+    await t.expect(droppableCellExists).notOk('Droppable cell class was not removed.');
+    await t.expect(appointmentIsDraggableSource).notOk('Draggable source class was not removed from appointment.');
+  }).before(async () => {
+    await createWidget('dxScheduler', {
+      ...getSchedulerOptions(),
+      appointmentDragging: {
+        [methodName]: (e) => {
+          e.cancel = true;
+        },
+      },
+    });
+  });
+});

--- a/testing/testcafe/tests/scheduler/dragAndDrop/pages/containerForTwoSchedulers.html
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/pages/containerForTwoSchedulers.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>TestCafe Tests Container For Drag and Drop</title>
+
+    <link rel="dx-theme" data-theme="generic.light" href="../../../../../../artifacts/css/dx.light.css"
+          data-active="true">
+    <link rel="dx-theme" data-theme="material.blue.light"
+          href="../../../../../../artifacts/css/dx.material.blue.light.css" data-active="false">
+
+    <script type="text/javascript" src="../../../../../../artifacts/js/jquery.min.js"></script>
+    <script type="text/javascript" src="../../../../../../artifacts/js/dx.all.debug.js"></script>
+</head>
+
+<body>
+<div style="display: flex;">
+    <div id="scheduler-first"></div>
+    <div id="scheduler-second"></div>
+</div>
+</body>
+
+</html>

--- a/testing/tests/DevExpress.ui.widgets.scheduler/workSpace.day.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/workSpace.day.tests.js
@@ -178,14 +178,6 @@ module('Work Space Day', {
         assert.ok($cell.hasClass(DROPPABLE_CELL_CLASS), 'cell has droppable class');
     });
 
-    test('droppable class should be removed on dxdrop', function(assert) {
-        const $cell = this.instance.$element().find('.' + CELL_CLASS).eq(2);
-        $cell.addClass(DROPPABLE_CELL_CLASS);
-
-        $($cell).trigger(dragEvents.drop);
-        assert.ok(!$cell.hasClass(DROPPABLE_CELL_CLASS), 'cell has no droppable class');
-    });
-
     test('Get date range', function(assert) {
         this.instance.option('currentDate', new Date(2015, 2, 16));
 


### PR DESCRIPTION
See ticket: https://supportcenter.devexpress.com/internal/ticket/details/T1094033