### PR TITLE
DataGrid/TreeList - Fix edit events arguments if changes are added using the "editing|changes" property (T1118182)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -512,24 +512,26 @@ const EditingController = modules.ViewController.inherit((function() {
 
         _handleChangesChange: function(args) {
             const dataController = this._dataController;
+            const changes = args.value;
 
             if(!args.value.length && !args.previousValue.length) {
                 return;
             }
 
-            this._processInsertChanges(args.value);
+            changes.forEach(change => {
+                if(change.type === 'insert') {
+                    this._addInsertInfo(change);
+                } else {
+                    const items = dataController.items();
+                    const rowIndex = dataController.getRowIndexByKey(change.key);
+
+                    this._addInternalData({ key: change.key, oldData: items[rowIndex]?.data });
+                }
+            });
 
             dataController.updateItems({
                 repaintChangesOnly: true,
                 isLiveUpdate: false
-            });
-        },
-
-        _processInsertChanges: function(changes) {
-            changes.forEach(change => {
-                if(change.type === 'insert') {
-                    this._addInsertInfo(change);
-                }
             });
         },
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -21231,6 +21231,155 @@ QUnit.module('Editing - public arguments of the events/templates', {
             }
         });
 
+        // T1118182
+        QUnit.test(`${editMode} mode - onRowInserting/onRowInserted should have correct arguments when inserting row via 'editing.changes' option`, function(assert) {
+            // arrange
+            const onRowInsertingSpy = sinon.spy();
+            const onRowInsertedSpy = sinon.spy();
+            const items = [
+                { id: 0, name: 'test1' },
+                { id: 1, name: 'test2' },
+                { id: 2, name: 'test3' },
+                { id: 3, name: 'test4' }
+            ];
+
+            this.options.onRowInserting = onRowInsertingSpy;
+            this.options.onRowInserted = onRowInsertedSpy;
+            this.options.editing = {
+                mode: editMode.toLowerCase()
+            };
+            this.options.dataSource = {
+                store: {
+                    data: items.slice(),
+                    type: 'array',
+                    key: 'id'
+                }
+            };
+
+            this.setupModules();
+            this.renderRowsView();
+            this.clock.tick();
+
+            // assert
+            assert.strictEqual(this.getVisibleRows().length, 4, 'count rows');
+
+            // act
+            this.option('editing.changes', [{
+                type: 'insert',
+                data: { id: 123, name: 'new' },
+            }]);
+            this.saveEditData();
+            this.clock.tick();
+
+            // assert
+            assert.strictEqual(this.getVisibleRows().length, 5, 'count rows');
+            assert.strictEqual(onRowInsertingSpy.callCount, 1, 'onRowInserting event - call count');
+            assert.strictEqual(onRowInsertedSpy.callCount, 1, 'onRowInserted event - call count');
+            assert.deepEqual(onRowInsertingSpy.getCall(0).args[0], { cancel: false, data: { id: 123, name: 'new' } }, 'onRowInserting event - args');
+            assert.deepEqual(onRowInsertedSpy.getCall(0).args[0], { key: 123, data: { id: 123, name: 'new' } }, 'onRowInserted event - args');
+        });
+
+        // T1118182
+        QUnit.test(`${editMode} mode - onRowUpdating/onRowUpdated should have correct arguments when updating row via 'editing.changes' option`, function(assert) {
+            // arrange
+            const onRowUpdatingSpy = sinon.spy();
+            const onRowUpdatedSpy = sinon.spy();
+            const items = [
+                { id: 0, name: 'test1' },
+                { id: 1, name: 'test2' },
+                { id: 2, name: 'test3' },
+                { id: 3, name: 'test4' }
+            ];
+
+            this.options.onRowUpdating = onRowUpdatingSpy;
+            this.options.onRowUpdated = onRowUpdatedSpy;
+            this.options.editing = {
+                mode: editMode.toLowerCase()
+            };
+            this.options.dataSource = {
+                store: {
+                    data: items.slice(),
+                    type: 'array',
+                    key: 'id'
+                }
+            };
+
+            this.setupModules();
+            this.renderRowsView();
+            this.clock.tick();
+
+            // assert
+            assert.strictEqual(this.getVisibleRows().length, 4, 'count rows');
+
+            // act
+            this.option('editing.changes', [{
+                type: 'update',
+                key: 1,
+                data: { name: 'update' }
+            }]);
+            this.saveEditData();
+            this.clock.tick();
+
+            // assert
+            assert.strictEqual(this.getVisibleRows().length, 4, 'count rows');
+            assert.strictEqual(onRowUpdatingSpy.callCount, 1, 'onRowUpdating event - call count');
+            assert.strictEqual(onRowUpdatedSpy.callCount, 1, 'onRowUpdated event - call count');
+            assert.deepEqual(onRowUpdatingSpy.getCall(0).args[0], { cancel: false, key: 1, newData: { name: 'update' }, oldData: { id: 1, name: 'update' } }, 'onRowUpdating event - args');
+            assert.deepEqual(onRowUpdatedSpy.getCall(0).args[0], { key: 1, data: { id: 1, name: 'update' } }, 'onRowUpdated event - args');
+        });
+
+        // T1118182
+        QUnit.test(`${editMode} mode - onRowRemoving/onRowRemoved should have correct arguments when removing row via 'editing.changes' option`, function(assert) {
+            // arrange
+            const onRowRemovingSpy = sinon.spy();
+            const onRowRemovedSpy = sinon.spy();
+            const items = [
+                { id: 0, name: 'test1' },
+                { id: 1, name: 'test2' },
+                { id: 2, name: 'test3' },
+                { id: 3, name: 'test4' }
+            ];
+
+            this.options.onRowRemoving = onRowRemovingSpy;
+            this.options.onRowRemoved = onRowRemovedSpy;
+            this.options.editing = {
+                mode: editMode.toLowerCase(),
+                confirmDelete: false,
+                texts: {
+                    confirmDeleteMessage: ''
+                }
+            };
+            this.options.dataSource = {
+                store: {
+                    data: items.slice(),
+                    type: 'array',
+                    key: 'id'
+                }
+            };
+
+            this.setupModules();
+            this.renderRowsView();
+            this.clock.tick();
+
+            // assert
+            assert.strictEqual(this.getVisibleRows().length, 4, 'count rows');
+
+            // act
+            this.option('editing.changes', [{
+                type: 'remove',
+                key: 1,
+            }]);
+            this.saveEditData();
+            this.clock.tick();
+
+            // assert
+            assert.strictEqual(this.getVisibleRows().length, 3, 'count rows');
+            assert.strictEqual(onRowRemovingSpy.callCount, 1, 'onRowRemoving event - call count');
+            assert.strictEqual(onRowRemovedSpy.callCount, 1, 'onRowRemoved event - call count');
+            assert.deepEqual(onRowRemovingSpy.getCall(0).args[0], { cancel: false, key: 1, data: items[1] }, 'onRowRemoving event - args');
+            assert.deepEqual(onRowRemovedSpy.getCall(0).args[0], { key: 1, data: items[1] }, 'onRowRemoved event - args');
+        });
+
         [true, false].forEach((repaintChangesOnly) => {
             QUnit.test(`Check the watch argument of the editCellTemplate in ${editMode} mode when repaintChangesOnly = ${repaintChangesOnly}`, function(assert) {
                 // arrange


### PR DESCRIPTION
See https://devexpress.com/issue=T1118182