### PR TITLE
DataGrid: Fix the "Cannot read properties of undefined (reading 'find')" error occurs when one of the columns is hidden (T1097980)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.filter_row.js
+++ b/js/ui/grid_core/ui.grid_core.filter_row.js
@@ -680,30 +680,32 @@ const ColumnHeadersViewFilterRowExtender = (function() {
                 return;
             }
 
-            const columns = this.getController('columns').getVisibleColumns();
-            const dataSource = this.getController('data').dataSource();
-            const filterRowController = this.getController('applyFilter');
+            const columns = this._columnsController.getVisibleColumns();
+            const dataSource = this._dataController.dataSource();
+            const applyFilterViewController = this._applyFilterViewController;
             const rowIndex = this.element().find('.' + this.addWidgetPrefix(FILTER_ROW_CLASS)).index();
 
             if(rowIndex === -1) {
                 return;
             }
 
-            columns.forEach((column) => {
+            columns.forEach((column, index) => {
                 if(!column.lookup) {
                     return;
                 }
 
-                const $cell = this._getCellElement(rowIndex, column.visibleIndex);
-                const editor = getEditorInstance($cell.find('.dx-editor-container'));
+                const $cell = this._getCellElement(rowIndex, index);
+                const editor = getEditorInstance($cell?.find('.dx-editor-container'));
 
-                filterRowController.setCurrentColumnForFiltering(column);
-                const filter = this.getController('data').getCombinedFilter();
-                filterRowController.setCurrentColumnForFiltering(null);
+                if(editor) {
+                    applyFilterViewController.setCurrentColumnForFiltering(column);
+                    const filter = this._dataController.getCombinedFilter();
+                    applyFilterViewController.setCurrentColumnForFiltering(null);
 
-                const lookupDataSource = gridCoreUtils.getWrappedLookupDataSource(column, dataSource, filter);
+                    const lookupDataSource = gridCoreUtils.getWrappedLookupDataSource(column, dataSource, filter);
 
-                editor?.option('dataSource', lookupDataSource);
+                    editor.option('dataSource', lookupDataSource);
+                }
             });
         },
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
@@ -2430,6 +2430,44 @@ QUnit.module('Filter Row with real dataController and columnsController', {
         assert.strictEqual(dropDownList2.find('.dx-item:eq(1)').text(), 'value1');
     });
 
+    // T1097980
+    QUnit.test('Filtering should not throw an exception when there is hidden column', function(assert) {
+        // arrange
+        const $testElement = $('#container');
+
+        this.options.columns = [{
+            dataField: 'column1',
+            allowFiltering: true,
+            visible: false,
+        }, {
+            dataField: 'column2',
+            allowFiltering: true,
+            lookup: {
+                dataSource: [{ id: 1, value: 'value1' }, { id: 2, value: 'value2' }],
+                valueExpr: 'id',
+                displayExpr: 'value'
+            }
+        }];
+        this.options.dataSource = [
+            { column1: 1, column2: 1 },
+            { column1: 2, column2: 2 },
+        ];
+        this.options.syncLookupFilterValues = true;
+
+        setupDataGridModules(this, ['data', 'columns', 'columnHeaders', 'filterRow', 'editorFactory'], {
+            initViews: true
+        });
+        this.columnHeadersView.render($testElement);
+        this.clock.tick(100);
+
+        // act
+        this.columnOption('column2', 'filterValue', 1);
+        this.clock.tick(100);
+
+        // assert
+        assert.ok(true, 'no exceptions');
+    });
+
 
     if(device.deviceType === 'desktop') {
     // T306751


### PR DESCRIPTION
See https://devexpress.com/issue=T1097980