### PR TITLE
 R2 React: Add CSS class & styles forwarding

### DIFF
--- a/packages/react/src/compatible-components/radio-group/radio-group.tsx
+++ b/packages/react/src/compatible-components/radio-group/radio-group.tsx
@@ -42,6 +42,8 @@ export function RadioGroupCompatible<T>({
   itemComponent: ItemComponent,
   valueExpr,
   displayExpr,
+  className,
+  style,
   ...otherProps
 }: CompatibleRadioGroupProps<T>) {
   useCompatibleLifecycle(otherProps);
@@ -59,31 +61,35 @@ export function RadioGroupCompatible<T>({
     return getItemLabel(item);
   };
 
+  const cssStyle = {
+    ...style,
+    width: otherProps.width || '',
+    height: otherProps.height || '',
+  };
+
   return (
     (otherProps.visible ?? true)
       ? (
-        // NOTE: It's a temporary solution
-        // because style & class wasn't added to base component props yet.
-        <div style={{ width: otherProps.width, height: otherProps.height }}>
-          <RadioGroup<T>
-            {...otherProps}
-            shortcutKey={otherProps.accessKey}
-            onFocus={otherProps.onFocusIn}
-            onBlur={otherProps.onFocusOut}
-          >
-            {items.map((item, index) => {
-              const value = getItemValue(item);
-              const key = `${value}-${index}`;
-              return (
-                <RadioButton
-                  key={key}
-                  value={value}
-                  label={renderLabel(item, index)}
-                />
-              );
-            })}
-          </RadioGroup>
-        </div>
+        <RadioGroup<T>
+          {...otherProps}
+          className={className}
+          style={cssStyle}
+          shortcutKey={otherProps.accessKey}
+          onFocus={otherProps.onFocusIn}
+          onBlur={otherProps.onFocusOut}
+        >
+          {items.map((item, index) => {
+            const value = getItemValue(item);
+            const key = `${value}-${index}`;
+            return (
+              <RadioButton
+                key={key}
+                value={value}
+                label={renderLabel(item, index)}
+              />
+            );
+          })}
+        </RadioGroup>
       )
       : null
   );

--- a/packages/react/src/compatible-components/radio-group/radio-group.tsx
+++ b/packages/react/src/compatible-components/radio-group/radio-group.tsx
@@ -44,9 +44,9 @@ export function RadioGroupCompatible<T>({
   displayExpr,
   className,
   style,
-  ...otherProps
+  ...restProps
 }: CompatibleRadioGroupProps<T>) {
-  useCompatibleLifecycle(otherProps);
+  useCompatibleLifecycle(restProps);
 
   const getItemLabel = compileGetter(displayExpr || '') as LabelGetter;
   const getItemValue = compileGetter(valueExpr || '') as ValueGetter;
@@ -63,20 +63,20 @@ export function RadioGroupCompatible<T>({
 
   const cssStyle = {
     ...style,
-    width: otherProps.width || '',
-    height: otherProps.height || '',
+    width: restProps.width || '',
+    height: restProps.height || '',
   };
 
   return (
-    (otherProps.visible ?? true)
+    (restProps.visible ?? true)
       ? (
         <RadioGroup<T>
-          {...otherProps}
+          {...restProps}
           className={className}
           style={cssStyle}
-          shortcutKey={otherProps.accessKey}
-          onFocus={otherProps.onFocusIn}
-          onBlur={otherProps.onFocusOut}
+          shortcutKey={restProps.accessKey}
+          onFocus={restProps.onFocusIn}
+          onBlur={restProps.onFocusOut}
         >
           {items.map((item, index) => {
             const value = getItemValue(item);

--- a/packages/react/src/components/radio-group/radio-group.tsx
+++ b/packages/react/src/components/radio-group/radio-group.tsx
@@ -3,7 +3,11 @@ import {
   RADIO_GROUP_ACTIONS as ACTIONS,
   createContainerPropsSelector,
   createRadioGroupStore,
+<<<<<<< HEAD
   RADIO_GROUP_CONTAINER_PROPS_MAPPER as PROPS_MAPPERS,
+=======
+  RADIO_GROUP_CONTAINER_PROPS_BUILDER as PROP_MAPPER,
+>>>>>>> f9a364655e (R2 React RG: Complete compatible base widget functionality.)
 } from '@devextreme/components';
 import {
   Children,
@@ -47,7 +51,11 @@ function RadioGroupInternal<T>({ componentRef, ...props }: RadioGroupProps<T>) {
   const valueChange = useCallbackRef(props.valueChange);
 
   const store = useMemo(() => createRadioGroupStore<T>({
+<<<<<<< HEAD
     readonly: PROPS_MAPPERS.getDomOptions(props),
+=======
+    readonly: PROP_MAPPER.getDomOptions(props),
+>>>>>>> f9a364655e (R2 React RG: Complete compatible base widget functionality.)
     value: isValueControlled ? props.value : props.defaultValue,
   }, {
     value: {
@@ -64,7 +72,11 @@ function RadioGroupInternal<T>({ componentRef, ...props }: RadioGroupProps<T>) {
     }
   }, [props.value]);
 
+<<<<<<< HEAD
   const readonlyValues = PROPS_MAPPERS.getDomOptions(props);
+=======
+  const readonlyValues = PROP_MAPPER.getDomOptions(props);
+>>>>>>> f9a364655e (R2 React RG: Complete compatible base widget functionality.)
   useSecondEffect(() => {
     store.addUpdate(ACTIONS.updateReadonly(readonlyValues));
   }, [...Object.values(readonlyValues)]);

--- a/packages/react/src/components/radio-group/radio-group.tsx
+++ b/packages/react/src/components/radio-group/radio-group.tsx
@@ -17,10 +17,18 @@ import {
   useRef,
 } from 'react';
 import {
-  useCallbackRef, useCustomComponentRef, useSecondEffect, useStoreSelector,
+  useCallbackRef,
+  useCustomComponentRef,
+  useSecondEffect,
+  useStoreSelector,
 } from '../../internal/hooks';
-import { EditorProps, FocusableProps, WithCustomRef } from '../../internal/props';
-import { withEditor } from '../common/hocs/with-editor';
+import {
+  CssForwardProps,
+  EditorProps,
+  FocusableProps,
+  WithCustomRef,
+} from '../../internal/props';
+import { withEditor } from '../common';
 import { RadioGroupStoreContext } from '../radio-common';
 
 import '@devextreme/styles/src/radio-group/radio-group.scss';
@@ -29,7 +37,7 @@ export type RadioGroupRef = {
   focus(options?: FocusOptions): void,
 };
 
-function RadioGroupInternal<T>({ componentRef, ...props }: RadioGroupProps<T>) {
+function RadioGroupInternal<T>({ componentRef, ...props }: RadioGroupProps<T>): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
 
   // NOTE: Workaround for the useImperativeHandler hook.
@@ -77,7 +85,8 @@ function RadioGroupInternal<T>({ componentRef, ...props }: RadioGroupProps<T>) {
     <RadioGroupStoreContext.Provider value={store}>
       <div
         ref={containerRef}
-        className={`dxr-radio-group ${containerProps.cssClass.join(' ')}`}
+        className={`dxr-radio-group ${containerProps.cssClass.join(' ')} ${props.className ?? ''}`}
+        style={props.style ?? {}}
         {...containerProps.attributes}
         onFocus={props.onFocus}
         onBlur={props.onBlur}
@@ -102,6 +111,7 @@ const RadioGroupEditor = withEditor(forwardRef(RadioGroupInternal));
 export type RadioGroupProps<T> = PropsWithChildren<
 EditorProps<T>
 & FocusableProps
+& CssForwardProps
 & WithCustomRef<RadioGroupRef>
 >;
 type RadioGroupType = <T>(p: RadioGroupProps<T> & { ref?: Ref<HTMLDivElement> }) => JSX.Element;

--- a/packages/react/src/components/radio-group/radio-group.tsx
+++ b/packages/react/src/components/radio-group/radio-group.tsx
@@ -3,11 +3,7 @@ import {
   RADIO_GROUP_ACTIONS as ACTIONS,
   createContainerPropsSelector,
   createRadioGroupStore,
-<<<<<<< HEAD
   RADIO_GROUP_CONTAINER_PROPS_MAPPER as PROPS_MAPPERS,
-=======
-  RADIO_GROUP_CONTAINER_PROPS_BUILDER as PROP_MAPPER,
->>>>>>> f9a364655e (R2 React RG: Complete compatible base widget functionality.)
 } from '@devextreme/components';
 import {
   Children,
@@ -51,11 +47,7 @@ function RadioGroupInternal<T>({ componentRef, ...props }: RadioGroupProps<T>) {
   const valueChange = useCallbackRef(props.valueChange);
 
   const store = useMemo(() => createRadioGroupStore<T>({
-<<<<<<< HEAD
     readonly: PROPS_MAPPERS.getDomOptions(props),
-=======
-    readonly: PROP_MAPPER.getDomOptions(props),
->>>>>>> f9a364655e (R2 React RG: Complete compatible base widget functionality.)
     value: isValueControlled ? props.value : props.defaultValue,
   }, {
     value: {
@@ -72,11 +64,7 @@ function RadioGroupInternal<T>({ componentRef, ...props }: RadioGroupProps<T>) {
     }
   }, [props.value]);
 
-<<<<<<< HEAD
   const readonlyValues = PROPS_MAPPERS.getDomOptions(props);
-=======
-  const readonlyValues = PROP_MAPPER.getDomOptions(props);
->>>>>>> f9a364655e (R2 React RG: Complete compatible base widget functionality.)
   useSecondEffect(() => {
     store.addUpdate(ACTIONS.updateReadonly(readonlyValues));
   }, [...Object.values(readonlyValues)]);

--- a/packages/react/src/internal/props.ts
+++ b/packages/react/src/internal/props.ts
@@ -37,6 +37,11 @@ export type WithCustomRef<TRef> = {
   componentRef?: RefObject<TRef>;
 };
 
+export type CssForwardProps = {
+  className?: string;
+  style?: Record<string, string>;
+};
+
 // --- compat ---
 export type CompatibleOmittedProps = keyof FocusablePropsCompatible
 & RootContainerDomOptions['accessKey'];

--- a/playgrounds/react/src/examples/radio-group-compatible/radio-group-compatible-controlled-playground.tsx
+++ b/playgrounds/react/src/examples/radio-group-compatible/radio-group-compatible-controlled-playground.tsx
@@ -1,5 +1,7 @@
 import { RadioGroupCompatible, RadioGroupRef } from '@devextreme/react';
-import { ChangeEvent, useReducer, useRef } from 'react';
+import {
+  ChangeEvent, useMemo, useReducer, useRef,
+} from 'react';
 
 interface PlaygroundBtnData {
   value: string;
@@ -14,6 +16,8 @@ interface PlaygroundBaseDomSettings {
   accessKey: string;
   disabled: boolean;
   hint?: string;
+  cssClass?: string;
+  cssStyles: Record<string, string>;
   width?: string;
   height?: string;
   logOnLifecycle: boolean;
@@ -38,6 +42,8 @@ type Actions =
   | { type: 'setAccessKey', accessKey: string }
   | { type: 'setDisabled', disabled: boolean }
   | { type: 'setHint', hint?: string }
+  | { type: 'setCssClass', cssClass?: string }
+  | { type: 'setCssStylesJson', cssStylesJson: string }
   | { type: 'setWidth', width?: string }
   | { type: 'setHeight', height?: string }
   | { type: 'setLogOnLifecycle', enabled: boolean }
@@ -47,6 +53,29 @@ type Actions =
   | { type: 'removeButton' }
   | { type: 'addButton' }
   | { type: 'setComponentMounted', mounted: boolean; };
+
+function setCssStylesJson(
+  state: PlaygroundState,
+  json: string,
+): PlaygroundState {
+  let styles: string | Record<string, string> = {};
+
+  try {
+    styles = JSON.parse(json);
+    styles = typeof styles === 'string' ? {} : styles;
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn(`Invalid css styles: ${json}`);
+  }
+
+  return {
+    ...state,
+    baseSettings: {
+      ...state.baseSettings,
+      cssStyles: styles as Record<string, string>,
+    },
+  };
+}
 
 function playgroundReducer(
   state: PlaygroundState,
@@ -71,6 +100,10 @@ function playgroundReducer(
       return { ...state, baseSettings: { ...state.baseSettings, disabled: action.disabled } };
     case 'setHint':
       return { ...state, baseSettings: { ...state.baseSettings, hint: action.hint } };
+    case 'setCssClass':
+      return { ...state, baseSettings: { ...state.baseSettings, cssClass: action.cssClass } };
+    case 'setCssStylesJson':
+      return setCssStylesJson(state, action.cssStylesJson);
     case 'setWidth':
       return { ...state, baseSettings: { ...state.baseSettings, width: action.width } };
     case 'setHeight':
@@ -138,6 +171,8 @@ export function RadioGroupCompatibleControlledPlayground() {
       accessKey: 'a',
       disabled: false,
       hint: 'Hello!',
+      cssClass: 'example-css-class',
+      cssStyles: { display: 'block' },
       width: '',
       height: '',
       logOnLifecycle: false,
@@ -150,6 +185,11 @@ export function RadioGroupCompatibleControlledPlayground() {
   const onInitialized = () => { state.baseSettings.logOnLifecycle && console.log('onInitialized'); };
   const onDisposing = () => { state.baseSettings.logOnLifecycle && console.log('onDisposing'); };
   /* eslint-enable @typescript-eslint/no-unused-expressions, no-alert */
+
+  const cssStylesString = useMemo(
+    () => JSON.stringify(state.baseSettings.cssStyles),
+    [],
+  );
 
   return (
     <div className="example">
@@ -175,6 +215,8 @@ export function RadioGroupCompatibleControlledPlayground() {
                   activeStateEnabled={state.baseSettings.activeCss}
                   disabled={state.baseSettings.disabled}
                   hint={state.baseSettings.hint}
+                  className={state.baseSettings.cssClass}
+                  style={state.baseSettings.cssStyles}
                   // compatible options
                   accessKey={state.baseSettings.accessKey}
                   width={state.baseSettings.width}
@@ -357,7 +399,31 @@ export function RadioGroupCompatibleControlledPlayground() {
           />
         </span>
       </div>
+      <div className="example__play-part">
+        <span className="example__block">
+          <span>CSS classes:</span>
+          <input
+            type="text"
+            className="example-input"
+            value={state.baseSettings.cssClass}
+            onChange={(
+              event: ChangeEvent<HTMLInputElement>,
+            ) => { dispatch({ type: 'setCssClass', cssClass: event?.target?.value }); }}
+          />
+          <span>CSS styles JSON:</span>
+          <input
+            type="text"
+            className="example-input"
+            defaultValue={cssStylesString}
+            onBlur={(
+              event: ChangeEvent<HTMLInputElement>,
+            ) => { dispatch({ type: 'setCssStylesJson', cssStylesJson: event?.target?.value }); }}
+          />
+        </span>
+      </div>
+
       <h4> Compatible options </h4>
+
       <div className="example__play-part">
         <div className="example__play-part">
           <span className="example__block">

--- a/playgrounds/react/src/examples/radio-group-compatible/radio-group-compatible-uncontrolled-playground.tsx
+++ b/playgrounds/react/src/examples/radio-group-compatible/radio-group-compatible-uncontrolled-playground.tsx
@@ -135,7 +135,7 @@ export function RadioGroupCompatibleUncontrolledPlayground() {
       tabIndex: 0,
       hoverCss: true,
       activeCss: true,
-      accessKey: 'b',
+      accessKey: 'a',
       disabled: false,
       hint: 'Hello!',
       width: '',

--- a/playgrounds/react/src/examples/radio-group-compatible/radio-group-compatible-uncontrolled-playground.tsx
+++ b/playgrounds/react/src/examples/radio-group-compatible/radio-group-compatible-uncontrolled-playground.tsx
@@ -1,5 +1,7 @@
 import { RadioGroupCompatible, RadioGroupRef } from '@devextreme/react';
-import { ChangeEvent, useReducer, useRef } from 'react';
+import {
+  ChangeEvent, useMemo, useReducer, useRef,
+} from 'react';
 
 interface PlaygroundBtnData {
   value: string;
@@ -14,6 +16,8 @@ interface PlaygroundBaseDomSettings {
   accessKey: string;
   disabled: boolean;
   hint?: string;
+  cssClass?: string;
+  cssStyles: Record<string, string>;
   width?: string;
   height?: string;
   logOnLifecycle: boolean;
@@ -38,6 +42,8 @@ type Actions =
   | { type: 'setAccessKey', accessKey: string }
   | { type: 'setDisabled', disabled: boolean }
   | { type: 'setHint', hint?: string }
+  | { type: 'setCssClass', cssClass?: string }
+  | { type: 'setCssStylesJson', cssStylesJson: string }
   | { type: 'setWidth', width?: string }
   | { type: 'setHeight', height?: string }
   | { type: 'setLogOnLifecycle', enabled: boolean }
@@ -47,6 +53,29 @@ type Actions =
   | { type: 'removeButton' }
   | { type: 'addButton' }
   | { type: 'setComponentMounted', mounted: boolean; };
+
+function setCssStylesJson(
+  state: PlaygroundState,
+  json: string,
+): PlaygroundState {
+  let styles: string | Record<string, string> = {};
+
+  try {
+    styles = JSON.parse(json);
+    styles = typeof styles === 'string' ? {} : styles;
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn(`Invalid css styles: ${json}`);
+  }
+
+  return {
+    ...state,
+    baseSettings: {
+      ...state.baseSettings,
+      cssStyles: styles as Record<string, string>,
+    },
+  };
+}
 
 function playgroundReducer(
   state: PlaygroundState,
@@ -71,6 +100,10 @@ function playgroundReducer(
       return { ...state, baseSettings: { ...state.baseSettings, disabled: action.disabled } };
     case 'setHint':
       return { ...state, baseSettings: { ...state.baseSettings, hint: action.hint } };
+    case 'setCssClass':
+      return { ...state, baseSettings: { ...state.baseSettings, cssClass: action.cssClass } };
+    case 'setCssStylesJson':
+      return setCssStylesJson(state, action.cssStylesJson);
     case 'setWidth':
       return { ...state, baseSettings: { ...state.baseSettings, width: action.width } };
     case 'setHeight':
@@ -138,6 +171,8 @@ export function RadioGroupCompatibleUncontrolledPlayground() {
       accessKey: 'a',
       disabled: false,
       hint: 'Hello!',
+      cssClass: 'example-css-class',
+      cssStyles: { display: 'block' },
       width: '',
       height: '',
       logOnLifecycle: false,
@@ -150,6 +185,11 @@ export function RadioGroupCompatibleUncontrolledPlayground() {
   const onInitialized = () => { state.baseSettings.logOnLifecycle && console.log('onInitialized'); };
   const onDisposing = () => { state.baseSettings.logOnLifecycle && console.log('onDisposing'); };
   /* eslint-enable @typescript-eslint/no-unused-expressions, no-alert */
+
+  const cssStylesString = useMemo(
+    () => JSON.stringify(state.baseSettings.cssStyles),
+    [],
+  );
 
   return (
     <div className="example">
@@ -175,6 +215,8 @@ export function RadioGroupCompatibleUncontrolledPlayground() {
                   activeStateEnabled={state.baseSettings.activeCss}
                   disabled={state.baseSettings.disabled}
                   hint={state.baseSettings.hint}
+                  className={state.baseSettings.cssClass}
+                  style={state.baseSettings.cssStyles}
                   // compatible options
                   accessKey={state.baseSettings.accessKey}
                   width={state.baseSettings.width}
@@ -350,7 +392,31 @@ export function RadioGroupCompatibleUncontrolledPlayground() {
           />
         </span>
       </div>
+      <div className="example__play-part">
+        <span className="example__block">
+          <span>CSS classes:</span>
+          <input
+            type="text"
+            className="example-input"
+            value={state.baseSettings.cssClass}
+            onChange={(
+              event: ChangeEvent<HTMLInputElement>,
+            ) => { dispatch({ type: 'setCssClass', cssClass: event?.target?.value }); }}
+          />
+          <span>CSS styles JSON:</span>
+          <input
+            type="text"
+            className="example-input"
+            defaultValue={cssStylesString}
+            onBlur={(
+              event: ChangeEvent<HTMLInputElement>,
+            ) => { dispatch({ type: 'setCssStylesJson', cssStylesJson: event?.target?.value }); }}
+          />
+        </span>
+      </div>
+
       <h4> Compatible options </h4>
+
       <div className="example__play-part">
         <div className="example__play-part">
           <span className="example__block">

--- a/playgrounds/react/src/examples/radio-group-compatible/radio-group-compatible-uncontrolled-playground.tsx
+++ b/playgrounds/react/src/examples/radio-group-compatible/radio-group-compatible-uncontrolled-playground.tsx
@@ -135,7 +135,7 @@ export function RadioGroupCompatibleUncontrolledPlayground() {
       tabIndex: 0,
       hoverCss: true,
       activeCss: true,
-      accessKey: 'a',
+      accessKey: 'b',
       disabled: false,
       hint: 'Hello!',
       width: '',

--- a/playgrounds/react/src/examples/radio-group/radio-group-controlled-playground.tsx
+++ b/playgrounds/react/src/examples/radio-group/radio-group-controlled-playground.tsx
@@ -1,5 +1,7 @@
 import { RadioButton, RadioGroup, RadioGroupRef } from '@devextreme/react';
-import { ChangeEvent, useReducer, useRef } from 'react';
+import {
+  ChangeEvent, useMemo, useReducer, useRef,
+} from 'react';
 
 interface PlaygroundBtnData {
   value: string;
@@ -14,6 +16,8 @@ interface PlaygroundBaseDomSettings {
   accessKey: string;
   disabled: boolean;
   hint?: string;
+  cssClass?: string;
+  cssStyles: Record<string, string>;
 }
 
 interface PlaygroundState {
@@ -33,10 +37,35 @@ type Actions =
   | { type: 'setAccessKey', accessKey: string }
   | { type: 'setDisabled', disabled: boolean }
   | { type: 'setHint', hint?: string }
+  | { type: 'setCssClass', cssClass?: string }
+  | { type: 'setCssStylesJson', cssStylesJson: string }
   | { type: 'setButtonLabel', idx: number, label?: string }
   | { type: 'setButtonValue', idx: number, value?: string }
   | { type: 'removeButton' }
   | { type: 'addButton' };
+
+function setCssStylesJson(
+  state: PlaygroundState,
+  json: string,
+): PlaygroundState {
+  let styles: string | Record<string, string> = {};
+
+  try {
+    styles = JSON.parse(json);
+    styles = typeof styles === 'string' ? {} : styles;
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn(`Invalid css styles: ${json}`);
+  }
+
+  return {
+    ...state,
+    baseSettings: {
+      ...state.baseSettings,
+      cssStyles: styles as Record<string, string>,
+    },
+  };
+}
 
 function playgroundReducer(
   state: PlaygroundState,
@@ -61,6 +90,10 @@ function playgroundReducer(
       return { ...state, baseSettings: { ...state.baseSettings, disabled: action.disabled } };
     case 'setHint':
       return { ...state, baseSettings: { ...state.baseSettings, hint: action.hint } };
+    case 'setCssClass':
+      return { ...state, baseSettings: { ...state.baseSettings, cssClass: action.cssClass } };
+    case 'setCssStylesJson':
+      return setCssStylesJson(state, action.cssStylesJson);
     case 'setButtonLabel':
       return {
         ...state,
@@ -114,8 +147,15 @@ export function RadioGroupControlledPlayground() {
       accessKey: 'a',
       disabled: false,
       hint: 'Hello!',
+      cssClass: 'example-css-class',
+      cssStyles: { display: 'block' },
     },
   });
+
+  const cssStylesString = useMemo(
+    () => JSON.stringify(state.baseSettings.cssStyles),
+    [],
+  );
 
   return (
     <div className="example">
@@ -135,6 +175,8 @@ export function RadioGroupControlledPlayground() {
             shortcutKey={state.baseSettings.accessKey}
             disabled={state.baseSettings.disabled}
             hint={state.baseSettings.hint}
+            className={state.baseSettings.cssClass}
+            style={state.baseSettings.cssStyles}
             onFocus={() => dispatch({ type: 'setFocus', focused: true })}
             onBlur={() => dispatch({ type: 'setFocus', focused: false })}
           >
@@ -298,6 +340,28 @@ export function RadioGroupControlledPlayground() {
             onChange={(
               event: ChangeEvent<HTMLInputElement>,
             ) => { dispatch({ type: 'setHint', hint: event?.target?.value }); }}
+          />
+        </span>
+      </div>
+      <div className="example__play-part">
+        <span className="example__block">
+          <span>CSS classes:</span>
+          <input
+            type="text"
+            className="example-input"
+            value={state.baseSettings.cssClass}
+            onChange={(
+              event: ChangeEvent<HTMLInputElement>,
+            ) => { dispatch({ type: 'setCssClass', cssClass: event?.target?.value }); }}
+          />
+          <span>CSS styles JSON:</span>
+          <input
+            type="text"
+            className="example-input"
+            defaultValue={cssStylesString}
+            onBlur={(
+              event: ChangeEvent<HTMLInputElement>,
+            ) => { dispatch({ type: 'setCssStylesJson', cssStylesJson: event?.target?.value }); }}
           />
         </span>
       </div>

--- a/playgrounds/react/src/examples/radio-group/radio-group-uncontrolled-playgorund.tsx
+++ b/playgrounds/react/src/examples/radio-group/radio-group-uncontrolled-playgorund.tsx
@@ -169,6 +169,7 @@ export function RadioGroupUncontrolledPlayground() {
             defaultValue={state.groupValue}
             valueChange={(groupValue) => { dispatch({ type: 'setValue', groupValue }); }}
             focusStateEnabled={state.baseSettings.focusCss}
+            tabIndex={state.baseSettings.tabIndex}
             hoverStateEnabled={state.baseSettings.hoverCss}
             activeStateEnabled={state.baseSettings.activeCss}
             shortcutKey={state.baseSettings.accessKey}

--- a/playgrounds/react/src/examples/radio-group/radio-group-uncontrolled-playgorund.tsx
+++ b/playgrounds/react/src/examples/radio-group/radio-group-uncontrolled-playgorund.tsx
@@ -1,5 +1,7 @@
 import { RadioButton, RadioGroup, RadioGroupRef } from '@devextreme/react';
-import { ChangeEvent, useReducer, useRef } from 'react';
+import {
+  ChangeEvent, useMemo, useReducer, useRef,
+} from 'react';
 
 interface PlaygroundBtnData {
   value: string;
@@ -14,6 +16,8 @@ interface PlaygroundBaseDomSettings {
   accessKey: string;
   disabled: boolean;
   hint?: string;
+  cssClass?: string;
+  cssStyles: Record<string, string>;
 }
 
 interface PlaygroundState {
@@ -33,10 +37,35 @@ type Actions =
   | { type: 'setAccessKey', accessKey: string }
   | { type: 'setDisabled', disabled: boolean }
   | { type: 'setHint', hint?: string }
+  | { type: 'setCssClass', cssClass?: string }
+  | { type: 'setCssStylesJson', cssStylesJson: string }
   | { type: 'setButtonLabel', idx: number, label?: string }
   | { type: 'setButtonValue', idx: number, value?: string }
   | { type: 'removeButton' }
   | { type: 'addButton' };
+
+function setCssStylesJson(
+  state: PlaygroundState,
+  json: string,
+): PlaygroundState {
+  let styles: string | Record<string, string> = {};
+
+  try {
+    styles = JSON.parse(json);
+    styles = typeof styles === 'string' ? {} : styles;
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn(`Invalid css styles: ${json}`);
+  }
+
+  return {
+    ...state,
+    baseSettings: {
+      ...state.baseSettings,
+      cssStyles: styles as Record<string, string>,
+    },
+  };
+}
 
 function playgroundReducer(
   state: PlaygroundState,
@@ -61,6 +90,10 @@ function playgroundReducer(
       return { ...state, baseSettings: { ...state.baseSettings, disabled: action.disabled } };
     case 'setHint':
       return { ...state, baseSettings: { ...state.baseSettings, hint: action.hint } };
+    case 'setCssClass':
+      return { ...state, baseSettings: { ...state.baseSettings, cssClass: action.cssClass } };
+    case 'setCssStylesJson':
+      return setCssStylesJson(state, action.cssStylesJson);
     case 'setButtonLabel':
       return {
         ...state,
@@ -114,8 +147,15 @@ export function RadioGroupUncontrolledPlayground() {
       accessKey: 'b',
       disabled: false,
       hint: 'Hello!',
+      cssClass: 'example-css-class',
+      cssStyles: { display: 'block' },
     },
   });
+
+  const cssStylesString = useMemo(
+    () => JSON.stringify(state.baseSettings.cssStyles),
+    [],
+  );
 
   return (
     <div className="example">
@@ -134,6 +174,8 @@ export function RadioGroupUncontrolledPlayground() {
             shortcutKey={state.baseSettings.accessKey}
             disabled={state.baseSettings.disabled}
             hint={state.baseSettings.hint}
+            className={state.baseSettings.cssClass}
+            style={state.baseSettings.cssStyles}
             onFocus={() => dispatch({ type: 'setFocus', focused: true })}
             onBlur={() => dispatch({ type: 'setFocus', focused: false })}
           >
@@ -290,6 +332,28 @@ export function RadioGroupUncontrolledPlayground() {
             onChange={(
               event: ChangeEvent<HTMLInputElement>,
             ) => { dispatch({ type: 'setHint', hint: event?.target?.value }); }}
+          />
+        </span>
+      </div>
+      <div className="example__play-part">
+        <span className="example__block">
+          <span>CSS classes:</span>
+          <input
+            type="text"
+            className="example-input"
+            value={state.baseSettings.cssClass}
+            onChange={(
+              event: ChangeEvent<HTMLInputElement>,
+            ) => { dispatch({ type: 'setCssClass', cssClass: event?.target?.value }); }}
+          />
+          <span>CSS styles JSON:</span>
+          <input
+            type="text"
+            className="example-input"
+            defaultValue={cssStylesString}
+            onBlur={(
+              event: ChangeEvent<HTMLInputElement>,
+            ) => { dispatch({ type: 'setCssStylesJson', cssStylesJson: event?.target?.value }); }}
           />
         </span>
       </div>


### PR DESCRIPTION
Forwarding of CSS className and inline styles added.
Because in the origin widgets, we have the ```cssClass``` option that forwards class names.