### PR TITLE
TreeList - Last row disappears after adding a new row if editing.refreshMode is set 'repaint' (T1097528)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -358,8 +358,10 @@ export default gridCore.Controller.inherit((function() {
             const keyInfo = this._getKeyInfo();
             const dataSource = this._dataSource;
             const groupCount = gridCore.normalizeSortingInfo(this.group()).length;
+            const totalCount = this.totalCount();
             const isReshapeMode = this.option('editing.refreshMode') === 'reshape';
             const isVirtualMode = this.option('scrolling.mode') === 'virtual';
+            const isLegacyMode = this.option('scrolling.legacyMode');
 
             changes = changes.filter(function(change) {
                 return !dataSource.paginate() || change.type !== 'insert' || change.index !== undefined;
@@ -384,7 +386,14 @@ export default gridCore.Controller.inherit((function() {
                 useInsertIndex: true
             });
 
-            if(this._currentTotalCount > 0 || !isReshapeMode && isVirtualMode) {
+            const needUpdateTotalCountCorrection =
+                this._currentTotalCount > 0 || (
+                    !isReshapeMode &&
+                    isVirtualMode &&
+                    (!isLegacyMode || totalCount === oldItemCount)
+                );
+
+            if(needUpdateTotalCountCorrection) {
                 this._totalCountCorrection += getItemCount() - oldItemCount;
             }
 

--- a/js/ui/grid_core/ui.grid_core.data_source_adapter.js
+++ b/js/ui/grid_core/ui.grid_core.data_source_adapter.js
@@ -358,7 +358,6 @@ export default gridCore.Controller.inherit((function() {
             const keyInfo = this._getKeyInfo();
             const dataSource = this._dataSource;
             const groupCount = gridCore.normalizeSortingInfo(this.group()).length;
-            const totalCount = this.totalCount();
             const isReshapeMode = this.option('editing.refreshMode') === 'reshape';
             const isVirtualMode = this.option('scrolling.mode') === 'virtual';
 
@@ -385,7 +384,7 @@ export default gridCore.Controller.inherit((function() {
                 useInsertIndex: true
             });
 
-            if(this._currentTotalCount > 0 || !isReshapeMode && isVirtualMode && totalCount === oldItemCount) {
+            if(this._currentTotalCount > 0 || !isReshapeMode && isVirtualMode) {
                 this._totalCountCorrection += getItemCount() - oldItemCount;
             }
 

--- a/js/ui/tree_list/ui.tree_list.data_source_adapter.js
+++ b/js/ui/tree_list/ui.tree_list.data_source_adapter.js
@@ -689,7 +689,7 @@ let DataSourceAdapterTreeList = DataSourceAdapter.inherit((function() {
         },
 
         totalItemsCount: function() {
-            return this._totalItemsCount;
+            return this._totalItemsCount + this._totalCountCorrection;
         },
 
         isRowExpanded: function(key, cache) {

--- a/testing/tests/DevExpress.ui.widgets.treeList/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/virtualScrolling.integration.tests.js
@@ -12,27 +12,33 @@ QUnit.testStart(function() {
 
 QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
     // T1097528
-    QUnit.test('Last row should not disappear after adding new row when refreshMode is repaint', function(assert) {
+    [true, false].forEach(legacyMode => {
+        QUnit.test('Last row should not disappear after adding new row when refreshMode is repaint', function(assert) {
         // arrange
-        const treeList = $('#treeList').dxTreeList({
-            dataSource: [{ id: 1 }, { id: 2 }],
-            keyExpr: 'id',
-            height: 100,
-            editing: {
-                refreshMode: 'repaint'
-            },
-        }).dxTreeList('instance');
+            const treeList = $('#treeList').dxTreeList({
+                dataSource: [{ id: 1 }, { id: 2 }],
+                keyExpr: 'id',
+                height: 100,
+                scrolling: {
+                    virtual: true,
+                    legacyMode
+                },
+                editing: {
+                    refreshMode: 'repaint'
+                },
+            }).dxTreeList('instance');
 
-        this.clock.tick(500);
+            this.clock.tick(500);
 
-        // assert
-        assert.strictEqual(treeList.getVisibleRows().length, 2, 'visible rows count');
+            // assert
+            assert.strictEqual(treeList.getVisibleRows().length, 2, 'visible rows count');
 
-        // act
-        treeList.addRow();
-        treeList.saveEditData();
+            // act
+            treeList.addRow();
+            treeList.saveEditData();
 
-        // assert
-        assert.strictEqual(treeList.getVisibleRows().length, 3, 'visible rows count');
+            // assert
+            assert.strictEqual(treeList.getVisibleRows().length, 3, 'visible rows count');
+        });
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.treeList/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/virtualScrolling.integration.tests.js
@@ -1,0 +1,38 @@
+import 'ui/tree_list';
+import { baseModuleConfig } from '../../helpers/dataGridHelper.js';
+import $ from 'jquery';
+
+QUnit.testStart(function() {
+    const markup = `
+        <div id="treeList"></div>
+    `;
+
+    $('#qunit-fixture').html(markup);
+});
+
+QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
+    // T1097528
+    QUnit.test('Last row should not disappear after adding new row when refreshMode is repaint', function(assert) {
+        // arrange
+        const treeList = $('#treeList').dxTreeList({
+            dataSource: [{ id: 1 }, { id: 2 }],
+            keyExpr: 'id',
+            height: 100,
+            editing: {
+                refreshMode: 'repaint'
+            },
+        }).dxTreeList('instance');
+
+        this.clock.tick(500);
+
+        // assert
+        assert.strictEqual(treeList.getVisibleRows().length, 2, 'visible rows count');
+
+        // act
+        treeList.addRow();
+        treeList.saveEditData();
+
+        // assert
+        assert.strictEqual(treeList.getVisibleRows().length, 3, 'visible rows count');
+    });
+});


### PR DESCRIPTION
TreeList used to ignore `_totalCountCorrection` variable in dataSourceAdapter, that's why on adding new rows in `repaint` mode last rows disappears.

 - I removed `totalCount === oldItemCount` from condition on updating `_totalCountCorrection`. In case of TreeList, this condition is always false cause `totalCount` represents all items in dataSource and `oldItemCount` represents only visible rows, collapsed children wasn't count. Also it seems to do same works as the `!isReshapeMode` condition does
- I added `_totalCountCorrection` to `totalItemsCount` method of treeList's dataSourceAdapter