### PR TITLE
Fix jquery RadioGroup component

### DIFF
--- a/packages/jquery/gulpfile.mjs
+++ b/packages/jquery/gulpfile.mjs
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import gulp from 'gulp';
 import babel from 'gulp-babel';
 import { generateInfernoFromReactComponents, ReactSrc } from './gulp/inferno-from-react.mjs';
@@ -9,6 +10,7 @@ function generateInfernoComponents() {
 }
 
 function patchGeneratedSources(done) {
+  fs.copyFileSync('./patch/radio-group.jsx', './src/generated/components/radio-group/radio-group.jsx');
   done();
 }
 
@@ -33,23 +35,20 @@ function generateInferno() {
 function build() {
   return gulp.series(
     generateInferno(),
-        gulp.parallel(
+    gulp.parallel(
       'js-bundles-debug',
       gulp.series(
         transpile,
-        copydts
-      )
-    )
-  )
+        copydts,
+      ),
+    ),
+  );
 }
 
 gulp.task('build-dev',
-  build(),
-);
+  build());
 
-gulp.task('watch', () =>
-  gulp.watch(
-    [...ReactSrc, './src/*'],
-    build(),
-  ),
-);
+gulp.task('watch', () => gulp.watch(
+  [...ReactSrc, './src/*'],
+  build(),
+));

--- a/packages/jquery/patch/radio-group.jsx
+++ b/packages/jquery/patch/radio-group.jsx
@@ -1,0 +1,18 @@
+import { HookContainer } from '@devextreme/runtime/inferno-hooks';
+import { forwardRef} from '@devextreme/runtime/inferno-hooks';
+import { RadioGroupInternal } from './radio-group-internal';
+import { withEditor } from '../common';
+import '@devextreme/styles/src/radio-group/radio-group.scss';
+const ReactRadioGroupInternalWrapper = RadioGroupInternal;
+function HooksRadioGroupInternalWrapper(props, ref) {
+    return (<HookContainer renderFn={ReactRadioGroupInternalWrapper} renderProps={props} renderRef={ref}/>);
+}
+const RadRadioGroupInternalForwardRef = forwardRef(HooksRadioGroupInternalWrapper);
+
+const RadioGroupWithEditor = withEditor(RadRadioGroupInternalForwardRef);
+
+function HooksRadioGroupWithEditor(props, ref) {
+  return (<HookContainer renderFn={RadioGroupWithEditor} renderProps={props} renderRef={ref}/>);
+}
+
+export const RadioGroup = forwardRef(HooksRadioGroupWithEditor);

