### PR TITLE
DataGrid doesn't clear text in the Filter Row after resetting state if applyFilter is "onClick" (T1118077)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -25,7 +25,7 @@ import { equalByValue } from '../../core/utils/common';
 import filterUtils from '../shared/filtering';
 
 const USER_STATE_FIELD_NAMES_15_1 = ['filterValues', 'filterType', 'fixed', 'fixedPosition'];
-const USER_STATE_FIELD_NAMES = ['visibleIndex', 'dataField', 'name', 'dataType', 'width', 'visible', 'sortOrder', 'lastSortOrder', 'sortIndex', 'groupIndex', 'filterValue', 'selectedFilterOperation', 'added'].concat(USER_STATE_FIELD_NAMES_15_1);
+const USER_STATE_FIELD_NAMES = ['visibleIndex', 'dataField', 'name', 'dataType', 'width', 'visible', 'sortOrder', 'lastSortOrder', 'sortIndex', 'groupIndex', 'filterValue', 'bufferedFilterValue', 'selectedFilterOperation', 'bufferedSelectedFilterOperation', 'added'].concat(USER_STATE_FIELD_NAMES_15_1);
 const IGNORE_COLUMN_OPTION_NAMES = { visibleWidth: true, bestFitWidth: true, bufferedFilterValue: true };
 const COMMAND_EXPAND_CLASS = 'dx-command-expand';
 const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || 9007199254740991/* IE11 */;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.integration.tests.js
@@ -506,4 +506,26 @@ QUnit.module('State storing', baseModuleConfig, () => {
         assert.strictEqual(columns[1].index, 1, 'second column index');
         assert.strictEqual(columns[2].index, 2, 'third column index');
     });
+
+    // T1118077
+    QUnit.test('Filter row editor\'s value should be reset after resetting state', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            columns: ['field1'],
+            dataSource: [],
+            filterRow: {
+                visible: true,
+                applyFilter: 'onClick',
+            },
+        });
+
+        this.clock.tick(100);
+
+        // act
+        $(dataGrid.element()).find('.dx-datagrid-filter-row .dx-texteditor-input').first().val('test').trigger('change');
+        dataGrid.state(null);
+
+        // assert
+        assert.strictEqual($(dataGrid.element()).find('.dx-datagrid-filter-row .dx-texteditor-input').first().val(), '', 'editor value is reset');
+    });
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
