### PR TITLE
DataGrid - filtering lookup columns with calculateCellValue doesn't work (T1103389)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.filter_row.js
+++ b/js/ui/grid_core/ui.grid_core.filter_row.js
@@ -481,8 +481,9 @@ const ColumnHeadersViewFilterRowExtender = (function() {
             const editorController = this.getController('editorFactory');
             const dataSource = this.getController('data').dataSource();
             const filterRowController = this.getController('applyFilter');
+            const isDefaultCalculateCellValue = options.calculateCellValue === options.defaultCalculateCellValue;
 
-            if(options.lookup && !options.calculateCellValue && this.option('syncLookupFilterValues')) {
+            if(options.lookup && isDefaultCalculateCellValue && this.option('syncLookupFilterValues')) {
                 filterRowController.setCurrentColumnForFiltering(options);
                 const filter = this.getController('data').getCombinedFilter();
                 filterRowController.setCurrentColumnForFiltering(null);
@@ -694,7 +695,7 @@ const ColumnHeadersViewFilterRowExtender = (function() {
                     return;
                 }
 
-                if(column.calculateCellValue) {
+                if(column.calculateCellValue !== column.defaultCalculateCellValue) {
                     return;
                 }
 

--- a/js/ui/grid_core/ui.grid_core.filter_row.js
+++ b/js/ui/grid_core/ui.grid_core.filter_row.js
@@ -482,7 +482,7 @@ const ColumnHeadersViewFilterRowExtender = (function() {
             const dataSource = this.getController('data').dataSource();
             const filterRowController = this.getController('applyFilter');
 
-            if(options.lookup && this.option('syncLookupFilterValues')) {
+            if(options.lookup && !options.calculateCellValue && this.option('syncLookupFilterValues')) {
                 filterRowController.setCurrentColumnForFiltering(options);
                 const filter = this.getController('data').getCombinedFilter();
                 filterRowController.setCurrentColumnForFiltering(null);
@@ -691,6 +691,10 @@ const ColumnHeadersViewFilterRowExtender = (function() {
 
             columns.forEach((column, index) => {
                 if(!column.lookup) {
+                    return;
+                }
+
+                if(column.calculateCellValue) {
                     return;
                 }
 

--- a/js/ui/grid_core/ui.grid_core.filter_row.js
+++ b/js/ui/grid_core/ui.grid_core.filter_row.js
@@ -481,9 +481,8 @@ const ColumnHeadersViewFilterRowExtender = (function() {
             const editorController = this.getController('editorFactory');
             const dataSource = this.getController('data').dataSource();
             const filterRowController = this.getController('applyFilter');
-            const isDefaultCalculateCellValue = options.calculateCellValue === options.defaultCalculateCellValue;
 
-            if(options.lookup && isDefaultCalculateCellValue && this.option('syncLookupFilterValues')) {
+            if(options.lookup && this.option('syncLookupFilterValues')) {
                 filterRowController.setCurrentColumnForFiltering(options);
                 const filter = this.getController('data').getCombinedFilter();
                 filterRowController.setCurrentColumnForFiltering(null);

--- a/js/ui/grid_core/ui.grid_core.filter_row.js
+++ b/js/ui/grid_core/ui.grid_core.filter_row.js
@@ -690,11 +690,7 @@ const ColumnHeadersViewFilterRowExtender = (function() {
             }
 
             columns.forEach((column, index) => {
-                if(!column.lookup) {
-                    return;
-                }
-
-                if(column.calculateCellValue !== column.defaultCalculateCellValue) {
+                if(!column.lookup || column.calculateCellValue !== column.defaultCalculateCellValue) {
                     return;
                 }
 

--- a/js/ui/grid_core/ui.grid_core.utils.js
+++ b/js/ui/grid_core/ui.grid_core.utils.js
@@ -584,6 +584,10 @@ export default {
     getWrappedLookupDataSource(column, dataSource, filter) {
         const lookupDataSourceOptions = this.normalizeLookupDataSource(column.lookup);
 
+        if(column.calculateCellValue !== column.defaultCalculateCellValue) {
+            return lookupDataSourceOptions;
+        }
+
         const hasLookupOptimization = column.displayField && isString(column.displayField);
         const group = normalizeGroupingLoadOptions(
             hasLookupOptimization ? [column.dataField, column.displayField] : column.dataField

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
@@ -2431,6 +2431,43 @@ QUnit.module('Filter Row with real dataController and columnsController', {
         assert.strictEqual(dropDownList2.find('.dx-item:eq(1)').text(), 'value1');
     });
 
+    // T1103389
+    QUnit.test('Lookup select box should not show only relevant values for unbound columns', function(assert) {
+        // arrange
+        const $testElement = $('#container');
+
+        this.options.columns = [{
+            calculateCellValue() {
+                return 1;
+            },
+            allowFiltering: true,
+            lookup: {
+                dataSource: [{ id: 1, value: 'value1' }, { id: 2, value: 'value2' }],
+                valueExpr: 'id',
+                displayExpr: 'value'
+            }
+        }];
+        this.options.dataSource = [ { }, { } ];
+        this.options.syncLookupFilterValues = true;
+
+        setupDataGridModules(this, ['data', 'columns', 'columnHeaders', 'filterRow', 'editorFactory'], {
+            initViews: true
+        });
+        this.columnHeadersView.render($testElement);
+
+        // act
+        const dropDown1 = $('.dx-dropdowneditor-button:eq(0)');
+
+        dropDown1.trigger('dxclick');
+
+        // assert
+        const dropDownList1 = $('.dx-list:eq(0)');
+
+        assert.strictEqual(dropDownList1.find('.dx-item').length, 3);
+        assert.strictEqual(dropDownList1.find('.dx-item:eq(1)').text(), 'value1');
+        assert.strictEqual(dropDownList1.find('.dx-item:eq(2)').text(), 'value2');
+    });
+
     // T1099516
     QUnit.test('Lookup select box should have actual values after dataSource reload', function(assert) {
         // arrange


### PR DESCRIPTION
DataGrid can't send request to get relevant lookup values if column is unbound (when `calculateCellValue` is specified)

I turned off this functionality for this case