### PR TITLE
ValidationEngine: validator should be detected as a part of a validation group if they are created on the same element (T1102012)

### DIFF
--- a/js/ui/validation_engine.js
+++ b/js/ui/validation_engine.js
@@ -522,6 +522,12 @@ const ValidationEngine = {
     },
 
     findGroup($element, model) {
+        const hasValidationGroup = $element.data()?.dxComponents?.includes('dxValidationGroup');
+        const validationGroup = hasValidationGroup && $element.dxValidationGroup('instance');
+
+        if(validationGroup) {
+            return validationGroup;
+        }
         // try to find out if this control is child of validation group
         const $dxGroup = $element.parents('.dx-validationgroup').first();
 

--- a/testing/tests/DevExpress.ui.widgets.editors/validationGroup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationGroup.tests.js
@@ -57,6 +57,23 @@ QUnit.module('General', {
         assert.ok(validator.validate.calledOnce, 'Validator should be validated as part of group');
     });
 
+    QUnit.test('validator should work a part of a validation group if they are created on the same element (T1102012)', function(assert) {
+        const $groupContainer = $('#dxValidationGroup');
+        const group = this.fixture.createGroup($groupContainer);
+        const $validator = $groupContainer.dxValidator({
+            adapter: sinon.createStubInstance(DefaultAdapter)
+        });
+        const validator = $validator.dxValidator('instance');
+        validator.validate = sinon.spy(validator.validate);
+
+        // act
+        triggerShownEvent($groupContainer);
+        ValidationEngine.validateGroup(group);
+
+        // assert
+        assert.ok(validator.validate.calledOnce, 'Validator should be validated as part of group');
+    });
+
     QUnit.test('group should be validated positively (async)', function(assert) {
         const $container = $('#dxValidationGroup');
         const group = this.fixture.createGroup($container);

--- a/testing/tests/DevExpress.ui.widgets.editors/validationGroup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validationGroup.tests.js
@@ -57,7 +57,7 @@ QUnit.module('General', {
         assert.ok(validator.validate.calledOnce, 'Validator should be validated as part of group');
     });
 
-    QUnit.test('validator should work a part of a validation group if they are created on the same element (T1102012)', function(assert) {
+    QUnit.test('validator should be validated as a part of a validation group if they are created on the same element (T1102012)', function(assert) {
         const $groupContainer = $('#dxValidationGroup');
         const group = this.fixture.createGroup($groupContainer);
         const $validator = $groupContainer.dxValidator({


### PR DESCRIPTION
Validation does not work correctly when using validator|adapter in a certain scenario