### PR TITLE
DataGrid - Common visibleIndex for banded columns (T1107108)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -432,11 +432,10 @@ export const columnsControllerModule = {
             };
 
             const updateColumnVisibleIndexes = function(that, currentColumn) {
-                let key;
                 let column;
-                const bandColumns = {};
                 const result = [];
                 const bandColumnsCache = that.getBandColumnsCache();
+                const bandedColumns = [];
                 const columns = that._columns.filter((column) => !column.command);
 
                 for(let i = 0; i < columns.length; i++) {
@@ -444,17 +443,13 @@ export const columnsControllerModule = {
                     const parentBandColumns = getParentBandColumns(i, bandColumnsCache.columnParentByIndex);
 
                     if(parentBandColumns.length) {
-                        const bandColumnIndex = parentBandColumns[parentBandColumns.length - 1].index;
-                        bandColumns[bandColumnIndex] = bandColumns[bandColumnIndex] || [];
-                        bandColumns[bandColumnIndex].push(column);
+                        bandedColumns.push(column);
                     } else {
                         result.push(column);
                     }
                 }
 
-                for(key in bandColumns) {
-                    normalizeIndexes(bandColumns[key], 'visibleIndex', currentColumn);
-                }
+                normalizeIndexes(bandedColumns, 'visibleIndex', currentColumn);
 
                 normalizeIndexes(result, 'visibleIndex', currentColumn);
             };

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.integration.tests.js
@@ -317,4 +317,51 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         assert.equal(column.dataField, 'lastName', 'dataField of column');
         assert.equal(columnIndex, 1, 'index of column');
     });
+
+    // T1107108
+    QUnit.test('Adaptive detail row should preserve item order in a banded layout', function(assert) {
+        // arrange
+        const items = [
+            { id: '1', value1: '1', value2: '2', value3: '3', value4: '4', value5: '5' },
+        ];
+        const dataGrid = $('#dataGrid').dxDataGrid({
+            dataSource: items,
+            columns: [
+                {
+                    caption: 'Band 1', columns: [
+                        { dataField: 'id' }
+                    ]
+                }, {
+                    caption: 'Band 2', columns: [
+                        { dataField: 'value1', hidingPriority: 5 },
+                        { dataField: 'value2', hidingPriority: 4 }
+                    ]
+                },
+                {
+                    caption: 'Band 3', columns: [
+                        { dataField: 'value3', hidingPriority: 3 },
+                        { dataField: 'value4', hidingPriority: 2 },
+                        { dataField: 'value5', hidingPriority: 1 }
+                    ]
+                }
+            ],
+            width: 200,
+            columnAutoWidth: true,
+            columnHidingEnabled: true,
+            masterDetail: null
+        });
+        // act
+        const instance = dataGrid.dxDataGrid('instance');
+
+        instance.expandAdaptiveDetailRow(items[0]);
+        this.clock.tick();
+
+        // assert
+        const detailRowItems = $(instance.element()).find('.dx-adaptive-item-text')
+            .map(function() { return this.innerHTML; })
+            .toArray()
+            .join('');
+        // assert
+        assert.equal(detailRowItems, '2345');
+    });
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -8246,16 +8246,16 @@ QUnit.module('Band columns', { beforeEach: setupModule, afterEach: teardownModul
         assert.equal(visibleColumns[1].visibleIndex, 1, 'visibleIndex of the second column');
 
         assert.strictEqual(visibleColumns[2].caption, 'TestField3', 'caption of the third column');
-        assert.equal(visibleColumns[2].visibleIndex, 0, 'visibleIndex of the third column');
+        assert.equal(visibleColumns[2].visibleIndex, 2, 'visibleIndex of the third column');
 
         assert.strictEqual(visibleColumns[3].caption, 'TestField4', 'caption of the fourth column');
-        assert.equal(visibleColumns[3].visibleIndex, 1, 'visibleIndex of the fourth column');
+        assert.equal(visibleColumns[3].visibleIndex, 3, 'visibleIndex of the fourth column');
 
         assert.strictEqual(visibleColumns[4].caption, 'TestField5', 'caption of the fifth column');
-        assert.equal(visibleColumns[4].visibleIndex, 0, 'visibleIndex of the fifth column');
+        assert.equal(visibleColumns[4].visibleIndex, 4, 'visibleIndex of the fifth column');
 
         assert.strictEqual(visibleColumns[5].caption, 'TestField6', 'caption of the sixth column');
-        assert.equal(visibleColumns[5].visibleIndex, 1, 'visibleIndex of the sixth column');
+        assert.equal(visibleColumns[5].visibleIndex, 5, 'visibleIndex of the sixth column');
     });
 
     QUnit.test('getVisibleIndex when there is band columns', function(assert) {


### PR DESCRIPTION
Using separate visibleIndex for every band of columns may result in columns from different bands having the same visible index, which leads to ordering errors for items in the adaptive detail row.