### PR TITLE
DataGrid: Fix the 'Cannot read properties of undefined (reading 'length')' error occurs if a cell value does not match a specified mask rule (T1116105)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1583,6 +1583,8 @@ const KeyboardNavigationController = core.ViewController.inherit({
         const keyPressEvent = createEvent(eventArgs, { type: 'keypress', target: $input.get(0) });
         const inputEvent = createEvent(eventArgs, { type: 'input', target: $input.get(0) });
 
+        inputEvent.originalEvent = createEvent(inputEvent.originalEvent, { data: editorValue }); // T1116105
+
         $input.get(0).select?.();
         eventsEngine.trigger($input, keyDownEvent);
 

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -1583,7 +1583,9 @@ const KeyboardNavigationController = core.ViewController.inherit({
         const keyPressEvent = createEvent(eventArgs, { type: 'keypress', target: $input.get(0) });
         const inputEvent = createEvent(eventArgs, { type: 'input', target: $input.get(0) });
 
-        inputEvent.originalEvent = createEvent(inputEvent.originalEvent, { data: editorValue }); // T1116105
+        if(inputEvent.originalEvent) {
+            inputEvent.originalEvent = createEvent(inputEvent.originalEvent, { data: editorValue }); // T1116105
+        }
 
         $input.get(0).select?.();
         eventsEngine.trigger($input, keyDownEvent);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
@@ -2902,5 +2902,43 @@ QUnit.module('Customize keyboard navigation', {
             const $input = $('.dx-row .dx-texteditor-input').eq(0);
             assert.equal($input.val(), '5', 'input value');
         });
+
+        // T1116105
+        testInDesktop(`${mode} - input value should not throw an exception for a column with a given mask when editOnKeyPress is enabled and startEditAction='dblClick'`, function(assert) {
+            // arrange
+            this.options = {
+                editing: {
+                    mode: 'cell',
+                    allowUpdating: true,
+                    startEditAction: 'dblClick'
+                },
+                keyboardNavigation: {
+                    editOnKeyPress: true
+                }
+            };
+
+            this.data = [{ name: 'Alex', room: 5 }];
+
+            this.columns = [{
+                dataField: 'name',
+                editorOptions: {
+                    mask: '#'
+                }
+            }, 'room'],
+
+            this.setupModule();
+            this.renderGridView();
+
+            // act
+            this.focusCell(0, 0);
+            this.clock.tick();
+            $(this.getCellElement(0, 0)).trigger($.Event('keydown', { key: 'b' }));
+            $(this.getCellElement(0, 0)).find('.dx-texteditor-input').first().trigger($.Event('beforeinput'));
+            this.clock.tick(300);
+
+            // assert
+            const $input = $('.dx-row .dx-texteditor-input').eq(0);
+            assert.equal($input.val(), '_', 'input value');
+        });
     });
 });


### PR DESCRIPTION
See https://devexpress.com/issue=T1116105