### PR TITLE
Use Omit type instead of Skip

### DIFF
--- a/js/core/index.d.ts
+++ b/js/core/index.d.ts
@@ -23,9 +23,6 @@ export type DeepPartial<T> = T extends object ? {
   [P in keyof T]?: T[P] extends Function ? T[P] : DeepPartial<T[P]>;
 } : T;
 
-// Omit does not exist in TS < 3.5.1
-export type Skip<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
 type ItemType<T> = T extends (infer TItem)[] ? TItem : T;
 type Property<T, TPropName extends string> = T extends Partial<Record<TPropName, infer TValue>> ? TValue : never;
 type OwnPropertyType<T, TPropName extends string> = Property<ItemType<T>, TPropName>;

--- a/js/ui/context_menu/ui.menu_base.d.ts
+++ b/js/ui/context_menu/ui.menu_base.d.ts
@@ -1,4 +1,3 @@
-import { Skip } from '../../core';
 import { DataSourceLike } from '../../data/data_source';
 import {
     AnimationConfig,
@@ -22,7 +21,7 @@ export interface dxMenuBaseOptions<
   TComponent extends dxMenuBase<any, TItem, TKey>,
   TItem extends dxMenuBaseItem = dxMenuBaseItem,
   TKey = any,
-> extends Skip<HierarchicalCollectionWidgetOptions<TComponent, TItem, TKey>, 'dataSource'> {
+> extends Omit<HierarchicalCollectionWidgetOptions<TComponent, TItem, TKey>, 'dataSource'> {
     /**
      * @docid
      * @default true

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -15,7 +15,6 @@ import {
 
 import {
     DeepPartial,
-    Skip,
 } from '../core/index';
 
 import {
@@ -2679,7 +2678,7 @@ export interface ColumnButtonBase {
 }
 
 /** @public */
-export type Scrollable = Skip<dxScrollable, '_templateManager' | '_cancelOptionChange' | '_getTemplate' | '_invalidate' | '_refresh' | '_notifyOptionChanged' | '_createElement'>;
+export type Scrollable = Omit<dxScrollable, '_templateManager' | '_cancelOptionChange' | '_getTemplate' | '_invalidate' | '_refresh' | '_notifyOptionChanged' | '_createElement'>;
 
 /** @public */
 export type AdaptiveDetailRowPreparingEvent<TRowData = any, TKey = any> = EventInfo<dxDataGrid<TRowData, TKey>> & AdaptiveDetailRowPreparingInfo;

--- a/js/ui/gantt.d.ts
+++ b/js/ui/gantt.d.ts
@@ -36,7 +36,6 @@ import {
 import {
     DxPromise,
 } from '../core/utils/deferred';
-import { Skip } from '../core/index';
 
 import {
     FirstDayOfWeek,
@@ -1454,7 +1453,7 @@ export type Column<TRowData = any, TKey = any> = dxGanttColumn<TRowData, TKey>;
  * @namespace DevExpress.ui
  * @deprecated Use the Column type instead
  */
-export type dxGanttColumn<TRowData = any, TKey = any> = Skip<dxGanttColumnBlank<TRowData, TKey>, 'allowEditing' | 'allowFixing' | 'allowHiding' | 'allowReordering' | 'allowResizing' | 'allowSearch' | 'buttons' | 'columns' | 'editCellTemplate' | 'editorOptions' | 'fixed' | 'fixedPosition' | 'formItem' | 'hidingPriority' | 'isBand' | 'lookup' | 'name' | 'ownerBand' | 'renderAsync' | 'setCellValue' | 'showEditorAlways' | 'showInColumnChooser' | 'type' | 'validationRules' >;
+export type dxGanttColumn<TRowData = any, TKey = any> = Omit<dxGanttColumnBlank<TRowData, TKey>, 'allowEditing' | 'allowFixing' | 'allowHiding' | 'allowReordering' | 'allowResizing' | 'allowSearch' | 'buttons' | 'columns' | 'editCellTemplate' | 'editorOptions' | 'fixed' | 'fixedPosition' | 'formItem' | 'hidingPriority' | 'isBand' | 'lookup' | 'name' | 'ownerBand' | 'renderAsync' | 'setCellValue' | 'showEditorAlways' | 'showInColumnChooser' | 'type' | 'validationRules' >;
 
 /**
  * @docid dxGanttColumn

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -5,10 +5,6 @@ import {
 } from '../core/element';
 
 import {
-    Skip,
-} from '../core/index';
-
-import {
     template,
 } from '../core/templates/template';
 
@@ -128,7 +124,7 @@ export type TreeListCommandColumnType = 'adaptive' | 'buttons' | 'drag';
 export type TreeListFilterMode = 'fullBranch' | 'withAncestors' | 'matchOnly';
 
 /** @public */
-export type Scrollable = Skip<dxScrollable, '_templateManager' | '_cancelOptionChange' | '_getTemplate' | '_invalidate' | '_refresh' | '_notifyOptionChanged' | '_createElement'>;
+export type Scrollable = Omit<dxScrollable, '_templateManager' | '_cancelOptionChange' | '_getTemplate' | '_invalidate' | '_refresh' | '_notifyOptionChanged' | '_createElement'>;
 
 /** @public */
 export type AdaptiveDetailRowPreparingEvent<TRowData = any, TKey = any> = EventInfo<dxTreeList<TRowData, TKey>> & AdaptiveDetailRowPreparingInfo;

--- a/js/ui/tree_view.d.ts
+++ b/js/ui/tree_view.d.ts
@@ -1,4 +1,3 @@
-import { Skip } from '../core';
 import { DataSourceLike } from '../data/data_source';
 import {
     DxElement,
@@ -100,7 +99,7 @@ export type SelectionChangedEvent<TKey = any> = EventInfo<dxTreeView<TKey>>;
  * @public
  */
 export interface dxTreeViewOptions<TKey = any>
-    extends Skip<HierarchicalCollectionWidgetOptions<dxTreeView<TKey>, dxTreeViewItem, TKey>, 'dataSource'>, SearchBoxMixinOptions {
+    extends Omit<HierarchicalCollectionWidgetOptions<dxTreeView<TKey>, dxTreeViewItem, TKey>, 'dataSource'>, SearchBoxMixinOptions {
     /**
      * @docid
      * @default true
@@ -612,7 +611,7 @@ export interface dxTreeViewNode<TKey = any> {
 }
 
 /** @public */
-export type Scrollable = Skip<dxScrollable, '_templateManager' | '_cancelOptionChange' | '_getTemplate' | '_invalidate' | '_refresh' | '_notifyOptionChanged' | '_createElement'>;
+export type Scrollable = Omit<dxScrollable, '_templateManager' | '_cancelOptionChange' | '_getTemplate' | '_invalidate' | '_refresh' | '_notifyOptionChanged' | '_createElement'>;
 
 /** @public */
 export type ExplicitTypes<TKey = any> = {

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -1757,11 +1757,6 @@ declare module DevExpress.core {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
   interface PromiseType<T> extends JQueryPromise<T> {}
-
-  /**
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
-   */
-  export type Skip<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
   /**
    * [descr:template]
    */
@@ -8460,7 +8455,7 @@ declare module DevExpress.ui {
       promise?: PromiseLike<void>;
       cancel: boolean;
     }
-    export type Scrollable = DevExpress.core.Skip<
+    export type Scrollable = Omit<
       dxScrollable,
       | '_templateManager'
       | '_cancelOptionChange'
@@ -13924,7 +13919,7 @@ declare module DevExpress.ui {
    * @deprecated Use the Column type instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please describe your scenario in the following GitHub Issue, and we will suggest a public alternative: {@link https://github.com/DevExpress/DevExtreme/issues/17885|Internal Types}.
    */
-  export type dxGanttColumn<TRowData = any, TKey = any> = DevExpress.core.Skip<
+  export type dxGanttColumn<TRowData = any, TKey = any> = Omit<
     dxGanttColumnBlank<TRowData, TKey>,
     | 'allowEditing'
     | 'allowFixing'
@@ -16445,7 +16440,7 @@ declare module DevExpress.ui {
     TComponent extends dxMenuBase<any, TItem, TKey>,
     TItem extends dxMenuBaseItem = dxMenuBaseItem,
     TKey = any
-  > extends DevExpress.core.Skip<
+  > extends Omit<
       HierarchicalCollectionWidgetOptions<TComponent, TItem, TKey>,
       'dataSource'
     > {
@@ -22757,7 +22752,7 @@ declare module DevExpress.ui {
       TKey = any
     > = DevExpress.events.EventInfo<dxTreeList<TRowData, TKey>> &
       DevExpress.ui.dxDataGrid.SavingInfo<TRowData, TKey>;
-    export type Scrollable = DevExpress.core.Skip<
+    export type Scrollable = Omit<
       dxScrollable,
       | '_templateManager'
       | '_cancelOptionChange'
@@ -23324,7 +23319,7 @@ declare module DevExpress.ui {
     > &
       DevExpress.events.ChangedOptionInfo;
     export type Properties<TKey = any> = dxTreeViewOptions<TKey>;
-    export type Scrollable = DevExpress.core.Skip<
+    export type Scrollable = Omit<
       dxScrollable,
       | '_templateManager'
       | '_cancelOptionChange'
@@ -23423,7 +23418,7 @@ declare module DevExpress.ui {
    * @deprecated use Properties instead
    */
   export interface dxTreeViewOptions<TKey = any>
-    extends DevExpress.core.Skip<
+    extends Omit<
         HierarchicalCollectionWidgetOptions<
           dxTreeView<TKey>,
           dxTreeViewItem,


### PR DESCRIPTION
We have to use `Skip` because `Omit` was not available in TypeScript 3.1