### PR TITLE
DataGrid - editing.editCell was called two times on clicking a cell with showEditorAlways='true' (T1126699)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -2437,15 +2437,21 @@ export const editingModule = {
                     const isEditedCell = editingController.isEditCell(e.rowIndex, columnIndex);
                     const allowEditing = allowUpdating && column && (column.allowEditing || isEditedCell);
                     const startEditAction = this.option('editing.startEditAction') || 'click';
+                    const isShowEditorAlways = column && column.showEditorAlways;
 
-                    if(eventName === 'down') {
-                        if((devices.real().ios || devices.real().android) && !isEditedCell) {
-                            resetActiveElement();
-                        }
-                        return column && column.showEditorAlways && allowEditing && editingController.editCell(e.rowIndex, columnIndex);
+                    if(isEditedCell) {
+                        return true;
                     }
 
-                    if(eventName === 'click' && startEditAction === 'dblClick' && !isEditedCell) {
+                    if(eventName === 'down') {
+                        if((devices.real().ios || devices.real().android)) {
+                            resetActiveElement();
+                        }
+
+                        return isShowEditorAlways && allowEditing && editingController.editCell(e.rowIndex, columnIndex);
+                    }
+
+                    if(eventName === 'click' && startEditAction === 'dblClick') {
                         const isError = false;
                         const withoutSaveEditData = row?.isNewRow;
                         editingController.closeEditCell(isError, withoutSaveEditData);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -49,7 +49,7 @@ import DataGridWrapper from '../../helpers/wrappers/dataGridWrappers.js';
 import 'ui/drop_down_box';
 import { CLICK_EVENT } from '../../helpers/grid/keyboardNavigationHelper.js';
 import { createDataGrid, baseModuleConfig } from '../../helpers/dataGridHelper.js';
-import { generateItems, MockEditingController } from '../../helpers/dataGridMocks.js';
+import { generateItems } from '../../helpers/dataGridMocks.js';
 import { getOuterHeight } from 'core/utils/size';
 
 const TEXTEDITOR_INPUT_SELECTOR = '.dx-texteditor-input';
@@ -3710,10 +3710,6 @@ QUnit.module('Editing', baseModuleConfig, () => {
                     allowUpdating: true
                 },
                 columns: ['selected', 'field2'],
-            });
-            dataGrid._controllers.editing = new MockEditingController({
-                mode: editMode,
-                allowUpdating: true
             });
             this.clock.tick(0);
 


### PR DESCRIPTION
(cherry picked from commit b1daea74e21e8aaa74c4740d0077608c933f188c)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
