### PR TITLE
DataGrid - fix SelectAll checkbox not updating on page change when allowSelectAll is page and repaintChangesOnly is true (T1106649)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.selection.js
+++ b/js/ui/grid_core/ui.grid_core.selection.js
@@ -660,7 +660,8 @@ export const selectionModule = {
                 },
                 _handleDataChanged: function(e) {
                     this.callBase(e);
-                    if(!e || e.changeType === 'refresh') {
+
+                    if(!e || e.changeType === 'refresh' || (e.repaintChangesOnly && e.changeType === 'update')) {
                         this._updateSelectAllValue();
                     }
                 },

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
@@ -431,6 +431,54 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.ok($selectAllElement.hasClass('dx-state-invisible'), 'select all is invisible');
     });
 
+    QUnit.test('SelectAll checkbox should have correct value on page change when allowSelectAll is page and repaintChangesOnly is true (T1106649)', function(assert) {
+        const array = [];
+        let i = 100;
+        while(i--) {
+            array.push({ id: i });
+        }
+        const dataGrid = createDataGrid({
+            dataSource: array,
+            keyExpr: 'id',
+            repaintChangesOnly: true,
+            selection: {
+                mode: 'multiple',
+                selectAllMode: 'page',
+                showCheckboxesMode: 'always',
+            },
+            paging: {
+                pageSize: 10,
+            },
+        });
+
+        this.clock.tick();
+        const $dataGridElement = $(dataGrid.element());
+        const $selectAllElement = $dataGridElement.find('.dx-datagrid-headers .dx-command-select .dx-select-checkbox');
+        const $checkboxElement = dataGrid.getCellElement(0, 0);
+
+        // act
+        $checkboxElement.click();
+        this.clock.tick();
+
+        // assert
+        assert.ok($selectAllElement.hasClass('dx-checkbox-indeterminate'));
+
+        // act
+        $dataGridElement.find('.dx-page').eq(1).click();
+        this.clock.tick();
+
+        // assert
+        assert.notOk($selectAllElement.hasClass('dx-checkbox-indeterminate'));
+
+        // act
+        $dataGridElement.find('.dx-page').eq(0).click();
+        this.clock.tick();
+
+        // assert
+        assert.ok($selectAllElement.hasClass('dx-checkbox-indeterminate'));
+    });
+
+
     QUnit.test('Disabled item should be selected when single mode is enabled (T1015840)', function(assert) {
         const dataGrid = createDataGrid({
             dataSource: [{ id: 1, disabled: false }, { id: 2, disabled: true }],

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
@@ -454,24 +454,24 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         this.clock.tick();
         const $dataGridElement = $(dataGrid.element());
         const $selectAllElement = $dataGridElement.find('.dx-datagrid-headers .dx-command-select .dx-select-checkbox');
-        const $checkboxElement = dataGrid.getCellElement(0, 0);
+        const $checkboxElement = $(dataGrid.getCellElement(0, 0));
 
         // act
-        $checkboxElement.click();
+        $checkboxElement.trigger('dxclick');
         this.clock.tick();
 
         // assert
         assert.ok($selectAllElement.hasClass('dx-checkbox-indeterminate'));
 
         // act
-        $dataGridElement.find('.dx-page').eq(1).click();
+        $dataGridElement.find('.dx-page').eq(1).trigger('dxclick');
         this.clock.tick();
 
         // assert
         assert.notOk($selectAllElement.hasClass('dx-checkbox-indeterminate'));
 
         // act
-        $dataGridElement.find('.dx-page').eq(0).click();
+        $dataGridElement.find('.dx-page').eq(0).trigger('dxclick');
         this.clock.tick();
 
         // assert


### PR DESCRIPTION
(cherry picked from commit b0f180038b9ec463cb03549f31ce99cfed8b503d)
