### PR TITLE
TileView: Fix `showScrollbar` doc comment

### DIFF
--- a/js/ui/tile_view.d.ts
+++ b/js/ui/tile_view.d.ts
@@ -113,6 +113,7 @@ export interface dxTileViewOptions<
     items?: Array<TItem>;
     /**
      * @docid
+     * @type Enums.ShowScrollbarMode
      * @default 'never'
      * @default 'onScroll' &for(Mac|Android|iOS)
      * @public


### PR DESCRIPTION
This will fix StrongMetaData Generator. Currently it fails:

```
System.Exception: Unknown enum: "dxTileView.showScrollbar". Suggested enums: ShowScrollbarMode
```

Please compare with the similar dxList option:
https://github.com/DevExpress/DevExtreme/blob/728e5979624f9f64792a302853b9078ce8e92ce4/js/ui/list.d.ts#L510-L516

I need updated StrongMetaData to fix https://devexpress.com/issue=T1102971