### PR TITLE
DataGrid - The state of command buttons is rendered incorrectly in some situations when specific virtual scrolling options are used with repaintChangesOnly and a disabled cache (T1136896)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.editing_row_based.js
+++ b/js/ui/grid_core/ui.grid_core.editing_row_based.js
@@ -2,9 +2,12 @@ import {
     EDIT_MODE_ROW,
     MODES_WITH_DELAYED_FOCUS,
     ROW_SELECTED_CLASS,
-    EDIT_FORM_CLASS
+    EDIT_FORM_CLASS,
+    EDITING_EDITROWKEY_OPTION_NAME
 
 } from './ui.grid_core.editing_constants';
+
+import { equalByValue } from '../../core/utils/common';
 
 const EDIT_ROW = 'dx-edit-row';
 
@@ -31,7 +34,7 @@ export const editingRowBasedModule = {
 
                 _isDefaultButtonVisible: function(button, options) {
                     const isRowMode = this.isRowBasedEditMode();
-                    const isEditRow = options.row && options.row.rowIndex === this._getVisibleEditRowIndex();
+                    const isEditRow = options.row && equalByValue(options.row.key, this.option(EDITING_EDITROWKEY_OPTION_NAME));
 
                     if(isRowMode) {
                         switch(button.name) {


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/24122