### PR TITLE
PivotGrid - A bound chart's value axis has incorrect value type (T1141142)

### DIFF
--- a/js/ui/pivot_grid/data_source.js
+++ b/js/ui/pivot_grid/data_source.js
@@ -458,7 +458,9 @@ export default Class.inherit((function() {
                 } else {
                     fieldsDictionary[fieldKey] = mergedField = field;
                 }
-                extend(mergedField, { dataType: dataTypes[field.dataField] });
+                if(dataTypes[field.dataField]) {
+                    mergedField.dataType ||= dataTypes[field.dataField];
+                }
                 delete fieldsDictionary[fieldKey];
                 removedFields[fieldKey] = storeField;
 

--- a/js/ui/pivot_grid/data_source.js
+++ b/js/ui/pivot_grid/data_source.js
@@ -458,8 +458,8 @@ export default Class.inherit((function() {
                 } else {
                     fieldsDictionary[fieldKey] = mergedField = field;
                 }
-                if(dataTypes[field.dataField]) {
-                    mergedField.dataType ||= dataTypes[field.dataField];
+                if(!mergedField.dataType && dataTypes[field.dataField]) {
+                    mergedField.dataType = dataTypes[field.dataField];
                 }
                 delete fieldsDictionary[fieldKey];
                 removedFields[fieldKey] = storeField;

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/dataSource_bundled.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/dataSource_bundled.tests.js
@@ -4232,7 +4232,28 @@ QUnit.module('dxPivotGrid dataSource with Store', {
         assert.ok(dataSource.isEmpty());
     });
 
+    // T1141142
+    QUnit.test('fields with same dataField should not pollute each other', function(assert) {
+        // arrange
+        const dataSource = createDataSource({
+            fields: [
+                { dataField: 'a', area: 'data', summaryType: 'sum', dataType: 'string' },
+                { dataField: 'a', area: 'row', summaryType: 'avg', dataType: 'number' },
+            ],
+            store: []
+        });
 
+        // assert
+        const [firstField, secondField] = dataSource.fields();
+
+        assert.strictEqual(firstField.area, 'data');
+        assert.strictEqual(firstField.summaryType, 'sum');
+        assert.strictEqual(firstField.dataType, 'string');
+
+        assert.strictEqual(secondField.area, 'row');
+        assert.strictEqual(secondField.summaryType, 'avg');
+        assert.strictEqual(secondField.dataType, 'number');
+    });
 });
 
 QUnit.module('Sorting', defaultEnvironment, () => {


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
