### PR TITLE
R2 React: Fix issue with cached selectors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "scripts": {
         "build:angular": "nx build @devextreme/angular",
         "build:core": "nx build @devextreme/core",
+        "build:components": "nx build @devextreme/components",
         "build:react": "nx build @devextreme/react",
         "build:jquery": "nx build @devextreme/jquery",
         "build:playgrounds": "nx run-many --target=build --projects=@playgrounds/angular,@playgrounds/react",

--- a/packages/components/src/radio-group/index.ts
+++ b/packages/components/src/radio-group/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/exports-last */
 import {
+  createSelector,
   createStore,
   Selector,
   StateConfigMap,
@@ -40,7 +41,10 @@ export const RADIO_GROUP_ACTIONS = {
 export function createCheckedSelector<T>(
   value: T,
 ): Selector<RadioGroupState<T>, boolean> {
-  return (state) => state.value === value;
+  return createSelector(
+    (state) => ({ stateValue: state.value }),
+    ({ stateValue }) => stateValue === value,
+  );
 }
 
 // === component ===

--- a/packages/core/src/selector.ts
+++ b/packages/core/src/selector.ts
@@ -11,7 +11,7 @@ export function createSelector<
   >(
   paramsGetter: (state: TState) => TParam,
   buildViewProp: (params: TParam) => TValue,
-  paramsComparer: Comparer<[TParam]> = shallowComparer,
+  paramsComparer: Comparer<TParam> = shallowComparer,
 ): Selector<TState, TValue> {
   const cached = memoize(buildViewProp, paramsComparer);
 

--- a/packages/core/src/utils/__test__/memoize.test.ts
+++ b/packages/core/src/utils/__test__/memoize.test.ts
@@ -5,7 +5,7 @@ describe('memoize', () => {
     const spyFunc = jest.fn();
     const cachedFunc = memoize(spyFunc, () => true);
 
-    cachedFunc();
+    cachedFunc({});
 
     expect(spyFunc).toHaveBeenCalled();
   });
@@ -15,7 +15,7 @@ describe('memoize', () => {
     const spyComparer = jest.fn();
     const cachedFunc = memoize(spyFunc, spyComparer);
 
-    cachedFunc();
+    cachedFunc({});
 
     expect(spyComparer).not.toHaveBeenCalled();
   });
@@ -26,9 +26,9 @@ describe('memoize', () => {
     const spyComparer = jest.fn().mockReturnValue(true);
     const cachedFunc = memoize(spyFunc, spyComparer);
 
-    cachedFunc(...args);
-    cachedFunc(...args);
-    cachedFunc(...args);
+    cachedFunc(args);
+    cachedFunc(args);
+    cachedFunc(args);
 
     expect(spyFunc).toHaveBeenCalledTimes(1);
   });
@@ -39,8 +39,8 @@ describe('memoize', () => {
     const spyFunc = jest.fn();
     const cachedFunc = memoize(spyFunc, spyComparer);
 
-    cachedFunc(...args);
-    cachedFunc(...args);
+    cachedFunc(args);
+    cachedFunc(args);
 
     expect(spyFunc).toHaveBeenCalledTimes(2);
   });
@@ -51,10 +51,10 @@ describe('memoize', () => {
     const spyComparer = jest.fn();
     const cachedFunc = memoize(spyFunc, spyComparer);
 
-    cachedFunc(...args);
-    cachedFunc(...args);
-    cachedFunc(...args);
-    cachedFunc(...args);
+    cachedFunc(args);
+    cachedFunc(args);
+    cachedFunc(args);
+    cachedFunc(args);
 
     expect(spyComparer).toHaveBeenCalledTimes(3);
   });
@@ -65,8 +65,8 @@ describe('memoize', () => {
     const spyComparer = jest.fn().mockReturnValue(true);
     const cachedFunc = memoize(spyFunc, spyComparer);
 
-    const firstResult = cachedFunc(...args);
-    const secondResult = cachedFunc(...args);
+    const firstResult = cachedFunc(args);
+    const secondResult = cachedFunc(args);
 
     expect(firstResult).toBe(secondResult);
   });
@@ -77,8 +77,8 @@ describe('memoize', () => {
     const spyComparer = jest.fn().mockReturnValue(false);
     const cachedFunc = memoize(spyFunc, spyComparer);
 
-    const firstResult = cachedFunc(...args);
-    const secondResult = cachedFunc(...args);
+    const firstResult = cachedFunc(args);
+    const secondResult = cachedFunc(args);
 
     expect(firstResult).not.toBe(secondResult);
   });

--- a/packages/core/src/utils/memoize.ts
+++ b/packages/core/src/utils/memoize.ts
@@ -1,28 +1,28 @@
 import { Comparer } from './types';
 
-export function memoize<TArgs extends unknown[], TReturn>(
-  func: (...params: TArgs) => TReturn,
-  comparer: Comparer<TArgs>,
-): (...arg: TArgs) => TReturn {
-  let cachedArg: TArgs;
+export function memoize<TParams, TReturn>(
+  func: (params: TParams) => TReturn,
+  comparer: Comparer<TParams>,
+): (params: TParams) => TReturn {
+  let cachedParams: TParams;
   let cachedResult: TReturn;
 
-  const updateCache = (...args: TArgs) => {
-    cachedArg = args;
-    cachedResult = func(...args);
+  const updateCache = (params: TParams) => {
+    cachedParams = params;
+    cachedResult = func(params);
     return cachedResult;
   };
 
-  const getCachedResult = (...arg: TArgs) => (
-    comparer(cachedArg, arg)
+  const getCachedResult = (params: TParams) => (
+    comparer(cachedParams, params)
       ? cachedResult
-      : updateCache(...arg)
+      : updateCache(params)
   );
 
-  let decoratedFunc = (...arg: TArgs) => {
+  let decoratedFunc = (params: TParams) => {
     decoratedFunc = getCachedResult;
-    return updateCache(...arg);
+    return updateCache(params);
   };
 
-  return (...arg: TArgs) => decoratedFunc(...arg);
+  return (params: TParams) => decoratedFunc(params);
 }

--- a/packages/react/src/components/radio-button/radio-button-hocs.tsx
+++ b/packages/react/src/components/radio-button/radio-button-hocs.tsx
@@ -45,7 +45,7 @@ function withRadioGroup<T>(RadioButton: RadioButtonRenderType<T>) {
     value,
     ...props
   }: CoreBoundRadioButtonProps<T>) {
-    const checked = useStoreSelector(store, createCheckedSelector(value));
+    const checked = useStoreSelector(store, createCheckedSelector, [value]);
 
     const handleSelected = () => {
       props.onSelected?.(value);

--- a/packages/react/src/internal/hooks/use-store.ts
+++ b/packages/react/src/internal/hooks/use-store.ts
@@ -3,15 +3,18 @@ import {
   Store,
   UnknownRecord,
 } from '@devextreme/core';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 export function useStoreSelector<
   TState extends UnknownRecord,
   TValue,
+  TSelectorDeps extends unknown[],
   >(
   store: Store<TState>,
-  selector: Selector<TState, TValue>,
+  createSelector: (...params: TSelectorDeps) => Selector<TState, TValue>,
+  selectorDeps: TSelectorDeps,
 ): TValue {
+  const selector = useMemo(() => createSelector(...selectorDeps), selectorDeps);
   const [state, setState] = useState(selector(store.getState()));
 
   useEffect(() => store.subscribe((stateValue: TState) => {


### PR DESCRIPTION
Fixed issue with recreated each time cached selectors.
[Look to the origin comment about this issue](https://github.com/DevExpress/DevExtreme/pull/23775#discussion_r1090514168)