### PR TITLE
T1148741 - DataGrid - navigateToRow doesn't scroll to a specified record if the component is sorted against a column with 'undefined' values (#23954)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.data_controller.d.ts
+++ b/js/ui/grid_core/ui.grid_core.data_controller.d.ts
@@ -279,7 +279,7 @@ export interface DataController extends State, Controller {
 
   _updatePageIndexes: (this: this, ...args: any) => any;
 
-  processUpdateFocusedRow: (this: this, ...args: any) => any;
+  _updateFocusedRow: (this: this, ...args: any) => any;
 
   isPagingByRendering: (this: this, ...args: any) => any;
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
@@ -3982,6 +3982,45 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(this.option('focusedRowKey'), 'Mark2', 'FocusedRowkey');
         assert.equal(this.pageIndex(), 2, 'PageIndex with the \'Mark2\' row');
     });
+    // T1148741
+    QUnit.test('Navigate to next page when focusedRowIndex and customizeColumns have defined', function(assert) {
+        // arrange
+        this.options = {
+            focusedRowEnabled: true,
+            autoNavigateToFocusedRow: true,
+            paging: {
+                pageSize: 2
+            },
+            keyExpr: 'name',
+            focusedRowIndex: 1,
+            customizeColumns: function() { },
+            columns: [
+                'name', { dataField: 'phone', sortOrder: 'asc' }, 'room'
+            ]
+        };
+
+        this.data = [
+            { name: 'Alex', phone: '555555', room: 1 },
+            { name: 'Ben', phone: '6666666', room: 2 },
+            { name: 'Dan', phone: '553355', room: 3 },
+            { name: 'Mark1', phone: '777777', room: 4 },
+            { name: 'Mark2', phone: '888888', room: 5 },
+            { name: 'Mark3', phone: '99999999', room: 6 }
+        ];
+
+        this.setupModule();
+
+        this.gridView.render($('#container'));
+
+        // act
+        this.pageIndex(1);
+        this.clock.tick();
+
+        // assert
+        assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
+        assert.equal(this.option('focusedRowKey'), 'Mark1', 'FocusedRowkey');
+        assert.equal(this.pageIndex(), 1, 'PageIndex with the \'Mark1\' row');
+    });
 
     QUnit.testInActiveWindow('Row should not focus on scrolling with the pointer (T861577)', function(assert) {
         if(device.deviceType === 'desktop') {


### PR DESCRIPTION
…ord if the component is sorted against a column with 'undefined' values (#23954)

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
