### PR TITLE
Scheduler: Fix allDayPanelModel d.ts default value in views.

### DIFF
--- a/js/ui/scheduler.d.ts
+++ b/js/ui/scheduler.d.ts
@@ -938,7 +938,7 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
       scrolling?: dxSchedulerScrolling;
       /**
        * @docid
-       * @default "allDay"
+       * @default "all"
        */
        allDayPanelMode?: AllDayPanelMode;
     }>;


### PR DESCRIPTION
Fixed 'allDayPanelMode' default value for the documentation of the views options in the scheduler.d.ts