### PR TITLE
ArrayStore: fix comparing with 'null' (T1102116)

### DIFF
--- a/js/data/array_query.js
+++ b/js/data/array_query.js
@@ -275,19 +275,24 @@ const compileCriteria = (function() {
 
         value = toComparable(value);
 
+        const compare = (obj, operatorFn) => {
+            obj = toComparable(getter(obj));
+            return [value, obj].includes(null) && value !== obj ? false : operatorFn(obj, value);
+        };
+
         switch(op.toLowerCase()) {
             case '=':
                 return compileEquals(getter, value);
             case '<>':
                 return compileEquals(getter, value, true);
             case '>':
-                return function(obj) { return toComparable(getter(obj)) > value; };
+                return (obj) => compare(obj, (a, b) => a > b);
             case '<':
-                return function(obj) { return toComparable(getter(obj)) < value; };
+                return (obj) => compare(obj, (a, b) => a < b);
             case '>=':
-                return function(obj) { return toComparable(getter(obj)) >= value; };
+                return (obj) => compare(obj, (a, b) => a >= b);
             case '<=':
-                return function(obj) { return toComparable(getter(obj)) <= value; };
+                return (obj) => compare(obj, (a, b) => a <= b);
             case 'startswith':
                 return function(obj) { return toComparable(toString(getter(obj))).indexOf(value) === 0; };
             case 'endswith':

--- a/testing/tests/DevExpress.data/queryArray.tests.js
+++ b/testing/tests/DevExpress.data/queryArray.tests.js
@@ -304,10 +304,10 @@ QUnit.test('group criterion with function', function(assert) {
 });
 
 QUnit.test('comparison operators', function(assert) {
-    assert.expect(6);
+    assert.expect(16);
 
     const done = assert.async();
-    const input = [{ f: 1 }, { f: 2 }];
+    const input = [{ f: 1 }, { f: 2 }, { f: null }];
 
     const check = function(crit, expectation) {
         return QUERY(input).filter(crit).enumerate().done(function(r) {
@@ -317,11 +317,21 @@ QUnit.test('comparison operators', function(assert) {
 
     $.when(
         check(['f', '=', 2], [{ f: 2 }]),
-        check(['f', '<>', 2], [{ f: 1 }]),
+        check(['f', '<>', 2], [{ f: 1 }, { f: null }]),
         check(['f', '>', 1], [{ f: 2 }]),
         check(['f', '>=', 2], [{ f: 2 }]),
         check(['f', '<', 2], [{ f: 1 }]),
-        check(['f', '<=', 1], [{ f: 1 }])
+        check(['f', '<=', 1], [{ f: 1 }]),
+        check(['f', '>', -1], [{ f: 1 }, { f: 2 }]),
+        check(['f', '>=', -2], [{ f: 1 }, { f: 2 }]),
+        check(['f', '<', -2], []),
+        check(['f', '<=', -1], []),
+        check(['f', '=', null], [{ f: null }]),
+        check(['f', '<>', null], [{ f: 1 }, { f: 2 }]),
+        check(['f', '>', null], []),
+        check(['f', '>=', null], [{ f: null }]),
+        check(['f', '<', null], []),
+        check(['f', '<=', null], [{ f: null }]),
     ).done(function() {
         done();
     });


### PR DESCRIPTION
DataGrid doesn't exclude records with 'null' Date when filtering by year 1969