### PR TITLE
DataGrid: add types for methods missing from declaration, but present in docs 

### DIFF
--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -2425,6 +2425,7 @@ export interface ColumnBase<TRowData = any> {
      * @public
      */
     calculateCellValue?: ((rowData: TRowData) => any);
+    defaultCalculateCellValue?: ColumnBase['calculateCellValue'];
     /**
      * @docid GridBaseColumn.calculateDisplayValue
      * @type_function_param1 rowData:object
@@ -2437,6 +2438,7 @@ export interface ColumnBase<TRowData = any> {
      * @public
      */
     calculateFilterExpression?: ((filterValue: any, selectedFilterOperation: string, target: string) => string | Array<any> | Function);
+    defaultCalculateFilterExpression?: ColumnBase['calculateFilterExpression'];
     /**
      * @docid GridBaseColumn.calculateSortValue
      * @type_function_param1 rowData:object

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -6557,6 +6557,7 @@ declare module DevExpress.ui {
        * [descr:GridBaseColumn.calculateCellValue]
        */
       calculateCellValue?: (rowData: TRowData) => any;
+      defaultCalculateCellValue?: ColumnBase['calculateCellValue'];
       /**
        * [descr:GridBaseColumn.calculateDisplayValue]
        */
@@ -6569,6 +6570,7 @@ declare module DevExpress.ui {
         selectedFilterOperation: string,
         target: string
       ) => string | Array<any> | Function;
+      defaultCalculateFilterExpression?: ColumnBase['calculateFilterExpression'];
       /**
        * [descr:GridBaseColumn.calculateSortValue]
        */


### PR DESCRIPTION
add types for defaultCalculateCellValue and defaultCalculateFilterExpression