### PR TITLE
Fix 'Artifact name is not valid' in workflows

### DIFF
--- a/.github/workflows/qunit_tests-additional-renovation.yml
+++ b/.github/workflows/qunit_tests-additional-renovation.yml
@@ -106,6 +106,12 @@ jobs:
         ]
 
     steps:
+    - name: Setup MATRIX_ENVS_NAME_SAFE
+      run: |
+        MATRIX_ENVS_NAME_SAFE=$(echo -n "${{ matrix.envs.name }}" | sed 's|/|-|g')
+        echo "MATRIX_ENVS_NAME_SAFE=$MATRIX_ENVS_NAME_SAFE"
+        echo "MATRIX_ENVS_NAME_SAFE=$MATRIX_ENVS_NAME_SAFE" >> $GITHUB_ENV
+
     # Prepare fast re-run start
     - name: Set default run status
       run: echo "default" > last_run_status
@@ -210,7 +216,7 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
-        name: RawLog-${{ matrix.envs.name }}
+        name: RawLog-${{ env.MATRIX_ENVS_NAME_SAFE }}
         path: ${{ github.workspace }}/testing/RawLog.txt
         if-no-files-found: ignore
 


### PR DESCRIPTION
Error:

> Error: Artifact name is not valid: RawLog-ui.grid(2/2)-firefox. Contains the following character:  Forward slash /
>
>Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n, Backslash \, Forward slash /


Discussion: https://github.com/actions/upload-artifact/issues/22

Experimental run: https://github.com/DevExpress/DevExtreme/actions/runs/2840226856
(see Artifacts)