### PR TITLE
DataGrid - It is not possible to navigate to another data page after focusing a row when sortOrder is applied and a lookup column is declared (T1126967)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -606,7 +606,7 @@ export const columnsControllerModule = {
                 that._previousColumns = that._columns;
                 that._columns = columns;
                 resetColumnsCache(that);
-                that.updateColumnDataTypes(undefined);
+                that.updateColumnDataTypes();
             }
 
             const updateColumnChanges = function(that, changeType, optionName, columnIndex) {
@@ -655,7 +655,7 @@ export const columnsControllerModule = {
                     that._columnChanges = undefined;
                     if(needReinit(columnChanges.optionNames)) {
                         that._reinitAfterLookupChanges = columnChanges?.optionNames['lookup'];
-                        that.reinit(undefined);
+                        that.reinit();
                         that._reinitAfterLookupChanges = undefined;
                     } else {
                         that.columnsChanged.fire(columnChanges);
@@ -1214,7 +1214,7 @@ export const columnsControllerModule = {
                 reinit: function(ignoreColumnOptionNames) {
                     this._columnsUserState = this.getUserState();
                     this._ignoreColumnOptionNames = ignoreColumnOptionNames || null;
-                    this.init(undefined);
+                    this.init();
 
                     if(ignoreColumnOptionNames) {
                         this._ignoreColumnOptionNames = null;
@@ -1872,7 +1872,7 @@ export const columnsControllerModule = {
                         column.showEditorAlways = isDefined(column.showEditorAlways) ? column.showEditorAlways : (dataType === 'boolean' && !column.cellTemplate && !column.lookup);
                     }
                 },
-                updateColumnDataTypes: function(dataSource, originalColumns) {
+                updateColumnDataTypes: function(dataSource) {
                     const that = this;
                     const dateSerializationFormat = that.option('dateSerializationFormat');
                     const firstItems = that._getFirstItems(dataSource);
@@ -1940,7 +1940,7 @@ export const columnsControllerModule = {
                             }
                         }
 
-                        that._updateColumnOptions(column, index, originalColumns);
+                        that._updateColumnOptions(column, index);
                     });
 
                     return isColumnDataTypesUpdated;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -396,6 +396,47 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.ok($(dataGrid.getRowElement(0)).hasClass('dx-row-focused'), 'first row has focused class');
     });
 
+    // T1126967
+    QUnit.test('autoNavigateToFocusedRow should not change page after lookup dataSource changing', function(assert) {
+        // arrange
+        const data = [
+            { id: 1 },
+            { id: 2 },
+            { id: 3 },
+            { id: 4 }
+        ];
+        const dataGrid = $('#dataGrid').dxDataGrid({
+            dataSource: data,
+            columns: [{
+                dataField: 'id',
+                lookup: {
+                    dataSource: [],
+                },
+                sortOrder: 'asc',
+            }],
+            keyExpr: 'id',
+            paging: {
+                pageSize: 2
+            },
+            autoNavigateToFocusedRow: true,
+            focusedRowEnabled: true,
+            focusedRowIndex: 0,
+        }).dxDataGrid('instance');
+        this.clock.tick();
+
+        // act
+        dataGrid.columnOption(0, 'lookup.dataSource', [{}]);
+        this.clock.tick();
+
+        dataGrid.pageIndex(1);
+        this.clock.tick();
+
+        // assert
+        assert.equal(dataGrid.option('focusedRowIndex'), 0, 'focusedRowIndex');
+        assert.equal(dataGrid.option('focusedRowKey'), 3, 'focusedRowKey');
+        assert.equal(dataGrid.option('paging.pageIndex'), 1, 'pageIndex');
+    });
+
     QUnit.test('Focused row should be visible if it\'s on the first page and page height larger than container one (T756177)', function(assert) {
         // arrange
         const data = [


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/23268