### PR TITLE
Renovation: Make the Angular RG fully generic.

### DIFF
--- a/packages/angular/projects/angular/src/compatible-components/radio-group/radio-group-compatible.component.ts
+++ b/packages/angular/projects/angular/src/compatible-components/radio-group/radio-group-compatible.component.ts
@@ -1,14 +1,13 @@
 import {
   ChangeDetectionStrategy, Component, ContentChild, Input,
 } from '@angular/core';
-import { RadioGroupValue } from '@devextreme/components/src';
 import { compileGetter, ItemLike } from '@devextreme/interim';
 import { TemplateCompatibleDirective } from '../../compatible-directives/template';
 import { RadioGroupBaseComponent } from '../../components/radio-common';
 
 // TODO: Move these to components package
 //  because these types equal to similar types in React RG compatible component.
-type ValueGetter = <T extends RadioGroupValue>(item: ItemLike) => T;
+type ValueGetter = <T>(item: ItemLike) => T;
 type LabelGetter = (item: ItemLike) => string;
 
 @Component({
@@ -28,7 +27,7 @@ type LabelGetter = (item: ItemLike) => string;
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RadioGroupCompatibleComponent<T extends RadioGroupValue>
+export class RadioGroupCompatibleComponent<T>
   extends RadioGroupBaseComponent<T> {
   @Input() value?: T;
 

--- a/packages/angular/projects/angular/src/components/radio-button/radio-button.component.ts
+++ b/packages/angular/projects/angular/src/components/radio-button/radio-button.component.ts
@@ -8,12 +8,7 @@ import {
   Optional,
   Output,
 } from '@angular/core';
-import {
-  filter,
-  map,
-  Subject,
-  takeUntil,
-} from 'rxjs';
+import { map } from 'rxjs';
 import { AngularTemplate } from '../../internal';
 import { RadioGroupService } from '../radio-common';
 
@@ -36,7 +31,7 @@ let nextUniqueId = 0;
         [value]="value"
         [attr.checked]="(checked$ | async) ? 'true' : null"
         (click)="onClick.emit($event)"
-        (change)="handleChange($event)"
+        (change)="handleChange()"
       />
       <dx-dynamic-template
         *ngIf="radioTemplateData$ | async as templateData"
@@ -66,8 +61,6 @@ implements OnInit, OnDestroy {
   // eslint-disable-next-line no-plusplus
   private uniqueId = `dx-radio-button-${++nextUniqueId}`;
 
-  private destroy$ = new Subject<void>();
-
   @Input() id = this.uniqueId;
 
   @Input() value!: T;
@@ -91,9 +84,6 @@ implements OnInit, OnDestroy {
   }
 
   // eslint-disable-next-line @angular-eslint/no-output-on-prefix
-  @Output() onChange = new EventEmitter<Event>();
-
-  // eslint-disable-next-line @angular-eslint/no-output-on-prefix
   @Output() onClick = new EventEmitter<MouseEvent>();
 
   // eslint-disable-next-line @angular-eslint/no-output-on-prefix
@@ -113,20 +103,14 @@ implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.strategy.onInit();
-    this.strategy.checked$.pipe(
-      filter((checked) => checked),
-      takeUntil(this.destroy$),
-    ).subscribe(() => { this.onSelected.emit(this.value); });
   }
 
   ngOnDestroy(): void {
     this.strategy.onDestroy();
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
-  handleChange(event: Event): void {
+  handleChange(): void {
     this.strategy.handleChange();
-    this.onChange.emit(event);
+    this.onSelected.emit(this.value);
   }
 }

--- a/packages/angular/projects/angular/src/components/radio-button/radio-button.strategies.ts
+++ b/packages/angular/projects/angular/src/components/radio-button/radio-button.strategies.ts
@@ -1,4 +1,4 @@
-import { RadioGroupCore, RadioGroupValue } from '@devextreme/components';
+import { RadioGroupCore } from '@devextreme/components';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { doIfContextExist, waitContextAndDo } from '../../internal';
 // TODO: Move this code to separate directory radio-common in the future.
@@ -8,7 +8,7 @@ const DEFAULT_CHECKED_VALUE = false;
 function createStandaloneStrategy(): RadioButtonStrategy {
   const checkedSubject = new BehaviorSubject<boolean>(DEFAULT_CHECKED_VALUE);
 
-  const handleChange = () => {};
+  const handleChange = () => { checkedSubject.next(true); };
 
   const setChecked = (value: boolean) => { checkedSubject.next(value); };
 
@@ -25,9 +25,9 @@ function createStandaloneStrategy(): RadioButtonStrategy {
   };
 }
 
-function createRadioGroupStrategy(
-  radioGroupCore$: Observable<RadioGroupCore<RadioGroupValue> | undefined>,
-  getRadioButtonValue: () => RadioGroupValue,
+function createRadioGroupStrategy<T>(
+  radioGroupCore$: Observable<RadioGroupCore<T> | undefined>,
+  getRadioButtonValue: () => T,
 ): RadioButtonStrategy {
   let unsubscribe: () => void | undefined;
   const checkedSubject = new BehaviorSubject<boolean>(DEFAULT_CHECKED_VALUE);
@@ -74,8 +74,8 @@ export interface RadioButtonStrategy {
 }
 
 export function createRadioButtonStrategy(
-  radioGroupCore$: Observable<RadioGroupCore<RadioGroupValue> | undefined> | undefined,
-  getRadioButtonValue: () => RadioGroupValue,
+  radioGroupCore$: Observable<RadioGroupCore<unknown> | undefined> | undefined,
+  getRadioButtonValue: () => unknown,
 ): RadioButtonStrategy {
   if (radioGroupCore$) {
     return createRadioGroupStrategy(radioGroupCore$, getRadioButtonValue);

--- a/packages/angular/projects/angular/src/components/radio-common/radio-group-base.component.ts
+++ b/packages/angular/projects/angular/src/components/radio-common/radio-group-base.component.ts
@@ -4,12 +4,11 @@ import {
   EventEmitter,
   Output,
 } from '@angular/core';
-import { RadioGroupValue } from '@devextreme/components';
 
 @Component({
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export abstract class RadioGroupBaseComponent<T extends RadioGroupValue> {
+export abstract class RadioGroupBaseComponent<T> {
   @Output() valueChange = new EventEmitter<T | undefined>();
 }

--- a/packages/angular/projects/angular/src/components/radio-common/radio-group.service.ts
+++ b/packages/angular/projects/angular/src/components/radio-common/radio-group.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { RadioGroupCore, RadioGroupValue } from '@devextreme/components';
+import { RadioGroupCore } from '@devextreme/components';
 import { ContextService } from '../../internal';
 
 @Injectable()
-export class RadioGroupService extends ContextService<RadioGroupCore<RadioGroupValue>> {}
+export class RadioGroupService extends ContextService<RadioGroupCore<unknown>> {}

--- a/packages/angular/projects/angular/src/components/radio-group/radio-group.component.ts
+++ b/packages/angular/projects/angular/src/components/radio-group/radio-group.component.ts
@@ -6,7 +6,6 @@ import {
 } from '@angular/core';
 import {
   createRadioGroupCore,
-  RadioGroupValue,
   ReadonlyProps,
   TemplateProps,
   ValueProps,
@@ -15,7 +14,7 @@ import { filter, map } from 'rxjs';
 import { doIfContextExist, Inputs } from '../../internal';
 import { RadioGroupBaseComponent, RadioGroupService } from '../radio-common';
 
-export type RadioGroupInputs<T extends RadioGroupValue> =
+export type RadioGroupInputs<T> =
   Inputs<ValueProps<T>, ReadonlyProps, TemplateProps>;
 
 @Component({
@@ -28,7 +27,7 @@ export type RadioGroupInputs<T extends RadioGroupValue> =
   providers: [RadioGroupService],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RadioGroupComponent<T extends RadioGroupValue>
+export class RadioGroupComponent<T>
   extends RadioGroupBaseComponent<T>
   implements OnInit, RadioGroupInputs<T> {
   private inputValue?: T;

--- a/playgrounds/angular/src/app/examples/radio-button/index.ts
+++ b/playgrounds/angular/src/app/examples/radio-button/index.ts
@@ -1,0 +1,2 @@
+export * from './radio-button-example.component';
+export * from './radio-button-example.module';

--- a/playgrounds/angular/src/app/examples/radio-button/radio-button-example.component.ts
+++ b/playgrounds/angular/src/app/examples/radio-button/radio-button-example.component.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+interface MyRadioGroupValue {
+  id: number,
+  data: {
+    label: string,
+    value: string,
+  }
+}
+
+const RG_VALUES: MyRadioGroupValue[] = [{
+  id: 0,
+  data: { label: 'Option 0', value: '🍑' },
+}, {
+  id: 1,
+  data: { label: 'Option 1', value: '🍏' },
+}, {
+  id: 2,
+  data: { label: 'Option 2', value: '🍌' },
+}];
+
+@Component({
+  selector: 'dx-radio-button-example',
+  template: `
+    <div class="example">
+      <div class="example__title">
+        RadioButton standalone example
+      </div>
+      <div class="example__control">
+        <dx-radio-button
+          *ngFor="let value of rgValues"
+          [checked]="value.id === 1"
+          [value]="value"
+          [label]="value.data.label"
+        ></dx-radio-button>
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RadioButtonExampleComponent {
+  rgValues = RG_VALUES;
+}

--- a/playgrounds/angular/src/app/examples/radio-button/radio-button-example.module.ts
+++ b/playgrounds/angular/src/app/examples/radio-button/radio-button-example.module.ts
@@ -1,0 +1,24 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { RadioButtonModule } from '@devextreme/angular';
+
+import { RadioButtonExampleComponent } from './radio-button-example.component';
+
+const routes = [{
+  path: '',
+  component: RadioButtonExampleComponent,
+}];
+
+@NgModule({
+  declarations: [
+    RadioButtonExampleComponent,
+  ],
+  imports: [
+    CommonModule,
+    RadioButtonModule,
+    RouterModule.forChild(routes),
+  ],
+})
+export class RadioButtonExampleModule {
+}

--- a/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat-example.component.ts
+++ b/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat-example.component.ts
@@ -5,6 +5,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   template: `
     <dx-radio-group-compat-simple></dx-radio-group-compat-simple>
     <dx-radio-group-compat-expr></dx-radio-group-compat-expr>
+    <dx-radio-group-compat-generic></dx-radio-group-compat-generic>
     <dx-radio-group-compat-template></dx-radio-group-compat-template>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat-expr.component.ts
+++ b/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat-expr.component.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject } from 'rxjs';
   template: `
     <div class="example">
       <div class="example__title">
-        RadioGroup simple example
+        RadioGroupCompat expressions example
       </div>
       <div class="example__control">
         <dx-radio-group-compat

--- a/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat-generic.component.ts
+++ b/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat-generic.component.ts
@@ -1,43 +1,57 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
-const RG_VALUES = [
-  'Mark',
-  'Mary',
-  'Lion',
-];
+interface MyRadioGroupValue {
+  id: number,
+  data: {
+    label: string,
+    value: string,
+  }
+}
+
+const RG_VALUES: MyRadioGroupValue[] = [{
+  id: 0,
+  data: { label: 'Option 0', value: '🍑' },
+}, {
+  id: 1,
+  data: { label: 'Option 1', value: '🍏' },
+}, {
+  id: 2,
+  data: { label: 'Option 2', value: '🍌' },
+}];
 
 @Component({
-  selector: 'dx-radio-group-compat-simple',
+  selector: 'dx-radio-group-compat-generic',
   template: `
     <div class="example">
       <div class="example__title">
-        RadioGroupCompat simple example
+        RadioGroupCompat fully generic example
       </div>
       <div class="example__control">
         <dx-radio-group-compat
           *ngIf="value$ | async as value"
           [items]="rgValues"
           [value]="value"
+          [displayExpr]="'data.label'"
           (valueChange)="setValue($event)">
         </dx-radio-group-compat>
       </div>
       <div class="example__info">
         <span>Selected value: </span>
-        <span>{{value$ | async}}</span>
+        <span>{{value$ | async | json}}</span>
       </div>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RadioGroupCompatSimpleExampleComponent {
-  private valueSubject = new BehaviorSubject<string | undefined>(RG_VALUES[1]);
+export class RadioGroupCompatGenericComponent {
+  private valueSubject = new BehaviorSubject<MyRadioGroupValue | undefined>(RG_VALUES[1]);
 
   rgValues = RG_VALUES;
 
   value$ = this.valueSubject.asObservable();
 
-  setValue(value?: string): void {
+  setValue(value?: MyRadioGroupValue): void {
     this.valueSubject.next(value);
   }
 }

--- a/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat-template.component.ts
+++ b/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat-template.component.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject } from 'rxjs';
   template: `
     <div class="example">
       <div class="example__title">
-        RadioGroup simple example
+        RadioGroupCompat templates example
       </div>
       <div class="example__control">
         <dx-radio-group-compat

--- a/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat.module.ts
+++ b/playgrounds/angular/src/app/examples/radio-group-compat/radio-group-compat.module.ts
@@ -7,6 +7,7 @@ import {
 } from '@devextreme/angular';
 import { RadioGroupCompatExampleComponent } from './radio-group-compat-example.component';
 import { RadioGroupCompatExprExampleComponent } from './radio-group-compat-expr.component';
+import { RadioGroupCompatGenericComponent } from './radio-group-compat-generic.component';
 import { RadioGroupCompatSimpleExampleComponent } from './radio-group-compat-simple.component';
 import { RadioGroupCompatTemplateExampleComponent } from './radio-group-compat-template.component';
 
@@ -21,6 +22,7 @@ const routes = [{
     RadioGroupCompatSimpleExampleComponent,
     RadioGroupCompatExprExampleComponent,
     RadioGroupCompatTemplateExampleComponent,
+    RadioGroupCompatGenericComponent,
   ],
   imports: [
     CommonModule,

--- a/playgrounds/angular/src/app/examples/radio-group/radio-group-customization-templates.component.ts
+++ b/playgrounds/angular/src/app/examples/radio-group/radio-group-customization-templates.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   template: `
     <div class="example">
       <div class="example__title">
-        RadioGroup customization via components example
+        RadioGroup customization via templates example
       </div>
       <div class="example__control">
         <dx-radio-group [value]="'1'">

--- a/playgrounds/angular/src/app/examples/radio-group/radio-group-example.component.ts
+++ b/playgrounds/angular/src/app/examples/radio-group/radio-group-example.component.ts
@@ -4,6 +4,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   selector: 'dx-radio-group-example',
   template: `
     <dx-radio-group-simple></dx-radio-group-simple>
+    <dx-radio-group-generic></dx-radio-group-generic>
     <dx-radio-group-customization-components></dx-radio-group-customization-components>
     <dx-radio-group-customization-templates></dx-radio-group-customization-templates>
   `,

--- a/playgrounds/angular/src/app/examples/radio-group/radio-group-example.module.ts
+++ b/playgrounds/angular/src/app/examples/radio-group/radio-group-example.module.ts
@@ -7,6 +7,7 @@ import { CustomRadioViewComponent } from './custom-components/custom-radio-view.
 import { RadioGroupCustomizationComponentsComponent } from './radio-group-customization-components.component';
 import { RadioGroupCustomizationTemplatesComponent } from './radio-group-customization-templates.component';
 import { RadioGroupExampleComponent } from './radio-group-example.component';
+import { RadioGroupGenericComponent } from './radio-group-generic.component';
 import { RadioGroupSimpleComponent } from './radio-group-simple.component';
 
 const routes = [{
@@ -20,6 +21,7 @@ const routes = [{
     RadioGroupSimpleComponent,
     RadioGroupCustomizationComponentsComponent,
     RadioGroupCustomizationTemplatesComponent,
+    RadioGroupGenericComponent,
     // custom components
     CustomLabelViewComponent,
     CustomRadioViewComponent,

--- a/playgrounds/angular/src/app/examples/radio-group/radio-group-generic.component.ts
+++ b/playgrounds/angular/src/app/examples/radio-group/radio-group-generic.component.ts
@@ -1,0 +1,61 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+interface MyRadioGroupValue {
+  id: number,
+  data: {
+    label: string,
+    value: string,
+  }
+}
+
+const RG_VALUES: MyRadioGroupValue[] = [{
+  id: 0,
+  data: { label: 'Option 0', value: '🍑' },
+}, {
+  id: 1,
+  data: { label: 'Option 1', value: '🍏' },
+}, {
+  id: 2,
+  data: { label: 'Option 2', value: '🍌' },
+}];
+
+@Component({
+  selector: 'dx-radio-group-generic',
+  template: `
+    <div class="example">
+      <div class="example__title">
+        RadioGroup fully generic example
+      </div>
+      <div class="example__control">
+        <dx-radio-group
+          *ngIf="value$ | async as value"
+          [value]="value"
+          (valueChange)="setValue($event)"
+        >
+          <dx-radio-button
+            *ngFor="let value of rgValues"
+            [value]="value"
+            [label]="value.data.label">
+          </dx-radio-button>
+        </dx-radio-group>
+      </div>
+      <div class="example__info">
+        <span>Selected value: </span>
+        <span>{{value$ | async | json}}</span>
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RadioGroupGenericComponent {
+  private valueSubject = new BehaviorSubject<MyRadioGroupValue | undefined>(RG_VALUES[0]);
+
+  rgValues = RG_VALUES;
+
+  value$ = this.valueSubject.asObservable();
+
+  setValue(value?: MyRadioGroupValue): void {
+    this.valueSubject.next(value);
+  }
+}

--- a/playgrounds/angular/src/app/home.component.ts
+++ b/playgrounds/angular/src/app/home.component.ts
@@ -4,8 +4,9 @@ import { AppRoutes } from './routing/app.routes';
 @Component({
   selector: 'app-home',
   template: `
+    <a [routerLink]="'/' + appRoutes.radioButton">RadioButton examples</a>
     <a [routerLink]="'/' + appRoutes.radioGroup">RadioGroup examples</a>
-    <a [routerLink]="'/' + appRoutes.radioGroupCompat">RadioGroup compatible examples</a>
+    <a [routerLink]="'/' + appRoutes.radioGroupCompat">RadioGroupCompat examples</a>
   `,
   styles: [`
     :host {

--- a/playgrounds/angular/src/app/routing/app.routes.ts
+++ b/playgrounds/angular/src/app/routing/app.routes.ts
@@ -1,5 +1,6 @@
 export enum AppRoutes {
   home = 'home',
+  radioButton = 'radio-button',
   radioGroup = 'radio-group',
   radioGroupCompat = 'radio-group-compat',
 }

--- a/playgrounds/angular/src/app/routing/app.routing-module.ts
+++ b/playgrounds/angular/src/app/routing/app.routing-module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { RadioButtonExampleModule } from '../examples/radio-button';
 import { RadioGroupExampleModule } from '../examples/radio-group';
 import { RadioGroupCompatExampleModule } from '../examples/radio-group-compat';
 import { HomeComponent } from '../home.component';
@@ -9,6 +10,10 @@ const routes: Routes = [
   {
     path: AppRoutes.home,
     component: HomeComponent,
+  },
+  {
+    path: AppRoutes.radioButton,
+    loadChildren: () => RadioButtonExampleModule,
   },
   {
     path: AppRoutes.radioGroup,


### PR DESCRIPTION
Angular radio group became fully generic.
Added new playground examples for the radio button.
Also, small fixes in naming and etc.