### PR TITLE
Fix a throwing exception while drugging a row in grid  if angular is used in a page (T1150251)

### DIFF
--- a/js/core/utils/type.js
+++ b/js/core/utils/type.js
@@ -2,10 +2,14 @@ const types = {
     '[object Array]': 'array',
     '[object Date]': 'date',
     '[object Object]': 'object',
-    '[object String]': 'string',
-    '[object Null]': 'null' };
+    '[object String]': 'string'
+};
 
 const type = function(object) {
+    if(object === null) {
+        return 'null';
+    }
+
     const typeOfObject = Object.prototype.toString.call(object);
 
     return typeof object === 'object' ?
@@ -55,7 +59,7 @@ const isEmptyObject = function(object) {
 };
 
 const isPlainObject = function(object) {
-    if(!object || Object.prototype.toString.call(object) !== '[object Object]') {
+    if(!object || type(object) !== 'object') {
         return false;
     }
     const proto = Object.getPrototypeOf(object);

--- a/testing/tests/DevExpress.core/utils.common.tests.js
+++ b/testing/tests/DevExpress.core/utils.common.tests.js
@@ -454,6 +454,18 @@ module('equalByValue', () => {
 
         assert.ok(equalByValue(guid1, guid2));
     });
+
+    test('The `equalByValue` should return false if one of objects is null (T1150251)', function(assert) {
+        const orig = Object.prototype.toString;
+
+        /* eslint-disable */
+        Object.prototype.toString = (obj) => orig(obj === null ? top : obj);
+
+        assert.strictEqual(equalByValue(null, {}), false);
+
+        Object.prototype.toString = orig;
+        /* eslint-enable */
+    });
 });
 
 

--- a/testing/tests/DevExpress.core/utils.type.tests.js
+++ b/testing/tests/DevExpress.core/utils.type.tests.js
@@ -8,6 +8,7 @@ QUnit.module('Type checking');
 
 QUnit.test('type method', function(assert) {
     const element = $('#qunit-fixture').html('"<div id="widget"></div>"');
+    const origObjectToString = Object.prototype.toString;
 
     assert.strictEqual(typeUtils.type(0), 'number', 'number');
     assert.strictEqual(typeUtils.type(null), 'null', 'null');
@@ -17,6 +18,14 @@ QUnit.test('type method', function(assert) {
     assert.strictEqual(typeUtils.type([]), 'array', 'array');
     assert.strictEqual(typeUtils.type(function() { }), 'function', 'function');
     assert.strictEqual(typeUtils.type(element[0].firstElementChild), 'object', 'HTMLDivElement');
+
+    /* eslint-disable */
+    Object.prototype.toString = (obj) => origObjectToString(obj === null ? top : obj); // T1150251
+
+    assert.strictEqual(typeUtils.type(null), 'null', 'null');
+
+    Object.prototype.toString = origObjectToString;
+    /* eslint-enable */
 });
 
 QUnit.test('isDefined', function(assert) {


### PR DESCRIPTION
Fix a throwing exception while drugging a row in grid  if angular is used in a page (T1150251)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
