### PR TITLE
TS build: Fix that path alias to TS files stay unresolved.

### DIFF
--- a/build/gulp/transpile.js
+++ b/build/gulp/transpile.js
@@ -63,7 +63,6 @@ const tsAliasBaseDir = path.resolve(__dirname, '../../js');
 const aliasTranspileConfig = {
     configFile: internalTsConfig,
     outDir: tsAliasBaseDir,
-    resolveFullPaths: true,
 }
 const createAliasTranspileAsync = async (config) => {
     // eslint-disable-next-line spellcheck/spell-checker

--- a/js/__internal/tsconfig.json
+++ b/js/__internal/tsconfig.json
@@ -1,5 +1,4 @@
 {
-
   "compilerOptions": {
     "baseUrl": "../",
     "outDir": "./build",
@@ -34,7 +33,16 @@
     //"useUnknownInCatchVariables": true,
     //"noImplicitOverride": true,
     "paths": {
-      "@js/*": ["./*"]
+      "@core-utils/*": ["./__internal/core/utils/*"],
+      "@js/*": ["./*"],
     },
   },
+  "tsc-alias": {
+    "verbose": false,
+    "resolveFullPaths": true,
+    "fileExtensions": {
+      "inputGlob": "js,ts",
+      "outputCheck": ["js", "ts"]
+    }
+  }
 }


### PR DESCRIPTION
Fixed the issue that the path alias from the tsconfig isn't resolved after the build.

**Problem:**
E.g. we have the following paths in the tsconfig:

```
"paths": {
  "@core-utils/*": "./__internal/core/utils/*"
}
```

And use is in TS module:
```
import { something } from '@core-utils/something';
```

**Expected behavior (after fix):**
After the build we see resolved import in the js module:
```
var something = require("../../../../core/utils/something");
```
**Current behavior:**
Import isn’t resolved:
```
var something = require("@core-uitls/something");
```