### PR TITLE
ASP.NET: disable alternative template syntax warning

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -12,8 +12,7 @@
                 require('./core/utils/iterator'),
                 require('./core/utils/dom').extractTemplateMarkup,
                 require('./core/utils/string').encodeHtml,
-                require('./core/utils/ajax'),
-                require('./core/utils/console')
+                require('./core/utils/ajax')
             );
         });
     } else {
@@ -26,20 +25,15 @@
             DevExpress.utils.iterator,
             DevExpress.utils.dom.extractTemplateMarkup,
             DevExpress.utils.string.encodeHtml,
-            DevExpress.utils.ajax,
-            DevExpress.utils.console
+            DevExpress.utils.ajax
         );
     }
-})(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils, extractTemplateMarkup, encodeHtml, ajax, console) {
+})(function($, setTemplateEngine, templateRendered, Guid, validationEngine, iteratorUtils, extractTemplateMarkup, encodeHtml, ajax) {
     var templateCompiler = createTemplateCompiler();
     var pendingCreateComponentRoutines = [ ];
-    var enableAlternativeTemplateTags = true;
-    var warnBug17028 = false;
 
     function createTemplateCompiler() {
-        var OPEN_TAG = '<%',
-            CLOSE_TAG = '%>',
-            ENCODE_QUALIFIER = '-',
+        var ENCODE_QUALIFIER = '-',
             INTERPOLATE_QUALIFIER = '=';
 
         var EXTENDED_OPEN_TAG = /[<[]%/g,
@@ -74,19 +68,12 @@
 
         return function(text) {
             var bag = ['var _ = [];', 'with(obj||{}) {'],
-                chunks = text.split(enableAlternativeTemplateTags ? EXTENDED_OPEN_TAG : OPEN_TAG);
-
-            if(warnBug17028 && chunks.length > 1) {
-                if(text.indexOf(OPEN_TAG) > -1) {
-                    console.logger.warn('Please use an alternative template syntax: https://community.devexpress.com/blogs/aspnet/archive/2020/01/29/asp-net-core-new-syntax-to-fix-razor-issue.aspx');
-                    warnBug17028 = false;
-                }
-            }
+                chunks = text.split(EXTENDED_OPEN_TAG);
 
             acceptText(bag, chunks.shift());
 
             for(var i = 0; i < chunks.length; i++) {
-                var tmp = chunks[i].split(enableAlternativeTemplateTags ? EXTENDED_CLOSE_TAG : CLOSE_TAG);
+                var tmp = chunks[i].split(EXTENDED_CLOSE_TAG);
                 if(tmp.length !== 2) {
                     throw 'Template syntax error';
                 }
@@ -200,14 +187,6 @@
             if(setTemplateEngine) {
                 setTemplateEngine(createTemplateEngine());
             }
-        },
-
-        enableAlternativeTemplateTags: function(value) {
-            enableAlternativeTemplateTags = value;
-        },
-
-        warnBug17028: function() {
-            warnBug17028 = true;
         },
 
         createValidationSummaryItems: function(validationGroup, editorNames) {

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -21,8 +21,7 @@
                 require('core/templates/template_engine_registry').setTemplateEngine,
                 aspnet,
                 function() { return require('ui/widget/ui.errors'); },
-                function() { return require('../../helpers/ajaxMock.js'); },
-                require('core/utils/console')
+                function() { return require('../../helpers/ajaxMock.js'); }
             );
         });
     } else {
@@ -31,11 +30,10 @@
             DevExpress.setTemplateEngine,
             DevExpress.aspnet,
             function() { return window.DevExpress_ui_widget_errors; },
-            function() { return window.ajaxMock; },
-            DevExpress.utils.console
+            function() { return window.ajaxMock; }
         );
     }
-}(function($, setTemplateEngine, aspnet, errorsAccessor, ajaxMockAccessor, console) {
+}(function($, setTemplateEngine, aspnet, errorsAccessor, ajaxMockAccessor) {
 
     if(QUnit.urlParams['nojquery']) {
         return;
@@ -266,21 +264,16 @@
             setTemplateEngine('default');
         }
     }, function() {
-        const testTemplate = function(name, templateSource, expected, enableAlternativeTemplateTags) {
+        const testTemplate = function(name, templateSource, expected) {
             QUnit.test(name, function(assert) {
                 const $template = $('#simpleTemplate');
 
                 $template.text(templateSource);
 
-                aspnet.enableAlternativeTemplateTags(enableAlternativeTemplateTags !== false);
-                try {
-                    $('#button').dxButton({
-                        text: 'Test button',
-                        template: $template
-                    });
-                } finally {
-                    aspnet.enableAlternativeTemplateTags(true);
-                }
+                $('#button').dxButton({
+                    text: 'Test button',
+                    template: $template
+                });
 
                 assert.equal($('.dx-button-content').text(), expected);
             });
@@ -348,10 +341,7 @@
         testTemplate('WA from T954324, nempty string', '<% var value = \'\'; %><%- (value != null ? value : \'\') %>', '');
         testTemplate('WA from T954324, nonempty string', '<% var value = \'a\'; %><%- (value != null ? value : \'\') %>', 'a');
 
-        QUnit.module('Alternative syntax (T831170)', function() {
-            testTemplate('enabled', 'a [%= \'b\' %] c', 'a b c');
-            testTemplate('disabled', '[%= 123 %]', '[%= 123 %]', false);
-        });
+        testTemplate('Alternative syntax (T831170)', 'a [%= \'b\' %] c', 'a b c');
     });
 
     QUnit.test('Transcluded content (T691770, T693379)', function(assert) {
@@ -573,28 +563,6 @@
         } finally {
             setTemplateEngine('default');
             delete window.__createCheckBox;
-        }
-    });
-
-    QUnit.test('Warn https://github.com/dotnet/aspnetcore/issues/17028', function(assert) {
-        aspnet.setTemplateEngine();
-        const spy = sinon.spy(console.logger, 'warn');
-        try {
-            aspnet.warnBug17028();
-
-            $('#qunit-fixture').html(`
-                <div id=widget1></div>
-                <div id=widget2></div>
-                <script id=template1 type=text/html><%= %></script>
-            `);
-
-            [1, 2].forEach(i => $('#widget' + i).dxButton({ template: $('#template1') }));
-
-            assert.equal(spy.callCount, 1);
-            assert.ok(spy.args[0][0].indexOf('alternative template syntax') > -1);
-        } finally {
-            setTemplateEngine('default');
-            spy.restore();
         }
     });
 


### PR DESCRIPTION
ASP.NET Core 3.0, which is out of support today, had an [issue](https://github.com/dotnet/aspnetcore/issues/37198) with handling [ERB-style constructs](https://docs.devexpress.com/AspNetCore/401029#erb-style-constructs) in Razor files.

In https://github.com/DevExpress/DevExtreme/pull/11934 and https://github.com/DevExpress/DevExtreme/pull/11934, we introduced an alternative syntax `[% %]` instead of `<% %>` and a console warning to encourage developers to use it.

Related blog: https://community.devexpress.com/blogs/aspnet/archive/2020/02/04/asp-net-core-new-syntax-to-fix-razor-issue.aspx

This PR keeps support for both `[% %]` and `<% %>` syntax, but removes the warning as we are about to end our support for legacy ASP.NET Core versions in 22.2.

**NOTE** do not merge until .NET part is ready