### PR TITLE
Dom utils: contains method should not raise error if target is a href element

### DIFF
--- a/js/core/utils/dom.js
+++ b/js/core/utils/dom.js
@@ -1,10 +1,25 @@
 import domAdapter from '../../core/dom_adapter';
 import $ from '../../core/renderer';
 import { each } from './iterator';
-import { isDefined, isRenderer, isWindow } from './type';
+import { isDefined, isRenderer, isWindow, isString } from './type';
 import { getWindow } from './window';
 
 const window = getWindow();
+
+const getRootNodeHost = (element) => {
+    if(!element.getRootNode) {
+        return undefined;
+    }
+
+    const host = element.getRootNode().host;
+
+    // NOTE: getRootNode().host can return a string if element is detached "a" element
+    if(isString(host)) {
+        return undefined;
+    }
+
+    return host;
+};
 
 export const resetActiveElement = () => {
     const activeElement = domAdapter.getActiveElement();
@@ -96,7 +111,7 @@ export const contains = (container, element) => {
     if(isWindow(container)) {
         return contains(container.document, element);
     }
-    return container.contains(element) || element.getRootNode && contains(container, element.getRootNode().host);
+    return container.contains(element) || contains(container, getRootNodeHost(element));
 };
 
 export const createTextElementHiddenCopy = (element, text, options) => {

--- a/testing/tests/DevExpress.core/utils.dom.tests.js
+++ b/testing/tests/DevExpress.core/utils.dom.tests.js
@@ -106,6 +106,20 @@ QUnit.test('it correctly detect the body element', function(assert) {
     assert.ok(domUtils.contains(document, body), 'Document contains the body element');
 });
 
+QUnit.test('it does not raise error if element is a href', function(assert) {
+    const hrefElement = $('<a>')
+            .attr({ href: 'text' })
+            .get(0);
+
+    try {
+        domUtils.contains(document, hrefElement)
+    } catch(e) {
+        assert.ok(false, `error is raised: ${e.message}`);
+    } finally {
+        assert.ok(true, 'no error raised');
+    }
+});
+
 QUnit.test('it correctly detects the window element', function(assert) {
     assert.ok(domUtils.contains(window, document.body), 'Window contains the body element');
 });


### PR DESCRIPTION
… 

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
