### PR TITLE
DataGrid - The `TypeError: this._contentReadyAction is not a function` is thrown after widget disposed if renderAsync property is set to `true` (T1138639)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_view.d.ts
+++ b/js/ui/grid_core/ui.grid_core.columns_view.d.ts
@@ -19,6 +19,8 @@ export class ColumnsView extends View {
 
   scrollChanged: any;
 
+  _templateTimeout?: number;
+
   // Methods:
   _handleDataChanged: (this: this, e: HandleDataChangedArguments) => void;
 

--- a/js/ui/grid_core/ui.grid_core.columns_view.js
+++ b/js/ui/grid_core/ui.grid_core.columns_view.js
@@ -400,7 +400,8 @@ const columnsViewMembers = {
     _renderDelayedTemplatesCoreAsync: function(templates) {
         const that = this;
         if(templates.length) {
-            getWindow().setTimeout(function() {
+            getWindow().clearTimeout(that._templateTimeout);
+            that._templateTimeout = getWindow().setTimeout(function() {
                 that._renderDelayedTemplatesCore(templates, true);
             });
         }
@@ -490,6 +491,7 @@ const columnsViewMembers = {
             model: options,
             deferred: templateDeferred,
             onRendered: () => {
+                if(that.component._disposed) return;
                 templateDeferred.resolve();
             }
         };
@@ -1191,6 +1193,9 @@ const columnsViewMembers = {
         }
 
         return false;
+    },
+    dispose: function() {
+        getWindow().clearTimeout(this._templateTimeout);
     }
 };
 

--- a/js/ui/grid_core/ui.grid_core.columns_view.js
+++ b/js/ui/grid_core/ui.grid_core.columns_view.js
@@ -3,7 +3,7 @@
 import { getOuterWidth, getWidth, getOuterHeight, getHeight } from '../../core/utils/size';
 import $ from '../../core/renderer';
 import domAdapter from '../../core/dom_adapter';
-import { getWindow } from '../../core/utils/window';
+import { getWindow, hasWindow } from '../../core/utils/window';
 import eventsEngine from '../../events/core/events_engine';
 import { data as elementData } from '../../core/element_data';
 import pointerEvents from '../../events/pointer';
@@ -1195,7 +1195,9 @@ const columnsViewMembers = {
         return false;
     },
     dispose: function() {
-        getWindow().clearTimeout(this._templateTimeout);
+        if(hasWindow()) {
+            getWindow().clearTimeout(this._templateTimeout);
+        }
     }
 };
 

--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -1209,6 +1209,7 @@ export const rowsModule = {
                 },
 
                 dispose: function() {
+                    this.callBase();
                     clearTimeout(this._hideLoadingTimeoutID);
                     this._scrollable && this._scrollable.dispose();
                 },

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
@@ -1,6 +1,6 @@
 QUnit.testStart(function() {
     const markup =
-'<style>\
+        '<style>\
     .qunit-fixture-static {\
         position: static !important;\
         left: 0 !important;\
@@ -135,8 +135,8 @@ QUnit.module('Rows view', {
 }, () => {
 
     QUnit.test('Create col elements by columns collection', function(assert) {
-    // arrange, act
-    // arrange
+        // arrange, act
+        // arrange
         const rowsView = this.createRowsView([{ values: [1, 2, 3, 4, 5] }], null, [{ caption: 'Column 1', width: 30 }, { caption: 'Column 2', width: 50 }, { caption: 'Column 3', width: 73 },
             { caption: 'Column 4' }, { caption: 'Column 5', width: 91 }]);
         const testElement = $('#container');
@@ -156,7 +156,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Add colgroup to table', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -171,7 +171,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Render rows', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -196,7 +196,7 @@ QUnit.module('Rows view', {
 
     // T311620
     QUnit.test('Render rows with empty data', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView([{ data: { test1: '   ', test2: undefined, test3: null, test4: '' }, values: ['   ', undefined, null, ''], rowType: 'data', dataIndex: 0 }]);
         const testElement = $('#container');
 
@@ -213,7 +213,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Render scrollable', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -250,7 +250,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Check WAI-ARIA attributes for data rows/cells after render rows', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -273,7 +273,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Check WAI-ARIA attributes for freeSpace rows/cells after render rows', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -296,7 +296,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Render Lookup Column', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items, null, [{}, { lookup: { calculateCellValue: function(value) { return 'Lookup ' + value; } } }, {}]);
         const testElement = $('#container');
 
@@ -319,8 +319,8 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Render Lookup Column with calculateDisplayValue', function(assert) {
-    // arrange
-        const rowsView = this.createRowsView(this.items, null, [{}, { calculateDisplayValue: function(data) { return 'Lookup ' + data.id; }, dataField: 'id', lookup: { } }, {}]);
+        // arrange
+        const rowsView = this.createRowsView(this.items, null, [{}, { calculateDisplayValue: function(data) { return 'Lookup ' + data.id; }, dataField: 'id', lookup: {} }, {}]);
         const testElement = $('#container');
 
         // act
@@ -342,7 +342,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Resized event not raised for grouped column', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items, null, [
             { dataField: 'test1', resizedCallbacks: $.Callbacks().add(function(width) { resizedColumns.push('test1'); resizedColumnWidths.push(width); }) },
             { dataField: 'test2', groupIndex: 0, resizedCallbacks: $.Callbacks().add(function(width) { resizedColumns.push('test2'); resizedColumnWidths.push(width); }) },
@@ -363,7 +363,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Resized event on resize after second render', function(assert) {
-    // arrange
+        // arrange
 
         const columns = [
             { dataField: 'test1', width: 100, resizedCallbacks: $.Callbacks().add(function(width) { resizedColumns.push('test1'); resizedColumnWidths.push(width); }) },
@@ -391,7 +391,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Resized event on second resize not raised', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items, null, [
             { dataField: 'test1', width: 100, resizedCallbacks: $.Callbacks().add(function() { resizedColumns.push('test1'); }) },
             { dataField: 'test2', resizedCallbacks: $.Callbacks().add(function() { resizedColumns.push('test2'); }) },
@@ -412,7 +412,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Resized event on second resize when container resized and columns with fixed width defined', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items, null, [
             { dataField: 'test1', width: 100, resizedCallbacks: $.Callbacks().add(function() { resizedColumns.push('test1'); }) },
             { dataField: 'test2', resizedCallbacks: $.Callbacks().add(function() { resizedColumns.push('test2'); }) },
@@ -435,7 +435,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Resized event on update width of column', function(assert) {
-    // arrange
+        // arrange
 
         const columns = [
             { dataField: 'test1', visibleWidth: 100, resizedCallbacks: $.Callbacks().add(function(width) { resizedColumns.push('test1'); widths.push(width); }) },
@@ -468,7 +468,7 @@ QUnit.module('Rows view', {
 
     // T174577
     QUnit.test('Resize after change scrolling options', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -483,7 +483,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Grid is not rendered on columnsChanged', function(assert) {
-    // arrange
+        // arrange
 
         const columns = [{ dataField: 'test1' }, { dataField: 'test2' }, { dataField: 'test3' }];
 
@@ -580,7 +580,8 @@ QUnit.module('Rows view', {
             { data: { name: 'test3', id: 31, date: new Date(2003, 2, 3) }, values: ['test3', 31, '3/03/2003'], rowType: 'data', dataIndex: 2 }];
 
         const columns = [
-            { allowFiltering: true, dataType: 'string',
+            {
+                allowFiltering: true, dataType: 'string',
                 cellTemplate: function(container, options) {
                     $('<span>test</span>').appendTo(container);
                 }
@@ -627,7 +628,8 @@ QUnit.module('Rows view', {
             { data: { name: 'test3', id: 31, date: new Date(2003, 2, 3) }, values: ['test3', 31, '3/03/2003'], rowType: 'data', dataIndex: 2 }];
 
         const columns = [
-            { allowFiltering: true, dataType: 'string',
+            {
+                allowFiltering: true, dataType: 'string',
                 cellTemplate: function(container) {
                     $('<div>')
                         .addClass('dx-template-wrapper')
@@ -738,7 +740,7 @@ QUnit.module('Rows view', {
 
     // T103538
     QUnit.test('Highlight searchText with rowTemplate', function(assert) {
-    // arrange
+        // arrange
         const columns = [{ allowFiltering: true, dataType: 'string' }, { allowFiltering: true, dataType: 'number' }, { allowFiltering: true, dataType: 'date' }];
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController, columns);
@@ -796,7 +798,7 @@ QUnit.module('Rows view', {
 
     // T106289
     QUnit.test('Highlight searchText with rowTemplate not replace tagName', function(assert) {
-    // arrange
+        // arrange
         const columns = [{ allowFiltering: true, dataType: 'string' }, { allowFiltering: true, dataType: 'number' }, { allowFiltering: true, dataType: 'date' }];
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController, columns);
@@ -823,7 +825,7 @@ QUnit.module('Rows view', {
 
     // T106289
     QUnit.test('Highlight searchText with rowTemplate not replace class', function(assert) {
-    // arrange
+        // arrange
         const columns = [{ allowFiltering: true, dataType: 'string' }, { allowFiltering: true, dataType: 'number' }, { allowFiltering: true, dataType: 'date' }];
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController, columns);
@@ -850,7 +852,7 @@ QUnit.module('Rows view', {
 
     // B254927
     QUnit.test('Highlight searchText with column edit', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController, [{ allowFiltering: true, dataType: 'string' }, { allowFiltering: true, dataType: 'number' }, { allowFiltering: true, dataType: 'date' }, { command: 'edit' }]);
         const testElement = $('#container');
@@ -881,7 +883,7 @@ QUnit.module('Rows view', {
 
     // B255151
     QUnit.test('Not highlight searchText when in column allowFiltering false', function(assert) {
-    // arrange
+        // arrange
         const columns = [{ allowFiltering: true, dataType: 'string' }, { allowFiltering: true, dataType: 'number' }, { allowFiltering: false, dataType: 'date' }];
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController, columns);
@@ -998,8 +1000,9 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Highlight searchText for lookup column (T449327)', function(assert) {
-    // arrange
-        const columns = [{ allowFiltering: true, dataType: 'number',
+        // arrange
+        const columns = [{
+            allowFiltering: true, dataType: 'number',
             lookup: {
                 dataType: 'string',
                 calculateCellValue: function(value) {
@@ -1030,7 +1033,7 @@ QUnit.module('Rows view', {
 
     // T534059
     QUnit.test('Highlighting search text for boolean column with set to \'trueText\' option', function(assert) {
-    // arrange
+        // arrange
         const columns = [{
             allowFiltering: true,
             dataType: 'boolean',
@@ -1071,7 +1074,7 @@ QUnit.module('Rows view', {
 
     // T534059
     QUnit.test('Highlighting search text for boolean column with set to \'falseText\' option', function(assert) {
-    // arrange
+        // arrange
         const columns = [{
             allowFiltering: true,
             dataType: 'boolean',
@@ -1111,7 +1114,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Highlighting search text for group row if templatesRenderAsynchronously is true (T808974)', function(assert) {
-    // arrange
+        // arrange
         const columns = [{
             allowCollapsing: true,
             allowFiltering: true,
@@ -1146,7 +1149,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('All rows are not isSelected by default', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -1159,7 +1162,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Click on row call changeItemSelection', function(assert) {
-    // arrange
+        // arrange
         const rowClickArgs = [];
 
         const dataController = new MockDataController({ items: this.items });
@@ -1190,7 +1193,7 @@ QUnit.module('Rows view', {
 
     // T489828
     QUnit.test('Click on row with metaKey should call changeItemSelection with control flag', function(assert) {
-    // arrange
+        // arrange
         const rowClickArgs = [];
 
         const dataController = new MockDataController({ items: this.items });
@@ -1213,7 +1216,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Click on row do not call changeItemSelection for showCheckBoxesMode always when mode is multiple', function(assert) {
-    // arrange
+        // arrange
         const rowClickArgs = [];
 
         const dataController = new MockDataController({ items: this.items });
@@ -1237,7 +1240,7 @@ QUnit.module('Rows view', {
 
     // T365183
     QUnit.test('Click on row call changeItemSelection for showCheckBoxesMode always when mode is single', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController);
         const testElement = $('#container');
@@ -1254,7 +1257,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Render selection from dataController rows state', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController);
         const testElement = $('#container');
@@ -1274,7 +1277,7 @@ QUnit.module('Rows view', {
 
 
     QUnit.test('Update selection on changed dataController event', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController);
         const testElement = $('#container');
@@ -1299,7 +1302,7 @@ QUnit.module('Rows view', {
     };
 
     QUnit.test('Show column with check boxes', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ values: [false, 'test1', 1, '1/01/2001'], rowType: 'data' }, { values: [true, 'test2', 2, '2/02/2002'], rowType: 'data' }, { values: [false, 'test3', 3, '3/03/2003'], rowType: 'data' }];
         const dataController = new MockDataController({ items: rows, selection: { mode: 'multiple', showCheckBoxesMode: 'always' } });
         const rowsView = this.createRowsView(this.items, dataController, [{ command: 'select', dataType: 'boolean' }, {}, {}, {}]);
@@ -1317,7 +1320,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Selection rows by click on checkbox', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ values: [false, 'test1', 1, '1/01/2001'], rowType: 'data' }, { values: [false, 'test2', 2, '2/02/2002'], rowType: 'data' }, { values: [false, 'test3', 3, '3/03/2003'], rowType: 'data' }];
         const dataController = new MockDataController({ items: rows, selection: { mode: 'multiple', showCheckBoxesMode: 'always' } });
         const rowsView = this.createRowsView(this.items, dataController, [{ command: 'select', dataType: 'boolean', cssClass: 'dx-command-select' }, {}, {}, {}]);
@@ -1389,7 +1392,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Render rows after "refresh" from data controller', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController, null);
         const testElement = $('#container');
@@ -1536,7 +1539,7 @@ QUnit.module('Rows view', {
             return {
                 allowRenderToDetachedContainer: false,
                 render: function(options) {
-                // T145808
+                    // T145808
                     assert.ok(!contentPositionUpdated, 'content position not updated');
                     options.container.text('Custom Template - ' + options.model.text);
                 }
@@ -1680,7 +1683,7 @@ QUnit.module('Rows view', {
 
     // B254287
     QUnit.test('Group row is not edit', function(assert) {
-    // arrange
+        // arrange
         this.items[0].rowType = 'group';
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController, null);
@@ -1816,7 +1819,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Selection on long tap when selectionWithCheckboxes started', function(assert) {
-    // arrange
+        // arrange
         const rowInfos = this.items;
         const dataController = new MockDataController({ items: rowInfos });
         const rowsView = this.createRowsView(rowInfos, dataController);
@@ -1841,7 +1844,7 @@ QUnit.module('Rows view', {
 
     // B254289
     QUnit.test('Selection on hold', function(assert) {
-    // arrange
+        // arrange
         const rowInfos = this.items;
         const dataController = new MockDataController({ items: rowInfos });
         const rowsView = this.createRowsView(rowInfos, dataController);
@@ -1873,7 +1876,7 @@ QUnit.module('Rows view', {
 
     // T437599
     QUnit.test('Selection on hold should not work when showCheckBoxesMode is always', function(assert) {
-    // arrange
+        // arrange
         const rowInfos = this.items;
         const dataController = new MockDataController({ items: rowInfos });
         const rowsView = this.createRowsView(rowInfos, dataController);
@@ -1905,7 +1908,7 @@ QUnit.module('Rows view', {
 
     // T355686
     QUnit.skipInShadowDomMode('ContextMenu on hold when touch and when assign items in onContextMenuPreparing', function(assert) {
-    // arrange
+        // arrange
         const rowInfos = this.items;
         const dataController = new MockDataController({ items: rowInfos });
         const rowsView = this.createRowsView(rowInfos, dataController);
@@ -2058,7 +2061,7 @@ QUnit.module('Rows view', {
 
     // T182190
     QUnit.test('Horizontal scroll when no data', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView([], null, [{ width: 200 }, { width: 200 }]);
         const $testElement = $('#container');
 
@@ -2079,7 +2082,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Render additional row for free space_B232625', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         let oldTableHeight;
         const $testElement = $('#container');
@@ -2120,7 +2123,7 @@ QUnit.module('Rows view', {
 
     // B253540
     QUnit.test('Render additional row for free space after resize', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items, null, [{ resizedCallbacks: $.Callbacks().add(function() { setHeight($('#container').find('tbody > tr'), 200); }) }, {}, {}]);
         const $testElement = $('#container');
 
@@ -2136,7 +2139,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Free space row with a command column', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items, virtualItemsCount: { begin: 20, end: 0 } });
         const rowsView = this.createRowsView(this.items, dataController, [{ command: 'expand' }, {}, {}, {}]);
         const $testElement = $('#container');
@@ -2151,7 +2154,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Free space row with a command column and cssClass', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items, virtualItemsCount: { begin: 20, end: 0 } });
         const rowsView = this.createRowsView(this.items, dataController, [{ command: 'expand', cssClass: 'command-cell' }, { cssClass: 'simple-cell' }, {}, {}]);
         const $testElement = $('#container');
@@ -2175,7 +2178,7 @@ QUnit.module('Rows view', {
 
     // B233350
     QUnit.test('Freespace row must be empty for virtual scroller and non-first page', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items, virtualItemsCount: { begin: 20, end: 0 } });
         const rowsView = this.createRowsView(this.items, dataController, null, false, { scrolling: { mode: 'virtual' } });
         const $testElement = $('#container');
@@ -2194,7 +2197,7 @@ QUnit.module('Rows view', {
 
     // B233350
     QUnit.test('Freespace row not must be empty for virtual scroller and first page', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items, virtualItemsCount: { begin: 0, end: 0 } });
         const rowsView = this.createRowsView(this.items, dataController);
         const $testElement = $('#container');
@@ -2248,7 +2251,7 @@ QUnit.module('Rows view', {
 
     // T112484
     QUnit.test('Height free space row for virtual scroller', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items, virtualItemsCount: { begin: 0, end: 0 } });
         const rowsView = this.createRowsView(this.items, dataController);
         const $testElement = $('#container');
@@ -2285,7 +2288,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Free space row with option showColumnLines true', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController);
         const testElement = $('#container');
@@ -2302,7 +2305,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Free space row with option showColumnLines false', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items });
         const rowsView = this.createRowsView(this.items, dataController);
         const testElement = $('#container');
@@ -2319,7 +2322,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Height of free space row is wrong_B254959', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items, pageSize: 10, pageIndex: 1, pageCount: 2 });
         const rowsView = this.createRowsView(this.items, dataController);
         const testElement = $('#container');
@@ -2340,7 +2343,7 @@ QUnit.module('Rows view', {
 
     // T174661
     QUnit.test('Update free space row height after insert/remove row', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const $testElement = $('#container');
 
@@ -2373,7 +2376,7 @@ QUnit.module('Rows view', {
 
     // T354748
     QUnit.test('Update content without data', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const $testElement = $('#container');
 
@@ -2393,7 +2396,7 @@ QUnit.module('Rows view', {
 
     // T391782
     QUnit.test('Remove last row', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView([this.items[0]]);
         const $testElement = $('#container');
 
@@ -2414,7 +2417,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Add css class for a last row when the showBorders and showRowLines are enabled and freeSpaceRow is hidden', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items, pageSize: 10, pageIndex: 1, pageCount: 2 });
         const rowsView = this.createRowsView(this.items, dataController, null, null, {
             showRowLines: true,
@@ -2433,7 +2436,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Remove css class for a last row when freeSpaceRow is shown', function(assert) {
-    // arrange
+        // arrange
         const dataController = new MockDataController({ items: this.items, pageSize: 10, pageIndex: 1, pageCount: 2 });
         const rowsView = this.createRowsView(this.items, dataController, null, null, {
             showRowLines: true,
@@ -2455,7 +2458,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show grouped columns', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2] }, { rowType: 'data', values: [null, null, 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, {}]);
@@ -2496,7 +2499,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show grouped columns with continuation messages', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuation: true } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2], data: { isContinuationOnNextPage: true } }, { rowType: 'group', groupIndex: 2, isExpanded: false, values: [1, 2, 3], data: { isContinuation: true, isContinuationOnNextPage: true } }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, { groupIndex: 2, caption: 'column 3', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }]);
@@ -2531,7 +2534,7 @@ QUnit.module('Rows view', {
 
     // B251665
     QUnit.test('Show grouped columns when virtual scrolling enabled', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }];
         const dataController = new MockDataController({ items: rows, virtualItemsCount: { begin: 10, end: 0 } });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }]);
@@ -2555,7 +2558,7 @@ QUnit.module('Rows view', {
 
     // B254928
     QUnit.test('Show grouped columns when infinite scrolling enabled', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true }]);
@@ -2576,7 +2579,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Group template', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true, items: [{}, {}] } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2], data: { items: [{}, {}, {}] } }, { rowType: 'data', values: ['', '', 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{
@@ -2588,7 +2591,8 @@ QUnit.module('Rows view', {
                 $('<div />')
                     .text(options.column.caption + ' - ' + options.text + ' (Count - ' + options.data.items.length + ')')
                     .appendTo(container);
-            } }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, {}]);
+            }
+        }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, {}]);
         const testElement = $('#container');
 
         // act
@@ -2603,7 +2607,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Group template returns jQuery element', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true, items: [{}, {}] } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2], data: { items: [{}, {}, {}] } }, { rowType: 'data', values: ['', '', 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{
@@ -2613,7 +2617,8 @@ QUnit.module('Rows view', {
             groupCellTemplate: function(container, options) {
                 return $('<div />')
                     .text(options.column.caption + ' - ' + options.text + ' (Count - ' + options.data.items.length + ')');
-            } }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, {}]);
+            }
+        }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, {}]);
         const testElement = $('#container');
 
         // act
@@ -2628,7 +2633,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Group template returns DOM-element', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true, items: [{}, {}] } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2], data: { items: [{}, {}, {}] } }, { rowType: 'data', values: ['', '', 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{
@@ -2638,7 +2643,8 @@ QUnit.module('Rows view', {
             groupCellTemplate: function(container, options) {
                 return ($('<div />')
                     .text(options.column.caption + ' - ' + options.text + ' (Count - ' + options.data.items.length + ')')).eq(0);
-            } }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, {}]);
+            }
+        }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, {}]);
         const testElement = $('#container');
 
         // act
@@ -2653,7 +2659,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show grouped columns when no allowCollapsing', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2] }, { values: ['', '', 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1' }, { groupIndex: 1, caption: 'column 2' }, {}]);
@@ -2690,7 +2696,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show grouped columns with select column', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1] }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2] }, { values: ['', '', 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ command: 'select' }, { command: 'expand', type: 'groupExpand', groupIndex: 0, caption: 'column 1', allowCollapsing: true, cellTemplate: expandCellTemplate }, { command: 'expand', type: 'groupExpand', groupIndex: 1, caption: 'column 2', cellTemplate: expandCellTemplate }, {}]);
@@ -2718,7 +2724,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show grouped columns with column command is empty', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1] }, { rowType: 'group', groupIndex: 1, isExpanded: true, values: [1, 2] }, { rowType: 'group', groupIndex: 2, isExpanded: true, values: [1, 2, 3] }, { values: [null, null, null, null] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true }, { groupIndex: 2, caption: 'column 3', allowCollapsing: true }, { command: 'empty' }]);
@@ -2752,7 +2758,7 @@ QUnit.module('Rows view', {
 
     // T125391
     QUnit.test('groupContinuesMessage parameter for group template', function(assert) {
-    // arrange
+        // arrange
         const rows = [
             { rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true, items: [{}, {}] } },
             { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2], data: { items: [{}, {}, {}] } },
@@ -2764,7 +2770,8 @@ QUnit.module('Rows view', {
             groupIndex: 0, caption: 'column 1', allowCollapsing: true,
             groupCellTemplate: function(container, options) {
                 groupContinuesMessage = options.groupContinuesMessage;
-            } }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true }, {}]);
+            }
+        }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true }, {}]);
         const testElement = $('#container');
 
         this.options.grouping = {
@@ -2780,7 +2787,7 @@ QUnit.module('Rows view', {
 
     // T125391
     QUnit.test('groupContinuedMessage parameter for group template', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuation: true, items: [{}, {}] } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2], data: { items: [{}, {}, {}] } }, { values: ['', '', 3] }];
         const dataController = new MockDataController({ items: rows });
         let passedGroupContinuedMessage;
@@ -2788,11 +2795,12 @@ QUnit.module('Rows view', {
             groupIndex: 0, caption: 'column 1', allowCollapsing: true,
             groupCellTemplate: function(container, options) {
                 passedGroupContinuedMessage = options.groupContinuedMessage;
-            } }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true }, {}]);
+            }
+        }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true }, {}]);
         const testElement = $('#container');
 
         this.options.grouping = {
-        // TODO: use sinon.js instead
+            // TODO: use sinon.js instead
             texts: { groupContinuedMessage: 'groupContinuedMessage' }
         };
         // act
@@ -2803,7 +2811,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show master detail', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', values: [true, 1] }, { rowType: 'detail', data: { detailInfo: 'Test Detail Information' } }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ command: 'expand', cellTemplate: gridCoreUtils.getExpandCellTemplate() }, {}]);
@@ -2834,7 +2842,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Detail grid render as delayed template', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', values: [true, 1] }, { rowType: 'detail', data: { detailInfo: 'Test Detail Information' } }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ command: 'expand' }, {}]);
@@ -2882,7 +2890,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('_getRowElements return right set of elements when using masterDetail', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', values: [true, 1] }, { rowType: 'detail', data: { detailInfo: 'Test Detail Information' } }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ command: 'expand' }, {}]);
@@ -2910,7 +2918,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show grouped columns and master detail', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2] }, { rowType: 'data', values: [null, null, true, 3] }, { rowType: 'detail', data: { detailInfo: 'Test Detail Information' } }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand', cellTemplate: expandCellTemplate }, { command: 'expand', cellTemplate: expandCellTemplate }, {}]);
@@ -2959,7 +2967,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Change Row Expand for master detail on expand button click ', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', key: 1, values: [false, 1] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ command: 'expand', cellTemplate: gridCoreUtils.getExpandCellTemplate() }, {}]);
@@ -2998,7 +3006,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show master detail_T163510', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', key: 1, values: [false, 1] }, {
             rowType: 'detail',
             data: { detailInfo: 'Test Detail Information' }
@@ -3021,7 +3029,7 @@ QUnit.module('Rows view', {
 
     // T225735
     QUnit.test('Show master detail with native checkbox', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', values: [true, 1] }, { rowType: 'detail', data: { detailInfo: 'Test Detail Information' } }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ command: 'expand' }, {}]);
@@ -3053,7 +3061,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show rowlines for master detail', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', key: 1, values: [false, 1] }, {
             rowType: 'detail',
             data: { detailInfo: 'Test Detail Information' }
@@ -3075,7 +3083,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Add class nowrap when wordWrapEnabled false', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView([{ values: [1, 2, 3, 4, 5] }], null, [{ caption: 'Column 1', width: 30 }, { caption: 'Column 2', width: 50 }, { caption: 'Column 3', width: 73 },
             { caption: 'Column 4' }, { caption: 'Column 5', width: 91 }]);
         const testElement = $('#container');
@@ -3089,7 +3097,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Remove class nowrap when wordWrapEnabled true', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView([{ values: [1, 2, 3, 4, 5] }], null, [{ caption: 'Column 1', width: 30 }, { caption: 'Column 2', width: 50 }, { caption: 'Column 3', width: 73 },
             { caption: 'Column 4' }, { caption: 'Column 5', width: 91 }]);
         const testElement = $('#container');
@@ -3103,7 +3111,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Set rows opacity', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -3128,7 +3136,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Set rows opacity for band column', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items, null, [
             [{ caption: 'Band column 1', index: 0, isBand: true }],
             [{ caption: 'Column 1', index: 1, ownerBand: 0 }, { caption: 'Column 2', index: 2, ownerBand: 0 }, { caption: 'Band column 2', index: 3, ownerBand: 0 }],
@@ -3159,7 +3167,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option showColumnLines true', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -3177,7 +3185,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option showColumnLines false', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -3195,7 +3203,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option showRowLines true', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -3214,7 +3222,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option showRowLines false', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -3232,7 +3240,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option rowAlternationEnabled true', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -3253,7 +3261,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option rowAlternationEnabled true when grouping', function(assert) {
-    // arrange
+        // arrange
         const items = [{
             rowType: 'group', groupIndex: 0, isExpanded: true, data: {
                 items: [{ name: 'test', id: 2, date: new Date(2002, 1, 2) }, { name: 'test', id: 3, date: new Date(2003, 2, 3) }], key: 'test'
@@ -3283,7 +3291,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option rowAlternationEnabled false', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
 
@@ -3301,7 +3309,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option onCellPrepared', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
         let resultCell;
@@ -3355,7 +3363,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('onCellPrepared for group rows', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2] }, { rowType: 'data', values: [null, null, 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true, command: 'expand' }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand' }, {}]);
@@ -3390,7 +3398,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('onCellPrepared for group rows (RTL)', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2] }, { rowType: 'data', values: [null, null, 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true, command: 'expand' }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand' }, {}]);
@@ -3426,7 +3434,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('onCellPrepared for called for command columns', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', values: [false, 'test1', 1, '1/01/2001'] }, { rowType: 'data', values: [true, 'test2', 2, '2/02/2002'] }, { rowType: 'data', values: [false, 'test3', 3, '3/03/2003'] }];
         const dataController = new MockDataController({ items: rows, selection: { mode: 'multiple', showCheckBoxesMode: 'always' } });
         const rowsView = this.createRowsView(this.items, dataController, [{ command: 'select', dataType: 'boolean' }, {}, {}, {}]);
@@ -3453,7 +3461,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option onCellPrepared for data rows', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2] }, { rowType: 'data', values: ['', '', 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true }, {}]);
@@ -3481,7 +3489,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Rows with option onRowPrepared', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const testElement = $('#container');
         let resultRow;
@@ -3534,7 +3542,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('onRowPrepared for group rows', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], data: { isContinuationOnNextPage: true } }, { rowType: 'group', groupIndex: 1, isExpanded: false, values: [1, 2] }, { rowType: 'data', values: [null, null, 3] }];
         const dataController = new MockDataController({ items: rows });
         const rowsView = this.createRowsView(rows, dataController, [{ groupIndex: 0, caption: 'column 1', allowCollapsing: true, command: 'expand' }, { groupIndex: 1, caption: 'column 2', allowCollapsing: true, command: 'expand' }, {}]);
@@ -3568,7 +3576,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('EncodeHtml is false for column', function(assert) {
-    // arrange
+        // arrange
         const items = [{ values: ['text', '<b><i>italic</i></b>'] }];
         const rowsView = this.createRowsView(items, null, [{ caption: 'Column 1' }, { caption: 'Column 2', encodeHtml: false }]);
         const testElement = $('#container');
@@ -3583,7 +3591,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('EncodeHtml is true for column', function(assert) {
-    // arrange
+        // arrange
         const items = [{ values: ['text', '<b><i>italic</i></b>'] }];
         const rowsView = this.createRowsView(items, null, [{ caption: 'Column 1' }, { caption: 'Column 2', encodeHtml: true }]);
         const testElement = $('#container');
@@ -3597,7 +3605,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('EncodeHtml is false for column with grouping', function(assert) {
-    // arrange
+        // arrange
         const items = [{ rowType: 'group', groupIndex: 0, values: ['<b><i>italic</i></b>', 'text2'] }];
         const rowsView = this.createRowsView(items, null, [{ caption: 'Column 1', encodeHtml: false, groupIndex: 0 }, { caption: 'Column 2' }], true);
         const testElement = $('#container');
@@ -3612,25 +3620,27 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show summary items in a group row', function(assert) {
-    // arrange
-        const items = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], summaryCells: [[],
-            [{
-                column: 'Column1',
-                summaryType: 'sum',
-                value: 1,
-                valueFormat: 'currency'
-            }, {
-                column: 'Column2',
-                summaryType: 'count',
-                value: 1,
-                displayFormat: '{0}-Count'
-            }, {
-                column: 'Column2',
-                columnCaption: 'Column 2',
-                summaryType: 'count',
-                value: 1
-            }]
-        ] }, { values: ['text', 'text2'] }];
+        // arrange
+        const items = [{
+            rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], summaryCells: [[],
+                [{
+                    column: 'Column1',
+                    summaryType: 'sum',
+                    value: 1,
+                    valueFormat: 'currency'
+                }, {
+                    column: 'Column2',
+                    summaryType: 'count',
+                    value: 1,
+                    displayFormat: '{0}-Count'
+                }, {
+                    column: 'Column2',
+                    columnCaption: 'Column 2',
+                    summaryType: 'count',
+                    value: 1
+                }]
+            ]
+        }, { values: ['text', 'text2'] }];
         const rowsView = this.createRowsView(items, null, [{ caption: 'Column 1', groupIndex: 0 }, { caption: 'Column 2' }], true);
         const testElement = $('#container');
 
@@ -3642,17 +3652,19 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show only one summary item in a group row', function(assert) {
-    // arrange
-        const items = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], summaryCells: [[],
-            [{
-                column: 'Column1',
-                summaryType: 'sum',
-                value: 1,
-                customizeText: function(itemInfo) {
-                    return 'Column1 ' + itemInfo.valueText;
-                }
-            }]
-        ] }, { values: ['text', 'text2'] }];
+        // arrange
+        const items = [{
+            rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], summaryCells: [[],
+                [{
+                    column: 'Column1',
+                    summaryType: 'sum',
+                    value: 1,
+                    customizeText: function(itemInfo) {
+                        return 'Column1 ' + itemInfo.valueText;
+                    }
+                }]
+            ]
+        }, { values: ['text', 'text2'] }];
         const rowsView = this.createRowsView(items, null, [{ caption: 'Column 1', groupIndex: 0 }, { caption: 'Column 2' }], true);
         const testElement = $('#container');
 
@@ -3664,7 +3676,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show summary in a group row when alignByColumn', function(assert) {
-    // arrange
+        // arrange
         const items = [{
             rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], summaryCells: [[],
                 [{
@@ -3696,7 +3708,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Show summary in a group row when two alignByColumn summary items', function(assert) {
-    // arrange
+        // arrange
         const items = [{
             rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], summaryCells: [[],
                 [{
@@ -3735,7 +3747,7 @@ QUnit.module('Rows view', {
 
     // T355321
     QUnit.test('Show summary in a group row when two alignByColumn summary items and groupIndex is null for all non-grouped columns', function(assert) {
-    // arrange
+        // arrange
         const items = [{
             rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], summaryCells: [[],
                 [{
@@ -3774,7 +3786,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Summary items are not displayed in a group row', function(assert) {
-    // arrange
+        // arrange
         const items = [{ rowType: 'group', groupIndex: 0, isExpanded: true, values: [1], summaryCells: [] },
             { values: ['text', 'text2'] }];
         const rowsView = this.createRowsView(items, null, [{ caption: 'Column 1', groupIndex: 0 }, { caption: 'Column 2' }], true);
@@ -3788,7 +3800,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Scroll to element by focus', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
         const rowsView = this.createRowsView(this.items, null, null, null, {
             keyboardNavigation: {
@@ -3818,7 +3830,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Width of column in master detail are not changed when it is changed in parent', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const rows = [{ rowType: 'data', values: [true, 1] }, { rowType: 'detail', data: { detailInfo: 'Test Detail Information' } }];
         const dataController = new MockDataController({ items: rows });
@@ -3854,7 +3866,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Invalidate instead of render for options', function(assert) {
-    // arrange
+        // arrange
         let renderCounter = 0;
         const rowsView = this.createRowsView(this.items);
 
@@ -3879,7 +3891,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Invalidate when data is loading', function(assert) {
-    // arrange
+        // arrange
         let renderCounter = 0;
         const rowsView = this.createRowsView(this.items);
 
@@ -3902,7 +3914,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Call resize method when the rowTemplate option is changed', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
 
         rowsView.render($('#container'));
@@ -3920,7 +3932,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('Call resize method when the loadPanel option is changed', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
 
         rowsView.render($('#container'));
@@ -3939,7 +3951,7 @@ QUnit.module('Rows view', {
 
     // T349039
     QUnit.test('Rows view (with wordWrapEnabled is true) in container with \'nowrap\' value of the white-space property', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView([{ values: [1, 2, 3, 4, 5] }], null, [{ caption: 'Column 1', width: 30 }, { caption: 'Column 2', width: 50 }, { caption: 'Column 3', width: 73 },
             { caption: 'Column 4' }, { caption: 'Column 5', width: 91 }]);
         const $testElement = $('#container');
@@ -3958,7 +3970,7 @@ QUnit.module('Rows view', {
 
     // T370318
     QUnit.test('Render free space row with rowTemplate', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
         const $testElement = $('#container');
 
@@ -3981,7 +3993,7 @@ QUnit.module('Rows view', {
 
     // T363929
     QUnit.test('Calculate widths when there is only group rows', function(assert) {
-    // arrange
+        // arrange
         this.items = [
             { values: [], rowType: 'group', dataIndex: 0 },
             { values: [], rowType: 'group', dataIndex: 1 },
@@ -4004,7 +4016,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('GetRowsElements method is called once when opacity is applied to rows', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items);
 
         rowsView.render($('#container'));
@@ -4019,7 +4031,7 @@ QUnit.module('Rows view', {
     });
 
     QUnit.test('loadPanel position correction if rowsView.height > window.height', function(assert) {
-    // arrange
+        // arrange
         const rowsView = this.createRowsView(this.items, null, null, null, { loadPanel: { enabled: true } });
         const $testElement = $('#container');
 
@@ -4074,7 +4086,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 }, () => {
 
     QUnit.test('onCellHoverChanged event handling', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
         let onCellHoverChanged;
 
@@ -4162,7 +4174,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.testInActiveWindow('ScrollToPage when virtual scrolling mode', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4189,7 +4201,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('set pageIndex scroll content when virtual scrolling mode', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4218,7 +4230,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T356666
     QUnit.test('None-zero initial pageIndex when virtual scrolling mode', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4246,7 +4258,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // B254955
     QUnit.test('set pageSize scroll content when virtual scrolling mode', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4265,7 +4277,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
 
         this.rowsView.scrollChanged.add(function(e) {
-        // assert
+            // assert
             assert.strictEqual(e.top, 0, 'scroll position after change pageSize');
             done();
         });
@@ -4275,7 +4287,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('reset scroll position on set pageIndex when standard scrolling mode', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4298,7 +4310,7 @@ QUnit.module('Rows view with real dataController and columnController', {
             if(scrollOffsetChangedCallCount === 1) {
                 assert.equal(e.top, 5, 'scroll position');
                 setTimeout(function() {
-                // act
+                    // act
                     that.dataController.pageIndex(1);
                 });
             } else {
@@ -4312,7 +4324,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('ScrollToPage when standard scrolling mode reset position to 0', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4333,7 +4345,7 @@ QUnit.module('Rows view with real dataController and columnController', {
             if(scrollOffsetChangedCallCount === 1) {
                 assert.equal(e.top, 5, 'scroll position');
                 setTimeout(function() {
-                // act
+                    // act
                     that.rowsView.scrollToPage(1);
                 });
             } else {
@@ -4348,7 +4360,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T225097
     QUnit.test('Scroll position is not reset on change dataSource', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4383,7 +4395,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T225097, T290984
     QUnit.test('Scroll position is not reset on change dataSource when virtual scrolling enabled', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4429,7 +4441,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Reset scroll position on change filter when virtual scrolling enabled', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const testElement = $('#container');
 
@@ -4588,7 +4600,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // B254492
     QUnit.test('free space row height for last page when dataGrid without height and pageCount > 1', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4613,7 +4625,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T142464
     QUnit.test('free space row height for last page when dataGrid without height and pageCount > 1 when virtual scrolling mode', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4639,7 +4651,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // B254901
     QUnit.test('not height free space row for last page when dataGrid with height and pageCount > 1', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4660,7 +4672,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Rows with cssClass', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container').height(600);
 
@@ -4699,7 +4711,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T821255
     QUnit.test('Rows with cssClass for grouped column with showWhenGrouped', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4730,7 +4742,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Add class dx-data-row on rows with type data', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4761,7 +4773,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T355291
     QUnit.test('Render groups when calculateDisplayValue is used', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4787,7 +4799,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T355291
     QUnit.test('Render groups when calculateDisplayValue as string is used', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4812,7 +4824,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Render groups when lookup is used', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4846,7 +4858,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Customize columns', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4883,7 +4895,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Customize columns with virtual scrolling', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4921,7 +4933,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Customize columns with customize trueText and falseText', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const testElement = $('#container');
 
@@ -4960,7 +4972,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Customize text is not called when command column is rendered', function(assert) {
-    // arrange
+        // arrange
         const values = [];
         const testElement = $('#container');
 
@@ -4986,7 +4998,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T199951
     QUnit.test('Render one time the master detail when expanded/collapsed item', function(assert) {
-    // arrange
+        // arrange
         let countCallTemplate = 0;
         const testElement = $('#container');
 
@@ -5042,7 +5054,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T492174
     QUnit.test('Master detail row template should not be rerendered after expand previous row', function(assert) {
-    // arrange
+        // arrange
         let countCallTemplate = 0;
         const $testElement = $('#container');
 
@@ -5074,7 +5086,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T281779
     QUnit.test('Show summary in a group row for column going after a grouped column', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.columns[0] = { dataField: 'name', groupIndex: 0 };
@@ -5106,7 +5118,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T281779
     QUnit.test('Show summary in a group row with showWhenGrouped true', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.dataSource.store = [{ name: 'Alex', lastName: 'Jobs', age: 15 }];
@@ -5147,7 +5159,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T281779
     QUnit.test('Show summary in a group row for column going after a grouped column with showWhenGrouped true', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.columns[0] = { dataField: 'name', groupIndex: 0, showWhenGrouped: true };
@@ -5180,7 +5192,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T281779
     QUnit.test('Show summary in a group row for column going after a grouped column with showWhenGrouped true and when has master detail', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.columns[0] = { dataField: 'name', groupIndex: 0, showWhenGrouped: true };
@@ -5222,7 +5234,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T411212
     QUnit.test('Show master detail with rowTemplate', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.masterDetail = {
@@ -5255,7 +5267,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T718316
     QUnit.test('Show master detail when row as tbody', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
         let $rowElements;
 
@@ -5287,7 +5299,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Do not hide noData block placed inside the masterDetail template', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         let noDataElements;
 
@@ -5319,7 +5331,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T436424
     QUnit.test('Show load panel after replace dataSource when scrolling mode is \'virtual\'', function(assert) {
-    // arrange
+        // arrange
         const clock = sinon.useFakeTimers();
         let isDataLoading;
         const $testElement = $('#container');
@@ -5353,7 +5365,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T604344
     QUnit.test('Scrollbar should be correct updated when specified a remote data', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         const clock = sinon.useFakeTimers();
         const $testElement = $('#container');
@@ -5396,7 +5408,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T341394
     QUnit.test('Show grouped column when cellTemplate is defined', function(assert) {
-    // arrange
+        // arrange
         const testElement = $('#container');
 
         this.options.grouping = {
@@ -5431,7 +5443,7 @@ QUnit.module('Rows view with real dataController and columnController', {
     });
 
     QUnit.test('Group row with the custom position of the group cell', function(assert) {
-    // arrange
+        // arrange
         const $testElement = $('#container');
 
         this.options.grouping = { allowCollapsing: true };
@@ -5455,7 +5467,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
     // T712541
     QUnit.test('Rows should be rendered properly on scrolling when virtual scrolling is enabled and a row template is used', function(assert) {
-    // arrange
+        // arrange
         const clock = sinon.useFakeTimers();
         const $testElement = $('#container');
         const store = new ArrayStore(generateItems(10000));
@@ -5618,7 +5630,7 @@ QUnit.module('Virtual scrolling', {
     beforeEach: function() {
         this.createRowsView = function(items, dataController) {
             const rowsView = createRowsView.apply(this, arguments);
-            const x = new virtualScrollingCore.VirtualScrollController(this.dataGrid, { pageIndex: function() {} });
+            const x = new virtualScrollingCore.VirtualScrollController(this.dataGrid, { pageIndex: function() { } });
             rowsView._dataController._itemSizes = {};
             rowsView._dataController.getVirtualContentSize = x.getVirtualContentSize;
             rowsView._dataController.getContentOffset = x.getContentOffset;
@@ -5652,7 +5664,7 @@ QUnit.module('Virtual scrolling', {
 }, () => {
 
     QUnit.test('Render rows with virtual items', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -5699,7 +5711,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('Render rows if row rendering mode is virtual', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -5740,7 +5752,7 @@ QUnit.module('Virtual scrolling', {
 
     // T154003
     QUnit.test('Render rows with virtual items count is more 1 000 000', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -5784,7 +5796,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('setViewportItemIndex for virtual scrolling when rowsView height defined', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const options = {
             items: [
@@ -5820,7 +5832,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('setViewportItemIndex for virtual scrolling when rowsView height defined and scrolling.timeout is defined', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -5880,7 +5892,7 @@ QUnit.module('Virtual scrolling', {
 
     // T154003
     QUnit.test('setViewportItemIndex to far for virtual scrolling when rowsView height defined and virtual items count is more 1 000 000', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const options = {
             items: [
@@ -5921,7 +5933,7 @@ QUnit.module('Virtual scrolling', {
 
     // T154003
     QUnit.test('setViewportItemIndex to near for virtual scrolling when rowsView height defined and virtual items count is more 1 000 000', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const options = {
             items: [
@@ -5967,7 +5979,7 @@ QUnit.module('Virtual scrolling', {
 
     QUnit.test('setViewportItemIndex for virtual scrolling when rowsView height auto and browser scroll used', function(assert) {
         if(devices.real().ios || ('callPhantom' in window)) {
-        // TODO reanimate for ios
+            // TODO reanimate for ios
             assert.ok(true);
             return;
         }
@@ -6019,7 +6031,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('Render rows with virtual items after render with not virtual items', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -6060,7 +6072,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('Render rows at end when virtual scrolling', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -6117,7 +6129,7 @@ QUnit.module('Virtual scrolling', {
 
     // T423722
     QUnit.test('Render rows at end when virtual scrolling enabled and rowTemplate is defined', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { rowType: 'data', values: [1] },
@@ -6140,11 +6152,11 @@ QUnit.module('Virtual scrolling', {
 
         this.options.rowTemplate = function(container, item) {
             const markup =
-            '<tbody>' +
+                '<tbody>' +
                 '<tr>' +
-                    '<td>' + item.values[0] + '</td>' +
+                '<td>' + item.values[0] + '</td>' +
                 '</tr>' +
-            '</tbody>';
+                '</tbody>';
 
             $(container).append(markup);
         };
@@ -6187,7 +6199,7 @@ QUnit.module('Virtual scrolling', {
 
 
     QUnit.test('Render rows at end when infinite scrolling', function(assert) {
-    // arrange
+        // arrange
         const options = {
             isLoaded: true,
             hasKnownLastPage: false,
@@ -6253,7 +6265,7 @@ QUnit.module('Virtual scrolling', {
 
     // T630906
     QUnit.test('Render rows at end when infinite scrolling for specific row height', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -6282,7 +6294,7 @@ QUnit.module('Virtual scrolling', {
 
     // B254821
     QUnit.test('Selection with virtual scrolling after scroll to second page', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { rowType: 'data', values: [1] },
@@ -6329,7 +6341,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('rowHeight/viewportSize calculation during Render rows with viewport', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -6359,7 +6371,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('Update rowsView on changed', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1] },
@@ -6413,7 +6425,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('rowHeight calculation when freeSpace row shown', function(assert) {
-    // arrange
+        // arrange
         const rows = [
             { values: [1], data: { field: 1 } },
             { values: [2], data: { field: 2 } },
@@ -6440,7 +6452,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('Add group space class for master detail', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ rowType: 'data', values: [true, 1] }, { rowType: 'detail', data: { detailInfo: 'Test Detail Information' } }];
         const dataController = new MockDataController({ items: rows, virtualItemsCount: { begin: 10, end: 10 } });
         const rowsView = this.createRowsView(rows, dataController, [{ command: 'expand' }, {}]);
@@ -6460,7 +6472,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('Change column visibility_T194439', function(assert) {
-    // arrange
+        // arrange
         const rows = [
             { values: [1, 2, 'test'] },
             { values: [2, 3, 'test'] },
@@ -6508,7 +6520,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('Change column lines visibility_T194439', function(assert) {
-    // arrange
+        // arrange
         const rows = [
             { values: [1, 2, 'test'] },
             { values: [2, 3, 'test'] },
@@ -6553,7 +6565,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('Set column widths for virtual table', function(assert) {
-    // arrange
+        // arrange
         const options = {
             items: [
                 { values: [1, 2, 3] },
@@ -6588,7 +6600,7 @@ QUnit.module('Virtual scrolling', {
 
     // T472955
     QUnit.test('Last data row of the last tbody should not have border bottom width', function(assert) {
-    // arrange
+        // arrange
         let $tbodyElements;
         const options = {
             isLoaded: true,
@@ -6687,7 +6699,7 @@ QUnit.module('Virtual scrolling', {
         });
 
         rowsView.scrollChanged.add(function() {
-        // assert
+            // assert
             $tableElement = $testElement.find('table').first();
             assert.equal($tableElement.find('.dx-data-row').length, 6, 'row count');
             assert.equal(rowsView._scrollTop, scrollTop, 'scroll top');
@@ -6696,7 +6708,7 @@ QUnit.module('Virtual scrolling', {
     });
 
     QUnit.test('getTopVisibleRowData when virtual scrolling enabled', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const rows = [
             { values: [1], data: { field: 1 } },
@@ -6722,7 +6734,7 @@ QUnit.module('Virtual scrolling', {
         rowsView.resize();
 
         rowsView.scrollChanged.add(function() {
-        // act, assert
+            // act, assert
             assert.deepEqual(rowsView.getTopVisibleRowData(), { field: 2 });
             done();
         });
@@ -6741,7 +6753,7 @@ QUnit.module('Scrollbar', {
 }, () => {
 
     QUnit.test('isScrollbarVisible', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ values: [1] }, { values: [2] }, { values: [3] }];
         const dataController = new MockDataController({
             items: rows
@@ -6758,7 +6770,7 @@ QUnit.module('Scrollbar', {
     });
 
     QUnit.test('No isScrollbarVisible', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ values: [1] }, { values: [2] }, { values: [3] }];
         const dataController = new MockDataController({
             items: rows
@@ -6774,7 +6786,7 @@ QUnit.module('Scrollbar', {
     });
 
     QUnit.test('getTopVisibleRowData without scrolling', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ values: [1], data: { field: 1 } }, { values: [2], data: { field: 2 } }, { values: [3], data: { field: 3 } }];
         const dataController = new MockDataController({
             items: rows
@@ -6792,7 +6804,7 @@ QUnit.module('Scrollbar', {
 
     // B252594
     QUnit.test('getTopVisibleRowData for one row', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
             items: rows
@@ -6809,7 +6821,7 @@ QUnit.module('Scrollbar', {
     });
 
     QUnit.test('getTopVisibleRowData with small scrolling', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const rows = [{ values: [1], data: { field: 1 } }, { values: [2], data: { field: 2 } }, { values: [3], data: { field: 3 } }];
         const dataController = new MockDataController({
@@ -6823,7 +6835,7 @@ QUnit.module('Scrollbar', {
         rowsView.resize();
 
         rowsView.scrollChanged.add(function() {
-        // act, assert
+            // act, assert
             assert.deepEqual(rowsView.getTopVisibleRowData(), { field: 1 });
             done();
         });
@@ -6832,7 +6844,7 @@ QUnit.module('Scrollbar', {
     });
 
     QUnit.test('getTopVisibleRowData with scrolling', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const rows = [
             { values: [1], data: { field: 1 } },
@@ -6850,7 +6862,7 @@ QUnit.module('Scrollbar', {
         rowsView.resize();
 
         rowsView.scrollChanged.add(function() {
-        // act, assert
+            // act, assert
             assert.deepEqual(rowsView.getTopVisibleRowData(), { field: 2 });
             done();
         });
@@ -6859,7 +6871,7 @@ QUnit.module('Scrollbar', {
     });
 
     QUnit.test('getTopVisibleRowData when virtual scrolling enabled after append next page', function(assert) {
-    // arrange
+        // arrange
         const done = assert.async();
         const options = {
             items: [
@@ -6893,7 +6905,7 @@ QUnit.module('Scrollbar', {
         });
 
         rowsView.scrollChanged.add(function() {
-        // act, assert
+            // act, assert
             assert.deepEqual(rowsView.getTopVisibleRowData(), { field: 5 });
             done();
         });
@@ -6902,7 +6914,7 @@ QUnit.module('Scrollbar', {
     });
 
     QUnit.test('Get width of horizontal scrollbar when both scrollbars are shown', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ values: [1] }, { values: [2] }, { values: [3] }, { values: [4] }, { values: [5] }];
         const dataController = new MockDataController({
             items: rows
@@ -6928,7 +6940,7 @@ QUnit.module('Scrollbar', {
     QUnit.test('The vertical scrollbar should not be shown when there is a horizontal scrollbar', function(assert) {
         // arrange
         const rows = [{ values: ['test1', 'test2', 'test3', 'test4'] }];
-        const columns = [{ dataField: 'field1', width: 300 }, { dataField: 'field2', width: 300 }, { dataField: 'field3', width: 300 }, { dataField: 'field4', width: 300 } ];
+        const columns = [{ dataField: 'field1', width: 300 }, { dataField: 'field2', width: 300 }, { dataField: 'field3', width: 300 }, { dataField: 'field4', width: 300 }];
         const rowsView = this.createRowsView(rows, null, columns, null, { scrolling: { useNative: true } });
         const $testElement = $('#container').width(600);
 
@@ -6942,9 +6954,9 @@ QUnit.module('Scrollbar', {
     });
 
     if(browser.webkit) {
-    // T606935
+        // T606935
         QUnit.test('The vertical scrollbar should not be shown on 200 dpi screens', function(assert) {
-        // arrange
+            // arrange
             const rows = [{ values: ['test1', 'test2', 'test3', 'test4'], rowType: 'data' }];
             const columns = ['field1', 'field2', 'field3', 'field4'];
             const rowsView = this.createRowsView(rows, null, columns, null, { scrolling: { useNative: true } });
@@ -6966,7 +6978,7 @@ QUnit.module('Scrollbar', {
     }
 
     QUnit.test('The vertical scrollbar should not be shown if free space row rendered and showRowLines set false', function(assert) {
-    // arrange
+        // arrange
         const rows = [{ values: ['test1', 'test2', 'test3', 'test4'], rowType: 'data' }];
         const columns = ['field1', 'field2', 'field3', 'field4'];
         const rowsView = this.createRowsView(rows, null, columns, null, { scrolling: { useNative: true } });
@@ -7045,7 +7057,7 @@ QUnit.module('No data text', {
 }, () => {
 
     QUnit.test('noDataText container invisible when rowsView with data', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7065,7 +7077,7 @@ QUnit.module('No data text', {
     });
 
     QUnit.test('noDataText container visible when rowsView without data', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7084,7 +7096,7 @@ QUnit.module('No data text', {
     });
 
     QUnit.test('noDataText is visible after set height', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7103,7 +7115,7 @@ QUnit.module('No data text', {
     });
 
     QUnit.test('Update noDataText container', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const noDataText = 'Custom no data text';
         const rows = [{ values: [], data: { field: 1 } }];
@@ -7129,7 +7141,7 @@ QUnit.module('No data text', {
 
     // B252554
     QUnit.test('noDataText not visible when data is loading', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7170,7 +7182,7 @@ QUnit.module('Bottom Load Panel', {
 }, () => {
 
     QUnit.test('Not render bottom Load panel when no appendMode and virtual', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7191,7 +7203,7 @@ QUnit.module('Bottom Load Panel', {
     });
 
     QUnit.test('Bottom Load panel is visible when hasKnownLastPage is false and appendMode', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7214,7 +7226,7 @@ QUnit.module('Bottom Load Panel', {
     });
 
     QUnit.test('Bottom Load panel is visible when hasKnownLastPage is false and virtual scrolling enabled', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7241,7 +7253,7 @@ QUnit.module('Bottom Load Panel', {
     });
 
     QUnit.test('Bottom Load panel is not render when hasKnownLastPage is true', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7263,7 +7275,7 @@ QUnit.module('Bottom Load Panel', {
     });
 
     QUnit.test('Bottom Load panel is not visible when hasKnownLastPage changed to true from false', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const options = {
@@ -7290,7 +7302,7 @@ QUnit.module('Bottom Load Panel', {
 
     // T129917
     QUnit.test('loadPanel options', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7323,7 +7335,7 @@ QUnit.module('Bottom Load Panel', {
     });
 
     QUnit.test('Load Panel is not visible when Bottom Load Panel is visible and pageIndex is more then 0', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7353,7 +7365,7 @@ QUnit.module('Bottom Load Panel', {
 
     // T536324
     QUnit.test('Load Panel is visible when Bottom Load Panel is visible and pageIndex is 0', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7382,7 +7394,7 @@ QUnit.module('Bottom Load Panel', {
     });
 
     QUnit.test('Load Panel is visible and bottom load panel is not visible when data is not loaded', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7410,7 +7422,7 @@ QUnit.module('Bottom Load Panel', {
     });
 
     QUnit.test('Remove load panel when changing option loadPanel visible false', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7443,7 +7455,7 @@ QUnit.module('Bottom Load Panel', {
     });
 
     QUnit.test('Change option loadPanel', function(assert) {
-    // arrange
+        // arrange
         const container = $('#container');
         const rows = [{ values: [1], data: { field: 1 } }];
         const dataController = new MockDataController({
@@ -7510,7 +7522,7 @@ QUnit.module('Custom Loading', {
 }, () => {
 
     QUnit.test('Custom loading message', function(assert) {
-    // arrange
+        // arrange
         const that = this;
 
         that.setupDataGrid();
@@ -7523,7 +7535,7 @@ QUnit.module('Custom Loading', {
     });
 
     QUnit.test('Default loading message', function(assert) {
-    // arrange
+        // arrange
         const that = this;
 
         that.setupDataGrid();
@@ -7536,7 +7548,7 @@ QUnit.module('Custom Loading', {
     });
 
     QUnit.test('Change loading message from custom to default', function(assert) {
-    // arrange
+        // arrange
         const that = this;
 
         that.setupDataGrid();
@@ -7561,7 +7573,7 @@ QUnit.module('Custom Loading', {
     });
 
     QUnit.test('No animation when data is not loaded', function(assert) {
-    // arrange
+        // arrange
         const that = this;
 
         that.setupDataGrid();
@@ -7587,7 +7599,7 @@ QUnit.module('Custom Loading', {
 
     // T181609(rejected), T387788
     QUnit.test('Update loadPanel', function(assert) {
-    // arrange
+        // arrange
         const that = this;
         let $loadPanelElement;
         const rows = [{ values: [1], data: { field: 1 } }];
@@ -7636,6 +7648,49 @@ QUnit.module('Render templates with renderAsync and templatesRenderAsynchronousl
         this.clock.restore();
     }
 }, () => {
+    // T1138639
+    QUnit.test('Remove templateTimeout on dispose', function(assert) {
+        // arrange
+        assert.expect(1);
+
+        const items = [
+            { data: { name: 'test1', id: 1, date: new Date(2001, 0, 1) }, values: ['test1', null], rowType: 'data', dataIndex: 0 }
+        ];
+        const renderAsync = true;
+        const templatesRenderAsynchronously = true;
+        const $testElement = $('#container');
+        const column = {
+            name: 'test',
+            command: 'edit',
+            type: 'buttons',
+            buttons: [{
+                template: '#testTemplate'
+            }]
+        };
+        const columns = [{ dataField: 'name' }, column];
+        const rowsView = this.createRowsView(items, null, columns, null, { renderAsync, templatesRenderAsynchronously });
+        let isTemplateRendered = false;
+        columns[1] = $.extend({}, columns[1], column);
+        rowsView.component._getTemplate = function() {
+            return {
+                render: function(options) {
+                    setTimeout(() => {
+                        isTemplateRendered = true;
+                    }, 50);
+                }
+            };
+        };
+
+
+        // act
+        rowsView.render($testElement, { changeType: 'refresh' });
+        rowsView.dispose();
+        this.clock.tick(150);
+
+        // assert
+        assert.ok(!isTemplateRendered, 'should not render template after dispose');
+    });
+
     [true, false].forEach((templatesRenderAsynchronously) => {
         [true, false].forEach((renderAsync) => {
             ['cellTemplate', 'editCellTemplate', 'groupCellTemplate'].forEach((templateName) => {


### PR DESCRIPTION
Add clearTimeout into the dispose method for removing scheduled template processing
OnRender can be called then component disposed so add the _disposing flag check to prevent error.