### PR TITLE
Fix error of rendering components order in react strict mode

### DIFF
--- a/js/core/inferno_renderer.js
+++ b/js/core/inferno_renderer.js
@@ -9,7 +9,7 @@ const remove = (element) => {
     const { parentNode } = element;
 
     if(parentNode) {
-        const nextSibling = null; // element.nextSibling;
+        const nextSibling = element.nextSibling;
         cleanDataRecursive(element);
         parentNode.$V = element.$V;
         render(null, parentNode);

--- a/js/core/inferno_renderer.js
+++ b/js/core/inferno_renderer.js
@@ -9,10 +9,11 @@ const remove = (element) => {
     const { parentNode } = element;
 
     if(parentNode) {
+        const nextSibling = null; // element.nextSibling;
         cleanDataRecursive(element);
         parentNode.$V = element.$V;
         render(null, parentNode);
-        parentNode.appendChild(element);
+        parentNode.insertBefore(element, nextSibling);
         element.innerHTML = '';
         delete parentNode.$V;
     }

--- a/js/renovation/component_wrapper/common/__tests__/component.test.tsx
+++ b/js/renovation/component_wrapper/common/__tests__/component.test.tsx
@@ -438,16 +438,24 @@ describe('Widget\'s container manipulations', () => {
     expect($('#components').children().get(1)).toBe($('#component').get(0));
   });
 
-  it('component container should not change its position after repaint', () => {
+  it('component container should not change its position after recreating', () => {
     /* This test is also relevant when the component is used in <React.StrictMode> */
     const instance = $('#component').dxTestWidget({}).dxTestWidget('instance');
 
     $('#components').append($('<div>')).prepend($('<div>'));
 
-    // instance._isNodeReplaced = false;
-    console.log('---------dispose->', instance.dispose);
     instance.dispose();
     instance._initMarkup();
+
+    expect($('#components').children().get(1)).toBe($('#component').get(0));
+  });
+
+  it('component container should not change its position after repaint', () => {
+    const instance = $('#component').dxTestWidget({}).dxTestWidget('instance');
+
+    $('#components').append($('<div>')).prepend($('<div>'));
+
+    instance.repaint();
 
     expect($('#components').children().get(1)).toBe($('#component').get(0));
   });

--- a/js/renovation/component_wrapper/common/__tests__/component.test.tsx
+++ b/js/renovation/component_wrapper/common/__tests__/component.test.tsx
@@ -438,6 +438,20 @@ describe('Widget\'s container manipulations', () => {
     expect($('#components').children().get(1)).toBe($('#component').get(0));
   });
 
+  it('component container should not change its position after repaint', () => {
+    /* This test is also relevant when the component is used in <React.StrictMode> */
+    const instance = $('#component').dxTestWidget({}).dxTestWidget('instance');
+
+    $('#components').append($('<div>')).prepend($('<div>'));
+
+    // instance._isNodeReplaced = false;
+    console.log('---------dispose->', instance.dispose);
+    instance.dispose();
+    instance._initMarkup();
+
+    expect($('#components').children().get(1)).toBe($('#component').get(0));
+  });
+
   it('should be rendered not in "div" container', () => {
     document.body.innerHTML = `
       <div id="components">


### PR DESCRIPTION
This problem only affects renovated components (button, checkbox, pager)