### PR TITLE
Restore tests related to android chrome 92

### DIFF
--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -172,10 +172,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
     });
 
     QUnit.test('Focused row should be visible in virtual scrolling mode', function(assert) {
-        if(devices.real().android) {
-            assert.ok(true, 'It\'s a bug under Android only');
-            return;
-        }
+
         // arrange
         const rowsViewWrapper = dataGridWrapper.rowsView;
         const data = [

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
@@ -6995,7 +6995,11 @@ QUnit.module('Scrollbar', {
         rowsView.resize();
 
         // assert
-        assert.strictEqual(getOuterHeight(rowsView.getScrollable().$content()), getOuterHeight($(rowsView.getScrollable().container())), 'No vertical scroll');
+        if(devices.real().android) {
+            assert.roughEqual(getOuterHeight(rowsView.getScrollable().$content()), getOuterHeight($(rowsView.getScrollable().container())), 0.9, 'Acceptable vertical scroll');
+        } else {
+            assert.strictEqual(getOuterHeight(rowsView.getScrollable().$content()), getOuterHeight($(rowsView.getScrollable().container())), 'No vertical scroll');
+        }
     });
 
     QUnit.test('getCell outside viewport should not return last visible row if rowRenderingMode is virtual (T1046754)', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
@@ -6981,10 +6981,7 @@ QUnit.module('Scrollbar', {
 
     // T697699
     QUnit.test('The vertical scrollbar should not be shown if showScrollbar is always', function(assert) {
-        if(devices.real().android) {
-            assert.ok(true, 'It\'s a bug under Android only');
-            return;
-        }
+
 
         // arrange
         const rows = [{ values: ['test1'], rowType: 'data' }];


### PR DESCRIPTION
These tests pass fine on an actual version of chrome (103) so there's no need to skip anymore