### PR TITLE
PivotGrid(T1150523): Remove redundant sort http request.

### DIFF
--- a/js/__internal/grids/pivot_grid/data_source/module.ts
+++ b/js/__internal/grids/pivot_grid/data_source/module.ts
@@ -1094,6 +1094,15 @@ const PivotGridDataSource = Class.inherit((function () {
       }
     },
 
+    sortLocal(): void {
+      this._sort(
+        this._descriptions,
+        this._data,
+        areExpressionsUsed(this._descriptions.values),
+      );
+      this._eventsStrategy.fireEvent('changed');
+    },
+
     paginate() {
       return this._paginate
         && this._store

--- a/js/__internal/grids/pivot_grid/field_chooser/const.ts
+++ b/js/__internal/grids/pivot_grid/field_chooser/const.ts
@@ -54,3 +54,8 @@ export const SORTABLE_CONST = {
     drag: 'drag',
   },
 };
+
+export enum SortOrder {
+  descending = 'desc',
+  ascending = 'asc',
+}

--- a/js/__internal/grids/pivot_grid/field_chooser/const.ts
+++ b/js/__internal/grids/pivot_grid/field_chooser/const.ts
@@ -2,7 +2,7 @@ export const ATTRIBUTES = {
   treeViewItem: 'tree-view-item',
   allowScrolling: 'allow-scrolling',
   itemGroup: 'item-group',
-};
+} as const;
 
 export const CLASSES = {
   area: {
@@ -41,21 +41,22 @@ export const CLASSES = {
   headerFilter: 'dx-header-filter',
   row: 'dx-row',
   widget: 'dx-widget',
-};
+} as const;
 
 export const ICONS = {
   measure: 'measure',
   hierarchy: 'hierarchy',
   dimension: 'dimension',
-};
+} as const;
 
 export const SORTABLE_CONST = {
   targets: {
     drag: 'drag',
   },
-};
+} as const;
 
-export enum SortOrder {
-  descending = 'desc',
-  ascending = 'asc',
-}
+export const SORT_ORDER = {
+  descending: 'desc',
+  ascending: 'asc',
+} as const;
+export type SortOrderType = typeof SORT_ORDER[keyof typeof SORT_ORDER];

--- a/js/__internal/grids/pivot_grid/field_chooser/module_base.ts
+++ b/js/__internal/grids/pivot_grid/field_chooser/module_base.ts
@@ -102,6 +102,7 @@ const FieldChooserBase = (Widget as any)
             cancel: localizationMessage.format('dxDataGrid-headerFilterCancel'),
           },
         },
+        // NOTE: private option added in fix of the T1150523 ticket.
         remoteSort: false,
       });
     },

--- a/js/__internal/grids/pivot_grid/field_chooser/utils.ts
+++ b/js/__internal/grids/pivot_grid/field_chooser/utils.ts
@@ -1,7 +1,7 @@
-import { SortOrder } from './const';
+import { SORT_ORDER, SortOrderType } from './const';
 
 export const reverseSortOrder = (
-  sortOrder: SortOrder,
-): SortOrder => (sortOrder === SortOrder.descending
-  ? SortOrder.ascending
-  : SortOrder.descending);
+  sortOrder: SortOrderType,
+): SortOrderType => (sortOrder === SORT_ORDER.descending
+  ? SORT_ORDER.ascending
+  : SORT_ORDER.descending);

--- a/js/__internal/grids/pivot_grid/field_chooser/utils.ts
+++ b/js/__internal/grids/pivot_grid/field_chooser/utils.ts
@@ -1,0 +1,7 @@
+import { SortOrder } from './const';
+
+export const reverseSortOrder = (
+  sortOrder: SortOrder,
+): SortOrder => (sortOrder === SortOrder.descending
+  ? SortOrder.ascending
+  : SortOrder.descending);

--- a/js/__internal/grids/pivot_grid/module_widget.ts
+++ b/js/__internal/grids/pivot_grid/module_widget.ts
@@ -1066,6 +1066,7 @@ const PivotGrid = (Widget as any).inherit({
       allowFieldDragging: that.option('fieldPanel.allowFieldDragging'),
       headerFilter: that.option('headerFilter'),
       visible: that.option('visible'),
+      remoteSort: that.option('scrolling.mode') === 'virtual',
     });
 
     const dataArea = that._renderDataArea(dataAreaElement);

