### PR TITLE
DataGrid: add types for methods missing from declaration, but present in docs 

### DIFF
--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -2420,17 +2420,29 @@ export interface ColumnBase<TRowData = any> {
      */
     allowSorting?: boolean;
     /**
+     * @docid GridBaseColumn.defaultCalculateCellValue
+     * @type_function_param1 rowData:object
+     * @public
+     */
+    defaultCalculateCellValue?: ((rowData: any) => any);
+    /**
      * @docid GridBaseColumn.calculateCellValue
      * @type_function_param1 rowData:object
      * @public
      */
-    calculateCellValue?: ((rowData: TRowData) => any);
+    calculateCellValue?: ((rowData: any) => any);
     /**
      * @docid GridBaseColumn.calculateDisplayValue
      * @type_function_param1 rowData:object
      * @public
      */
     calculateDisplayValue?: string | ((rowData: TRowData) => any);
+    /**
+     * @docid GridBaseColumn.defaultCalculateFilterExpression
+     * @type_function_return Filter expression
+     * @public
+     */
+    defaultCalculateFilterExpression?: ((filterValue: any, selectedFilterOperation: string, target: string) => string | Array<any> | Function);
     /**
      * @docid GridBaseColumn.calculateFilterExpression
      * @type_function_return Filter expression
@@ -2751,6 +2763,12 @@ export interface ColumnLookup {
    * @default undefined
    */
   valueExpr?: string;
+  /**
+   * @docid GridBaseColumn.defaultCalculateCellValue
+   * @type_function_param1 rowData:object
+   * @public
+   */
+  defaultCalculateCellValue?: ((rowData: any) => any);
   /**
    * @docid GridBaseColumn.lookup.calculateCellValue
    * @type_function_param1 rowData:object

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1552,6 +1552,10 @@ declare module DevExpress.common.grids {
      */
     valueExpr?: string;
     /**
+     * [descr:GridBaseColumn.defaultCalculateCellValue]
+     */
+    defaultCalculateCellValue?: (rowData: any) => any;
+    /**
      * [descr:GridBaseColumn.lookup.calculateCellValue]
      */
     calculateCellValue?: (rowData: any) => any;
@@ -6554,13 +6558,25 @@ declare module DevExpress.ui {
        */
       allowSorting?: boolean;
       /**
+       * [descr:GridBaseColumn.defaultCalculateCellValue]
+       */
+      defaultCalculateCellValue?: (rowData: any) => any;
+      /**
        * [descr:GridBaseColumn.calculateCellValue]
        */
-      calculateCellValue?: (rowData: TRowData) => any;
+      calculateCellValue?: (rowData: any) => any;
       /**
        * [descr:GridBaseColumn.calculateDisplayValue]
        */
       calculateDisplayValue?: string | ((rowData: TRowData) => any);
+      /**
+       * [descr:GridBaseColumn.defaultCalculateFilterExpression]
+       */
+      defaultCalculateFilterExpression?: (
+        filterValue: any,
+        selectedFilterOperation: string,
+        target: string
+      ) => string | Array<any> | Function;
       /**
        * [descr:GridBaseColumn.calculateFilterExpression]
        */


### PR DESCRIPTION
add types for defaultCalculateCellValue and defaultCalculateFilterExpression