### PR TITLE
Scheduler: stabilize testcafe tests.

### DIFF
--- a/testing/testcafe/helpers/restoreBrowserSize.ts
+++ b/testing/testcafe/helpers/restoreBrowserSize.ts
@@ -1,5 +1,18 @@
-const width = 1200;
-const height = 800;
+// eslint-disable-next-line @typescript-eslint/no-type-alias
+type BrowserSizeType = [number, number];
+const DEFAULT_BROWSER_SIZE: BrowserSizeType = [1200, 800];
 
-export const restoreBrowserSize = async (t: TestController):
-Promise<any> => t.resizeWindow(width, height);
+const restoreBrowserSize = async (t: TestController):
+Promise<any> => {
+  const [width, height] = DEFAULT_BROWSER_SIZE;
+  await t.resizeWindow(width, height);
+};
+
+export type {
+  BrowserSizeType,
+};
+
+export {
+  DEFAULT_BROWSER_SIZE,
+  restoreBrowserSize,
+};

--- a/testing/testcafe/helpers/safeSizeTest.ts
+++ b/testing/testcafe/helpers/safeSizeTest.ts
@@ -1,0 +1,74 @@
+import { BrowserSizeType, DEFAULT_BROWSER_SIZE, restoreBrowserSize } from './restoreBrowserSize';
+
+type TestCafeFn = (t: TestController) => Promise<any>;
+
+const emptyFunction = () => Promise.resolve();
+
+const setBrowserSize = async (
+  t: TestController,
+  size: BrowserSizeType,
+) => {
+  const [width, height] = size;
+  await t.resizeWindow(width, height);
+};
+
+const decorateTestCafeBefore = (
+  testCafeTest: TestFn,
+  size: BrowserSizeType,
+): void => {
+  const originBefore = testCafeTest.before;
+
+  const decoratedBefore = (beforeFunc: TestCafeFn): TestFn => {
+    const decoratedFunc = async (t: TestController) => {
+      await setBrowserSize(t, size);
+      return beforeFunc(t);
+    };
+
+    originBefore(decoratedFunc);
+    return testCafeTest;
+  };
+
+  Object.defineProperty(testCafeTest, 'before', {
+    get: () => decoratedBefore,
+  });
+};
+
+const decorateTestCafeAfter = (
+  testCafeTest: TestFn,
+): void => {
+  const originAfter = testCafeTest.after;
+
+  const decoratedAfter = (afterFunc: TestCafeFn): TestFn => {
+    const decoratedFunc = async (t: TestController) => {
+      await restoreBrowserSize(t);
+      return afterFunc(t);
+    };
+
+    originAfter(decoratedFunc);
+    return testCafeTest;
+  };
+
+  Object.defineProperty(testCafeTest, 'after', {
+    get: () => decoratedAfter,
+  });
+};
+
+const safeSizeTest = (
+  name: string,
+  testFunction: TestCafeFn,
+  size: BrowserSizeType = DEFAULT_BROWSER_SIZE,
+): TestFn => {
+  const testCafeTest = test(name, testFunction);
+
+  decorateTestCafeBefore(testCafeTest, size);
+  decorateTestCafeAfter(testCafeTest);
+
+  testCafeTest.before(emptyFunction);
+  testCafeTest.after(emptyFunction);
+
+  return testCafeTest;
+};
+
+export {
+  safeSizeTest,
+};

--- a/testing/testcafe/tests/renovation/scheduler/appointments/adaptive.ts
+++ b/testing/testcafe/tests/renovation/scheduler/appointments/adaptive.ts
@@ -1,4 +1,5 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
+import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 import Scheduler from '../../../../model/scheduler';
 import { multiPlatformTest, createWidget } from '../../../../helpers/multi-platform-test';
 
@@ -99,5 +100,5 @@ fixture('Renovated scheduler - Adaptive appointments');
         showCurrentTimeIndicator: false,
       });
     },
-  );
+  ).after(async (t) => restoreBrowserSize(t));
 });

--- a/testing/testcafe/tests/renovation/scheduler/appointments/cross-scrolling.ts
+++ b/testing/testcafe/tests/renovation/scheduler/appointments/cross-scrolling.ts
@@ -153,7 +153,8 @@ const test = multiPlatformTest({
   platforms: [/* 'jquery', */'react'],
 });
 
-fixture('Renovated scheduler - Cross-scrolling');
+// NOTE RENOVATION TESTCAFE: All these test scenarios have analogs in jQuery's testcafe tests.
+fixture.skip('Renovated scheduler - Cross-scrolling');
 
 ['day', 'week', 'workWeek', 'month'].forEach((currentView) => {
   test(`it should render appointments correctly if currentView is ${currentView} and cross-scrolling is enabled`, async (t, { screenshotComparerOptions }) => {

--- a/testing/testcafe/tests/renovation/scheduler/appointments/overflow-indicators.ts
+++ b/testing/testcafe/tests/renovation/scheduler/appointments/overflow-indicators.ts
@@ -1,4 +1,5 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
+import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 import Scheduler from '../../../../model/scheduler';
 import { multiPlatformTest, createWidget } from '../../../../helpers/multi-platform-test';
 
@@ -95,6 +96,6 @@ fixture('Renovated scheduler - Overflow indicator');
           showCurrentTimeIndicator: false,
         });
       },
-    );
+    ).after(async (t) => restoreBrowserSize(t));
   });
 });

--- a/testing/testcafe/tests/renovation/scheduler/appointments/recurrence.ts
+++ b/testing/testcafe/tests/renovation/scheduler/appointments/recurrence.ts
@@ -1,4 +1,5 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
+import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 import Scheduler from '../../../../model/scheduler';
 import { multiPlatformTest, createWidget } from '../../../../helpers/multi-platform-test';
 
@@ -75,5 +76,5 @@ fixture('Renovated scheduler - Recurrent appointments');
         showCurrentTimeIndicator: false,
       });
     },
-  );
+  ).after(async (t) => restoreBrowserSize(t));
 });

--- a/testing/testcafe/tests/renovation/scheduler/appointments/reduced.ts
+++ b/testing/testcafe/tests/renovation/scheduler/appointments/reduced.ts
@@ -1,4 +1,5 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
+import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 import Scheduler from '../../../../model/scheduler';
 import { multiPlatformTest, createWidget } from '../../../../helpers/multi-platform-test';
 
@@ -124,7 +125,7 @@ test('it should render reduced appointment correctly if currentView is month', a
       showCurrentTimeIndicator: false,
     });
   },
-);
+).after(async (t) => restoreBrowserSize(t));
 
 test('it should render reduced appointment correctly if currentView is timelineDay', async (t, { screenshotComparerOptions }) => {
   const scheduler = new Scheduler(SCHEDULER_SELECTOR);
@@ -199,4 +200,4 @@ test('it should render reduced appointment correctly if currentView is timelineD
       showCurrentTimeIndicator: false,
     });
   },
-);
+).after(async (t) => restoreBrowserSize(t));

--- a/testing/testcafe/tests/renovation/scheduler/appointments/regular.ts
+++ b/testing/testcafe/tests/renovation/scheduler/appointments/regular.ts
@@ -1,4 +1,5 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
+import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 import Scheduler from '../../../../model/scheduler';
 import { multiPlatformTest, createWidget } from '../../../../helpers/multi-platform-test';
 
@@ -211,5 +212,5 @@ fixture('Renovated scheduler - Regular appointments');
       ],
       showCurrentTimeIndicator: false,
     }),
-  );
+  ).after(async (t) => restoreBrowserSize(t));
 });

--- a/testing/testcafe/tests/renovation/scheduler/header/viewSwitcher.ts
+++ b/testing/testcafe/tests/renovation/scheduler/header/viewSwitcher.ts
@@ -6,7 +6,8 @@ const test = multiPlatformTest({
   platforms: ['jquery', 'react'],
 });
 
-fixture('Scheduler header - View switcher');
+// NOTE RENOVATION TESTCAFE: All these test scenarios have analogs in jQuery's testcafe tests.
+fixture.skip('Scheduler header - View switcher');
 
 test('it should correctly switch a differently typed views (T1080992)', async (t) => {
   const scheduler = new Scheduler('#container');

--- a/testing/testcafe/tests/renovation/scheduler/resources/resources.ts
+++ b/testing/testcafe/tests/renovation/scheduler/resources/resources.ts
@@ -1,4 +1,5 @@
 import url from '../../../../helpers/getPageUrl';
+import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 import Scheduler from '../../../../model/scheduler';
 import { multiPlatformTest, createWidget } from '../../../../helpers/multi-platform-test';
 
@@ -79,7 +80,7 @@ fixture`Resources`
         label: 'Priority',
       }],
     },
-  ));
+  )).after(async (t) => restoreBrowserSize(t));
 });
 
 test('Scheduler should renders correctly if resource dataSource is not set', async (t) => {
@@ -117,4 +118,4 @@ test('Scheduler should renders correctly if resource dataSource is not set', asy
       label: 'Room',
     }],
   },
-));
+)).after(async (t) => restoreBrowserSize(t));

--- a/testing/testcafe/tests/scheduler/adaptive.weekView.ts
+++ b/testing/testcafe/tests/scheduler/adaptive.weekView.ts
@@ -1,5 +1,6 @@
 import createWidget from '../../helpers/createWidget';
 import url from '../../helpers/getPageUrl';
+import { safeSizeTest } from '../../helpers/safeSizeTest';
 import Scheduler from '../../model/scheduler';
 
 fixture`Week view in adaptive mode`
