### PR TITLE
DataGrid - Columns have incorrect width on the first render after updating from 22.1.4 to 22.1.6 if renderAsync and columnAutoWidth are set to "true" (T1126234)

### DIFF
--- a/js/ui/data_grid/ui.data_grid.summary.js
+++ b/js/ui/data_grid/ui.data_grid.summary.js
@@ -99,7 +99,7 @@ export const FooterView = ColumnsView.inherit((function() {
 
         _updateContent: function($newTable, change) {
             if(change && change.changeType === 'update' && change.columnIndices) {
-                return this._waitAsyncTemplates(change).done(() => {
+                return this.waitAsyncTemplates(change).done(() => {
                     const $row = this.getTableElement().find('.dx-row');
                     const $newRow = $newTable.find('.dx-row');
 

--- a/js/ui/grid_core/ui.grid_core.columns_view.js
+++ b/js/ui/grid_core/ui.grid_core.columns_view.js
@@ -397,7 +397,7 @@ export const ColumnsView = modules.View.inherit(columnStateMixin).inherit({
 
             const options = templateParameters.options;
             const doc = domAdapter.getDocument();
-            const needWaitAsyncTemplates = this._needWaitAsyncTemplates();
+            const needWaitAsyncTemplates = this.needWaitAsyncTemplates();
 
             if(!isAsync || $(options.container).closest(doc).length || needWaitAsyncTemplates) {
                 if(change) {
@@ -886,19 +886,19 @@ export const ColumnsView = modules.View.inherit(columnStateMixin).inherit({
         return $scrollContainer;
     },
 
-    _needWaitAsyncTemplates: function() {
+    needWaitAsyncTemplates: function() {
         return this.option('templatesRenderAsynchronously') && this.option('renderAsync') === false;
     },
 
-    _waitAsyncTemplates: function(change, forceWaiting) {
-        const needWaitAsyncTemplates = this._needWaitAsyncTemplates();
-        const templateDeferreds = (forceWaiting || needWaitAsyncTemplates && (change?.changeType !== 'update' || change?.isLiveUpdate)) && change?.templateDeferreds ? change?.templateDeferreds : [];
+    waitAsyncTemplates: function(change, forceWaiting) {
+        const needWaitAsyncTemplates = this.needWaitAsyncTemplates();
+        const templateDeferreds = (forceWaiting || needWaitAsyncTemplates && (change?.changeType !== 'update' || change?.isLiveUpdate || change.isMasterDetail)) && change?.templateDeferreds ? change?.templateDeferreds : [];
 
         return when.apply(this, templateDeferreds);
     },
 
     _updateContent: function($newTableElement, change) {
-        return this._waitAsyncTemplates(change).done(() => {
+        return this.waitAsyncTemplates(change).done(() => {
             this.setTableElement($newTableElement);
             this._wrapTableInScrollContainer($newTableElement);
         });

--- a/js/ui/grid_core/ui.grid_core.editing.js
+++ b/js/ui/grid_core/ui.grid_core.editing.js
@@ -2563,7 +2563,7 @@ export const editingModule = {
                 _renderCore: function(change) {
                     this.callBase.apply(this, arguments);
 
-                    this._waitAsyncTemplates(change, true).done(() => {
+                    this.waitAsyncTemplates(change, true).done(() => {
                         this._editingController._focusEditorIfNeed();
                     });
                 }

--- a/js/ui/grid_core/ui.grid_core.grid_view.js
+++ b/js/ui/grid_core/ui.grid_core.grid_view.js
@@ -64,8 +64,7 @@ const ResizingController = modules.ViewController.inherit({
             this._refreshSizesHandler = (e) => {
                 dataController.changed.remove(this._refreshSizesHandler);
 
-                const templateDeferreds = e && e.templateDeferreds || [];
-                when.apply(this, templateDeferreds).done(() => {
+                this._rowsView.waitAsyncTemplates(e).done(() => {
                     this._refreshSizes(e);
                 });
             };

--- a/js/ui/grid_core/ui.grid_core.master_detail.js
+++ b/js/ui/grid_core/ui.grid_core.master_detail.js
@@ -105,7 +105,8 @@ export const masterDetailModule = {
 
                             that.updateItems({
                                 changeType: 'update',
-                                rowIndices: that._getRowIndicesForExpand(key)
+                                rowIndices: that._getRowIndicesForExpand(key),
+                                isMasterDetail: true,
                             });
 
                             result = new Deferred().resolve();

--- a/js/ui/grid_core/ui.grid_core.rows.js
+++ b/js/ui/grid_core/ui.grid_core.rows.js
@@ -300,7 +300,7 @@ export const rowsModule = {
                 },
 
                 _updateContent: function(newTableElement, change) {
-                    return this._waitAsyncTemplates(change).done(() => {
+                    return this.waitAsyncTemplates(change).done(() => {
                         const tableElement = this.getTableElement();
                         const contentElement = this._findContentElement();
                         const changeType = change && change.changeType;

--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -430,7 +430,7 @@ const VirtualScrollingRowsViewExtender = (function() {
         },
 
         renderDelayedTemplates: function(e) {
-            this._waitAsyncTemplates(e).done(() => {
+            this.waitAsyncTemplates(e).done(() => {
                 this._updateContentPosition(true);
             });
             this.callBase.apply(this, arguments);
@@ -485,7 +485,7 @@ const VirtualScrollingRowsViewExtender = (function() {
 
             const contentTable = contentElement.children().first();
             if(changeType === 'append' || changeType === 'prepend') {
-                this._waitAsyncTemplates(change).done(() => {
+                this.waitAsyncTemplates(change).done(() => {
                     const $tBodies = this._getBodies(tableElement);
                     if($tBodies.length === 1) {
                         this._getBodies(contentTable)[changeType === 'append' ? 'append' : 'prepend']($tBodies.children());

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -1343,11 +1343,12 @@ QUnit.module('Async render', baseModuleConfig, () => {
         assert.equal($(dataGrid.getCellElement(0, 0)).text(), 'Test\u00A0', 'template is applied');
     });
 
-    QUnit.test('Column auto width should be calculated after cell is rendered', function(assert) {
+    QUnit.test('Column auto width should be calculated after cell is rendered in react', function(assert) {
         const dataGrid = createDataGrid({
             dataSource: [{ id: 1 }],
             columnAutoWidth: true,
             width: 500,
+            templatesRenderAsynchronously: true,
             columns: ['column1', {
                 dataField: 'id',
                 renderAsync: true,
@@ -1423,6 +1424,35 @@ QUnit.module('Async render', baseModuleConfig, () => {
         assert.equal(cellTemplateArgs.length, 1, 'cell template is called');
         assert.equal(cellTemplateArgs[0].rowType, 'data', 'cell template rowType');
         assert.equal(cellTemplateArgs[0].column.dataField, 'template', 'cell template column');
+    });
+
+    // T1126234
+    QUnit.test('component should resize on first render without async if renderAsync = true', function(assert) {
+        // act
+        const grid = createDataGrid({
+            dataSource: [{ id: 1 }],
+            filterRow: {
+                visible: true
+            },
+            renderAsync: true,
+            columns: ['id'],
+            selection: {
+                mode: 'multiple',
+            }
+        });
+
+        const resizingController = grid.getController('resizing');
+        const refreshSizes = sinon.spy(resizingController, '_refreshSizes');
+        const originalHandler = resizingController._refreshSizesHandler;
+        resizingController._refreshSizesHandler = function() {
+            originalHandler.apply(this, arguments);
+
+            // assert
+            assert.deepEqual(refreshSizes.callCount, 1, 'resize is called immediately'); 1;
+        };
+
+        // act
+        this.clock.tick();
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -1349,6 +1349,7 @@ QUnit.module('Async render', baseModuleConfig, () => {
             columnAutoWidth: true,
             width: 500,
             templatesRenderAsynchronously: true,
+            renderAsync: false,
             columns: ['column1', {
                 dataField: 'id',
                 renderAsync: true,
@@ -4575,6 +4576,7 @@ QUnit.module('templates', baseModuleConfig, () => {
                 columns: ['text'],
                 dataRowTemplate: 'rowTemplate',
                 templatesRenderAsynchronously: true,
+                renderAsync: false,
                 integrationOptions: {
                     templates: {
                         rowTemplate: {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -319,6 +319,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 },
             ],
             templatesRenderAsynchronously: true,
+            renderAsync: false,
             integrationOptions: {
                 templates: {
                     buttonTemplate: {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/masterDetail.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/masterDetail.integration.tests.js
@@ -1154,7 +1154,8 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             masterDetail: {
                 enabled: true,
                 template,
-            }
+            },
+            templatesRenderAsynchronously: true,
         }).dxDataGrid('instance');
 
         const originalRenderTemplate = dataGrid.getView('rowsView').renderTemplate;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/masterDetail.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/masterDetail.integration.tests.js
@@ -1156,6 +1156,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
                 template,
             },
             templatesRenderAsynchronously: true,
+            renderAsync: false,
         }).dxDataGrid('instance');
 
         const originalRenderTemplate = dataGrid.getView('rowsView').renderTemplate;


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/23679