### PR TITLE
GitHub Actions - Add the ability to pin specific browser versions

### DIFF
--- a/.github/actions/pin-browsers/action.yml
+++ b/.github/actions/pin-browsers/action.yml
@@ -1,0 +1,34 @@
+name: "Pin Browsers"
+description: "Fill CHROME_VERSION,  FIREFOX_VERSION variables below to enable this action"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+
+      env:
+        # List of browser versions
+        # Chrome:  https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
+        # Firefox: https://www.ubuntuupdates.org/package/ubuntu_mozilla_security/focal/main/base/firefox
+        CHROME_VERSION:  ""
+        FIREFOX_VERSION: ""
+
+      run: |
+
+        if [ -n "$CHROME_VERSION" ]; then
+          curl -L "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb" > /tmp/chrome.deb
+          sudo dpkg -i /tmp/chrome.deb
+          unlink /tmp/chrome.deb
+          google-chrome-stable --version
+        else
+          echo "Skip Chrome upgrade"
+        fi
+
+        if [ -n "$FIREFOX_VERSION" ]; then
+          curl -L "http://ppa.launchpad.net/ubuntu-mozilla-security/ppa/ubuntu/pool/main/f/firefox/firefox_${FIREFOX_VERSION}_amd64.deb" > /tmp/firefox.deb
+          sudo dpkg -i /tmp/firefox.deb
+          unlink /tmp/firefox.deb
+          firefox --version
+        else
+          echo "Skip Firefox upgrade"
+        fi

--- a/.github/actions/pin-browsers/action.yml
+++ b/.github/actions/pin-browsers/action.yml
@@ -10,8 +10,8 @@ runs:
         # List of browser versions
         # Chrome:  https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
         # Firefox: https://www.ubuntuupdates.org/package/ubuntu_mozilla_security/focal/main/base/firefox
-        CHROME_VERSION:  "104.0.5112.101-1"
-        FIREFOX_VERSION: "104.0+build2-0ubuntu0.20.04.1"
+        CHROME_VERSION:  ""
+        FIREFOX_VERSION: ""
 
       run: |
 

--- a/.github/actions/pin-browsers/action.yml
+++ b/.github/actions/pin-browsers/action.yml
@@ -10,8 +10,8 @@ runs:
         # List of browser versions
         # Chrome:  https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
         # Firefox: https://www.ubuntuupdates.org/package/ubuntu_mozilla_security/focal/main/base/firefox
-        CHROME_VERSION:  ""
-        FIREFOX_VERSION: ""
+        CHROME_VERSION:  "104.0.5112.101-1"
+        FIREFOX_VERSION: "104.0+build2-0ubuntu0.20.04.1"
 
       run: |
 

--- a/.github/workflows/devextreme_npm_tests.yml
+++ b/.github/workflows/devextreme_npm_tests.yml
@@ -66,6 +66,8 @@ jobs:
     - name: Get sources
       uses: actions/checkout@v2
 
+    - uses: ./.github/actions/pin-browsers
+
     - name: Restore npm cache
       uses: actions/cache@v2
       with:
@@ -145,6 +147,8 @@ jobs:
 
     - name: Get sources
       uses: actions/checkout@v2
+
+    - uses: ./.github/actions/pin-browsers
 
     - name: Create directory link
       run: cd ../ && ln -s DevExtreme devextreme
@@ -281,6 +285,8 @@ jobs:
     steps:
     - name: Get sources
       uses: actions/checkout@v2
+
+    - uses: ./.github/actions/pin-browsers
 
     - name: Use Node.js
       uses: actions/setup-node@v2

--- a/.github/workflows/qunit_tests-additional-renovation.yml
+++ b/.github/workflows/qunit_tests-additional-renovation.yml
@@ -139,6 +139,8 @@ jobs:
     - name: Get sources
       uses: actions/checkout@v2
 
+    - uses: ./.github/actions/pin-browsers
+
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/qunit_tests-renovation.yml
+++ b/.github/workflows/qunit_tests-renovation.yml
@@ -71,6 +71,8 @@ jobs:
     - name: Get sources
       uses: actions/checkout@v2
 
+    - uses: ./.github/actions/pin-browsers
+
 #    - name: Update apt
 #      run: |
 #        sudo apt-get update

--- a/.github/workflows/qunit_tests.yml
+++ b/.github/workflows/qunit_tests.yml
@@ -66,6 +66,8 @@ jobs:
     - name: Get sources
       uses: actions/checkout@v2
 
+    - uses: ./.github/actions/pin-browsers
+
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/testcafe_tests.yml
+++ b/.github/workflows/testcafe_tests.yml
@@ -88,6 +88,8 @@ jobs:
     - name: Get sources
       uses: actions/checkout@v2
 
+    - uses: ./.github/actions/pin-browsers
+
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
This allows to run CI against newer browser versions in a PR.

Suggested flow:
- Enable browser upgrade in `.github/actions/pin-browsers/action.yml` via a PR
- Fix all issues and merge the PR
- [Upgrade browsers in our self-hosted runner image](https://github.com/DevExpress/devextreme-shr2/blob/main/docs/Image-Update.md) with confidence
- Disable browser upgrade in `.github/actions/pin-browsers/action.yml`

On the other hand, we can use the same approach to use old browser versions in old branches which we don't want to upgrade/fix.