### PR TITLE
DataGrid: add types for methods missing from declaration, but present in docs

### DIFF
--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -2323,6 +2323,12 @@ export interface ColumnBase<TRowData = any> {
      */
     allowSorting?: boolean;
     /**
+     * @docid GridBaseColumn.defaultCalculateCellValue
+     * @type_function_param1 rowData:object
+     * @public
+     */
+    defaultCalculateCellValue?: ((rowData: any) => any);
+    /**
      * @docid GridBaseColumn.calculateCellValue
      * @type_function_param1 rowData:object
      * @public
@@ -2334,6 +2340,12 @@ export interface ColumnBase<TRowData = any> {
      * @public
      */
     calculateDisplayValue?: string | ((rowData: TRowData) => any);
+    /**
+     * @docid GridBaseColumn.defaultCalculateFilterExpression
+     * @type_function_return Filter expression
+     * @public
+     */
+    defaultCalculateFilterExpression?: ((filterValue: any, selectedFilterOperation: string, target: string) => string | Array<any> | Function);
     /**
      * @docid GridBaseColumn.calculateFilterExpression
      * @type_function_return Filter expression
@@ -2634,6 +2646,12 @@ export interface ColumnLookup {
    * @default undefined
    */
   valueExpr?: string;
+  /**
+   * @docid GridBaseColumn.defaultCalculateCellValue
+   * @type_function_param1 rowData:object
+   * @public
+   */
+  defaultCalculateCellValue?: ((rowData: any) => any);
   /**
    * @docid GridBaseColumn.lookup.calculateCellValue
    * @type_function_param1 rowData:object

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -6487,6 +6487,10 @@ declare module DevExpress.ui {
        */
       allowSorting?: boolean;
       /**
+       * [descr:GridBaseColumn.defaultCalculateCellValue]
+       */
+      defaultCalculateCellValue?: (rowData: any) => any;
+      /**
        * [descr:GridBaseColumn.calculateCellValue]
        */
       calculateCellValue?: (rowData: TRowData) => any;
@@ -6494,6 +6498,14 @@ declare module DevExpress.ui {
        * [descr:GridBaseColumn.calculateDisplayValue]
        */
       calculateDisplayValue?: string | ((rowData: TRowData) => any);
+      /**
+       * [descr:GridBaseColumn.defaultCalculateFilterExpression]
+       */
+      defaultCalculateFilterExpression?: (
+        filterValue: any,
+        selectedFilterOperation: string,
+        target: string
+      ) => string | Array<any> | Function;
       /**
        * [descr:GridBaseColumn.calculateFilterExpression]
        */
@@ -6904,6 +6916,10 @@ declare module DevExpress.ui {
        * [descr:GridBaseColumn.lookup.valueExpr]
        */
       valueExpr?: string;
+      /**
+       * [descr:GridBaseColumn.defaultCalculateCellValue]
+       */
+      defaultCalculateCellValue?: (rowData: any) => any;
       /**
        * [descr:GridBaseColumn.lookup.calculateCellValue]
        */


### PR DESCRIPTION
add types for defaultCalculateCellValue and defaultCalculateFilterExpression
