### PR TITLE
T1152491: DataGrid - Cell values are not re-validated when changed via the 'editing.changes' option (#24018)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.validating.js
+++ b/js/ui/grid_core/ui.grid_core.validating.js
@@ -470,11 +470,16 @@ const ValidatingController = modules.Controller.inherit((function() {
             };
             let validationResult = this.getCellValidationResult(cellParams);
             const stateRestored = validationResultIsValid(validationResult);
+            const adapter = validator.option('adapter');
             if(!stateRestored) {
                 validationResult = validator.validate();
+            } else {
+                const currentCellValue = adapter.getValue();
+                if(!equalByValue(currentCellValue, validationResult.value)) {
+                    validationResult = validator.validate();
+                }
             }
             const deferred = new Deferred();
-            const adapter = validator.option('adapter');
             if(stateRestored && validationResult.status === VALIDATION_STATUS.pending) {
                 this.updateCellValidationResult(cellParams);
                 adapter.applyValidationResults(validationResult);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -10620,7 +10620,7 @@ QUnit.module('Refresh modes', {
             allowUpdating: true,
             allowDeleting: true
         });
-        
+
         this.options.columns = [
             {
                 type: 'buttons',
@@ -10641,16 +10641,16 @@ QUnit.module('Refresh modes', {
         this.setupModules();
         this.cellValue(0, 'state', 'active');
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
-        
+
         // assert
         assert.equal($linkElements.length, 2);
         assert.ok($linkElements.eq(0).hasClass('dx-icon-active-icon'), 'the edit link');
         assert.ok($linkElements.eq(1).hasClass('dx-icon-custom'), 'the custom link');
         assert.notOk($linkElements.eq(1).hasClass('dx-state-disabled'), 'the custom link is enabled');
-        
+
         // act
         this.cellValue(0, 'state', 'disabled');
-        
+
         // assert
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
         assert.equal($linkElements.length, 2);
@@ -10663,7 +10663,7 @@ QUnit.module('Refresh modes', {
     QUnit.test('Changing command column if repaintChangesOnly is true and push API is used', function(assert) {
         // arrange
         let $linkElements;
-        
+
         this.options.columns = [
             {
                 type: 'buttons',
@@ -10689,14 +10689,14 @@ QUnit.module('Refresh modes', {
 
         // act
         this.setupModules();
-        
+
         // assert
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
         assert.equal($linkElements.length, 2);
         assert.ok($linkElements.eq(0).hasClass('dx-icon-active-icon'), 'the edit link');
         assert.ok($linkElements.eq(1).hasClass('dx-icon-custom'), 'the custom link');
         assert.notOk($linkElements.eq(1).hasClass('dx-state-disabled'), 'the custom link is enabled');
-        
+
         // act
         this.options.dataSource.store().push([
             {
@@ -10706,7 +10706,7 @@ QUnit.module('Refresh modes', {
             }
         ]);
         this.clock.tick();
-        
+
         // assert
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
         assert.equal($linkElements.length, 2);
@@ -14825,6 +14825,83 @@ QUnit.module('Editing with validation', {
             done();
         });
     });
+    // T1152491 - DataGrid - Cell values are not re-validated when changed via the 'editing.changes' option
+    QUnit.test('validatingController.validateCell should call the validate method of the current validator if cell value chenged (first modify using editing API)', function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+        const done = assert.async();
+
+        rowsView.render(testElement);
+
+        this.applyOptions({
+            editing: {
+                mode: 'batch'
+            },
+            columns: [{
+                dataField: 'name',
+                validationRules: [{ type: 'required' }]
+            }]
+        });
+
+        this.option('editing.changes', [{
+            key: this.getKeyByRowIndex(0),
+            data: { name: '' },
+            type: 'update'
+        }]);
+
+        // act
+        this.option('editing.changes', [{
+            key: this.getKeyByRowIndex(0),
+            data: { name: 'val' },
+            type: 'update'
+        }]);
+
+        const validator = $(this.getCellElement(0, 0)).dxValidator('instance');
+        this.validatingController.validateCell(validator).done(result => {
+            // assert
+            assert.strictEqual(result.status, 'valid', 'status === "valid"');
+
+            done();
+        });
+    });
+    QUnit.test('validatingController.validateCell should call the validate method of the current validator if cell value chenged', function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const testElement = $('#container');
+        const done = assert.async();
+
+        rowsView.render(testElement);
+
+        this.applyOptions({
+            editing: {
+                mode: 'batch'
+            },
+            columns: [{
+                dataField: 'name',
+                validationRules: [{ type: 'required' }]
+            }]
+        });
+
+        this.editCell(0, 0);
+        this.cellValue(0, 0, '');
+
+        // act
+        this.option('editing.changes', [{
+            key: this.getKeyByRowIndex(0),
+            data: { name: 'val' },
+            type: 'update'
+        }]);
+
+        const validator = $(this.getCellElement(0, 0)).dxValidator('instance');
+        this.validatingController.validateCell(validator).done(result => {
+            // assert
+            assert.strictEqual(result.status, 'valid', 'status === "valid"');
+
+            done();
+        });
+    });
+
 
     QUnit.test('validatingController - validation result should be cached', function(assert) {
         // arrange


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
