### PR TITLE
Scrollable: Remove deferred from updateRtlPosition.

### DIFF
--- a/js/ui/scroll_view/ui.scrollable.simulated.js
+++ b/js/ui/scroll_view/ui.scrollable.simulated.js
@@ -1012,22 +1012,18 @@ export const SimulatedStrategy = Class.inherit({
 
         this._updateBounds();
         if(this._isHorizontalAndRtlEnabled()) {
-            deferUpdate(() => {
-                let scrollLeft = this._getMaxOffset().left - this._rtlConfig.scrollRight;
+            let scrollLeft = this._getMaxOffset().left - this._rtlConfig.scrollRight;
 
-                if(scrollLeft <= 0) {
-                    scrollLeft = 0;
-                    this._rtlConfig.scrollRight = this._getMaxOffset().left;
-                }
+            if(scrollLeft <= 0) {
+                scrollLeft = 0;
+                this._rtlConfig.scrollRight = this._getMaxOffset().left;
+            }
 
-                deferRender(() => {
-                    if(this._getScrollOffset().left !== scrollLeft) {
-                        this._rtlConfig.skipUpdating = true;
-                        this._component.scrollTo({ left: scrollLeft });
-                        this._rtlConfig.skipUpdating = false;
-                    }
-                });
-            });
+            if(this._getScrollOffset().left !== scrollLeft) {
+                this._rtlConfig.skipUpdating = true;
+                this._component.scrollTo({ left: scrollLeft });
+                this._rtlConfig.skipUpdating = false;
+            }
         }
     },
 


### PR DESCRIPTION
Removed the deferUpdate / deferRender from the dxScrollable with ```rtlEnabled: true```

These deferred caused two issues:
- Unable to scroll to right in PivotGrid with ```rtlEnabled: true``` 
[Link to the reproduced example](https://codepen.io/williamvinogradov/pen/poOzPGB)
- Horizontal scroll shaking in DataGrid with ```rtlEnabled: true```
[Link to the reproduced example](https://codepen.io/williamvinogradov/pen/xxaKdaZ)

Therefore together with the Grid & Components teams, we decide to remove this async behavior in scrollable.