### PR TITLE
Fix a regression when TestCafe tests failed with a timeout again

### DIFF
--- a/.github/workflows/testcafe_tests.yml
+++ b/.github/workflows/testcafe_tests.yml
@@ -137,10 +137,10 @@ jobs:
         [ "${{ matrix.ARGS.inProgressRenovation }}" == "true" ] && META_RENOVATION="--meta renovation"
         [ "${{ matrix.ARGS.indices }}" != "" ] && INDICES="--indices ${{ matrix.ARGS.indices }}"
         [ "${{ matrix.ARGS.platform }}" != "" ] && PLATFORM="--platform ${{ matrix.ARGS.platform }}"
-        export TESTCAFE_DASHBOARD_DEVEXTREME_LAYOUT_TESTING_ENABLED=true
+        export TESTCAFE_DASHBOARD_LAYOUT_TESTING_ENABLED=true
         export TESTCAFE_DASHBOARD_DEVEXTREME_TOKEN=eyJwcm9qZWN0SWQiOiI3MDEyMTgyZC1iMzliLTQyYWMtYjRlZC02YWY2MWMyZmQyNzgiLCJ0b2tlblNlY3JldCI6ImtUODN0QjU1dFdyeWJva2VsdlpDb051R3pzOFZOYzVuaDI4dXNFb3pFd2hPOUZDZlRVaXh5OXBvVC8wS3hDZFAwd05SKzlmVkk0WWh3dXl2ZkhtZDFudTE0MHJqdEUxVnByTlI4Z1RTRHJwZlRPN1dZZXNEUnovUDRTOFF1L3NPTWNjSXpzWno1Y0ZIY2xVSFZKTVVTRVIxVGtaRlgwZTlhUU5tRTBaY1FPTmVkenovREFseGQ4YVoxZnNkN2dSd2VFNjBhSjNueG1vOHNGbGJwazVsYmlvN2JoVy9VTnBvWSs1Q0tFcVFvQ0JSTHJFSlUybUNxNkdGbmhtbmxUTW9SRXpjWDBjUlMwMk41NWlTakNMMXRxdlpMajc4MnB6ZnFrRWo1d29UT0dLY3V1bThRaXE2L1FnaWR2MFV0VWFTaGZvVW9sazhTWFlXNGtxWVNSalR1QT09In0=
         export TESTCAFE_DASHBOARD_DEVEXTREME_URL=https://devextreme.resolve.sh
-        export TESTCAFE_DASHBOARD_DEVEXTREME_BUILD_ID=${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+        export TESTCAFE_DASHBOARD_BUILD_ID=${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
         all_args="--concurrency 2 --browsers=chrome:devextreme-shr2 --componentFolder ${{ matrix.ARGS.componentFolder }} --quarantineMode ${{ matrix.ARGS.quarantineMode}} $META_RENOVATION $INDICES $PLATFORM"
         echo "$all_args"
         npm run test-testcafe -- $all_args

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,7 +168,7 @@
         "systemjs-plugin-text": "0.0.11",
         "terser-webpack-plugin": "5.3.6",
         "testcafe": "2.1.0",
-        "testcafe-reporter-dashboard-devextreme": "1.3.1",
+        "testcafe-reporter-dashboard-devextreme": "1.3.2",
         "through2": "2.0.5",
         "ts-jest": "26.5.6",
         "typescript": "4.2.4",
@@ -27092,9 +27092,9 @@
       }
     },
     "node_modules/testcafe-reporter-dashboard-devextreme": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.3.1.tgz",
-      "integrity": "sha512-sr9P1TiEsla10ccykKvbX9XboT9lPxiLuZasXomJHS9JrN8Gw6kT10mD+UUi3PHgYjjjpdYWxXCOljg79P+ALg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.3.2.tgz",
+      "integrity": "sha512-EwUgZlqRBE4BcYMdiuiBBZE5LAwnrfZVdY8Zcf91QkXB1NrkNbkryxcK35LH77DriLAtDsJjG9Ij+Q4UM2bMWw==",
       "dev": true,
       "dependencies": {
         "fp-ts": "^2.12.1",
@@ -51010,9 +51010,9 @@
       }
     },
     "testcafe-reporter-dashboard-devextreme": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.3.1.tgz",
-      "integrity": "sha512-sr9P1TiEsla10ccykKvbX9XboT9lPxiLuZasXomJHS9JrN8Gw6kT10mD+UUi3PHgYjjjpdYWxXCOljg79P+ALg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.3.2.tgz",
+      "integrity": "sha512-EwUgZlqRBE4BcYMdiuiBBZE5LAwnrfZVdY8Zcf91QkXB1NrkNbkryxcK35LH77DriLAtDsJjG9Ij+Q4UM2bMWw==",
       "dev": true,
       "requires": {
         "fp-ts": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@typescript-eslint/eslint-plugin": "5.45.0",
     "@typescript-eslint/experimental-utils": "5.45.0",
     "@vasily.strelyaev/tcd-screenshot-updater": "0.2.0",
-    "testcafe-reporter-dashboard-devextreme": "1.3.1",
+    "testcafe-reporter-dashboard-devextreme": "1.3.2",
     "angular": "1.8.3",
     "ast-types": "0.14.2",
     "autoprefixer": "10.4.13",


### PR DESCRIPTION
I released v1.3.0 and v1.3.1 of the TestCafe Dashboard plugin (DevExtreme edition) without some commits from v1.2.x. Hence, the `lamda@edge timeout` appeared again in your test logs.

This PR updates the plugin to a recovery version 1.3.2.

Env names also slightly changed (not all of them include `_DEVEXTREME_` now). This will fix another regression where jobs were not consolidated in a single build. 