### PR TITLE
DataGrid: Fix highlight rows when the scrolling mode is set to 'virtual' and the rowAlternationEnabled property is set to 'true' (T1131109)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_controller.js
+++ b/js/ui/grid_core/ui.grid_core.data_controller.js
@@ -514,14 +514,19 @@ export const dataControllerModule = {
                 getRowIndexDelta: function() {
                     return 0;
                 },
+                getDataIndex: function(change) {
+                    const visibleItems = this._items;
+                    const lastVisibleItem = change.changeType === 'append' && visibleItems.length > 0 ? visibleItems[visibleItems.length - 1] : null;
+
+                    return isDefined(lastVisibleItem?.dataIndex) ? lastVisibleItem.dataIndex + 1 : 0;
+                },
                 _processItems: function(items, change) {
                     const that = this;
                     const rowIndexDelta = that.getRowIndexDelta();
                     const changeType = change.changeType;
                     const visibleColumns = that._columnsController.getVisibleColumns(null, changeType === 'loadingAll');
-                    const visibleItems = that._items;
-                    const lastVisibleItem = changeType === 'append' && visibleItems.length > 0 ? visibleItems[visibleItems.length - 1] : null;
-                    const dataIndex = isDefined(lastVisibleItem?.dataIndex) ? lastVisibleItem.dataIndex + 1 : 0;
+                    const dataIndex = this.getDataIndex(change);
+
                     const options = {
                         visibleColumns: visibleColumns,
                         dataIndex: dataIndex
@@ -535,6 +540,7 @@ export const dataControllerModule = {
                             result.push(item);
                         }
                     });
+
                     return result;
                 },
                 _processItem: function(item, options) {

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -1227,6 +1227,13 @@ export const virtualScrollingModule = {
 
                         return offset;
                     },
+                    getDataIndex: function(change) {
+                        if(this.option(LEGACY_SCROLLING_MODE) === false) {
+                            return this.getRowIndexOffset(true);
+                        }
+
+                        return this.callBase.apply(this, arguments);
+                    },
                     viewportSize: function() {
                         const rowsScrollController = this._rowsScrollController;
                         const dataSource = this._dataSource;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -1117,6 +1117,47 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         assert.deepEqual(alternatedRowIndexes, [2, 4], 'row indexes with dx-row-alt class');
     });
 
+    // T1131109
+    QUnit.test('row alternation should be correct if virtual scrolling is enabled and pageSize = 1', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            height: 300,
+            dataSource: generateDataSource(100),
+            scrolling: {
+                mode: 'virtual',
+                useNative: false
+            },
+            paging: {
+                pageSize: 1
+            },
+            rowAlternationEnabled: true
+        });
+        this.clock.tick(200);
+
+        // assert
+        let dataIndexes = dataGrid.getVisibleRows().map((row) => row.dataIndex);
+        let alternatedRowIndexes = dataIndexes.filter((_, index) => $(dataGrid.getRowElement(index)).hasClass('dx-row-alt'));
+        assert.deepEqual(dataIndexes, [0, 1, 2, 3, 4, 5, 6, 7, 8], 'dataIndex values in rows');
+        assert.deepEqual(alternatedRowIndexes, [1, 3, 5, 7], 'row indexes with dx-row-alt class');
+
+        // arrange
+        const scrollable = dataGrid.getScrollable();
+
+        // act
+        scrollable.scrollTo({ y: 200 });
+        $(scrollable.container()).trigger('scroll');
+        this.clock.tick(200);
+        scrollable.scrollTo({ y: 300 });
+        $(scrollable.container()).trigger('scroll');
+        this.clock.tick(200);
+
+        // assert
+        dataIndexes = dataGrid.getVisibleRows().map((row) => row.dataIndex);
+        alternatedRowIndexes = dataIndexes.filter((_, index) => $(dataGrid.getRowElement(index)).hasClass('dx-row-alt'));
+        assert.deepEqual(dataIndexes, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17], 'dataIndex values in rows');
+        assert.deepEqual(alternatedRowIndexes, [9, 11, 13, 15, 17], 'row indexes with dx-row-alt class');
+    });
+
     // T583229
     QUnit.test('The same page should not load when scrolling in virtual mode', function(assert) {
         const pageIndexesForLoad = [];


### PR DESCRIPTION
See https://devexpress.com/issue=T1131109