### PR TITLE
Add run of qunit tests that are run only with jquery

### DIFF
--- a/.github/workflows/qunit_tests-additional-renovation.yml
+++ b/.github/workflows/qunit_tests-additional-renovation.yml
@@ -64,6 +64,7 @@ jobs:
           { CONSTEL: "misc", TZ: 'PST8PDT', name: 'misc-PST8PDT' },
           { CONSTEL: "misc", TZ: 'Japan', name: 'misc-Japan' },
           { CONSTEL: "misc", TZ: 'Australia/ACT', name: 'misc-Australia' },
+          { CONSTEL: "misc", JQUERY: true, name: 'misc-jQuery' },
           { CONSTEL: "ui.editors", TZ: 'PST8PDT', name: 'ui.editors-PST8PDT' },
           { CONSTEL: "ui.editors", TZ: 'Japan', name: 'ui.editors-Japan' },
           { CONSTEL: "ui.editors", TZ: 'Australia/ACT', name: 'ui.editors-Australia' },


### PR DESCRIPTION
Without running with jQuery approach, following tests are skipped:

```
DevExpress.aspnet/aspnet_bundled.tests.js
DevExpress.aspnet/aspnet.tests.js
DevExpress.core/utils.deferred.tests.js
DevExpress.jquery/bundled.tests.js
DevExpress.jquery/easing.tests.js
DevExpress.jquery/eventRegistrator.tests.js
DevExpress.jquery/selectors.tests.js
```

and some more specific cased inside tests themselves 