--- a/testing/testcafe/tests/pivotGrid/sort/T1150523_localSort.ts
+++ b/testing/testcafe/tests/pivotGrid/sort/T1150523_localSort.ts
@@ -1,0 +1,126 @@
+import { RequestLogger, RequestMock } from 'testcafe';
+import createWidget from '../../../helpers/createWidget';
+import url from '../../../helpers/getPageUrl';
+import { isMaterial } from '../../../helpers/themeUtils';
+import PivotGrid from '../../../model/pivotGrid';
+
+const testFixture = () => (isMaterial() ? fixture.skip : fixture);
+
+testFixture()`pivotGrid_sort`
+  .page(url(__dirname, '../../containerAspNet.html'));
+
+const requestLogger = RequestLogger(/\/api\/data/);
+const apiRequestMock = RequestMock()
+  .onRequestTo(/\/api\/data\?skip/)
+  .respond(
+    {
+      data: [
+        { id: 0, label: 'A', value: 10 },
+        { id: 1, label: 'B', value: 20 },
+        { id: 2, label: 'C', value: 30 },
+      ],
+    },
+    200,
+    { 'access-control-allow-origin': '*' },
+  )
+  .onRequestTo(/\/api\/data\?group/)
+  .respond(
+    {
+      data: [
+        {
+          key: 'A',
+          items: null,
+          summary: [10],
+        },
+        {
+          key: 'B',
+          items: null,
+          summary: [20],
+        },
+        {
+          key: 'C',
+          items: null,
+          summary: [30],
+        },
+      ],
+    },
+    200,
+    { 'access-control-allow-origin': '*' },
+  );
+
+test('Should sort without DataSource reload if scrolling mode isn\'t virtual', async (t) => {
+  const pivotGrid = new PivotGrid('#container');
+  await t.addRequestHooks(requestLogger);
+
+  await t.click(pivotGrid.getColumnHeaderArea().getAction());
+
+  const requestCount = await requestLogger.count(() => true);
+  await t.expect(requestCount).eql(0);
+
+  await t.removeRequestHooks(requestLogger);
+}).before(async (t) => {
+  await t.addRequestHooks(apiRequestMock);
+  return createWidget('dxPivotGrid', () => ({
+    allowSorting: true,
+    fieldPanel: { visible: true },
+    dataSource: {
+      remoteOperations: true,
+      store: (window as any).DevExpress.data.AspNet.createStore({
+        key: 'id',
+        loadUrl: 'https://api/data',
+      }),
+      fields: [
+        {
+          dataField: 'label',
+          area: 'column',
+        },
+        {
+          dataField: 'value',
+          dataType: 'number',
+          area: 'data',
+        },
+      ],
+    },
+  }));
+}).after(async (t) => {
+  await t.removeRequestHooks(apiRequestMock);
+});
+
+test('Should sort with DataSource reload if scrolling mode is virtual', async (t) => {
+  const pivotGrid = new PivotGrid('#container');
+  await t.addRequestHooks(requestLogger);
+
+  await t.click(pivotGrid.getColumnHeaderArea().getAction());
+
+  const requestCount = await requestLogger.count(() => true);
+  await t.expect(requestCount).eql(1);
+
+  await t.removeRequestHooks(requestLogger);
+}).before(async (t) => {
+  await t.addRequestHooks(apiRequestMock);
+  return createWidget('dxPivotGrid', () => ({
+    allowSorting: true,
+    fieldPanel: { visible: true },
+    scrolling: { mode: 'virtual' },
+    dataSource: {
+      remoteOperations: true,
+      store: (window as any).DevExpress.data.AspNet.createStore({
+        key: 'id',
+        loadUrl: 'https://api/data',
+      }),
+      fields: [
+        {
+          dataField: 'label',
+          area: 'column',
+        },
+        {
+          dataField: 'value',
+          dataType: 'number',
+          area: 'data',
+        },
+      ],
+    },
+  }));
+}).after(async (t) => {
+  await t.removeRequestHooks(apiRequestMock);
+});

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
@@ -48,6 +48,7 @@ const createMockDataSource = function(options) {
             return false;
         },
         load: sinon.stub(),
+        sortLocal: sinon.stub(),
         on: sinon.stub(),
         off: sinon.stub(),
         isLoading: sinon.stub().returns(false)


### PR DESCRIPTION
See the [T1150523](https://supportcenter.devexpress.com/ticket/details/T1150523) ticket

Remove redundant DataSource reload on the ```sort``` action