### PR TITLE
Review all _renderCore and return deferred then need

### DIFF
--- a/js/ui/grid_core/ui.grid_core.column_fixing.js
+++ b/js/ui/grid_core/ui.grid_core.column_fixing.js
@@ -791,7 +791,7 @@ const RowsViewFixedColumnsExtender = extend({}, baseFixedColumns, {
     _renderCore: function(change) {
         this._detachHoverEvents();
 
-        this.callBase(change);
+        const deferred = this.callBase(change);
 
         const isFixedColumns = this._isFixedColumns;
 
@@ -800,6 +800,7 @@ const RowsViewFixedColumnsExtender = extend({}, baseFixedColumns, {
         if(this.option('hoverStateEnabled') && isFixedColumns) {
             this._attachHoverEvents();
         }
+        return deferred;
     },
 
     setRowsOpacity: function(columnIndex, value) {

--- a/js/ui/grid_core/ui.grid_core.columns_resizing_reordering.js
+++ b/js/ui/grid_core/ui.grid_core.columns_resizing_reordering.js
@@ -47,9 +47,10 @@ const allowReordering = function(that) {
 
 const TrackerView = modules.View.inherit({
     _renderCore: function() {
-        this.callBase();
+        const deferred = this.callBase();
         this.element().addClass(this.addWidgetPrefix(TRACKER_CLASS));
         this.hide();
+        return deferred;
     },
 
     _unsubscribeFromCallback: function() {
@@ -116,10 +117,11 @@ const SeparatorView = modules.View.inherit({
     _renderSeparator: function() { },
 
     _renderCore: function(options) {
-        this.callBase(options);
+        const deferred = this.callBase(options);
         this._isShown = true;
         this._renderSeparator();
         this.hide();
+        return deferred;
     },
 
     show: function() {

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -2566,7 +2566,7 @@ export const editingModule = {
                 _renderCore: function(change) {
                     this.callBase.apply(this, arguments);
 
-                    this._waitAsyncTemplates(change, true).done(() => {
+                    return this._waitAsyncTemplates(change, true).done(() => {
                         this._editingController._focusEditorIfNeed();
                     });
                 }

--- a/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
+++ b/js/ui/grid_core/ui.grid_core.keyboard_navigation.js
@@ -2064,8 +2064,9 @@ export const keyboardNavigationModule = {
                     }
                 },
                 _renderCore: function(change) {
-                    this.callBase.apply(this, arguments);
+                    const deferred = this.callBase.apply(this, arguments);
                     this._renderFocusByChange(change);
+                    return deferred;
                 },
                 _editCellPrepared: function($cell) {
                     const editorInstance = this._getEditorInstance($cell);

--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -672,11 +672,12 @@ export const rowsModule = {
                     this.setAria('role', 'presentation', $element);
 
                     const $table = this._renderTable({ change: change });
-                    this._updateContent($table, change);
+                    const deferred = this._updateContent($table, change);
 
                     this.callBase(change);
 
                     this._lastColumnWidths = null;
+                    return deferred;
                 },
 
                 _getRows: function(change) {

--- a/js/ui/grid_core/ui.grid_core.search.js
+++ b/js/ui/grid_core/ui.grid_core.search.js
@@ -317,7 +317,7 @@ export const searchModule = {
                 },
 
                 _renderCore: function() {
-                    this.callBase.apply(this, arguments);
+                    const deferred = this.callBase.apply(this, arguments);
 
                     // T103538
                     if(this.option().rowTemplate || this.option('dataRowTemplate')) {
@@ -331,6 +331,7 @@ export const searchModule = {
                             this._highlightSearchText(this.getTableElement());
                         }
                     }
+                    return deferred;
                 },
 
                 _updateCell: function($cell, parameters) {

--- a/js/ui/grid_core/ui.grid_core.selection.js
+++ b/js/ui/grid_core/ui.grid_core.selection.js
@@ -875,8 +875,9 @@ export const selectionModule = {
                 },
 
                 _renderCore: function(change) {
-                    this.callBase(change);
+                    const deferred = this.callBase(change);
                     this._updateCheckboxesClass();
+                    return deferred;
                 },
 
                 _updateCheckboxesClass: function() {

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -440,7 +440,7 @@ const VirtualScrollingRowsViewExtender = (function() {
         _renderCore: function(e) {
             const startRenderTime = new Date();
 
-            this.callBase.apply(this, arguments);
+            const deferred = this.callBase.apply(this, arguments);
 
             const dataSource = this._dataController._dataSource;
 
@@ -454,6 +454,7 @@ const VirtualScrollingRowsViewExtender = (function() {
                     dataSource._renderTime = (new Date() - startRenderTime);
                 }
             }
+            return deferred;
         },
 
         _getRowElements: function(tableElement) {


### PR DESCRIPTION
The base _renderCore can return deferred, so we return callBase.apply deferred to prevent disinheritance