### PR TITLE
DataGrid - editCellTemplate sets the "title" attribute of <i> elements to an empty string in certain usage scenarios in FireFox (T1117557)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_view.js
+++ b/js/ui/grid_core/ui.grid_core.columns_view.js
@@ -245,26 +245,35 @@ export const ColumnsView = modules.View.inherit(columnStateMixin).inherit({
                 const $element = $(e.target);
                 const $cell = $(e.currentTarget);
                 const $row = $cell.parent();
-                const isDataRow = $row.hasClass('dx-data-row');
-                const isHeaderRow = $row.hasClass('dx-header-row');
-                const isGroupRow = $row.hasClass(GROUP_ROW_CLASS);
-                const isMasterDetailRow = $row.hasClass(DETAIL_ROW_CLASS);
-                const isFilterRow = $row.hasClass(that.addWidgetPrefix(FILTER_ROW_CLASS));
                 const visibleColumns = that._columnsController.getVisibleColumns();
                 const rowOptions = $row.data('options');
                 const columnIndex = $cell.index();
                 const cellOptions = rowOptions && rowOptions.cells && rowOptions.cells[columnIndex];
                 const column = cellOptions ? cellOptions.column : visibleColumns[columnIndex];
 
-                if(!isMasterDetailRow && !isFilterRow && (!isDataRow || (isDataRow && column && !column.cellTemplate)) &&
-                    (!isHeaderRow || (isHeaderRow && column && !column.headerCellTemplate)) &&
-                    (!isGroupRow || (isGroupRow && column && (column.groupIndex === undefined || !column.groupCellTemplate)))) {
+                const isHeaderRow = $row.hasClass('dx-header-row');
+                const isDataRow = $row.hasClass('dx-data-row');
+                const isMasterDetailRow = $row.hasClass(DETAIL_ROW_CLASS);
+                const isGroupRow = $row.hasClass(GROUP_ROW_CLASS);
+                const isFilterRow = $row.hasClass(that.addWidgetPrefix(FILTER_ROW_CLASS));
+
+                const isDataRowWithTemplate = isDataRow && (!column || column.cellTemplate);
+                const isHeaderRowWithTemplate = isHeaderRow && (!column || column.headerCellTemplate);
+                const isGroupCellWithTemplate = isGroupRow && (!column || (column.groupIndex && column.groupCellTemplate));
+
+                const shouldShowHint = !isMasterDetailRow
+                                    && !isFilterRow
+                                    && !isDataRowWithTemplate
+                                    && !isHeaderRowWithTemplate
+                                    && !isGroupCellWithTemplate;
+
+                if(shouldShowHint) {
                     if($element.data(CELL_HINT_VISIBLE)) {
                         $element.removeAttr('title');
                         $element.data(CELL_HINT_VISIBLE, false);
                     }
 
-                    const difference = $element[0].scrollWidth - $element[0].clientWidth; // T598499
+                    const difference = $element[0].scrollWidth - $element[0].clientWidth;
                     if(difference > 0 && !isDefined($element.attr('title'))) {
                         $element.attr('title', $element.text());
                         $element.data(CELL_HINT_VISIBLE, true);

--- a/js/ui/grid_core/ui.grid_core.columns_view.js
+++ b/js/ui/grid_core/ui.grid_core.columns_view.js
@@ -258,11 +258,13 @@ export const ColumnsView = modules.View.inherit(columnStateMixin).inherit({
                 const isFilterRow = $row.hasClass(that.addWidgetPrefix(FILTER_ROW_CLASS));
 
                 const isDataRowWithTemplate = isDataRow && (!column || column.cellTemplate);
+                const isEditorShown = isDataRow && cellOptions && (rowOptions.isEditing || cellOptions.isEditing || column?.showEditorAlways);
                 const isHeaderRowWithTemplate = isHeaderRow && (!column || column.headerCellTemplate);
                 const isGroupCellWithTemplate = isGroupRow && (!column || (column.groupIndex && column.groupCellTemplate));
 
                 const shouldShowHint = !isMasterDetailRow
                                     && !isFilterRow
+                                    && !isEditorShown
                                     && !isDataRowWithTemplate
                                     && !isHeaderRowWithTemplate
                                     && !isGroupCellWithTemplate;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsView.tests.js
@@ -398,6 +398,28 @@ QUnit.module('API methods', {
         assert.strictEqual(lastCellElement.attr('title'), undefined, 'not has attribute title in last cell');
     });
 
+    // T1117557
+    QUnit.test('Not set title attribute when cell is editing', function(assert) {
+        // arrange
+        const that = this;
+        const $container = $('#container').width(200);
+
+        that.option('cellHintEnabled', true);
+
+        that.columns.length = 0;
+        that.columns.push({ caption: 'Column 2', width: 100, showEditorAlways: true });
+
+        const $table = $(that.columnsView._createTable());
+        $container.html($('<div class = \'dx-datagrid-headers dx-datagrid-nowrap\' />').append($table.append(that.columnsView._createColGroup(that.columns), $('<tr class = "dx-row"><td><div class="dx-datagrid-text-content">Test Test Test Test Test</div></td></tr>'))));
+
+        // act
+        const firstCellElement = $table.find('td').first();
+        firstCellElement.trigger('mousemove');
+
+        // assert
+        assert.strictEqual(firstCellElement.attr('title'), undefined, 'not has attribute title in cell');
+    });
+
     QUnit.test('Invalidate instead of render for options', function(assert) {
         // arrange
         let renderCounter = 0;


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/22774