### PR TITLE
Fix build & CI

### DIFF
--- a/build/gulp/styles/style-compiler.js
+++ b/build/gulp/styles/style-compiler.js
@@ -7,7 +7,6 @@ const replace = require('gulp-replace');
 const plumber = require('gulp-plumber');
 const sass = require('gulp-dart-sass');
 
-const fiber = require('fibers');
 const cleanCss = require('gulp-clean-css');
 const autoPrefix = require('gulp-autoprefixer');
 const parseArguments = require('minimist');
@@ -33,7 +32,6 @@ const compileBundles = (bundles) => {
         }))
         .on('data', (chunk) => console.log('Build: ', chunk.path))
         .pipe(sass({
-            fiber,
             functions
         }))
         .pipe(autoPrefix())

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rrule": "2.6.6",
     "showdown": "^1.9.1",
     "turndown": "~7.0.0",
-    "preact": "^10.4.5"
+    "preact": "10.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "eslint-plugin-react": "7.20.3",
     "eslint-plugin-spellcheck": "0.0.11",
     "exceljs": "3.3.1",
-    "fibers": "^5.0.0",
     "globalize": "^1.3.0",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^7.0.1",

--- a/testing/tests/Renovation/button.tests.js
+++ b/testing/tests/Renovation/button.tests.js
@@ -411,8 +411,10 @@ QUnit.module('keyboard navigation', moduleConfig, () => {
 
         const keyboard = keyboardMock(element);
 
-        element.trigger('focusin');
-        keyboard.keyDown('enter');
+        act(() => {
+            element.trigger('focusin');
+            keyboard.keyDown('enter');
+        });
 
         assert.ok(clickHandler.calledOnce, 'Handler should be called');
 


### PR DESCRIPTION
1. `fibers@5.0.2` requires Python and `node-gyp` during install. Decided to remove it because of its obsolescence (refer to https://github.com/laverdet/node-fibers#readme, https://github.com/sass/dart-sass/issues/986). It is an optional feature of https://github.com/alpakaio/gulp-dart-sass

2. `preact@10.10` [adds additional setTimeout](https://github.com/preactjs/preact/releases/tag/10.10.0). Me and @MikeVitik decided to pin `preact` version in this old branch.