### PR TITLE
DataGrid - remove aria-selected attr if selection.mode is none (T1109408)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.selection.js
+++ b/js/ui/grid_core/ui.grid_core.selection.js
@@ -838,7 +838,11 @@ export const selectionModule = {
                         if(isSelected) {
                             $row.addClass(ROW_SELECTION_CLASS);
                         }
-                        this.setAria('selected', isSelected, $row);
+
+                        const selectionMode = this.option(SELECTION_MODE);
+                        if(selectionMode !== 'none') {
+                            this.setAria('selected', isSelected, $row);
+                        }
                     }
 
                     return $row;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
@@ -197,6 +197,23 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.equal($('#dataGrid').find('.dx-row.dx-selection').length, 2, 'isSelected rows');
     });
 
+    // T1109408
+    QUnit.test('Aria-selected should not present if selection.mode is none', function(assert) {
+        // arrange
+        $('#dataGrid').dxDataGrid({
+            loadingTimeout: null,
+            dataSource: [{
+                ID: 0
+            }],
+            keyExpr: 'ID',
+            columns: ['ID'],
+            showBorders: true,
+            selection: { mode: 'none' },
+        });
+        // assert
+        $('.dx-data-row').each((ind, item) => assert.notOk(item.hasAttribute('aria-selected')));
+    });
+
     // T489478
     QUnit.test('Console errors should not be occurs when stateStoring enabled with selectedRowKeys value', function(assert) {
         sinon.spy(errors, 'log');


### PR DESCRIPTION
(cherry picked from commit c0788799860d25f271693444719a7456ff21b172)
(cherry picked from commit c8d06eb4020a133184bb24b6aef05e45cf1bd5dc)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
