### PR TITLE
DataGrid: Fix filter row was losing focus after changing column filterValue when another column was filtered and filter panel is visible (T1093656, T1096053)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -21,6 +21,7 @@ import { when, Deferred } from '../../core/utils/deferred';
 import Store from '../../data/abstract_store';
 import { DataSource } from '../../data/data_source/data_source';
 import { normalizeDataSourceOptions } from '../../data/data_source/utils';
+import { equalByValue } from '../../core/utils/common';
 import filterUtils from '../shared/filtering';
 
 const USER_STATE_FIELD_NAMES_15_1 = ['filterValues', 'filterType', 'fixed', 'fixedPosition'];
@@ -712,7 +713,7 @@ export const columnsControllerModule = {
                     return optionGetter(column, { functionsAsIs: true });
                 }
                 const prevValue = optionGetter(column, { functionsAsIs: true });
-                if(prevValue !== value) {
+                if(!equalByValue(prevValue, value)) {
                     if(optionName === 'groupIndex' || optionName === 'calculateGroupValue') {
                         changeType = 'grouping';
                         updateSortOrderWhenGrouping(that, column, value, prevValue);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filtering.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filtering.integration.tests.js
@@ -1479,4 +1479,43 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.columnOption(0, 'filterValue', 35);
         dataGrid.columnOption(0, 'filterValue', null);
     });
+
+    // T1093656, T1096053
+    QUnit.testInActiveWindow('Filter row editor should have focus when filterPanel is visible', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            filterRow: { visible: true },
+            columns: [
+                { dataField: 'field1' },
+                {
+                    dataField: 'field2',
+                    filterValue: 4,
+                    selectedFilterOperation: '='
+                }
+            ],
+            filterPanel: {
+                visible: true
+            },
+            dataSource: [{ field1: 1, field2: 2 }, { field1: 3, field2: 4 }]
+        });
+
+        this.clock.tick(100);
+
+        // assert
+        assert.equal(dataGrid.getVisibleRows().length, 1, 'row count');
+
+        // act
+        const $input = $(dataGrid.$element()).find('.dx-datagrid-filter-row').first().find('.dx-texteditor-input').first();
+        $input
+            .trigger('focus')
+            .val('1')
+            .trigger('change');
+        this.clock.tick(100);
+
+        // assert
+        const $focusedInput = $(dataGrid.$element()).find('.dx-datagrid-filter-row .dx-texteditor-input:focus');
+        assert.deepEqual($focusedInput.get(0), $input.get(0), 'filter cell has focus after filter applyed');
+        assert.strictEqual(dataGrid.getVisibleRows().length, 0, 'row count after filtering');
+        assert.deepEqual(dataGrid.option('filterValue'), [['field2', '=', 4], 'and', ['field1', '=', 1]], 'filterValue');
+    });
 });


### PR DESCRIPTION
See https://devexpress.com/issue=T1093656
See https://devexpress.com/issue=T1096053