### PR TITLE
DataGrid - Rerender occurs on changing editing.changes with two-way binding (T1128881)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -40,6 +40,7 @@ import {
     VIEWPORT_BOTTOM_NEW_ROW_POSITION,
     VIEWPORT_TOP_NEW_ROW_POSITION
 } from './ui.grid_core.editing_constants';
+import { deepExtendArraySafe } from '../../core/utils/object';
 
 const READONLY_CLASS = 'readonly';
 const LINK_CLASS = 'dx-link';
@@ -149,6 +150,8 @@ const EditingController = modules.ViewController.inherit((function() {
             this._dataController = this.getController('data');
             this._rowsView = this.getView('rowsView');
             this._lastOperation = null;
+            // this contains the value of 'editing.changes' option, to check if it has changed in onOptionChanged
+            this._changes = [];
 
             if(this._deferreds) {
                 this._deferreds.forEach(d => d.reject('cancel'));
@@ -475,6 +478,14 @@ const EditingController = modules.ViewController.inherit((function() {
             eventsEngine.off(domAdapter.getDocument(), clickEventName, this._saveEditorHandler);
         },
 
+        _silentOption: function(name, value) {
+            if(name === 'editing.changes') {
+                this._changes = deepExtendArraySafe([], value);
+            }
+
+            this.callBase.apply(this, arguments);
+        },
+
         optionChanged: function(args) {
             if(args.name === 'editing') {
                 const fullName = args.fullName;
@@ -483,7 +494,10 @@ const EditingController = modules.ViewController.inherit((function() {
                     this._handleEditRowKeyChange(args);
                 } else if(fullName === EDITING_CHANGES_OPTION_NAME) {
                     // to prevent render on optionChanged called by two-way binding - T1128881
-                    if(args.previousValue !== args.value) {
+                    const isEqual = equalByValue(args.value, this._changes, -1);
+
+                    if(!isEqual) {
+                        this._changes = deepExtendArraySafe([], args.value);
                         this._handleChangesChange(args);
                     }
                 } else if(!args.handled) {

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -482,7 +482,10 @@ const EditingController = modules.ViewController.inherit((function() {
                 if(fullName === EDITING_EDITROWKEY_OPTION_NAME) {
                     this._handleEditRowKeyChange(args);
                 } else if(fullName === EDITING_CHANGES_OPTION_NAME) {
-                    this._handleChangesChange(args);
+                    // to prevent render on optionChanged called by two-way binding - T1128881
+                    if(args.previousValue !== args.value) {
+                        this._handleChangesChange(args);
+                    }
                 } else if(!args.handled) {
                     this._columnsController.reinit();
                     this.init();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -3695,15 +3695,25 @@ QUnit.module('Editing', baseModuleConfig, () => {
             dataGrid.addRow();
             setCellValue(0, 0, 'helllo');
 
+            // arrange
+            let renderCounter = 0;
+            const contentReadyHandler = () => {
+                renderCounter++;
+            };
+            dataGrid.on('contentReady', contentReadyHandler);
+
             const insertRowChanges = dataGrid.option('editing.changes');
 
             insertRowChanges[0].data.field1 = 'test_text';
+
+            // act
             dataGrid.option('editing.changes', insertRowChanges);
             twoWayBindingChanges(insertRowChanges);
 
             // assert
             const value = dataGrid.cellValue(0, 'field1');
-            assert.strictEqual(value, 'test_text', 'render should not called');
+            assert.strictEqual(value, 'test_text', 'value must be changed');
+            assert.strictEqual(renderCounter, 1, 'render must be called 1 time');
         } catch(e) {
             assert.ok(false, 'exception is thrown');
         }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -3557,6 +3557,109 @@ QUnit.module('Editing', baseModuleConfig, () => {
         });
     });
 
+    // T1128881
+    QUnit.test('Form should not be rerendered while editing with enabled two-way binding on editing.changes', function(assert) {
+        try {
+            const editMode = 'form';
+
+            // arrange
+            const dataGrid = createDataGrid({
+                dataSource: [{ field1: 'test1', field2: 'test2', field3: 'test3' }],
+                repaintChangesOnly: true,
+                editing: {
+                    mode: editMode,
+                    allowEditing: true,
+                },
+                columns: ['field1', 'field2', 'field3'],
+            });
+            this.clock.tick(100);
+
+            const setCellValue = (rowIndex, columnIndex, value) => {
+                const $input = $(dataGrid.getCellElement(rowIndex, columnIndex)).find('input');
+
+                $input.val(value);
+                $input.trigger('change');
+            };
+
+            // act
+            dataGrid.editRow(0);
+
+            // arrange
+            const twoWayBindingChanges = () => {
+                dataGrid.option('editing.changes', dataGrid.option('editing.changes'));
+            };
+
+            let renderCalled = false;
+            const contentReadyHandler = () => {
+                renderCalled = true;
+            };
+
+            dataGrid.on('contentReady', contentReadyHandler);
+
+            // act
+            setCellValue(0, 0, 'hey');
+            twoWayBindingChanges();
+
+            // assert
+            assert.notOk(renderCalled, 'rerender should not be called');
+        } catch(e) {
+            assert.ok(false, 'exception is thrown');
+        }
+    });
+
+    // T1128881
+    QUnit.test('Form should not be rerendered while adding with enabled two-way binding on editing.changes and hidden columns', function(assert) {
+        try {
+            const editMode = 'form';
+
+            // arrange
+            const dataGrid = createDataGrid({
+                dataSource: [{ field1: 'test1', field2: 'test2', field3: 'test3' }],
+                repaintChangesOnly: true,
+                editing: {
+                    mode: editMode,
+                    allowEditing: true,
+                },
+                columns: [{
+                    dataField: 'field1',
+                    visible: false
+                }, 'field2', 'field3'],
+            });
+            this.clock.tick(100);
+
+            const setCellValue = (rowIndex, columnIndex, value) => {
+                const $input = $(dataGrid.getCellElement(rowIndex, columnIndex)).find('input');
+
+                $input.val(value);
+                $input.trigger('change');
+            };
+
+            // act
+            dataGrid.addRow();
+
+            // arrange
+            const twoWayBindingChanges = () => {
+                dataGrid.option('editing.changes', dataGrid.option('editing.changes'));
+            };
+
+            let renderCalled = false;
+            const contentReadyHandler = () => {
+                renderCalled = true;
+            };
+
+            dataGrid.on('contentReady', contentReadyHandler);
+
+            // act
+            setCellValue(0, 0, 'hey');
+            twoWayBindingChanges();
+
+            // assert
+            assert.notOk(renderCalled, 'rerender should not be called');
+        } catch(e) {
+            assert.ok(false, 'exception is thrown');
+        }
+    });
+
     // T1122209
     QUnit.test('The form edit mode - Validation should work if value of a column with custom setCellValue changed', function(assert) {
         try {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -3558,7 +3558,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
     });
 
     // T1128881
-    QUnit.test('Form should not be rerendered while editing with enabled two-way binding on editing.changes', function(assert) {
+    QUnit.test('editing.changes two-way binding - Form should not be rendered when edit a row', function(assert) {
         try {
             const editMode = 'form';
 
@@ -3608,7 +3608,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
     });
 
     // T1128881
-    QUnit.test('Form should not be rerendered while adding with enabled two-way binding on editing.changes and hidden columns', function(assert) {
+    QUnit.test('editing.changes two-way binding - Form should not be rendered when add a row', function(assert) {
         try {
             const editMode = 'form';
 
@@ -3655,6 +3655,55 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // assert
             assert.notOk(renderCalled, 'rerender should not be called');
+        } catch(e) {
+            assert.ok(false, 'exception is thrown');
+        }
+    });
+
+    // T1128881
+    QUnit.test('editing.changes two-way binding - form must be rerendered after \'editing.changes\' options has been changed by variable', function(assert) {
+        try {
+            const editMode = 'form';
+
+            // arrange
+            const dataGrid = createDataGrid({
+                dataSource: [{ field1: 'test1', field2: 'test2', field3: 'test3' }],
+                repaintChangesOnly: true,
+                editing: {
+                    mode: editMode,
+                    allowEditing: true,
+                },
+                columns: [{
+                    dataField: 'field1',
+                    visible: false
+                }, 'field2', 'field3'],
+            });
+            this.clock.tick(100);
+
+            const setCellValue = (rowIndex, columnIndex, value) => {
+                const $input = $(dataGrid.getCellElement(rowIndex, columnIndex)).find('input');
+
+                $input.val(value);
+                $input.trigger('change');
+            };
+
+            const twoWayBindingChanges = (x) => {
+                dataGrid.option('editing.changes', dataGrid.option('editing.changes'));
+            };
+
+            // act
+            dataGrid.addRow();
+            setCellValue(0, 0, 'helllo');
+
+            const insertRowChanges = dataGrid.option('editing.changes');
+
+            insertRowChanges[0].data.field1 = 'test_text';
+            dataGrid.option('editing.changes', insertRowChanges);
+            twoWayBindingChanges(insertRowChanges);
+
+            // assert
+            const value = dataGrid.cellValue(0, 'field1');
+            assert.strictEqual(value, 'test_text', 'render should not called');
         } catch(e) {
             assert.ok(false, 'exception is thrown');
         }


### PR DESCRIPTION
(cherry picked from commit 753022d7b0c48b9d8ea8d5f0f76fbc63f9fb2e22)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
