### PR TITLE
TestCafe Dashboard: use a plugin version that logs errors, not throws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@typescript-eslint/eslint-plugin": "5.42.0",
         "@typescript-eslint/experimental-utils": "5.42.0",
         "@vasily.strelyaev/tcd-screenshot-updater": "0.2.0",
-        "@vasily.strelyaev/testcafe-reporter-dashboard-devextreme": "1.0.0",
+        "@vasily.strelyaev/testcafe-reporter-dashboard-devextreme": "1.1.0",
         "angular": "1.8.3",
         "ast-types": "0.14.2",
         "autoprefixer": "10.4.13",
@@ -4178,9 +4178,9 @@
       }
     },
     "node_modules/@vasily.strelyaev/testcafe-reporter-dashboard-devextreme": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vasily.strelyaev/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.0.0.tgz",
-      "integrity": "sha512-kfkLZD9O3gwVWhFaGF+uQiog7vNhvyd7M32PTnCobf/Ot4FvC06wrcdqcsrvRztV0vFHqPg3kdyWOoECkru2nA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vasily.strelyaev/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.1.0.tgz",
+      "integrity": "sha512-LgGLxxuEEXkZ2N2OktJD3+8cL++839+YA4QVpRbpTYdbB5LYVI4WxXKzOXieASqwxJMgTM92i0oGHl1pm+SzSg==",
       "dev": true,
       "dependencies": {
         "fp-ts": "^2.12.1",
@@ -34480,9 +34480,9 @@
       "dev": true
     },
     "@vasily.strelyaev/testcafe-reporter-dashboard-devextreme": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vasily.strelyaev/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.0.0.tgz",
-      "integrity": "sha512-kfkLZD9O3gwVWhFaGF+uQiog7vNhvyd7M32PTnCobf/Ot4FvC06wrcdqcsrvRztV0vFHqPg3kdyWOoECkru2nA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vasily.strelyaev/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.1.0.tgz",
+      "integrity": "sha512-LgGLxxuEEXkZ2N2OktJD3+8cL++839+YA4QVpRbpTYdbB5LYVI4WxXKzOXieASqwxJMgTM92i0oGHl1pm+SzSg==",
       "dev": true,
       "requires": {
         "fp-ts": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@typescript-eslint/eslint-plugin": "5.42.0",
     "@typescript-eslint/experimental-utils": "5.42.0",
     "@vasily.strelyaev/tcd-screenshot-updater": "0.2.0",
-    "@vasily.strelyaev/testcafe-reporter-dashboard-devextreme": "1.0.0",
+    "@vasily.strelyaev/testcafe-reporter-dashboard-devextreme": "1.1.0",
     "angular": "1.8.3",
     "ast-types": "0.14.2",
     "autoprefixer": "10.4.13",


### PR DESCRIPTION
This TestCafe Dashboard plugin version logs errors, instead of throwing them. Test tasks won't fail when something goes wrong with TestCafe Dashboard - the report just won't be published.