### PR TITLE
Use 'config:js-lib' base in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "extends": [
-        "config:base"
+        "config:js-lib"
     ],
     "prConcurrentLimit": 2,
     "semanticCommits": "enabled",


### PR DESCRIPTION
https://docs.renovatebot.com/presets-config/#configjs-lib

It is `config:base` + `:pinOnlyDevDependencies`

Explanation: https://docs.renovatebot.com/dependency-pinning/#so-whats-best

> 2. Browser or dual browser/node.js libraries that are consumed/`required()`'d by others should keep using SemVer ranges for `dependencies` but can use pinned dependencies for `devDependencies`