### PR TITLE
T1117147 - Knockout - Checkbox stops working after moving from 20.2.7 to 22.1.5

### DIFF
--- a/js/renovation/component_wrapper/common/__tests__/component.test.tsx
+++ b/js/renovation/component_wrapper/common/__tests__/component.test.tsx
@@ -1,6 +1,8 @@
 /**
  * @jest-environment jsdom
  */
+// import ko from 'knockout';
+import variableWrapper from '../../../../core/utils/variable_wrapper';
 // eslint-disable-next-line import/named
 import renderer, { dxElementWrapper } from '../../../../core/renderer';
 import './utils/test_components/empty';
@@ -449,6 +451,10 @@ describe('Widget\'s container manipulations', () => {
 });
 
 describe('option', () => {
+  afterEach(() => {
+    variableWrapper.resetInjection();
+  });
+
   it('should return default props of component', () => {
     $('#component').dxOptionsTestWidget({});
 
@@ -675,6 +681,20 @@ describe('option', () => {
 
     expect($component.dxTestWidget('getLastPassedProps')).toMatchObject(options);
   });
+
+  it('unwrap knockout observable props (T1117147)', () => {
+    function koObservableFake() { return 'value'; }
+    variableWrapper.inject({
+      unwrap: (v) => (v === koObservableFake ? v() : v),
+    });
+    const options = {
+      text: koObservableFake,
+    };
+    $('#component').dxOptionsTestWidget(options);
+    expect($('#component').dxOptionsTestWidget('getLastPassedProps')).toMatchObject({
+      text: 'value',
+    });
+  });
 });
 
 describe('templates and slots', () => {
@@ -734,7 +754,7 @@ describe('templates and slots', () => {
   it('should unsubscribe from all events for nested jquery components when disposing parent component', () => {
     $('#component').dxTemplatedTestWidget({
       template(_: never, element: Element) {
-        one(element, 'dxFakeEvent', () => {});
+        one(element, 'dxFakeEvent', () => { });
         $(element).html('<span>Template content</span>');
       },
     });

--- a/js/renovation/component_wrapper/common/component.ts
+++ b/js/renovation/component_wrapper/common/component.ts
@@ -13,7 +13,9 @@ import DOMComponent from '../../../core/dom_component';
 import { extend } from '../../../core/utils/extend';
 import { getPublicElement } from '../../../core/element';
 import type { UserDefinedElement } from '../../../core/element';
-import { isDefined, isRenderer, isString } from '../../../core/utils/type';
+import {
+  isDefined, isRenderer, isString,
+} from '../../../core/utils/type';
 import { TemplateModel, TemplateWrapper } from './template_wrapper';
 import { updatePropsImmutable } from '../utils/update_props_immutable';
 import type { Option, TemplateComponent } from './types';
@@ -157,11 +159,23 @@ export default class ComponentWrapper extends DOMComponent<ComponentWrapperProps
     ) as Record<string, unknown>;
   }
 
+  _getUnwrappedOption(): Record<string, unknown> {
+    const unwrappedProps = {};
+    Object
+      .keys(this.option())
+      .forEach((key) => {
+        unwrappedProps[key] = this.option(key);
+      });
+    return unwrappedProps;
+  }
+
   _initializeComponent(): void {
     super._initializeComponent();
 
     this._templateManager?.addDefaultTemplates(this.getDefaultTemplates());
-    this._props = this._optionsWithDefaultTemplates(this.option());
+    const optionProxy = this._getUnwrappedOption();
+
+    this._props = this._optionsWithDefaultTemplates(optionProxy);
     this._propsInfo.templates.forEach((template) => {
       this._componentTemplates[template] = this._createTemplateComponent(this._props[template]);
     });
@@ -219,7 +233,7 @@ export default class ComponentWrapper extends DOMComponent<ComponentWrapperProps
       const { attributes } = element;
       const attrs = Array.from<{ name: string; value: unknown }>(attributes)
         .filter((attr) => !this._propsInfo.templates.includes(attr.name)
-      && attributes[attr.name]?.specified)
+          && attributes[attr.name]?.specified)
         .reduce((result, { name, value }) => {
           const updatedAttributes = result;
           const isDomAttr = name in element;


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
