### PR TITLE
T1152491: DataGrid - Cell values are not re-validated when changed via the 'editing.changes' option

### DIFF
--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -472,8 +472,13 @@ const ValidatingController = modules.Controller.inherit((function() {
             const stateRestored = validationResultIsValid(validationResult);
             const adapter = validator.option('adapter');
             if(!stateRestored) {
-                const isSameValue = validationResult ? adapter.getValue() === validationResult.value : false;
-                if(!isSameValue) { validationResult = validator.validate(); }
+                validationResult = validator.validate();
+            } else {
+                const currentCellValue = adapter.getValue();
+                const isSameValue = currentCellValue === validationResult.value;
+                if(!isSameValue) {
+                    validationResult = validator.validate();
+                }
             }
             const deferred = new Deferred();
             if(stateRestored && validationResult.status === VALIDATION_STATUS.pending) {

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -475,7 +475,7 @@ const ValidatingController = modules.Controller.inherit((function() {
                 validationResult = validator.validate();
             } else {
                 const currentCellValue = adapter.getValue();
-                if(equalByValue(currentCellValue, validationResult.value)) {
+                if(!equalByValue(currentCellValue, validationResult.value)) {
                     validationResult = validator.validate();
                 }
             }

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -475,8 +475,7 @@ const ValidatingController = modules.Controller.inherit((function() {
                 validationResult = validator.validate();
             } else {
                 const currentCellValue = adapter.getValue();
-                const isSameValue = currentCellValue === validationResult.value;
-                if(!isSameValue) {
+                if(equalByValue(currentCellValue, validationResult.value)) {
                     validationResult = validator.validate();
                 }
             }

--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -470,11 +470,12 @@ const ValidatingController = modules.Controller.inherit((function() {
             };
             let validationResult = this.getCellValidationResult(cellParams);
             const stateRestored = validationResultIsValid(validationResult);
+            const adapter = validator.option('adapter');
             if(!stateRestored) {
-                validationResult = validator.validate();
+                const isSameValue = validationResult ? adapter.getValue() === validationResult.value : false;
+                if(!isSameValue) { validationResult = validator.validate(); }
             }
             const deferred = new Deferred();
-            const adapter = validator.option('adapter');
             if(stateRestored && validationResult.status === VALIDATION_STATUS.pending) {
                 this.updateCellValidationResult(cellParams);
                 adapter.applyValidationResults(validationResult);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -10622,7 +10622,7 @@ QUnit.module('Refresh modes', {
             allowUpdating: true,
             allowDeleting: true
         });
-        
+
         this.options.columns = [
             {
                 type: 'buttons',
@@ -10643,16 +10643,16 @@ QUnit.module('Refresh modes', {
         this.setupModules();
         this.cellValue(0, 'state', 'active');
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
-        
+
         // assert
         assert.equal($linkElements.length, 2);
         assert.ok($linkElements.eq(0).hasClass('dx-icon-active-icon'), 'the edit link');
         assert.ok($linkElements.eq(1).hasClass('dx-icon-custom'), 'the custom link');
         assert.notOk($linkElements.eq(1).hasClass('dx-state-disabled'), 'the custom link is enabled');
-        
+
         // act
         this.cellValue(0, 'state', 'disabled');
-        
+
         // assert
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
         assert.equal($linkElements.length, 2);
@@ -10665,7 +10665,7 @@ QUnit.module('Refresh modes', {
     QUnit.test('Changing command column if repaintChangesOnly is true and push API is used', function(assert) {
         // arrange
         let $linkElements;
-        
+
         this.options.columns = [
             {
                 type: 'buttons',
@@ -10691,14 +10691,14 @@ QUnit.module('Refresh modes', {
 
         // act
         this.setupModules();
-        
+
         // assert
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
         assert.equal($linkElements.length, 2);
         assert.ok($linkElements.eq(0).hasClass('dx-icon-active-icon'), 'the edit link');
         assert.ok($linkElements.eq(1).hasClass('dx-icon-custom'), 'the custom link');
         assert.notOk($linkElements.eq(1).hasClass('dx-state-disabled'), 'the custom link is enabled');
-        
+
         // act
         this.options.dataSource.store().push([
             {
@@ -10708,7 +10708,7 @@ QUnit.module('Refresh modes', {
             }
         ]);
         this.clock.tick();
-        
+
         // assert
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
         assert.equal($linkElements.length, 2);
@@ -14827,6 +14827,44 @@ QUnit.module('Editing with validation', {
             done();
         });
     });
+    // T1152491 - DataGrid - Cell values are not re-validated when changed via the 'editing.changes' option
+    QUnit.test('validatingController.validateCell should call the validate method of the current validator if cell value chenged', function(assert) {
+            // arrange
+            const rowsView = this.rowsView;
+            const testElement = $('#container');
+            const done = assert.async();
+
+            rowsView.render(testElement);
+
+            this.applyOptions({
+                editing: {
+                    mode: 'batch'
+                },
+                columns: [{
+                    dataField: 'name',
+                    validationRules: [{ type: 'required' }]
+                }]
+            });
+
+            this.editCell(0, 0);
+            this.cellValue(0, 0, '');
+
+            // act
+            this.option('editing.changes', [{
+                key: this.getKeyByRowIndex(0),
+                data: { name: 'val' },
+                type: 'update'
+            }]);
+
+            const validator = $(this.getCellElement(0, 0)).dxValidator('instance');
+            this.validatingController.validateCell(validator).done(result => {
+                // assert
+                assert.strictEqual(result.status, 'valid', 'status === "invalid"');
+
+                done();
+            });
+    });
+
 
     QUnit.test('validatingController - validation result should be cached', function(assert) {
         // arrange

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -14828,41 +14828,80 @@ QUnit.module('Editing with validation', {
         });
     });
     // T1152491 - DataGrid - Cell values are not re-validated when changed via the 'editing.changes' option
+    QUnit.test('validatingController.validateCell should call the validate method of the current validator if cell value chenged (first modify using editing API)', function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+        const done = assert.async();
+
+        rowsView.render(testElement);
+
+        this.applyOptions({
+            editing: {
+                mode: 'batch'
+            },
+            columns: [{
+                dataField: 'name',
+                validationRules: [{ type: 'required' }]
+            }]
+        });
+
+        this.option('editing.changes', [{
+            key: this.getKeyByRowIndex(0),
+            data: { name: '' },
+            type: 'update'
+        }]);
+
+        // act
+        this.option('editing.changes', [{
+            key: this.getKeyByRowIndex(0),
+            data: { name: 'val' },
+            type: 'update'
+        }]);
+
+        const validator = $(this.getCellElement(0, 0)).dxValidator('instance');
+        this.validatingController.validateCell(validator).done(result => {
+            // assert
+            assert.strictEqual(result.status, 'valid', 'status === "valid"');
+
+            done();
+        });
+    });
     QUnit.test('validatingController.validateCell should call the validate method of the current validator if cell value chenged', function(assert) {
-            // arrange
-            const rowsView = this.rowsView;
-            const testElement = $('#container');
-            const done = assert.async();
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+        const done = assert.async();
 
-            rowsView.render(testElement);
+        rowsView.render(testElement);
 
-            this.applyOptions({
-                editing: {
-                    mode: 'batch'
-                },
-                columns: [{
-                    dataField: 'name',
-                    validationRules: [{ type: 'required' }]
-                }]
-            });
+        this.applyOptions({
+            editing: {
+                mode: 'batch'
+            },
+            columns: [{
+                dataField: 'name',
+                validationRules: [{ type: 'required' }]
+            }]
+        });
 
-            this.editCell(0, 0);
-            this.cellValue(0, 0, '');
+        this.editCell(0, 0);
+        this.cellValue(0, 0, '');
 
-            // act
-            this.option('editing.changes', [{
-                key: this.getKeyByRowIndex(0),
-                data: { name: 'val' },
-                type: 'update'
-            }]);
+        // act
+        this.option('editing.changes', [{
+            key: this.getKeyByRowIndex(0),
+            data: { name: 'val' },
+            type: 'update'
+        }]);
 
-            const validator = $(this.getCellElement(0, 0)).dxValidator('instance');
-            this.validatingController.validateCell(validator).done(result => {
-                // assert
-                assert.strictEqual(result.status, 'valid', 'status === "invalid"');
+        const validator = $(this.getCellElement(0, 0)).dxValidator('instance');
+        this.validatingController.validateCell(validator).done(result => {
+            // assert
+            assert.strictEqual(result.status, 'valid', 'status === "valid"');
 
-                done();
-            });
+            done();
+        });
     });
 
 


### PR DESCRIPTION
After applying editing changes, the validation module doesn't check the current cell value in the ValidationCell method and uses validationResult for the previous unchanged value.

Solution: Get the current cell value and compare it with the value in validationResult. If they are different, force the validation. Because adapter.getValue can be costly, add this logic to a separate else block.