### PR TITLE
TreeList: Fix the "Cannot read properties of undefined (reading 'index')" error is thrown when a custom command button's template is defined  (T1136079)

### DIFF
--- a/js/ui/tree_list/ui.tree_list.rows.js
+++ b/js/ui/tree_list/ui.tree_list.rows.js
@@ -70,7 +70,7 @@ export const RowsView = rowsModule.views.rowsView.inherit((function() {
 
             const firstDataColumnIndex = that._columnsController.getFirstDataColumnIndex();
 
-            if(renderingTemplate && options.column.index === firstDataColumnIndex) {
+            if(renderingTemplate && options.column?.index === firstDataColumnIndex) {
                 resultTemplate = {
                     render: function(options) {
                         const $container = options.container;

--- a/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
@@ -854,6 +854,34 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         // assert
         assert.equal($headerPanel.css('border-bottom-width'), '0px', 'bottom border width');
     });
+
+    // T1136079
+    QUnit.test('No exceptions when a custom command button\'s template is defined', function(assert) {
+        // arrange, act
+        createTreeList({
+            dataSource: [
+                { id: 0, parentId: -1, c0: 'c0' },
+                { id: 1, parentId: 0, c0: 'c1' }
+            ],
+            columns: [
+                {
+                    type: 'buttons',
+                    buttons: [{
+                        template: () => {
+                            return $('<span>test</span>');
+                        }
+                    }]
+                },
+                'id',
+                'c0'
+            ]
+        });
+
+        this.clock.tick(100);
+
+        // assert
+        assert.ok(true, 'not exception');
+    });
 });
 
 QUnit.module('Option Changed', defaultModuleConfig, () => {


### PR DESCRIPTION
See https://devexpress.com/issue=T1136079