### PR TITLE
Scheduler - Remove an extra CSS class from the header cell

### DIFF
--- a/js/renovation/ui/scheduler/workspaces/base/header_panel/date_header/__tests__/cell.test.tsx
+++ b/js/renovation/ui/scheduler/workspaces/base/header_panel/date_header/__tests__/cell.test.tsx
@@ -178,7 +178,6 @@ describe('DateHeaderCell', () => {
           expect(combineClasses)
             .toHaveBeenCalledWith({
               'dx-scheduler-header-panel-cell': true,
-              'dx-scheduler-cell-sizes-horizontal': true,
               'dx-scheduler-header-panel-current-time-cell': 'today',
               'dx-scheduler-header-panel-week-cell': 'isWeekDayCell',
               class: true,

--- a/js/renovation/ui/scheduler/workspaces/base/header_panel/date_header/cell.tsx
+++ b/js/renovation/ui/scheduler/workspaces/base/header_panel/date_header/cell.tsx
@@ -104,7 +104,6 @@ export class DateHeaderCell extends JSXComponent(DateHeaderCellProps) {
 
     const cellClasses = combineClasses({
       'dx-scheduler-header-panel-cell': true,
-      'dx-scheduler-cell-sizes-horizontal': true,
       'dx-scheduler-header-panel-current-time-cell': today,
       'dx-scheduler-header-panel-week-cell': isWeekDayCell,
       [className]: !!className,

--- a/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
+++ b/js/ui/scheduler/workspaces/ui.scheduler.work_space.js
@@ -2891,7 +2891,7 @@ class SchedulerWorkSpace extends WidgetObserver {
     }
 
     _getHeaderPanelCellClass(i) {
-        const cellClass = HEADER_PANEL_CELL_CLASS + ' ' + HORIZONTAL_SIZES_CLASS;
+        const cellClass = HEADER_PANEL_CELL_CLASS;
 
         return this._groupedStrategy.addAdditionalGroupCellClasses(
             cellClass, i + 1, undefined, undefined, this.isGroupedByDate(),

--- a/testing/tests/DevExpress.ui.widgets.scheduler/workSpace.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/workSpace.markup.tests.js
@@ -604,15 +604,6 @@ QUnit.module('Workspace Week markup', weekModuleConfig, () => {
         assert.ok($element.hasClass('dx-scheduler-work-space-week'), 'dxSchedulerWorkSpaceWeek has \'dx-scheduler-workspace-week\' css class');
     });
 
-    QUnit.test('Header cells should have a special css classes', function(assert) {
-        const $element = this.instance.$element();
-        const classes = $element.find('.dx-scheduler-header-panel th').attr('class').split(' ');
-
-        assert.ok($.inArray('dx-scheduler-header-panel-cell', classes) > -1, 'Cell has a css class');
-        assert.ok($.inArray(HORIZONTAL_SIZES_CLASS, classes) > -1, 'Cell has a css class');
-        assert.notOk($.inArray(VERTICAL_SIZES_CLASS, classes) > -1, 'Cell hasn\'t a css class');
-    });
-
     QUnit.test('Scheduler all day panel should contain one row & 7 cells', function(assert) {
         this.instance.option('showAllDayPanel', true);
 


### PR DESCRIPTION
Remove the 'dx-scheduler-cell-sizes-horizontal' CSS class from the header cell
