### PR TITLE
TagBox: mousedown on input wrapper should not be prevented on focusin (T1102475) (#22337)

### DIFF
--- a/js/ui/tag_box.js
+++ b/js/ui/tag_box.js
@@ -578,7 +578,7 @@ const TagBox = SelectBox.inherit({
 
         eventsEngine.off(this._inputWrapper(), eventName);
         eventsEngine.on(this._inputWrapper(), eventName, (e) => {
-            if(e.target !== this._input()[0]) {
+            if(e.target !== this._input()[0] && this._isFocused()) {
                 e.preventDefault();
             }
         });

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -5918,10 +5918,23 @@ QUnit.module('single line mode', {
             assert.ok(e.isDefaultPrevented(), 'mousedown was prevented and lead to focusout prevent');
         });
 
+        this.instance.focus();
         $inputWrapper.trigger('mousedown');
     });
 
     QUnit.test('mousedown should not be prevented when input field clicked (T1046705)', function(assert) {
+        const $inputWrapper = this.$element.find(`.${DROP_DOWN_EDITOR_INPUT_WRAPPER}`);
+        const $input = this.$element.find(`.${TEXTBOX_CLASS}`);
+
+        $inputWrapper.on('mousedown', e => {
+            assert.notOk(e.isDefaultPrevented(), 'mousedown was not prevented');
+        });
+
+        this.instance.focus();
+        $input.trigger('mousedown');
+    });
+
+    QUnit.test('mousedown should not be prevented on first focusin (T1102475)', function(assert) {
         const $inputWrapper = this.$element.find(`.${DROP_DOWN_EDITOR_INPUT_WRAPPER}`);
         const $input = this.$element.find(`.${TEXTBOX_CLASS}`);
 


### PR DESCRIPTION
… 

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
