### PR TITLE
TransitionExecutor - fix: api requires jqury but it should not (T1101319)

### DIFF
--- a/js/animation/transition_executor/transition_executor.js
+++ b/js/animation/transition_executor/transition_executor.js
@@ -27,6 +27,7 @@ export const TransitionExecutor = Class.inherit({
     },
 
     _createAnimations: function($elements, initialConfig, configModifier, type) {
+        $elements = $($elements);
         const that = this;
         const result = [];
 

--- a/testing/tests/DevExpress.animation/transitionExecutors.tests.js
+++ b/testing/tests/DevExpress.animation/transitionExecutors.tests.js
@@ -133,6 +133,41 @@ QUnit.test('stop', function(assert) {
     assert.equal(resultDeferred.state(), 'resolved');
 });
 
+QUnit.test('works without jquery', function(assert) {
+    const animationStopLog = [];
+    const $toEnter = document.createElement('div');
+    const $toLeave = document.createElement('div');
+    const animationConfig = { duration: 555 };
+
+    fx.createAnimation = function(element, config) {
+        const fxAnimateDeferred = $.Deferred();
+        const result = new MockAnimation({
+            element: element,
+            config: config,
+            deferred: fxAnimateDeferred,
+            stop: function() {
+                animationStopLog.push(arguments);
+                fxAnimateDeferred.resolve();
+            }
+        });
+
+        return result;
+    };
+
+    const transitionExecutor = new TransitionExecutorModule.TransitionExecutor();
+
+    transitionExecutor.enter($toEnter, animationConfig);
+    transitionExecutor.leave($toLeave, animationConfig);
+    const resultDeferred = transitionExecutor.start();
+    assert.equal(animationStopLog.length, 0);
+    assert.equal(resultDeferred.state(), 'pending');
+
+    transitionExecutor.stop();
+
+    assert.equal(animationStopLog.length, 2);
+    assert.equal(resultDeferred.state(), 'resolved');
+});
+
 QUnit.test('enter/leave/start direction parameter', function(assert) {
     const createAnimationLog = [];
     const animationSetupLog = [];


### PR DESCRIPTION
…

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
