### PR TITLE
DataGrid - A focused row is not visible if calculateSortValue that returns an object and customSortingMethod is used to sort key values (T1105332)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -707,9 +707,21 @@ export const focusModule = {
                                 }
                             } else {
                                 const filterOperation = sortInfo.desc ? '>' : '<';
-                                let sortFilter = [selector, filterOperation, value];
-                                if(!sortInfo.desc) {
-                                    sortFilter = [sortFilter, 'or', [selector, '=', null]];
+
+                                let sortFilter;
+                                if(sortInfo.compare) {
+                                    sortFilter = (data) => {
+                                        if(filterOperation === '<') {
+                                            return sortInfo.compare(value, getter(data)) >= 1;
+                                        } else {
+                                            return sortInfo.compare(value, getter(data)) <= -1;
+                                        }
+                                    };
+                                } else {
+                                    sortFilter = [selector, filterOperation, value];
+                                    if(!sortInfo.desc) {
+                                        sortFilter = [sortFilter, 'or', [selector, '=', null]];
+                                    }
                                 }
 
                                 filter = [sortFilter, 'or', filter];

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -256,6 +256,50 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
     });
 
+    QUnit.test('Test \'autoNavigateToFocusedRow\' option if focused row key is not visible and custom sortingMethod is used (T1105332)', function(assert) {
+        // arrange
+        const data = [
+            { name: 'Alex', phone: 1, room: 6 },
+            { name: 'Dan', phone: 2, room: 5 },
+            { name: 'Ben', phone: 3, room: 4 },
+            { name: 'Sean', phone: 4, room: 3 },
+            { name: 'Smith', phone: 5, room: 2 },
+            { name: 'Zeb', phone: 6, room: 1 }
+        ];
+        const dataGrid = $('#dataGrid').dxDataGrid({
+            height: 80,
+            dataSource: data,
+            columns: [
+                'name', {
+                    dataField: 'phone',
+                    calculateSortValue(data) {
+                        return { sort: data.phone };
+                    },
+                    sortOrder: 'desc',
+                    sortIndex: 0,
+                    sortingMethod: function(a, b) {
+                        return b.sort - a.sort;
+                    }
+                }, 'room'
+            ],
+            keyExpr: 'name',
+            autoNavigateToFocusedRow: true,
+            focusedRowEnabled: true,
+            focusedRowKey: 'Zeb',
+            paging: {
+                pageSize: 2
+            },
+        }).dxDataGrid('instance');
+
+        // act
+        this.clock.tick();
+
+        // assert
+        assert.equal(dataGrid.pageIndex(), 2, 'Page index changed');
+        assert.equal(dataGrid.option('focusedRowKey'), 'Zeb', 'focusedRowKey');
+        assert.equal(dataGrid.option('focusedRowIndex'), 1, 'focusedRowIndex');
+    });
+
     QUnit.test('Test \'autoNavigateToFocusedRow\' option if focused row key is visible', function(assert) {
         // arrange
         const data = [


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/22344