### PR TITLE
HtmlEditor: toolbar menu items' disabled state should be correctly updated on selection change even if menu has not been opened yet (t1117604)

### DIFF
--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -348,6 +348,9 @@ if(Quill) {
                             e.component.$element().toggleClass(`dx-${item.name.toLowerCase()}-format`, !!item.name);
                             this._toolbarWidgets.add(item.name, e.component);
                         }
+                    },
+                    onDisposing: () => {
+                        this._toolbarWidgets.remove(item.name);
                     }
                 }
             };

--- a/js/ui/html_editor/modules/toolbar.js
+++ b/js/ui/html_editor/modules/toolbar.js
@@ -448,6 +448,14 @@ if(Quill) {
             TABLE_OPERATIONS.forEach((operationName) => {
                 const isInsertTable = operationName === 'insertTable';
                 const widget = this._toolbarWidgets.getByName(operationName);
+                if(!widget) {
+                    this.toolbarInstance.option('items').forEach(item => {
+                        if(item.name === operationName) {
+                            const isDisabled = isInsertTable ? isTableOperationsEnabled : !isTableOperationsEnabled;
+                            item.options.disabled = isDisabled;
+                        }
+                    });
+                }
 
                 this._updateManipulationWidget(widget, isInsertTable ? !isTableOperationsEnabled : isTableOperationsEnabled);
             });

--- a/js/ui/html_editor/modules/widget_collector.js
+++ b/js/ui/html_editor/modules/widget_collector.js
@@ -13,6 +13,10 @@ export default class WidgetCollector {
         this._collection.push({ name, instance });
     }
 
+    remove(name) {
+        this._collection = this._collection.filter(item => item.name !== name);
+    }
+
     getByName(widgetName) {
         let widget = null;
 

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -1370,10 +1370,21 @@ testModule('Toolbar items disable state update', {
 }, () => {
     const COLOR_ITEMS = ['color', 'background'];
     const BUTTON_FORMAT_ITEMS = ['bold', 'italic', 'link', 'strike', 'underline', 'blockquote', 'code-block', 'codeBlock', 'variable'];
+    const EDITOR_FORMAT_ITEMS = [{
+        name: 'size',
+        value: 'large',
+        acceptedValues: ['large']
+    }, {
+        name: 'font',
+        value: 'cursive',
+        acceptedValues: ['cursive']
+    }, {
+        name: 'header',
+        value: 3,
+        acceptedValues: [3]
+    }];
 
-    testModule('when items are located not in menu', {
-
-    }, () => {
+    testModule('when items are located not in menu', () => {
         test('table formats on table focus', function(assert) {
             this.options.items = TABLE_OPERATIONS;
             const toolbar = new Toolbar(this.quillMock, this.options);
@@ -1551,6 +1562,34 @@ testModule('Toolbar items disable state update', {
                 assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), false, `${buttonItemName} button has no ${ACTIVE_FORMAT_CLASS} class`);
             });
         });
+
+        EDITOR_FORMAT_ITEMS.forEach((item) => {
+            const { name: editorItemName, value } = item;
+
+            test(`${editorItemName} editor if format is applied`, function(assert) {
+                this.options.items = [item];
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [editorItemName]: value });
+
+                toolbar.updateFormatWidgets();
+
+                const actualValue = this.getFormatItemElement().dxSelectBox('instance').option('value');
+                assert.strictEqual(actualValue, value, 'value is correct');
+            });
+
+            test(`${editorItemName} editor if format is not applied`, function(assert) {
+                this.options.items = [item];
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [editorItemName]: value });
+                toolbar.updateFormatWidgets();
+
+                this.quillMock.getFormat = () => ({});
+                toolbar.updateFormatWidgets();
+
+                const actualValue = this.getFormatItemElement().dxSelectBox('instance').option('value');
+                assert.strictEqual(actualValue, null, 'value is restored');
+            });
+        });
     });
 
     testModule('when items are located in menu and it was not opened yet', {
@@ -1559,7 +1598,19 @@ testModule('Toolbar items disable state update', {
             this.openDropDownMenu = () => {
                 $(`.${TOOLBAR_CLASS} .${DROPDOWNMENU_BUTTON_CLASS}`).trigger('dxclick');
             };
-            this.mapToMenuItems = (items) => items.map(name => ({ name, locateInMenu: 'always' }));
+            this.mapToMenuItems = (items) => items.map(item => {
+                if(typeof item === 'string') {
+                    return {
+                        name: item,
+                        locateInMenu: 'always'
+                    };
+                } else {
+                    return {
+                        ...item,
+                        locateInMenu: 'always'
+                    };
+                }
+            });
         }
     }, () => {
         test('table formats in menu on table focus (t1117604)', function(assert) {
@@ -1761,6 +1812,38 @@ testModule('Toolbar items disable state update', {
 
                 const $formatItemElement = this.getFormatItemElement();
                 assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), false, `${buttonItemName} button has no ${ACTIVE_FORMAT_CLASS} class`);
+            });
+        });
+
+        EDITOR_FORMAT_ITEMS.forEach((item) => {
+            const { name: editorItemName, value } = item;
+
+            test(`${editorItemName} editor in menu if format is applied`, function(assert) {
+                this.options.items = this.mapToMenuItems([item]);
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [editorItemName]: value });
+
+                toolbar.updateFormatWidgets();
+
+                this.openDropDownMenu();
+
+                const actualValue = this.getFormatItemElement().dxSelectBox('instance').option('value');
+                assert.strictEqual(actualValue, value, 'value is correct');
+            });
+
+            test(`${editorItemName} editor in menu if format is not applied`, function(assert) {
+                this.options.items = this.mapToMenuItems([item]);
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [editorItemName]: value });
+                toolbar.updateFormatWidgets();
+
+                this.quillMock.getFormat = () => ({});
+                toolbar.updateFormatWidgets();
+
+                this.openDropDownMenu();
+
+                const actualValue = this.getFormatItemElement().dxSelectBox('instance').option('value');
+                assert.strictEqual(actualValue, null, 'value is restored');
             });
         });
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -1362,11 +1362,14 @@ testModule('Toolbar items disable state update', {
         this.getDisabledFormats = () => {
             return this.$element.find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}.${DISABLED_STATE_CLASS}`);
         };
+        this.getFormatItemElement = () => this.$element.find(`.${TOOLBAR_FORMAT_WIDGET_CLASS}`);
     },
     afterEach: function() {
         simpleModuleConfig.afterEach.apply(this, arguments);
     }
 }, () => {
+    const COLOR_ITEMS = ['color', 'background'];
+
     testModule('when items are located not in menu', {
 
     }, () => {
@@ -1488,6 +1491,38 @@ testModule('Toolbar items disable state update', {
             const $disabledFormatWidgets = this.getDisabledFormats();
             const isRedoButtonDisabled = $disabledFormatWidgets.length === 1;
             assert.strictEqual(isRedoButtonDisabled, true, 'redo button is disabled');
+        });
+
+        COLOR_ITEMS.forEach(colorItemName => {
+            test(`${colorItemName} button if ${colorItemName} format is applied`, function(assert) {
+                this.options.items = [colorItemName];
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [colorItemName]: 'blue' });
+
+                toolbar.updateFormatWidgets();
+
+                const $formatItemElement = this.getFormatItemElement();
+                const $icon = $formatItemElement.find(`.${ICON_CLASS}`);
+
+                assert.strictEqual($icon.css('borderBottomColor'), 'rgb(0, 0, 255)', `${colorItemName} button bottomBorderColor is correct`);
+                assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), true, `${colorItemName} button has ${ACTIVE_FORMAT_CLASS} class`);
+            });
+
+            test(`${colorItemName} button if ${colorItemName} format is not applied`, function(assert) {
+                this.options.items = [colorItemName];
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [colorItemName]: 'blue' });
+                toolbar.updateFormatWidgets();
+
+                this.quillMock.getFormat = () => ({});
+                toolbar.updateFormatWidgets();
+
+                const $formatItemElement = this.getFormatItemElement();
+                const $icon = $formatItemElement.find(`.${ICON_CLASS}`);
+
+                assert.strictEqual($icon.css('borderBottomColor'), 'rgba(0, 0, 0, 0)', `${colorItemName} button bottomBorderColor is transparent`);
+                assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), false, `${colorItemName} button has no ${ACTIVE_FORMAT_CLASS} class`);
+            });
         });
     });
 
@@ -1634,6 +1669,42 @@ testModule('Toolbar items disable state update', {
             const $disabledFormatWidgets = this.getDisabledFormats();
             const isRedoButtonDisabled = $disabledFormatWidgets.length === 1;
             assert.strictEqual(isRedoButtonDisabled, true, 'redo button is disabled');
+        });
+
+        COLOR_ITEMS.forEach(colorItemName => {
+            test(`${colorItemName} button in menu if ${colorItemName} format is applied`, function(assert) {
+                this.options.items = this.mapToMenuItems([colorItemName]);
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [colorItemName]: 'blue' });
+
+                toolbar.updateFormatWidgets();
+
+                this.openDropDownMenu();
+
+                const $formatItemElement = this.getFormatItemElement();
+                const $icon = $formatItemElement.find(`.${ICON_CLASS}`);
+
+                assert.strictEqual($icon.css('borderBottomColor'), 'rgb(0, 0, 255)', `${colorItemName} button bottomBorderColor is correct`);
+                assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), true, `${colorItemName} button has ${ACTIVE_FORMAT_CLASS} class`);
+            });
+
+            test(`${colorItemName} button in menu if ${colorItemName} format is not applied`, function(assert) {
+                this.options.items = this.mapToMenuItems([colorItemName]);
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [colorItemName]: 'blue' });
+                toolbar.updateFormatWidgets();
+
+                this.quillMock.getFormat = () => ({});
+                toolbar.updateFormatWidgets();
+
+                this.openDropDownMenu();
+
+                const $formatItemElement = this.getFormatItemElement();
+                const $icon = $formatItemElement.find(`.${ICON_CLASS}`);
+
+                assert.strictEqual($icon.css('borderBottomColor'), 'rgba(0, 0, 0, 0)', `${colorItemName} button bottomBorderColor is transparent`);
+                assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), false, `${colorItemName} button has no ${ACTIVE_FORMAT_CLASS} class`);
+            });
         });
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -1369,6 +1369,7 @@ testModule('Toolbar items disable state update', {
     }
 }, () => {
     const COLOR_ITEMS = ['color', 'background'];
+    const BUTTON_FORMAT_ITEMS = ['bold', 'italic', 'link', 'strike', 'underline', 'blockquote', 'code-block', 'codeBlock', 'variable'];
 
     testModule('when items are located not in menu', {
 
@@ -1522,6 +1523,32 @@ testModule('Toolbar items disable state update', {
 
                 assert.strictEqual($icon.css('borderBottomColor'), 'rgba(0, 0, 0, 0)', `${colorItemName} button bottomBorderColor is transparent`);
                 assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), false, `${colorItemName} button has no ${ACTIVE_FORMAT_CLASS} class`);
+            });
+        });
+
+        BUTTON_FORMAT_ITEMS.forEach(buttonItemName => {
+            test(`${buttonItemName} button if format is applied`, function(assert) {
+                this.options.items = [buttonItemName];
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [buttonItemName]: true });
+
+                toolbar.updateFormatWidgets();
+
+                const $formatItemElement = this.getFormatItemElement();
+                assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), true, `${buttonItemName} button has ${ACTIVE_FORMAT_CLASS} class`);
+            });
+
+            test(`${buttonItemName} button if format is not applied`, function(assert) {
+                this.options.items = [buttonItemName];
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [buttonItemName]: true });
+                toolbar.updateFormatWidgets();
+
+                this.quillMock.getFormat = () => ({});
+                toolbar.updateFormatWidgets();
+
+                const $formatItemElement = this.getFormatItemElement();
+                assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), false, `${buttonItemName} button has no ${ACTIVE_FORMAT_CLASS} class`);
             });
         });
     });
@@ -1704,6 +1731,36 @@ testModule('Toolbar items disable state update', {
 
                 assert.strictEqual($icon.css('borderBottomColor'), 'rgba(0, 0, 0, 0)', `${colorItemName} button bottomBorderColor is transparent`);
                 assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), false, `${colorItemName} button has no ${ACTIVE_FORMAT_CLASS} class`);
+            });
+        });
+
+        BUTTON_FORMAT_ITEMS.forEach(buttonItemName => {
+            test(`${buttonItemName} button in menu if format is applied`, function(assert) {
+                this.options.items = this.mapToMenuItems([buttonItemName]);
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [buttonItemName]: true });
+
+                toolbar.updateFormatWidgets();
+
+                this.openDropDownMenu();
+
+                const $formatItemElement = this.getFormatItemElement();
+                assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), true, `${buttonItemName} button has ${ACTIVE_FORMAT_CLASS} class`);
+            });
+
+            test(`${buttonItemName} button in menu if format is not applied`, function(assert) {
+                this.options.items = this.mapToMenuItems([buttonItemName]);
+                const toolbar = new Toolbar(this.quillMock, this.options);
+                this.quillMock.getFormat = () => ({ [buttonItemName]: true });
+                toolbar.updateFormatWidgets();
+
+                this.quillMock.getFormat = () => ({});
+                toolbar.updateFormatWidgets();
+
+                this.openDropDownMenu();
+
+                const $formatItemElement = this.getFormatItemElement();
+                assert.strictEqual($formatItemElement.hasClass(ACTIVE_FORMAT_CLASS), false, `${buttonItemName} button has no ${ACTIVE_FORMAT_CLASS} class`);
             });
         });
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/htmlEditorParts/toolbarModule.tests.js
@@ -1421,13 +1421,73 @@ testModule('Toolbar items disable state update', {
             this.quillMock.getFormat = () => ({ bold: true });
             toolbar.updateFormatWidgets();
 
-            this.quillMock.getFormat = () => ({ bold: false });
+            this.quillMock.getFormat = () => ({});
             toolbar.updateFormatWidgets();
 
             const $disabledFormatWidgets = this.getDisabledFormats();
             const isClearButtonDisabled = $disabledFormatWidgets.length === 1;
 
             assert.strictEqual(isClearButtonDisabled, true, 'clear button is disabled');
+        });
+
+        test('undo button if undo stack is not empty', function(assert) {
+            this.quillMock.history = {
+                undo: sinon.stub(),
+                stack: { undo: ['test'], redo: [] }
+            };
+            this.options.items = ['undo'];
+            const toolbar = new Toolbar(this.quillMock, this.options);
+
+            toolbar.updateHistoryWidgets();
+
+            const $disabledFormatWidgets = this.getDisabledFormats();
+            const isUndoButtonDisabled = $disabledFormatWidgets.length === 1;
+            assert.strictEqual(isUndoButtonDisabled, false, 'undo button is enabled');
+        });
+
+        test('undo button if undo stack is empty', function(assert) {
+            this.quillMock.history = {
+                undo: sinon.stub(),
+                stack: { undo: [], redo: [] }
+            };
+            this.options.items = ['undo'];
+            const toolbar = new Toolbar(this.quillMock, this.options);
+
+            toolbar.updateHistoryWidgets();
+
+            const $disabledFormatWidgets = this.getDisabledFormats();
+            const isUndoButtonDisabled = $disabledFormatWidgets.length === 1;
+            assert.strictEqual(isUndoButtonDisabled, true, 'undo button is disabled');
+        });
+
+        test('redo button if redo stack is not empty', function(assert) {
+            this.quillMock.history = {
+                redo: sinon.stub(),
+                stack: { undo: [], redo: ['test'] }
+            };
+            this.options.items = ['redo'];
+            const toolbar = new Toolbar(this.quillMock, this.options);
+
+            toolbar.updateHistoryWidgets();
+
+            const $disabledFormatWidgets = this.getDisabledFormats();
+            const isRedoButtonDisabled = $disabledFormatWidgets.length === 1;
+            assert.strictEqual(isRedoButtonDisabled, false, 'undo button is enabled');
+        });
+
+        test('redo button if redo stack is empty', function(assert) {
+            this.quillMock.history = {
+                redo: sinon.stub(),
+                stack: { undo: [], redo: [] }
+            };
+            this.options.items = ['redo'];
+            const toolbar = new Toolbar(this.quillMock, this.options);
+
+            toolbar.updateHistoryWidgets();
+
+            const $disabledFormatWidgets = this.getDisabledFormats();
+            const isRedoButtonDisabled = $disabledFormatWidgets.length === 1;
+            assert.strictEqual(isRedoButtonDisabled, true, 'redo button is disabled');
         });
     });
 
@@ -1506,6 +1566,74 @@ testModule('Toolbar items disable state update', {
             const isClearButtonDisabled = $disabledFormatWidgets.length === 1;
 
             assert.strictEqual(isClearButtonDisabled, true, 'clear button is disabled');
+        });
+
+        test('undo button in menu if undo stack is not empty', function(assert) {
+            this.quillMock.history = {
+                undo: sinon.stub(),
+                stack: { undo: ['test'], redo: [] }
+            };
+            this.options.items = this.mapToMenuItems(['undo']);
+            const toolbar = new Toolbar(this.quillMock, this.options);
+
+            toolbar.updateHistoryWidgets();
+
+            this.openDropDownMenu();
+
+            const $disabledFormatWidgets = this.getDisabledFormats();
+            const isUndoButtonDisabled = $disabledFormatWidgets.length === 1;
+            assert.strictEqual(isUndoButtonDisabled, false, 'undo button is enabled');
+        });
+
+        test('undo button in menu if undo stack is empty', function(assert) {
+            this.quillMock.history = {
+                undo: sinon.stub(),
+                stack: { undo: [], redo: [] }
+            };
+            this.options.items = this.mapToMenuItems(['undo']);
+            const toolbar = new Toolbar(this.quillMock, this.options);
+
+            toolbar.updateHistoryWidgets();
+
+            this.openDropDownMenu();
+
+            const $disabledFormatWidgets = this.getDisabledFormats();
+            const isUndoButtonDisabled = $disabledFormatWidgets.length === 1;
+            assert.strictEqual(isUndoButtonDisabled, true, 'undo button is disabled');
+        });
+
+        test('redo button in menu if redo stack is not empty', function(assert) {
+            this.quillMock.history = {
+                redo: sinon.stub(),
+                stack: { undo: [], redo: ['test'] }
+            };
+            this.options.items = this.mapToMenuItems(['redo']);
+            const toolbar = new Toolbar(this.quillMock, this.options);
+
+            toolbar.updateHistoryWidgets();
+
+            this.openDropDownMenu();
+
+            const $disabledFormatWidgets = this.getDisabledFormats();
+            const isRedoButtonDisabled = $disabledFormatWidgets.length === 1;
+            assert.strictEqual(isRedoButtonDisabled, false, 'undo button is enabled');
+        });
+
+        test('redo button in menu if redo stack is empty', function(assert) {
+            this.quillMock.history = {
+                redo: sinon.stub(),
+                stack: { undo: [], redo: [] }
+            };
+            this.options.items = this.mapToMenuItems(['redo']);
+            const toolbar = new Toolbar(this.quillMock, this.options);
+
+            toolbar.updateHistoryWidgets();
+
+            this.openDropDownMenu();
+
+            const $disabledFormatWidgets = this.getDisabledFormats();
+            const isRedoButtonDisabled = $disabledFormatWidgets.length === 1;
+            assert.strictEqual(isRedoButtonDisabled, true, 'redo button is disabled');
         });
     });
 });


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
