### PR TITLE
Scheduler: fixes allDayPanelMode='hidden' by initializing (#22365)

### DIFF
--- a/js/ui/scheduler/ui.scheduler.js
+++ b/js/ui/scheduler/ui.scheduler.js
@@ -926,6 +926,12 @@ class Scheduler extends Widget {
         return { paginate: false };
     }
 
+    _initAllDayPanel() {
+        if(this.option('allDayPanelMode') === 'hidden') {
+            this.option('showAllDayPanel', false);
+        }
+    }
+
     _init() {
         this._initExpressions({
             startDate: this.option('startDateExpr'),
@@ -941,6 +947,8 @@ class Scheduler extends Widget {
         });
 
         super._init();
+
+        this._initAllDayPanel();
 
         this._initDataSource();
 

--- a/testing/testcafe/model/scheduler/index.ts
+++ b/testing/testcafe/model/scheduler/index.ts
@@ -16,6 +16,8 @@ export const CLASS = {
   dateTable: 'dx-scheduler-date-table',
   dateTableCell: 'dx-scheduler-date-table-cell',
   allDayTableCell: 'dx-scheduler-all-day-table-cell',
+  allDayTitle: 'dx-scheduler-all-day-title',
+  allDayRow: 'dx-scheduler-all-day-table-row',
   focusedCell: 'dx-scheduler-focused-cell',
   selectedCell: 'dx-state-focused',
   droppableCell: 'dx-scheduler-date-table-droppable-cell',
@@ -45,6 +47,10 @@ export default class Scheduler extends Widget {
   readonly dateTableCells: Selector;
 
   readonly allDayTableCells: Selector;
+
+  readonly allDayRow: Selector;
+
+  readonly allDayTitle: Selector;
 
   readonly dateTableRows: Selector;
 
@@ -80,6 +86,8 @@ export default class Scheduler extends Widget {
     this.workSpace = this.element.find(`.${CLASS.workSpace}`);
     this.dateTableCells = this.element.find(`.${CLASS.dateTableCell}`);
     this.allDayTableCells = this.element.find(`.${CLASS.allDayTableCell}`);
+    this.allDayRow = this.element.find(`.${CLASS.allDayRow}`);
+    this.allDayTitle = this.element.find(`.${CLASS.allDayTitle}`);
     this.dateTable = this.element.find(`.${CLASS.dateTable}`);
     this.dateTableRows = this.element.find(`.${CLASS.dateTableRow}`);
     this.dateTableScrollable = this.element.find(`.${CLASS.dateTableScrollable}`);

--- a/testing/testcafe/tests/scheduler/workSpace.ts
+++ b/testing/testcafe/tests/scheduler/workSpace.ts
@@ -141,3 +141,29 @@ test('Hidden scheduler should not resize', async (t) => {
   currentDate: new Date(2021, 1, 1),
   height: 400,
 }));
+
+test('All day panel should be hidden when allDayPanelMode=hidden by initializing scheduler', async (t) => {
+  const scheduler = new Scheduler('#container');
+
+  await t
+    .expect(scheduler.allDayTitle.exists)
+    .eql(false);
+
+  await t
+    .expect(scheduler.allDayRow.exists)
+    .eql(false);
+}).before(async () => createWidget('dxScheduler', {
+  currentDate: new Date(2021, 2, 28),
+  currentView: 'day',
+  allDayPanelMode: 'hidden',
+  dataSource: [{
+    text: 'Book Flights to San Fran for Sales Trip',
+    startDate: new Date('2021-03-28T17:00:00.000Z'),
+    endDate: new Date('2021-03-28T18:00:00.000Z'),
+    allDay: true,
+  }, {
+    text: 'Customer Workshop',
+    startDate: new Date('2021-03-29T17:30:00.000Z'),
+    endDate: new Date('2021-04-03T19:00:00.000Z'),
+  }],
+}));


### PR DESCRIPTION
* fixed showing all day panel on hidden mode

Co-authored-by: artemiy.dmitrochenko <artemiy.dmitrochenko@devexpress.com>
(cherry picked from commit b348fd4e18545e6f79595ed06769d8849d15eacd)
