### PR TITLE
DataGrid - The state of command buttons is rendered incorrectly in some situations when specific virtual scrolling options are used with repaintChangesOnly and a disabled cache (T1136896)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing_row_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_row_based.js
@@ -7,6 +7,8 @@ import {
 
 } from './ui.grid_core.editing_constants';
 
+import { equalByValue } from '../../core/utils/common';
+
 const EDIT_ROW = 'dx-edit-row';
 
 export const editingRowBasedModule = {
@@ -32,7 +34,7 @@ export const editingRowBasedModule = {
 
                 _isDefaultButtonVisible: function(button, options) {
                     const isRowMode = this.isRowBasedEditMode();
-                    const isEditRow = options.row && options.row.key === this.option(EDITING_EDITROWKEY_OPTION_NAME);
+                    const isEditRow = options.row && equalByValue(options.row.key, this.option(EDITING_EDITROWKEY_OPTION_NAME));
 
                     if(isRowMode) {
                         switch(button.name) {

--- a/js/ui/grid_core/ui.grid_core.editing_row_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_row_based.js
@@ -2,7 +2,8 @@ import {
     EDIT_MODE_ROW,
     MODES_WITH_DELAYED_FOCUS,
     ROW_SELECTED_CLASS,
-    EDIT_FORM_CLASS
+    EDIT_FORM_CLASS,
+    EDITING_EDITROWKEY_OPTION_NAME
 
 } from './ui.grid_core.editing_constants';
 
@@ -31,7 +32,7 @@ export const editingRowBasedModule = {
 
                 _isDefaultButtonVisible: function(button, options) {
                     const isRowMode = this.isRowBasedEditMode();
-                    const isEditRow = options.row && options.row.rowIndex === this._getVisibleEditRowIndex();
+                    const isEditRow = options.row && options.row.key === this.option(EDITING_EDITROWKEY_OPTION_NAME);
 
                     if(isRowMode) {
                         switch(button.name) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -6345,6 +6345,58 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             $('#qunit-fixture').removeClass('qunit-fixture-static');
         }
     });
+
+    // T1136896
+    QUnit.test('Editing buttons should rerender correctly after scrolling if repaintChangesOnly=true', function(assert) {
+        // arrange
+        const data = [...new Array(14)].map((_, i) => ({
+            id: i+1
+        }));
+
+        const dataGrid = createDataGrid({
+            height: 200,
+            loadingTimeout: null,
+            dataSource: data,
+            keyExpr: 'id',
+            scrolling: {
+                mode: 'virtual',
+            },
+            editing: {
+                mode: 'row',
+                allowUpdating: true,
+                allowDeleting: true,
+            },
+            repaintChangesOnly: true,          
+        });
+        this.clock.tick();
+
+        // act
+        dataGrid.option('editing.editRowKey', 14);
+
+        this.clock.tick();
+        $(dataGrid.getScrollable().container()).triggerHandler('scroll');
+        $(dataGrid.getScrollable().container()).triggerHandler('scroll');
+        this.clock.tick();
+
+
+        const $rows = $('.dx-data-row');
+        assert.strictEqual($rows.length, 6);
+
+        Array.from($rows).forEach((row, i) => {
+            const $row = $(row);
+            if (i === 5) { // editing row
+                assert.strictEqual($row.find('a').length, 2);
+                assert.strictEqual($row.find('a:eq(0)').text(), 'Save')
+                assert.strictEqual($row.find('a:eq(1)').text(), 'Cancel')
+                return;
+            }   
+
+            // other rows
+            assert.strictEqual($row.find('a').length, 2);
+            assert.strictEqual($row.find('a:eq(0)').text(), 'Edit')
+            assert.strictEqual($row.find('a:eq(1)').text(), 'Delete')
+        })
+    });
 });
 
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
