### PR TITLE
DataGrid - persist focusedRowKey when triggering selection on a same row T1105369

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -961,6 +961,7 @@ const KeyboardNavigationController = core.ViewController.inherit({
                 this._isNeedFocus = false;
                 this._isHiddenFocus = false;
             } else {
+                $cell = this._getFocusedCell();
                 const $target = event && $(event.target).closest(NON_FOCUSABLE_ELEMENTS_SELECTOR + ', td');
                 const skipFocusEvent = $target && $target.not($cell).is(NON_FOCUSABLE_ELEMENTS_SELECTOR);
                 const isEditor = !!column && !column.command && $cell.hasClass(EDITOR_CELL_CLASS);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
@@ -643,6 +643,41 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         // assert
         assert.deepEqual(selectedRowKeys, [1, 2], 'both rows are selected');
     });
+
+    QUnit.test('Selection should persist when triggering selection on an already selected row (T1105369)', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            dataSource: [{
+                'id': 1,
+            }, {
+                'id': 2,
+            }],
+            keyExpr: 'id',
+            focusedRowEnabled: true,
+            onFocusedRowChanged: (e) => {
+                if(e.row) {
+                    e.component.selectRows([e.row.key], false);
+                }
+            },
+            selection: {
+                mode: 'multiple',
+                showCheckBoxesMode: 'always'
+            },
+        });
+        this.clock.tick();
+
+        const $checkBox = $(dataGrid.getRowElement(0)).find('.dx-checkbox');
+        // act
+        $checkBox.trigger('dxclick');
+        this.clock.tick();
+        $checkBox.trigger('dxpointerdown');
+        this.clock.tick();
+
+        // assert
+        assert.deepEqual(dataGrid.getSelectedRowKeys(), [1], 'row is selected');
+        assert.ok(dataGrid.isRowFocused(1), 'row is focused');
+    });
+
 });
 
 QUnit.module('Virtual row rendering', baseModuleConfig, () => {


### PR DESCRIPTION
cherrypicked from https://github.com/DevExpress/DevExtreme/pull/22459