### PR TITLE
Testcafe CI: Set reporter to 'minimal'.

### DIFF
--- a/testing/testcafe/runner.js
+++ b/testing/testcafe/runner.js
@@ -104,7 +104,7 @@ function getArgs() {
             browsers: 'chrome',
             test: '',
             meta: '',
-            reporter: process.env.CI === 'true' ? 'list' : 'minimal',
+            reporter: 'minimal',
             componentFolder: '',
             file: '*',
             cache: true,


### PR DESCRIPTION
Rollback Testcafe runner option.
