### PR TITLE
DataGrid: Fix the "TypeError: Cannot read properties of null" error occurs when the legacyMode is set to true and rowRenderingMode is set to virtual (T1094867)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -804,7 +804,7 @@ export const virtualScrollingModule = {
                     },
                     _loadDataSource: function() {
                         if(this._rowsScrollController && isVirtualPaging(this)) {
-                            const { loadPageCount } = (isDefined(this._loadViewportParams) && this.getLoadPageParams()) || {};
+                            const { loadPageCount } = isDefined(this._loadViewportParams) ? this.getLoadPageParams() : {};
 
                             loadPageCount >= 1 && this._dataSource?.loadPageCount(loadPageCount);
                         }

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -804,7 +804,7 @@ export const virtualScrollingModule = {
                     },
                     _loadDataSource: function() {
                         if(this._rowsScrollController && isVirtualPaging(this)) {
-                            const { loadPageCount } = this.getLoadPageParams() ?? {};
+                            const { loadPageCount } = (isDefined(this._loadViewportParams) && this.getLoadPageParams()) || {};
 
                             loadPageCount >= 1 && this._dataSource?.loadPageCount(loadPageCount);
                         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -5800,6 +5800,33 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             assert.deepEqual(names, ['test 3', 'test 2', 'test 1']);
         });
     });
+
+    // T1094867
+    QUnit.test('Virtual scrolling in legacyMode should work with stateStoring and rowRenderingMode \'virtual\'', function(assert) {
+        // arrange
+        createDataGrid({
+            height: 440,
+            dataSource: [...new Array(20).keys()].map(i => ({ id: i })),
+            scrolling: {
+                mode: 'virtual',
+                rowRenderingMode: 'virtual',
+                legacyMode: true
+            },
+            keyExpr: 'id',
+            stateStoring: {
+                enabled: true,
+                type: 'custom',
+                customLoad: function() {
+                    return { pageIndex: 0 };
+                }
+            },
+        });
+
+        this.clock.tick(100);
+
+        // assert
+        assert.ok(true, 'no errors');
+    });
 });
 
 


### PR DESCRIPTION
See https://devexpress.com/issue=T1094867