### PR TITLE
DataGrid - Form edit mode - Fields are not validated if custom setCellValue is set (T1122209)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1828,7 +1828,7 @@ const EditingController = modules.ViewController.inherit((function() {
                 const row = dataController.getVisibleRows()[rowIndex];
 
                 if(row) {
-                    options.row = row; // T1122209
+                    options.row.values = row.values; // T1122209
                     options.values = row.values;
                 }
 

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -1828,6 +1828,7 @@ const EditingController = modules.ViewController.inherit((function() {
                 const row = dataController.getVisibleRows()[rowIndex];
 
                 if(row) {
+                    options.row = row; // T1122209
                     options.values = row.values;
                 }
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -3557,6 +3557,89 @@ QUnit.module('Editing', baseModuleConfig, () => {
         });
     });
 
+    // T1122209
+    QUnit.test('The form edit mode - Validation should work if value of a column with custom setCellValue changed', function(assert) {
+        try {
+            const editMode = 'form';
+
+            // arrange
+            const dataGrid = createDataGrid({
+                dataSource: [{ field1: 'test1', field2: 'test2', field3: 'test3' }],
+                repaintChangesOnly: true,
+                editing: {
+                    mode: editMode,
+                    allowAdding: true
+                },
+                columns: [
+                    {
+                        dataField: 'field1',
+                        setCellValue: function(newData, value) {
+                            this.defaultSetCellValue(newData, value);
+                        },
+                        validationRules: [{ type: 'required' }]
+                    },
+                    {
+                        dataField: 'field2',
+                        validationRules: [{
+                            type: 'custom',
+                            validationCallback: function(data) {
+                                return data.value !== 'incorrect';
+                            }
+                        }]
+                    },
+                    {
+                        dataField: 'field3',
+                        validationRules: [{ type: 'required' }]
+                    }
+                ],
+            });
+
+            this.clock.tick(100);
+
+            const isValidCell = (rowIndex, columnIndex) => {
+                return !$(dataGrid.getCellElement(rowIndex, columnIndex)).find('.dx-invalid').length;
+            };
+
+            const setCellValue = (rowIndex, columnIndex, value) => {
+                const $input = $(dataGrid.getCellElement(rowIndex, columnIndex)).find('input');
+
+                $input.val(value);
+                $input.trigger('change');
+            };
+
+            // act
+            dataGrid.addRow();
+            this.clock.tick();
+
+            // assert
+            assert.ok(isNewRowExists(dataGrid, editMode), 'there is a new row');
+
+            // act
+            setCellValue(0, 0, 'test');
+            this.clock.tick();
+
+            // assert
+            assert.ok(isValidCell(0, 0), 'first cell is valid');
+            assert.ok(isValidCell(0, 1), 'second cell is valid');
+            assert.ok(isValidCell(0, 2), 'third cell is valid');
+
+            // act
+            setCellValue(0, 1, 'incorrect');
+            this.clock.tick();
+
+            setCellValue(0, 2, 'test');
+            this.clock.tick();
+            setCellValue(0, 2, '');
+            this.clock.tick();
+
+            // assert
+            assert.notOk(isValidCell(0, 1), 'second cell is not valid');
+            assert.notOk(isValidCell(0, 2), 'third cell is not valid');
+        } catch(e) {
+            assert.ok(false, 'exception is thrown');
+        }
+    });
+
     // T1089428
     QUnit.test('totalCount should be correct after removing/adding rows when refreshMode is reshape and scrolling.mode is virtual', function(assert) {
         // arrange


### PR DESCRIPTION
(cherry picked from commit 09eaf5ab1759ecae6397a33b18b6af84b3fe9114)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
