### PR TITLE
DataGrid: Fix columns resizing if allowResizing is disabled when columnResizingMode is set to 'widget' while a column is fixed on the right  (T1098769)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.column_fixing.js
+++ b/js/ui/grid_core/ui.grid_core.column_fixing.js
@@ -987,34 +987,22 @@ export const columnFixingModule = {
                         const columnsController = that._columnsController;
                         const columns = columnsController && that._columnsController.getVisibleColumns();
                         const fixedColumns = columnsController && that._columnsController.getFixedColumns();
+                        const transparentColumnIndex = getTransparentColumnIndex(fixedColumns);
+                        const correctIndex = columns.length - fixedColumns.length;
                         const cells = that._columnHeadersView.getFixedColumnElements();
-                        let pointsByFixedColumns = [];
 
                         that.callBase();
 
                         if(cells && cells.length > 0) {
-                            pointsByFixedColumns = gridCoreUtils.getPointsByColumns(cells, function(point) {
-                                return that._pointCreated(point, cells.length, fixedColumns);
+                            that._pointsByFixedColumns = gridCoreUtils.getPointsByColumns(cells, function(point) {
+                                if(point.index > transparentColumnIndex) {
+                                    point.columnIndex += correctIndex;
+                                    point.index += correctIndex;
+                                }
+
+                                return that._pointCreated(point, columns.length, columns);
                             });
-
-                            that._pointsByFixedColumns = normalizeColumnIndicesByPoints(columns, fixedColumns, pointsByFixedColumns);
                         }
-                    },
-
-                    _pointCreated: function(point, cellsLength, columns) {
-                        const isWidgetResizingMode = this.option('columnResizingMode') === 'widget';
-
-                        if(point.index > 0 && point.index < cellsLength) {
-                            const currentColumn = columns[point.columnIndex - 1] || {};
-                            const nextColumn = columns[point.columnIndex] || {};
-
-                            if(currentColumn.fixed || nextColumn.fixed) {
-                                point.columnIndex -= 1;
-                                return !((currentColumn.allowResizing || currentColumn.command === COMMAND_TRANSPARENT) && (isWidgetResizingMode || nextColumn.allowResizing || nextColumn.command === COMMAND_TRANSPARENT));
-                            }
-                        }
-
-                        return this.callBase.apply(this, arguments);
                     },
 
                     _getTargetPoint: function(pointsByColumns, currentX, deltaX) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
@@ -2648,6 +2648,43 @@ QUnit.module('Headers reordering and resizing with fixed columns', {
         assert.deepEqual(pointsByFixedColumns[0], { columnIndex: 0, index: 1, x: -9900, y: -10000 }, 'first point');
         assert.deepEqual(pointsByFixedColumns[1], { columnIndex: 1, index: 2, x: -9775, y: -10000 }, 'second point');
     });
+
+    // T1098769
+    QUnit.test('Resizing (columnResizingMode=\'widget\') - get points by columns when all columns have resizing disabled and there is a fixed column with a fixed position on the right', function(assert) {
+        // arrange
+        const that = this;
+        const $testElement = $('#container').width(800);
+
+        that.setupDataGrid({
+            allowColumnResizing: true,
+            columnResizingMode: 'widget',
+            showColumnHeaders: true,
+            columns: [
+                {
+                    caption: 'Column 1', width: 200, allowResizing: false
+                },
+                {
+                    caption: 'Column 2', width: 200, allowResizing: false
+                },
+                {
+                    caption: 'Column 3', width: 200, allowResizing: false
+                },
+                {
+                    caption: 'Column 4', width: 200, allowResizing: false, fixed: true, fixedPosition: 'right'
+                }
+            ]
+        });
+        that.columnHeadersView.render($testElement);
+
+        // act
+        that.columnsResizerController._generatePointsByColumns();
+        const pointsByColumns = that.columnsResizerController._pointsByColumns;
+        const pointsByFixedColumns = that.columnsResizerController._pointsByFixedColumns;
+
+        // assert
+        assert.equal(pointsByColumns.length, 0, 'count points by columns');
+        assert.equal(pointsByFixedColumns.length, 0, 'count points by fixed columns');
+    });
 });
 
 QUnit.module('Fixed columns with band columns', {


### PR DESCRIPTION
See https://devexpress.com/issue=T1098769