### PR TITLE
DataGrid - A lookup column's header filter loads data infinitely when scrolling (T1100536 and T1100782)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.utils.js
+++ b/js/ui/grid_core/ui.grid_core.utils.js
@@ -14,7 +14,6 @@ import { normalizeSortingInfo as normalizeSortingInfoUtility } from '../../data/
 import formatHelper from '../../format_helper';
 import { getWindow } from '../../core/utils/window';
 import eventsEngine from '../../events/core/events_engine';
-import { DataSource } from '../../data/data_source/data_source';
 import ArrayStore from '../../data/array_store';
 import { normalizeDataSourceOptions } from '../../data/data_source/utils';
 import variableWrapper from '../../core/utils/variable_wrapper';
@@ -606,16 +605,15 @@ export default {
                             [column.lookup.displayExpr]: column.displayValueMap[item.key] ?? item.items[0].key
                         }));
 
-                        const newDataSource = new DataSource({
-                            ...loadOptions,
-                            store: new ArrayStore({
-                                data: lookupItems,
-                                key: column.lookup.valueExpr,
-                            })
+                        const store = new ArrayStore({
+                            data: lookupItems,
+                            key: column.lookup.valueExpr,
                         });
 
-                        newDataSource
-                            .load(loadOptions)
+                        store.load({
+                            ...lookupDataSourceOptions,
+                            ...loadOptions
+                        })
                             .done(d.resolve)
                             .fail(d.fail);
                     } else {
@@ -626,12 +624,11 @@ export default {
                             'or'
                         );
 
-                        (new DataSource({
+                        lookupDataSourceOptions.store.load({
                             ...lookupDataSourceOptions,
                             ...loadOptions,
                             filter: this.combineFilters([filter, loadOptions.filter], 'and'),
-                        }))
-                            .load(loadOptions)
+                        })
                             .done(d.resolve)
                             .fail(d.fail);
                     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
@@ -2540,7 +2540,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
 
     // T1100782
     [true, false].forEach((hasLookupOptimization) => {
-        QUnit.test(`Lookup select box should pass correct group load options for lookup dataSource, hasLookupOptimization: ${hasLookupOptimization}`, function(assert) {
+        QUnit.test(`Lookup select box should pass correct load options (skip, take, filter) for lookup dataSource, hasLookupOptimization: ${hasLookupOptimization}`, function(assert) {
             // arrange
             const loadSpy = sinon.spy((loadOptions) => {
                 const d = $.Deferred();
@@ -2548,7 +2548,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
                     [...new Array(100).keys()].map(i => ({ id: i, value: `value${i}` }))
                 ).load(loadOptions).done(items => d.resolve({
                     data: items,
-                    totalCount: 2,
+                    totalCount: 100,
                 }));
 
                 return d;
@@ -2591,7 +2591,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
             const dropDownList1 = $('.dx-list:eq(0)');
             assert.strictEqual(dropDownList1.find('.dx-item').length, 91); // 90 rows + (All)
             assert.strictEqual(dropDownList1.find('.dx-item:eq(1)').text(), 'value10');
-            assert.strictEqual(dropDownList1.find('.dx-item:eq(2)').text(), 'value11');
+            assert.strictEqual(dropDownList1.find('.dx-item:eq(-1)').text(), 'value99');
         });
     });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -4310,7 +4310,7 @@ QUnit.module('Header Filter with real columnsController', {
         });
 
         // T1100536
-        QUnit.test(`Lookup header filter should pass correct group load options for lookup dataSource, lookupOptimization = ${hasLookupOptimization}`, function(assert) {
+        QUnit.test(`Lookup header filter should pass correct load options (skip, take, filter) for lookup dataSource, lookupOptimization = ${hasLookupOptimization}`, function(assert) {
             // arrange
             this.options.columns = [{
                 dataField: 'column1',

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -4349,7 +4349,7 @@ QUnit.module('Header Filter with real columnsController', {
 
             // act
             const list = $popupContent.find('.dx-list').dxList('instance');
-            list.scrollBy(1000);
+            list.scrollBy(100);
             this.clock.tick();
 
             // assert

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -4350,6 +4350,7 @@ QUnit.module('Header Filter with real columnsController', {
             // act
             const list = $popupContent.find('.dx-list').dxList('instance');
             list.scrollBy(1000);
+            this.clock.tick();
 
             // assert
             $listItemElements = $popupContent.find('.dx-list-item-content');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -4308,6 +4308,56 @@ QUnit.module('Header Filter with real columnsController', {
             assert.equal($listItemElements.length, 1, 'count list item');
             assert.strictEqual($listItemElements.eq(0).text(), 'value1');
         });
+
+        // T1100536
+        QUnit.test(`Lookup header filter should pass correct group load options for lookup dataSource, lookupOptimization = ${hasLookupOptimization}`, function(assert) {
+            // arrange
+            this.options.columns = [{
+                dataField: 'column1',
+                allowFiltering: true,
+                lookup: {
+                    dataSource: [...new Array(100).keys()].map(i => ({ id: i, value: `value${i}` })),
+                    valueExpr: 'id',
+                    displayExpr: 'value',
+                },
+                calculateDisplayValue: hasLookupOptimization ? 'text' : undefined,
+            }];
+
+            this.options.dataSource = [...new Array(100).keys()].map(i => ({
+                column1: i, text: `value${i}`
+            }));
+
+
+            this.options.syncLookupFilterValues = true;
+
+            const $testElement = $('#container');
+
+            this.setupDataGrid();
+            this.columnHeadersView.render($testElement);
+            this.headerFilterView.render($testElement);
+
+            // act
+            this.headerFilterController.showHeaderFilterMenu(0);
+
+            // assert
+            const $popupContent = this.headerFilterView.getPopupContainer().$content();
+            let $listItemElements = $popupContent.find('.dx-list-item-content');
+            assert.equal($listItemElements.length, 21, 'count list item');
+            assert.strictEqual($listItemElements.eq(0).text(), '(Blanks)');
+            assert.strictEqual($listItemElements.eq(1).text(), 'value0');
+            assert.strictEqual($listItemElements.eq(-1).text(), 'value19');
+
+            // act
+            const list = $popupContent.find('.dx-list').dxList('instance');
+            list.scrollBy(1000);
+
+            // assert
+            $listItemElements = $popupContent.find('.dx-list-item-content');
+            assert.equal($listItemElements.length, 41, 'count list item');
+            assert.strictEqual($listItemElements.eq(0).text(), '(Blanks)');
+            assert.strictEqual($listItemElements.eq(1).text(), 'value0');
+            assert.strictEqual($listItemElements.eq(-1).text(), 'value39');
+        });
     });
 
     // T938460


### PR DESCRIPTION
DataSource doesn't have `loadOptions` param in `load()` method as store does and ignores this params if they are passed in constructor, unlike `filter` param. I added modification of this param in `customizeStoreLoadOption` callback.

Also I tried calling `.load` directly from store, but in this case there are problems with `searchOperation` params, which is supported in DataSource level 