### PR TITLE
Datagrid - HighlightDataCell should not trigger on initialization for non-editable cells with cellTemplate (T1109778)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -2147,18 +2147,7 @@ const EditingController = modules.ViewController.inherit((function() {
             return buttonItems;
         },
 
-        highlightDataCell: function($cell, parameters) {
-            const cellModified = this.isCellModified(parameters);
-            const shouldHighlight =
-                cellModified &&
-                parameters.column.setCellValue &&
-                (
-                    this.getEditMode() !== EDIT_MODE_ROW ||
-                    !parameters.row.isEditing
-                );
-
-            shouldHighlight && $cell.addClass(CELL_MODIFIED);
-        },
+        highlightDataCell: function($cell, params) { this.shouldHighlightCell(params) && $cell.addClass(CELL_MODIFIED); },
 
         _afterInsertRow: noop,
 
@@ -2204,6 +2193,17 @@ const EditingController = modules.ViewController.inherit((function() {
             const rows = this._dataController.items();
 
             return visibleEditRowIndex >= 0 ? rows[visibleEditRowIndex].isNewRow : false;
+        },
+
+        shouldHighlightCell: function(parameters) {
+            const cellModified = this.isCellModified(parameters);
+            return cellModified &&
+                parameters.column.setCellValue &&
+                (
+                    this.getEditMode() !== EDIT_MODE_ROW ||
+                    !parameters.row.isEditing
+                );
+
         }
     };
 })());
@@ -2494,10 +2494,11 @@ export const editingModule = {
                         this._editCellPrepared($cell);
                     }
 
-                    if(parameters.column && !isCommandCell) {
+                    const hasTemplate = !!parameters.column?.cellTemplate;
+
+                    if(parameters.column && !isCommandCell && (!hasTemplate || editingController.shouldHighlightCell(parameters))) {
                         editingController.highlightDataCell($cell, parameters);
                     }
-
                     this.callBase.apply(this, arguments);
                 },
                 _editCellPrepared: noop,

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -2808,6 +2808,25 @@ QUnit.module('Editing', {
         assert.strictEqual(value, 1, 'value === 1');
         assert.notOk(this.editingController._deferreds.length, 'deferreds should be empty');
     });
+
+
+    QUnit.test('HighlightDataCell should not trigger for non editable templates (T1109778)', function(assert) {
+        this.columns.length = 0;
+        this.columns.push({
+            cellTemplate: function(container, options) {
+                $('<div>').appendTo(container).dxTextBox({
+                    readOnly: true,
+                    editable: false,
+                    value: options.value
+                });
+            }
+        });
+        const spy = sinon.spy(this.editingController, 'highlightDataCell');
+
+        this.rowsView.render(this.gridContainer);
+
+        assert.notOk(spy.called);
+    });
 });
 
 QUnit.module('Editing with real dataController', {


### PR DESCRIPTION
cherrypicked from https://github.com/DevExpress/DevExtreme/pull/22532