### PR TITLE
DataGrid - Lookup column shows incorrect values if calculateDisplayValue is set to true and the 'form' or 'popup' editing mode is used (T1136955)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing_form_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_form_based.js
@@ -298,8 +298,8 @@ export const editingFormBasedModule = {
                             }, column.editorOptions, item.editorOptions)
                         }),
                         columnIndex: column.index,
-                        setValue: !isReadOnly && column.allowEditing && function(value) {
-                            that.updateFieldValue(cellOptions, value);
+                        setValue: !isReadOnly && column.allowEditing && function(value, text) {
+                            that.updateFieldValue(cellOptions, value, text);
                         }
                     });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -3959,6 +3959,39 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
         assert.equal($popupContent.length, 1, 'There is editing popup');
     });
+
+    // T1136955
+    QUnit.test('Editing lookups with lookup optimization in form should work', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            dataSource: [{ value: 1, displayValue: 'text1' }],
+            columns: [{
+                dataField: 'value',
+                calculateDisplayValue: 'displayValue',
+                lookup: {
+                    dataSource: [{ id: 1, text: 'text1' }, { id: 2, text: 'text2' }],
+                    valueExpr: 'id',
+                    displayExpr: 'text',
+                },
+            }],
+            editing: {
+                mode: 'form',
+                allowUpdating: true,
+            },
+        });
+        this.clock.tick();
+
+        // act
+        dataGrid.editRow(0);
+        $(dataGrid.getCellElement(0, 0)).find('.dx-selectbox').dxSelectBox('option', 'value', 2);
+        dataGrid.saveEditData();
+        this.clock.tick();
+
+        // assert
+        const $cell = $(dataGrid.getCellElement(0, 0));
+        assert.strictEqual($cell.text(), 'text2', 'new lookup display value');
+    });
+
 });
 
 QUnit.module('Validation with virtual scrolling and rendering', {


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/23594