### PR TITLE
DataGrid - Popup should not repaint if summary.recalculateWhileEditing is enabled - T1118387

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -531,7 +531,8 @@ const EditingController = modules.ViewController.inherit((function() {
 
             dataController.updateItems({
                 repaintChangesOnly: true,
-                isLiveUpdate: false
+                isLiveUpdate: false,
+                isOptionChanged: true
             });
         },
 

--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -104,7 +104,7 @@ export const editingFormBasedModule = {
 
                         const onlyInsertChanges = args.changeTypes?.length && args.changeTypes.every(item => item === 'insert');
 
-                        if((args.changeType === 'refresh' || hasEditRow) && !onlyInsertChanges) {
+                        if((args.changeType === 'refresh' || (hasEditRow && args.isOptionChanged)) && !onlyInsertChanges) {
                             this._repaintEditPopup();
                         }
                     }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -6793,6 +6793,42 @@ QUnit.module('Editing state', baseModuleConfig, () => {
         });
     });
 
+    // T1118387
+    QUnit.test('Focus should not be reset if field used in summary is changed and summary.recalculateWhileEditing is enabled', function(assert) {
+        const dataGrid = $('#dataGrid').dxDataGrid({
+            dataSource: [{ id: 1, value: 15, field: 'field' }],
+            keyExpr: 'id',
+            editing: {
+                allowUpdating: true,
+                mode: 'popup'
+            },
+            repaintChangesOnly: true,
+            summary: {
+                recalculateWhileEditing: true,
+                totalItems: [
+                    { column: 'value', summaryType: 'sum' }
+                ]
+            },
+            columns: ['id', 'value', 'field']
+        }).dxDataGrid('instance');
+        this.clock.tick();
+
+        dataGrid.editRow(0);
+        this.clock.tick();
+
+        const popup = $(dataGrid.getController('editing').getPopupContent());
+        const valueInput = popup.find('.dx-texteditor-input').eq(1);
+        const fieldInput = popup.find('.dx-texteditor-input').eq(2);
+
+        valueInput.trigger('focus').val('35').trigger('change');
+        this.clock.tick();
+
+        fieldInput.trigger('focus');
+        this.clock.tick();
+
+        assert.deepEqual(document.activeElement.id, fieldInput.attr('id'), 'focus is not reset after changing the field used for a summary');
+    });
+
     QUnit.test('Pager should not be hidden after delete row using onSaving event handler', function(assert) {
         // arrange
         const items = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];


### PR DESCRIPTION
(cherry picked from commit f48beb814d98396df860dfaac76347eb67dcc5b8)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
