### PR TITLE
Initial support styles and themes for react

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,6 +12,7 @@
     "@devextreme/components": "1.0.0",
     "@devextreme/interim": "1.0.0",
     "@devextreme/core": "1.0.0",
+    "@devextreme/styles": "1.0.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "rxjs": "^7.5.6",
     "ts-essentials": "^9.3.0",

--- a/packages/react/rollup/rollup.config.mjs
+++ b/packages/react/rollup/rollup.config.mjs
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import postcss from 'rollup-plugin-postcss';
 import {
   checkExternalPackage,
   checkWatchMode,
@@ -25,6 +26,7 @@ function getBundleConfig(outputDir, format) {
         },
         outputToFilesystem: true,
       }),
+      postcss(),
     ],
     external: checkExternalPackage,
   };

--- a/packages/react/src/components/radio-button/radio-button-internal.tsx
+++ b/packages/react/src/components/radio-button/radio-button-internal.tsx
@@ -1,4 +1,5 @@
 import { ChangeEventHandler } from 'react';
+import '@devextreme/styles/src/radio-button/radio-button.scss';
 import {
   LabelTemplateProps,
   RadioButtonRenderProps,
@@ -22,9 +23,8 @@ export function RadioButtonInternal<T>({
   const handleChange: ChangeEventHandler<HTMLInputElement> = () => {
     onSelected?.(value);
   };
-
   return (
-    <span>
+    <span className="dxr-radio-button">
       <label
         htmlFor={inputId}
         style={{ cursor: 'pointer', userSelect: 'none', margin: '2px' }}

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -2,10 +2,16 @@
   "name": "@devextreme/styles",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
-    "no-test": "echo \"Error: no test specified\" && exit 0"
+    "build": "npx node-sass ./src/themes -o ./lib/themes",
+    "watch": "npx node-sass -w ./src/themes -o ./lib/themes"
   },
+  "files": ["lib/*.css"],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "rollup": "^3.2.5",
+    "rollup-plugin-scss": "^4.0.0",
+    "node-sass":"^8.0.0"
+  }
 }

--- a/packages/styles/src/radio-button/radio-button.scss
+++ b/packages/styles/src/radio-button/radio-button.scss
@@ -1,0 +1,3 @@
+.dxr-radio-button {
+    background-color: var(--dx-background-color);
+}

--- a/packages/styles/src/themes/dark.scss
+++ b/packages/styles/src/themes/dark.scss
@@ -1,0 +1,3 @@
+:root, .dx-theme-dark {
+    --dx-background-color: gray
+}

--- a/packages/styles/src/themes/light.scss
+++ b/packages/styles/src/themes/light.scss
@@ -1,0 +1,3 @@
+:root, .dx-theme-light {
+    --dx-background-color: orange;
+}


### PR DESCRIPTION
Set up the styles package. The main idea of this package is to contain all styles that are used in cross-platform components.
Component styles are written using Sass and stored in SCSS files. They use CSS variables for theming, and the values of these variables are set in the corresponding theming SCSS files in the src/themes folder. These SCSS files are converted to CSS and stored in the /lib/themes folder. To support theme scoping scenarios, all theme selectors have both :root and dx-theme-* specific class selectors.
React components import SCSS from @devextreme/styles/src/{component-name}/*.scss. The imported SCSS files are included in the bundle during the build.