@@ -75,8 +76,7 @@ const roughEqual = (actual: number, expected: number): boolean => {
   windowWidth: 800,
   name: 'align by center in tablet',
 }].forEach((testCase) => {
-  test(`Mobile tooltip should be ${testCase.name} screen`, async (t) => {
-    await t.resizeWindow(testCase.windowWidth, 700);
+  safeSizeTest(`Mobile tooltip should be ${testCase.name} screen`, async (t) => {
     await t
       .click(scheduler.collectors.get(0).element);
 
@@ -94,12 +94,10 @@ const roughEqual = (actual: number, expected: number): boolean => {
       .ok()
       .expect(roughEqual(width, testCase.width))
       .ok();
-  }).before(async () => createScheduler(sampleData, '80%'));
+  }, [testCase.windowWidth, 700]).before(async () => createScheduler(sampleData, '80%'));
 });
 
-test('Compact appointment should be center by vertical alignment', async (t) => {
-  await t.resizeWindow(350, 600);
-
+safeSizeTest('Compact appointment should be center by vertical alignment', async (t) => {
   await t
     .expect(scheduler.getAppointmentCount()).eql(0)
     .expect(scheduler.collectors.count).eql(3);
@@ -117,11 +115,9 @@ test('Compact appointment should be center by vertical alignment', async (t) => 
     .ok()
     .expect(roughEqual(await scheduler.collectors.get(2).element.getBoundingClientRectProperty('left'), 177))
     .ok();
-}).before(async () => createScheduler(sampleDataNotRoundedMinutes));
+}, [350, 600]).before(async () => createScheduler(sampleDataNotRoundedMinutes));
 
-test('With a large browser width, should be visible common appointment instead of a compact', async (t) => {
-  await t.resizeWindow(350, 600);
-
+safeSizeTest('With a large browser width, should be visible common appointment instead of a compact', async (t) => {
   await t
     .expect(scheduler.getAppointmentCount()).eql(0)
     .expect(scheduler.collectors.count).eql(2)
@@ -151,4 +147,4 @@ test('With a large browser width, should be visible common appointment instead o
     .ok()
     .expect(roughEqual(await scheduler.collectors.get(1).element.getBoundingClientRectProperty('left'), 236.5))
     .ok();
-}).before(async () => createScheduler(sampleData));
+}, [350, 600]).before(async () => createScheduler(sampleData));

--- a/testing/testcafe/tests/scheduler/agenda/API.ts
+++ b/testing/testcafe/tests/scheduler/agenda/API.ts
@@ -1,11 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import url from '../../../helpers/getPageUrl';
 
 fixture`Agenda:API`
   .page(url(__dirname, '../../container.html'));
 
-test('Html elements should be absent in Agenda view', async (t) => {
+safeSizeTest('Html elements should be absent in Agenda view', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t

--- a/testing/testcafe/tests/scheduler/agenda/adaptive.ts
+++ b/testing/testcafe/tests/scheduler/agenda/adaptive.ts
@@ -1,6 +1,8 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
+import { ADAPTIVE_SIZE } from '../const';
 
 fixture`Agenda:adaptive`
   .page(url(__dirname, '../../container.html'));
@@ -59,12 +61,8 @@ Promise<void> => {
     groups: ['priorityId'],
     text: 'groups',
   }].forEach((testCase) => {
-    test(testCase.text, async (t) => {
-      await t.resizeWindow(400, 600);
+    safeSizeTest(testCase.text, async (t) => {
       await t.expect(await compareScreenshot(t, `agenda-${testCase.text}-adaptive-rtl=${rtlEnabled}.png`)).ok();
-    }).before(async () => createScheduler(testCase.groups, rtlEnabled))
-      .after(async (t) => {
-        await t.resizeWindow(1200, 800);
-      });
+    }, ADAPTIVE_SIZE).before(async () => createScheduler(testCase.groups, rtlEnabled));
   });
 });

--- a/testing/testcafe/tests/scheduler/agenda/editing.ts
+++ b/testing/testcafe/tests/scheduler/agenda/editing.ts
@@ -1,11 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import url from '../../../helpers/getPageUrl';
 
 fixture`Agenda:Editing`
   .page(url(__dirname, '../../container.html'));
 
-test('It should be possible to delete an appointment', async (t) => {
+safeSizeTest('It should be possible to delete an appointment', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t
@@ -39,7 +40,7 @@ test('It should be possible to delete an appointment', async (t) => {
   }, true);
 });
 
-test('It should be possible to change the data source of agenda resources', async (t) => {
+safeSizeTest('It should be possible to change the data source of agenda resources', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t

--- a/testing/testcafe/tests/scheduler/agenda/layout.ts
+++ b/testing/testcafe/tests/scheduler/agenda/layout.ts
@@ -1,5 +1,6 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import url from '../../../helpers/getPageUrl';
 
@@ -138,19 +139,19 @@ const createScheduler = async (
 
 [false, true].forEach((rtlEnabled) => {
   [undefined, resourcesData].forEach((resources) => {
-    test(`Agenda test layout(rtl=${rtlEnabled}, resources=${!!resources}`, async (t) => {
+    safeSizeTest(`Agenda test layout(rtl=${rtlEnabled}, resources=${!!resources}`, async (t) => {
       await t.expect(await compareScreenshot(t, `agenda-layout-rtl=${rtlEnabled}-resources=${!!resources}.png`)).ok();
     }).before(async () => createScheduler(rtlEnabled, resources, undefined));
   });
 });
 
 [false, true].forEach((rtlEnabled) => {
-  test(`Agenda test layout with groups(rtl=${rtlEnabled}`, async (t) => {
+  safeSizeTest(`Agenda test layout with groups(rtl=${rtlEnabled}`, async (t) => {
     await t.expect(await compareScreenshot(t, `agenda-layout-groups-rtl=${rtlEnabled}.png`)).ok();
   }).before(async () => createScheduler(rtlEnabled, resourcesData, ['roomId']));
 });
 
-test('Agenda test appointment state', async (t) => {
+safeSizeTest('Agenda test appointment state', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t.hover(scheduler.getAppointment('Final Budget Review', 0).element);

--- a/testing/testcafe/tests/scheduler/agenda/switchingToAgenda.ts
+++ b/testing/testcafe/tests/scheduler/agenda/switchingToAgenda.ts
@@ -1,12 +1,13 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import url from '../../../helpers/getPageUrl';
 
 fixture`Agenda:view switching`
   .page(url(__dirname, '../../container.html'));
 
-test('View switching should work for empty agenda', async (t) => {
+safeSizeTest('View switching should work for empty agenda', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/agenda/tooltip.ts
+++ b/testing/testcafe/tests/scheduler/agenda/tooltip.ts
@@ -1,11 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import url from '../../../helpers/getPageUrl';
 
 fixture`Agenda:Tooltip`
   .page(url(__dirname, '../../container.html'));
 
-test('Tooltip\'s date should be equal to date of current appointment(T1037028)', async (t) => {
+safeSizeTest('Tooltip\'s date should be equal to date of current appointment(T1037028)', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointmentName = 'Text';
 

--- a/testing/testcafe/tests/scheduler/appointmentForm.ts
+++ b/testing/testcafe/tests/scheduler/appointmentForm.ts
@@ -1,12 +1,13 @@
 import { Selector } from 'testcafe';
 import createWidget from '../../helpers/createWidget';
 import url from '../../helpers/getPageUrl';
+import { safeSizeTest } from '../../helpers/safeSizeTest';
 import Scheduler from '../../model/scheduler';
 
 fixture`Appointment popup form`
   .page(url(__dirname, '../container.html'));
 
-test('Subject and description fields should be empty after showing popup on empty cell', async (t) => {
+safeSizeTest('Subject and description fields should be empty after showing popup on empty cell', async (t) => {
   const APPOINTMENT_TEXT = 'Website Re-Design Plan';
 
   const scheduler = new Scheduler('#container');
@@ -41,7 +42,7 @@ test('Subject and description fields should be empty after showing popup on empt
   ],
 }, true));
 
-test('Custom form shouldn\'t throw exception, after second show appointment form(T812654)', async (t) => {
+safeSizeTest('Custom form shouldn\'t throw exception, after second show appointment form(T812654)', async (t) => {
   const APPOINTMENT_TEXT = 'Website Re-Design Plan';
   const TEXT_EDITOR_CLASS = '.dx-texteditor-input';
   const CHECKBOX_CLASS = '.dx-checkbox.dx-widget';
@@ -98,7 +99,7 @@ test('Custom form shouldn\'t throw exception, after second show appointment form
   ],
 }, true));
 
-test('Appointment should have correct form data on consecutive shows (T832711)', async (t) => {
+safeSizeTest('Appointment should have correct form data on consecutive shows (T832711)', async (t) => {
   const APPOINTMENT_TEXT = 'Google AdWords Strategy';
 
   const scheduler = new Scheduler('#container');
@@ -138,7 +139,7 @@ test('Appointment should have correct form data on consecutive shows (T832711)',
   height: 580,
 }, true));
 
-test('From elements for disabled appointments should be read only (T835731)', async (t) => {
+safeSizeTest('From elements for disabled appointments should be read only (T835731)', async (t) => {
   const APPOINTMENT_TEXT = 'Install New Router in Dev Room';
   const scheduler = new Scheduler('#container');
   const { appointmentPopup } = scheduler;
@@ -175,7 +176,7 @@ test('From elements for disabled appointments should be read only (T835731)', as
   height: 600,
 }));
 
-test('AppointmentForm should display correct dates in work-week when firstDayOfWeek is used', async (t) => {
+safeSizeTest('AppointmentForm should display correct dates in work-week when firstDayOfWeek is used', async (t) => {
   const scheduler = new Scheduler('#container');
   const { appointmentPopup } = scheduler;
 

--- a/testing/testcafe/tests/scheduler/appointmentForm/dataEditors.ts
+++ b/testing/testcafe/tests/scheduler/appointmentForm/dataEditors.ts
@@ -1,11 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Appointment popup form:date editors`
   .page(url(__dirname, '../../container.html'));
 
-test('Form date editors should be pass numeric chars according by date mask', async (t) => {
+safeSizeTest('Form date editors should be pass numeric chars according by date mask', async (t) => {
   const scheduler = new Scheduler('#container');
   const { appointmentPopup } = scheduler;
 
@@ -44,7 +45,7 @@ test('Form date editors should be pass numeric chars according by date mask', as
   height: 600,
 }, true));
 
-test('Form date editors should not be pass chars according by date mask', async (t) => {
+safeSizeTest('Form date editors should not be pass chars according by date mask', async (t) => {
   const scheduler = new Scheduler('#container');
   const { appointmentPopup } = scheduler;
 
@@ -83,7 +84,7 @@ test('Form date editors should not be pass chars according by date mask', async 
   height: 600,
 }, true));
 
-test('Form date editors should not be pass chars after remove all characters according by date mask', async (t) => {
+safeSizeTest('Form date editors should not be pass chars after remove all characters according by date mask', async (t) => {
   const scheduler = new Scheduler('#container');
   const { appointmentPopup } = scheduler;
 

--- a/testing/testcafe/tests/scheduler/appointmentForm/showAppointmentPopup.ts
+++ b/testing/testcafe/tests/scheduler/appointmentForm/showAppointmentPopup.ts
@@ -1,4 +1,5 @@
 import { ClientFunction } from 'testcafe';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
@@ -11,7 +12,7 @@ const showAppointmentPopup = ClientFunction(() => {
   instance.showAppointmentPopup();
 });
 
-test('Invoke showAppointmentPopup method shouldn\'t raise error if value of currentDate property as a string', async (t) => {
+safeSizeTest('Invoke showAppointmentPopup method shouldn\'t raise error if value of currentDate property as a string', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await showAppointmentPopup();
@@ -29,7 +30,7 @@ test('Invoke showAppointmentPopup method shouldn\'t raise error if value of curr
   height: 600,
 }, true));
 
-test('Show appointment popup if deffereRendering is false (T1069753)', async (t) => {
+safeSizeTest('Show appointment popup if deffereRendering is false (T1069753)', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointmentByIndex(0);
 

--- a/testing/testcafe/tests/scheduler/appointmentForm/timezoneEditors.ts
+++ b/testing/testcafe/tests/scheduler/appointmentForm/timezoneEditors.ts
@@ -1,5 +1,6 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Layout:AppointmentForm:TimezoneEditors(T1080932)`
@@ -18,7 +19,7 @@ const inputClassName = '.dx-texteditor-input';
 const startDateTimeZoneValue = '(GMT -10:00) Etc - GMT+10';
 const endDateTimeZoneValue = '(GMT -08:00) US - Alaska';
 
-test('TimeZone editors should be have data after hide forms data(T1080932)', async (t) => {
+safeSizeTest('TimeZone editors should be have data after hide forms data(T1080932)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { appointmentPopup } = scheduler;
 
@@ -47,7 +48,7 @@ test('TimeZone editors should be have data after hide forms data(T1080932)', asy
   }, true);
 });
 
-test('TimeZone editors should be have data in default case(T1080932)', async (t) => {
+safeSizeTest('TimeZone editors should be have data in default case(T1080932)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t.doubleClick(scheduler.getAppointmentByIndex(0).element);

--- a/testing/testcafe/tests/scheduler/appointmentOverlapping/basic.ts
+++ b/testing/testcafe/tests/scheduler/appointmentOverlapping/basic.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import { simpleData, allDayData } from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Appointment overlapping in Scheduler`
   .page(url(__dirname, '../../container.html'));
 
-test('Multi-day appointment should not overlap other appointments when specific width is set, \'auto\' mode (T864456)', async (t) => {
+safeSizeTest('Multi-day appointment should not overlap other appointments when specific width is set, \'auto\' mode (T864456)', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('Appointment 1', 1);
 
@@ -22,7 +23,7 @@ test('Multi-day appointment should not overlap other appointments when specific 
   dataSource: simpleData,
 }));
 
-test('Simple appointment should not overlap allDay appointment when specific width is set, \'auto\' mode (T864456)', async (t) => {
+safeSizeTest('Simple appointment should not overlap allDay appointment when specific width is set, \'auto\' mode (T864456)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { element } = scheduler.getAppointment('Appointment 4');
 
@@ -33,7 +34,7 @@ test('Simple appointment should not overlap allDay appointment when specific wid
   dataSource: allDayData,
 }));
 
-test('Crossing allDay appointments should not overlap each other (T893674)', async (t) => {
+safeSizeTest('Crossing allDay appointments should not overlap each other (T893674)', async (t) => {
   const scheduler = new Scheduler('#container');
   const firstAppointment = scheduler.getAppointment('Appointment 1');
   const secondAppointment = scheduler.getAppointment('Appointment 2');

--- a/testing/testcafe/tests/scheduler/appointments/allDay/allDay.ts
+++ b/testing/testcafe/tests/scheduler/appointments/allDay/allDay.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 
 fixture`Scheduler - All day appointments`
   .page(url(__dirname, './containers/containerAllDay.html'));
@@ -23,9 +24,7 @@ const data = [{
   endDate: new Date(2021, 3, 4, 23, 59, 59),
 }];
 
-test('it should skip weekend days in workWeek', async (t) => {
-  await t.resizeWindow(1200, 800);
-
+safeSizeTest('it should skip weekend days in workWeek', async (t) => {
   const {
     takeScreenshot,
     compareResults,
@@ -54,7 +53,7 @@ test('it should skip weekend days in workWeek', async (t) => {
   '#workweek',
 ));
 
-test('it should skip weekend days in timelineWorkWeek', async (t) => {
+safeSizeTest('it should skip weekend days in timelineWorkWeek', async (t) => {
   const {
     takeScreenshot,
     compareResults,

--- a/testing/testcafe/tests/scheduler/appointments/allDay/allDayTimelines.ts
+++ b/testing/testcafe/tests/scheduler/appointments/allDay/allDayTimelines.ts
@@ -1,7 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
-import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 const CLICK_OPTIONS = { speed: 0.1 };
@@ -10,7 +10,7 @@ const SCHEDULER_SELECTOR = '#container';
 fixture`Scheduler - All day appointments`
   .page(url(__dirname, '../../../container.html'));
 
-test('it should display the all-day appointment in two dates if the end date equals midnight',
+safeSizeTest('it should display the all-day appointment in two dates if the end date equals midnight',
   async (t) => {
     const scheduler = new Scheduler(SCHEDULER_SELECTOR);
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -26,7 +26,7 @@ test('it should display the all-day appointment in two dates if the end date equ
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
+  }).before(async () => {
   await createWidget(
     'dxScheduler',
     {
@@ -43,5 +43,4 @@ test('it should display the all-day appointment in two dates if the end date equ
       currentDate: '2021-04-30T00:00:00Z',
     },
   );
-  await restoreBrowserSize(t);
 });

--- a/testing/testcafe/tests/scheduler/appointments/dependendOptions.ts
+++ b/testing/testcafe/tests/scheduler/appointments/dependendOptions.ts
@@ -1,11 +1,12 @@
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import createWidget from '../../../helpers/createWidget';
 
 fixture`Appointment dependend options`
   .page(url(__dirname, '../../container.html'));
 
-test('cellDuration (T1076138)', async (t) => {
+safeSizeTest('cellDuration (T1076138)', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('test-appt');
 

--- a/testing/testcafe/tests/scheduler/appointments/displayArguments.ts
+++ b/testing/testcafe/tests/scheduler/appointments/displayArguments.ts
@@ -1,4 +1,5 @@
 import { ClientFunction } from 'testcafe';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
@@ -7,7 +8,7 @@ fixture`Display* arguments in appointment templates and events`
   .page(url(__dirname, '../../container.html'));
 
 [undefined, 'America/Los_Angeles'].forEach((timeZone) => {
-  test(`displayStartDate and displayEndDate arguments should be right with timeZone='${timeZone}'`, async (t) => {
+  safeSizeTest(`displayStartDate and displayEndDate arguments should be right with timeZone='${timeZone}'`, async (t) => {
     const scheduler = new Scheduler('#container');
     const etalon = '09:30:00 10:00:00';
 

--- a/testing/testcafe/tests/scheduler/appointments/editing.ts
+++ b/testing/testcafe/tests/scheduler/appointments/editing.ts
@@ -1,6 +1,7 @@
 import { ClientFunction } from 'testcafe';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 const CLICK_OPTIONS = { speed: 0.1 };
@@ -12,7 +13,7 @@ const UPDATED_APPOINTMENT_TITLE = `${INITIAL_APPOINTMENT_TITLE}${ADDITIONAL_TITL
 fixture`Appointment Editing`
   .page(url(__dirname, '../../container.html'));
 
-test('Should correctly update appointment if dataSource is a simple array', async (t) => {
+safeSizeTest('Should correctly update appointment if dataSource is a simple array', async (t) => {
   const scheduler = new Scheduler(SCHEDULER_SELECTOR);
   const appointment = scheduler.getAppointment(INITIAL_APPOINTMENT_TITLE);
   const updatedAppointment = scheduler.getAppointment(UPDATED_APPOINTMENT_TITLE);
@@ -42,7 +43,7 @@ test('Should correctly update appointment if dataSource is a simple array', asyn
   height: 600,
 }, true));
 
-test('Should correctly update appointment if dataSource is a Store with key array', async (t) => {
+safeSizeTest('Should correctly update appointment if dataSource is a Store with key array', async (t) => {
   const scheduler = new Scheduler(SCHEDULER_SELECTOR);
   const appointment = scheduler.getAppointment(INITIAL_APPOINTMENT_TITLE);
   const updatedAppointment = scheduler.getAppointment(UPDATED_APPOINTMENT_TITLE);

--- a/testing/testcafe/tests/scheduler/appointments/multiday.ts
+++ b/testing/testcafe/tests/scheduler/appointments/multiday.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
@@ -11,7 +12,7 @@ fixture`Scheduler - Multiday appointments`
   'month',
   'timelineMonth',
 ].forEach((currentView) => {
-  test(`it should not cut multiday appointment in ${currentView} view`, async (t) => {
+  safeSizeTest(`it should not cut multiday appointment in ${currentView} view`, async (t) => {
     const {
       takeScreenshot,
       compareResults,

--- a/testing/testcafe/tests/scheduler/appointments/resources.ts
+++ b/testing/testcafe/tests/scheduler/appointments/resources.ts
@@ -1,7 +1,11 @@
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
-import createWidget, { disposeWidgets } from '../../../helpers/createWidget';
+import createWidget from '../../../helpers/createWidget';
 import TagBox from '../../../model/tagBox';
+
+fixture`Appointment resources`
+  .page(url(__dirname, '../../container.html'));
 
 const dataSource = [{
   text: 'test-appt-1',
@@ -27,11 +31,7 @@ const priorityData = [{
   color: 'rgb(225, 142, 146)',
 }];
 
-fixture.disablePageReloads`Appointment resources`
-  .page(url(__dirname, '../../container.html'))
-  .afterEach(async () => disposeWidgets());
-
-test('Resource color should be correct if group is set in "views"', async (t) => {
+safeSizeTest('Resource color should be correct if group is set in "views"', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment1 = scheduler.getAppointment('test-appt-1');
   const appointment2 = scheduler.getAppointment('test-appt-2');
@@ -68,7 +68,7 @@ test('Resource color should be correct if group is set in "views"', async (t) =>
   }],
 }));
 
-test('Resource with allowMultiple should be set correctly for new the appointment (T1075028)', async (t) => {
+safeSizeTest('Resource with allowMultiple should be set correctly for new the appointment (T1075028)', async (t) => {
   const scheduler = new Scheduler('#container');
   const cell = scheduler.getDateTableCell(2, 0);
   const popup = scheduler.appointmentPopup;
@@ -114,7 +114,7 @@ test('Resource with allowMultiple should be set correctly for new the appointmen
   }],
 }));
 
-test('Resource color should be correct for the complex resource id without grouping', async (t) => {
+safeSizeTest('Resource color should be correct for the complex resource id without grouping', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointmentA = scheduler.getAppointment('a');
   const appointmentB = scheduler.getAppointment('b');

--- a/testing/testcafe/tests/scheduler/appointments/timelines.ts
+++ b/testing/testcafe/tests/scheduler/appointments/timelines.ts
@@ -1,11 +1,12 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 
 fixture`Timeline Appointments`
   .page(url(__dirname, '../../container.html'));
 
-test('all-day and ordinary appointments should overlap each other correctly in timeline views (T1017889)', async (t) => {
+safeSizeTest('all-day and ordinary appointments should overlap each other correctly in timeline views (T1017889)', async (t) => {
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
   await t

--- a/testing/testcafe/tests/scheduler/cellsSelection/bothDirectionsVirtualScrolling.ts
+++ b/testing/testcafe/tests/scheduler/cellsSelection/bothDirectionsVirtualScrolling.ts
@@ -1,4 +1,5 @@
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import {
   createScheduler,
@@ -23,7 +24,7 @@ const baseConfig = {
   currentView: 'week',
 };
 
-test('Selected cells shouldn\'t disapppear on scroll', async (t) => {
+safeSizeTest('Selected cells shouldn\'t disapppear on scroll', async (t) => {
   await t
     .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));
 
@@ -38,7 +39,7 @@ test('Selected cells shouldn\'t disapppear on scroll', async (t) => {
   ...baseConfig,
 }));
 
-test('Selected cells shouldn\'t disapppear on scroll when horizontal grouping is used', async (t) => {
+safeSizeTest('Selected cells shouldn\'t disapppear on scroll when horizontal grouping is used', async (t) => {
   await t
     .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));
 
@@ -58,7 +59,7 @@ test('Selected cells shouldn\'t disapppear on scroll when horizontal grouping is
   ...baseConfig,
 }));
 
-test('Selected cells shouldn\'t disapppear on scroll when appointments are grouped by date', async (t) => {
+safeSizeTest('Selected cells shouldn\'t disapppear on scroll when appointments are grouped by date', async (t) => {
   await t
     .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 2));
 
@@ -79,7 +80,7 @@ test('Selected cells shouldn\'t disapppear on scroll when appointments are group
   }],
 }));
 
-test('Selected cells shouldn\'t disapppear on scroll when appointments are grouped vertically', async (t) => {
+safeSizeTest('Selected cells shouldn\'t disapppear on scroll when appointments are grouped vertically', async (t) => {
   await t
     .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));
 
@@ -100,7 +101,7 @@ test('Selected cells shouldn\'t disapppear on scroll when appointments are group
   }],
 }));
 
-test('All-day panel\'s selected cells shouldn\'t disapppear on scroll when horizontal grouping is used', async (t) => {
+safeSizeTest('All-day panel\'s selected cells shouldn\'t disapppear on scroll when horizontal grouping is used', async (t) => {
   await t
     .dragToElement(scheduler.getAllDayTableCell(0), scheduler.getAllDayTableCell(1));
 
@@ -116,7 +117,7 @@ test('All-day panel\'s selected cells shouldn\'t disapppear on scroll when horiz
   showAllDayPanel: true,
 }));
 
-test('All-day panel\'s selected cells shouldn\'t disapppear on scroll when vertical grouping is used', async (t) => {
+safeSizeTest('All-day panel\'s selected cells shouldn\'t disapppear on scroll when vertical grouping is used', async (t) => {
   await t
     .dragToElement(scheduler.getAllDayTableCell(0), scheduler.getAllDayTableCell(1));
 
@@ -137,7 +138,7 @@ test('All-day panel\'s selected cells shouldn\'t disapppear on scroll when verti
   }],
 }));
 
-test('Selection should work in month view', async (t) => {
+safeSizeTest('Selection should work in month view', async (t) => {
   await t
     .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));
 
@@ -166,7 +167,7 @@ test('Selection should work in month view', async (t) => {
   }],
 }));
 
-test('Selection should work in timeline views', async (t) => {
+safeSizeTest('Selection should work in timeline views', async (t) => {
   const checkSelection = async (): Promise<void> => {
     await t
       .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));

--- a/testing/testcafe/tests/scheduler/cellsSelection/cellsSelection.ts
+++ b/testing/testcafe/tests/scheduler/cellsSelection/cellsSelection.ts
@@ -1,11 +1,12 @@
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import createWidget from '../../../helpers/createWidget';
 
 fixture`Scheduler: Cells Selection in Virtual Scrolling`
   .page(url(__dirname, '../../container.html'));
 
-test('Selection should work correctly with all-day panel appointments', async (t) => {
+safeSizeTest('Selection should work correctly with all-day panel appointments', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t

--- a/testing/testcafe/tests/scheduler/cellsSelection/virtualScrollingCellSelection.ts
+++ b/testing/testcafe/tests/scheduler/cellsSelection/virtualScrollingCellSelection.ts
@@ -1,4 +1,5 @@
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import {
   createScheduler,
@@ -17,7 +18,7 @@ fixture`Scheduler: Cells Selection in Virtual Scrolling`
 const scheduler = new Scheduler('#container');
 
 [true, false].forEach((showAllDayPanel) => {
-  test(`Selected cells shouldn't disapppear on scroll when showAllDayPanel is equal to ${showAllDayPanel}`, async (t) => {
+  safeSizeTest(`Selected cells shouldn't disapppear on scroll when showAllDayPanel is equal to ${showAllDayPanel}`, async (t) => {
     await t
       .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));
 
@@ -30,7 +31,7 @@ const scheduler = new Scheduler('#container');
     await checkSelectionWhenFocusedInViewport(t, scheduler, 8, 6, 1);
   }).before(async () => createScheduler({ showAllDayPanel }));
 
-  test(`Selected cells shouldn't disapppear on scroll when showAllDayPanel is equal to ${showAllDayPanel} and horizontal grouping is used`, async (t) => {
+  safeSizeTest(`Selected cells shouldn't disapppear on scroll when showAllDayPanel is equal to ${showAllDayPanel} and horizontal grouping is used`, async (t) => {
     await t
       .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));
 
@@ -50,7 +51,7 @@ const scheduler = new Scheduler('#container');
     }],
   }));
 
-  test(`Selected cells shouldn't disapppear on scroll when showAllDayPanel is equal to ${showAllDayPanel} and appointments are grouped by date`, async (t) => {
+  safeSizeTest(`Selected cells shouldn't disapppear on scroll when showAllDayPanel is equal to ${showAllDayPanel} and appointments are grouped by date`, async (t) => {
     await t
       .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 2));
 
@@ -71,7 +72,7 @@ const scheduler = new Scheduler('#container');
     }],
   }));
 
-  test(`Selected cells shouldn't disapppear on scroll when showAllDayPanel is equal to ${showAllDayPanel} and appointments are grouped vertically`, async (t) => {
+  safeSizeTest(`Selected cells shouldn't disapppear on scroll when showAllDayPanel is equal to ${showAllDayPanel} and appointments are grouped vertically`, async (t) => {
     await t
       .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));
 
@@ -99,7 +100,7 @@ const scheduler = new Scheduler('#container');
   }));
 });
 
-test('All-day panel\'s selected cells shouldn\'t disapppear on scroll when horizontal grouping is used', async (t) => {
+safeSizeTest('All-day panel\'s selected cells shouldn\'t disapppear on scroll when horizontal grouping is used', async (t) => {
   await t
     .dragToElement(scheduler.getAllDayTableCell(0), scheduler.getAllDayTableCell(1));
 
@@ -115,7 +116,7 @@ test('All-day panel\'s selected cells shouldn\'t disapppear on scroll when horiz
   groups: ['resourceId0'],
 }));
 
-test('All-day panel\'s selected cells shouldn\'t disapppear on scroll when vertical grouping is used', async (t) => {
+safeSizeTest('All-day panel\'s selected cells shouldn\'t disapppear on scroll when vertical grouping is used', async (t) => {
   await t
     .dragToElement(scheduler.getAllDayTableCell(0), scheduler.getAllDayTableCell(1));
 
@@ -135,7 +136,7 @@ test('All-day panel\'s selected cells shouldn\'t disapppear on scroll when verti
   }],
 }));
 
-test('Selection should work correctly while scrolling', async (t) => {
+safeSizeTest('Selection should work correctly while scrolling', async (t) => {
   await selectCells(
     scheduler.dateTable,
     scheduler.getDateTableCell(0, 0),
@@ -155,7 +156,7 @@ test('Selection should work correctly while scrolling', async (t) => {
   groups: ['resourceId0'],
 }));
 
-test('Selection should work correctly while scrolling when appointments are grouped vertically', async (t) => {
+safeSizeTest('Selection should work correctly while scrolling when appointments are grouped vertically', async (t) => {
   await selectCells(
     scheduler.dateTable,
     scheduler.getDateTableCell(0, 0),
@@ -179,7 +180,7 @@ test('Selection should work correctly while scrolling when appointments are grou
   }],
 }));
 
-test('Selection should work in month view', async (t) => {
+safeSizeTest('Selection should work in month view', async (t) => {
   await t
     .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));
 
@@ -200,7 +201,7 @@ test('Selection should work in month view', async (t) => {
   currentView: 'month',
 }));
 
-test('Selection should work in timeline views', async (t) => {
+safeSizeTest('Selection should work in timeline views', async (t) => {
   const checkSelection = async (): Promise<void> => {
     await t
       .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 1));

--- a/testing/testcafe/tests/scheduler/const/index.ts
+++ b/testing/testcafe/tests/scheduler/const/index.ts
@@ -1,0 +1,7 @@
+import { BrowserSizeType } from '../../../helpers/restoreBrowserSize';
+
+const ADAPTIVE_SIZE: BrowserSizeType = [400, 600];
+
+export {
+  ADAPTIVE_SIZE,
+};

--- a/testing/testcafe/tests/scheduler/dataSource/load.ts
+++ b/testing/testcafe/tests/scheduler/dataSource/load.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
@@ -5,7 +6,7 @@ import url from '../../../helpers/getPageUrl';
 fixture`Scheduler - DataSource loading`
   .page(url(__dirname, '../../container.html'));
 
-test('it should correctly load items with post processing', async (t) => {
+safeSizeTest('it should correctly load items with post processing', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment0 = scheduler.getAppointment('appt-0');
 

--- a/testing/testcafe/tests/scheduler/deleteAppointments.ts
+++ b/testing/testcafe/tests/scheduler/deleteAppointments.ts
@@ -1,5 +1,6 @@
 import createWidget from '../../helpers/createWidget';
 import url from '../../helpers/getPageUrl';
+import { safeSizeTest } from '../../helpers/safeSizeTest';
 import Scheduler from '../../model/scheduler';
 
 fixture`Delete appointments`
@@ -39,10 +40,9 @@ const createSimpleData = (): Record<string, unknown>[] => [{
   EndDate: new Date(2017, 4, 22, 13, 0, 0, 0),
 }];
 
-test('Recurrence appointments should be deleted by click on \'delete\' button', async (t) => {
+safeSizeTest('Recurrence appointments should be deleted by click on \'delete\' button', async (t) => {
   await t
     .setTestSpeed(0.1)
-    .resizeWindow(1200, 800)
     .expect(scheduler.getAppointmentCount()).eql(6)
     .click(scheduler.getAppointment('Text', 3).element)
 
@@ -64,7 +64,7 @@ test('Recurrence appointments should be deleted by click on \'delete\' button', 
     .eql(0);
 }).before(async () => createScheduler(createRecurrenceData()));
 
-test('Recurrence appointments should be deleted by press \'delete\' key', async (t) => {
+safeSizeTest('Recurrence appointments should be deleted by press \'delete\' key', async (t) => {
   await t
     .setTestSpeed(0.1)
     .expect(scheduler.getAppointmentCount()).eql(6)
@@ -86,7 +86,7 @@ test('Recurrence appointments should be deleted by press \'delete\' key', async 
     .eql(0);
 }).before(async () => createScheduler(createRecurrenceData()));
 
-test('Common appointments should be deleted by click on \'delete\' button and press \'delete\' key', async (t) => {
+safeSizeTest('Common appointments should be deleted by click on \'delete\' button and press \'delete\' key', async (t) => {
   await t
     .expect(scheduler.getAppointmentCount()).eql(2)
     .click(scheduler.getAppointment('Text').element)

--- a/testing/testcafe/tests/scheduler/dragAndDrop/DNDToFakeCell.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/DNDToFakeCell.ts
@@ -1,12 +1,13 @@
 import { Selector } from 'testcafe';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Drag-n-drop to fake cell`
   .page(url(__dirname, './pages/containerWithFakeCell.html'));
 
-test('Should not select cells outside the scheduler(T1040795)', async (t) => {
+safeSizeTest('Should not select cells outside the scheduler(T1040795)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const { element } = scheduler.getAppointment('app');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/T1017720.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/T1017720.ts
@@ -3,12 +3,13 @@ import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import { extend } from '../../../../../js/core/utils/extend';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`T1017720`
   .page(url(__dirname, './pages/containerWithDnD.html'));
 
-test('Drag-n-drop appointment above SVG element(T1017720)', async (t) => {
+safeSizeTest('Drag-n-drop appointment above SVG element(T1017720)', async (t) => {
   const scheduler = new Scheduler('#scheduler');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
   const draggableAppointment = scheduler.getAppointment('text');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/T1046067.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/T1046067.ts
@@ -1,11 +1,12 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`T1046067`
   .page(url(__dirname, './pages/T1046067.html'));
 
-test('Drag-n-Drop appointment where disabled property is set as a function (T1046067)', async (t) => {
+safeSizeTest('Drag-n-Drop appointment where disabled property is set as a function (T1046067)', async (t) => {
   const scheduler = new Scheduler('#scheduler');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
   const disabledAppointment = scheduler.getAppointment('disabled-appt');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/T1080232.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/T1080232.ts
@@ -1,4 +1,5 @@
 import { Selector } from 'testcafe';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Appointment (T1080232)`
   .page(url(__dirname, './pages/T1080232.html'));
 
-test('it should correctly drag external item to the appointment after drag appointment', async (t) => {
+safeSizeTest('it should correctly drag external item to the appointment after drag appointment', async (t) => {
   const scheduler = new Scheduler('#container');
   const dragItem = Selector('.drag-item');
   const cell01 = scheduler.getDateTableCell(1, 0);

--- a/testing/testcafe/tests/scheduler/dragAndDrop/appointmentCollector.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/appointmentCollector.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import { appointmentCollectorData } from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import createWidget from '../../../helpers/createWidget';
@@ -8,7 +9,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Drag-and-drop behaviour for the appointment tooltip`
   .page(url(__dirname, '../../container.html'));
 
-test('Drag-n-drop between a scheduler table cell and the appointment tooltip', async (t) => {
+safeSizeTest('Drag-n-drop between a scheduler table cell and the appointment tooltip', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('Approve Personal Computer Upgrade Plan');
   const collector = scheduler.collectors.find('2');
@@ -41,7 +42,7 @@ test('Drag-n-drop between a scheduler table cell and the appointment tooltip', a
   width: 1000,
 }));
 
-test('Drag-n-drop in same table cell', async (t) => {
+safeSizeTest('Drag-n-drop in same table cell', async (t) => {
   const scheduler = new Scheduler('#container');
   const collector = scheduler.collectors.find('2');
   const { appointmentTooltip } = scheduler;
@@ -62,7 +63,7 @@ test('Drag-n-drop in same table cell', async (t) => {
   width: 1000,
 }));
 
-test('Drag-n-drop to the cell below should work in month view (T1005115)', async (t) => {
+safeSizeTest('Drag-n-drop to the cell below should work in month view (T1005115)', async (t) => {
   const scheduler = new Scheduler('#container');
   const collector = scheduler.collectors.find('1 more');
   const { appointmentTooltip } = scheduler;
@@ -104,7 +105,7 @@ test('Drag-n-drop to the cell below should work in month view (T1005115)', async
   height: 800,
 }));
 
-test('Drag-n-drop to the cell on the left should work in week view (T1005115)', async (t) => {
+safeSizeTest('Drag-n-drop to the cell on the left should work in week view (T1005115)', async (t) => {
   const scheduler = new Scheduler('#container');
   const collector = scheduler.collectors.find('1');
   const { appointmentTooltip } = scheduler;

--- a/testing/testcafe/tests/scheduler/dragAndDrop/basic.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/basic.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import { dataSource } from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -22,7 +23,7 @@ fixture`Drag-and-drop appointments in the Scheduler basic views`
   dataSource,
 })));
 
-test('Drag-n-drop in the "month" view', async (t) => {
+safeSizeTest('Drag-n-drop in the "month" view', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Brochure Design Review');
 
@@ -38,7 +39,7 @@ test('Drag-n-drop in the "month" view', async (t) => {
   height: 834,
 }));
 
-test('Drag-n-drop when browser has horizontal scroll', async (t) => {
+safeSizeTest('Drag-n-drop when browser has horizontal scroll', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Staff Productivity Report');
 
@@ -57,7 +58,7 @@ test('Drag-n-drop when browser has horizontal scroll', async (t) => {
   width: 1800,
 }));
 
-test('Drag-n-drop when browser has vertical scroll', async (t) => {
+safeSizeTest('Drag-n-drop when browser has vertical scroll', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Staff Productivity Report');
 
@@ -76,7 +77,7 @@ test('Drag-n-drop when browser has vertical scroll', async (t) => {
   height: 1800,
 }));
 
-test('Drag recurrent appointment occurrence from collector (T832887)', async (t) => {
+safeSizeTest('Drag recurrent appointment occurrence from collector (T832887)', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('Recurrence two');
   const collector = scheduler.collectors.find('2');
@@ -123,7 +124,7 @@ test('Drag recurrent appointment occurrence from collector (T832887)', async (t)
   currentDate: new Date(2019, 2, 26),
 }));
 
-test('Drag-n-drop the appointment to the left column to the cell that has the same time', async (t) => {
+safeSizeTest('Drag-n-drop the appointment to the left column to the cell that has the same time', async (t) => {
   const scheduler = new Scheduler('#container');
   const screenshotZone = scheduler.workSpace;
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);

--- a/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/dragAppointmentInEqualCellIndexes.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/dragAppointmentInEqualCellIndexes.ts
@@ -1,6 +1,10 @@
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
+
+fixture`Drag-n-drop appointments between two schedulers with equal cell indexes (T1094035)`
+  .page(url(__dirname, '../pages/containerForTwoSchedulers.html'));
 
 const FIRST_SCHEDULER_SELECTOR = '#scheduler-first';
 const SECOND_SCHEDULER_SELECTOR = '#scheduler-second';
@@ -28,10 +32,7 @@ const getSchedulerOptions = (dataSource) => ({
   },
 });
 
-fixture`Drag-n-drop appointments between two schedulers with equal cell indexes (T1094035)`
-  .page(url(__dirname, '../pages/containerForTwoSchedulers.html'));
-
-test('Should not lose drag-n-dropped appointment in the second scheduler', async (t) => {
+safeSizeTest('Should not lose drag-n-dropped appointment in the second scheduler', async (t) => {
   const firstScheduler = new Scheduler(FIRST_SCHEDULER_SELECTOR);
   const secondScheduler = new Scheduler(SECOND_SCHEDULER_SELECTOR);
 

--- a/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/dragAppointmentWithDataSource.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/dragAppointmentWithDataSource.ts
@@ -1,7 +1,11 @@
 import { ClientFunction } from 'testcafe';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
+
+fixture`Drag-n-drop appointments between two schedulers with async DataSource (T1094033)`
+  .page(url(__dirname, '../pages/containerForTwoSchedulers.html'));
 
 interface TestAppointment {
   id: number;
@@ -81,10 +85,7 @@ const createSchedulerWithRemoteDataSource = async (
   }, { dependencies: { selector, options, appointments } })();
 };
 
-fixture`Drag-n-drop appointments between two schedulers with async DataSource (T1094033)`
-  .page(url(__dirname, '../pages/containerForTwoSchedulers.html'));
-
-test('Should set correct start and end dates in drag&dropped appointment', async (t) => {
+safeSizeTest('Should set correct start and end dates in drag&dropped appointment', async (t) => {
   const firstScheduler = new Scheduler(FIRST_SCHEDULER_SELECTOR);
   const secondScheduler = new Scheduler(SECOND_SCHEDULER_SELECTOR);
 

--- a/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/removeDroppableCellClass.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/betweenSchedulers/removeDroppableCellClass.ts
@@ -1,6 +1,10 @@
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
+
+fixture`Cancel drag-n-drop when dragging an appointment from one scheduler to another`
+  .page(url(__dirname, '../pages/containerForTwoSchedulers.html'));
 
 const FIRST_SCHEDULER_SELECTOR = '#scheduler-first';
 const SECOND_SCHEDULER_SELECTOR = '#scheduler-second';
@@ -38,11 +42,8 @@ const getSchedulerOptions = (dataSource, currentDate, cancelMethodName) => ({
   },
 });
 
-fixture`Cancel drag-n-drop when dragging an appointment from one scheduler to another`
-  .page(url(__dirname, '../pages/containerForTwoSchedulers.html'));
-
 METHODS_TO_CANCEL.forEach((methodName) => {
-  test(`Should remove drag-n-drop classes if event was canceled in method ${methodName}`, async (t) => {
+  safeSizeTest(`Should remove drag-n-drop classes if event was canceled in method ${methodName}`, async (t) => {
     const firstScheduler = new Scheduler(FIRST_SCHEDULER_SELECTOR);
     const secondScheduler = new Scheduler(SECOND_SCHEDULER_SELECTOR);
 

--- a/testing/testcafe/tests/scheduler/dragAndDrop/dragAppointmentAfterResize.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/dragAppointmentAfterResize.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
@@ -5,7 +6,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Drag-n-drop appointment after resize (T835545)`
   .page(url(__dirname, '../../container.html'));
 
-['day', 'week', 'month', 'timelineDay', 'timelineWeek', 'timelineMonth'].forEach((view) => test(
+['day', 'week', 'month', 'timelineDay', 'timelineWeek', 'timelineMonth'].forEach((view) => safeSizeTest(
   `After drag-n-drop appointment, size of appointment shouldn't change in the '${view}' view`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { element, resizableHandle } = scheduler.getAppointment('app');

--- a/testing/testcafe/tests/scheduler/dragAndDrop/externalDragging.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/externalDragging.ts
@@ -1,4 +1,5 @@
 import { Selector } from 'testcafe';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Drag-n-drop from another draggable area`
   .page(url(__dirname, './pages/containerWithDnD.html'));
 
-test('Drag-n-drop an appointment when "cellDuration" changes dynamically', async (t) => {
+safeSizeTest('Drag-n-drop an appointment when "cellDuration" changes dynamically', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await scheduler.option('cellDuration', 10);

--- a/testing/testcafe/tests/scheduler/dragAndDrop/insideScheduler/removeDroppableCellClass.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/insideScheduler/removeDroppableCellClass.ts
@@ -1,5 +1,6 @@
 import url from '../../../../helpers/getPageUrl';
 import createWidget from '../../../../helpers/createWidget';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Cancel drag-n-drop when dragging an appointment inside the scheduler`
@@ -27,7 +28,7 @@ const getSchedulerOptions = () => ({
 });
 
 METHODS_TO_CANCEL.forEach((methodName) => {
-  test(`Should remove drag-n-drop classes if event was canceled in method ${methodName}`, async (t) => {
+  safeSizeTest(`Should remove drag-n-drop classes if event was canceled in method ${methodName}`, async (t) => {
     const scheduler = new Scheduler(SCHEDULER_SELECTOR);
 
     const appointmentToMoveElement = scheduler

--- a/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/base.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/base.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Outlook dragging base tests`
@@ -53,7 +54,7 @@ test('Basic drag-n-drop movements in groups', async (t) => {
   width: 1000,
 }));
 
-test('Basic drag-n-drop movements from tooltip in week view', async (t) => {
+safeSizeTest('Basic drag-n-drop movements from tooltip in week view', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -100,7 +101,7 @@ test('Basic drag-n-drop movements from tooltip in week view', async (t) => {
   width: 1000,
 }));
 
-test('Basic drag-n-drop movements from tooltip in month view', async (t) => {
+safeSizeTest('Basic drag-n-drop movements from tooltip in month view', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -162,7 +163,7 @@ test('Basic drag-n-drop movements from tooltip in month view', async (t) => {
     endDate: new Date(2021, 2, 3, 11, 0),
   }],
 }].forEach(({ currentView, dataSource }) => {
-  test(`Basic drag-n-drop movements in ${currentView} view`, async (t) => {
+  safeSizeTest(`Basic drag-n-drop movements in ${currentView} view`, async (t) => {
     const scheduler = new Scheduler('#container');
     const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 
@@ -190,7 +191,7 @@ test('Basic drag-n-drop movements from tooltip in month view', async (t) => {
   }));
 });
 
-test('Basic drag-n-drop movements', async (t) => {
+safeSizeTest('Basic drag-n-drop movements', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 
@@ -229,7 +230,7 @@ test('Basic drag-n-drop movements', async (t) => {
   width: 1000,
 }));
 
-test('Basic drag-n-drop movements with mouse offset', async (t) => {
+safeSizeTest('Basic drag-n-drop movements with mouse offset', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 
@@ -268,7 +269,7 @@ test('Basic drag-n-drop movements with mouse offset', async (t) => {
   width: 1000,
 }));
 
-test('Basic drag-n-drop all day appointment movements', async (t) => {
+safeSizeTest('Basic drag-n-drop all day appointment movements', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 
@@ -307,7 +308,7 @@ test('Basic drag-n-drop all day appointment movements', async (t) => {
   width: 1000,
 }));
 
-test('Basic drag-n-drop movements within the cell', async (t) => {
+safeSizeTest('Basic drag-n-drop movements within the cell', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 
@@ -342,7 +343,7 @@ test('Basic drag-n-drop movements within the cell', async (t) => {
   width: 1000,
 }));
 
-test('Basic drag-n-drop small appointments', async (t) => {
+safeSizeTest('Basic drag-n-drop small appointments', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 
@@ -381,7 +382,7 @@ test('Basic drag-n-drop small appointments', async (t) => {
   width: 1000,
 }));
 
-test('Basic drag-n-drop long appointments', async (t) => {
+safeSizeTest('Basic drag-n-drop long appointments', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 

--- a/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/schedulerInContainer/schedulerInContainer.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/schedulerInContainer/schedulerInContainer.ts
@@ -2,12 +2,13 @@ import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 
 fixture`Outlook dragging, for case scheduler in container`
   .page(url(__dirname, '../../../../container.html'));
 
-test('Dragging should be work right in case dxScheduler placed in dxTabPanel', async (t) => {
+safeSizeTest('Dragging should be work right in case dxScheduler placed in dxTabPanel', async (t) => {
   const scheduler = new Scheduler('.dx-scheduler');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);

--- a/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/schedulerInContainer/schedulerInTransformContainer.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/schedulerInContainer/schedulerInTransformContainer.ts
@@ -1,12 +1,13 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 
 fixture`Outlook dragging, for case scheduler in container with transform style`
   .page(url(__dirname, './containerWithTransform.html'));
 
-test('Dragging should be work right in case dxScheduler placed in container with transform style', async (t) => {
+safeSizeTest('Dragging should be work right in case dxScheduler placed in container with transform style', async (t) => {
   const scheduler = new Scheduler('.dx-scheduler');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);

--- a/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/shiftedContainer.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/outlookDragging/shiftedContainer.ts
@@ -1,12 +1,13 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Outlook dragging base tests in shifted container`
   .page(url(__dirname, 'shiftedContainer.html'));
 
-test('Basic drag-n-drop movements in shifted container', async (t) => {
+safeSizeTest('Basic drag-n-drop movements in shifted container', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 

--- a/testing/testcafe/tests/scheduler/dragAndDrop/timeline.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/timeline.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import { dataSource } from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Drag-and-drop appointments in the Scheduler timeline views`
   .page(url(__dirname, '../../container.html'));
 
-['timelineDay', 'timelineWeek', 'timelineWorkWeek'].forEach((view) => test(`Drag-n-drop in the "${view}" view`, async (t) => {
+['timelineDay', 'timelineWeek', 'timelineWorkWeek'].forEach((view) => safeSizeTest(`Drag-n-drop in the "${view}" view`, async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Brochure Design Review');
 
@@ -21,7 +22,7 @@ fixture`Drag-and-drop appointments in the Scheduler timeline views`
   dataSource,
 })));
 
-test('Drag-n-drop in the "timelineMonth" view', async (t) => {
+safeSizeTest('Drag-n-drop in the "timelineMonth" view', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Brochure Design Review');
 

--- a/testing/testcafe/tests/scheduler/dragAndDrop/verticalGrouping.ts
+++ b/testing/testcafe/tests/scheduler/dragAndDrop/verticalGrouping.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Drag-and-drop appointments in the Scheduler with vertical grouping`
   .page(url(__dirname, '../../container.html'));
 
-test('Should drag appoinment to the previous day`s cell (T1025952)', async (t) => {
+safeSizeTest('Should drag appoinment to the previous day`s cell (T1025952)', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('appointment');
 

--- a/testing/testcafe/tests/scheduler/grouping/groupingByDate.ts
+++ b/testing/testcafe/tests/scheduler/grouping/groupingByDate.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Drag-and-drop appointments into allDay panel in the grouped Scheduler `
   .page(url(__dirname, '../../container.html'));
 
-test('Drag-n-drop between dateTable and allDay panel, groupByDate=true', async (t) => {
+safeSizeTest('Drag-n-drop between dateTable and allDay panel, groupByDate=true', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Website Re-Design Plan');
 

--- a/testing/testcafe/tests/scheduler/grouping/monthViewVerticalGrouping.ts
+++ b/testing/testcafe/tests/scheduler/grouping/monthViewVerticalGrouping.ts
@@ -1,7 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
-import { restoreBrowserSize } from '../../../helpers/restoreBrowserSize';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 const CLICK_OPTIONS = { speed: 0.1 };
@@ -10,7 +10,7 @@ const SCHEDULER_SELECTOR = '#container';
 fixture`Month view vertical grouping `
   .page(url(__dirname, '../../container.html'));
 
-test('Scrolling: usual. Shouldn\'t overlap the next group with long all-day appointment in the month view (T1122185)', async (t) => {
+safeSizeTest('Scrolling: usual. Shouldn\'t overlap the next group with long all-day appointment in the month view (T1122185)', async (t) => {
   const scheduler = new Scheduler(SCHEDULER_SELECTOR);
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -22,7 +22,7 @@ test('Scrolling: usual. Shouldn\'t overlap the next group with long all-day appo
 
   await t.expect(compareResults.isValid())
     .ok(compareResults.errorMessages());
-}).before(async (t) => {
+}).before(async () => {
   await createWidget(
     'dxScheduler',
     {
@@ -60,5 +60,4 @@ test('Scrolling: usual. Shouldn\'t overlap the next group with long all-day appo
       ],
     },
   );
-  await restoreBrowserSize(t);
 });

--- a/testing/testcafe/tests/scheduler/header/dateNavigator.ts
+++ b/testing/testcafe/tests/scheduler/header/dateNavigator.ts
@@ -1,5 +1,6 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Date navigator`
@@ -12,7 +13,7 @@ fixture`Date navigator`
   agendaDuration: 40,
   result: '11 May-19 Jun 2021',
 }].forEach(({ agendaDuration, result }) => {
-  test(`Caption of date navigator should be valid after change view to Agenda with agendaDuration=${agendaDuration}`, async (t) => {
+  safeSizeTest(`Caption of date navigator should be valid after change view to Agenda with agendaDuration=${agendaDuration}`, async (t) => {
     const { toolbar } = new Scheduler('#container');
 
     await t

--- a/testing/testcafe/tests/scheduler/header/header.ts
+++ b/testing/testcafe/tests/scheduler/header/header.ts
@@ -1,11 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Scheduler header`
   .page(url(__dirname, '../../container.html'));
 
-test('dateNavigator buttons should not be selected after clicking', async (t) => {
+safeSizeTest('dateNavigator buttons should not be selected after clicking', async (t) => {
   const { toolbar } = new Scheduler('#container');
 
   await t
@@ -25,7 +26,7 @@ test('dateNavigator buttons should not be selected after clicking', async (t) =>
   height: 580,
 }));
 
-test('dateNavigator buttons should have "contained" styling mode with generic theme', async (t) => {
+safeSizeTest('dateNavigator buttons should have "contained" styling mode with generic theme', async (t) => {
   const { toolbar } = new Scheduler('#container');
 
   await t

--- a/testing/testcafe/tests/scheduler/header/header_material.ts
+++ b/testing/testcafe/tests/scheduler/header/header_material.ts
@@ -2,12 +2,13 @@ import { Selector } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Scheduler header: material theme`
   .page(url(__dirname, '../../containerMaterial.html'));
 
-test('dateNavigator buttons should have "text" styling mode with material theme', async (t) => {
+safeSizeTest('dateNavigator buttons should have "text" styling mode with material theme', async (t) => {
   const { toolbar } = new Scheduler('#container');
 
   await t
@@ -25,7 +26,7 @@ test('dateNavigator buttons should have "text" styling mode with material theme'
   height: 580,
 }));
 
-test('viewSwitcher dropdown button popup should have a specified class', async (t) => {
+safeSizeTest('viewSwitcher dropdown button popup should have a specified class', async (t) => {
   const { toolbar } = new Scheduler('#container');
   const dropDownButton = toolbar.viewSwitcher.getDropDownButton();
 
@@ -42,7 +43,7 @@ test('viewSwitcher dropdown button popup should have a specified class', async (
   height: 580,
 }));
 
-test('The toolbar should not display if the config is empty', async (t) => {
+safeSizeTest('The toolbar should not display if the config is empty', async (t) => {
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
   const scheduler = new Scheduler('#container');
@@ -68,7 +69,7 @@ test('The toolbar should not display if the config is empty', async (t) => {
   toolbar: [],
 }, true));
 
-test('The viewSwitcher should not drop down if only one view', async (t) => {
+safeSizeTest('The viewSwitcher should not drop down if only one view', async (t) => {
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
   const { toolbar } = new Scheduler('#container');

--- a/testing/testcafe/tests/scheduler/header/viewSwitcher.ts
+++ b/testing/testcafe/tests/scheduler/header/viewSwitcher.ts
@@ -1,11 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Scheduler header - View switcher`
   .page(url(__dirname, '../../container.html'));
 
-test('it should correctly switch a differently typed views (T1080992)', async (t) => {
+safeSizeTest('it should correctly switch a differently typed views (T1080992)', async (t) => {
   const scheduler = new Scheduler('#container');
   const {
     toolbar: {

--- a/testing/testcafe/tests/scheduler/hotkeysBehaviour/hotkeysBehaviour.ts
+++ b/testing/testcafe/tests/scheduler/hotkeysBehaviour/hotkeysBehaviour.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -8,7 +9,7 @@ fixture`Hotkeys for appointments update and navigation`
   .page(url(__dirname, '../../container.html'));
 
 ['week', 'month'].forEach((view) => {
-  test(`Navigate between appointments in the "${view}" view (Tab/Shift+Tab)`, async (t) => {
+  safeSizeTest(`Navigate between appointments in the "${view}" view (Tab/Shift+Tab)`, async (t) => {
     const scheduler = new Scheduler('#container');
     const firstAppointment = scheduler.getAppointment('Website Re-Design Plan');
     const secondAppointment = scheduler.getAppointment('Book Flights to San Fran for Sales Trip');
@@ -32,7 +33,7 @@ fixture`Hotkeys for appointments update and navigation`
     dataSource,
   }));
 
-  test(`Remove appointment in the "${view}" view (Del)`, async (t) => {
+  safeSizeTest(`Remove appointment in the "${view}" view (Del)`, async (t) => {
     const scheduler = new Scheduler('#container');
     const appointment = scheduler.getAppointment('Website Re-Design Plan');
 
@@ -48,7 +49,7 @@ fixture`Hotkeys for appointments update and navigation`
     dataSource,
   }));
 
-  test(`Show appointment popup in the "${view}" view (Enter)`, async (t) => {
+  safeSizeTest(`Show appointment popup in the "${view}" view (Enter)`, async (t) => {
     const scheduler = new Scheduler('#container');
     const appointment = scheduler.getAppointment('Website Re-Design Plan');
     const { appointmentPopup } = scheduler;
@@ -65,7 +66,7 @@ fixture`Hotkeys for appointments update and navigation`
     dataSource,
   }));
 
-  test(`Navigate between tooltip appointments in the "${view}" view (Up/Down)`, async (t) => {
+  safeSizeTest(`Navigate between tooltip appointments in the "${view}" view (Up/Down)`, async (t) => {
     const scheduler = new Scheduler('#container');
     const collector = scheduler.collectors.find('3');
     const { appointmentPopup } = scheduler;
@@ -92,7 +93,7 @@ fixture`Hotkeys for appointments update and navigation`
   }));
 });
 
-test('Navigate between toolbar items', async (t) => {
+safeSizeTest('Navigate between toolbar items', async (t) => {
   const { toolbar } = new Scheduler('#container');
   const { navigator, viewSwitcher } = toolbar;
 
@@ -126,7 +127,7 @@ test('Navigate between toolbar items', async (t) => {
   currentView: 'day',
 }));
 
-test('Navigate between custom toolbar items', async (t) => {
+safeSizeTest('Navigate between custom toolbar items', async (t) => {
   const { toolbar } = new Scheduler('#container');
   const { navigator, viewSwitcher } = toolbar;
 

--- a/testing/testcafe/tests/scheduler/layout/adaptive/generic/adaptive.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/generic/adaptive.ts
@@ -1,7 +1,9 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
+import { ADAPTIVE_SIZE } from '../../../const';
 import {
   createDataSetForScreenShotTests,
   resourceDataSource,
@@ -9,7 +11,6 @@ import {
   verticalViews,
   horizontalViews,
 } from '../../utils';
-import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
 fixture`Scheduler: Adaptive Generic theme layout`
   .page(url(__dirname, '../../../../container.html'));
@@ -26,7 +27,7 @@ const createScheduler = async (
 };
 
 [false, true].forEach((crossScrollingEnabled) => {
-  test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled}`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled}`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -35,25 +36,21 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`generic-view=${view}-crossScrolling=${!!crossScrollingEnabled}.png`, scheduler.workSpace),
+        await takeScreenshot(`generic-view=${view}-crossScrolling=${crossScrollingEnabled}.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views,
       currentView: 'day',
       crossScrollingEnabled,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 
-  test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping is used`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping is used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -62,15 +59,13 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`generic-view=${view}-crossScrolling=${!!crossScrollingEnabled}-horizontal.png`, scheduler.workSpace),
+        await takeScreenshot(`generic-view=${view}-crossScrolling=${crossScrollingEnabled}-horizontal.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views: horizontalViews,
       currentView: 'day',
@@ -78,11 +73,9 @@ const createScheduler = async (
       groups: ['priorityId'],
       resources: resourceDataSource,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 
-  test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping is used`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping is used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -91,15 +84,13 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`generic-view=${view}-crossScrolling=${!!crossScrollingEnabled}-vertical.png`, scheduler.workSpace),
+        await takeScreenshot(`generic-view=${view}-crossScrolling=${crossScrollingEnabled}-vertical.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views: verticalViews,
       currentView: 'day',
@@ -107,7 +98,5 @@ const createScheduler = async (
       groups: ['priorityId'],
       resources: resourceDataSource,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/adaptive/generic/adaptiveRTL.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/generic/adaptiveRTL.ts
@@ -1,7 +1,9 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
+import { ADAPTIVE_SIZE } from '../../../const';
 import {
   createDataSetForScreenShotTests,
   resourceDataSource,
@@ -9,7 +11,6 @@ import {
   verticalViews,
   horizontalViews,
 } from '../../utils';
-import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
 fixture`Scheduler: Adaptive Generic theme layout in RTL`
   .page(url(__dirname, '../../../../container.html'));
@@ -27,7 +28,7 @@ const createScheduler = async (
 };
 
 [false, true].forEach((crossScrollingEnabled) => {
-  test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} in RTL`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} in RTL`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -36,25 +37,21 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`generic-view=${view}-crossScrolling=${!!crossScrollingEnabled}-rtl.png`, scheduler.workSpace),
+        await takeScreenshot(`generic-view=${view}-crossScrolling=${crossScrollingEnabled}-rtl.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views,
       currentView: 'day',
       crossScrollingEnabled,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 
-  test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping and RTL are used`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping and RTL are used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -63,15 +60,13 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`generic-view=${view}-crossScrolling=${!!crossScrollingEnabled}-horizontal-rtl.png`, scheduler.workSpace),
+        await takeScreenshot(`generic-view=${view}-crossScrolling=${crossScrollingEnabled}-horizontal-rtl.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views: horizontalViews,
       currentView: 'day',
@@ -79,11 +74,9 @@ const createScheduler = async (
       groups: ['priorityId'],
       resources: resourceDataSource,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 
-  test(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping and RTL are used`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in generic theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping and RTL are used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -92,15 +85,13 @@ const createScheduler = async (
       await scheduler.option('currentView', view.type);
 
       await t.expect(
-        await takeScreenshot(`generic-view=${view.type}-crossScrolling=${!!crossScrollingEnabled}-vertical-rtl.png`, scheduler.workSpace),
+        await takeScreenshot(`generic-view=${view.type}-crossScrolling=${crossScrollingEnabled}-vertical-rtl.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views: verticalViews,
       currentView: 'day',
@@ -108,7 +99,5 @@ const createScheduler = async (
       groups: ['priorityId'],
       resources: resourceDataSource,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/adaptive/material/adaptive.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/material/adaptive.ts
@@ -1,7 +1,9 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
+import { ADAPTIVE_SIZE } from '../../../const';
 import {
   createDataSetForScreenShotTests,
   resourceDataSource,
@@ -9,7 +11,6 @@ import {
   verticalViews,
   horizontalViews,
 } from '../../utils';
-import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
 fixture`Scheduler: Adaptive material theme layout`
   .page(url(__dirname, '../../../../containerMaterial.html'));
@@ -26,7 +27,7 @@ const createScheduler = async (
 };
 
 [false, true].forEach((crossScrollingEnabled) => {
-  test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled}`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled}`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -35,25 +36,21 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`material-view=${view}-crossScrolling=${!!crossScrollingEnabled}.png`, scheduler.workSpace),
+        await takeScreenshot(`material-view=${view}-crossScrolling=${crossScrollingEnabled}.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views,
       currentView: 'day',
       crossScrollingEnabled,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 
-  test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping is used`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping is used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -62,15 +59,13 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`material-view=${view}-crossScrolling=${!!crossScrollingEnabled}-horizontal.png`, scheduler.workSpace),
+        await takeScreenshot(`material-view=${view}-crossScrolling=${crossScrollingEnabled}-horizontal.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views: horizontalViews,
       currentView: 'day',
@@ -78,11 +73,9 @@ const createScheduler = async (
       groups: ['priorityId'],
       resources: resourceDataSource,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 
-  test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping is used`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping is used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -91,15 +84,13 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`material-view=${view}-crossScrolling=${!!crossScrollingEnabled}-vertical.png`, scheduler.workSpace),
+        await takeScreenshot(`material-view=${view}-crossScrolling=${crossScrollingEnabled}-vertical.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views: verticalViews,
       currentView: 'day',
@@ -107,7 +98,5 @@ const createScheduler = async (
       groups: ['priorityId'],
       resources: resourceDataSource,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/adaptive/material/adaptiveRTL.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/material/adaptiveRTL.ts
@@ -1,7 +1,9 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
+import { ADAPTIVE_SIZE } from '../../../const';
 import {
   createDataSetForScreenShotTests,
   resourceDataSource,
@@ -9,7 +11,6 @@ import {
   verticalViews,
   horizontalViews,
 } from '../../utils';
-import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
 fixture`Scheduler: Adaptive Material theme layout in RTL`
   .page(url(__dirname, '../../../../containerMaterial.html'));
@@ -27,7 +28,7 @@ const createScheduler = async (
 };
 
 [false, true].forEach((crossScrollingEnabled) => {
-  test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} in RTL`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} in RTL`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -36,25 +37,21 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`material-view=${view}-crossScrolling=${!!crossScrollingEnabled}-rtl.png`, scheduler.workSpace),
+        await takeScreenshot(`material-view=${view}-crossScrolling=${crossScrollingEnabled}-rtl.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views,
       currentView: 'day',
       crossScrollingEnabled,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 
-  test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping and RTL are used`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when horizontal grouping and RTL are used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -63,15 +60,13 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`material-view=${view}-crossScrolling=${!!crossScrollingEnabled}-horizontal-rtl.png`, scheduler.workSpace),
+        await takeScreenshot(`material-view=${view}-crossScrolling=${crossScrollingEnabled}-horizontal-rtl.png`, scheduler.workSpace),
       ).ok();
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views: horizontalViews,
       currentView: 'day',
@@ -79,11 +74,9 @@ const createScheduler = async (
       groups: ['priorityId'],
       resources: resourceDataSource,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 
-  test(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping and RTL are used`, async (t) => {
+  safeSizeTest(`Adaptive views layout test in material theme, crossScrollingEnabled=${crossScrollingEnabled} when vertical grouping and RTL are used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -94,16 +87,14 @@ const createScheduler = async (
       // Another bug in RTL in month view
       if (crossScrollingEnabled || view.type !== 'month') {
         await t.expect(
-          await takeScreenshot(`material-view=${view.type}-crossScrolling=${!!crossScrollingEnabled}-vertical-rtl.png`, scheduler.workSpace),
+          await takeScreenshot(`material-view=${view.type}-crossScrolling=${crossScrollingEnabled}-vertical-rtl.png`, scheduler.workSpace),
         ).ok();
       }
     }
 
     await t.expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }).before(async (t) => {
-    await t.resizeWindow(400, 600);
-
+  }, ADAPTIVE_SIZE).before(async () => {
     await createScheduler({
       views: verticalViews,
       currentView: 'day',
@@ -111,7 +102,5 @@ const createScheduler = async (
       groups: ['priorityId'],
       resources: resourceDataSource,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/adaptive/resize/browserResize.ts
+++ b/testing/testcafe/tests/scheduler/layout/adaptive/resize/browserResize.ts
@@ -1,8 +1,8 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
-import { restoreBrowserSize } from '../../../../../helpers/restoreBrowserSize';
 
 fixture`Layout:BrowserResize`
   .page(url(__dirname, '../../../../container.html'));
@@ -114,7 +114,7 @@ const resourceDataSource = [{
   currentView: 'timelineDay',
   currentDate: new Date(2017, 4, 26),
 }].forEach(({ currentView, currentDate }) => {
-  test(`Appointment layout after resize should be rendered right in '${currentView}'`, async (t) => {
+  safeSizeTest(`Appointment layout after resize should be rendered right in '${currentView}'`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -143,7 +143,5 @@ const resourceDataSource = [{
       startDayHour: 9,
       height: 600,
     });
-  }).after(async (t) => {
-    await restoreBrowserSize(t);
   });
 });

--- a/testing/testcafe/tests/scheduler/layout/appointmentForm/allDay.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointmentForm/allDay.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import url from '../../../../helpers/getPageUrl';
 fixture`Layout:AppointmentForm:AllDay`
   .page(url(__dirname, '../../../container.html'));
 
-test('Start and end dates should be reflect the current day(appointment is already available case)', async (t) => {
+safeSizeTest('Start and end dates should be reflect the current day(appointment is already available case)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -56,7 +57,7 @@ test('Start and end dates should be reflect the current day(appointment is alrea
   }, true);
 });
 
-test('Start and end dates should be reflect the current day(create new appointment case)', async (t) => {
+safeSizeTest('Start and end dates should be reflect the current day(create new appointment case)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -100,7 +101,7 @@ test('Start and end dates should be reflect the current day(create new appointme
   }, true);
 });
 
-test('StartDate and endDate should have correct type after "allDay" and "repeat" option are changed (T1002864)', async (t) => {
+safeSizeTest('StartDate and endDate should have correct type after "allDay" and "repeat" option are changed (T1002864)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { appointmentPopup } = scheduler;
 

--- a/testing/testcafe/tests/scheduler/layout/appointmentForm/integerFormatNumberBox.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointmentForm/integerFormatNumberBox.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import url from '../../../../helpers/getPageUrl';
 fixture`Layout:AppointmentForm:IntegerFormatNumberBox`
   .page(url(__dirname, '../../../container.html'));
 
-test('dxNumberBox should not allow to enter not integer chars(T1002864)', async (t) => {
+safeSizeTest('dxNumberBox should not allow to enter not integer chars(T1002864)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { appointmentPopup } = scheduler;
 

--- a/testing/testcafe/tests/scheduler/layout/appointments/allDay/longAppointment.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/allDay/longAppointment.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import url from '../../../../../helpers/getPageUrl';
 fixture`Layout:Appointments:AllDay`
   .page(url(__dirname, '../../../../container.html'));
 
-test('Long all day appointment should be render, if him ended on next view day in currentView: \'day\'(T1021963)', async (t) => {
+safeSizeTest('Long all day appointment should be render, if him ended on next view day in currentView: \'day\'(T1021963)', async (t) => {
   const { workSpace, toolbar } = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -44,7 +45,7 @@ test('Long all day appointment should be render, if him ended on next view day i
   }, true);
 });
 
-test('Long all day appointment should be render, if him ended on next view day in currentView:', async (t) => {
+safeSizeTest('Long all day appointment should be render, if him ended on next view day in currentView:', async (t) => {
   const { workSpace, toolbar } = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/appointments/collector.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/collector.ts
@@ -1,12 +1,13 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Appointments collector`
   .page(url(__dirname, '../../../container.html'));
 
-test('Appointment collector has correct offset when adaptivityEnabled=true', async (t) => {
+safeSizeTest('Appointment collector has correct offset when adaptivityEnabled=true', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);

--- a/testing/testcafe/tests/scheduler/layout/appointments/dataSource.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/dataSource.ts
@@ -5,6 +5,7 @@ import url from '../../../../helpers/getPageUrl';
 fixture`DataSource`
   .page(url(__dirname, './pages/containerWithArrayStore.html'));
 
+// TODO SKIPPED TEST: Why this test is skipped?
 test.skip('Appointment key should be deleted when removing an appointment from series (T1024213)', async (t) => {
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/appointments/disable.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/disable.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import url from '../../../../helpers/getPageUrl';
 fixture`Layout:Appointments:disable`
   .page(url(__dirname, '../../../container.html'));
 
-test('Appointment popup should be readOnly if appointment is disabled', async (t) => {
+safeSizeTest('Appointment popup should be readOnly if appointment is disabled', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/appointments/longAppointments.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/longAppointments.ts
@@ -1,9 +1,12 @@
 // T1086079
-
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+
+fixture`Layout:Appointments:longAppointments(T1086079)`
+  .page(url(__dirname, '../../../container.html'));
 
 const dataSource = [{
   text: 'Website Re-Design Plan',
@@ -14,10 +17,7 @@ const dataSource = [{
 
 const appointmentName = 'Website Re-Design Plan';
 
-fixture`Layout:Appointments:longAppointments(T1086079)`
-  .page(url(__dirname, '../../../container.html'));
-
-test('Control should be render top part of recurrent long appointment in day view(T1086079)', async (t) => {
+safeSizeTest('Control should be render top part of recurrent long appointment in day view(T1086079)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -53,7 +53,7 @@ test('Control should be render top part of recurrent long appointment in day vie
   }, true);
 });
 
-test('Control should be render top part of recurrent long appointment in week view(T1086079)', async (t) => {
+safeSizeTest('Control should be render top part of recurrent long appointment in week view(T1086079)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/appointments/two-schedulers.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/two-schedulers.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import url from '../../../../helpers/getPageUrl';
 fixture`Layout:Appointments:two-schedulers`
   .page(url(__dirname, '../../../container.html'));
 
-test('Appointment\'s dragging should be work properly, if on page placed two dxSchedulers(T1020820)', async (t) => {
+safeSizeTest('Appointment\'s dragging should be work properly, if on page placed two dxSchedulers(T1020820)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/appointments/visible.ts
+++ b/testing/testcafe/tests/scheduler/layout/appointments/visible.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
@@ -8,7 +9,7 @@ fixture`Layout:Appointments:visible`
 
 [1, 0].forEach((maxAppointmentsPerCell) => {
   [true, false, undefined].forEach((visible) => {
-    test(`Appointments should be filtered by visible property(visible='${visible}', maxAppointmentsPerCell='${maxAppointmentsPerCell}'`, async (t) => {
+    safeSizeTest(`Appointments should be filtered by visible property(visible='${visible}', maxAppointmentsPerCell='${maxAppointmentsPerCell}'`, async (t) => {
       const scheduler = new Scheduler('#container');
       const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/customization/cellSizes.ts
+++ b/testing/testcafe/tests/scheduler/layout/customization/cellSizes.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Scheduler: Layout Customization: Cell Sizes`
@@ -65,7 +66,7 @@ const views = [{
   groupOrientation: 'vertical',
 }];
 
-test('Cell sizes customization should work', async (t) => {
+safeSizeTest('Cell sizes customization should work', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -86,7 +87,7 @@ test('Cell sizes customization should work', async (t) => {
   });
 });
 
-test('Cell sizes customization should work when all-day panel is enabled', async (t) => {
+safeSizeTest('Cell sizes customization should work when all-day panel is enabled', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/customization/groupPanel.ts
+++ b/testing/testcafe/tests/scheduler/layout/customization/groupPanel.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Scheduler: Layout Customization: Group Panel`
@@ -61,7 +62,7 @@ const views = [{
 }];
 
 [false, true].forEach((crossScrollingEnabled) => {
-  test('Group panel customization should work', async (t) => {
+  safeSizeTest('Group panel customization should work', async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/customization/headerPanel.ts
+++ b/testing/testcafe/tests/scheduler/layout/customization/headerPanel.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Scheduler: Layout Customization: Header Panel`
@@ -61,7 +62,7 @@ const views = [{
 }];
 
 [false, true].forEach((crossScrollingEnabled) => {
-  test('Header panel customization should work', async (t) => {
+  safeSizeTest('Header panel customization should work', async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/customization/timePanel.ts
+++ b/testing/testcafe/tests/scheduler/layout/customization/timePanel.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Scheduler: Layout Customization: Time Panel`
@@ -61,7 +62,7 @@ const createScheduler = async (
 
 [false, true].forEach((crossScrollingEnabled) => {
   ['week', 'agenda'].forEach((view) => {
-    test(`Time panel customization should work in ${view} view`, async (t) => {
+    safeSizeTest(`Time panel customization should work in ${view} view`, async (t) => {
       const scheduler = new Scheduler('#container');
       const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/resources/base/generic.ts
+++ b/testing/testcafe/tests/scheduler/layout/resources/base/generic.ts
@@ -1,6 +1,7 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 import { createDataSetForScreenShotTests } from '../../utils';
 
@@ -36,7 +37,7 @@ const resources = [{
 
 [undefined, resources].forEach((resourcesValue) => {
   ['day', 'week', 'workWeek', 'month'].forEach((view) => {
-    test(`Base views layout test in generic theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
+    safeSizeTest(`Base views layout test in generic theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
       const scheduler = new Scheduler('#container');
 
       await t.click(scheduler.getAppointment('1 appointment', 0).element, { speed: 0.5 });
@@ -49,7 +50,7 @@ const resources = [{
 
 [undefined, resources].forEach((resourcesValue) => {
   ['timelineDay', 'timelineWeek', 'timelineWorkWeek', 'timelineMonth'].forEach((view) => {
-    test(`Timeline views layout test in generic theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
+    safeSizeTest(`Timeline views layout test in generic theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
       const scheduler = new Scheduler('#container');
 
       await t.click(scheduler.getAppointment('1 appointment', 0).element, { speed: 0.5 });

--- a/testing/testcafe/tests/scheduler/layout/resources/base/material.ts
+++ b/testing/testcafe/tests/scheduler/layout/resources/base/material.ts
@@ -1,5 +1,6 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 import url from '../../../../../helpers/getPageUrl';
 import { createDataSetForScreenShotTests, resourceDataSource } from '../../utils';
@@ -7,7 +8,7 @@ import { createDataSetForScreenShotTests, resourceDataSource } from '../../utils
 fixture`Scheduler: Material theme layout`
   .page(url(__dirname, '../../../../containerMaterial.html'));
 
-test('Scheduler should have correct height in month view (T927862)', async (t) => {
+safeSizeTest('Scheduler should have correct height in month view (T927862)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const boundingClientRect = await scheduler.dateTable.boundingClientRect;
@@ -37,7 +38,7 @@ const createScheduler = async (view: string, resourcesValue?: unknown[]): Promis
 
 [undefined, resourceDataSource].forEach((resourcesValue) => {
   ['agenda', 'day', 'week', 'workWeek', 'month'].forEach((view) => {
-    test(`Base views layout test in material theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
+    safeSizeTest(`Base views layout test in material theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
       const scheduler = new Scheduler('#container');
 
       await t.click(scheduler.getAppointment('1 appointment', 0).element, { speed: 0.5 });
@@ -50,7 +51,7 @@ const createScheduler = async (view: string, resourcesValue?: unknown[]): Promis
 
 [undefined, resourceDataSource].forEach((resourcesValue) => {
   ['timelineDay', 'timelineWeek', 'timelineWorkWeek', 'timelineMonth'].forEach((view) => {
-    test(`Timeline views layout test in material theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
+    safeSizeTest(`Timeline views layout test in material theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
       const scheduler = new Scheduler('#container');
 
       await t.click(scheduler.getAppointment('1 appointment', 0).element, { speed: 0.5 });

--- a/testing/testcafe/tests/scheduler/layout/resources/groups/generic.ts
+++ b/testing/testcafe/tests/scheduler/layout/resources/groups/generic.ts
@@ -1,6 +1,7 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import { createDataSetForScreenShotTests, resourceDataSource } from '../../utils';
 
 fixture`Scheduler: Generic theme layout`
@@ -27,7 +28,7 @@ const createScheduler = async (view: string, groupOrientation: string): Promise<
 
 ['vertical', 'horizontal'].forEach((groupOrientation) => {
   ['day', 'week', 'workWeek', 'month'].forEach((view) => {
-    test(`Base views layout test in generic theme with groups(view='${view}', groupOrientation=${groupOrientation})`, async (t) => {
+    safeSizeTest(`Base views layout test in generic theme with groups(view='${view}', groupOrientation=${groupOrientation})`, async (t) => {
       await t
         .expect(await compareScreenshot(t, `generic-groups(view=${view}-orientation=${groupOrientation}).png`)).ok();
     }).before(async () => createScheduler(view, groupOrientation));
@@ -36,7 +37,7 @@ const createScheduler = async (view: string, groupOrientation: string): Promise<
 
 ['vertical', 'horizontal'].forEach((groupOrientation) => {
   ['timelineDay', 'timelineWeek', 'timelineWorkWeek', 'timelineMonth'].forEach((view) => {
-    test(`Timeline views layout test in generic theme with groups(view='${view}', groupOrientation=${groupOrientation})`, async (t) => {
+    safeSizeTest(`Timeline views layout test in generic theme with groups(view='${view}', groupOrientation=${groupOrientation})`, async (t) => {
       await t
         .expect(await compareScreenshot(t, `generic-groups(view=${view}-orientation=${groupOrientation}).png`)).ok();
     }).before(async () => createScheduler(view, groupOrientation));

--- a/testing/testcafe/tests/scheduler/layout/resources/groups/material.ts
+++ b/testing/testcafe/tests/scheduler/layout/resources/groups/material.ts
@@ -1,6 +1,7 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import { createDataSetForScreenShotTests, resourceDataSource } from '../../utils';
 
 fixture`Scheduler: Material theme layout`
@@ -27,7 +28,7 @@ const createScheduler = async (view: string, groupOrientation: string): Promise<
 
 ['vertical', 'horizontal'].forEach((groupOrientation) => {
   ['agenda', 'day', 'week', 'workWeek', 'month'].forEach((view) => {
-    test(`Base views layout test in material theme with groups(view='${view}', groupOrientation=${groupOrientation})`, async (t) => {
+    safeSizeTest(`Base views layout test in material theme with groups(view='${view}', groupOrientation=${groupOrientation})`, async (t) => {
       await t
         .expect(await compareScreenshot(t, `material-groups(view=${view}-orientation=${groupOrientation}).png`)).ok();
     }).before(async () => createScheduler(view, groupOrientation));
@@ -36,7 +37,7 @@ const createScheduler = async (view: string, groupOrientation: string): Promise<
 
 ['vertical', 'horizontal'].forEach((groupOrientation) => {
   ['timelineDay', 'timelineWeek', 'timelineWorkWeek', 'timelineMonth'].forEach((view) => {
-    test(`Timeline views layout test in material theme with groups(view='${view}', groupOrientation=${groupOrientation})`, async (t) => {
+    safeSizeTest(`Timeline views layout test in material theme with groups(view='${view}', groupOrientation=${groupOrientation})`, async (t) => {
       await t
         .expect(await compareScreenshot(t, `material-groups(view=${view}-orientation=${groupOrientation}).png`)).ok();
     }).before(async () => createScheduler(view, groupOrientation));

--- a/testing/testcafe/tests/scheduler/layout/templates/appointmentTemplate.ts
+++ b/testing/testcafe/tests/scheduler/layout/templates/appointmentTemplate.ts
@@ -1,5 +1,6 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
@@ -8,7 +9,7 @@ fixture`Layout:Templates:appointmentTemplate`
   .page(url(__dirname, '../../../container.html'));
 
 ['day', 'workWeek', 'month', 'timelineDay', 'timelineWorkWeek', 'agenda'].forEach((currentView) => {
-  test(`appointmentTemplate layout should be rendered right in '${currentView}'`, async (t) => {
+  safeSizeTest(`appointmentTemplate layout should be rendered right in '${currentView}'`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/templates/cellTemplate.ts
+++ b/testing/testcafe/tests/scheduler/layout/templates/cellTemplate.ts
@@ -1,5 +1,6 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
@@ -8,7 +9,7 @@ fixture`Layout:Templates:CellTemplate`
   .page(url(__dirname, '../../../container.html'));
 
 ['day', 'workWeek', 'month', 'timelineDay', 'timelineWorkWeek', 'timelineMonth'].forEach((currentView) => {
-  test(`dataCellTemplate and dateCellTemplate layout should be rendered right in '${currentView}'`, async (t) => {
+  safeSizeTest(`dataCellTemplate and dateCellTemplate layout should be rendered right in '${currentView}'`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/templates/tooltipTemplate.ts
+++ b/testing/testcafe/tests/scheduler/layout/templates/tooltipTemplate.ts
@@ -1,5 +1,6 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
@@ -7,7 +8,7 @@ import url from '../../../../helpers/getPageUrl';
 fixture`Layout:Templates:appointmentTooltipTemplate`
   .page(url(__dirname, '../../../container.html'));
 
-test('appointmentTooltipTemplate layout should be rendered right', async (t) => {
+safeSizeTest('appointmentTooltipTemplate layout should be rendered right', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/timeIndication/shader.ts
+++ b/testing/testcafe/tests/scheduler/layout/timeIndication/shader.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Scheduler: Current Time Indication: Shader`
@@ -40,7 +41,7 @@ const createScheduler = async (
 };
 
 [false, true].forEach((crossScrollingEnabled) => {
-  test(`Shader should be displayed correctly when crossScrollingEnabled=${crossScrollingEnabled}`, async (t) => {
+  safeSizeTest(`Shader should be displayed correctly when crossScrollingEnabled=${crossScrollingEnabled}`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -49,7 +50,7 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`shader-in-${view}-crossScrolling=${!!crossScrollingEnabled}.png`, scheduler.workSpace),
+        await takeScreenshot(`shader-in-${view}-crossScrolling=${crossScrollingEnabled}.png`, scheduler.workSpace),
       ).ok();
     }
 
@@ -62,7 +63,7 @@ const createScheduler = async (
     });
   });
 
-  test(`Shader should be displayed correctly when crossScrollingEnabled=${crossScrollingEnabled} and horizontal grouping is used`, async (t) => {
+  safeSizeTest(`Shader should be displayed correctly when crossScrollingEnabled=${crossScrollingEnabled} and horizontal grouping is used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -71,7 +72,7 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`shader-in-${view}-crossScrolling=${!!crossScrollingEnabled}-horizontal-grouping.png`, scheduler.workSpace),
+        await takeScreenshot(`shader-in-${view}-crossScrolling=${crossScrollingEnabled}-horizontal-grouping.png`, scheduler.workSpace),
       ).ok();
     }
 
@@ -100,7 +101,7 @@ const createScheduler = async (
     });
   });
 
-  test(`Shader should be displayed correctly when crossScrollingEnabled=${crossScrollingEnabled} and vertical grouping is used`, async (t) => {
+  safeSizeTest(`Shader should be displayed correctly when crossScrollingEnabled=${crossScrollingEnabled} and vertical grouping is used`, async (t) => {
     const scheduler = new Scheduler('#container');
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -109,7 +110,7 @@ const createScheduler = async (
       await scheduler.option('currentView', view);
 
       await t.expect(
-        await takeScreenshot(`shader-in-${view}-crossScrolling=${!!crossScrollingEnabled}-vertical-grouping.png`, scheduler.workSpace),
+        await takeScreenshot(`shader-in-${view}-crossScrolling=${crossScrollingEnabled}-vertical-grouping.png`, scheduler.workSpace),
       ).ok();
     }
 

--- a/testing/testcafe/tests/scheduler/layout/views/crossScrolling.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/crossScrolling.ts
@@ -1,12 +1,13 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Scheduler: View with cross-scrolling`
   .page(url(__dirname, '../../../container.html'));
 
-test('Scrollable synchronization should work after changing current date (T1027231)', async (t) => {
+safeSizeTest('Scrollable synchronization should work after changing current date (T1027231)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await scheduler.option('currentDate', new Date(2021, 4, 5));
@@ -48,7 +49,7 @@ test('Scrollable synchronization should work after changing current date (T10272
   }, true);
 });
 
-test('Scrollable should be prepared correctly after change visibility (T1032171)', async (t) => {
+safeSizeTest('Scrollable should be prepared correctly after change visibility (T1032171)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await scheduler.option('visible', true);

--- a/testing/testcafe/tests/scheduler/layout/views/day/allDay.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/day/allDay.ts
@@ -1,9 +1,11 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
 
+// TODO SKIPPED TEST: Why this test case skipped?
 fixture.skip`Layout:Views:Day:AllDay`
   .page(url(__dirname, '../../../../container.html'));
 
@@ -17,7 +19,7 @@ const enableNativeScroll = ClientFunction(() => {
       const testName = `Day view with interval and crossScrollingEnabled(groupOrientation='${groupOrientation}', showAllDayPanel='${showAllDayPanel}', intervalCount='${intervalCount}')
       layout test`;
 
-      test(testName, async (t) => {
+      safeSizeTest(testName, async (t) => {
         const scheduler = new Scheduler('#container');
         await enableNativeScroll();
 

--- a/testing/testcafe/tests/scheduler/layout/views/firstDayOfWeek.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/firstDayOfWeek.ts
@@ -1,12 +1,13 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 
 fixture`Scheduler: View with first day of week`
   .page(url(__dirname, '../../../container.html'));
 
-test('WorkWeek should generate correct start view date', async (t) => {
+safeSizeTest('WorkWeek should generate correct start view date', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t.expect(

--- a/testing/testcafe/tests/scheduler/layout/views/intervalCount/viewsWithStartDate.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/intervalCount/viewsWithStartDate.ts
@@ -1,4 +1,5 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
@@ -44,7 +45,7 @@ fixture`Layout: Views: IntervalCount with StartDate`
 }].forEach(({
   view, currentDate, startDate, intervalCount,
 }) => {
-  test(`startDate should work in ${view} view`, async (t) => {
+  safeSizeTest(`startDate should work in ${view} view`, async (t) => {
     const scheduler = new Scheduler('#container');
 
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -96,7 +97,7 @@ fixture`Layout: Views: IntervalCount with StartDate`
 }].forEach(({
   view, currentDate, startDate, intervalCount,
 }) => {
-  test(`startDate should work in ${view} view when it indicates the same week as the start as currentDate`, async (t) => {
+  safeSizeTest(`startDate should work in ${view} view when it indicates the same week as the start as currentDate`, async (t) => {
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
     await t

--- a/testing/testcafe/tests/scheduler/layout/views/material/withoutAllDay.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/material/withoutAllDay.ts
@@ -1,12 +1,13 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 
 fixture`Scheduler: Material theme without all-day panel`
   .page(url(__dirname, '../../../../containerMaterial.html'));
 
-test('Week view without all-day panel should be rendered correctly', async (t) => {
+safeSizeTest('Week view without all-day panel should be rendered correctly', async (t) => {
   const scheduler = new Scheduler('#container');
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 

--- a/testing/testcafe/tests/scheduler/layout/views/timeline/month.ts
+++ b/testing/testcafe/tests/scheduler/layout/views/timeline/month.ts
@@ -1,12 +1,13 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../../../helpers/createWidget';
 import url from '../../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../../model/scheduler';
 
 fixture`Scheduler: Layout Views: Timeline Month`
   .page(url(__dirname, '../../../../container.html'));
 
-test('Header cells should be aligned with date-table cells in timeline-month when current date changes', async (t) => {
+safeSizeTest('Header cells should be aligned with date-table cells in timeline-month when current date changes', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await scheduler.option('currentDate', new Date(2020, 11, 1));

--- a/testing/testcafe/tests/scheduler/month/longAppointments.ts
+++ b/testing/testcafe/tests/scheduler/month/longAppointments.ts
@@ -1,6 +1,7 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Scheduler: long appointments in month view`
@@ -22,27 +23,23 @@ fixture`Scheduler: long appointments in month view`
       endDate: new Date(2020, 0, 20),
     },
   ].forEach((appointment) => {
-    test(`Long appointment should display valid on month view(rtl='${rtlEnabled}', text='${appointment.text}')`, async (t) => {
+    safeSizeTest(`Long appointment should display valid on month view(rtl='${rtlEnabled}', text='${appointment.text}')`, async (t) => {
       const scheduler = new Scheduler('#container');
       await t.expect(await compareScreenshot(t, `month-long-appointment(rtl=${rtlEnabled}, text=${appointment.text}).png`, scheduler.workSpace)).ok();
     })
       .meta({ renovation: true })
-      .before(async (t) => {
-        await t.resizeWindow(1200, 800);
-
-        return createWidget('dxScheduler', {
-          dataSource: [appointment],
-          views: ['month'],
-          currentView: 'month',
-          rtlEnabled,
-          currentDate: new Date(2020, 0, 1),
-        });
-      });
+      .before(async () => createWidget('dxScheduler', {
+        dataSource: [appointment],
+        views: ['month'],
+        currentView: 'month',
+        rtlEnabled,
+        currentDate: new Date(2020, 0, 1),
+      }));
   });
 });
 
 [false, true].forEach((rtlEnabled) => {
-  test(`Long appointment(several months) should display valid on month view(rtl='${rtlEnabled})`, async (t) => {
+  safeSizeTest(`Long appointment(several months) should display valid on month view(rtl='${rtlEnabled})`, async (t) => {
     const { toolbar, workSpace } = new Scheduler('#container');
 
     await t
@@ -55,24 +52,20 @@ fixture`Scheduler: long appointments in month view`
     await t
       .click(toolbar.navigator.nextButton)
       .expect(await compareScreenshot(t, `month-long-appointment-several-months-march(rtl=${rtlEnabled}).png`, workSpace)).ok();
-  }).before(async (t) => {
-    await t.resizeWindow(1200, 800);
-
-    return createWidget('dxScheduler', {
-      dataSource: [{
-        text: 'Text',
-        startDate: new Date(2020, 0, 6),
-        endDate: new Date(2020, 2, 10),
-      }],
-      views: ['month'],
-      currentView: 'month',
-      rtlEnabled,
-      currentDate: new Date(2020, 0, 1),
-    });
-  });
+  }).before(async () => createWidget('dxScheduler', {
+    dataSource: [{
+      text: 'Text',
+      startDate: new Date(2020, 0, 6),
+      endDate: new Date(2020, 2, 10),
+    }],
+    views: ['month'],
+    currentView: 'month',
+    rtlEnabled,
+    currentDate: new Date(2020, 0, 1),
+  }));
 });
 
-test('Long recurrence appointment should display valid on month view', async (t) => {
+safeSizeTest('Long recurrence appointment should display valid on month view', async (t) => {
   const { toolbar, workSpace } = new Scheduler('#container');
 
   await t
@@ -81,18 +74,14 @@ test('Long recurrence appointment should display valid on month view', async (t)
   await t
     .click(toolbar.navigator.nextButton)
     .expect(await compareScreenshot(t, 'month-long-recurrence-appointment-several-months-february.png', workSpace)).ok();
-}).before(async (t) => {
-  await t.resizeWindow(1200, 800);
-
-  return createWidget('dxScheduler', {
-    dataSource: [{
-      text: 'Text',
-      startDate: new Date(2020, 0, 6),
-      endDate: new Date(2020, 0, 10),
-      recurrenceRule: 'FREQ=DAILY;INTERVAL=5',
-    }],
-    views: ['month'],
-    currentView: 'month',
-    currentDate: new Date(2020, 0, 1),
-  });
-});
+}).before(async () => createWidget('dxScheduler', {
+  dataSource: [{
+    text: 'Text',
+    startDate: new Date(2020, 0, 6),
+    endDate: new Date(2020, 0, 10),
+    recurrenceRule: 'FREQ=DAILY;INTERVAL=5',
+  }],
+  views: ['month'],
+  currentView: 'month',
+  currentDate: new Date(2020, 0, 1),
+}));

--- a/testing/testcafe/tests/scheduler/nativeScrolling.ts
+++ b/testing/testcafe/tests/scheduler/nativeScrolling.ts
@@ -1,6 +1,7 @@
 import { ClientFunction } from 'testcafe';
 import createWidget from '../../helpers/createWidget';
 import url from '../../helpers/getPageUrl';
+import { safeSizeTest } from '../../helpers/safeSizeTest';
 import Scheduler from '../../model/scheduler';
 
 fixture`Scheduler: NativeScrolling`
@@ -15,7 +16,7 @@ const scrollToTime = ClientFunction(() => {
   instance.scrollToTime(date.getHours() - 1, 30, date);
 });
 
-test('ScrollToTime works correctly with timelineDay and timelineWeek view (T749957)', async (t) => {
+safeSizeTest('ScrollToTime works correctly with timelineDay and timelineWeek view (T749957)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const views = [{

--- a/testing/testcafe/tests/scheduler/navigator.ts
+++ b/testing/testcafe/tests/scheduler/navigator.ts
@@ -1,4 +1,5 @@
 import createWidget from '../../helpers/createWidget';
+import { safeSizeTest } from '../../helpers/safeSizeTest';
 import Scheduler from '../../model/scheduler';
 import { extend } from '../../../../js/core/utils/extend';
 import url from '../../helpers/getPageUrl';
@@ -16,7 +17,7 @@ const createScheduler = async (options = {}): Promise<void> => {
   }), true);
 };
 
-test('Navigator can change week when current date interval is more than diff between current date and `max` (T830754)', async (t) => {
+safeSizeTest('Navigator can change week when current date interval is more than diff between current date and `max` (T830754)', async (t) => {
   const { toolbar } = new Scheduler('#container');
 
   // Navigation `next` must be enabled at default
@@ -34,7 +35,7 @@ test('Navigator can change week when current date interval is more than diff bet
   currentView: 'week',
 }));
 
-test('Navigator can change week when current date interval is more than diff between current date and `min` (T830754)', async (t) => {
+safeSizeTest('Navigator can change week when current date interval is more than diff between current date and `min` (T830754)', async (t) => {
   const { toolbar } = new Scheduler('#container');
 
   // Navigation `prev` must be enabled at default
@@ -52,7 +53,7 @@ test('Navigator can change week when current date interval is more than diff bet
   currentView: 'week',
 }));
 
-test('Navigator can change month when current date interval is more than diff between current date and `max` (T830754)', async (t) => {
+safeSizeTest('Navigator can change month when current date interval is more than diff between current date and `max` (T830754)', async (t) => {
   const { toolbar } = new Scheduler('#container');
 
   // Navigation `next` must be enabled at default
@@ -70,7 +71,7 @@ test('Navigator can change month when current date interval is more than diff be
   currentView: 'month',
 }));
 
-test('Navigator can change month when current date interval is more than diff between current date and `min` (T830754)', async (t) => {
+safeSizeTest('Navigator can change month when current date interval is more than diff between current date and `min` (T830754)', async (t) => {
   const { toolbar } = new Scheduler('#container');
 
   // Navigation `prev` must be enabled at default

--- a/testing/testcafe/tests/scheduler/recurrences/appointmentTooltip.timeZone.ts
+++ b/testing/testcafe/tests/scheduler/recurrences/appointmentTooltip.timeZone.ts
@@ -1,11 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Appointment tooltip with recurrence appointment and custom time zone`
   .page(url(__dirname, '../../container.html'));
 
-test('Time in appointment tooltip should has valid value in case with recurrence appointment and custom time zone(T848058)', async (t) => {
+safeSizeTest('Time in appointment tooltip should has valid value in case with recurrence appointment and custom time zone(T848058)', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointmentCount = await scheduler.getAppointmentCount();
 
@@ -32,7 +33,7 @@ test('Time in appointment tooltip should has valid value in case with recurrence
   height: 600,
 }));
 
-test('The only one displayed part of recurrence appointment '
+safeSizeTest('The only one displayed part of recurrence appointment '
   + 'must have correct offset after DST(T1034216)', async (t) => {
   const scheduler = new Scheduler('#container');
 

--- a/testing/testcafe/tests/scheduler/recurrences/basic.ts
+++ b/testing/testcafe/tests/scheduler/recurrences/basic.ts
@@ -1,4 +1,5 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -7,7 +8,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Rendering of the recurrence appointments in  Scheduler `
   .page(url(__dirname, '../../container.html'));
 
-test('Drag-n-drop recurrence appointment between dateTable and allDay panel', async (t) => {
+safeSizeTest('Drag-n-drop recurrence appointment between dateTable and allDay panel', async (t) => {
   const scheduler = new Scheduler('#container');
   const draggableAppointment = scheduler.getAppointment('Simple recurrence appointment');
 
@@ -30,7 +31,7 @@ test('Drag-n-drop recurrence appointment between dateTable and allDay panel', as
   recurrenceEditMode: 'series',
 }));
 
-test('Appointments in DST should not have offset when '
+safeSizeTest('Appointments in DST should not have offset when '
   + 'recurring appointment timezoine not equal to scheduler timezone', async (t) => {
   const scheduler = new Scheduler('#container');
 
@@ -67,7 +68,7 @@ test('Appointments in DST should not have offset when '
   firstDayOfWeek: 1,
 }));
 
-test('Appointments in end of DST should have correct offset', async (t) => {
+safeSizeTest('Appointments in end of DST should have correct offset', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t
@@ -94,7 +95,7 @@ test('Appointments in end of DST should have correct offset', async (t) => {
   firstDayOfWeek: 1,
 }));
 
-test('Appointment displayed without errors if it was only one DST in year(T1037853)', async (t) => {
+safeSizeTest('Appointment displayed without errors if it was only one DST in year(T1037853)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t

--- a/testing/testcafe/tests/scheduler/resizeAppointments/allDay.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/allDay.ts
@@ -1,4 +1,5 @@
 import { compareScreenshot } from 'devextreme-screenshot-comparer';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Resize appointments in All Day Panel`
   .page(url(__dirname, '../../container.html'));
 
-test('Resize in the workWeek view between weeks', async (t) => {
+safeSizeTest('Resize in the workWeek view between weeks', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment1 = scheduler.getAppointment('1st');
   const appointment2 = scheduler.getAppointment('2nd');

--- a/testing/testcafe/tests/scheduler/resizeAppointments/basic.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/basic.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Resize appointments in the Scheduler basic views`
   .page(url(__dirname, '../../container.html'));
 
-['day', 'week', 'workWeek'].forEach((view) => test(`Resize in the "${view}" view`, async (t) => {
+['day', 'week', 'workWeek'].forEach((view) => safeSizeTest(`Resize in the "${view}" view`, async (t) => {
   const scheduler = new Scheduler('#container');
   const resizableAppointment = scheduler.getAppointment('Brochure Design Review');
 
@@ -39,7 +40,7 @@ fixture`Resize appointments in the Scheduler basic views`
   dataSource,
 })));
 
-test('Resize in the "month" view', async (t) => {
+safeSizeTest('Resize in the "month" view', async (t) => {
   const scheduler = new Scheduler('#container');
   const resizableAppointment = scheduler.getAppointment('Brochure Design Review');
 
@@ -72,7 +73,7 @@ test('Resize in the "month" view', async (t) => {
   dataSource,
 }));
 
-test('Resize should work correctly with startDateExpr (T944693)', async (t) => {
+safeSizeTest('Resize should work correctly with startDateExpr (T944693)', async (t) => {
   const scheduler = new Scheduler('#container');
   const resizableAppointment = scheduler.getAppointment('Brochure Design Review');
 

--- a/testing/testcafe/tests/scheduler/resizeAppointments/cancelAppointmentResize.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/cancelAppointmentResize.ts
@@ -1,4 +1,5 @@
 import { ClientFunction } from 'testcafe';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import createScheduler from '../dragAndDrop/init/widget.setup';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Cancel appointment D-n-D`
   .page(url(__dirname, '../../container.html'));
 
-test('onAppointmentUpdating - newDate should be correct after cancel appointment resize and cellDuration=24h (T1070565)', async (t) => {
+safeSizeTest('onAppointmentUpdating - newDate should be correct after cancel appointment resize and cellDuration=24h (T1070565)', async (t) => {
   const scheduler = new Scheduler('#container');
   const resizableAppointment = scheduler.getAppointment('Test Resize');
   const etalonISOEndDate = 'Fri Jun 04 2021';

--- a/testing/testcafe/tests/scheduler/resizeAppointments/timeline.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/timeline.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import dataSource from './init/widget.data';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -6,7 +7,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Resize appointments in the Scheduler basic views`
   .page(url(__dirname, '../../container.html'));
 
-['timelineDay', 'timelineWeek', 'timelineWorkWeek'].forEach((view) => test(`Resize in the "${view}" view`, async (t) => {
+['timelineDay', 'timelineWeek', 'timelineWorkWeek'].forEach((view) => safeSizeTest(`Resize in the "${view}" view`, async (t) => {
   const scheduler = new Scheduler('#container');
   const resizableAppointment = scheduler.getAppointment('Brochure Design Review');
 
@@ -39,7 +40,7 @@ fixture`Resize appointments in the Scheduler basic views`
   dataSource,
 })));
 
-test('Resize in the "timelineMonth" view', async (t) => {
+safeSizeTest('Resize in the "timelineMonth" view', async (t) => {
   const scheduler = new Scheduler('#container');
   const resizableAppointment = scheduler.getAppointment('Brochure Design Review');
 
@@ -72,17 +73,16 @@ test('Resize in the "timelineMonth" view', async (t) => {
   dataSource,
 }));
 
-test('Resize appointment on timelineWeek view with custom startDayHour & endDayHour (T804779)', async (t) => {
+safeSizeTest('Resize appointment on timelineWeek view with custom startDayHour & endDayHour (T804779)', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('Appointment');
 
   await t
-    .resizeWindow(1400, 800)
     .drag(appointment.resizableHandle.right, -400, 0)
     .expect(appointment.size.width).eql('200px')
     .expect(appointment.date.time)
     .eql('2:00 PM - 3:00 PM');
-}).before(async () => createScheduler({
+}, [1400, 800]).before(async () => createScheduler({
   views: [{
     type: 'timelineWeek', startDayHour: 10, endDayHour: 16, cellDuration: 60,
   }],
@@ -97,7 +97,7 @@ test('Resize appointment on timelineWeek view with custom startDayHour & endDayH
 }));
 
 // T948164
-test('Resize should work correctly when cell\'s width is not an integer', async (t) => {
+safeSizeTest('Resize should work correctly when cell\'s width is not an integer', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('Appointment');
 

--- a/testing/testcafe/tests/scheduler/resizeAppointments/verticalGrouping.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/verticalGrouping.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import createScheduler from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
 import Scheduler from '../../../model/scheduler';
@@ -5,7 +6,7 @@ import Scheduler from '../../../model/scheduler';
 fixture`Resize appointments in the Scheduler with vertical groupping`
   .page(url(__dirname, '../../container.html'));
 
-test('Should correctly calculate group resizing area (T1025952)', async (t) => {
+safeSizeTest('Should correctly calculate group resizing area (T1025952)', async (t) => {
   const scheduler = new Scheduler('#container');
   const firstAppointment = scheduler.getAppointment('first');
   const secondAppointment = scheduler.getAppointment('second');
@@ -65,7 +66,7 @@ test('Should correctly calculate group resizing area (T1025952)', async (t) => {
   ],
 }));
 
-test('Should correctly calculate group resizing area after scroll (T1041672)', async (t) => {
+safeSizeTest('Should correctly calculate group resizing area after scroll (T1041672)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await scheduler.scrollTo(new Date(2021, 3, 21, 9, 30), { priorityId: 2 });

--- a/testing/testcafe/tests/scheduler/resizeAppointments/zooming.ts
+++ b/testing/testcafe/tests/scheduler/resizeAppointments/zooming.ts
@@ -1,16 +1,14 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Resize appointments - Zooming`
   .page(url(__dirname, './pages/zooming.html'));
 
-test('Vertical resize with zooming', async (t) => {
+safeSizeTest('Vertical resize with zooming', async (t) => {
   const scheduler = new Scheduler('#container');
   const resizableAppointment = scheduler.getAppointment('Appt-01');
-
-  await t
-    .resizeWindow(1200, 800);
 
   await t
     .drag(resizableAppointment.resizableHandle.bottom, 0, 430, { offsetY: 20 });

--- a/testing/testcafe/tests/scheduler/timezone/T1102713/recurrenceAppointmentInDstTimeEditing.ts
+++ b/testing/testcafe/tests/scheduler/timezone/T1102713/recurrenceAppointmentInDstTimeEditing.ts
@@ -1,10 +1,13 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import url from '../../../../helpers/getPageUrl';
 import createWidget from '../../../../helpers/createWidget';
-import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import Scheduler from '../../../../model/scheduler';
 import AppointmentDialog from '../../../../model/scheduler/appointment/dialog';
 import Appointment from '../../../../model/scheduler/appointment';
+
+fixture`Editing recurrent appointment in DST time`
+  .page(url(__dirname, '../../../container.html'));
 
 interface ITestResizeOptions {
   direction: keyof Appointment['resizableHandle'];
@@ -92,9 +95,7 @@ async function resizeTestFunction(t: TestController,
     .ok(compareResults.errorMessages());
 }
 
-async function configureScheduler(t: TestController, { start, end }: { start: Date; end: Date }) {
-  await restoreBrowserSize(t);
-
+async function configureScheduler({ start, end }: { start: Date; end: Date }) {
   await createWidget('dxScheduler', {
     dataSource: [{
       startDate: start,
@@ -112,92 +113,89 @@ async function configureScheduler(t: TestController, { start, end }: { start: Da
   });
 }
 
-fixture`Editing recurrent appointment in DST time`
-  .page(url(__dirname, '../../../container.html'));
-
 // === EDITING POPUP ===
-test('Editing popup: should have correctly been edited from editing popup. DST - winter time', async (t) => {
+safeSizeTest('Editing popup: should have correctly been edited from editing popup. DST - winter time', async (t) => {
   await editingPopupTestFunction(t, 'popup__winter-time');
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.winter);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.winter);
 });
 
-test('Editing popup: should have correctly been edited from editing popup. DST - summer time', async (t) => {
+safeSizeTest('Editing popup: should have correctly been edited from editing popup. DST - summer time', async (t) => {
   await editingPopupTestFunction(t, 'popup__summer-time');
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.summer);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.summer);
 });
 
 // === DRAG_N_DROP ===
-test('Drag-n-drop up: should have correctly been edited. DST - winter time', async (t) => {
+safeSizeTest('Drag-n-drop up: should have correctly been edited. DST - winter time', async (t) => {
   await dragAndDropTestFunction(t, 'drag-n-drop-up__winter-time', {
     rowIdx: 1,
     cellIdx: 1,
   });
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.winter);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.winter);
 });
 
-test('Drag-n-drop down: should have correctly been edited. DST - winter time', async (t) => {
+safeSizeTest('Drag-n-drop down: should have correctly been edited. DST - winter time', async (t) => {
   await dragAndDropTestFunction(t, 'drag-n-drop-down__winter-time', {
     rowIdx: 4,
     cellIdx: 1,
   });
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.winter);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.winter);
 });
 
-test('Drag-n-drop up: should have correctly been edited. DST - summer time', async (t) => {
+safeSizeTest('Drag-n-drop up: should have correctly been edited. DST - summer time', async (t) => {
   await dragAndDropTestFunction(t, 'drag-n-drop-up__summer-time', {
     rowIdx: 1,
     cellIdx: 1,
   });
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.summer);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.summer);
 });
 
-test('Drag-n-drop down: should have correctly been edited. DST - summer time', async (t) => {
+safeSizeTest('Drag-n-drop down: should have correctly been edited. DST - summer time', async (t) => {
   await dragAndDropTestFunction(t, 'drag-n-drop-down__summer-time', {
     rowIdx: 4,
     cellIdx: 1,
   });
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.summer);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.summer);
 });
 
 // === RESIZE ===
-test('Resize top: should have correctly been edited. DST - winter time', async (t) => {
+safeSizeTest('Resize top: should have correctly been edited. DST - winter time', async (t) => {
   await resizeTestFunction(t, 'resize-top__winter-time', {
     direction: 'top',
     value: 100,
   });
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.winter);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.winter);
 });
 
-test('Resize bottom: should have correctly been edited. DST - winter time', async (t) => {
+safeSizeTest('Resize bottom: should have correctly been edited. DST - winter time', async (t) => {
   await resizeTestFunction(t, 'resize-bottom__winter-time', {
     direction: 'bottom',
     value: 100,
   });
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.winter);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.winter);
 });
 
-test('Resize top: should have correctly been edited. DST - summer time', async (t) => {
+safeSizeTest('Resize top: should have correctly been edited. DST - summer time', async (t) => {
   await resizeTestFunction(t, 'resize-top__summer-time', {
     direction: 'top',
     value: 100,
   });
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.summer);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.summer);
 });
 
-test('Resize bottom: should have correctly been edited. DST - summer time', async (t) => {
+safeSizeTest('Resize bottom: should have correctly been edited. DST - summer time', async (t) => {
   await resizeTestFunction(t, 'resize-bottom__summer-time', {
     direction: 'bottom',
     value: 100,
   });
-}).before(async (t) => {
-  await configureScheduler(t, APPOINTMENT_DATETIME.summer);
+}).before(async () => {
+  await configureScheduler(APPOINTMENT_DATETIME.summer);
 });

--- a/testing/testcafe/tests/scheduler/timezone/recurrence/appointmentWithoutTimezone.ts
+++ b/testing/testcafe/tests/scheduler/timezone/recurrence/appointmentWithoutTimezone.ts
@@ -1,11 +1,14 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import { getScreenshotName } from '../timezoneTestingUtils';
 import createWidget from '../../../../helpers/createWidget';
 import SelectBox from '../../../../model/selectBox';
 import Scheduler from '../../../../model/scheduler';
-import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
+
+fixture`Recurrent appointments without timezone in scheduler with timezone`
+  .page(url(__dirname, '../../../container.html'));
 
 const SELECT_SELECTOR = '#container';
 const SCHEDULER_SELECTOR = '#otherContainer';
@@ -40,10 +43,7 @@ const selectTimezoneInUI = async (t: TestController, selectBox: SelectBox, timez
   await t.click(timezonesList.getItem(timezoneIdx).element, TEST_CURSOR_OPTIONS);
 };
 
-fixture`Recurrent appointments without timezone in scheduler with timezone`
-  .page(url(__dirname, '../../../container.html'));
-
-test('Should correctly display the recurrent weekly appointment without timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent weekly appointment without timezone', async (t) => {
   const selectBox = new SelectBox(SELECT_SELECTOR);
   const schedulerWorkspace = new Scheduler(SCHEDULER_SELECTOR).workSpace;
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -61,10 +61,8 @@ test('Should correctly display the recurrent weekly appointment without timezone
 
   await t.expect(compareResults.isValid())
     .ok(compareResults.errorMessages());
-}).before(async (t) => {
+}).before(async () => {
   const schedulerTimezone = TEST_TIMEZONES[1];
-
-  await restoreBrowserSize(t);
 
   await createTimezoneSelect(SELECT_SELECTOR, TEST_TIMEZONES, SCHEDULER_SELECTOR);
   await createWidget('dxScheduler', {
@@ -85,7 +83,7 @@ test('Should correctly display the recurrent weekly appointment without timezone
   }, false, SCHEDULER_SELECTOR);
 });
 
-test('Should correctly display the recurrent monthly appointment without timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent monthly appointment without timezone', async (t) => {
   const selectBox = new SelectBox(SELECT_SELECTOR);
   const schedulerWorkspace = new Scheduler(SCHEDULER_SELECTOR).workSpace;
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -103,10 +101,8 @@ test('Should correctly display the recurrent monthly appointment without timezon
 
   await t.expect(compareResults.isValid())
     .ok(compareResults.errorMessages());
-}).before(async (t) => {
+}).before(async () => {
   const schedulerTimezone = TEST_TIMEZONES[1];
-
-  await restoreBrowserSize(t);
 
   await createTimezoneSelect(SELECT_SELECTOR, TEST_TIMEZONES, SCHEDULER_SELECTOR);
   await createWidget('dxScheduler', {
@@ -127,7 +123,7 @@ test('Should correctly display the recurrent monthly appointment without timezon
   }, false, SCHEDULER_SELECTOR);
 });
 
-test('Should correctly display the recurrent yearly appointment without timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent yearly appointment without timezone', async (t) => {
   const selectBox = new SelectBox(SELECT_SELECTOR);
   const schedulerWorkspace = new Scheduler(SCHEDULER_SELECTOR).workSpace;
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -145,10 +141,8 @@ test('Should correctly display the recurrent yearly appointment without timezone
 
   await t.expect(compareResults.isValid())
     .ok(compareResults.errorMessages());
-}).before(async (t) => {
+}).before(async () => {
   const schedulerTimezone = TEST_TIMEZONES[1];
-
-  await restoreBrowserSize(t);
 
   await createTimezoneSelect(SELECT_SELECTOR, TEST_TIMEZONES, SCHEDULER_SELECTOR);
   await createWidget('dxScheduler', {
@@ -169,7 +163,7 @@ test('Should correctly display the recurrent yearly appointment without timezone
   }, false, SCHEDULER_SELECTOR);
 });
 
-test('Should correctly display morning weekly recurrent appointment in a greater timezone.', async (t) => {
+safeSizeTest('Should correctly display morning weekly recurrent appointment in a greater timezone.', async (t) => {
   const schedulerWorkspace = new Scheduler(SCHEDULER_SELECTOR).workSpace;
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -177,10 +171,8 @@ test('Should correctly display morning weekly recurrent appointment in a greater
 
   await t.expect(compareResults.isValid())
     .ok(compareResults.errorMessages());
-}).before(async (t) => {
+}).before(async () => {
   const schedulerTimezone = TEST_TIMEZONES[0];
-
-  await restoreBrowserSize(t);
 
   await createTimezoneSelect(SELECT_SELECTOR, TEST_TIMEZONES, SCHEDULER_SELECTOR);
   await createWidget('dxScheduler', {
@@ -200,7 +192,7 @@ test('Should correctly display morning weekly recurrent appointment in a greater
   }, false, SCHEDULER_SELECTOR);
 });
 
-test('Should correctly display \'corner\' weekly recurrent appointments in a greater timezone.', async (t) => {
+safeSizeTest('Should correctly display \'corner\' weekly recurrent appointments in a greater timezone.', async (t) => {
   const schedulerWorkspace = new Scheduler(SCHEDULER_SELECTOR).workSpace;
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
@@ -208,10 +200,8 @@ test('Should correctly display \'corner\' weekly recurrent appointments in a gre
 
   await t.expect(compareResults.isValid())
     .ok(compareResults.errorMessages());
-}).before(async (t) => {
+}).before(async () => {
   const schedulerTimezone = TEST_TIMEZONES[0];
-
-  await restoreBrowserSize(t);
 
   await createTimezoneSelect(SELECT_SELECTOR, TEST_TIMEZONES, SCHEDULER_SELECTOR);
   await createWidget('dxScheduler', {

--- a/testing/testcafe/tests/scheduler/timezone/recurrence/monthlyRecurrentAppointment.ts
+++ b/testing/testcafe/tests/scheduler/timezone/recurrence/monthlyRecurrentAppointment.ts
@@ -1,21 +1,19 @@
 import url from '../../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import { getAppointmentTime, screenshotTestFunc } from '../timezoneTestingUtils';
 import createWidget from '../../../../helpers/createWidget';
-import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 
 const SCREENSHOT_BASE_NAME = 'timezone-monthly-recurrent';
 
 fixture`Monthly recurrent appointments with timezones`
   .page(url(__dirname, '../../../container.html'));
 
-test('Should correctly display the recurrent monthly appointment with the same timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent monthly appointment with the same timezone', async (t) => {
   // expected date: 4/28/2021 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'same-date__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -37,14 +35,12 @@ test('Should correctly display the recurrent monthly appointment with the same t
   });
 });
 
-test('Should correctly display the recurrent monthly appointment with a greater time timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent monthly appointment with a greater time timezone', async (t) => {
   // expected date: 4/29/2021 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'same-date__greater-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -66,14 +62,12 @@ test('Should correctly display the recurrent monthly appointment with a greater 
   });
 });
 
-test('Should correctly display the recurrent monthly appointment with a lower time timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent monthly appointment with a lower time timezone', async (t) => {
   // expected date: 4/27/2021 12:00 PM - 2:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'same-date__lower-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -95,15 +89,13 @@ test('Should correctly display the recurrent monthly appointment with a lower ti
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment
+safeSizeTest(`Should correctly display the recurrent monthly appointment
 if start date lower that recurrent date with the same time timezone`, async (t) => {
   // expected date: 4/28/2021 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'lower-date__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -125,15 +117,13 @@ if start date lower that recurrent date with the same time timezone`, async (t) 
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment
+safeSizeTest(`Should correctly display the recurrent monthly appointment
 if start date lower that recurrent date with a greater time timezone`, async (t) => {
   // expected date: 4/29/2021 2:00 AM - 4:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'lower-date__greater-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -155,15 +145,13 @@ if start date lower that recurrent date with a greater time timezone`, async (t)
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment
+safeSizeTest(`Should correctly display the recurrent monthly appointment
 if start date lower that recurrent date with a lower time timezone`, async (t) => {
   // expected date: 4/27/2021 4:00 PM - 6:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'lower-date__lower-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -185,15 +173,13 @@ if start date lower that recurrent date with a lower time timezone`, async (t) =
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment at first date
+safeSizeTest(`Should correctly display the recurrent monthly appointment at first date
 if start date greater that recurrent date with a same time timezone`, async (t) => {
   // expected no visible date
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__same-timezone__same-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -215,15 +201,13 @@ if start date greater that recurrent date with a same time timezone`, async (t) 
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment at next date
+safeSizeTest(`Should correctly display the recurrent monthly appointment at next date
 if start date greater that recurrent date with a same time timezone`, async (t) => {
   // expected date: 5/26/2021 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__same-timezone__next-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -245,15 +229,13 @@ if start date greater that recurrent date with a same time timezone`, async (t) 
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment at first date
+safeSizeTest(`Should correctly display the recurrent monthly appointment at first date
 if start date greater that recurrent date with a greater time timezone`, async (t) => {
   // expected no visible date
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__greater-timezone__same-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -275,15 +257,13 @@ if start date greater that recurrent date with a greater time timezone`, async (
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment at next date
+safeSizeTest(`Should correctly display the recurrent monthly appointment at next date
 if start date greater that recurrent date with a greater time timezone`, async (t) => {
   // expected date: 5/27/2021 2:00 AM - 4:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__greater-timezone__next-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -305,15 +285,13 @@ if start date greater that recurrent date with a greater time timezone`, async (
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment at first date
+safeSizeTest(`Should correctly display the recurrent monthly appointment at first date
 if start date greater that recurrent date with a lower time timezone`, async (t) => {
   // expected no visible date
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__lower-timezone__same-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -335,15 +313,13 @@ if start date greater that recurrent date with a lower time timezone`, async (t)
   });
 });
 
-test(`Should correctly display the recurrent monthly appointment at next date
+safeSizeTest(`Should correctly display the recurrent monthly appointment at next date
 if start date greater that recurrent date with a lower time timezone`, async (t) => {
   // expected date: 5/25/2021 4:00 PM - 6:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__lower-timezone__next-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{

--- a/testing/testcafe/tests/scheduler/timezone/recurrence/weeklyRecurrentAppointment.ts
+++ b/testing/testcafe/tests/scheduler/timezone/recurrence/weeklyRecurrentAppointment.ts
@@ -1,7 +1,7 @@
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import url from '../../../../helpers/getPageUrl';
 import createWidget from '../../../../helpers/createWidget';
 import { getAppointmentTime, screenshotTestFunc } from '../timezoneTestingUtils';
-import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 
 const SCREENSHOT_BASE_NAME = 'timezone-weekly-recurrent';
 
@@ -10,14 +10,12 @@ fixture`Weekly recurrent appointments with timezones`
 
 // === One day in week tests section ===
 
-test('Should correctly display the recurrent (one day at week) appointment with the same timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent (one day at week) appointment with the same timezone', async (t) => {
   // expected date: 4/28/2021 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -39,14 +37,12 @@ test('Should correctly display the recurrent (one day at week) appointment with 
   });
 });
 
-test('Should correctly display the recurrent (one day at week) morning appointment with the same timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent (one day at week) morning appointment with the same timezone', async (t) => {
   // expected date: 4/28/2021 12:00 AM - 2:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-morning-appointment__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -68,15 +64,13 @@ test('Should correctly display the recurrent (one day at week) morning appointme
   });
 });
 
-test('Should correctly display the recurrent (one day at week) evening appointment with the same timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent (one day at week) evening appointment with the same timezone', async (t) => {
   // expected date: 4/28/2021 10:00 PM - 12:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-evening-appointment__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
 
-  await restoreBrowserSize(t);
-
   await createWidget('dxScheduler', {
     dataSource: [{
       allDay: false,
@@ -97,15 +91,13 @@ test('Should correctly display the recurrent (one day at week) evening appointme
   });
 });
 
-test(`Should correctly display the recurrent (one day at week) appointment
+safeSizeTest(`Should correctly display the recurrent (one day at week) appointment
 with a greater time timezone and day shift to the next day`, async (t) => {
   // expected date: 4/29/2021 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__day-shift__greater-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -127,14 +119,12 @@ with a greater time timezone and day shift to the next day`, async (t) => {
   });
 });
 
-test('Should correctly display the recurrent (one day at week) appointment with a lower timezone and day shift to the previous day', async (t) => {
+safeSizeTest('Should correctly display the recurrent (one day at week) appointment with a lower timezone and day shift to the previous day', async (t) => {
   // expected date: 4/27/2021 6:00 PM - 8:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__day-shift__lower-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-10';
   const schedulerTimezone = 'Etc/GMT+2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -156,14 +146,12 @@ test('Should correctly display the recurrent (one day at week) appointment with 
   });
 });
 
-test('Should correctly display the recurrent (one day at week) appointment with timezone week shift to the previous week', async (t) => {
+safeSizeTest('Should correctly display the recurrent (one day at week) appointment with timezone week shift to the previous week', async (t) => {
   // expected date: 4/25/2021 6:00 AM - 8:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__week-shift__lower-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-10';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -185,14 +173,12 @@ test('Should correctly display the recurrent (one day at week) appointment with 
   });
 });
 
-test('Should correctly display the recurrent (one day at week) appointment with timezone week shift to the next week', async (t) => {
+safeSizeTest('Should correctly display the recurrent (one day at week) appointment with timezone week shift to the next week', async (t) => {
   // expected date: 4/25/2021 4:00 PM - 6:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__week-shift__greater-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -214,15 +200,13 @@ test('Should correctly display the recurrent (one day at week) appointment with 
   });
 });
 
-test(`Should correctly display the recurrent (one day at week) appointment
+safeSizeTest(`Should correctly display the recurrent (one day at week) appointment
 with timezone view period shift to the next view period at the first week`, async (t) => {
   // expected no visible date
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__next-view-shift__first-week');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -244,15 +228,13 @@ with timezone view period shift to the next view period at the first week`, asyn
   });
 });
 
-test(`Should correctly display the recurrent (one day at week) appointment
+safeSizeTest(`Should correctly display the recurrent (one day at week) appointment
 with timezone view period shift to the next view period at the second week`, async (t) => {
   // expected date: 5/2/2021 4:00 PM - 6:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__next-view-shift__second-week');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -274,15 +256,13 @@ with timezone view period shift to the next view period at the second week`, asy
   });
 });
 
-test(`Should correctly display the recurrent (one day at week) appointment
+safeSizeTest(`Should correctly display the recurrent (one day at week) appointment
 with timezone view period shift to the previous view period at the first week`, async (t) => {
   // expected date: 5/1/2021 6:00 AM - 8:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__previous-view-shift__first-week');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-10';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -304,15 +284,13 @@ with timezone view period shift to the previous view period at the first week`, 
   });
 });
 
-test(`Should correctly display the recurrent (one day at week) appointment
+safeSizeTest(`Should correctly display the recurrent (one day at week) appointment
 with timezone view period shift to the previous view period at the second week`, async (t) => {
   // expected date: 4/24/2021 6:00 AM - 8:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__previous-view-shift__before-week');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-10';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -336,16 +314,14 @@ with timezone view period shift to the previous view period at the second week`,
 
 // === multiple day in week tests section ===
 
-test('Should correctly display recurrent appointment with multiple day in week on the first week in same timezone', async (t) => {
+safeSizeTest('Should correctly display recurrent appointment with multiple day in week on the first week in same timezone', async (t) => {
   // expected dates:
   // 4/28/2021 10:00 AM - 2:00 AM
   // 4/29/2021 10:00 AM - 2:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'multiple-appointment__first-week__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -367,17 +343,15 @@ test('Should correctly display recurrent appointment with multiple day in week o
   });
 });
 
-test('Should correctly display recurrent appointment with multiple day in week on the second week in same timezone', async (t) => {
+safeSizeTest('Should correctly display recurrent appointment with multiple day in week on the second week in same timezone', async (t) => {
   // expected dates:
   // 5/4/2021 10:00 AM - 2:00 AM
   // 5/5/2021 10:00 AM - 2:00 AM
   // 5/6/2021 10:00 AM - 2:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'multiple-appointment__second-week__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -399,16 +373,14 @@ test('Should correctly display recurrent appointment with multiple day in week o
   });
 });
 
-test('Should correctly display recurrent appointment with multiple day in week on the first week in a greater time timezone', async (t) => {
+safeSizeTest('Should correctly display recurrent appointment with multiple day in week on the first week in a greater time timezone', async (t) => {
   // expected dates:
   // 4/29/2021 1:00 AM - 5:00 AM
   // 4/30/2021 1:00 AM - 5:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'multiple-appointment__first-week__greater-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const timezone = 'Etc/GMT-5';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -430,17 +402,15 @@ test('Should correctly display recurrent appointment with multiple day in week o
   });
 });
 
-test('Should correctly display recurrent appointment with multiple day in week on the second week in a greater time timezone', async (t) => {
+safeSizeTest('Should correctly display recurrent appointment with multiple day in week on the second week in a greater time timezone', async (t) => {
   // expected dates:
   // 5/5/2021 1:00 AM - 5:00 AM
   // 5/6/2021 1:00 AM - 5:00 AM
   // 5/7/2021 1:00 AM - 5:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'multiple-appointment__second-week__greater-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const timezone = 'Etc/GMT-5';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -462,16 +432,14 @@ test('Should correctly display recurrent appointment with multiple day in week o
   });
 });
 
-test('Should correctly display recurrent appointment with multiple day in week on the first week in a lower time timezone', async (t) => {
+safeSizeTest('Should correctly display recurrent appointment with multiple day in week on the first week in a lower time timezone', async (t) => {
   // expected dates:
   // 4/27/2021 7:00 PM - 11:00 PM
   // 4/28/2021 7:00 PM - 11:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'multiple-appointment__first-week__lower-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-10';
   const timezone = 'Etc/GMT+5';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -493,17 +461,15 @@ test('Should correctly display recurrent appointment with multiple day in week o
   });
 });
 
-test('Should correctly display recurrent appointment with multiple day in week on the second week in a lower time timezone', async (t) => {
+safeSizeTest('Should correctly display recurrent appointment with multiple day in week on the second week in a lower time timezone', async (t) => {
   // expected dates:
   // 5/3/2021 7:00 PM - 11:00 PM
   // 5/4/2021 7:00 PM - 11:00 PM
   // 5/5/2021 7:00 PM - 11:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'multiple-appointment__second-week__lower-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-10';
   const timezone = 'Etc/GMT+5';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -527,15 +493,13 @@ test('Should correctly display recurrent appointment with multiple day in week o
 
 // === maximum timezone offset tests section ===
 
-test(`Should correctly display recurrent appointment with multiple day in week
+safeSizeTest(`Should correctly display recurrent appointment with multiple day in week
  on the first week with maximum positive timezone offset`, async (t) => {
   // expected date: 5/1/2021 12:00 AM - 2:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__first-week__max-positive-timezone-offset');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+12';
   const timezone = 'Etc/GMT-14';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -557,18 +521,16 @@ test(`Should correctly display recurrent appointment with multiple day in week
   });
 });
 
-test(`Should correctly display recurrent appointment with multiple day in week
+safeSizeTest(`Should correctly display recurrent appointment with multiple day in week
  on the first week with maximum positive timezone offset`, async (t) => {
   // expected dates:
   // 5/6/2021 12:00 AM - 2:00 AM
   // 5/7/2021 12:00 AM - 2:00 AM
   // 5/8/2021 12:00 AM - 2:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__second-week__max-positive-timezone-offset');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+12';
   const timezone = 'Etc/GMT-14';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -590,17 +552,15 @@ test(`Should correctly display recurrent appointment with multiple day in week
   });
 });
 
-test(`Should correctly display recurrent appointment with multiple day in week
+safeSizeTest(`Should correctly display recurrent appointment with multiple day in week
  on the first week with maximum negative timezone offset`, async (t) => {
   // expected dates:
   // 4/26/2021 10:00 PM - 12:00 AM
   // 5/1/2021 10:00 PM - 12:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__first-week__max-negative-timezone-offset');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-14';
   const timezone = 'Etc/GMT+12';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -622,18 +582,16 @@ test(`Should correctly display recurrent appointment with multiple day in week
   });
 });
 
-test(`Should correctly display recurrent appointment with multiple day in week
+safeSizeTest(`Should correctly display recurrent appointment with multiple day in week
  on the first week with maximum negative timezone offset`, async (t) => {
   // expected dates:
   // 5/2/2021 10:00 PM - 12:00 AM
   // 5/3/2021 10:00 PM - 12:00 AM
   // 5/8/2021 10:00 PM - 12:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'one-appointment__second-week__max-negative-timezone-offset');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-14';
   const timezone = 'Etc/GMT+12';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{

--- a/testing/testcafe/tests/scheduler/timezone/recurrence/yearlyRecurrentAppointment.ts
+++ b/testing/testcafe/tests/scheduler/timezone/recurrence/yearlyRecurrentAppointment.ts
@@ -1,21 +1,19 @@
+import { safeSizeTest } from '../../../../helpers/safeSizeTest';
 import url from '../../../../helpers/getPageUrl';
 import { getAppointmentTime, screenshotTestFunc } from '../timezoneTestingUtils';
 import createWidget from '../../../../helpers/createWidget';
-import { restoreBrowserSize } from '../../../../helpers/restoreBrowserSize';
 
 const SCREENSHOT_BASE_NAME = 'timezone-yearly-recurrent';
 
 fixture`Yearly recurrent appointments with timezones`
   .page(url(__dirname, '../../../container.html'));
 
-test('Should correctly display the recurrent yearly appointment with the same timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent yearly appointment with the same timezone', async (t) => {
   // expected date: 4/28/2021 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'same-date__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -37,14 +35,12 @@ test('Should correctly display the recurrent yearly appointment with the same ti
   });
 });
 
-test('Should correctly display the recurrent yearly appointment with a greater time timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent yearly appointment with a greater time timezone', async (t) => {
   // expected date: 4/29/2021 2:00 AM - 4:00 AM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'same-date__greater-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -66,14 +62,12 @@ test('Should correctly display the recurrent yearly appointment with a greater t
   });
 });
 
-test('Should correctly display the recurrent yearly appointment with a lower time timezone', async (t) => {
+safeSizeTest('Should correctly display the recurrent yearly appointment with a lower time timezone', async (t) => {
   // expected date: 4/27/2021 2:00 PM - 4:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'same-date__lower-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -95,15 +89,13 @@ test('Should correctly display the recurrent yearly appointment with a lower tim
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment if start date
 lower than recurrent date with the same timezone`, async (t) => {
   // expected date: 4/28/2021 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'lower-date__same-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -125,15 +117,13 @@ lower than recurrent date with the same timezone`, async (t) => {
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment if start date
 lower than recurrent date with a greater time timezone`, async (t) => {
   // expected date: 4/29/2021 2:00 AM - 4:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'lower-date__greater-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -155,15 +145,13 @@ lower than recurrent date with a greater time timezone`, async (t) => {
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment if start date
 lower than recurrent date with a lower time timezone`, async (t) => {
   // expected date: 4/27/2021 4:00 PM - 6:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'lower-date__lower-timezone');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -185,15 +173,13 @@ lower than recurrent date with a lower time timezone`, async (t) => {
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment at first date if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment at first date if start date
 greater than recurrent date with the same timezone`, async (t) => {
   // expected no visible date
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__same-timezone__same-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -215,15 +201,13 @@ greater than recurrent date with the same timezone`, async (t) => {
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment at next date if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment at next date if start date
 greater than recurrent date with the same timezone`, async (t) => {
   // expected date: 4/28/2022 10:00 AM - 12:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__same-timezone__next-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+1';
   const schedulerTimezone = 'Etc/GMT+1';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -245,15 +229,13 @@ greater than recurrent date with the same timezone`, async (t) => {
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment at first date if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment at first date if start date
 greater than recurrent date with a greater time timezone`, async (t) => {
   // expected no visible date
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__greater-timezone__same-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -275,15 +257,13 @@ greater than recurrent date with a greater time timezone`, async (t) => {
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment at next date if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment at next date if start date
 greater than recurrent date with a greater time timezone`, async (t) => {
   // expected date: 4/29/2022 2:00 AM - 4:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__greater-timezone__next-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT+10';
   const schedulerTimezone = 'Etc/GMT-2';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -305,15 +285,13 @@ greater than recurrent date with a greater time timezone`, async (t) => {
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment at first date if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment at first date if start date
 greater than recurrent date with a lower time timezone`, async (t) => {
   // expected no visible date
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__lower-timezone__same-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{
@@ -335,15 +313,13 @@ greater than recurrent date with a lower time timezone`, async (t) => {
   });
 });
 
-test(`Should correctly display the recurrent yearly appointment at next date if start date
+safeSizeTest(`Should correctly display the recurrent yearly appointment at next date if start date
 greater than recurrent date with a lower time timezone`, async (t) => {
   // expected date: 4/27/2022 4:00 PM - 6:00 PM
   await screenshotTestFunc(t, SCREENSHOT_BASE_NAME, 'greater-date__lower-timezone__next-view-date');
-}).before(async (t) => {
+}).before(async () => {
   const appointmentTimezone = 'Etc/GMT-2';
   const schedulerTimezone = 'Etc/GMT+10';
-
-  await restoreBrowserSize(t);
 
   await createWidget('dxScheduler', {
     dataSource: [{

--- a/testing/testcafe/tests/scheduler/tooltipBehaviour/tooltipBehavior.ts
+++ b/testing/testcafe/tests/scheduler/tooltipBehaviour/tooltipBehavior.ts
@@ -1,3 +1,4 @@
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import dataSource from './init/widget.data';
 import { createScheduler, scroll } from './init/widget.setup';
 import url from '../../../helpers/getPageUrl';
@@ -6,15 +7,14 @@ import Scheduler from '../../../model/scheduler';
 fixture`Appointment tooltip behavior during scrolling in the Scheduler (T755449)`
   .page(url(__dirname, '../../container.html'));
 
-test('The tooltip of collector should not scroll page and immediately hide', async (t) => {
+safeSizeTest('The tooltip of collector should not scroll page and immediately hide', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t
-    .resizeWindow(600, 450)
     .click(scheduler.collectors.find('7').element, { speed: 0.2 })
     .expect(scheduler.appointmentTooltip.isVisible())
     .ok();
-}).before(async () => createScheduler({
+}, [600, 450]).before(async () => createScheduler({
   views: [{
     type: 'week',
     name: 'week',
@@ -52,33 +52,27 @@ test('The tooltip of collector should not scroll page and immediately hide', asy
     startDate: new Date(2017, 4, 22, 9, 30),
     endDate: new Date(2017, 4, 22, 11, 30),
   }],
-})).after(async (t) => {
-  await t.resizeWindow(1200, 800);
-});
+}));
 
-test('The tooltip should not hide after automatic scrolling during an appointment click', async (t) => {
+safeSizeTest('The tooltip should not hide after automatic scrolling during an appointment click', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('Brochure Design Review');
 
   await t
-    .resizeWindow(600, 400)
     .click(appointment.element, { speed: 0.2 })
     .expect(scheduler.appointmentTooltip.isVisible())
     .ok();
-}).before(async () => createScheduler({
+}, [600, 400]).before(async () => createScheduler({
   views: ['week'],
   currentView: 'week',
   dataSource,
-})).after(async (t) => {
-  await t.resizeWindow(1200, 800);
-});
+}));
 
-test('The tooltip should hide after manually scrolling in the browser', async (t) => {
+safeSizeTest('The tooltip should hide after manually scrolling in the browser', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointment('Brochure Design Review');
 
   await t
-    .resizeWindow(600, 400)
     .click(appointment.element, { speed: 0.2 })
     .expect(scheduler.appointmentTooltip.isVisible())
     .ok();
@@ -86,10 +80,8 @@ test('The tooltip should hide after manually scrolling in the browser', async (t
   await t
     .wait(500)
     .expect(scheduler.appointmentTooltip.isVisible()).notOk();
-}).before(async () => createScheduler({
+}, [600, 400]).before(async () => createScheduler({
   views: ['week'],
   currentView: 'week',
   dataSource,
-})).after(async (t) => {
-  await t.resizeWindow(1200, 800);
-});
+}));

--- a/testing/testcafe/tests/scheduler/twoSchedulers.ts
+++ b/testing/testcafe/tests/scheduler/twoSchedulers.ts
@@ -1,5 +1,6 @@
 import { ClientFunction } from 'testcafe';
 import createWidget from '../../helpers/createWidget';
+import { safeSizeTest } from '../../helpers/safeSizeTest';
 import Scheduler from '../../model/scheduler';
 import url from '../../helpers/getPageUrl';
 
@@ -20,7 +21,7 @@ const dispose = ClientFunction((container) => {
   ($(container) as any).dxScheduler('dispose');
 });
 
-test('First scheduler should work after removing second (T1063130)', async (t) => {
+safeSizeTest('First scheduler should work after removing second (T1063130)', async (t) => {
   const scheduler = new Scheduler('#container');
   const { navigator } = scheduler.toolbar;
 

--- a/testing/testcafe/tests/scheduler/virtualScrolling/T1091980.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrolling/T1091980.ts
@@ -1,12 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Scheduler: Virtual scrolling`
   .page(url(__dirname, '../../container.html'));
 
-test('it should correctly render virtual table if scheduler sizes are set in % (T1091980)', async (t) => {
-  await t.resizeWindow(1200, 800);
+safeSizeTest('it should correctly render virtual table if scheduler sizes are set in % (T1091980)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t

--- a/testing/testcafe/tests/scheduler/virtualScrolling/appointments.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrolling/appointments.ts
@@ -1,13 +1,14 @@
 import { getStyleAttribute, setStyleAttribute } from '../../../helpers/domElement';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import { scrollTo } from './utils';
 
 fixture`Scheduler: Virtual Scrolling`
   .page(url(__dirname, '../../container.html'));
 
-test('Appointment should not repaint after scrolling if present on viewport', async (t) => {
+safeSizeTest('Appointment should not repaint after scrolling if present on viewport', async (t) => {
   const scheduler = new Scheduler('#container');
   const { element } = scheduler.getAppointment('', 0);
 

--- a/testing/testcafe/tests/scheduler/virtualScrolling/layout.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrolling/layout.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer, compareScreenshot } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import {
   resources,
@@ -32,8 +33,7 @@ const createScheduler = async (
   }, true);
 };
 
-test('Virtual scrolling layout in scheduler views', async (t) => {
-  await t.resizeWindow(1200, 800);
+safeSizeTest('Virtual scrolling layout in scheduler views', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -63,7 +63,7 @@ test('Virtual scrolling layout in scheduler views', async (t) => {
   await createScheduler({});
 });
 
-test('Virtual scrolling layout in scheduler views when horizontal grouping is enabled', async (t) => {
+safeSizeTest('Virtual scrolling layout in scheduler views when horizontal grouping is enabled', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -96,8 +96,7 @@ test('Virtual scrolling layout in scheduler views when horizontal grouping is en
   });
 });
 
-test('Virtual scrolling layout in scheduler views when grouping by date is enabled', async (t) => {
-  await t.resizeWindow(1200, 800);
+safeSizeTest('Virtual scrolling layout in scheduler views when grouping by date is enabled', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -131,8 +130,7 @@ test('Virtual scrolling layout in scheduler views when grouping by date is enabl
   });
 });
 
-test('Header cells should be aligned with date-table cells in timeline-month when current date changes and virtual scrolling is used', async (t) => {
-  await t.resizeWindow(1200, 800);
+safeSizeTest('Header cells should be aligned with date-table cells in timeline-month when current date changes and virtual scrolling is used', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await scheduler.option('currentDate', new Date(2020, 11, 1));

--- a/testing/testcafe/tests/scheduler/virtualScrolling/resources.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrolling/resources.ts
@@ -1,11 +1,12 @@
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 
 fixture`Scheduler: Generic theme layout`
   .page(url(__dirname, '../../container.html'));
 
-test('Should correctly render view if virtual scrolling and groupByDate', async (t) => {
+safeSizeTest('Should correctly render view if virtual scrolling and groupByDate', async (t) => {
   const scheduler = new Scheduler('#container');
   const appointment = scheduler.getAppointmentByIndex(0);
 

--- a/testing/testcafe/tests/scheduler/virtualScrolling/zooming.ts
+++ b/testing/testcafe/tests/scheduler/virtualScrolling/zooming.ts
@@ -1,6 +1,7 @@
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../../helpers/createWidget';
 import url from '../../../helpers/getPageUrl';
+import { safeSizeTest } from '../../../helpers/safeSizeTest';
 import Scheduler from '../../../model/scheduler';
 import {
   resources,
@@ -30,7 +31,7 @@ const createScheduler = async (
   }, true);
 };
 
-test('Virtual scrolling layout in scheduler views when horizontal grouping is enabled and zooming is used', async (t) => {
+safeSizeTest('Virtual scrolling layout in scheduler views when horizontal grouping is enabled and zooming is used', async (t) => {
   const scheduler = new Scheduler('#container');
 
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);

--- a/testing/testcafe/tests/scheduler/workSpace.ts
+++ b/testing/testcafe/tests/scheduler/workSpace.ts
@@ -1,6 +1,7 @@
 import { ClientFunction } from 'testcafe';
 import { createScreenshotsComparer } from 'devextreme-screenshot-comparer';
 import createWidget from '../../helpers/createWidget';
+import { safeSizeTest } from '../../helpers/safeSizeTest';
 import Scheduler from '../../model/scheduler';
 import { extend } from '../../../../js/core/utils/extend';
 import url from '../../helpers/getPageUrl';
@@ -21,11 +22,10 @@ const createScheduler = async (options = {}): Promise<void> => {
   }));
 };
 
-test('Vertical selection between two workspace cells should focus cells between them (T804954)', async (t) => {
+safeSizeTest('Vertical selection between two workspace cells should focus cells between them (T804954)', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t
-    .resizeWindow(1200, 800)
     .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(3, 0))
     .expect(scheduler.dateTableCells.filter('.dx-state-focused').count).eql(4);
 }).before(async () => createScheduler({
@@ -34,12 +34,11 @@ test('Vertical selection between two workspace cells should focus cells between 
   currentView: 'day',
 }));
 
-test('Horizontal selection between two workspace cells should focus cells between them', async (t) => {
+safeSizeTest('Horizontal selection between two workspace cells should focus cells between them', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t
     .setTestSpeed(0.5)
-    .resizeWindow(1200, 800)
     .dragToElement(scheduler.getDateTableCell(0, 0), scheduler.getDateTableCell(0, 3))
     .expect(scheduler.dateTableCells.filter('.dx-state-focused').count)
     .eql(4);
@@ -59,7 +58,7 @@ test('Horizontal selection between two workspace cells should focus cells betwee
   }],
 }));
 
-test('Vertical grouping should work correctly when there is one group', async (t) => {
+safeSizeTest('Vertical grouping should work correctly when there is one group', async (t) => {
   const scheduler = new Scheduler('#container');
 
   await t
@@ -93,7 +92,7 @@ const resize = ClientFunction((container) => {
   instance._workSpace._dimensionChanged();
 });
 
-test('Hidden scheduler should not resize', async (t) => {
+safeSizeTest('Hidden scheduler should not resize', async (t) => {
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
   await hideShow('#container');


### PR DESCRIPTION
- Increased the count of the parallel testcafe test jobs for the scheduler widget.
- Added safeSizeTest helper to stabilize etalons wrong size issues
- Turned off some duplicates in the scheduler's renovation testcafe tests