### PR TITLE
DataGrid - The "TypeError: Cannot read properties of null (reading 'remoteOperations')" error is thrown if the data source is null (T1123779)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.utils.js
+++ b/js/ui/grid_core/ui.grid_core.utils.js
@@ -582,6 +582,10 @@ export default {
     },
 
     getWrappedLookupDataSource(column, dataSource, filter) {
+        if(!dataSource) {
+            return [];
+        }
+
         const lookupDataSourceOptions = this.normalizeLookupDataSource(column.lookup);
 
         if(column.calculateCellValue !== column.defaultCalculateCellValue) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
@@ -2768,6 +2768,36 @@ QUnit.module('Filter Row with real dataController and columnsController', {
         assert.ok(true, 'no exceptions');
     });
 
+    // T1097980
+    QUnit.test('Filtering should not throw an exception when dataSource is null', function(assert) {
+        // arrange
+        const $testElement = $('#container');
+
+        this.options.columns = [{
+            dataField: 'column1',
+            allowFiltering: true,
+            visible: false,
+        }, {
+            dataField: 'column2',
+            allowFiltering: true,
+            lookup: {
+                dataSource: [{ id: 1, value: 'value1' }, { id: 2, value: 'value2' }],
+                valueExpr: 'id',
+                displayExpr: 'value'
+            }
+        }];
+        this.options.dataSource = null;
+        this.options.syncLookupFilterValues = true;
+
+        setupDataGridModules(this, ['data', 'columns', 'columnHeaders', 'filterRow', 'editorFactory'], {
+            initViews: true
+        });
+        this.columnHeadersView.render($testElement);
+        this.clock.tick(100);
+
+        // assert
+        assert.ok(true, 'no exceptions');
+    });
 
     if(device.deviceType === 'desktop') {
     // T306751


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/23013 instead of https://github.com/DevExpress/DevExtreme/pull/23018
