### PR TITLE
The "arguments[1] is not a function" error when NamedTemplate contains HTML-encoded expression within RazorBlock (T1146301)

### DIFF
--- a/js/aspnet.js
+++ b/js/aspnet.js
@@ -60,9 +60,9 @@
                 bag.push('_.push(');
                 var expression = value;
                 if(encode) {
-                    expression = 'arguments[1]((' + value + ' !== null && ' + value + ' !== undefined) ? ' + value + ' : "")';
+                    expression = 'encodeHtml((' + value + ' !== null && ' + value + ' !== undefined) ? ' + value + ' : "")';
                     if(/^\s*$/.test(value)) {
-                        expression = 'arguments[1](' + value + ')';
+                        expression = 'encodeHtml(' + value + ')';
                     }
                 }
                 bag.push(expression);
@@ -97,7 +97,7 @@
             bag.push('}', 'return _.join(\'\')');
 
             // eslint-disable-next-line no-new-func
-            return new Function('obj', bag.join(''));
+            return new Function('obj', 'encodeHtml', bag.join(''));
         };
     }
 

--- a/testing/tests/DevExpress.aspnet/aspnet.tests.js
+++ b/testing/tests/DevExpress.aspnet/aspnet.tests.js
@@ -415,6 +415,33 @@
         }
     });
 
+    QUnit.test('T1146301 - NamedTemplate with expression inside Content RazorBlock', function(assert) {
+        aspnet.setTemplateEngine();
+        try {
+            $('#qunit-fixture').html(
+                '<div id="template-holder-widget"></div>' +
+                '<script>var rawJsStringWithHtmlTags = "<b>Encoded</b>";</script>' +
+                '<script id="template-nested-func" type="text/html">' +
+                '<%!function(){%>\
+                   <div id="<%=arguments[0]%>">\
+                     <div id="nested-function-expr"><%- rawJsStringWithHtmlTags %></div>\
+                   </div>\
+                   <%DevExpress.aspnet.createComponent("dxScrollView",{},arguments[0])%>\
+                 <%}("dx-data-guid")%>' +
+                '</script>'
+            );
+
+            const widgetElement = $('#template-holder-widget');
+            widgetElement.dxButton({
+                template: $('#template-nested-func')
+            });
+
+            assert.equal($('#nested-function-expr').html(), '&lt;b&gt;Encoded&lt;/b&gt;');
+        } finally {
+            setTemplateEngine('default');
+        }
+    });
+
     QUnit.test('T758209', function(assert) {
         aspnet.setTemplateEngine();
 


### PR DESCRIPTION
Cherry-pick of #24032