--- a/packages/jquery/src/radio-button.js
+++ b/packages/jquery/src/radio-button.js
@@ -3,20 +3,6 @@ import { ComponentWrapper } from './component-wrapper';
 import { RadioButton as RadioButtonInferno } from './generated/components/radio-button';
 
 export class RadioButton extends ComponentWrapper {
-  _initializeComponent() {
-    super._initializeComponent();
-    this._propsInfo.templates.forEach((template) => {
-      this._componentTemplates[template] = this._createTemplateComponent(
-        this._props[template],
-        template,
-      );
-    });
-  }
-
-  getProps() {
-    return super.getProps();
-  }
-
   get _propsInfo() {
     return {
       twoWay: [['checked', 'defaultChecked']],

--- a/packages/jquery/src/radio-group.js
+++ b/packages/jquery/src/radio-group.js
@@ -3,18 +3,8 @@ import { EditorWrapper } from './editor-wrapper';
 import { RadioGroupCompatible as RadioButtonCompatibleInferno } from './generated/compatible-components/radio-group';
 
 export class RadioGroupCompatible extends EditorWrapper {
-  _initializeComponent() {
-    super._initializeComponent();
-    this._propsInfo.templates.forEach((template) => {
-      this._componentTemplates[template] = this._createTemplateComponent(
-        this._props[template],
-        template,
-      );
-    });
-  }
-
-  getProps() {
-    return super.getProps();
+  focus() {
+    this.viewRef.focus();
   }
 
   get _propsInfo() {
@@ -23,7 +13,11 @@ export class RadioGroupCompatible extends EditorWrapper {
       allowNull: ['value'],
       elements: [],
       templates: ['itemRender'],
-      props: ['items', 'displayExpr', 'valueExpr', 'itemRender', 'value', 'defaultValue', 'valueChange'],
+      props: ['items', 'displayExpr', 'valueExpr', 'itemRender', 'value', 'defaultValue', 'valueChange',
+        'name', 'errors',
+        'active', 'disabled', 'visible', 'shortcutKey', 'tabIndex', 'hint', 'width', 'height',
+        'focusStateEnabled', 'hoverStateEnabled', 'activeStateEnabled',
+        'onFocus', 'onBlur'],
     };
   }
 

--- a/packages/react/src/compatible-components/radio-group/radio-group.tsx
+++ b/packages/react/src/compatible-components/radio-group/radio-group.tsx
@@ -36,7 +36,6 @@ type CompatibleRadioGroupProps<T> = Omit<RadioGroupProps<T>, CompatibleOmittedPr
 type ValueGetter = <T>(item: ItemLike) => T;
 type LabelGetter = (item: ItemLike) => string;
 
-//* Component={"name":"RadioGroupCompatible", "jQueryRegistered":true}
 function RadioGroupCompatibleInternal<T>(
   {
     items,
@@ -102,6 +101,7 @@ type RadioGroupCompatibleType = <T>(
   p: CompatibleRadioGroupProps<T> & { ref?: Ref<RadioGroupRef> }
 ) => JSX.Element;
 
+//* Component={"name":"RadioGroupCompatible", "jQueryRegistered":true, "hasApiMethod":true}
 export const RadioGroupCompatible = forwardRef(
   RadioGroupCompatibleInternal,
 ) as RadioGroupCompatibleType;

--- a/packages/react/src/components/common/hocs/with-editor.tsx
+++ b/packages/react/src/components/common/hocs/with-editor.tsx
@@ -1,5 +1,5 @@
 import {
-  ComponentType, ForwardedRef, forwardRef, useCallback, useMemo, useState,
+  ComponentType, ForwardedRef, useCallback, useMemo, useState,
 } from 'react';
 import { EditorProps } from '../../../internal/props';
 import { EditorContext } from '../contexts/editor-context';
@@ -46,5 +46,5 @@ export function withEditor<T>(Component: EditorType<T>) {
       </EditorContext.Provider>
     );
   }
-  return forwardRef(Editor);
+  return Editor;
 }

--- a/packages/react/src/components/radio-group/index.ts
+++ b/packages/react/src/components/radio-group/index.ts
@@ -1,1 +1,4 @@
+import type { RadioGroupProps, RadioGroupRef } from './types';
+
 export * from './radio-group';
+export { RadioGroupProps, RadioGroupRef };

--- a/packages/react/src/components/radio-group/radio-group-internal.tsx
+++ b/packages/react/src/components/radio-group/radio-group-internal.tsx
@@ -1,0 +1,88 @@
+import {
+  RADIO_GROUP_ACTIONS as ACTIONS,
+  createContainerPropsSelector,
+  createRadioGroupStore,
+  RADIO_GROUP_CONTAINER_PROPS_MAPPER as PROPS_MAPPERS,
+} from '@devextreme/components';
+import {
+  Children,
+  cloneElement, ForwardedRef, isValidElement, useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react';
+import {
+  useCallbackRef,
+  useSecondEffect,
+  useStoreSelector,
+} from '../../internal/hooks/index';
+import { EditorProps } from '../../internal/props';
+import { RadioGroupStoreContext } from '../radio-common/index';
+import type { RadioGroupProps, RadioGroupRef } from './types';
+import '@devextreme/styles/src/radio-group/radio-group.scss';
+
+export function RadioGroupInternal<T>(
+  props: RadioGroupProps<T>,
+  componentRef: ForwardedRef<RadioGroupRef>,
+): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(componentRef, () => ({
+    focus(options?: FocusOptions) {
+      containerRef.current?.focus(options);
+    },
+  }), [containerRef.current]);
+
+  const isValueControlled = useMemo(() => Object.hasOwnProperty.call(props, 'value'), []);
+  const valueChange = useCallbackRef(props.valueChange);
+
+  const store = useMemo(() => createRadioGroupStore<T>({
+    readonly: PROPS_MAPPERS.getDomOptions(props),
+    value: isValueControlled ? props.value : props.defaultValue,
+  }, {
+    value: {
+      controlledMode: isValueControlled,
+      changeCallback: (value: T) => { valueChange.current(value); },
+    },
+  }), []);
+
+  const containerProps = useStoreSelector(store, createContainerPropsSelector, []);
+
+  useSecondEffect(() => {
+    if (isValueControlled) {
+      store.addUpdate(ACTIONS.updateValue(props.value));
+    }
+  }, [props.value]);
+
+  const readonlyValues = PROPS_MAPPERS.getDomOptions(props);
+  useSecondEffect(() => {
+    store.addUpdate(ACTIONS.updateReadonly(readonlyValues));
+  }, [...Object.values(readonlyValues)]);
+
+  useSecondEffect(() => {
+    store.commitPropsUpdates();
+  });
+
+  return (
+    <RadioGroupStoreContext.Provider value={store}>
+      <div
+        ref={containerRef}
+        className={`dxr-radio-group ${containerProps.cssClass.join(' ')} ${props.className ?? ''}`}
+        style={props.style ?? {}}
+        {...containerProps.attributes}
+        onFocus={props.onFocus}
+        onBlur={props.onBlur}
+      >
+        {props.name
+          ? Children.map(
+            props.children,
+            child => (
+              isValidElement<EditorProps<T>>(child)
+                ? cloneElement(child, { name: props.name })
+                : child
+            ),
+          )
+          : props.children}
+      </div>
+    </RadioGroupStoreContext.Provider>
+  );
+}

--- a/packages/react/src/components/radio-group/radio-group-internal.tsx
+++ b/packages/react/src/components/radio-group/radio-group-internal.tsx
@@ -68,6 +68,7 @@ export function RadioGroupInternal<T>(
         ref={containerRef}
         className={`dxr-radio-group ${containerProps.cssClass.join(' ')} ${props.className ?? ''}`}
         style={props.style ?? {}}
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...containerProps.attributes}
         onFocus={props.onFocus}
         onBlur={props.onBlur}

--- a/packages/react/src/components/radio-group/radio-group.tsx
+++ b/packages/react/src/components/radio-group/radio-group.tsx
@@ -1,115 +1,19 @@
 /* eslint-disable react/jsx-props-no-spreading, import/exports-last */
 import {
-  RADIO_GROUP_ACTIONS as ACTIONS,
-  createContainerPropsSelector,
-  createRadioGroupStore,
-  RADIO_GROUP_CONTAINER_PROPS_MAPPER as PROPS_MAPPERS,
-} from '@devextreme/components';
-import {
-  Children,
-  cloneElement, ForwardedRef,
   forwardRef,
-  isValidElement,
   memo,
-  PropsWithChildren,
   Ref,
-  useImperativeHandle,
-  useMemo,
-  useRef,
 } from 'react';
-import {
-  useCallbackRef,
-  useSecondEffect,
-  useStoreSelector,
-} from '../../internal/hooks';
-import {
-  CssForwardProps,
-  EditorProps,
-  FocusableProps,
-} from '../../internal/props';
 import { withEditor } from '../common';
-import { RadioGroupStoreContext } from '../radio-common';
 
-import '@devextreme/styles/src/radio-group/radio-group.scss';
+import { RadioGroupInternal } from './radio-group-internal';
+import type { RadioGroupProps, RadioGroupRef } from './types';
 
-export type RadioGroupRef = {
-  focus(options?: FocusOptions): void,
-};
+//* Component={"name":"RadioGroupInternalForwardRef", "hasApiMethod":true}
+const RadioGroupInternalForwardRef = forwardRef(RadioGroupInternal);
 
-function RadioGroupInternal<T>(
-  props: RadioGroupProps<T>,
-  componentRef: ForwardedRef<RadioGroupRef>,
-): JSX.Element {
-  const containerRef = useRef<HTMLDivElement>(null);
+//* Component={"name":"RadioGroupWithEditor"}
+const RadioGroupWithEditor = withEditor(RadioGroupInternalForwardRef);
 
-  useImperativeHandle(componentRef, () => ({
-    focus(options?: FocusOptions) {
-      containerRef.current?.focus(options);
-    },
-  }), [containerRef.current]);
-
-  const isValueControlled = useMemo(() => Object.hasOwnProperty.call(props, 'value'), []);
-  const valueChange = useCallbackRef(props.valueChange);
-
-  const store = useMemo(() => createRadioGroupStore<T>({
-    readonly: PROPS_MAPPERS.getDomOptions(props),
-    value: isValueControlled ? props.value : props.defaultValue,
-  }, {
-    value: {
-      controlledMode: isValueControlled,
-      changeCallback: (value: T) => { valueChange.current(value); },
-    },
-  }), []);
-
-  const containerProps = useStoreSelector(store, createContainerPropsSelector, []);
-
-  useSecondEffect(() => {
-    if (isValueControlled) {
-      store.addUpdate(ACTIONS.updateValue(props.value));
-    }
-  }, [props.value]);
-
-  const readonlyValues = PROPS_MAPPERS.getDomOptions(props);
-  useSecondEffect(() => {
-    store.addUpdate(ACTIONS.updateReadonly(readonlyValues));
-  }, [...Object.values(readonlyValues)]);
-
-  useSecondEffect(() => {
-    store.commitPropsUpdates();
-  });
-
-  return (
-    <RadioGroupStoreContext.Provider value={store}>
-      <div
-        ref={containerRef}
-        className={`dxr-radio-group ${containerProps.cssClass.join(' ')} ${props.className ?? ''}`}
-        style={props.style ?? {}}
-        {...containerProps.attributes}
-        onFocus={props.onFocus}
-        onBlur={props.onBlur}
-      >
-        {props.name
-          ? Children.map(
-            props.children,
-            child => (
-              isValidElement<EditorProps<T>>(child)
-                ? cloneElement(child, { name: props.name })
-                : child
-            ),
-          )
-          : props.children}
-      </div>
-    </RadioGroupStoreContext.Provider>
-  );
-}
-
-const RadioGroupEditor = withEditor(forwardRef(RadioGroupInternal));
-
-export type RadioGroupProps<T> = PropsWithChildren<
-EditorProps<T>
-& FocusableProps
-& CssForwardProps
->;
 type RadioGroupType = <T>(p: RadioGroupProps<T> & { ref?: Ref<RadioGroupRef> }) => JSX.Element;
-//* Component={"name":"RadioGroup"}
-export const RadioGroup = memo(RadioGroupEditor) as RadioGroupType;
+export const RadioGroup = memo(forwardRef(RadioGroupWithEditor)) as RadioGroupType;

--- a/packages/react/src/components/radio-group/radio-group.tsx
+++ b/packages/react/src/components/radio-group/radio-group.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading, import/exports-last */
 import {
   forwardRef,
   memo,

--- a/packages/react/src/components/radio-group/types.ts
+++ b/packages/react/src/components/radio-group/types.ts
@@ -1,0 +1,16 @@
+import { PropsWithChildren } from 'react';
+import {
+  CssForwardProps,
+  EditorProps,
+  FocusableProps,
+} from '../../internal/props';
+
+export type RadioGroupRef = {
+  focus(options?: FocusOptions): void,
+};
+
+export type RadioGroupProps<T> = PropsWithChildren<
+EditorProps<T> &
+FocusableProps &
+CssForwardProps
+>;


### PR DESCRIPTION
Add patch for radio-group because forwardRef for HOC component isn't supported by now.
Split radio-group to radio-group-internal and radio-group to simplify the patch.
Add the missing props info into the radio group component. 
 