### PR TITLE
DataGrid - Fix last fixed row offset when the scrolling mode is set to 'virtual' and showScrollbar is set to 'always' (T1100701)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.column_fixing.js
+++ b/js/ui/grid_core/ui.grid_core.column_fixing.js
@@ -851,7 +851,7 @@ const RowsViewFixedColumnsExtender = extend({}, baseFixedColumns, {
         if(e.scrollOffset.top < 0) {
             elasticScrollTop = -e.scrollOffset.top;
         } else if(e.reachedBottom) {
-            const $scrollableContent = $(this._findContentElement());
+            const $scrollableContent = $(e.component.content());
             const $scrollableContainer = $(e.component.container());
             const maxScrollTop = Math.max($scrollableContent.get(0).clientHeight - $scrollableContainer.get(0).clientHeight, 0);
             elasticScrollTop = maxScrollTop - e.scrollOffset.top;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
@@ -57,6 +57,13 @@ const generateData = function(countItems) {
     return result;
 };
 
+const setScrollerSpacing = function(rowsView) {
+    const vScrollbarWidth = rowsView.getScrollbarWidth();
+    const hScrollbarWidth = rowsView.getScrollbarWidth(true);
+
+    rowsView.setScrollerSpacing(vScrollbarWidth, hScrollbarWidth);
+};
+
 setTemplateEngine('hogan');
 
 QUnit.module('Fixed columns', {
@@ -1293,6 +1300,61 @@ QUnit.module('Fixed columns', {
         that.rowsView.render(that.gridContainer);
         that.rowsView.height(50);
         that.rowsView.resize();
+
+        const scrollableInstance = that.rowsView.element().dxScrollable('instance');
+        const $fixTable = that.gridContainer.find('.dx-datagrid-rowsview').children('.dx-datagrid-content-fixed').find('table');
+        const $table = that.gridContainer.find('.dx-datagrid-rowsview').children('.dx-scrollable-wrapper').find('table').first();
+
+        // assert
+        assert.ok(scrollableInstance, 'has scrollable');
+        assert.equal(getOuterHeight(that.rowsView.element()), 50, 'height rowsView');
+        assert.equal(that.gridContainer.find('.dx-datagrid-rowsview').children('.dx-scrollable-wrapper').find('.dx-datagrid-content').length, 1, 'has main content');
+        assert.ok(that.gridContainer.find('.dx-datagrid-rowsview').children('.dx-datagrid-content-fixed').length, 'has fix content');
+        assert.equal($fixTable.position().top, 0, 'fixed table - position top');
+
+        const scrollChanged = function(e) {
+            // assert
+            assert.ok($fixTable.position().top < 0, 'position top is defined');
+            assert.ok($table.find('.dx-virtual-row').eq(0).height() > 0, 'virtual row has height');
+            assert.roughEqual($fixTable.position().top, -e.top, 1.01, 'fixed table - position top');
+            that.rowsView.scrollChanged.remove(scrollChanged);
+            done();
+        };
+        that.rowsView.scrollChanged.add(scrollChanged);
+
+        dataOptions.virtualItemsCount.begin = 800;
+        dataOptions.virtualItemsCount.end = 0;
+        that.rowsView.resize();
+
+        // act
+        scrollableInstance.scrollTo({ y: 20000 });
+    });
+
+    // T1100701
+    QUnit.test('Synchronize position fixed table with main table when scrolling mode virtual and showScrollbar is \'always\'', function(assert) {
+        // arrange
+        const that = this;
+        const done = assert.async();
+
+        const dataOptions = {
+            virtualItemsCount: {
+                begin: 0,
+                end: 800
+            }
+        };
+
+        that.setupDataGrid(dataOptions);
+
+        that.options.scrolling = {
+            mode: 'virtual',
+            showScrollbar: 'always',
+            useNative: false
+        };
+
+        that.rowsView.render(that.gridContainer);
+        that.rowsView.height(50);
+        that.rowsView.resize();
+        setScrollerSpacing(that.rowsView);
 
         const scrollableInstance = that.rowsView.element().dxScrollable('instance');
         const $fixTable = that.gridContainer.find('.dx-datagrid-rowsview').children('.dx-datagrid-content-fixed').find('table');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
@@ -1334,7 +1334,6 @@ QUnit.module('Fixed columns', {
     QUnit.test('Synchronize position fixed table with main table when scrolling mode virtual and showScrollbar is \'always\'', function(assert) {
         // arrange
         const that = this;
-        const done = assert.async();
 
         const dataOptions = {
             virtualItemsCount: {
@@ -1353,8 +1352,8 @@ QUnit.module('Fixed columns', {
 
         that.rowsView.render(that.gridContainer);
         that.rowsView.height(50);
-        that.rowsView.resize();
         setScrollerSpacing(that.rowsView);
+        that.rowsView.resize();
 
         const scrollableInstance = that.rowsView.element().dxScrollable('instance');
         const $fixTable = that.gridContainer.find('.dx-datagrid-rowsview').children('.dx-datagrid-content-fixed').find('table');
@@ -1367,22 +1366,19 @@ QUnit.module('Fixed columns', {
         assert.ok(that.gridContainer.find('.dx-datagrid-rowsview').children('.dx-datagrid-content-fixed').length, 'has fix content');
         assert.equal($fixTable.position().top, 0, 'fixed table - position top');
 
-        const scrollChanged = function(e) {
-            // assert
-            assert.ok($fixTable.position().top < 0, 'position top is defined');
-            assert.ok($table.find('.dx-virtual-row').eq(0).height() > 0, 'virtual row has height');
-            assert.roughEqual($fixTable.position().top, -e.top, 1.01, 'fixed table - position top');
-            that.rowsView.scrollChanged.remove(scrollChanged);
-            done();
-        };
-        that.rowsView.scrollChanged.add(scrollChanged);
-
+        // arrange
         dataOptions.virtualItemsCount.begin = 800;
         dataOptions.virtualItemsCount.end = 0;
         that.rowsView.resize();
 
         // act
         scrollableInstance.scrollTo({ y: 20000 });
+        $(scrollableInstance.content()).trigger('scroll');
+
+        // assert
+        assert.ok($fixTable.position().top < 0, 'position top is defined');
+        assert.ok($table.find('.dx-virtual-row').eq(0).height() > 0, 'virtual row has height');
+        assert.roughEqual($fixTable.position().top, -scrollableInstance.scrollTop(), 1.01, 'fixed table - position top');
     });
 
     QUnit.test('Check that fixed column has virtual rows (T642937)', function(assert) {


### PR DESCRIPTION
See https://devexpress.com/issue=T1100701