### PR TITLE
FileManager - Fix synchronisation of disabled state of copy/move dialog buttons with a folder selection (T1092300)

### DIFF
--- a/js/ui/file_manager/ui.file_manager.dialog.folder_chooser.js
+++ b/js/ui/file_manager/ui.file_manager.dialog.folder_chooser.js
@@ -13,7 +13,7 @@ const FILE_MANAGER_DIALOG_FOLDER_CHOOSER_POPUP = 'dx-filemanager-dialog-folder-c
 class FileManagerFolderChooserDialog extends FileManagerDialogBase {
 
     show() {
-        this._resetDialogSelectedDirectory();
+        this._setSelectedDirInfo(null);
         this._filesTreeView?.refresh();
         super.show();
     }
@@ -21,13 +21,19 @@ class FileManagerFolderChooserDialog extends FileManagerDialogBase {
     switchToCopyDialog(targetItemInfos) {
         this._targetItemInfos = targetItemInfos;
         this._setTitle(messageLocalization.format('dxFileManager-dialogDirectoryChooserCopyTitle'));
-        this._setButtonText(messageLocalization.format('dxFileManager-dialogDirectoryChooserCopyButtonText'));
+        this._setApplyButtonOptions({
+            text: messageLocalization.format('dxFileManager-dialogDirectoryChooserCopyButtonText'),
+            disabled: true
+        });
     }
 
     switchToMoveDialog(targetItemInfos) {
         this._targetItemInfos = targetItemInfos;
         this._setTitle(messageLocalization.format('dxFileManager-dialogDirectoryChooserMoveTitle'));
-        this._setButtonText(messageLocalization.format('dxFileManager-dialogDirectoryChooserMoveButtonText'));
+        this._setApplyButtonOptions({
+            text: messageLocalization.format('dxFileManager-dialogDirectoryChooserMoveButtonText'),
+            disabled: true
+        });
     }
 
     _getDialogOptions() {
@@ -65,13 +71,14 @@ class FileManagerFolderChooserDialog extends FileManagerDialogBase {
         return this._selectedDirectoryInfo;
     }
 
-    _resetDialogSelectedDirectory() {
-        this._selectedDirectoryInfo = null;
+    _onFilesTreeViewDirectoryClick({ itemData }) {
+        this._setSelectedDirInfo(itemData);
+        this._filesTreeView.updateCurrentDirectory();
     }
 
-    _onFilesTreeViewDirectoryClick({ itemData }) {
-        this._selectedDirectoryInfo = itemData;
-        this._filesTreeView.updateCurrentDirectory();
+    _setSelectedDirInfo(dirInfo) {
+        this._selectedDirectoryInfo = dirInfo;
+        this._setApplyButtonOptions({ disabled: !dirInfo });
     }
 
     _onPopupShown() {

--- a/js/ui/file_manager/ui.file_manager.dialog.js
+++ b/js/ui/file_manager/ui.file_manager.dialog.js
@@ -121,8 +121,8 @@ class FileManagerDialogBase extends Widget {
         this._popup.option('title', newTitle);
     }
 
-    _setButtonText(newText) {
-        this._popup.option('toolbarItems[0].options.text', newText);
+    _setApplyButtonOptions(options) {
+        this._popup.option('toolbarItems[0].options', options);
     }
 
     _getDefaultOptions() {

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
@@ -1972,4 +1972,76 @@ QUnit.module('Editing operations', moduleConfig, () => {
         assert.strictEqual(this.wrapper.getDetailsItemName(0), fileName1, '1st file is still in the initial dir');
         assert.strictEqual(this.wrapper.getDetailsItemName(1), fileName2, '2nd file is still in the initial dir');
     });
+
+    test('the \'copy\' dialog button must be disabled and dialog remains open after click on it if no folders are selected (T1092300)', function(assert) {
+        let $cells = this.wrapper.getColumnCellsInDetailsView(2);
+        const initialCount = $cells.length;
+        const $cell = $cells.eq(0);
+
+        assert.equal(this.wrapper.getFocusedItemText(), 'Files', 'root folder selected');
+        assert.equal(this.wrapper.getDetailsItemName(0), 'File 1.txt', 'has target file');
+
+        $cell.trigger(CLICK_EVENT).click();
+        this.clock.tick(400);
+
+        this.wrapper.getToolbarButton('Copy to').trigger('dxclick');
+        this.clock.tick(400);
+        assert.ok(this.wrapper.getFolderChooserDialog().is(':visible'), 'Folder chooser dialog is visible');
+        assert.ok(this.wrapper.getDialogButton('Copy').hasClass(Consts.DISABLED_STATE_CLASS), '\'Copy\' dialog button is disabled');
+
+        this.wrapper.getDialogButton('Copy').trigger('dxclick');
+        this.clock.tick(400);
+
+        $cells = this.wrapper.getColumnCellsInDetailsView(2);
+        assert.equal($cells.length, initialCount, 'file count not changed');
+        assert.equal(this.wrapper.getDetailsItemName(0), 'File 1.txt', 'first file is the target file');
+        assert.equal(this.wrapper.getDetailsItemName(1), 'File 2.jpg', 'second file is not target file');
+        assert.ok(this.wrapper.getFolderChooserDialog().is(':visible'), 'Folder chooser dialog is still visible');
+
+        this.wrapper.getFolderNodes(true).eq(3).trigger('dxclick');
+        this.wrapper.getDialogButton('Copy').trigger('dxclick');
+        this.clock.tick(400);
+
+        assert.equal(this.wrapper.getFocusedItemText(), 'Folder 3', 'root folder selected');
+        $cells = this.wrapper.getColumnCellsInDetailsView(2);
+        assert.equal($cells.length, 1, 'file count is correct');
+        assert.equal(this.wrapper.getDetailsItemName(0), 'File 1.txt', 'first file is the target file');
+        assert.notOk(this.wrapper.getFolderChooserDialog().is(':visible'), 'Folder chooser dialog is invisible');
+    });
+
+    test('the \'move\' dialog button must be disabled and dialog remains open after click on it if no folders are selected (T1092300)', function(assert) {
+        let $cells = this.wrapper.getColumnCellsInDetailsView(2);
+        const initialCount = $cells.length;
+        const $cell = $cells.eq(0);
+
+        assert.equal(this.wrapper.getFocusedItemText(), 'Files', 'root folder selected');
+        assert.equal(this.wrapper.getDetailsItemName(0), 'File 1.txt', 'has target file');
+
+        $cell.trigger(CLICK_EVENT).click();
+        this.clock.tick(400);
+
+        this.wrapper.getToolbarButton('Move to').trigger('dxclick');
+        this.clock.tick(400);
+        assert.ok(this.wrapper.getFolderChooserDialog().is(':visible'), 'Folder chooser dialog is visible');
+        assert.ok(this.wrapper.getDialogButton('Move').hasClass(Consts.DISABLED_STATE_CLASS), '\'Move\' dialog button is disabled');
+
+        this.wrapper.getDialogButton('Move').trigger('dxclick');
+        this.clock.tick(400);
+
+        $cells = this.wrapper.getColumnCellsInDetailsView(2);
+        assert.equal($cells.length, initialCount, 'file count not changed');
+        assert.equal(this.wrapper.getDetailsItemName(0), 'File 1.txt', 'first file is the target file');
+        assert.equal(this.wrapper.getDetailsItemName(1), 'File 2.jpg', 'second file is not target file');
+        assert.ok(this.wrapper.getFolderChooserDialog().is(':visible'), 'Folder chooser dialog is still visible');
+
+        this.wrapper.getFolderNodes(true).eq(3).trigger('dxclick');
+        this.wrapper.getDialogButton('Move').trigger('dxclick');
+        this.clock.tick(400);
+
+        assert.equal(this.wrapper.getFocusedItemText(), 'Folder 3', 'root folder selected');
+        $cells = this.wrapper.getColumnCellsInDetailsView(2);
+        assert.equal($cells.length, 1, 'file count is correct');
+        assert.equal(this.wrapper.getDetailsItemName(0), 'File 1.txt', 'first file is the target file');
+        assert.notOk(this.wrapper.getFolderChooserDialog().is(':visible'), 'Folder chooser dialog is invisible');
+    });
 });

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
@@ -1999,6 +1999,9 @@ QUnit.module('Editing operations', moduleConfig, () => {
         assert.ok(this.wrapper.getFolderChooserDialog().is(':visible'), 'Folder chooser dialog is still visible');
 
         this.wrapper.getFolderNodes(true).eq(3).trigger('dxclick');
+        this.clock.tick(200);
+        assert.notOk(this.wrapper.getDialogButton('Copy').hasClass(Consts.DISABLED_STATE_CLASS), '\'Copy\' dialog button is enabled');
+
         this.wrapper.getDialogButton('Copy').trigger('dxclick');
         this.clock.tick(400);
 
@@ -2035,6 +2038,9 @@ QUnit.module('Editing operations', moduleConfig, () => {
         assert.ok(this.wrapper.getFolderChooserDialog().is(':visible'), 'Folder chooser dialog is still visible');
 
         this.wrapper.getFolderNodes(true).eq(3).trigger('dxclick');
+        this.clock.tick(200);
+        assert.notOk(this.wrapper.getDialogButton('Move').hasClass(Consts.DISABLED_STATE_CLASS), '\'Move\' dialog button is enabled');
+
         this.wrapper.getDialogButton('Move').trigger('dxclick');
         this.clock.tick(400);
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
