### PR TITLE
BaseWidget - fix: no repeat widget dispose() if it has been disposed (T1072778)

### DIFF
--- a/js/viz/core/base_widget.js
+++ b/js/viz/core/base_widget.js
@@ -432,6 +432,11 @@ const baseWidget = isServerSide ? getEmptyComponent() : DOMComponent.inherit({
 
     _dispose: function() {
         const that = this;
+
+        if(this._disposed) {
+            return;
+        }
+
         that.callBase.apply(that, arguments);
         that._toggleParentsScrollSubscription(false);
         that._removeResizeHandler();

--- a/testing/tests/DevExpress.viz.core/baseWidget.tests.js
+++ b/testing/tests/DevExpress.viz.core/baseWidget.tests.js
@@ -1563,3 +1563,17 @@ QUnit.test('Change disabled option if root has empty pointer-events attr', funct
 
     assert.deepEqual(this.renderer.root.attr.lastCall.args, [{ 'pointer-events': '', filter: null }]);
 });
+
+/* T1072778  (it refers to the test "Changing props in..." in devextreme-vue/.../component.test  )*/
+QUnit.test('Repeat disposing', function(assert) {
+    this.createWidget();
+    this.widget._dispose();
+
+    try {
+        this.widget._dispose();
+        assert.ok(true, 'the error is not thrown');
+    } catch(e) {
+        assert.ok(false, 'the error is thrown');
+    }
+
+});


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
