### PR TITLE
Fix bash -e behavior in docker-ci.sh

### DIFF
--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -47,7 +47,6 @@ function run_test_impl {
     [ "$NORENOVATION" == "true" ] && url="$url&norenovation=true"
 
     if [ -n "$TZ" ]; then
-        echo foo >> /etc/hosts
         ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
         echo "$TZ" > /etc/timezone
         date

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -46,9 +46,8 @@ function run_test_impl {
     [ -n "$PERF" ] && url="$url&include=DevExpress.performance&workerInWindow=true"
     [ "$NORENOVATION" == "true" ] && url="$url&norenovation=true"
 
-    echo foo >> /etc/hosts
-
     if [ -n "$TZ" ]; then
+        echo foo >> /etc/hosts
         ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
         echo "$TZ" > /etc/timezone
         date

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -46,6 +46,8 @@ function run_test_impl {
     [ -n "$PERF" ] && url="$url&include=DevExpress.performance&workerInWindow=true"
     [ "$NORENOVATION" == "true" ] && url="$url&norenovation=true"
 
+    echo foo >> /etc/hosts
+
     if [ -n "$TZ" ]; then
         ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
         echo "$TZ" > /etc/timezone

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -19,14 +19,14 @@ function run_ts {
 }
 
 function run_test {
-    iteration=0
+    local i
+    local status
 
-    while [ $iteration -ne 3 ]
-    do
-        iteration=$(($iteration+1))
-        if run_test_impl; then
-            exit 0
-        fi
+    for i in {1..3}; do
+        set +e
+        (set -e; run_test_impl); status=$?
+        set -e
+        [ $status == 0 ] && exit 0
     done
 
     exit 1

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -91,7 +91,7 @@ function run_test_impl {
     case "$BROWSER" in
 
         "firefox")
-            kill -9 $(ps -x | grep firefox | awk '{print $1}')
+            kill -9 $(ps -x | grep firefox | awk '{print $1}') || true
 
             local profile_path="/firefox-profile" 
             [ "$GITHUBACTION" == "true" ] && profile_path="/tmp/firefox-profile"


### PR DESCRIPTION
https://stackoverflow.com/q/4072984

Before fix:
```
./docker-ci.sh: line 49: /etc/hosts: Permission denied
QUnit runner server listens on http://0.0.0.0:20080...
```
Execution should be aborted after the 'Permission denied' error but it continues

After the fix:
```
./docker-ci.sh: line 49: /etc/hosts: Permission denied
./docker-ci.sh: line 49: /etc/hosts: Permission denied
./docker-ci.sh: line 49: /etc/hosts: Permission denied
Error: Process completed with exit code 1.
```