### PR TITLE
Upgrade sinon to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -155,7 +155,7 @@
         "recast": "0.22.0",
         "sass-embedded": "1.54.4",
         "shelljs": "0.8.5",
-        "sinon": "2.0.0",
+        "sinon": "2.4.1",
         "staged-git-files": "1.3.0",
         "string-replace-loader": "3.1.0",
         "stylelint": "14.16.1",
@@ -25285,9 +25285,9 @@
       "dev": true
     },
     "node_modules/sinon": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.0.0.tgz",
-      "integrity": "sha512-o2Qy9mZQsNqWh6ueL7kTnV35AszGl3MbYkfqgehYdqINFAT5geOeK2Y3VSFeyRXdfYK4v/+QMI7hmG+FDzooag==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
       "dev": true,
       "dependencies": {
         "diff": "^3.1.0",
@@ -49909,9 +49909,9 @@
       }
     },
     "sinon": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.0.0.tgz",
-      "integrity": "sha512-o2Qy9mZQsNqWh6ueL7kTnV35AszGl3MbYkfqgehYdqINFAT5geOeK2Y3VSFeyRXdfYK4v/+QMI7hmG+FDzooag==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
       "dev": true,
       "requires": {
         "diff": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,7 +155,7 @@
         "recast": "0.22.0",
         "sass-embedded": "1.54.4",
         "shelljs": "0.8.5",
-        "sinon": "1.10.3",
+        "sinon": "2.0.0",
         "staged-git-files": "1.3.0",
         "string-replace-loader": "3.1.0",
         "stylelint": "14.16.1",
@@ -11946,13 +11946,13 @@
       }
     },
     "node_modules/formatio": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz",
-      "integrity": "sha512-db27e1R5chXs7pZcJAh7aPC5iJRKRuCJEUF0cFWBdfG/Q0ZMehLg+dbibkXU5uyNM5AjmwBma8PkloxR+l2I1w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha512-YAF05v8+XCxAyHOdiiAmHdgCVPrWO8X744fYIPtBciIorh5LndWfi1gjeJ16sTbJhzek9kd+j3YByhohtz5Wmg==",
       "deprecated": "This package is unmaintained. Use @sinonjs/formatio instead",
       "dev": true,
       "dependencies": {
-        "samsam": "~1.1"
+        "samsam": "1.x"
       }
     },
     "node_modules/fp-ts": {
@@ -19754,6 +19754,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/lolex": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha512-/bpxDL56TG5LS5zoXxKqA6Ro5tkOS5M8cm/7yQcwLIKIcM2HR5fjjNCaIhJNv96SEk4hNGSafYMZK42Xv5fihQ==",
+      "dev": true
+    },
     "node_modules/looks-same": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-7.3.0.tgz",
@@ -20819,6 +20825,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -22045,6 +22057,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -24685,9 +24712,9 @@
       "dev": true
     },
     "node_modules/samsam": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.3.tgz",
-      "integrity": "sha512-t9rCPskf50hZ53eH8Z+cSWD4LfJBac+8vSSuzi1Y2HzygyXxtAl0BaR3hr6iI6A+nFQbkmJNC/brQLNEeVnrmg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "deprecated": "This package has been deprecated in favour of @sinonjs/samsam",
       "dev": true
     },
@@ -25258,16 +25285,31 @@
       "dev": true
     },
     "node_modules/sinon": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.10.3.tgz",
-      "integrity": "sha512-96UnuPQ46c7M11TuxW6J7WZyjQdJN03kjpaIM87qZFC5hHocZ3+IfslbEZ63r373Zt/MEGqQvqLtZ+Te5Mh4jg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.0.0.tgz",
+      "integrity": "sha512-o2Qy9mZQsNqWh6ueL7kTnV35AszGl3MbYkfqgehYdqINFAT5geOeK2Y3VSFeyRXdfYK4v/+QMI7hmG+FDzooag==",
       "dev": true,
       "dependencies": {
-        "formatio": "~1.0",
-        "util": ">=0.10.3 <1"
+        "diff": "^3.1.0",
+        "formatio": "1.2.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
+        "text-encoding": "0.6.4",
+        "type-detect": "^4.0.0"
       },
       "engines": {
         "node": ">=0.1.103"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/sisteransi": {
@@ -27687,6 +27729,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha512-hJnc6Qg3dWoOMkqP53F0dzRIgtmsAge09kxUIqGrEUS4qr5rWLckGYaQAVr+opBrIMRErGgy6f5aPnyPpyGRfg==",
+      "deprecated": "no longer maintained",
+      "dev": true
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
@@ -39365,12 +39414,12 @@
       }
     },
     "formatio": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz",
-      "integrity": "sha512-db27e1R5chXs7pZcJAh7aPC5iJRKRuCJEUF0cFWBdfG/Q0ZMehLg+dbibkXU5uyNM5AjmwBma8PkloxR+l2I1w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha512-YAF05v8+XCxAyHOdiiAmHdgCVPrWO8X744fYIPtBciIorh5LndWfi1gjeJ16sTbJhzek9kd+j3YByhohtz5Wmg==",
       "dev": true,
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.x"
       }
     },
     "fp-ts": {
@@ -45540,6 +45589,12 @@
         }
       }
     },
+    "lolex": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha512-/bpxDL56TG5LS5zoXxKqA6Ro5tkOS5M8cm/7yQcwLIKIcM2HR5fjjNCaIhJNv96SEk4hNGSafYMZK42Xv5fihQ==",
+      "dev": true
+    },
     "looks-same": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-7.3.0.tgz",
@@ -46375,6 +46430,12 @@
           "dev": true
         }
       }
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -47333,6 +47394,23 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -49377,9 +49455,9 @@
       "dev": true
     },
     "samsam": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.3.tgz",
-      "integrity": "sha512-t9rCPskf50hZ53eH8Z+cSWD4LfJBac+8vSSuzi1Y2HzygyXxtAl0BaR3hr6iI6A+nFQbkmJNC/brQLNEeVnrmg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sane": {
@@ -49831,13 +49909,27 @@
       }
     },
     "sinon": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.10.3.tgz",
-      "integrity": "sha512-96UnuPQ46c7M11TuxW6J7WZyjQdJN03kjpaIM87qZFC5hHocZ3+IfslbEZ63r373Zt/MEGqQvqLtZ+Te5Mh4jg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.0.0.tgz",
+      "integrity": "sha512-o2Qy9mZQsNqWh6ueL7kTnV35AszGl3MbYkfqgehYdqINFAT5geOeK2Y3VSFeyRXdfYK4v/+QMI7hmG+FDzooag==",
       "dev": true,
       "requires": {
-        "formatio": "~1.0",
-        "util": ">=0.10.3 <1"
+        "diff": "^3.1.0",
+        "formatio": "1.2.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
+        "text-encoding": "0.6.4",
+        "type-detect": "^4.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        }
       }
     },
     "sisteransi": {
@@ -51787,6 +51879,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/testcafe-safe-storage/-/testcafe-safe-storage-1.1.2.tgz",
       "integrity": "sha512-6km7D26+KCQGeFlSQ9fVEU7tD8qdioSpqzxU8CCZkd2KzBS0jTFkqaJ54rPaLdd5+wdhgO3+as3LMm4F0EDeYA==",
+      "dev": true
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha512-hJnc6Qg3dWoOMkqP53F0dzRIgtmsAge09kxUIqGrEUS4qr5rWLckGYaQAVr+opBrIMRErGgy6f5aPnyPpyGRfg==",
       "dev": true
     },
     "text-hex": {

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "recast": "0.22.0",
     "sass-embedded": "1.54.4",
     "shelljs": "0.8.5",
-    "sinon": "2.0.0",
+    "sinon": "2.4.1",
     "staged-git-files": "1.3.0",
     "string-replace-loader": "3.1.0",
     "stylelint": "14.16.1",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "recast": "0.22.0",
     "sass-embedded": "1.54.4",
     "shelljs": "0.8.5",
-    "sinon": "1.10.3",
+    "sinon": "2.0.0",
     "staged-git-files": "1.3.0",
     "string-replace-loader": "3.1.0",
     "stylelint": "14.16.1",

--- a/testing/helpers/chartMocks.js
+++ b/testing/helpers/chartMocks.js
@@ -1098,7 +1098,7 @@ export const MockAxis = function(renderOptions) {
         isFirstDrawing() {
             return true;
         },
-        getMarginOptions: sinon.stub.returns({}),
+        getMarginOptions: sinon.stub().returns({}),
         applyVisualRangeSetter: sinon.spy(),
         _setVisualRange: sinon.spy(),
         _getAdjustedBusinessRange: sinon.spy(),

--- a/testing/helpers/fileManagerHelpers.js
+++ b/testing/helpers/fileManagerHelpers.js
@@ -972,7 +972,7 @@ export const getFileChunkCount = (file, chunkSize) => {
 
 export const stubFileReader = object => {
     if(!(object['_createFileReader'].restore && object['_createFileReader'].restore.sinon)) {
-        sinon.stub(object, '_createFileReader', () => new FileReaderMock());
+        sinon.stub(object, '_createFileReader').callsFake(() => new FileReaderMock());
     }
 };
 

--- a/testing/tests/DevExpress.angular/widgets.tests.js
+++ b/testing/tests/DevExpress.angular/widgets.tests.js
@@ -174,7 +174,7 @@ QUnit.test('dxDataGrid', function(assert) {
 
     initMarkup($markup, controller, this);
 
-    this.clock.tick(30);
+    this.clock.tick(40);
 
     const $cols = $('.dx-datagrid-rowsview col');
     assert.roughEqual(parseInt($cols[0].style.width), 100, 1.01);
@@ -205,7 +205,7 @@ QUnit.test('dxDataGrid - search with row template should highlight data without 
     };
 
     initMarkup($markup, controller, this);
-    this.clock.tick(30);
+    this.clock.tick(40);
 
     assert.equal($($('.mycell')[0]).text(), 'text.1');
 
@@ -264,7 +264,7 @@ QUnit.test('dxDataGrid - search with cell template should highlight data without
     };
 
     initMarkup($markup, controller, this);
-    this.clock.tick(30);
+    this.clock.tick(40);
 
     assert.equal($($('.mycell')[0]).text(), 'text1');
 
@@ -321,7 +321,7 @@ QUnit.test('dxDataGrid - row template should rendered correctly with grouping', 
     };
 
     initMarkup($markup, controller, this);
-    this.clock.tick(30);
+    this.clock.tick(40);
 
     const $rows = $('.dx-datagrid-rowsview tbody > tr');
 
@@ -423,7 +423,7 @@ QUnit.test('Two-way binding', function(assert) {
 
     const scope = $markup.scope();
 
-    this.clock.tick(30);
+    this.clock.tick(40);
 
     let $rows = $markup.find('.dx-data-row');
     assert.equal($rows.length, 2, 'row count');
@@ -460,7 +460,7 @@ QUnit.test('Two-way binding when columnFixing', function(assert) {
 
     const scope = $markup.scope();
 
-    this.clock.tick(30);
+    this.clock.tick(40);
 
     let $rows = $markup.find('.dx-datagrid-content-fixed .dx-data-row');
     assert.equal($rows.length, 2, 'row count');
@@ -500,7 +500,7 @@ QUnit.test('Two-way binding does not work for inserted rows', function(assert) {
 
     const scope = $markup.scope();
 
-    this.clock.tick(30);
+    this.clock.tick(40);
 
     scope.$apply(function() {
         scope.grid.addRow();
@@ -538,7 +538,7 @@ QUnit.test('Assign selectedRowKeys option via binding', function(assert) {
 
     const scope = $markup.scope();
 
-    this.clock.tick(30);
+    this.clock.tick(40);
     scope.$apply(function() {
         scope.selectedRowKeys = [{ field1: 1, field2: 2 }];
         scope.selectedRowKeysInstance = scope.selectedRowKeys;
@@ -576,12 +576,12 @@ QUnit.test('Change selection.mode option via binding and refresh', function(asse
 
     const scope = $markup.scope();
 
-    this.clock.tick(30);
+    this.clock.tick(40);
 
 
     $($markup.find('.dx-data-row').eq(0).children().first()).trigger('dxclick');
 
-    this.clock.tick(30);
+    this.clock.tick(40);
 
 
     scope.$apply(function() {
@@ -590,7 +590,7 @@ QUnit.test('Change selection.mode option via binding and refresh', function(asse
         scope.grid.refresh();
     });
 
-    this.clock.tick(30);
+    this.clock.tick(40);
 
 
     assert.equal($markup.find('.dx-header-row').eq(0).children().length, 2, 'two cells in header row');
@@ -619,7 +619,7 @@ QUnit.test('Scope refreshing count on init', function(assert) {
 
     initMarkup($markup, controller, this);
 
-    this.clock.tick(30);
+    this.clock.tick(40);
 
     assert.equal(refreshingCount, 4);
 });
@@ -922,7 +922,7 @@ QUnit.test('dxDateBox with list strategy automatically scrolls to selected item 
 
     initMarkup($markup, function() {}, this);
 
-    this.clock.tick();
+    this.clock.tick(40);
 
     const $popupContent = $('.dx-popup-content');
     const $selectedItem = $popupContent.find('.dx-list-item-selected');

--- a/testing/tests/DevExpress.core/utils.ajax.tests.js
+++ b/testing/tests/DevExpress.core/utils.ajax.tests.js
@@ -80,7 +80,7 @@ QUnit.test('responseType arraybuffer', function(assert) {
     xhr.response = buffer;
     xhr.respond();
 
-    assert.equal(result, buffer);
+    assert.deepEqual(result, buffer);
 });
 
 QUnit.test('upload events', function(assert) {
@@ -156,7 +156,7 @@ QUnit.test('Set request header', function(assert) {
 
     assert.equal(xhr.method, 'GET');
     assert.equal(xhr.url, '/some-url');
-    assert.equal(xhr.requestHeaders['Content-Type'], 'text/html');
+    assert.equal(xhr.requestHeaders['Content-Type'], 'text/html;charset=utf-8'); // https://github.com/sinonjs/nise/issues/33
     assert.equal(xhr.requestHeaders['Accept'], 'application/xml');
     assert.equal(xhr.requestHeaders['X-Requested-With'], 'XMLHttpRequest');
 });
@@ -175,7 +175,7 @@ QUnit.test('Set request header and content-type', function(assert) {
 
     assert.equal(xhr.method, 'GET');
     assert.equal(xhr.url, '/some-url');
-    assert.equal(xhr.requestHeaders['Content-Type'], 'text/html');
+    assert.equal(xhr.requestHeaders['Content-Type'], 'text/html;charset=utf-8'); // https://github.com/sinonjs/nise/issues/33
     assert.equal(xhr.requestHeaders['Accept'], '*/*');
 });
 
@@ -219,10 +219,11 @@ QUnit.test('Default Content-Type', function(assert) {
 
     assert.equal(xhr1.method, 'GET');
     assert.equal(xhr1.url, '/some-url');
-    assert.equal(xhr1.requestHeaders['Content-Type'], undefined);
+    // https://chromium.googlesource.com/chromium/src/third_party/+/refs/heads/main/sinonjs/src/sinon.js?autodive=0%2F%2F#3795
+    assert.equal(xhr1.requestHeaders['Content-Type'], 'text/plain;charset=utf-8');
     assert.equal(xhr1.requestHeaders['Accept'], '*/*');
 
-    assert.equal(xhr2.requestHeaders['Content-Type'], undefined);
+    assert.equal(xhr2.requestHeaders['Content-Type'], 'text/plain;charset=utf-8');
 
     assert.equal(xhr3.method, 'POST');
     assert.equal(xhr3.requestHeaders['Content-Type'], 'application/x-www-form-urlencoded;charset=utf-8');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.integration.tests.js
@@ -104,7 +104,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
             const adaptiveColumnsController = instance.getController('adaptiveColumns');
             let $visibleColumns;
 
-            this.clock.tick();
+            this.clock.tick(10);
             $visibleColumns = $(instance.$element().find('.dx-header-row td:not(.dx-datagrid-hidden-column)'));
 
             // act
@@ -118,7 +118,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
 
             $('#container').width(450);
             instance.updateDimensions();
-            this.clock.tick();
+            this.clock.tick(10);
 
             $visibleColumns = $(instance.$element().find('.dx-header-row td:not(.dx-datagrid-hidden-column)'));
 
@@ -149,7 +149,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         const adaptiveColumnsController = instance.getController('adaptiveColumns');
         let $visibleColumns;
 
-        this.clock.tick();
+        this.clock.tick(10);
         $visibleColumns = $(instance.$element().find('.dx-header-row td'));
         const $hiddenColumn = $('.dx-datagrid-hidden-column').eq(0);
 
@@ -168,7 +168,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
 
         $('#container').width(450);
         instance.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
         $visibleColumns = $(instance.$element().find('.dx-header-row td'));
 
         // assert
@@ -194,7 +194,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         const adaptiveColumnsController = instance.getController('adaptiveColumns');
         let $visibleColumns;
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $visibleColumns = $(instance.$element().find('.dx-header-row td'));
 
@@ -214,7 +214,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         $('#container').width(900);
         instance.updateDimensions();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $visibleColumns = $(instance.$element().find('.dx-header-row td'));
 
@@ -276,7 +276,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
 
         // act
         instance.expandAdaptiveDetailRow(dataSource[0]);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.find('.dx-field-item-content').first().trigger('mouseover');
         dataGrid.find('.dx-field-item-content').first().trigger('mouseout');
 
@@ -310,7 +310,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
 
         // act
         instance.expandAdaptiveDetailRow(dataSource[0]);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.find('.dx-field-item-content').trigger('dxclick');
 
         // assert
@@ -354,7 +354,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         const instance = dataGrid.dxDataGrid('instance');
 
         instance.expandAdaptiveDetailRow(items[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const detailRowItems = $(instance.element()).find('.dx-adaptive-item-text')
@@ -383,7 +383,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
             e.shiftKey = shift;
             target.trigger(e);
         };
-        this.clock.tick();
+        this.clock.tick(10);
         let $lastDataCell = $(dataGrid.getCellElement(0, 5));
         const $commandCell = $(dataGrid.getCellElement(0, 6));
         const $firstNextRow = $(dataGrid.getCellElement(1, 0));
@@ -391,7 +391,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         // act
         dataGrid.focus($lastDataCell);
         fireKeyDown($lastDataCell, 'Tab');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         // tab
@@ -401,7 +401,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         // act
         dataGrid.focus($firstNextRow);
         fireKeyDown($firstNextRow, 'Tab', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         // shift tab
@@ -411,7 +411,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         // act
         dataGrid.focus($lastDataCell);
         fireKeyDown($lastDataCell, 'ArrowRight');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         // right arrow
@@ -422,7 +422,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
         $lastDataCell = $(dataGrid.getCellElement(0, 4));
         dataGrid.focus($lastDataCell);
         fireKeyDown($lastDataCell, 'Tab');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         // tab to visible
@@ -431,7 +431,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
 
         // act
         dataGrid.option('width', 600);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($commandCell.hasClass('dx-command-adaptive-hidden'), 'command cell is hidden after subsequent width increase');
@@ -447,7 +447,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
                 { id: 1, field1: 'string', field2: 'string', field3: 'string', field4: 'string', field5: 'string' }
             ],
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
         const $commandCell = $(dataGrid.getCellElement(0, 6));
         // assert
         assert.ok($commandCell.hasClass('dx-command-adaptive-hidden'), 'command cell is hidden');
@@ -456,7 +456,7 @@ QUnit.module('Adaptive columns', baseModuleConfig, () => {
 
         // act
         dataGrid.option('width', 400);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($commandCell.hasClass('dx-command-adaptive-hidden'), 'command cell is not hidden');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
@@ -81,7 +81,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.columnsController.columnOption('command:adaptive', 'visible'), 'adaptive command column is visible');
@@ -107,7 +107,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(cssInvokeCounter, 0, 'no $.css() invokes for width/height CSS properties');
@@ -126,7 +126,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.columnsController.columnOption('command:adaptive', 'adaptiveHidden'), 'adaptive command column is not shown');
@@ -142,11 +142,11 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
         this.option('columnHidingEnabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.columnsController.columnOption('command:adaptive', 'visible'), 'adaptive command column is shown');
@@ -187,7 +187,7 @@ QUnit.module('AdaptiveColumns', {
 
         this.gridView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.adaptiveColumnsController.getHiddenColumns().length, 0, 'There is no hidden columns');
@@ -199,11 +199,11 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
         this.option('columnHidingEnabled', false);
-        this.clock.tick();
+        this.clock.tick(10);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.columnsController.columnOption('command:adaptive', 'adaptiveHidden'), 'adaptive command column is hidden');
@@ -218,7 +218,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.rowsView.isClickableElement($('.dx-data-row td').eq(1)), 'row click isn\'t ignored');
@@ -236,12 +236,12 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-datagrid').width(600);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cols = $('.dx-datagrid-rowsview col');
 
@@ -256,14 +256,14 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
         this.columnsController.columnOption('command:adaptive', 'visibleIndex', -1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-datagrid').width(600);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cols = $('.dx-datagrid-rowsview col');
 
@@ -290,7 +290,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $cols = $('.dx-datagrid-rowsview col');
@@ -319,7 +319,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.gridView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $cols = $('.dx-datagrid-rowsview col');
@@ -353,7 +353,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $tables = $('.dx-datagrid-rowsview table');
@@ -377,7 +377,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $tables = $('.dx-datagrid-rowsview table');
@@ -402,7 +402,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $tables = $('.dx-datagrid-rowsview table');
@@ -439,12 +439,12 @@ QUnit.module('AdaptiveColumns', {
 
         $('.dx-datagrid').width(100);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
         let $cols = $('.dx-datagrid-rowsview col');
         const adaptiveRowsWidth = parseFloat($cols.eq($cols.length - 1).css('width'));
 
         this.dataController.collapseAll();
-        this.clock.tick();
+        this.clock.tick(10);
 
         $cols = $('.dx-datagrid-headers col');
         const adaptiveHeadersWidth = parseFloat($cols.eq($cols.length - 1).css('width'));
@@ -495,7 +495,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.columnsController.columnOption('command:adaptive', 'visible'), 'adaptive command column is shown');
@@ -509,7 +509,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick');
@@ -530,7 +530,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick');
@@ -565,7 +565,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -597,7 +597,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick');
@@ -634,7 +634,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick');
@@ -662,12 +662,12 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger(CLICK_NAMESPACE);
         this.columnsController.columnOption('lastName', 'visible', false);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-form .dx-field-item-content').length, 1, 'items count');
@@ -690,14 +690,14 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger(CLICK_NAMESPACE);
         this.columnsController.columnOption('lastName', 'visible', false);
-        this.clock.tick();
+        this.clock.tick(10);
         this.columnsController.columnOption('lastName', 'visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-form .dx-field-item-content').length, 2, 'items count');
@@ -720,14 +720,14 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger(CLICK_NAMESPACE);
         this.columnsController.columnOption('lastName', 'visible', false);
-        this.clock.tick();
+        this.clock.tick(10);
         this.columnsController.columnOption('middleName', 'visible', false);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-form .dx-field-item-content').length, 0, 'items count');
@@ -752,16 +752,16 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.columnsController.columnOption('command:adaptive', 'visibleIndex', -1);
-        this.clock.tick();
+        this.clock.tick(10);
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger(CLICK_NAMESPACE);
         this.columnsController.columnOption('lastName', 'visible', false);
-        this.clock.tick();
+        this.clock.tick(10);
         this.columnsController.columnOption('middleName', 'visible', false);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const cols = $('col');
@@ -795,7 +795,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick');
@@ -820,7 +820,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick.dxDataGridAdaptivity');
@@ -837,13 +837,13 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick.dxDataGridAdaptivity');
         $('.dx-datagrid').width(600);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cols = $('.dx-datagrid-rowsview col');
 
@@ -870,7 +870,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick.dxDataGridAdaptivity');
@@ -909,7 +909,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick.dxDataGridAdaptivity');
@@ -943,7 +943,7 @@ QUnit.module('AdaptiveColumns', {
         this.columnHeadersView.render($container);
         this.rowsView.render($container);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.columnsResizerController.pointsByColumns(), [{
@@ -979,7 +979,7 @@ QUnit.module('AdaptiveColumns', {
         this.columnHeadersView.render($container);
         this.rowsView.render($container);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.columnsResizerController.pointsByColumns(), [], 'points by columns');
@@ -1011,7 +1011,7 @@ QUnit.module('AdaptiveColumns', {
         this.columnHeadersView.render($container);
         this.rowsView.render($container);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.columnsResizerController.pointsByColumns().length, 1, 'points by columns count');
@@ -1044,7 +1044,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($container);
         this.draggingHeaderView.render($container);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const that = this;
@@ -1088,7 +1088,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($container);
         this.draggingHeaderView.render($container);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const that = this;
@@ -1137,7 +1137,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($container);
         this.columnsSeparatorView.render($container);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.columnsResizerController._isResizing = true;
@@ -1171,7 +1171,7 @@ QUnit.module('AdaptiveColumns', {
         this.columns[1].width = 200;
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const columns = this.exportController._getColumns();
@@ -1195,11 +1195,11 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $editors = $('.dx-form .dx-texteditor');
@@ -1216,7 +1216,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const col = $('.dx-datagrid-rowsview table').eq(0).find('col').get(1);
@@ -1232,12 +1232,12 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-datagrid').width(600);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const col = $('.dx-datagrid-rowsview table').eq(0).find('col').get(1);
@@ -1255,7 +1255,7 @@ QUnit.module('AdaptiveColumns', {
         this.columnHeadersView.render($('#container'));
         this.rowsView.render($('#container2'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const col = $('.dx-datagrid-headers table').eq(0).find('col').get(1);
@@ -1276,7 +1276,7 @@ QUnit.module('AdaptiveColumns', {
         this.columnHeadersView.render($('#container'));
         this.rowsView.render($('#container2'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $cols = $('.dx-datagrid-headers table').eq(0).find('col');
@@ -1299,12 +1299,12 @@ QUnit.module('AdaptiveColumns', {
         this.columnHeadersView.render($('#container'));
         this.rowsView.render($('#container2'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-datagrid').width(600);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const col = $('.dx-datagrid-headers table').eq(0).find('col').get(1);
@@ -1329,7 +1329,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.footerView.render($('#container2'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const col = $('.dx-datagrid-total-footer table').eq(0).find('col').get(1);
@@ -1354,12 +1354,12 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         this.footerView.render($('#container2'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-datagrid').width(600);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const col = $('.dx-datagrid-total-footer table').eq(0).find('col').get(1);
@@ -1375,7 +1375,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-command-adaptive.dx-command-adaptive-hidden').length, 2);
@@ -1387,12 +1387,12 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-datagrid').width(200);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-command-adaptive.dx-command-adaptive-hidden').length, 0);
@@ -1404,7 +1404,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $hiddenColumns;
         this.resizingController._getBestFitWidths = function() {
@@ -1415,7 +1415,7 @@ QUnit.module('AdaptiveColumns', {
         // act
         $('.dx-datagrid').width(250);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($hiddenColumns.length, 0);
@@ -1438,13 +1438,13 @@ QUnit.module('AdaptiveColumns', {
         };
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.expandRow(this.items[0]);
         $('.dx-datagrid').width(200);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-master-detail-row .dx-master-detail-cell.dx-datagrid-hidden-column').length, 0, 'master detail cell is not hidden');
@@ -1468,7 +1468,7 @@ QUnit.module('AdaptiveColumns', {
 
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-data-row .dx-command-adaptive:not(.dx-datagrid-hidden-column)').length, 2, 'the adaptive column is shown');
@@ -1480,11 +1480,11 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.columnsController.columnOption('command:adaptive', 'visible', false);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-data-row .dx-datagrid-adaptive-more').length, 0, 'command adaptive element');
@@ -1510,14 +1510,14 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
 
         $('.dx-datagrid').width(500);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-adaptive-detail-row .test-template').length, 1, 'cell template is shown');
@@ -1543,7 +1543,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-data-row .dx-command-adaptive.dx-command-adaptive-hidden').length, 2, 'command adaptive element');
@@ -1568,7 +1568,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-data-row .dx-command-adaptive.dx-command-adaptive-hidden').length, 2, 'command adaptive element should be hidden');
@@ -1591,7 +1591,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const rowsViewWrapper = dataGridWrapper.rowsView;
@@ -1620,7 +1620,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-data-row .dx-datagrid-adaptive-more').length, 2, 'command adaptive element');
@@ -1642,7 +1642,7 @@ QUnit.module('AdaptiveColumns', {
 
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-data-row .dx-datagrid-adaptive-more').length, 1, 'command adaptive element');
@@ -1665,7 +1665,7 @@ QUnit.module('AdaptiveColumns', {
 
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-data-row .dx-datagrid-adaptive-more').length, 2, 'command adaptive element');
@@ -1689,7 +1689,7 @@ QUnit.module('AdaptiveColumns', {
 
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-data-row .dx-datagrid-adaptive-more').length, 2, 'command adaptive element');
@@ -1704,7 +1704,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -1725,7 +1725,7 @@ QUnit.module('AdaptiveColumns', {
         this.rowsView.render($('#container'));
         sinon.spy(this.rowsView, '_getRowElements');
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.rowsView._getRowElements.calledOnce);
@@ -1740,7 +1740,7 @@ QUnit.module('AdaptiveColumns', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         $('.dx-data-row .dx-datagrid-adaptive-more').first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const form = $('#container').find('.dx-form').dxForm('instance');
         const colWidth = form.option('colCount');
@@ -1775,7 +1775,7 @@ QUnit.module('AdaptiveColumns', {
         // act
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const hiddenColumns = this.adaptiveColumnsController.getHiddenColumns();
@@ -1807,7 +1807,7 @@ QUnit.module('AdaptiveColumns', {
         // act
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const hiddenColumns = this.adaptiveColumnsController.getHiddenColumns();
@@ -1851,7 +1851,7 @@ QUnit.module('AdaptiveColumns', {
         // act
         this.rowsView.render($testElement);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($(this.rowsView.getRowElement(0)).children('.dx-command-adaptive').html(), '&nbsp;', 'adaptive cell');
@@ -1970,11 +1970,11 @@ QUnit.module('API', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('.dx-adaptive-detail-row').length, 'render field items');
@@ -1988,7 +1988,7 @@ QUnit.module('API', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $adaptiveCommand = $(this.getRowElement(0)).find('.dx-command-adaptive');
@@ -1996,7 +1996,7 @@ QUnit.module('API', {
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('.dx-adaptive-detail-row').length, 'render field items');
@@ -2004,7 +2004,7 @@ QUnit.module('API', {
 
         // act
         this.adaptiveColumnsController.collapseAdaptiveDetailRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!$('.dx-adaptive-detail-row').length, 'there is no field items');
@@ -2019,7 +2019,7 @@ QUnit.module('API', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $firstAdaptiveCommand = $(this.getRowElement(0)).find('.dx-command-adaptive');
@@ -2029,7 +2029,7 @@ QUnit.module('API', {
 
         // act
         $firstAdaptiveCommand.find('.dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($firstAdaptiveCommand.attr('aria-label'), 'Hide additional data', 'command cell aria-label'); // T947070
@@ -2037,7 +2037,7 @@ QUnit.module('API', {
 
         // act
         $secondAdaptiveCommand.find('.dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($firstAdaptiveCommand.attr('aria-label'), 'Display additional data', 'command cell aria-label'); // T947070
@@ -2052,18 +2052,18 @@ QUnit.module('API', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.adaptiveColumnsController.isAdaptiveDetailRowExpanded(this.items[0]), 'row is expanded');
 
         // act
         this.adaptiveColumnsController.collapseAdaptiveDetailRow(this.items[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.adaptiveColumnsController.isAdaptiveDetailRowExpanded(this.items[0]), 'row is collapsed');
@@ -2081,7 +2081,7 @@ QUnit.module('API', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2108,7 +2108,7 @@ QUnit.module('API', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.expandRow(this.items[0]);
@@ -2137,7 +2137,7 @@ QUnit.module('API', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2166,7 +2166,7 @@ QUnit.module('API', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.expandRow(this.items[0]);
@@ -2195,7 +2195,7 @@ QUnit.module('API', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2224,14 +2224,14 @@ QUnit.module('API', {
         setupDataGrid(this);
         this.rowsView.render($testElement);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         $rowElements = $testElement.find('tbody.dx-row');
         assert.strictEqual($rowElements.length, 3, 'row count');
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $rowElements = $testElement.find('tbody.dx-row');
@@ -2267,17 +2267,17 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let adaptiveDetailForm = $('.dx-adaptive-detail-row .dx-form').dxForm('instance');
         assert.notStrictEqual(adaptiveDetailForm, undefined, 'adaptive detail form is initialized');
 
         this.editingController.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         adaptiveDetailForm = $('.dx-adaptive-detail-row .dx-form').dxForm('instance');
         assert.strictEqual(adaptiveDetailForm, undefined, 'adaptive detail form is not initialized');
@@ -2296,12 +2296,12 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.editingController.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-datagrid').width(100);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $formItemElements = $('#container').find('.dx-datagrid-edit-form').first().find('.dx-datagrid-edit-form-item');
         assert.equal($formItemElements.length, 2, 'count editor');
@@ -2326,7 +2326,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
@@ -2352,7 +2352,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -2430,7 +2430,7 @@ QUnit.module('Editing', {
 
         // act
         editor.option('value', 'Man');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $editors = $('.dx-texteditor');
@@ -2466,7 +2466,7 @@ QUnit.module('Editing', {
 
         // act
         editor.option('value', 'Man');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $editors = $('.dx-texteditor');
@@ -2493,7 +2493,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -2531,7 +2531,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -2565,7 +2565,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2597,7 +2597,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -2644,7 +2644,7 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2677,7 +2677,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2706,7 +2706,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2734,7 +2734,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -2760,7 +2760,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -2786,7 +2786,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2813,7 +2813,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2844,7 +2844,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -2878,11 +2878,11 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $editors = $('.dx-form .dx-texteditor');
@@ -2904,13 +2904,13 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
         sinon.spy(this.editingController, '_delayedInputFocus');
         $('.dx-field-item-content').first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._delayedInputFocus.callCount, 1, 'editor is focused');
@@ -2929,7 +2929,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -2971,7 +2971,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3029,7 +3029,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3076,7 +3076,7 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3085,11 +3085,11 @@ QUnit.module('Editing', {
 
         $($itemsContent.last()).trigger('dxclick');
         const editor = $('.dx-texteditor').first().dxNumberBox('instance');
-        this.clock.tick();
+        this.clock.tick(10);
         editor.option('value', 102);
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $itemsContent = $('.dx-field-item-content');
 
         // assert
@@ -3127,7 +3127,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3174,7 +3174,7 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3182,17 +3182,17 @@ QUnit.module('Editing', {
         let editor;
 
         $($itemsContent.last()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         editor = $('.dx-texteditor').first().dxNumberBox('instance');
         editor.option('value', 14);
         $itemsContent = $('.dx-field-item-content');
         $($itemsContent.eq(0)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         editor = $('.dx-texteditor').first().dxTextBox('instance');
         editor.option('value', 'Test');
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $itemsContent = $('.dx-field-item-content');
 
         // assert
@@ -3231,20 +3231,20 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
 
         let $itemsContent = $('.dx-field-item-content');
         $($itemsContent.eq(0)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const editor = $('.dx-texteditor').first().dxTextBox('instance');
         editor.option('value', 'Test');
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $itemsContent = $('.dx-field-item-content');
@@ -3281,7 +3281,7 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         let editor;
         let $itemsContent;
@@ -3290,17 +3290,17 @@ QUnit.module('Editing', {
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
         $itemsContent = $('.dx-field-item-content');
         $($itemsContent.eq(1)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         editor = $('.dx-texteditor').first().dxNumberBox('instance');
         editor.option('value', 30);
         $itemsContent = $('.dx-field-item-content');
         $($itemsContent.eq(0)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         editor = $('.dx-texteditor').first().dxTextBox('instance');
         editor.option('value', 'test');
         $(document.body).trigger('dxpointerdown');
         $(document.body).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         this.adaptiveColumnsController.collapseAdaptiveDetailRow(dataSource[0]);
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
 
@@ -3349,7 +3349,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3396,7 +3396,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3434,12 +3434,12 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
         $('.dx-field-item-content').first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $editors = $('.dx-form .dx-texteditor');
@@ -3478,7 +3478,7 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3486,16 +3486,16 @@ QUnit.module('Editing', {
         const $itemsContent = $('.dx-field-item-content');
 
         $($itemsContent.last()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const editor = $('.dx-texteditor').first().dxNumberBox('instance');
         editor.option('value', 102);
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $('.dx-datagrid').width(1000);
         this.resizingController.resize();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($('.dx-cell-modified').text(), '102', 'text of modified cell');
     });
@@ -3530,7 +3530,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3562,7 +3562,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -3604,7 +3604,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -3657,7 +3657,7 @@ QUnit.module('Editing', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
@@ -3682,7 +3682,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
@@ -3709,7 +3709,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
@@ -3741,7 +3741,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
@@ -3773,7 +3773,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
@@ -3799,16 +3799,16 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $itemsContent = $('.dx-adaptive-detail-row .dx-field-item-content');
 
         $($itemsContent.first()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         const editors = $('.dx-texteditor');
 
         // assert
@@ -3818,7 +3818,7 @@ QUnit.module('Editing', {
         editors.first().dxTextBox('instance').option('value', '12test');
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.adaptiveColumnsController.hasAdaptiveDetailRowExpanded(), 'row is collapsed');
@@ -3848,7 +3848,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
@@ -3882,7 +3882,7 @@ QUnit.module('Editing', {
         this.rowsView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
@@ -3966,12 +3966,12 @@ QUnit.module('Validation', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
         this.editingController.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('.dx-form .dx-texteditor input').first().focus();
 
@@ -4011,11 +4011,11 @@ QUnit.module('Validation', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('.dx-form .dx-texteditor input').first().focus();
 
@@ -4024,7 +4024,7 @@ QUnit.module('Validation', {
         this.clock.tick(10);
 
         this.editingController.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(this.adaptiveColumnsController.isAdaptiveDetailRowExpanded(dataSource[0]), 'the adaptive row is expanded');
     });
@@ -4057,7 +4057,7 @@ QUnit.module('Validation', {
         setupDataGrid(this, renderer($parentContainer.get(0)));
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -4065,13 +4065,13 @@ QUnit.module('Validation', {
         let $itemsContent = $('.dx-field-item-content');
 
         $($itemsContent.first()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const editor = $('.dx-form .dx-texteditor').first().dxTextBox('instance');
         editor.option('value', '');
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('.dx-field-item-content.dx-validator').length === 1, 'item element has a validation styles');
@@ -4080,7 +4080,7 @@ QUnit.module('Validation', {
         // act
         $itemsContent = $('.dx-field-item-content');
         $($itemsContent.first()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('.dx-field-item-content > .dx-widget.dx-validator').length === 1, 'editor into a form item has a validation styles');
@@ -4117,7 +4117,7 @@ QUnit.module('Validation', {
         setupDataGrid(this, renderer($parentContainer.get(0)));
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -4125,13 +4125,13 @@ QUnit.module('Validation', {
         let $itemsContent = $('.dx-field-item-content');
 
         $itemsContent.first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const editor = $('.dx-form .dx-texteditor').first().dxTextBox('instance');
         editor.option('value', '');
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('.dx-field-item-content.dx-validator').length === 1, 'item element has a validation styles');
@@ -4140,7 +4140,7 @@ QUnit.module('Validation', {
         // act
         $itemsContent = $('.dx-field-item-content');
         $itemsContent.first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('.dx-field-item-content > .dx-widget.dx-validator').length === 1, 'editor into a form item has a validation styles');
@@ -4177,14 +4177,14 @@ QUnit.module('Validation', {
         setupDataGrid(this, renderer($parentContainer.get(0)));
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
         const $itemsContent = $('.dx-field-item-content');
 
         $($itemsContent.first()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-invalid-message.dx-widget').length, 0, 'Validation message is not shown');
@@ -4218,7 +4218,7 @@ QUnit.module('Validation', {
         setupDataGrid(this, renderer($parentContainer.get(0)));
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
         const showRevertButtonStub = sinon.stub(this.editorFactoryController, '_showRevertButton');
 
         // act
@@ -4227,13 +4227,13 @@ QUnit.module('Validation', {
         const $itemsContent = $('.dx-field-item-content');
 
         $($itemsContent.first()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const editor = $('.dx-form .dx-texteditor').first().dxTextBox('instance');
         editor.option('value', '');
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('.dx-field-item-content > .dx-widget.dx-validator').length === 1, 'item element has a validation styles');
@@ -4287,7 +4287,7 @@ QUnit.module('Validation', {
         setupDataGrid(this, $parentContainer);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(dataSource[0]);
@@ -4295,13 +4295,13 @@ QUnit.module('Validation', {
         let $itemsContent = $('.dx-field-item-content');
 
         $($itemsContent.eq(1)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const editor = $('.dx-form .dx-texteditor').first().dxTextBox('instance');
         editor.option('value', '');
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $itemsContent = $('.dx-field-item-content');
 
@@ -4323,11 +4323,11 @@ QUnit.module('Validation', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.rowsView.component.columnOption('C2', 'sortOrder', '0');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.rowsView._adaptiveColumnsController.getHiddenColumns().length, 0, 'has not hidden adaptive columns');
@@ -4348,11 +4348,11 @@ QUnit.module('Validation', {
         setupDataGrid(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.rowsView.component.columnOption('C2', 'sortOrder', '0');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.rowsView._adaptiveColumnsController.getHiddenColumns().length, 0, 'has not hidden adaptive columns');
@@ -4432,7 +4432,7 @@ QUnit.module('Keyboard navigation', {
         this.gridView.render($('#container'));
         this.adaptiveColumnsController.updateHidingQueue(this.columnsController.getColumns());
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.adaptiveColumnsController.expandAdaptiveDetailRow(this.items[0]);
     },
@@ -4443,7 +4443,7 @@ QUnit.module('Keyboard navigation', {
 
     triggerFormItemClick: function(index) {
         $('.dx-field-item-content').eq(index).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
     },
 
     beforeEach: function() {
@@ -4469,7 +4469,7 @@ QUnit.module('Keyboard navigation', {
 
         // act
         eventsEngine.triggerHandler($nextItemContent, 'focus');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $input = this.getActiveInputElement();
@@ -4488,7 +4488,7 @@ QUnit.module('Keyboard navigation', {
 
         // act
         eventsEngine.triggerHandler($nextItemContent, 'focus');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $input = this.getActiveInputElement();
@@ -4504,11 +4504,11 @@ QUnit.module('Keyboard navigation', {
         const e = $.Event('keydown');
         e.key = 'Tab';
         this.getActiveInputElement().trigger(e);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell = this.$dataGrid.find('td:not([class])').eq(1);
         eventsEngine.triggerHandler($cell, 'focus');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $input = this.getActiveInputElement();
         assert.equal($input.val(), 'Super', 'current input is correct');
@@ -4526,16 +4526,16 @@ QUnit.module('Keyboard navigation', {
 
         $('.dx-datagrid').width(500);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.editingController.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const e = $.Event('keydown');
         e.key = 'Tab';
         this.getActiveInputElement().trigger(e);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.getActiveInputElement().val(), 'Full Name');
@@ -4557,13 +4557,13 @@ QUnit.module('Keyboard navigation', {
         };
         this.setupModule();
         this.editingController.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const e = $.Event('keydown');
         e.key = 'Tab';
         this.getActiveInputElement().trigger(e);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { columnIndex: 3, rowIndex: 0 });
@@ -4590,7 +4590,7 @@ QUnit.module('Keyboard navigation', {
         this.setupModule();
 
         $('.dx-field-item-content').eq(0).focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(rowClickCounter, 0, 'onRowClick event was not thrown');
@@ -4628,7 +4628,7 @@ QUnit.module('Keyboard navigation', {
         // browser will focus element with tabIndex, if it was clicked
         $fieldItemContent.focus();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(rowDblClickCounter, 0, 'onRowDblClick was not called');
@@ -4643,14 +4643,14 @@ QUnit.module('Keyboard navigation', {
         // arrange
         this.setupModule();
         this.editingController.editCell(2, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const e = $.Event('keydown');
         e.key = 'Tab';
         e.shiftKey = true;
         this.getActiveInputElement().trigger(e);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.getActiveInputElement().val(), 'Full Name');
@@ -4665,7 +4665,7 @@ QUnit.module('Keyboard navigation', {
         // arrange
         this.setupModule();
         this.editingController.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const e = $.Event('keydown');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnChooserModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnChooserModule.tests.js
@@ -100,7 +100,7 @@ QUnit.module('Column chooser', {
         // act
         this.renderColumnChooser();
         this.columnChooserView._popupContainer.option('visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
         const $overlayWrapper = this.columnChooserView._popupContainer.$wrapper();
 
         // assert
@@ -121,7 +121,7 @@ QUnit.module('Column chooser', {
         // act
         this.renderColumnChooser();
         this.columnChooserView._popupContainer.option('visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
         const $overlayWrapper = this.columnChooserView._popupContainer.$wrapper();
 
         // assert
@@ -529,7 +529,7 @@ QUnit.module('Column chooser', {
         // act
         this.renderColumnChooser();
         this.columnChooserView._popupContainer.option('visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
         const $overlayWrapper = this.columnChooserView._popupContainer.$wrapper();
 
         // assert
@@ -548,7 +548,7 @@ QUnit.module('Column chooser', {
         // act
         this.renderColumnChooser();
         this.columnChooserView._popupContainer.option('visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(searchBoxWrapper.getEditorInput().attr('aria-label'), messageLocalization.format('Search'), 'Search box input aria-label attribute');
@@ -1116,7 +1116,7 @@ QUnit.module('Column chooser', {
 
         const popupInstance = this.columnChooserView._popupContainer;
         popupInstance.option('visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($(popupInstance.content()).find('.dx-column-chooser-item').length, 2, 'hidden column count');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnFixing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnFixing.integration.tests.js
@@ -140,7 +140,7 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
         const adaptiveColumnsController = instance.getController('adaptiveColumns');
         let $cells;
 
-        this.clock.tick();
+        this.clock.tick(10);
         $cells = $(instance.$element().find('.dx-header-row').first().find('td'));
 
         // act
@@ -153,7 +153,7 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
 
         $('#container').width(800);
         instance.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
         $cells = $(instance.$element().find('.dx-header-row').first().find('td'));
         const $unfixedColumns = $(instance.$element().find('.dx-header-row').last().find('td'));
 
@@ -362,7 +362,7 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const columns = dataGrid.getController('columns').getVisibleColumns();
         const adaptiveColumnWidth = columns[3].visibleWidth;
@@ -509,7 +509,7 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($dataGrid.find('.dx-datagrid-rowsview table').length, 2, 'two rowsview tables');
         assert.equal($dataGrid.dxDataGrid('instance').getView('rowsView').getTableElements().length, 2, 'two rowsview tables');
@@ -517,7 +517,7 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
         // act
         $dataGrid.dxDataGrid('instance').option('columnFixing.enabled', false);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($dataGrid.find('.dx-datagrid-rowsview table').length, 1, 'one main rowsview table');
@@ -588,7 +588,7 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
                 }
             ]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         for(let rowIndex = 0; rowIndex < 5; rowIndex++) {
             for(let columnIndex = 0; columnIndex < 5; columnIndex++) {
@@ -596,7 +596,7 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
 
                 // act
                 $cell.trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
                 $cell = $(dataGrid.getCellElement(rowIndex, columnIndex));
 
                 // assert
@@ -652,11 +652,11 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
                 }
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         const $detailGridContainer = $(dataGrid.element()).find('.mygrid');
 
         // assert
@@ -691,7 +691,7 @@ QUnit.module('Fixed columns', baseModuleConfig, () => {
                 e.component.columnOption(0, 'fixed', true);
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $rows = $(dataGrid.getRowElement(0));

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnResizing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnResizing.integration.tests.js
@@ -814,7 +814,7 @@ QUnit.module('Column Resizing', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         const $cols = $dataGrid.find('colgroup').first().find('col');
 
         // assert
@@ -841,7 +841,7 @@ QUnit.module('Column Resizing', baseModuleConfig, () => {
 
         // act
         dataGrid.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $headerRowsCells = dataGrid.$element().find('.dx-header-row').children();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsHeadersView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsHeadersView.tests.js
@@ -807,7 +807,7 @@ QUnit.module('Headers', {
         // act
         headerElement.trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         sortElements = testElement.find('.' + 'dx-sort-up');
         assert.equal(sortElements.length, 1, 'up sort');
@@ -817,7 +817,7 @@ QUnit.module('Headers', {
         headerElement = testElement.find('td');
         headerElement.trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         sortElements = testElement.find('.' + 'dx-sort-down');
         assert.equal(sortElements.length, 1, 'down sort');
@@ -827,7 +827,7 @@ QUnit.module('Headers', {
         headerElement = testElement.find('td');
         headerElement.eq(0).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         sortElements = testElement.find('.' + 'dx-sort');
@@ -851,7 +851,7 @@ QUnit.module('Headers', {
 
         // act
         headerElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(headerElement.attr('aria-sort'), 'none');
     });
@@ -873,7 +873,7 @@ QUnit.module('Headers', {
 
         // act
         headerElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(headerElement.attr('aria-sort'), 'none');
     });
@@ -895,7 +895,7 @@ QUnit.module('Headers', {
 
         // act
         headerElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(headerElement.attr('aria-sort'), 'ascending');
     });
@@ -921,7 +921,7 @@ QUnit.module('Headers', {
         // act
         popupMenu.find('.dx-menu-item').first().trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('td').first().find('.dx-sort-up').length, 1, 'has element with class dx-sort-up');
@@ -948,7 +948,7 @@ QUnit.module('Headers', {
         // act
         popupMenu.find('.dx-menu-item').eq(1).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('td').first().find('.dx-sort-down').length, 1, 'has element with class dx-sort-down');
@@ -979,7 +979,7 @@ QUnit.module('Headers', {
         // act
         popupMenu.find('.dx-menu-item').last().trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('td').first().find('.dx-sort-up').length, 0, 'not has element with class dx-sort-up');
@@ -1143,7 +1143,7 @@ QUnit.module('Headers', {
         // act
         testElement.find('td').last().trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.strictEqual(testElement.find('td').last().find('.dx-sort:not(.dx-sort-none)').length, 0);
     });
@@ -2365,7 +2365,7 @@ QUnit.module('Headers with band columns', {
         // act
         $popupMenu.find('.dx-menu-item').first().trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($cell.find('.dx-sort-up').length, 1, 'has element with class dx-sort-up');
@@ -2877,7 +2877,7 @@ QUnit.module('Multiple sorting', {
             const $headerCells = $testElement.find('.dx-header-row').children();
 
             $headerCells.eq(1).trigger($.Event('dxclick', { [key]: true }));
-            this.clock.tick();
+            this.clock.tick(10);
 
             const cols = this.columnsController.getVisibleColumns();
             assert.strictEqual(cols[0].sortOrder, undefined, 'first column has not sort order');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -221,7 +221,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
 
         // act
         dataSource.store().push([{ type: 'remove', key: 1 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(pushedSpy.callCount, 1, 'the pushed callback was called only once');
@@ -248,7 +248,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
 
         // act
         dataSource.store().push([{ type: 'remove', key: 1 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataPushedHandlerSpy.callCount, 1, 'the handler of the pushed callback was called only once');
@@ -359,7 +359,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
 
         this.dataController.optionChanged({ name: 'dataSource' });
         this.dataController.optionChanged({ name: 'grouping' });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(loadingSpy.callCount, 1, 'loading called once');
@@ -435,12 +435,12 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         this.dataController.setDataSource(dataSource);
         dataSource.load();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const items = this.dataController.items();
         this.columnsController.columnOption(1, 'visible', false);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.notStrictEqual(this.dataController.items(), items);
         assert.strictEqual(changedCount, 2);
@@ -582,7 +582,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         // act
         this.dataController.collapseAll();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changedCallCount, 1, 'changed called one time');
@@ -637,7 +637,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         // act
         this.dataController.collapseAll();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changedCallCount, 1, 'changed called one time after collapseAll');
@@ -673,7 +673,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
 
         // act
         this.dataController.collapseAll();
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.expandRow(['Alex']);
 
@@ -2272,7 +2272,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         });
         dataController.setDataSource(dataSource);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataController.items()[0].values[1], new Date(1987, 4, 5));
@@ -2303,7 +2303,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         });
         dataController.setDataSource(dataSource);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataController.items()[0].values[1], new Date(1985, 2, 21));
@@ -2336,7 +2336,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         });
         dataController.setDataSource(dataSource);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataController.items()[0].values[1], new Date(Date.UTC(1985, 2, 21)));
@@ -2373,7 +2373,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         });
         dataController.setDataSource(dataSource);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         lookupLoadResult = $.Deferred();
         // act
@@ -2389,7 +2389,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
             refreshed = true;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(changedCount, 0, 'changed call count');
         assert.ok(!refreshed, 'not refreshed');
@@ -2400,7 +2400,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         // assert
         assert.equal(changedCount, 0, 'changed call count');
         assert.ok(!refreshed, 'not refreshed');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(changedCount, 1, 'changed call count');
         assert.ok(refreshed, 'refreshed');
     });
@@ -2442,7 +2442,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
 
         // act
         dataController.refresh(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changedCount, 1, 'changed call count');
@@ -2479,7 +2479,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
 
         // act
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changedCount, 1, 'changed call count');
@@ -2513,7 +2513,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         });
         dataController.setDataSource(dataSource);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         dataController.changed.add(function(args) {
@@ -2526,7 +2526,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
 
         // act
         this.columnsController.changeSortOrder(0, 'desc');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changedCount, 1, 'changed call count');
@@ -2737,7 +2737,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         // act
         this.option('dataSource', dataSource);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.items().length, 3);
@@ -3338,7 +3338,7 @@ QUnit.module('Paging', { beforeEach: setupPagingModule, afterEach: teardownPagin
             changedCallCount++;
         });
         dataController.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataController.pageIndex(), 1);
         assert.equal(changedCallCount, 1);
     });
@@ -3595,7 +3595,7 @@ QUnit.module('Virtual scrolling', { beforeEach: setupVirtualScrollingModule, aft
         dataController.setViewportItemIndex(999);
         assert.strictEqual(this.dataController.pageIndex(), 49);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(dataController.items().length, 21, 'items');
 
@@ -3634,7 +3634,7 @@ QUnit.module('Virtual scrolling', { beforeEach: setupVirtualScrollingModule, aft
         dataController.setViewportItemIndex(998);
         assert.strictEqual(this.dataController.pageIndex(), 49);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(dataController.items().length, 39);
 
@@ -3735,7 +3735,7 @@ const setupVirtualRenderingModule = function() {
     this.dataController.viewportSize(10);
     this.dataController._dataSource._renderTime = 50;
 
-    this.clock.tick();
+    this.clock.tick(10);
 
     this.changedArgs = [];
 
@@ -3872,7 +3872,7 @@ QUnit.module('Virtual rendering', { beforeEach: setupVirtualRenderingModule, aft
     QUnit.test('scroll to second render page and expand row after expand row on the first page and refresh', function(assert) {
         this.dataController.expandRow(1);
         this.dataController.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.setViewportPosition(50);
         this.dataController.expandRow(5);
 
@@ -4051,7 +4051,7 @@ QUnit.module('Virtual rendering', { beforeEach: setupVirtualRenderingModule, aft
         this.option('scrolling.rowRenderingMode', 'standard');
         this.dataController.viewportItemSize(10);
         this.dataController.viewportSize(10);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         assert.strictEqual(this.dataController.items().length, 10);
         assert.strictEqual(this.dataController.items()[0].key, 0);
@@ -4077,7 +4077,7 @@ QUnit.module('Virtual rendering', { beforeEach: setupVirtualRenderingModule, aft
         this.dataController.optionChanged({ name: 'scrolling' });
         this.dataController.viewportItemSize(10);
         this.dataController.viewportSize(10);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         assert.strictEqual(this.dataController.items().length, 10);
         assert.strictEqual(this.dataController.items()[0].key, 0);
@@ -4100,19 +4100,19 @@ QUnit.module('Virtual rendering', { beforeEach: setupVirtualRenderingModule, aft
         this.option('scrolling.rowRenderingMode', 'standard');
         this.dataController.viewportItemSize(10);
         this.dataController.viewportSize(10);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.expandRow(1);
         this.dataController.expandRow(19);
         this.dataController.expandRow(20);
 
         this.dataController.setViewportPosition(200);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.changedArgs = [];
         this.dataController.setViewportPosition(400);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.dataController.items().length, 10);
@@ -4131,7 +4131,7 @@ QUnit.module('Virtual rendering', { beforeEach: setupVirtualRenderingModule, aft
     QUnit.test('Search should work correctly when rowRenderingMode is set to \'virtual\'', function(assert) {
     // arrange, act
         this.option('searchPanel.text', 'test');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.dataController.items().length, 0, 'item count');
@@ -4139,7 +4139,7 @@ QUnit.module('Virtual rendering', { beforeEach: setupVirtualRenderingModule, aft
 
         // act
         this.option('searchPanel.text', '');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.dataController.items().length, 10, 'item count');
@@ -4391,20 +4391,20 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
             pageSize: 2
         });
         this.dataController.viewportSize(2);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.changed.add(function(e) {
             changedArgs.push(e);
         });
 
         this.dataController.setViewportItemIndex(7);
         // act
-        this.clock.callTimer(this.clock.firstTimerInRange());
+        this.clock.next();
 
         // assert
         assert.equal(changedArgs.length, 0);
 
         // act
-        this.clock.callTimer(this.clock.firstTimerInRange());
+        this.clock.next();
 
         // assert
         assert.equal(changedArgs.length, 2);
@@ -4429,7 +4429,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
             changedArgs.push(e);
         });
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changedArgs.length, 3);
@@ -4457,7 +4457,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
             changedArgs.push(e);
         });
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changedArgs.length, 4);
@@ -4479,9 +4479,9 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
         const dataController = this.dataController;
 
 
-        this.clock.tick();
+        this.clock.tick(10);
         dataController.setViewportItemIndex(7);
-        this.clock.tick();
+        this.clock.tick(10);
         dataController.changed.add(function(e) {
             changedArgs.push(e);
             virtualItems.push(dataController.virtualItemsCount());
@@ -4489,7 +4489,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
         // act
         dataController.reload(true);
-        this.clock.callTimer(this.clock.firstTimerInRange());
+        this.clock.next();
 
         // assert
         assert.deepEqual(changedArgs, []);
@@ -4497,7 +4497,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
         assert.ok(dataController.isLoaded());
 
         // act
-        this.clock.callTimer(this.clock.firstTimerInRange());
+        this.clock.next();
 
         // assert
         assert.equal(changedArgs.length, 2);
@@ -4599,7 +4599,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
             finalized = true;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(finalized);
     });
 
@@ -4607,8 +4607,6 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
     QUnit.test('update loading on reload when error occurred', function(assert) {
         let finalized;
         let loadResult;
-
-        const clock = this.clock;
 
         this.options.loadingTimeout = 0;
 
@@ -4648,11 +4646,11 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
             finalized = true;
         });
 
-        clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(finalized);
-        clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!dataController.isLoaded(), 'isLoaded after error');
@@ -4678,7 +4676,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
 
         dataController.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataController.loadingChanged.add(function() {
             events.push('loadingChanged');
@@ -4690,7 +4688,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
         // act
         dataController.reload(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(events, ['loadingChanged', 'loadingChanged', 'changed']);
@@ -4833,7 +4831,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
         dataController.load();
         dataController.viewportSize(3);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!isLoading, 'not loading');
@@ -4844,7 +4842,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
         dataController.changeRowExpand([0]);
 
         assert.ok(isLoading, 'loading started');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(!isLoading, 'loading ended');
     });
 
@@ -5019,7 +5017,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
         // act
         this.dataController.setViewportPosition(500);
-        this.clock.tick();
+        this.clock.tick(10);
         const visibleItems = this.dataController.items();
         const loadedItems = this.dataController.dataSource().items();
 
@@ -5066,7 +5064,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
         // act
         this.dataController.viewportSize(15);
         this.dataController.setViewportPosition(100);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.getLoadPageParams(), { pageIndex: 0, loadPageCount: 1, skipForCurrentPage: 5 }, 'load page params after scrolling');
@@ -5104,9 +5102,9 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
         this.dataController.viewportSize(15);
         this.dataController.setViewportPosition(50);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.setViewportPosition(0);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.changed.add(changedSpy);
 
         let renderedItemIds = this.dataController.items().map(i => i.data.id);
@@ -5116,7 +5114,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
         // act
         this.dataController.setViewportPosition(100);
-        this.clock.tick();
+        this.clock.tick(10);
 
         renderedItemIds = this.dataController.items().map(i => i.data.id);
         const change = changedSpy.args[0][0];
@@ -5161,10 +5159,10 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
         this.dataController.viewportSize(15);
         this.dataController.setViewportPosition(50);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.setViewportPosition(0);
         this.dataController.setViewportPosition(1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.changed.add(changedSpy);
 
         let renderedItemIds = this.dataController.items().map(i => i.data.id);
@@ -5174,7 +5172,7 @@ QUnit.module('Virtual scrolling (ScrollingDataSource)', {
 
         // act
         this.dataController.setViewportPosition(10);
-        this.clock.tick();
+        this.clock.tick(10);
 
         renderedItemIds = this.dataController.items().map(i => i.data.id);
 
@@ -5757,7 +5755,7 @@ QUnit.module('Infinite scrolling', {
         this.dataController.setViewportItemIndex(10);
         this.dataController.setViewportItemIndex(10);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(loadingCount, 1);
@@ -5810,7 +5808,7 @@ QUnit.module('Infinite scrolling', {
 
         // act
         this.dataController.setViewportItemIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.dataController.pageIndex(), 0);
@@ -6023,7 +6021,7 @@ QUnit.module('Infinite scrolling (ScrollingDataSource)', {
             pageSize: 3
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const dataController = this.dataController;
 
@@ -6034,7 +6032,7 @@ QUnit.module('Infinite scrolling (ScrollingDataSource)', {
         dataController.pageIndex(0);
         dataController.load();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataController.pageIndex(), 0, 'page index');
@@ -6122,7 +6120,7 @@ QUnit.module('Infinite scrolling (ScrollingDataSource)', {
 
         // act
         this.dataController.setViewportPosition(500);
-        this.clock.tick();
+        this.clock.tick(10);
         const visibleItems = this.dataController.items();
         const loadedItems = this.dataController.dataSource().items();
 
@@ -6168,9 +6166,9 @@ QUnit.module('Infinite scrolling (ScrollingDataSource)', {
 
         this.dataController.viewportSize(15);
         this.dataController.setViewportPosition(50);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.setViewportPosition(0);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.changed.add(changedSpy);
 
         let renderedItemIds = this.dataController.items().map(i => i.data.id);
@@ -6180,7 +6178,7 @@ QUnit.module('Infinite scrolling (ScrollingDataSource)', {
 
         // act
         this.dataController.setViewportPosition(100);
-        this.clock.tick();
+        this.clock.tick(10);
 
         renderedItemIds = this.dataController.items().map(i => i.data.id);
         const change = changedSpy.args[0][0];
@@ -6225,10 +6223,10 @@ QUnit.module('Infinite scrolling (ScrollingDataSource)', {
 
         this.dataController.viewportSize(15);
         this.dataController.setViewportPosition(50);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.setViewportPosition(0);
         this.dataController.setViewportPosition(1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.changed.add(changedSpy);
 
         let renderedItemIds = this.dataController.items().map(i => i.data.id);
@@ -6238,7 +6236,7 @@ QUnit.module('Infinite scrolling (ScrollingDataSource)', {
 
         // act
         this.dataController.setViewportPosition(10);
-        this.clock.tick();
+        this.clock.tick(10);
 
         renderedItemIds = this.dataController.items().map(i => i.data.id);
 
@@ -6971,7 +6969,7 @@ QUnit.module('Filtering', {
         });
         that.dataController.setDataSource(that.dataSource);
         that.dataSource.load();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // arrange
         that.dataController.changed.add(function() {
@@ -6980,7 +6978,7 @@ QUnit.module('Filtering', {
 
         // act
         that.columnOption('name', 'filterType', 'exclude');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(that.columnsController.getColumns()[0].filterType, 'exclude', 'filterType is changed');
@@ -7009,7 +7007,7 @@ QUnit.module('Filtering', {
         that.dataController.setDataSource(that.dataSource);
         that.dataSource.load();
         that.dataController.searchByText('Bob');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const items = that.dataController.items();
@@ -7029,7 +7027,7 @@ QUnit.module('Filtering', {
 
         // act
         that.dataController.clearFilter();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         columns = that.columnsController.getColumns();
@@ -8013,7 +8011,7 @@ QUnit.module('Filtering', {
         this.dataController.setDataSource(this.dataSource);
         this.dataSource.load();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.items().length, 1);
@@ -9126,7 +9124,7 @@ QUnit.module('Editing', { beforeEach: function() {
         // act
         this.editingController.getFirstEditableCellInRow = function() { return $([]); };
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.editRow(0);
@@ -9181,7 +9179,7 @@ QUnit.module('Error handling', {
         this.dataController.dataErrorOccurred.add(function(error) {
             callbackDataErrors.push(error.message);
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataErrors, ['Load error']);
@@ -9216,7 +9214,7 @@ QUnit.module('Error handling', {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataErrors.length, 1);
@@ -9250,7 +9248,7 @@ QUnit.module('Error handling', {
             callbackDataErrors.push(error.message);
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataErrors, ['Load error']);
@@ -9284,7 +9282,7 @@ QUnit.module('Error handling', {
 
         this.editingController.getFirstEditableCellInRow = function() { return $([]); };
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.addRow();
@@ -9322,7 +9320,7 @@ QUnit.module('Error handling', {
         // act
         setupDataGridModules(this, ['data', 'columns', 'editing']);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.deleteRow(0);
@@ -9462,7 +9460,7 @@ QUnit.module('Remote Grouping', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!storeLoadOptions.group, 'no group option');
@@ -9497,7 +9495,7 @@ QUnit.module('Remote Grouping', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.totalCount(), 2, 'totalCount');
@@ -9533,7 +9531,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), []);
@@ -9567,7 +9565,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!storeLoadOptions.skip && !storeLoadOptions.take, 'no paging options');
@@ -9603,7 +9601,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.items().length, 2, 'two items are loaded');
@@ -9648,7 +9646,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!errorId, 'no errors');
@@ -9696,7 +9694,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(storeLoadOptions.totalSummary, [{ selector: 'age', summaryType: 'count' }], 'totalSummary option');
@@ -9744,7 +9742,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!errorId, 'no errors');
@@ -9788,9 +9786,9 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.filter(['age', '>', 20]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.getVisibleRows().length, 1, 'rows are filtered');
@@ -9827,7 +9825,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, 0, 'skip option');
@@ -9888,7 +9886,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, undefined, 'skip option');
@@ -9961,7 +9959,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, undefined, 'skip option');
@@ -10029,7 +10027,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, 0, 'skip option');
@@ -10089,7 +10087,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, 0, 'skip option');
@@ -10150,7 +10148,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, undefined, 'no skip option');
@@ -10215,7 +10213,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, undefined, 'no skip option');
@@ -10285,7 +10283,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, undefined, 'no skip option');
@@ -10353,7 +10351,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.pageIndex(1);
 
         const items = this.dataController.items();
@@ -10409,7 +10407,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(storeLoadOptions.skip, undefined, 'no skip option');
@@ -10446,7 +10444,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10477,7 +10475,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.items().length, 1);
@@ -10511,7 +10509,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10549,7 +10547,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10593,7 +10591,7 @@ QUnit.module('Summary', {
                 }
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10639,7 +10637,7 @@ QUnit.module('Summary', {
                 }
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10680,7 +10678,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10724,7 +10722,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10768,7 +10766,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), []);
@@ -10794,7 +10792,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10832,7 +10830,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10873,7 +10871,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(errorId, 'E1026', 'error message');
@@ -10916,7 +10914,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -10968,7 +10966,7 @@ QUnit.module('Summary', {
 
         // act
         setupDataGridModules(this, ['data', 'columns', 'selection', 'summary']);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.footerItems(), [{
@@ -11026,14 +11024,14 @@ QUnit.module('Summary', {
         };
 
         setupDataGridModules(this, ['data', 'columns', 'selection', 'summary', 'grouping']);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const changedSpy = sinon.spy();
         this.dataController.changed.add(changedSpy);
 
         // act
         this.selectRows([1, 2]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(changedSpy.callCount, 2);
@@ -11069,7 +11067,7 @@ QUnit.module('Summary', {
         };
 
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.options.summary.totalItems.push({
@@ -11078,7 +11076,7 @@ QUnit.module('Summary', {
         });
 
         this.dataController.optionChanged({ name: 'summary' });
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // assert
@@ -11118,7 +11116,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11162,7 +11160,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.dataController.items().length, 5);
@@ -11198,7 +11196,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.dataController.items().length, 7);
@@ -11237,7 +11235,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11277,7 +11275,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11315,7 +11313,7 @@ QUnit.module('Summary', {
         };
 
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.columnsController.columnOption('name', 'groupIndex', 0);
@@ -11353,11 +11351,11 @@ QUnit.module('Summary', {
         };
 
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.option('sortByGroupSummaryInfo', [{ summaryItem: 'count' }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // assert
@@ -11409,7 +11407,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11445,7 +11443,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11485,7 +11483,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const headerFilterDataSource = new DataSource(this.headerFilterController.getDataSource(this.getVisibleColumns()[1]));
         let headerFilterItems;
@@ -11513,7 +11511,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.dataController._findSummaryItem(summaryItems, 'count'), 0, 'find by summaryType');
@@ -11551,7 +11549,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11596,7 +11594,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11645,7 +11643,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11705,7 +11703,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11759,7 +11757,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.expandRow(['Alex']);
 
@@ -11800,7 +11798,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11841,7 +11839,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11882,7 +11880,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11921,7 +11919,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11954,7 +11952,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -11987,7 +11985,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -12033,7 +12031,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -12090,7 +12088,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -12138,7 +12136,7 @@ QUnit.module('Summary', {
 
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataController.isLoading());
@@ -12222,7 +12220,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('Total summary items without editing', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.getTotalValues(), [5, 20]);
@@ -12231,7 +12229,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('modify cell', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.setValue(0, 3);
 
         // assert
@@ -12241,7 +12239,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('modify cell and cancelEditData', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.setValue(0, 3);
         this.cancelEditData();
 
@@ -12252,7 +12250,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('add row', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.addRow();
 
         // assert
@@ -12263,7 +12261,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('add row if data is grouped', function(assert) {
         // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.getDataSource().group('id');
         this.getDataSource().load();
         this.addRow();
@@ -12276,7 +12274,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('add row and modify cell', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.addRow();
         this.setValue(0, 1);
 
@@ -12287,7 +12285,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('add row and delete row', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.addRow();
         this.deleteRow(0);
 
@@ -12298,7 +12296,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('delete row', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.deleteRow(3);
 
         // assert
@@ -12309,7 +12307,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('delete row if data is grouped', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.getDataSource().group('id');
         this.getDataSource().load();
 
@@ -12328,7 +12326,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('modify cell and delete row', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.setValue(3, 100);
         this.deleteRow(3);
 
@@ -12339,7 +12337,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('delete row and undelete row', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.deleteRow(3);
         this.undeleteRow(3);
 
@@ -12350,7 +12348,7 @@ QUnit.module('Summary with Editing', {
     QUnit.test('modify cell, delete row and undelete row', function(assert) {
     // act
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
         this.setValue(3, 100);
         this.deleteRow(3);
         this.undeleteRow(3);
@@ -12361,7 +12359,7 @@ QUnit.module('Summary with Editing', {
 
     QUnit.test('partial update after editing', function(assert) {
         this.setupDataGridModules();
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.addRow();
 
@@ -12721,7 +12719,7 @@ QUnit.module('Master Detail', {
         this.options.loadingTimeout = 0;
         this.setupDataGrid();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.changeRowExpand([0]);
@@ -12730,7 +12728,7 @@ QUnit.module('Master Detail', {
         assert.equal(events.length, 1, 'one expand event called');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -13763,7 +13761,7 @@ QUnit.module('Refresh changesOnly', {
 
         this.dataController.refresh(true);
         this.dataController.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -13788,7 +13786,7 @@ QUnit.module('Refresh changesOnly', {
 
         this.dataController.refresh();
         this.dataController.refresh(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -13813,7 +13811,7 @@ QUnit.module('Refresh changesOnly', {
 
         this.dataController.refresh(true);
         this.dataController.refresh(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -14320,7 +14318,7 @@ QUnit.module('Using DataSource instance', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.dataSource.filter(), 'no filter');
@@ -14330,7 +14328,7 @@ QUnit.module('Using DataSource instance', {
         // act
         this.dataSource.filter(['field1', '=', 2]);
         this.dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const filter = this.dataSource.filter();
@@ -14350,7 +14348,7 @@ QUnit.module('Using DataSource instance', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.changed.add(function() {
             changes.push('data');
@@ -14364,7 +14362,7 @@ QUnit.module('Using DataSource instance', {
         this.dataSource.group('field1');
         this.dataSource.pageSize(5);
         this.dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.columnOption(0, 'groupIndex'), 0);
@@ -14390,7 +14388,7 @@ QUnit.module('Using DataSource instance', {
             dataSource: this.dataSource
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.changed.add(function() {
             changes.push('data');
@@ -14403,7 +14401,7 @@ QUnit.module('Using DataSource instance', {
         // act
         this.dataSource.sort({ selector: 'field3', desc: true });
         this.dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.columnOption(0, 'sortIndex'), undefined);
@@ -14427,12 +14425,12 @@ QUnit.module('Using DataSource instance', {
             dataSource: this.dataSource
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataSource.pageIndex(1);
         this.dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.pageIndex(), 1);
@@ -14447,7 +14445,7 @@ QUnit.module('Using DataSource instance', {
             scrolling: { mode: 'infinite' }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.totalItemsCount(), 3);
@@ -14455,7 +14453,7 @@ QUnit.module('Using DataSource instance', {
 
         // act
         this.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.totalItemsCount(), 5);
@@ -14466,7 +14464,7 @@ QUnit.module('Using DataSource instance', {
 
         // act
         this.dataSource.reload(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.totalItemsCount(), 3);
@@ -14484,7 +14482,7 @@ QUnit.module('Using DataSource instance', {
             grouping: { autoExpandAll: true }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(this.columnsController.getGroupColumns().length, 1, 'grouped columns count');
         assert.deepEqual(this.dataController._dataSource.group(), [{ selector: 'field1', desc: false, isExpanded: true }], 'dataSource group when autoExpandAll true');
@@ -14492,7 +14490,7 @@ QUnit.module('Using DataSource instance', {
         // act
         this.option('grouping.autoExpandAll', false);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.columnsController.getGroupColumns().length, 1, 'grouped columns count');
@@ -14514,7 +14512,7 @@ QUnit.module('Using DataSource instance', {
             dataSource: this.dataSource
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.items().length, 3, 'items count');
@@ -14529,7 +14527,7 @@ QUnit.module('Using DataSource instance', {
             dataSource: this.dataSource
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         try {
         // act
@@ -14579,14 +14577,14 @@ QUnit.module('Exporting', {
         let allItems;
         this.setupDataGridModules({});
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.loadAll().done(function(items) {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.items().length, 0, 'items count');
@@ -14606,7 +14604,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.dataErrorOccurred.add(function(e) {
             dataErrorOccurredArgs.push(e);
@@ -14621,7 +14619,7 @@ QUnit.module('Exporting', {
             error = e;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.items().length, 0, 'items count');
@@ -14644,7 +14642,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.changed.add(function() {
             changedCallCount++;
@@ -14655,7 +14653,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.items().length, 3, 'items count');
@@ -14692,7 +14690,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.changed.add(function() {
             changedCallCount++;
@@ -14703,7 +14701,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.items().length, 2, 'items count');
@@ -14745,7 +14743,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(this.dataController.pageCount(), 4, 'pageCount');
 
@@ -14759,7 +14757,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.items().length, 4, 'items count');
@@ -14817,7 +14815,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(this.dataController.pageCount(), 1, 'pageCount');
 
@@ -14832,7 +14830,7 @@ QUnit.module('Exporting', {
             allSummary = summary;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(changedCallCount, 0, 'changed call count');
@@ -14896,7 +14894,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(this.dataController.pageCount(), 1, 'pageCount');
 
@@ -14911,7 +14909,7 @@ QUnit.module('Exporting', {
             allSummary = summary;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(changedCallCount, 0, 'changed call count');
@@ -14986,7 +14984,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(this.dataController.pageCount(), 1, 'pageCount');
 
@@ -15003,7 +15001,7 @@ QUnit.module('Exporting', {
             allSummary = summary;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(loadArgs.length, 0, 'load count');
@@ -15030,7 +15028,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.expandRow(this.array[0]);
@@ -15039,7 +15037,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.items()[1].rowType, 'detail', 'detail row in original items');
@@ -15065,7 +15063,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.updateFieldValue({
@@ -15079,7 +15077,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(allItems.length, 5, 'all items count');
@@ -15098,14 +15096,14 @@ QUnit.module('Exporting', {
             columns: ['field1', { dataField: 'field2', filterValue: 3 }, 'field3']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.loadAll().done(function(items) {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(allItems.length, 2, 'all items count');
@@ -15122,14 +15120,14 @@ QUnit.module('Exporting', {
             columns: [{ dataField: 'group', dataType: 'number', groupIndex: 0 }, 'id']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.loadAll().done(function(items) {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(allItems.length, 3, 'all items count');
@@ -15153,7 +15151,7 @@ QUnit.module('Exporting', {
             isLoadAllFailed = true;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(isLoadAllFailed, 'loadAll failed');
@@ -15172,7 +15170,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.beginCustomLoading('test');
@@ -15180,7 +15178,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
         this.dataController.endCustomLoading();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(allItems.length, 5, 'loaded all item count');
@@ -15200,7 +15198,7 @@ QUnit.module('Exporting', {
             columns: ['field1', 'field2', 'field3']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // act
@@ -15212,7 +15210,7 @@ QUnit.module('Exporting', {
 
         this.dataController.pageIndex(1);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!isLoadAllFailed, 'loadAll is not failed');
@@ -15236,14 +15234,14 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.loadAll().done(function(items) {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(allItems.length, 5, 'all items count');
@@ -15262,7 +15260,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.changed.add(function() {
             changedCallCount++;
@@ -15273,7 +15271,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.items().length, 3, 'items count');
@@ -15311,7 +15309,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataController.changed.add(function() {
             changedCallCount++;
@@ -15322,7 +15320,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.dataController.items().length, 2, 'items count');
@@ -15367,14 +15365,14 @@ QUnit.module('Exporting', {
             columns: [{ dataField: 'field1', filterValues: [2] }, 'field2', 'field3']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataController.loadAll([this.array[1], this.array[2], this.array[3]]).done(function(items) {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(allItems.length, 2, 'two items are loaded');
@@ -15395,7 +15393,7 @@ QUnit.module('Exporting', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editingController.updateFieldValue({
@@ -15409,7 +15407,7 @@ QUnit.module('Exporting', {
             allItems = items;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(allItems.length, 2, 'all items count');
@@ -15512,7 +15510,7 @@ QUnit.module('onOptionChanged', {
         const that = this;
 
         that.option.restore();
-        sinon.stub(that, 'option', function(optionName, value) {
+        sinon.stub(that, 'option').callsFake(function(optionName, value) {
             if(optionName === 'paging.pageSize' && value === 3) {
                 pageSize = that.dataController.dataSource().pageSize();
             }

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.resizing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.resizing.tests.js
@@ -86,7 +86,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         const $dataGrid = $(dataGrid.element());
 
-        clock.tick();
+        clock.tick(10);
         const container = $dataGrid.find('.dx-toolbar-label');
 
         assert.equal(container.length, 1);
@@ -592,7 +592,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         $('#dataGrid').parent().width(300);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('#dataGrid').width(), 300, 'width 100% is applied');
@@ -637,7 +637,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         });
         const dataGrid = $dataGrid.dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const firstRenderHeight = $dataGrid.height();
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -170,7 +170,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($('.dx-widget').attr('role'), 'presentation', 'Widget role');
 
@@ -253,7 +253,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             columns: [{ type: 'selection' }, { caption: 'test' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $secondCell = rowsViewWrapper.getCellElement(0, 1);
@@ -296,7 +296,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('[aria-describedby]').length, 0, 'No elements with aria-describedby attribute');
@@ -321,7 +321,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('noDataText option', function(assert) {
@@ -635,7 +635,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.navigateToRow('Zeb');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageIndex(), 2, 'Page index');
@@ -688,7 +688,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             paging: { pageSize: 2 }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = dataGrid.getView('rowsView');
         rows = rowsView.element().find('.dx-row').filter(function(index, element) { return !$(element).hasClass('dx-freespace-row'); });
@@ -701,7 +701,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         dataGrid.pageIndex(4);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         rows = rowsView.element().find('.dx-row').filter(function(index, element) { return !$(element).hasClass('dx-freespace-row'); });
         for(i = 0; i < rows.length; ++i) {
@@ -718,18 +718,18 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 caption: 'Band',
             }]
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('columns[0].columns', [{ dataField: 'name', ownerBand: 0 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGridWrapper.headers.getHeaderItemTextContent(1, 0), 'Name', 'name is applied');
 
         // act
         dataGrid.columnOption('Band', 'columns', [{ dataField: 'name', ownerBand: 0 }, { dataField: 'age', ownerBand: 0 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGridWrapper.headers.getHeaderItemTextContent(1, 0), 'Name', 'name is applied');
@@ -796,7 +796,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         const keyOfSpy = sinon.spy(arrayStore, 'keyOf');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(keyOfSpy.callCount, 5, 'keyOf call count');
@@ -806,7 +806,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             arrayStore.push([{ type: 'update', key: i, data: { id: i } }]);
         }
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(keyOfSpy.callCount, 55, 'keyOf call count');
@@ -844,7 +844,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(dataGrid.isReady(), 'dataGrid is ready');
@@ -864,7 +864,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [{ ID: 1, field1: 'John' }, { field1: 'Olivia' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $errorRow = $($(dataGrid.$element()).find('.dx-error-row'));
@@ -883,7 +883,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [{ ID: 1, key: 'John' }, { key: 'Olivia' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $errorRow = $($(dataGrid.$element()).find('.dx-error-row'));
@@ -901,7 +901,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [{ ID: 1, field1: 'John' }, { ID: null, field1: 'Olivia' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $errorRow = $($(dataGrid.$element()).find('.dx-error-row'));
@@ -916,7 +916,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: []
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option({
@@ -1018,7 +1018,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: []
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(toolbarPreparingCallCount, 1, 'onToolbarPreparing is called once');
@@ -1142,11 +1142,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                     rowIndices.push(e.rowIndex);
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             rowIndices = [];
             for(let i = 0; i < 2; i++) {
                 $(dataGrid.getCellElement(i, 0)).trigger('dxclick');
@@ -1172,11 +1172,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                     rowIndex = e.rowIndex;
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             $(dataGrid.getCellElement(1, 0)).trigger('dxclick');
 
 
@@ -1200,11 +1200,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                     rowIndices.push(e.rowIndex);
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             rowIndices = [];
             for(let i = 0; i < 2; i++) {
                 $(dataGrid.getCellElement(i, 0)).trigger('dxdblclick');
@@ -1230,11 +1230,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                     rowIndex = e.rowIndex;
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             $(dataGrid.getCellElement(1, 0)).trigger('dxdblclick');
 
 
@@ -1314,7 +1314,7 @@ QUnit.module('Rendered on server', baseModuleConfig, () => {
         assert.equal(dataGrid.$element().find('.dx-data-row').length, 2, 'two data rows are rendered');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleRows().length, 1, 'visible rows are filtered');
@@ -1343,7 +1343,7 @@ QUnit.module('Async render', baseModuleConfig, () => {
 
         assert.equal(buttonTemplateCallCount, 0, 'template is not rendered');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(buttonTemplateCallCount, 1, 'template is rendered asynchronously');
         assert.equal($(dataGrid.getCellElement(0, 0)).text(), 'Test\u00A0', 'template is applied');
@@ -1423,7 +1423,7 @@ QUnit.module('Async render', baseModuleConfig, () => {
 
         // act
         cellPreparedCells = [];
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(cellPreparedCells, ['data-template'], 'asynchronous cellPrepared calls');
@@ -1458,7 +1458,7 @@ QUnit.module('Async render', baseModuleConfig, () => {
         };
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
     });
 });
 
@@ -1628,13 +1628,13 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             columns: ['id']
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.option('dataSource', [{ id: 1 }]);
         dataGrid.option('height', 300);
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         const $noData = $($(dataGrid.$element()).find('.dx-datagrid-nodata'));
@@ -1810,7 +1810,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             },
             columns: ['a', 'b']
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('filterPanel.visible', true); // causes reloading a data source
@@ -1821,7 +1821,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
         // act
         dataGrid.option('columns', ['a', { dataField: 'b', groupIndex: 0 }]);
-        this.clock.tick();
+        this.clock.tick(10);
         const $filterPanelViewElement = $(dataGrid.getView('filterPanelView').element());
 
         // assert
@@ -1961,7 +1961,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const changedSpy = sinon.spy();
         const loadingSpy = sinon.spy();
@@ -1975,7 +1975,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             pageSize: 2
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(changedSpy.callCount, 1, 'changed is called');
@@ -2143,7 +2143,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             columnAutoWidth: true,
             dataSource: [{ id: 1 }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.resetOption('scrolling');
         dataGrid.dispose();
@@ -2162,7 +2162,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             editing,
             dataSource: [{ id: 1 }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.resetOption('editing');
         dataGrid.option('editing', editing);
@@ -2188,7 +2188,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         // assert
         assert.equal(contentReadyCallCount, 0, 'onContentReady call count');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(contentReadyCallCount, 1, 'onContentReady call count');
@@ -2203,7 +2203,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         // act
         dataGrid.columnOption(0, 'visible', false);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(contentReadyCallCount, 1, 'onContentReady call count');
@@ -2233,7 +2233,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         assert.equal(contentReadyCallCount, 0);
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('#dataGrid').find('.dx-data-row').length, 1);
@@ -2298,14 +2298,14 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.pageIndex(1).done(function() {
             doneCalled = true;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(doneCalled, true);
@@ -2325,7 +2325,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.pageIndex(0).done(function() {
@@ -2376,14 +2376,14 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getView('columnHeadersView').element().find('td').length, 2, 'count columns');
 
         // act
         dataGrid.option('groupPanel.visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getView('headerPanel').element().find('.dx-datagrid-group-panel').length, 1, 'has group panel');
@@ -2391,7 +2391,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
         // act
         dataGrid.columnOption(0, { visible: false });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getView('columnHeadersView').element().find('td').length, 1, 'count columns');
@@ -2409,7 +2409,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const rowsViewElement = $dataGrid.find('.dx-datagrid-rowsview');
@@ -2428,7 +2428,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const rowsViewElement = $dataGrid.find('.dx-datagrid-rowsview');
@@ -2441,7 +2441,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             dataSource: [{ field1: '1', field2: '2' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $dataGrid.dxDataGrid('instance').columnOption('field1', 'visible', false);
 
@@ -2460,7 +2460,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
         const dataGrid = $dataGrid.dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.getController('columns').columnsChanged.add(function(e) {
             columnsChangedArgs.push(e);
@@ -2495,7 +2495,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
         const dataGrid = $dataGrid.dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual($dataGrid.find('.dx-header-row').children().length, 3, 'header cells count');
         assert.strictEqual($dataGrid.find('.dx-data-row').children().length, 3, 'data cells count');
@@ -2506,7 +2506,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         dataGrid.refresh();
         dataGrid.endUpdate();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($dataGrid.find('.dx-header-row').children().length, 2, 'header cells count');
@@ -2907,7 +2907,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         assert.equal(dataGrid.getView('rowsView')._loadPanel.option('message'), 'Test');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getView('rowsView')._loadPanel.option('message'), 'Test');
@@ -3057,11 +3057,11 @@ QUnit.module('API methods', baseModuleConfig, () => {
         }
 
         load();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal($('#testElement').text(), titleText, 'title text');
 
         load();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal($('#testElement').text(), titleText, 'title text after refresh');
     });
 
@@ -3203,7 +3203,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.focus($(dataGrid.getCellElement(0, 0)));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(!errorMessage, 'There is no errors');
     });
 
@@ -3221,7 +3221,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             onContentReady: () => eventArray.push('onContentReady')
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(eventArray[0], 'onDataErrorOccurred', 'onDataErrorOccurred event fired first');
@@ -3230,7 +3230,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         // act
         const errorCloseButton = $(dataGrid._$element.find('.dx-closebutton').eq(0));
         errorCloseButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(eventArray[2], 'onContentReady', 'onContentReady event fired after closing error row');
@@ -3276,7 +3276,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ id: 1111 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // assert
@@ -3295,7 +3295,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ id: 1111 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(initializedComponent, dataGrid, 'component in onInitialized callback is correct');
@@ -3572,7 +3572,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         const store = dataSource.store();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         store.update(1, { field1: 'test11' });
         store.insert({ id: 5, field1: 'test5' });
@@ -3583,7 +3583,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.refresh(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(dataGrid.getCellElement(0, 1)).hasClass(CELL_UPDATED_CLASS));
@@ -3598,7 +3598,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         store.insert({ id: 6, field1: 'test6' });
 
         dataGrid.refresh(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.getCellElement(0, 1)).hasClass(CELL_UPDATED_CLASS));
@@ -3648,7 +3648,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         const store = dataSource.store();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         store.update(1, { field1: 'test111' });
@@ -3687,7 +3687,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataSource.store().update(1, { field1: 'test5' });
 
@@ -3697,7 +3697,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         assert.strictEqual($(dataGrid.getCellElement(0, 1)).text(), 'test1', 'first row - value of the second cell');
         // act
         dataGrid.refresh(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $updatedCellElements = $(dataGrid.$element()).find('.dx-data-row').first().children();
@@ -3737,7 +3737,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             columns: ['id', 'field1']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cellElements = $(dataGrid.$element()).find('.dx-data-row').first().children();
 
@@ -3774,7 +3774,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: dataSource
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataSource.store().remove(2);
@@ -3816,7 +3816,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             columns: ['id', 'field1']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(cellPreparedArgs.length, 4, 'cellPrepared call count');
@@ -3874,11 +3874,11 @@ QUnit.module('API methods', baseModuleConfig, () => {
             columns: ['id', 'field1']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.getDataSource().store().push([{ type: 'update', key: 1, data: { field1: 'updated' } }]);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const activeRowKey = 1;
@@ -3914,7 +3914,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             columns: ['id', 'field1']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         cellPreparedArgs = [];
         // act
@@ -4301,7 +4301,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             columns: [{ dataField: 'column1', cellTemplate: $('#scriptTestTemplate1').get(0) }, { dataField: 'column2', cellTemplate: $('#scriptTestTemplate2').get(0) }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $cells = $($(dataGrid.$element()).find('.dx-datagrid-rowsview').find('table > tbody').find('td'));
@@ -4320,7 +4320,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             columns: [{ dataField: 'column1', cellTemplate: $template1 }, { dataField: 'column2', cellTemplate: $template2 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $cells = $($(dataGrid.$element()).find('.dx-datagrid-rowsview').find('table > tbody').find('td'));
@@ -4339,7 +4339,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             columns: [{ dataField: 'column1', cellTemplate: 'test' }, { dataField: 'column2', cellTemplate: 'test2' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $cells = $($(dataGrid.$element()).find('.dx-datagrid-rowsview').find('table > tbody').find('td'));
@@ -4504,7 +4504,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             columns: [{ dataField: 'column1' }, { dataField: 'column2' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('rowElement argument of dataRowTemplate option is correct', function(assert) {
@@ -4522,7 +4522,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             columns: [{ dataField: 'column1' }, { dataField: 'column2' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('deprecate warnings should not be fired for dataRowTemplate', function(assert) {
@@ -4535,7 +4535,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             dataSource: [{ id: 1 }],
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(log.callCount, 0, 'error.log is not called');
 
@@ -4552,7 +4552,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             dataSource: [{ id: 1 }],
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(log.callCount, 1, 'error.log is called once');
         assert.deepEqual(log.getCall(0).args, [
@@ -4602,11 +4602,11 @@ QUnit.module('templates', baseModuleConfig, () => {
                 },
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             dataGrid.pageIndex(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $rows = $(dataGrid.element()).find('.dx-row');
             assert.equal($rows.length, 4, 'row count');
@@ -4649,7 +4649,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.getDataSource().store().push([{
@@ -4659,7 +4659,7 @@ QUnit.module('templates', baseModuleConfig, () => {
                 text: 'updated'
             }
         }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $firstRow = $(dataGrid.getRowElement(0));
         assert.equal($firstRow.find('.my-cell').text(), 'updated', 'cell is updated');
@@ -4703,7 +4703,7 @@ QUnit.module('templates', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $rowElements = $(dataGrid.element()).find('.dx-datagrid-rowsview table > .dx-row');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataSource.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataSource.tests.js
@@ -105,7 +105,7 @@ QUnit.module('Grid DataSource', {
             source.load();
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(changeCallCount, 1);
         assert.equal(source.pageIndex(), 3);
@@ -125,7 +125,7 @@ QUnit.module('Grid DataSource', {
             changeCallCount++;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(changeCallCount, 1);
         assert.equal(source.pageSize(), 3);
@@ -143,7 +143,7 @@ QUnit.module('Grid DataSource', {
             changeCallCount++;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(changeCallCount, 1);
         assert.equal(source.pageSize(), 0);
@@ -164,7 +164,7 @@ QUnit.module('Grid DataSource', {
             });
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(changeCallCount, 1);
         assert.deepEqual(source.items(), [1, 2, 3, 4, 5]);
@@ -206,7 +206,7 @@ QUnit.module('Grid DataSource', {
             finalized = true;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(finalized);
     });
 
@@ -234,7 +234,7 @@ QUnit.module('Grid DataSource', {
             loaded = true;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // act
@@ -247,7 +247,7 @@ QUnit.module('Grid DataSource', {
         totalCountDeferred = $.Deferred();
         totalCountDeferred.resolve(3);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!loaded);
@@ -317,7 +317,7 @@ QUnit.module('Grid DataSource', {
         // act
         source.load();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changeCallCount, 1);
@@ -1802,18 +1802,18 @@ QUnit.module('Grouping with basic remoteOperations', {
 
         source.load();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         source.changeRowExpand([1]);
         source.load();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         source.filter(['field2', '>', 3]);
         source.reload();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(source.totalItemsCount(), 1, 'total items count');
@@ -2130,23 +2130,23 @@ QUnit.module('Grouping with basic remoteOperations. Second level', {
 
 
         source.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         source.changeRowExpand([1, 2]);
-        this.clock.tick();
+        this.clock.tick(10);
         source.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         source.changeRowExpand([1, 3]);
-        this.clock.tick();
+        this.clock.tick(10);
         source.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         source.group(['field1', { selector: 'field2', desc: true }]);
 
         source.reload();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(source.totalItemsCount(), 3);
@@ -6564,11 +6564,11 @@ QUnit.module('Cache', {
             reshapeOnPush: true
         });
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataSource.store().push([{ type: 'remove', key: 1 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataSource.items()[0], 2, 'first item on page');
@@ -6581,11 +6581,11 @@ QUnit.module('Cache', {
             pushAggregationTimeout: 0
         });
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataSource.store().push([{ type: 'remove', key: 1 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataSource.items()[0], 2, 'first item on page');
@@ -6613,14 +6613,14 @@ QUnit.module('Cache', {
             }]
         });
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(stepCount, 4, 'summary is calculated');
 
         // act
         dataSource.pageIndex(1);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(stepCount, 4, 'summary is not recalculated');
@@ -6653,14 +6653,14 @@ QUnit.module('Cache', {
             }]
         });
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(stepCount, 4, 'summary is calculated');
 
         // act
         dataSource.pageIndex(1);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(stepCount, 8, 'summary is recalculated');
@@ -6690,13 +6690,13 @@ QUnit.module('Cache', {
             }]
         });
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(stepCount, 4, 'summary is calculated');
 
         // act
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(stepCount, 8, 'summary is recalculated');
@@ -6717,7 +6717,7 @@ QUnit.module('Cache', {
             }
         });
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 1, 'first load');
@@ -6726,7 +6726,7 @@ QUnit.module('Cache', {
         dataSource.pageIndex(1);
         dataSource.loadPageCount(2);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 2, 'second load');
@@ -6736,7 +6736,7 @@ QUnit.module('Cache', {
         dataSource.pageIndex(2);
         dataSource.loadPageCount(1);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 2, 'data is loaded from cache');
@@ -6746,7 +6746,7 @@ QUnit.module('Cache', {
         dataSource.pageIndex(1);
         dataSource.loadPageCount(2);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 2, 'data is loaded from cache');
@@ -6845,7 +6845,7 @@ QUnit.module('Cache', {
             }
         });
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 1, 'first load');
@@ -6855,7 +6855,7 @@ QUnit.module('Cache', {
         dataSource.pageIndex(1);
         dataSource.loadPageCount(2);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 2, 'second load');
@@ -6866,7 +6866,7 @@ QUnit.module('Cache', {
         dataSource.pageSize(2);
         dataSource.loadPageCount(1);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 2, 'data is loaded from the cache');
@@ -6887,7 +6887,7 @@ QUnit.module('Cache', {
             cacheEnabled: false,
         });
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 1, 'first load');
@@ -6896,7 +6896,7 @@ QUnit.module('Cache', {
         dataSource.pageIndex(1);
         dataSource.loadPageCount(2);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 2, 'second load');
@@ -6906,7 +6906,7 @@ QUnit.module('Cache', {
         dataSource.pageIndex(2);
         dataSource.loadPageCount(1);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 3, 'third load');
@@ -6916,7 +6916,7 @@ QUnit.module('Cache', {
         dataSource.pageIndex(1);
         dataSource.loadPageCount(2);
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.loadingCount, 4, 'fourth load');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -1210,7 +1210,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             ]
         });
 
-        this.clock.tick(300);
+        this.clock.tick(400);
 
         const $dataGridTables = $dataGrid.find('.dx-datagrid-table');
         // assert
@@ -7382,7 +7382,7 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
 
             // act
             dataGrid.addRow();
-            this.clock.tick(300);
+            this.clock.tick(400);
 
             // assert
             const visibleRows = dataGrid.getVisibleRows();
@@ -7850,12 +7850,12 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
                 }
             };
 
-            this.clock.tick(300);
+            this.clock.tick(400);
 
             if(newRowPosition === 'viewportTop' || newRowPosition === 'viewportBottom') {
                 // act
                 dataGrid.getScrollable().scrollTo({ top: 1500 });
-                this.clock.tick(300);
+                this.clock.tick(400);
 
                 // assert
                 assert.strictEqual(dataGrid.getTopVisibleRowData().id, 45, 'first visible row data after scroll');
@@ -7863,7 +7863,7 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
 
             // act
             dataGrid.addRow();
-            this.clock.tick(300);
+            this.clock.tick(400);
             newRowInfo = getNewRowInfo();
 
             // assert
@@ -7874,7 +7874,7 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
             // act
             $(dataGrid.getCellElement(newRowInfo.visibleIndex, 1)).find('.dx-texteditor-input').val('111').trigger('change');
             dataGrid.getScrollable().scrollTo({ top: newRowPosition === 'first' ? 3500 : 0 });
-            this.clock.tick(300);
+            this.clock.tick(400);
 
             // assert
             assert.ok(dataGrid.getVisibleRows()[0].key >= newRowPosition === 'first' ? 91 : 1, 'top visible row key');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -83,11 +83,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [{ field1: '1', field2: '2' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-texteditor [id]').length, 0, 'editors has no accessibility id');
@@ -125,7 +125,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         columnsWrapper.getCommandButtons().each((_, button) => {
@@ -156,7 +156,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 }
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $buttons = columnsWrapper.getCommandButtons();
             const $commandCell = $(dataGrid.getCellElement(0, 0));
@@ -187,7 +187,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 ]
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const $commandCell = $(dataGrid.getCellElement(0, 0));
@@ -217,7 +217,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $buttons = columnsWrapper.getCommandButtons();
 
@@ -246,7 +246,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.deleteRow(0);
@@ -292,7 +292,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $commandCell = $(dataGrid.getCellElement(0, 1));
@@ -335,7 +335,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $commandCell = $(dataGrid.getCellElement(0, 1));
@@ -357,15 +357,15 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [...new Array(20)].map((x, i) => ({ name: i }))
         });
 
-        clock.tick();
+        clock.tick(10);
         const scrollable = $('.dx-scrollable').dxScrollable('instance');
 
         scrollable.scrollTo({ y: 5 });
-        clock.tick();
+        clock.tick(10);
 
         // act
         dataGrid.addRow();
-        clock.tick();
+        clock.tick(10);
 
         // assert
         assert.ok(scrollable.scrollTop() <= 1, 'first row is not overlayed by parent container');
@@ -387,15 +387,15 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [...new Array(20)].map((x, i) => ({ name: i }))
         });
 
-        clock.tick();
+        clock.tick(10);
         const scrollable = $('.dx-scrollable').dxScrollable('instance');
 
         scrollable.scrollTo({ y: 10 });
-        clock.tick();
+        clock.tick(10);
 
         // act
         dataGrid.addRow();
-        clock.tick();
+        clock.tick(10);
 
         // assert
         assert.ok(scrollable.scrollTop() <= 1, 'first row is not overlayed by parent container');
@@ -626,7 +626,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.cellValue(0, 1, 'test');
         dataGrid.closeEditCell();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(counter, 2);
@@ -658,7 +658,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         $(dataGrid.$element().find('.dx-data-row > td').eq(0)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.$element()).find(TEXTEDITOR_INPUT_SELECTOR).length, 1, 'one editor is shown');
@@ -702,7 +702,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         gridInstance.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $freeSpaceRow = $grid.find('.dx-freespace-row');
@@ -732,12 +732,12 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         });
         const dataGrid = $grid.dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.cellValue(0, 'field1', 'updated');
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.saveEditData();
 
         // act
@@ -769,11 +769,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         dataGrid.addRow();
         dataGrid.cellValue(0, 0, '2');
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.closeEditCell();
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.option('dataSource', array);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.getCellElement(0, 0)).find('.dx-texteditor-input').val(), '2', 'first row doesn\'t dissapear');
@@ -801,7 +801,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         instance.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($dataGrid.find('.dx-form #template1').text(), 'Template1', 'the underscore template is rendered correctly');
@@ -887,9 +887,9 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.selectRows(1);
 
         $dataGrid.find('.dx-link-delete').first().trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
         $dataGrid.find('.dx-link-delete').first().trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.getVisibleRows().length, 1, 'row count');
@@ -1027,7 +1027,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataGrid.deleteRow(0);
             dataGrid.deleteRow(0);
             dataGrid.getScrollable().scrollTo({ y: 10000 });
-            this.clock.tick();
+            this.clock.tick(10);
 
             for(let i = 0; i < 25; i++) {
                 dataGrid.getScrollable().scrollTo({ y: 10000 });
@@ -1066,11 +1066,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 { type: 'remove', key: 2 },
                 { type: 'remove', key: 3 },
             ]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             for(let i = 0; i < 5; i++) {
                 dataGrid.getScrollable().scrollTo({ y: 10000 });
-                this.clock.tick();
+                this.clock.tick(10);
             }
 
             // assert
@@ -1116,7 +1116,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataGrid.saveEditData();
             for(let i = 0; i < 25; i++) {
                 dataGrid.getScrollable().scrollTo({ y: 10000 });
-                this.clock.tick();
+                this.clock.tick(10);
             }
 
             // assert
@@ -1157,7 +1157,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataGrid.getScrollable().scrollTo({ y: 10000 });
             dataGrid.getScrollable().scrollTo({ y: 0 });
             dataGrid.getDataSource().store().push([{ type: 'insert', data: { id: 987654321 }, index: 0 }]);
-            this.clock.tick();
+            this.clock.tick(10);
             for(let i = 0; i < 20; i++) {
                 dataGrid.getScrollable().scrollTo({ y: 10000 });
             }
@@ -1460,14 +1460,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $tableElements = dataGrid.$element().find('.dx-datagrid-rowsview').find('table');
         assert.roughEqual(getOuterHeight($tableElements.eq(0)), 68, 3.01, 'height main table');
 
         dataGrid.closeEditCell();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $tableElements = dataGrid.$element().find('.dx-datagrid-rowsview').find('table');
@@ -1501,20 +1501,20 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             columns: ['Prefix', 'FirstName']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('input')
             .val('new')
             .change();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-error-message').length, 1, 'Error message is shown');
@@ -1541,7 +1541,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             .trigger('dxclick');
 
         $(dataGrid.getRowElement(0)).find('.dx-command-edit > .dx-link-edit').trigger(pointerEvents.up).click();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $firstRowEditors = $(dataGrid.getRowElement(1)).find('.dx-texteditor');
 
@@ -1551,7 +1551,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getRowElement(0)).find('.dx-command-edit > .dx-link-cancel').trigger(pointerEvents.up).click();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(dataGrid.getRowElement(1)).find('.dx-texteditor').length, 'row doesn\'t have editor');
@@ -1603,17 +1603,17 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [...Array(10)].map((_, i) => { return { id: i + 1 }; })
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.pageIndex(2);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.pageIndex(3);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.pageIndex(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($($(dataGrid.$element()).find('.dx-error-row')).length, 0, 'no errors');
@@ -1633,7 +1633,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }, 'description']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dataCells = $(dataGrid.getRowElement(0)).find('td');
 
@@ -1687,21 +1687,21 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(dataGrid.getVisibleRows()[0].isNewRow, 'grid has new row');
 
         // act
         nestedDataGrid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(nestedDataGrid.getVisibleRows()[0].isNewRow, 'nested grid has new row');
 
         // act
         nestedDataGrid.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $cellElements = $(nestedDataGrid.getRowElement(0)).children();
@@ -1710,7 +1710,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         $cellElements.first().find('.dx-texteditor-input').first().trigger('dxpointerdown').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $overlayWrapper = $(dataGrid.element()).find('.dx-overlay-wrapper.dx-datagrid-invalid-message');
@@ -1749,13 +1749,13 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                     columnFixing: { enabled: true }
                 });
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 for(let i = 1; i <= 3; i++) {
                     // act
                     let $cellElement = $(dataGrid.getCellElement(1, i));
                     $cellElement.trigger('dxclick');
-                    this.clock.tick();
+                    this.clock.tick(10);
                     $cellElement = $(dataGrid.getCellElement(1, i));
 
                     // assert
@@ -1765,7 +1765,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                     // act
                     $cellElement.find('.dx-texteditor-input').val(i).trigger('change');
                     dataGrid.closeEditCell();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.strictEqual(dataGrid.cellValue(1, i), `${i}`, `cell ${i} has modified value`);
@@ -1787,7 +1787,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 },
                 onCellClick: cellClickSpy
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             dataGrid.addRow();
@@ -1854,11 +1854,11 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 allowUpdating: true
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(dataGrid.getCellElement(0, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.getCellElement(0, 0)).hasClass('dx-cell-focus-disabled'), 'cell has dx-cell-focus-disabled class');
@@ -1874,14 +1874,14 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 allowUpdating: true
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(dataGrid.getCellElement(0, 1)).trigger(pointerEvents.down);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(dataGrid.getCellElement(0, 1)).hasClass('dx-cell-focus-disabled'), 'cell has not dx-cell-focus-disabled class');
@@ -1908,7 +1908,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
         // act
         const selectCheckBox = rowsViewWrapper.getDataRow(1).getSelectCheckBox();
         selectCheckBox.getElement().trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedRowChangingFiresCount, 1, 'onFocusedRowChanging fires count');
@@ -1945,7 +1945,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
         // act
         const selectCheckBox = rowsViewWrapper.getDataRow(1).getSelectCheckBox();
         selectCheckBox.getElement().trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedRowChangingFiresCount, 1, 'onFocusedRowChanging fires count');
@@ -2025,7 +2025,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
         dataGrid.editRow(0);
         dataGrid.option('editing.form.items[1].editorOptions', { height: 100 });
         dataGrid.cellValue(0, 'name', 'new name');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $popupEditors = $('.dx-popup-content').find('.dx-texteditor');
@@ -2060,11 +2060,11 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             dataGrid.editCell(1, 0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const navigationController = dataGrid.getController('keyboardNavigation');
             navigationController._keyDownHandler({ key: 'Tab', keyName: 'tab', originalEvent: $.Event('keydown', { target: $(dataGrid.getCellElement(0, 0)) }) });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal($(dataGrid.getCellElement(0, 1)).find('input').length, 0, `cell is not being edited in '${editingMode}' editing mode`);
@@ -2091,15 +2091,15 @@ QUnit.module('Editing', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         dataGridWrapper.filterPanel.getPanelText().trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
         filterBuilder.getItemValueTextElement(0).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         headerFilterMenu.getDropDownListItem(1).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         headerFilterMenu.getButtonOK().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(filterBuilder.getItemValueTextParts().length, 2, 'IsAnyOf operation applyed');
@@ -2169,7 +2169,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const rowHeight = $(grid.getRowElement(0)).height();
         this.clock.restore();
 
@@ -2210,10 +2210,10 @@ QUnit.module('Editing', baseModuleConfig, () => {
         };
 
         const grid = createDataGrid(gridConfig);
-        this.clock.tick();
+        this.clock.tick(10);
 
         grid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
@@ -2223,7 +2223,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
         this.clock.tick(1000);
         $secondCell = $(grid.getCellElement(0, 1));
         $secondCell.trigger(pointerEvents.down).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $secondCell = $(grid.getCellElement(0, 1));
 
         // assert
@@ -2253,10 +2253,10 @@ QUnit.module('Editing', baseModuleConfig, () => {
         };
 
         const grid = createDataGrid(gridConfig);
-        this.clock.tick();
+        this.clock.tick(10);
 
         grid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $secondCell = $(grid.getCellElement(0, 1));
         $secondCell.trigger(pointerEvents.down).trigger('dxclick');
@@ -2298,10 +2298,10 @@ QUnit.module('Editing', baseModuleConfig, () => {
         };
 
         const grid = createDataGrid(gridConfig);
-        this.clock.tick();
+        this.clock.tick(10);
         let $firstCell = $(grid.getCellElement(0, 0));
         $firstCell.trigger(pointerEvents.down).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $firstCell = $(grid.getCellElement(0, 0));
 
         // assert
@@ -2311,7 +2311,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
         $inputElement.val('');
         $inputElement.trigger('change');
         headerPanel.getElement().trigger(pointerEvents.down).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $firstCell = $(grid.getCellElement(0, 0));
 
         // assert
@@ -2348,14 +2348,14 @@ QUnit.module('Editing', baseModuleConfig, () => {
         };
 
         const grid = createDataGrid(gridConfig);
-        this.clock.tick();
+        this.clock.tick(10);
         let $firstCell = $(grid.getCellElement(0, 0));
         $firstCell.trigger(pointerEvents.down).trigger('dxclick');
 
         const $inputElement = rowsView.getCell(0, 0).getEditor().getInputElement();
         $inputElement.val('');
         $inputElement.trigger('change');
-        this.clock.tick();
+        this.clock.tick(10);
         $firstCell = $(grid.getCellElement(0, 0));
 
         // assert
@@ -2393,11 +2393,11 @@ QUnit.module('Editing', baseModuleConfig, () => {
         };
 
         const grid = createDataGrid(gridConfig);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $firstCell = $(grid.getCellElement(0, 0));
         $firstCell.trigger(pointerEvents.down).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $firstCell = $(grid.getCellElement(0, 0));
 
         assert.ok($firstCell.hasClass('dx-focused'), 'cell is focused');
@@ -2407,7 +2407,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
         $inputElement.trigger('change');
 
         headerPanel.getElement().trigger(pointerEvents.down).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $firstCell = $(grid.getCellElement(0, 0));
 
         // assert
@@ -2471,7 +2471,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
             };
 
             const grid = createDataGrid(gridConfig);
-            this.clock.tick();
+            this.clock.tick(10);
             $(grid.getCellElement(0, 0)).trigger('dxclick');
             const $dropDownIcon = $(grid.element()).find('.dx-dropdowneditor-icon');
 
@@ -2480,7 +2480,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
 
             $dropDownIcon.trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
             const $dropDownGridElement = $('.dx-overlay-wrapper.dx-dropdowneditor-overlay .my-class');
 
             // assert
@@ -2494,7 +2494,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             $row1.trigger('dxpointerdown');
             $row1.trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
             const $dropDownPopupElement = $('.dx-overlay-wrapper.dx-dropdowneditor-overlay');
             const $dropDownBoxElement = $(grid.getCellElement(0, 0)).find('.dx-dropdownbox');
 
@@ -2527,10 +2527,10 @@ QUnit.module('Editing', baseModuleConfig, () => {
             };
 
             const grid = createDataGrid(gridConfig);
-            this.clock.tick();
+            this.clock.tick(10);
 
             grid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $firstCell = $(grid.getCellElement(0, 0));
 
@@ -2563,10 +2563,10 @@ QUnit.module('Editing', baseModuleConfig, () => {
         };
 
         const grid = createDataGrid(gridConfig);
-        this.clock.tick();
+        this.clock.tick(10);
 
         grid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $firstCell = $(grid.getCellElement(0, 0));
 
@@ -2599,10 +2599,10 @@ QUnit.module('Editing', baseModuleConfig, () => {
             };
 
             const grid = createDataGrid(gridConfig);
-            this.clock.tick();
+            this.clock.tick(10);
 
             grid.editCell(0, 0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $firstCell = $(grid.getCellElement(0, 0));
 
@@ -2635,17 +2635,17 @@ QUnit.module('Editing', baseModuleConfig, () => {
         };
 
         const grid = createDataGrid(gridConfig);
-        this.clock.tick();
+        this.clock.tick(10);
         grid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         grid.cellValue(0, 0, 'test1');
-        this.clock.tick();
+        this.clock.tick(10);
 
         try {
             grid.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
             grid.dispose();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(true);
@@ -2675,11 +2675,11 @@ QUnit.module('Editing', baseModuleConfig, () => {
         };
 
         const grid = createDataGrid(gridConfig);
-        this.clock.tick();
+        this.clock.tick(10);
         grid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
         grid.cellValue(0, 0, '');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell = $(grid.getCellElement(0, 0));
         const errorOverlay = $cell.find('.dx-invalid-message.dx-overlay').dxOverlay('instance');
@@ -2725,9 +2725,9 @@ QUnit.module('Editing', baseModuleConfig, () => {
             // act
             $(grid.$element()).find('input').val(123).trigger('change');
             action === 'close edit cell' ? grid.closeEditCell() : grid.cancelEditData();
-            this.clock.tick();
+            this.clock.tick(10);
             $(grid.getCellElement(0, 1)).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
             const callCount = action === 'close edit cell' ? 3 : 4;
 
             // assert
@@ -2775,15 +2775,15 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 } else {
                     dataGrid.editCell(0, 0);
                 }
-                this.clock.tick();
+                this.clock.tick(10);
                 $(dataGrid.getCellElement(0, 0)).find('.dx-texteditor-input').focus();
-                this.clock.tick();
+                this.clock.tick(10);
                 if(editMode !== 'Row') {
                     dataGrid.editCell(0, 1);
-                    this.clock.tick();
+                    this.clock.tick(10);
                 }
                 $(dataGrid.getCellElement(0, 1)).find('.dx-texteditor-input').focus();
-                this.clock.tick();
+                this.clock.tick(10);
 
 
                 // assert
@@ -2830,17 +2830,17 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
         // act
         dataGrid.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.cellValue(0, 1, '');
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.editCell(0, 2);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.cellValue(0, 2, '');
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(validatedRowKeys, [1, 3], 'validated row keys');
@@ -2898,7 +2898,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             $(dataGrid.element()).find('.dx-icon-edit-button-addrow').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             let $firstRow = $(dataGrid.getRowElement(0));
             const $inputElement = $firstRow.find('.dx-texteditor-input').first();
@@ -2908,9 +2908,9 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             $inputElement.val('tst').trigger('change');
-            this.clock.tick();
+            this.clock.tick(10);
             $(dataGrid.getRowElement(1)).find('.dx-link-delete').trigger('click');
-            this.clock.tick();
+            this.clock.tick(10);
             const visibleRows = dataGrid.getVisibleRows();
 
             // assert
@@ -2955,7 +2955,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
             // act
             let $firstCell = $(dataGrid.getCellElement(0, 0));
             $firstCell.trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
             $firstCell = $(dataGrid.getCellElement(0, 0));
 
             // assert
@@ -2964,9 +2964,9 @@ QUnit.module('Editing', baseModuleConfig, () => {
             // act
             const $inputElement = $firstCell.find('.dx-texteditor-input').first();
             $inputElement.val('tst').trigger('change');
-            this.clock.tick();
+            this.clock.tick(10);
             $(dataGrid.getRowElement(1)).find('.dx-link-delete').trigger('click');
-            this.clock.tick();
+            this.clock.tick(10);
             const visibleRows = dataGrid.getVisibleRows();
 
             // assert
@@ -3076,9 +3076,9 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             dataGrid.editRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
             dataGrid.cellValue(0, 0, 1);
-            this.clock.tick();
+            this.clock.tick(10);
             let $field2EditorElement = $(dataGrid.getCellElement(0, 1)).find('.dx-dropdowneditor');
             let $field2EditorIcon = $field2EditorElement.find('.dx-dropdowneditor-icon');
             $field2EditorIcon.trigger('dxclick');
@@ -3091,7 +3091,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
             // act
             $field2EditorIcon.trigger('dxclick');
             dataGrid.cellValue(0, 0, 2);
-            this.clock.tick();
+            this.clock.tick(10);
             $field2EditorElement = $(dataGrid.getCellElement(0, 1)).find('.dx-dropdowneditor');
             $field2EditorIcon = $field2EditorElement.find('.dx-dropdowneditor-icon');
             $field2EditorIcon.trigger('dxclick');
@@ -3104,7 +3104,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
             // act
             $field2EditorIcon.trigger('dxclick');
             dataGrid.cellValue(0, 0, 3);
-            this.clock.tick();
+            this.clock.tick(10);
             $field2EditorElement = $(dataGrid.getCellElement(0, 1)).find('.dx-dropdowneditor');
             $field2EditorIcon = $field2EditorElement.find('.dx-dropdowneditor-icon');
             $field2EditorIcon.trigger('dxclick');
@@ -3147,11 +3147,11 @@ QUnit.module('Editing', baseModuleConfig, () => {
                     allowUpdating: true
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             $(dataGrid.getCellElement(0, 1)).find('.dx-checkbox').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(dataGrid.cellValue(0, 1), false, 'cell value after the first click');
@@ -3160,7 +3160,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             $(dataGrid.getCellElement(0, 1)).find('.dx-checkbox').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(dataGrid.cellValue(0, 1), true, 'cell value after the second click');
@@ -3170,7 +3170,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             $(dataGrid.getCellElement(0, 1)).find('.dx-checkbox').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(dataGrid.cellValue(0, 1), false, 'cell value after the third click');
@@ -3210,18 +3210,18 @@ QUnit.module('Editing', baseModuleConfig, () => {
                     allowUpdating: true
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             $(dataGrid.element()).find('.dx-datagrid-addrow-button').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($(dataGrid.getRowElement(0)).hasClass('dx-row-inserted'), 'first row is inserted');
 
             // act
             $(dataGrid.getRowElement(1)).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($(dataGrid.getCellElement(0, 1)).hasClass('dx-datagrid-invalid'), 'cell is invalid after the first click');
@@ -3229,11 +3229,11 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             $(dataGrid.getCellElement(0, 1)).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
             $(dataGrid.getCellElement(0, 1)).find('.dx-checkbox').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
             $(dataGrid.getRowElement(1)).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(insertSpy.callCount, 1, 'insert is called after the last click');
@@ -3259,15 +3259,15 @@ QUnit.module('Editing', baseModuleConfig, () => {
                     allowUpdating: true
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
             dataGrid.editCell(0, 0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const $firstCell = $(dataGrid.getCellElement(0, 0));
             const $firstInput = $firstCell.find('input.dx-texteditor-input');
             $firstInput.focus();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($firstCell.hasClass('dx-focused'));
@@ -3281,10 +3281,10 @@ QUnit.module('Editing', baseModuleConfig, () => {
             $firstInput.val('123');
             let $secondCell = $(dataGrid.getCellElement(0, 1));
             $secondCell.find('.dx-checkbox').trigger(pointerEvents.down);
-            this.clock.tick();
+            this.clock.tick(10);
             $secondCell = $(dataGrid.getCellElement(0, 1));
             $secondCell.find('.dx-checkbox').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(dataGrid.cellValue(0, 0), '123', 'first cell value');
@@ -3317,17 +3317,17 @@ QUnit.module('Editing', baseModuleConfig, () => {
                     },
                 }]
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             const getLookupCell = () => dataGrid.getCellElement(0, 1);
 
             const selectLookupValue = (lookupValueIndex) => {
                 $(getLookupCell()).trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
                 $(getLookupCell()).find('.dx-dropdowneditor-button').trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
                 $('.dx-scrollable-wrapper .dx-scrollview-content .dx-item-content').eq(lookupValueIndex).trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
             };
 
             // act
@@ -3362,16 +3362,16 @@ QUnit.module('Editing', baseModuleConfig, () => {
                     allowUpdating: true
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
             dataGrid.editCell(0, 1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const $input = $(dataGrid.getCellElement(0, 1)).find('input.dx-texteditor-input');
             $input.val('123');
             $input.trigger('change');
             dataGrid.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($(dataGrid.getCellElement(0, 0)).hasClass('dx-datagrid-invalid'), 'unmodified cell is invalid');
@@ -3432,7 +3432,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         idCallCount = 0;
 
@@ -3458,11 +3458,11 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 allowUpdating: true,
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-link-edit').trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $textBox = $('.dx-textbox');
@@ -3491,16 +3491,16 @@ QUnit.module('Editing', baseModuleConfig, () => {
                     allowUpdating: true,
                 },
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             dataGrid.editRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const editor1 = $(dataGrid.getCellElement(0, 0)).find('.dx-textbox').dxTextBox('instance');
 
             // act
             editor1.option('value', 'test');
-            this.clock.tick();
+            this.clock.tick(10);
 
 
             // assert
@@ -3525,11 +3525,11 @@ QUnit.module('Editing', baseModuleConfig, () => {
                     allowAdding: true
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             dataGrid.editRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($(dataGrid.getRowElement(0)).hasClass('dx-edit-row'), 'row is in editing mode');
@@ -3545,7 +3545,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($(dataGrid.getRowElement(0)).hasClass('dx-row-inserted'), 'first inserted row');
@@ -3590,14 +3590,14 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
                 // act
                 dataGrid.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.ok(isNewRowExists(dataGrid, editMode), 'there is a new row');
 
                 // act
                 dataGrid.cancelEditData();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.notOk(isNewRowExists(dataGrid, editMode), 'no new row');
@@ -3821,14 +3821,14 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(isNewRowExists(dataGrid, editMode), 'there is a new row');
 
             // act
             setCellValue(0, 0, 'test');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(isValidCell(0, 0), 'first cell is valid');
@@ -3837,12 +3837,12 @@ QUnit.module('Editing', baseModuleConfig, () => {
 
             // act
             setCellValue(0, 1, 'incorrect');
-            this.clock.tick();
+            this.clock.tick(10);
 
             setCellValue(0, 2, 'test');
-            this.clock.tick();
+            this.clock.tick(10);
             setCellValue(0, 2, '');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.notOk(isValidCell(0, 1), 'second cell is not valid');
@@ -3875,7 +3875,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 ],
             });
             const navigationController = dataGrid.getController('keyboardNavigation');
-            this.clock.tick(0);
+            this.clock.tick(10);
 
             const emulateEnterKeyPress = () => {
                 const event = $.Event('keydown', { target: $('#qunit-fixture').find(':focus').get(0) });
@@ -3888,14 +3888,14 @@ QUnit.module('Editing', baseModuleConfig, () => {
             const $input = $(dataGrid.getCellElement(0, 1)).find('input');
             $input.val('');
             $input.trigger('change');
-            this.clock.tick();
+            this.clock.tick(10);
             $input.trigger('focus');
-            this.clock.tick();
+            this.clock.tick(10);
 
             emulateEnterKeyPress();
-            this.clock.tick();
+            this.clock.tick(10);
             emulateEnterKeyPress();
-            this.clock.tick();
+            this.clock.tick(10);
 
             const validationMessages = $('.dx-invalid-message.dx-widget');
             assert.strictEqual(validationMessages.length, 1, 'only 1 validation message must be shown');
@@ -3924,14 +3924,14 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 },
                 columns: ['selected', 'field2'],
             });
-            this.clock.tick(0);
+            this.clock.tick(10);
 
             // act
             const clickWithMouseDownEvent = (element) => {
                 $(element).trigger('dxpointerdown');
-                this.clock.tick();
+                this.clock.tick(10);
                 $(element).trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
             };
 
             const checkbox2 = $(dataGrid.getCellElement(0, 0)).find('.dx-checkbox');
@@ -3963,25 +3963,25 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 mode: 'virtual',
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.totalCount(), 2, 'totalCount before update');
 
         // act
         dataGrid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.totalCount(), 3, 'totalCount after adding row');
 
         // act
         dataGrid.deleteRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.deleteRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.totalCount(), 1, 'totalCount after removing rows');
@@ -4002,7 +4002,7 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 editRowKey: 1,
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $popupContent = dataGrid.getController('editing').getPopupContent() || [];
@@ -4029,13 +4029,13 @@ QUnit.module('Editing', baseModuleConfig, () => {
                 allowUpdating: true,
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editRow(0);
         $(dataGrid.getCellElement(0, 0)).find('.dx-selectbox').dxSelectBox('option', 'value', 2);
         dataGrid.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $cell = $(dataGrid.getCellElement(0, 0));
@@ -4109,7 +4109,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
         $firstCell.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4125,7 +4125,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         $firstCell.trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4144,7 +4144,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         // act
         scrollable.scrollTo({ y: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
         $input = $firstCell.find('input');
@@ -4168,7 +4168,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         dataGrid.addRow();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4181,7 +4181,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
         // act
         $firstCell.trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4200,7 +4200,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         // act
         scrollable.scrollTo({ y: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
         $input = $firstCell.find('input');
@@ -4227,7 +4227,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
         $firstCell.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4243,7 +4243,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         $firstCell.trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4262,7 +4262,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         // act
         scrollable.scrollTo({ y: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
         $input = $firstCell.find('input');
@@ -4291,7 +4291,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
         $firstCell.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4307,7 +4307,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         $firstCell.trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4321,7 +4321,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         const $saveButton = $('.dx-datagrid-save-button');
         $saveButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(dataGrid.$element().find('dx-datagrid-invalid').length, 'no invalid cells');
@@ -4329,7 +4329,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         // act
         scrollable.scrollTo({ y: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
         $input = $firstCell.find('input');
@@ -4366,7 +4366,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         dataGrid.addRow();
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4379,7 +4379,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
         // act
         $firstCell.trigger('dxclick');
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4389,19 +4389,19 @@ QUnit.module('Validation with virtual scrolling and rendering', {
         // act
         const scrollable = dataGrid.getScrollable();
         scrollable.scrollTo({ y: 1000 });
-        that.clock.tick();
+        that.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
         dataGrid.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.notOk(dataGrid.$element().find('dx-datagrid-invalid').length, 'no invalid cells');
 
         // act
         scrollable.scrollTo({ y: 0 });
-        that.clock.tick();
+        that.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
         $input = $firstCell.find('input');
@@ -4469,7 +4469,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
 
         dataGrid.addRow();
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4482,7 +4482,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
         // act
         $firstCell.trigger('dxclick');
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
@@ -4492,19 +4492,19 @@ QUnit.module('Validation with virtual scrolling and rendering', {
         // act
         const scrollable = dataGrid.getScrollable();
         scrollable.scrollTo({ y: 1000 });
-        that.clock.tick();
+        that.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
 
         dataGrid.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.notOk(dataGrid.$element().find('dx-datagrid-invalid').length, 'no invalid cells');
 
         // act
         scrollable.scrollTo({ y: 0 });
-        that.clock.tick();
+        that.clock.tick(10);
 
         $firstCell = $(dataGrid.getCellElement(0, 0));
         $input = $firstCell.find('input');
@@ -4562,7 +4562,7 @@ QUnit.module('Validation with virtual scrolling and rendering', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $cellElement = $(dataGrid.getCellElement(0, 1));
@@ -4644,7 +4644,7 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 500 });
@@ -4676,13 +4676,13 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
         const store = dataGrid.getDataSource().store();
 
         // act
         store.push([{ type: 'remove', key: 12 }]);
         store.push([{ type: 'remove', key: 11 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($('#dataGrid').find('.dx-datagrid-rowsview').find('.dx-virtual-row').length, 0, 'no virtual rows');
@@ -4704,7 +4704,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             dataSource: []
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $addRowButton = dataGrid.$element().find('.dx-datagrid-addrow-button');
@@ -4724,7 +4724,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
         // act
         dataGrid.option('editing.allowUpdating', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $deleteButton = dataGrid.$element().find('.dx-command-edit .dx-link-edit');
@@ -4732,7 +4732,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
         // act
         dataGrid.option('editing.allowUpdating', false);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $deleteButton = dataGrid.$element().find('.dx-command-edit .dx-link-edit');
@@ -4813,14 +4813,14 @@ QUnit.module('Assign options', baseModuleConfig, () => {
                 }
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         changeEditorValue();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $popupEditorInput = $('.dx-popup-content').find('.dx-texteditor').eq(0).find('input').eq(0);
@@ -4966,7 +4966,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.addRow();
@@ -4974,7 +4974,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         dataGrid.addRow();
 
         dataGrid.option('dataSource', items); // angular binding
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleRows = dataGrid.getVisibleRows();
@@ -5004,7 +5004,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fx.off = false;
 
@@ -5014,13 +5014,13 @@ QUnit.module('API methods', baseModuleConfig, () => {
         $inputElement.val('name1').trigger('change');
         dataGrid.saveEditData();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $inputElement = $('.dx-popup-content').find('input').first();
         $inputElement.val('name2').trigger('change');
         dataGrid.saveEditData();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleRows = dataGrid.getVisibleRows();
@@ -5050,12 +5050,12 @@ QUnit.module('API methods', baseModuleConfig, () => {
             },
             columns: ['id', { dataField: 'value', allowEditing: true }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
         this.clock.tick(1000);
 
         // act
         $('.dx-checkbox').eq(0).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-checkbox').eq(0).attr('aria-checked'), 'true', 'checkbox is checked');
@@ -5081,7 +5081,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             repaintChangesOnly: true,
             columns: ['name', 'value']
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editCell(0, 0);
@@ -5094,9 +5094,9 @@ QUnit.module('API methods', baseModuleConfig, () => {
         let $checkbox = $('.dx-checkbox').eq(0);
         $input.trigger('change');
         $checkbox.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
         $checkbox.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $checkbox = $('.dx-checkbox').eq(0);
@@ -5123,9 +5123,9 @@ QUnit.module('API methods', baseModuleConfig, () => {
         });
         const navigationController = dataGrid.getController('keyboardNavigation');
 
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         $('#qunit-fixture').find(':focus').on('focusout', function(e) {
             // emulate browser behaviour
             $(e.target).trigger('change');
@@ -5135,7 +5135,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         // act
         const event = $.Event('keydown', { target: $('#qunit-fixture').find(':focus').get(0) });
         navigationController._keyDownHandler({ key: 'Enter', keyName: 'enter', originalEvent: event });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(event.isDefaultPrevented(), 'keydown event is prevented');
@@ -5156,9 +5156,9 @@ QUnit.module('API methods', baseModuleConfig, () => {
             columns: [{ dataField: 'name', showEditorAlways: true }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         $('#qunit-fixture').find(':focus').on('focusout', function(e) {
             // emulate browser behaviour
             $(e.target).trigger('change');
@@ -5169,7 +5169,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         const $secondRowEditor = $(dataGrid.getRowElement(1)).find('.dx-texteditor-input');
         $secondRowEditor.trigger('dxpointerdown');
         $secondRowEditor.trigger('focus');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataSource[0].name, 'test', 'data is changed');
@@ -5195,7 +5195,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
                 dataType: 'date'
             }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(dataGrid.getCellElement(0, 0)).trigger('dxclick');
@@ -5233,11 +5233,11 @@ QUnit.module('API methods', baseModuleConfig, () => {
                 },
             }],
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $input = $('.dx-texteditor-input');
         const editor = rowsViewWrapper.getDataRow(0).getCell(0).getEditor();
@@ -5252,7 +5252,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         // act
         const event = $.Event('keydown', { key: 'enter' });
         $input.trigger(event);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.cellValue(0, 'BirthDate'), newValue, 'value is changed');
@@ -5281,11 +5281,11 @@ QUnit.module('API methods', baseModuleConfig, () => {
                         editorOptions: { useMaskBehavior }
                     }]
                 });
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // act
                 dataGrid.editCell(0, 0);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 let editor = rowsViewWrapper.getDataRow(0).getCell(0).getEditor();
                 const instance = editor.getElement().dxDateBox('instance');
@@ -5328,16 +5328,16 @@ QUnit.module('API methods', baseModuleConfig, () => {
         });
         const that = this;
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         dataGrid.cellValue(0, 0, '');
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         $(dataGrid.getCellElement(0, 0)).trigger('dxclick');
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         dataGrid.updateDimensions();
 
@@ -5470,13 +5470,13 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         triggerTabPress(dataGrid.getCellElement(0, 0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         triggerTabPress(dataGrid.getCellElement(0, 1));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getView('rowsView').getScrollable().scrollLeft(), 400, 'Correct offset');
@@ -5692,7 +5692,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.editCell(0, 1);
 
         dataSource.store().update(1, { field1: 'test5' });
@@ -5702,7 +5702,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.refresh(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.getCellElement(0, 1)).is($cell), 'first cell isn\'t updated');
@@ -5735,12 +5735,12 @@ QUnit.module('API methods', baseModuleConfig, () => {
             columns: ['id', 'field1']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.editCell(0, 1);
         dataGrid.closeEditCell();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const activeRowKey = 1;
@@ -5789,13 +5789,13 @@ QUnit.module('API methods', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.editCell(0, 1);
 
         for(let i = 0; i < 5; i++) {
             dataSource.store().update(1, { field1: 'changed' + i });
             dataGrid.refresh(true);
-            this.clock.tick();
+            this.clock.tick(10);
         }
 
         // assert
@@ -5839,7 +5839,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.expandRow(1);
 
         dataSource.store().update(1, { field1: 'changed' });
@@ -5849,7 +5849,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.refresh(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.element()).find('.detail').is($detail), 'detail element isn\'t updated');
@@ -5905,13 +5905,13 @@ QUnit.module('API methods', baseModuleConfig, () => {
         });
 
         dataGrid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.cancelEditData();
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
         $(dataGrid.getCellElement(2, 1)).find('.dx-link-delete').trigger('dxpointerdown').trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.getVisibleRows()[2].removed, true, 'row 2 is marked as removed');
@@ -5936,14 +5936,14 @@ QUnit.module('API methods', baseModuleConfig, () => {
                 }]
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.deleteRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.getVisibleRows().length, 0, 'row is removed');
@@ -6013,17 +6013,17 @@ QUnit.module('API methods', baseModuleConfig, () => {
                 },
             ],
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(dataGrid.getCellElement(0, 'StateID')).find('.dx-selectbox').dxSelectBox('instance').option('value', 2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(dataGrid.getCellElement(0, 'StateID')).find('.dx-selectbox').dxSelectBox('instance').option('value', 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const selectBox = $(dataGrid.getCellElement(0, 'CityID')).find('.dx-selectbox').dxSelectBox('instance');
@@ -6051,7 +6051,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         overlayTarget = dataGrid.$element().find('.dx-invalid-message').data('dxOverlay').option('position.of');
@@ -6059,12 +6059,12 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.closeEditCell();
-        this.clock.tick();
+        this.clock.tick(10);
 
         themes.isMaterial = function() { return true; };
 
         dataGrid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         overlayTarget = dataGrid.$element().find('.dx-invalid-message').data('dxOverlay').option('position.of');
@@ -6111,7 +6111,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         dataGrid.addRow();
         dataGrid.cellValue(0, 0, 3);
@@ -6124,7 +6124,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.saveEditData();
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(isLoadingOccurs, true, 'loadingChanged is occurs');
@@ -6184,12 +6184,12 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: array
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.cellValue(2, 1, 666);
         dataGrid.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleRows().length, 4, 'visible row count');
@@ -6214,7 +6214,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
                     mode: editMode.toLowerCase()
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             if(editMode === 'Row') {
@@ -6222,7 +6222,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             } else {
                 dataGrid.editCell(0, 0);
             }
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $editor = $(dataGrid.getCellElement(0, 0)).find('.dx-dropdowneditor');
 
@@ -6267,11 +6267,11 @@ QUnit.module('API methods', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editCell(5, 5);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cellElement = $(dataGrid.getCellElement(5, 5));
         const $revertButton = $(dataGrid.element()).find('.dx-datagrid-revert-tooltip .dx-overlay-content');
@@ -6292,7 +6292,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             left: $validationMessage.offset().left - $cellElement.offset().left,
         };
         dataGrid.getScrollable().scrollTo({ top: 100, left: 100 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($revertButton.offset().top - $cellElement.offset().top, revertButtonDiff.top, 'top revert position relative to the cell is not changed');
@@ -6327,13 +6327,13 @@ QUnit.module('API methods', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         for(let i = 0; i < 5; i++) {
             dataGrid.editRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             dataGrid.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
         }
 
         // assert
@@ -6364,7 +6364,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             } else {
                 dataGrid.editRow(0);
             }
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const $input = $(dataGrid.getCellElement(0, 0)).find('.dx-texteditor-input');
@@ -6399,7 +6399,7 @@ QUnit.module('Column Resizing', baseModuleConfig, () => {
 
         sinon.spy(resizingController, 'resize');
         sinon.spy(rowsView, 'synchronizeRows');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(resizingController.resize.callCount, 1, 'resize call count before editCell');
         assert.equal(rowsView.synchronizeRows.callCount, 1, 'synchronizeRows call count before editCell');
 
@@ -6594,7 +6594,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
                         }
                     }).dxDataGrid('instance');
 
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     let visibleRows = dataGrid.getVisibleRows();
@@ -6613,7 +6613,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.saveEditData();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.deepEqual(dataGrid.option('editing.changes'), [], 'change are empty');
@@ -6646,11 +6646,11 @@ QUnit.module('Editing state', baseModuleConfig, () => {
                         }
                     }).dxDataGrid('instance');
 
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // act
                     dataGrid.option('editing.changes', changes);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     let visibleRows = dataGrid.getVisibleRows();
@@ -6669,7 +6669,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.saveEditData();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.deepEqual(dataGrid.option('editing.changes'), [], 'change are empty');
@@ -6703,11 +6703,11 @@ QUnit.module('Editing state', baseModuleConfig, () => {
                         }
                     }).dxDataGrid('instance');
 
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // act
                     dataGrid.option('editing.changes', changes);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     let visibleRows = dataGrid.getVisibleRows();
@@ -6715,7 +6715,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.pageIndex(1);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     visibleRows = dataGrid.getVisibleRows();
@@ -6733,7 +6733,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.saveEditData();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.deepEqual(dataGrid.option('editing.changes'), [], 'change are empty');
@@ -6768,7 +6768,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
                         }
                     }).dxDataGrid('instance');
 
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     let visibleRows = dataGrid.getVisibleRows();
@@ -6776,7 +6776,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.pageIndex(1);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     visibleRows = dataGrid.getVisibleRows();
@@ -6795,7 +6795,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.saveEditData();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.deepEqual(dataGrid.option('editing.changes'), [], 'change are empty');
@@ -6835,11 +6835,11 @@ QUnit.module('Editing state', baseModuleConfig, () => {
                         }
                     }).dxDataGrid('instance');
 
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // act
                     dataGrid.option('editing.changes', changes);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     let visibleRows = dataGrid.getVisibleRows();
@@ -6849,7 +6849,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.pageIndex(1);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     visibleRows = dataGrid.getVisibleRows();
@@ -6867,7 +6867,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.saveEditData();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.deepEqual(dataGrid.option('editing.changes'), [], 'change are empty');
@@ -6907,11 +6907,11 @@ QUnit.module('Editing state', baseModuleConfig, () => {
                         }
                     }).dxDataGrid('instance');
 
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // act
                     dataGrid.option('editing.changes', changes);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     let visibleRows = dataGrid.getVisibleRows();
@@ -6920,7 +6920,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.pageIndex(1);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     visibleRows = dataGrid.getVisibleRows();
@@ -6939,7 +6939,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                     // act
                     dataGrid.saveEditData();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.deepEqual(dataGrid.option('editing.changes'), [], 'change are empty');
@@ -7012,7 +7012,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
             const $firstRow = $(dataGrid.getRowElement(0));
 
             $firstRow.find('input').first().val('test').trigger('change');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.deepEqual(dataGrid.option('editing.changes'), [], 'changes are reset');
@@ -7020,7 +7020,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
             // act
             $firstRow.find('input').eq(1).val('test').trigger('change');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.deepEqual(dataGrid.option('editing.changes'), [], 'changes are reset');
@@ -7049,7 +7049,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
             const $firstRow = $(dataGrid.getRowElement(0));
 
             $firstRow.find('input').first().val('test').trigger('change');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.deepEqual(dataGrid.option('editing.changes'), [], 'changes are reset');
@@ -7146,7 +7146,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
             } else {
                 dataGrid.editRow(0);
             }
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             switch(editMode) {
@@ -7206,7 +7206,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
                 }
                 dataGrid.option(`editing.${editingOption}`, optionValue);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.equal(onToolbarPreparingSpy.callCount, 1, 'onToolbarPreparing should not be called on option change');
@@ -7232,20 +7232,20 @@ QUnit.module('Editing state', baseModuleConfig, () => {
             },
             columns: ['id', 'value', 'field']
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const popup = $(dataGrid.getController('editing').getPopupContent());
         const valueInput = popup.find('.dx-texteditor-input').eq(1);
         const fieldInput = popup.find('.dx-texteditor-input').eq(2);
 
         valueInput.trigger('focus').val('35').trigger('change');
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldInput.trigger('focus');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(document.activeElement.id, fieldInput.attr('id'), 'focus is not reset after changing the field used for a summary');
     });
@@ -7273,11 +7273,11 @@ QUnit.module('Editing state', baseModuleConfig, () => {
                 e.promise.resolve();
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('#dataGrid .dx-link-delete').eq(0).trigger('dxpointerdown').trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('#dataGrid .dx-datagrid-pager').is(':visible'), 'Pager is visible');
@@ -7297,14 +7297,14 @@ QUnit.module('Editing state', baseModuleConfig, () => {
             onEditCanceling,
             onEditCanceled
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('#dataGrid .dx-link-cancel').eq(0).trigger('dxpointerdown').trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(onEditCanceling.callCount, 1, 'onEditCanceling call count');
@@ -7335,7 +7335,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getCellElement(0, 1)).find('.dx-checkbox').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         let $secondCell = $(dataGrid.getCellElement(0, 1));
@@ -7344,7 +7344,7 @@ QUnit.module('Editing state', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getCellElement(0, 1)).find('.dx-checkbox').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $secondCell = $(dataGrid.getCellElement(0, 1));
@@ -7713,7 +7713,7 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
             // act
             $(dataGrid.getCellElement(newRowVisibleIndex, 1)).find('.dx-texteditor-input').val('111').trigger('change');
             dataGrid.pageIndex(pageIndexToChange);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(dataGrid.pageIndex(), pageIndexToChange, 'page index is changed manually');
@@ -7721,7 +7721,7 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
 
             // act
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(dataGrid.pageIndex(), pageIndexToChange === 0 ? 1 : 0, 'switched to page with a new row');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -116,7 +116,7 @@ QUnit.module('Editing', {
             const isLink = $targetElement.hasClass('dx-link');
             const event = $.Event(isLink ? 'click' : 'dxclick');
             $($targetElement).trigger(event);
-            this.clock.tick();
+            this.clock.tick(10);
             return event;
         };
         this.keyboardNavigationController._focusedView = this.rowsView;
@@ -530,7 +530,7 @@ QUnit.module('Editing', {
         assert.equal(cancelEditDataCallCount, 0, 'cancelEditData is not called'); // T630875
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(cancelEditDataCallCount, 1, 'cancelEditData is called');
@@ -563,7 +563,7 @@ QUnit.module('Editing', {
 
         // act
         const event = this.click(testElement.find('tbody > tr').first(), '.dx-link:contains(Edit)');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(editRowCallCount, 1);
@@ -597,7 +597,7 @@ QUnit.module('Editing', {
 
         // act
         this.click(testElement.find('tbody > tr').first(), '.dx-link:contains(Edit)');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(getInputElements(testElement.find('tbody > tr').first()).length);
@@ -794,9 +794,9 @@ QUnit.module('Editing', {
         assert.equal(testElement.find('td').first().find('input').length, 1);
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         testElement.find('td').first().find('input').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement).length, 1, 'editor is not closed');
@@ -832,7 +832,7 @@ QUnit.module('Editing', {
 
         // act
         $($boolCell).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
         $boolCell = testElement.find('td').eq(3);
         // assert
         assert.ok(!$boolCell.hasClass('dx-datagrid-readonly'));
@@ -1384,7 +1384,7 @@ QUnit.module('Editing', {
 
             // act
             testElement.find('tbody > tr').first().find('a').trigger('click'); // show confirm
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(body.find('.dx-dialog').length, 'has dialog');
@@ -1610,7 +1610,7 @@ QUnit.module('Editing', {
 
         rowsView.render(testElement);
         testElement.find('td').first().trigger('dxclick'); // Edit
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1);
@@ -1620,7 +1620,7 @@ QUnit.module('Editing', {
         // act
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 0);
@@ -1644,7 +1644,7 @@ QUnit.module('Editing', {
 
         // act
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1, 'editor is rendered');
@@ -1672,7 +1672,7 @@ QUnit.module('Editing', {
 
         // act
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1, 'editor is rendered');
@@ -1714,7 +1714,7 @@ QUnit.module('Editing', {
 
         rowsView.render(testElement);
         testElement.find('td').first().trigger('dxclick'); // Edit
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1);
 
@@ -1723,7 +1723,7 @@ QUnit.module('Editing', {
         $(document).trigger('dxpointerdown');
         testElement.find('input').first().trigger('change');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 0);
@@ -1753,10 +1753,10 @@ QUnit.module('Editing', {
         assert.equal($calendar.length, 1, 'popup calendar count');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         $($calendar).trigger('dxpointerdown');
         $($calendar).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1, 'editor count');
@@ -1781,13 +1781,13 @@ QUnit.module('Editing', {
 
         rowsView.render($('#container'));
         rowsViewWrapper.getCellElement(0, 2).trigger('dxclick'); // Edit
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         let editor = rowsViewWrapper.getDataRow(0).getCell(2).getEditor();
         editor.getInputElement().trigger('dxpointerdown');
         rowsViewWrapper.getElement().find('tbody').first().trigger('dxclick'); // chrome 73+
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         editor = rowsViewWrapper.getDataRow(0).getCell(2).getEditor();
@@ -1832,14 +1832,14 @@ QUnit.module('Editing', {
         assert.equal($addButton.length, 1, 'add button is rendered');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         $addButton.trigger('dxpointerdown');
         $addButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         const $secondCell = $('.dx-popup-wrapper .dx-datagrid .dx-data-row > td').eq(1);
         $secondCell.trigger('dxpointerdown');
         $secondCell.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // assert
@@ -1866,7 +1866,7 @@ QUnit.module('Editing', {
         popupInstance.show();
         const $popupContent = popupInstance.$overlayContent();
         $($popupContent.find('td').first()).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(getInputElements($popupContent).length, 1, 'has input');
@@ -1874,7 +1874,7 @@ QUnit.module('Editing', {
         // act
         $($popupContent).trigger('dxpointerdown');
         $($popupContent).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(getInputElements($popupContent).length, 0, 'not has input');
@@ -1906,10 +1906,10 @@ QUnit.module('Editing', {
         assert.equal($otherMonthDay.length, 1, 'over month day element');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         $($otherMonthDay).trigger('dxpointerdown');
         $($otherMonthDay).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1, 'editor count');
@@ -1931,14 +1931,14 @@ QUnit.module('Editing', {
         rowsView.render(that.gridContainer);
         that.gridContainer.find('tbody > tr').first().find('td').eq(2).trigger('dxclick'); // Edit
 
-        this.clock.tick();
+        this.clock.tick(10);
         const $focusOverlay = that.gridContainer.find('.dx-datagrid-focus-overlay');
         assert.equal($focusOverlay.length, 1, 'focus overlay count');
 
         // act
         $($focusOverlay).trigger('dxpointerdown');
         $($focusOverlay).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(that.gridContainer.find('tbody > tr').first()).length, 1, 'editor count');
@@ -2041,7 +2041,7 @@ QUnit.module('Editing', {
         getInputElements(testElement).eq(0).trigger('change');
         mouse.up();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(updateArgs, [['test1', { 'name': 'Test1' }], ['test2', { 'name': 'Test2' }]], 'changed rows are saved');
@@ -2073,7 +2073,7 @@ QUnit.module('Editing', {
 
         // act
         mouse.down();
-        this.clock.tick();
+        this.clock.tick(10);
         mouse.up();
 
         // assert
@@ -2184,7 +2184,7 @@ QUnit.module('Editing', {
 
         // act
         this.editingController.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(updateArgs, [['test1', { 'name': 'Test1' }]]);
@@ -2215,7 +2215,7 @@ QUnit.module('Editing', {
 
         rowsView.render(testElement);
         testElement.find('td').first().trigger('dxclick'); // Edit
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1, 'has input');
@@ -2228,7 +2228,7 @@ QUnit.module('Editing', {
         testElement.find('.dx-freespace-row').first().trigger('dxpointerdown');
         testElement.find('.dx-freespace-row').first().trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 0, 'not has input');
         assert.ok(!updateArgs, 'no update');
@@ -2500,7 +2500,7 @@ QUnit.module('Editing', {
         });
 
         that.deleteRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.editCell(0, 0);
@@ -2604,7 +2604,7 @@ QUnit.module('Editing', {
         const $firstCell = $testElement.find('tbody > tr > td').first();
         $firstCell.focus();
         $firstCell.trigger(pointerEvents.up);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.notOk($testElement.find('.dx-datagrid-focus-overlay').is(':visible'), 'not visible focus overlay');
@@ -2708,7 +2708,7 @@ QUnit.module('Editing', {
 
         // act
         $testElement.find('td').eq(1).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(that.editingController.closeEditCell.callCount, 1, 'count call closeEditCell');
@@ -2736,7 +2736,7 @@ QUnit.module('Editing', {
 
         // act
         $testElement.find('td').first().trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(getInputElements($testElement).length, 1, 'has input');
@@ -2896,7 +2896,7 @@ QUnit.module('Editing with real dataController', {
             const $targetElement = this.find($element, selector);
             const isLink = $targetElement.hasClass('dx-link');
             $($targetElement).trigger(isLink ? 'click' : 'dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
         };
     },
     afterEach: function() {
@@ -3140,7 +3140,7 @@ QUnit.module('Editing with real dataController', {
 
         this.editingController.closeEditCell();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($testElement.find('td').eq(1).text(), '16', 'we will keep value that we increment by arrow up key');
@@ -3171,7 +3171,7 @@ QUnit.module('Editing with real dataController', {
 
         this.editingController.closeEditCell();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($testElement.find('td').eq(1).text(), '14', 'we will keep value that we decrement by arrow down key');
@@ -3205,7 +3205,7 @@ QUnit.module('Editing with real dataController', {
         $input.change();
         $($input).trigger($.Event('keydown', { key: TAB_KEY }));
         this.editingController.closeEditCell();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!testElement.find('td').eq(1).hasClass('dx-cell-modified'), 'cell is not modified');
@@ -3220,7 +3220,7 @@ QUnit.module('Editing with real dataController', {
         $($input).trigger($.Event('keydown', { key: TAB_KEY }));
 
         this.editingController.closeEditCell();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(testElement.find('td').eq(1).hasClass('dx-cell-modified'), 'cell is modified');
@@ -3357,7 +3357,7 @@ QUnit.module('Editing with real dataController', {
         this.addRow().done(() => {
             doneExecuteCount++;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(doneExecuteCount, 1, 'done was executed');
@@ -3866,7 +3866,7 @@ QUnit.module('Editing with real dataController', {
         testElement.find('input').first().trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.addRow();
 
@@ -4037,7 +4037,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').eq(0)).length, 1, 'When insert row and cell editing - focus first cell');
@@ -4098,7 +4098,7 @@ QUnit.module('Editing with real dataController', {
             .trigger('change');
 
         that.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(testElement.find('td:contains(modifiedValue)').length);
@@ -4215,7 +4215,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 1, 'count input');
@@ -4226,7 +4226,7 @@ QUnit.module('Editing with real dataController', {
 
         $(document).trigger('dxpointerdown'); // Save
         $(document).trigger('dxclick'); // Save
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 0, 'count input');
@@ -4249,7 +4249,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 1, 'count input');
@@ -4260,7 +4260,7 @@ QUnit.module('Editing with real dataController', {
 
         $(document).trigger('dxpointerdown'); // Save
         $(document).trigger('dxclick'); // Save
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 0, 'count input');
@@ -4307,7 +4307,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 1, 'count input');
@@ -4317,7 +4317,7 @@ QUnit.module('Editing with real dataController', {
         testElement.find('input').first().trigger('change');
 
         // $(document).trigger("dxclick"); // Save
-        // that.clock.tick();
+        // that.clock.tick(10);
         that.saveEditData();
 
         // assert
@@ -4365,7 +4365,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 1, 'count input');
@@ -4375,7 +4375,7 @@ QUnit.module('Editing with real dataController', {
         testElement.find('input').first().trigger('change');
 
         // $(document).trigger("dxclick"); // Save
-        // that.clock.tick();
+        // that.clock.tick(10);
         that.saveEditData();
 
         // assert
@@ -4429,7 +4429,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 1, 'count input');
@@ -4489,7 +4489,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 1, 'count input');
@@ -4540,7 +4540,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 1, 'count input');
@@ -4551,7 +4551,7 @@ QUnit.module('Editing with real dataController', {
 
         $(document).trigger('dxpointerdown'); // Save
         $(document).trigger('dxclick'); // Save
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 0, 'count input');
@@ -4589,7 +4589,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, booleanColumnIndex);
-        that.clock.tick();
+        that.clock.tick(10);
 
         let $checkbox = testElement.find('.dx-row').first().find('.dx-checkbox');
 
@@ -4601,7 +4601,7 @@ QUnit.module('Editing with real dataController', {
 
         $(document).trigger('dxpointerdown'); // Save
         $(document).trigger('dxclick'); // Save
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $checkbox = testElement.find('.dx-row').first().find('.dx-checkbox');
@@ -4632,7 +4632,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.cellValue(0, 0, 'test');
-        that.clock.tick();
+        that.clock.tick(10);
 
         assert.equal(testElement.find('.dx-row').first().find('.dx-cell-modified').length, 1, 'one modified value');
         assert.ok(testElement.find('.dx-row').first().children().eq(0).hasClass('dx-cell-modified'), 'first cell is modified');
@@ -4770,7 +4770,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.deepEqual(editingStartKeys, [undefined, undefined], 'onEditingStart called twice with undefined key');
@@ -4799,7 +4799,7 @@ QUnit.module('Editing with real dataController', {
         // act
         that.cellValue(0, 0, 'Test');
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(onRowUpdatingArgs.length, 1, 'onRowUpdating called once');
@@ -4927,7 +4927,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.deleteRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
         $('.dx-dialog-button').first().trigger('dxclick');
         this.clock.tick(DIALOG_ANIMATION_TIMEOUT);
 
@@ -5069,7 +5069,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.deleteRow(1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(testElement.find('.dx-data-row').length, 6, 'row is removed');
@@ -5094,7 +5094,7 @@ QUnit.module('Editing with real dataController', {
 
         that.cellValue(0, 0, 'test');
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(testElement.find('.dx-data-row').length, 7, 'row count');
@@ -5102,7 +5102,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.deleteRow(1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(testElement.find('.dx-data-row').length, 6, 'row is removed');
@@ -5131,7 +5131,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.deleteRow(1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(testElement.find('.dx-data-row').length, 6, 'row is removed');
@@ -5270,7 +5270,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('.dx-select-checkbox').closest('td').first().trigger('dxpointerdown');
         $('.dx-select-checkbox').closest('td').first().trigger('dxclick');
@@ -5300,7 +5300,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         testElement.find('td').first().next().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1, 'has input');
@@ -5312,7 +5312,7 @@ QUnit.module('Editing with real dataController', {
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!getInputElements(testElement.find('tbody > tr').first()).length, 'not has input');
@@ -5399,7 +5399,7 @@ QUnit.module('Editing with real dataController', {
         testElement.find('.dx-texteditor-input').first().trigger('change');
 
         that.editingController.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $modifiedCell = testElement.find('td.dx-cell-modified');
@@ -5478,7 +5478,7 @@ QUnit.module('Editing with real dataController', {
         });
 
         testElement.find('td').first().trigger('dxclick'); // Edit
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1);
@@ -5488,7 +5488,7 @@ QUnit.module('Editing with real dataController', {
         // act
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 0);
@@ -5510,7 +5510,7 @@ QUnit.module('Editing with real dataController', {
 
         rowsView.render(testElement);
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1);
@@ -5518,7 +5518,7 @@ QUnit.module('Editing with real dataController', {
         testElement.find('input').first().trigger('change');
 
         this.editCell(0, 2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 1);
@@ -5528,7 +5528,7 @@ QUnit.module('Editing with real dataController', {
         // act
         $(document).trigger('dxpointerdown');
         $(document).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement.find('tbody > tr').first()).length, 0);
@@ -5713,7 +5713,7 @@ QUnit.module('Editing with real dataController', {
         that.editCell(0, 0);
 
         selectBoxInstance.option('value', 2);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(saveEditDataCallCount, 1, 'save edit data called once');
@@ -5844,7 +5844,7 @@ QUnit.module('Editing with real dataController', {
         $checkBox.focus().trigger('dxclick');
 
         updateDeferred.resolve();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(updateCallCount, 1, 'update called once');
@@ -5920,7 +5920,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         this.editingController.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // assert
@@ -6134,7 +6134,7 @@ QUnit.module('Editing with real dataController', {
         rowsView.render(that.gridContainer);
 
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.ok(that.gridContainer.find('.dx-datagrid-focus-overlay').is(':visible'), 'visible focus overlay');
@@ -6144,7 +6144,7 @@ QUnit.module('Editing with real dataController', {
 
         // assert
         assert.ok(!that.gridContainer.find('.dx-datagrid-focus-overlay').is(':visible'), 'not visible focus overlay');
-        that.clock.tick();
+        that.clock.tick(10);
         assert.ok(that.gridContainer.find('.dx-datagrid-focus-overlay').is(':visible'), 'visible focus overlay');
     });
 
@@ -6412,7 +6412,7 @@ QUnit.module('Editing with real dataController', {
         that.columnsController.init();
 
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $cellElement = $(rowsView.element().find('tbody > tr').first().children().first());
@@ -6423,7 +6423,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         lookupInstance.option('value', 'test1');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $cellElement = $(rowsView.element().find('tbody > tr').first().children().first());
@@ -6450,7 +6450,7 @@ QUnit.module('Editing with real dataController', {
         that.columnsController.init();
 
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         const $input1 = $(rowsView.getCellElement(0, 0)).find('.dx-texteditor-input');
         let $input2 = $(rowsView.getCellElement(0, 1)).find('.dx-texteditor-input');
@@ -6462,7 +6462,7 @@ QUnit.module('Editing with real dataController', {
             $input2.get(0).setSelectionRange(1, 2);
         }
         $input1.trigger('change');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $cellElement = $(rowsView.getCellElement(0, 1));
@@ -6494,7 +6494,7 @@ QUnit.module('Editing with real dataController', {
         that.columnsController.init();
 
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         const $input = $(rowsView.getCellElement(0, 0)).find('.dx-texteditor-input');
 
@@ -6506,7 +6506,7 @@ QUnit.module('Editing with real dataController', {
         mouse.down();
         $input.trigger('change');
         mouse.up();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $secondCell = $(rowsView.getCellElement(0, 1));
@@ -6562,7 +6562,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataController.items().length, 8, 'item was added');
@@ -6596,7 +6596,7 @@ QUnit.module('Editing with real dataController', {
 
         this.gridView.render(testElement);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsViewHeight = $('.dx-datagrid-rowsview').height();
 
@@ -6624,7 +6624,7 @@ QUnit.module('Editing with real dataController', {
 
         this.gridView.render(testElement);
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.addRow();
@@ -6650,7 +6650,7 @@ QUnit.module('Editing with real dataController', {
         this.columnsController.init();
 
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.rowsView.render(testElement);
 
@@ -6669,7 +6669,7 @@ QUnit.module('Editing with real dataController', {
         assert.strictEqual(changeCount, 0, 'data is not changed');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(changeCount, 1, 'data is changed once');
@@ -6736,7 +6736,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         this.rowsView.render($testElement);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(editorPreparingHandler.getCall(0).args[0].command, 'select', 'The editorPreparing event argument - select column');
@@ -6836,7 +6836,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         items = that.dataController.items();
@@ -6866,7 +6866,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.gridContainer.find('tbody > tr').first().find('td').first().trigger('dxclick'); // Edit
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $focusOverlay = that.gridContainer.find('.dx-datagrid-focus-overlay');
@@ -6901,7 +6901,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.gridContainer.find('.dx-datagrid-content-fixed tbody > tr').first().find('td').first().trigger('dxclick'); // Edit
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $focusOverlay = that.gridContainer.find('.dx-datagrid-focus-overlay');
@@ -6937,7 +6937,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.gridContainer.find('tbody > tr').first().find('td').last().trigger('dxclick'); // Edit
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $focusOverlay = that.gridContainer.find('.dx-datagrid-focus-overlay');
@@ -6970,11 +6970,11 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 5);
-        that.clock.tick();
+        that.clock.tick(10);
         const $selectBox = $(rowsView.getCellElement(0, 5)).find('.dx-selectbox');
         $selectBox.dxSelectBox('instance').option('value', 2);
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $cell = testElement.find('.dx-row').first().children('td').eq(5);
@@ -7010,11 +7010,11 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 5);
-        that.clock.tick();
+        that.clock.tick(10);
         const $selectBox = $(rowsView.getCellElement(0, 5)).find('.dx-selectbox');
         $selectBox.dxSelectBox('instance').reset();
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $cell = testElement.find('.dx-row').first().children('td').eq(5);
@@ -7049,11 +7049,11 @@ QUnit.module('Editing with real dataController', {
 
             // act
             that.editCell(0, 5);
-            that.clock.tick();
+            that.clock.tick(10);
             const $selectBox = $(rowsView.getCellElement(0, 5)).find('.dx-selectbox');
             $selectBox.dxSelectBox('instance').option('value', 1);
             that.closeEditCell();
-            that.clock.tick();
+            that.clock.tick(10);
 
             // assert
             const $cell = testElement.find('.dx-row').first().children('td').eq(5);
@@ -7087,11 +7087,11 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 5);
-        that.clock.tick();
+        that.clock.tick(10);
         const $selectBox = $(rowsView.getCellElement(0, 5)).find('.dx-selectbox');
         const $cellBeforeChange = testElement.find('.dx-row').first().children('td').eq(5);
         $selectBox.dxSelectBox('instance').option('value', 2);
-        that.clock.tick();
+        that.clock.tick(10);
         const $cellAfterChange = testElement.find('.dx-row').first().children('td').eq(5);
 
         // assert
@@ -7175,7 +7175,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         that.editCell(0, 5);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $selectBox = $(rowsView.getCellElement(0, 5)).find('.dx-selectbox');
@@ -7223,7 +7223,7 @@ QUnit.module('Editing with real dataController', {
         // act
         testElement.find('tbody > tr').first().find('input').eq(0).val('Test name');
         testElement.find('tbody > tr').first().find('input').eq(0).trigger('change');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('tbody > tr').first().find('input').eq(0).val(), 'Test name');
@@ -7298,7 +7298,7 @@ QUnit.module('Editing with real dataController', {
         // act
         $targetInput.val('Test name');
         $targetInput.trigger('change');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($testElement.find('tbody > tr').first().find('.dx-texteditor').first().hasClass('dx-invalid'));
@@ -7339,7 +7339,7 @@ QUnit.module('Editing with real dataController', {
         // act
         $targetInput.val('Test name');
         $targetInput.trigger('change');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(validationCallback.callCount, 0, 'validation is not occurs');
@@ -7523,7 +7523,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         $(that.gridContainer.find('tbody > tr').first().find('td').first().find('.dx-selectbox-container')).trigger('dxclick'); // Edit
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $focusOverlay = that.gridContainer.find('.dx-datagrid-focus-overlay');
@@ -7567,7 +7567,7 @@ QUnit.module('Editing with real dataController', {
         // act
         that.cancelEditData();
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal($testElement.find('.dx-edit-row').length, 1, 'one edit row');
@@ -8033,7 +8033,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         $linkElement.trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!clicked, 'not clicked when disabled');
@@ -8044,7 +8044,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         $linkElement.trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(clicked, 'clicked when isn\'t disabled');
@@ -8114,7 +8114,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         $linkElements.first().trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.notOk($testElement.find('.dx-datagrid-rowsview tbody > tr').first().hasClass('dx-edit-row'), 'row not editable');
@@ -8218,7 +8218,7 @@ QUnit.module('Editing with real dataController', {
 
         // act
         $(rowsView.getCellElement(0, 0)).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         const $inputElement = getInputElements($(rowsView.getCellElement(0, 0))).first();
         $inputElement.val('test');
@@ -8229,7 +8229,7 @@ QUnit.module('Editing with real dataController', {
         // act
         eventsEngine.trigger($inputElement[0], 'change');
         $(rowsView.getCellElement(0, 1)).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(editCellTemplate.callCount, 1);
@@ -8458,7 +8458,7 @@ QUnit.module('Editing with real dataController', {
 
         template.reset();
         that.editingController.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(template.callCount, 1, 'template is called');
@@ -8556,10 +8556,10 @@ QUnit.module('Editing with real dataController', {
                     // act
                     if(doubleChange) {
                         getEditor('lookup1').option('value', 3);
-                        this.clock.tick();
+                        this.clock.tick(10);
                     }
                     getEditor('lookup1').option('value', 2);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     checkEditorRecreating('id', !repaintChangesOnly);
@@ -8572,7 +8572,7 @@ QUnit.module('Editing with real dataController', {
                     dataSourceCallCount = 0;
                     getEditor('lookup2').option('opened', true);
                     getEditor('lookup2').option('value', 21);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.equal(getEditor('lookup2').option('text'), 'value21', 'lookup2 text is updated');
@@ -8581,7 +8581,7 @@ QUnit.module('Editing with real dataController', {
 
                     // act
                     getEditor('lookup1').option('value', 3);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     checkEditorRecreating('id', !repaintChangesOnly);
@@ -8631,7 +8631,7 @@ QUnit.module('Editing with real dataController', {
             // act
             $targetInput.val('').trigger('change');
             this.closeEditCell();
-            this.clock.tick();
+            this.clock.tick(10);
 
             let $secondCell = $(this.getCellElement(0, 1));
 
@@ -8640,7 +8640,7 @@ QUnit.module('Editing with real dataController', {
 
             // act
             this.cancelEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             $secondCell = $(this.getCellElement(0, 1));
 
@@ -8723,7 +8723,7 @@ QUnit.module('Editing with real dataController', {
 
             this.editorFactoryController.init();
             rowsView.render($testElement);
-            this.clock.tick();
+            this.clock.tick(10);
 
             if(editMode === 'Row') {
                 this.editRow(0);
@@ -8731,7 +8731,7 @@ QUnit.module('Editing with real dataController', {
                 this.editCell(0, 0);
             }
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.ok(isEditorCell, 'cell is rendered for an editor');
         });
@@ -8954,7 +8954,7 @@ QUnit.module('Editing with real dataController', {
 
                 // act
                 this.option('editing.editRowKey', null);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 this.checkRowIsNotEdited(assert, $(rowsView.getRowElement(0)), editMode);
@@ -9267,7 +9267,7 @@ QUnit.module('Editing with real dataController', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
                 const newRowKey = this.option('editing.editRowKey');
 
                 // assert
@@ -9312,7 +9312,7 @@ QUnit.module('Editing with real dataController', {
             // act
             const oldChanges = this.option('editing.changes');
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const newChanges = this.option('editing.changes');
@@ -9341,7 +9341,7 @@ QUnit.module('Editing with real dataController', {
             // act
             previousChanges = this.option('editing.changes');
             this.cellValue(0, 0, 'test');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             newChanges = this.option('editing.changes');
@@ -9357,7 +9357,7 @@ QUnit.module('Editing with real dataController', {
             // act
             previousChanges = newChanges;
             this.cellValue(0, 1, 'test2');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             newChanges = this.option('editing.changes');
@@ -9392,7 +9392,7 @@ QUnit.module('Editing with real dataController', {
             // act
             const oldChanges = this.option('editing.changes');
             this.deleteRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const newChanges = this.option('editing.changes');
@@ -9423,7 +9423,7 @@ QUnit.module('Editing with real dataController', {
             // act
             const oldChanges = this.option('editing.changes');
             this.deleteRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const newChanges = this.option('editing.changes');
@@ -9550,7 +9550,7 @@ QUnit.module('Editing with real dataController', {
                         key,
                         type: 'insert'
                     }]);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     visibleRows = this.getVisibleRows();
@@ -9596,7 +9596,7 @@ QUnit.module('Editing with real dataController', {
                     key: 1,
                     type: 'remove'
                 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let visibleRows = this.getVisibleRows();
@@ -9648,7 +9648,7 @@ QUnit.module('Editing with real dataController', {
                     type: 'update',
                     data: { name: 'test' }
                 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 visibleRows = this.getVisibleRows();
@@ -9678,7 +9678,7 @@ QUnit.module('Editing with real dataController', {
 
             // act
             this.editRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.deepEqual(this.option('editing.changes'), [], 'no changes');
@@ -9709,7 +9709,7 @@ QUnit.module('Editing with real dataController', {
 
             // act
             this.editRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             this.option('editing.changes', [{
                 data: { name: 'asd' },
@@ -9735,7 +9735,7 @@ QUnit.module('Editing with real dataController', {
 
             // act
             this.editCell(0, 0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.deepEqual(this.option('editing.changes'), [], 'no changes');
@@ -10714,7 +10714,7 @@ QUnit.module('Refresh modes', {
               data: { state: 'disabled'}
             }
         ]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $linkElements = $(this.getCellElement(0, 0)).find('.dx-link');
@@ -10775,11 +10775,11 @@ QUnit.module('Refresh modes', {
             };
             this.options.selectedRowKeys = [1, 2];
             this.setupModules();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.deleteRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.getVisibleRows().length, 2);
@@ -10917,7 +10917,7 @@ QUnit.module('Editing with validation', {
 
         // act
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         const $checkbox = $(rowsView.element().find('tbody > tr').first().find('td .dx-checkbox').first());
 
@@ -10960,7 +10960,7 @@ QUnit.module('Editing with validation', {
         inputElement.trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = rowsView.element().find('tbody > tr').first().find('td');
 
@@ -10976,7 +10976,7 @@ QUnit.module('Editing with validation', {
         inputElement.trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = rowsView.element().find('tbody > tr').first().find('td');
 
@@ -11167,7 +11167,7 @@ QUnit.module('Editing with validation', {
         testElement.find('.dx-texteditor-input').first().trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
         that.saveEditData();
 
         cells = rowsView.element().find('td');
@@ -11363,7 +11363,7 @@ QUnit.module('Editing with validation', {
         testElement.find('input').first().trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement).length, 0, 'not has input');
@@ -11404,7 +11404,7 @@ QUnit.module('Editing with validation', {
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
         const selectBoxButton = $(rowsView.getCellElement(0, 0)).find('.dx-selectbox .dx-dropdowneditor-button').dxButton('instance');
         $(selectBoxButton.$element()).trigger('dxclick');
 
@@ -11569,11 +11569,11 @@ QUnit.module('Editing with validation', {
         testElement.find('.dx-texteditor-input').trigger('change');
 
         that.closeEditCell(); // close edit cell
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.editCell(0, 1); // edit cell
         that.editorFactoryController.focus(testElement.find('td').eq(1).children()); // focus cell
-        that.clock.tick();
+        that.clock.tick(10);
     });
 
     // T629168
@@ -11608,13 +11608,13 @@ QUnit.module('Editing with validation', {
         that.editCell(0, 0);
         testElement.find('input').val('').trigger('change');
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.editorFactoryController.focus(this.rowsView.element().find('td').eq(0));
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.resize();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('.dx-invalid-message.dx-widget').length, 1, 'validation tooltip count = 1');
@@ -11814,7 +11814,7 @@ QUnit.module('Editing with validation', {
         $($inputElement).trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         $cells = $(rowsView.element().find('tbody > tr').first().find('td'));
 
@@ -11824,7 +11824,7 @@ QUnit.module('Editing with validation', {
 
         // act
         $($cells.eq(1)).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         $cells = $(rowsView.element().find('tbody > tr').first().find('td'));
 
@@ -11845,7 +11845,7 @@ QUnit.module('Editing with validation', {
         $($inputElement).trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         $cells = $(rowsView.element().find('tbody > tr').first().find('td'));
 
@@ -11854,7 +11854,7 @@ QUnit.module('Editing with validation', {
 
         // act
         $($cells.eq(1)).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(getInputElements($testElement).length, 1, 'has input');
@@ -11894,14 +11894,14 @@ QUnit.module('Editing with validation', {
         const editor = $cell.find('.dx-switch').dxSwitch('instance');
 
         eventsEngine.trigger(editor.$element(), 'focus');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($cell.find('.dx-overlay').length, 0, 'no tooltip');
 
         // act
         editor.option('value', false);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($cell.find('.dx-overlay').length, 1, 'tooltip is rendered');
@@ -11934,7 +11934,7 @@ QUnit.module('Editing with validation', {
 
         // act
         $(this.getCellElement(0, 0)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(this.getCellElement(0, 0)).find('.dx-overlay').length, 2, 'validation and revert tooltips are rendered');
@@ -11977,7 +11977,7 @@ QUnit.module('Editing with validation', {
 
         // act
         cells.eq(1).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement).length, 1, 'has input');
@@ -11988,7 +11988,7 @@ QUnit.module('Editing with validation', {
         eventsEngine.trigger(inputElement[0], 'change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = $(rowsView.element()).find('.dx-data-row').last().find('td');
 
@@ -11998,7 +11998,7 @@ QUnit.module('Editing with validation', {
 
         // act
         cells.eq(1).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = $(rowsView.element()).find('.dx-data-row').last().find('td');
 
@@ -12051,7 +12051,7 @@ QUnit.module('Editing with validation', {
 
         // act
         cells.eq(1).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(getInputElements(testElement).length, 1, 'has input');
@@ -12062,7 +12062,7 @@ QUnit.module('Editing with validation', {
         eventsEngine.trigger(inputElement[0], 'change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = $(rowsView.element()).find('.dx-data-row').last().find('td');
 
@@ -12072,7 +12072,7 @@ QUnit.module('Editing with validation', {
 
         // act
         cells.eq(1).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = $(rowsView.element()).find('.dx-data-row').last().find('td');
 
@@ -12116,7 +12116,7 @@ QUnit.module('Editing with validation', {
 
         that.cellValue(0, 2, '');
         that.editCell(0, 2);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         tooltipInstance = $testElement.find('tbody td').eq(2).find('.dx-overlay.dx-invalid-message').dxOverlay('instance');
@@ -12127,7 +12127,7 @@ QUnit.module('Editing with validation', {
 
         // act
         eventsEngine.trigger(getInputElements($testElement.find('tbody td').eq(2))[0], 'dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const selectBoxInstance = $testElement.find('tbody td').eq(2).find('.dx-selectbox').dxSelectBox('instance');
@@ -12139,7 +12139,7 @@ QUnit.module('Editing with validation', {
 
         // act
         eventsEngine.trigger($testElement.find('tbody td').eq(2).find('.dx-dropdowneditor-button')[0], 'dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         // T724201
@@ -12177,7 +12177,7 @@ QUnit.module('Editing with validation', {
 
         that.cellValue(0, 0, '');
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const tooltipInstance = $testElement.find('tbody td').eq(0).find('.dx-overlay.dx-invalid-message').dxOverlay('instance');
@@ -12220,11 +12220,11 @@ QUnit.module('Editing with validation', {
 
         that.cellValue(0, 0, '');
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         eventsEngine.trigger(getInputElements($testElement.find('tbody td').eq(0))[0], 'dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const selectBoxInstance = $testElement.find('tbody td').eq(0).find('.dx-selectbox').dxSelectBox('instance');
@@ -12273,11 +12273,11 @@ QUnit.module('Editing with validation', {
 
         that.cellValue(0, 2, '');
         that.editCell(0, 2);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         eventsEngine.trigger(getInputElements($testElement.find('tbody td').eq(2))[0], 'dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const selectBoxInstance = $testElement.find('tbody td').eq(2).find('.dx-selectbox').dxSelectBox('instance');
@@ -12409,7 +12409,7 @@ QUnit.module('Editing with validation', {
 
         try {
             this.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(true, 'no errors');
@@ -12441,10 +12441,10 @@ QUnit.module('Editing with validation', {
 
         // act
         this.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
         let $input = $(rowsView.element().find('.dx-data-row').first().find('td').eq(2).find('.dx-texteditor-input'));
         $input.get(0).focus();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $input = $(rowsView.element().find('.dx-data-row').first().find('td').eq(2).find('.dx-texteditor-input'));
@@ -12459,7 +12459,7 @@ QUnit.module('Editing with validation', {
         $input.get(0).focus();
 
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.ok($input.is(':focus'), 'Text editor is focused after call saveEditData');
@@ -12496,11 +12496,11 @@ QUnit.module('Editing with validation', {
 
         // assert
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         $input.focus();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.ok($input.is(':focus'), 'Text editor is focused after call saveEditData');
@@ -12510,7 +12510,7 @@ QUnit.module('Editing with validation', {
         // act
         $input.val('123');
         $($input).trigger('change');
-        that.clock.tick();
+        that.clock.tick(10);
         $input = $(rowsView.element().find('.dx-data-row').first().find('td').eq(2).find('.dx-texteditor-input'));
 
         // assert
@@ -12748,7 +12748,7 @@ QUnit.module('Editing with validation', {
         };
 
         this.editCell(0, 2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($cellWithRevertButton.index(), 1, 'cell index where the revert button is located');
@@ -12797,7 +12797,7 @@ QUnit.module('Editing with validation', {
         };
 
         this.editCell(0, 2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($cellWithRevertButton.index(), 1, 'cell index where the revert button is located');
@@ -12826,23 +12826,23 @@ QUnit.module('Editing with validation', {
 
         // act
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cells = $(this.rowsView.element().find('tbody > tr').first().find('td'));
         const inputElement = getInputElements($cells).first();
         this.focus(this.getCellElement(0, 0));
         inputElement.val('');
         inputElement.trigger('change');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-revert-button').length, 1, 'revert button was shown');
 
         // act
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.focus(this.getCellElement(0, 1));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-revert-button').length, 0, 'revert button was hidden');
@@ -12873,7 +12873,7 @@ QUnit.module('Editing with validation', {
         const $input = getInputElements($cells).first();
         $input.val(101);
         $($input).trigger('change');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-revert-button').attr('title'), 'Cancel test bla', 'hint for revert button');
@@ -12904,17 +12904,17 @@ QUnit.module('Editing with validation', {
         $($cells.find('input').first()).trigger('change');
 
         this.editCell(0, 2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $cells = $(this.rowsView.element().find('tbody > tr').first().find('td'));
         $cells.find('input').first().val(16);
         $($cells.find('input').first()).trigger('change');
 
         this.editCell(0, 2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $revertButton = $('.dx-revert-button');
@@ -12947,7 +12947,7 @@ QUnit.module('Editing with validation', {
         const $input = getInputElements($cells).first();
         $input.val(101);
         $($input).trigger('change');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $revertButton = $('.dx-revert-button');
 
@@ -12956,7 +12956,7 @@ QUnit.module('Editing with validation', {
 
         // act
         $($revertButton).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $cells = $(this.rowsView.element().find('tbody > tr').first().find('td'));
@@ -12990,7 +12990,7 @@ QUnit.module('Editing with validation', {
         $($input).trigger('change');
         this.closeEditCell();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($input[0].value, 'Ben', 'new value');
@@ -13054,7 +13054,7 @@ QUnit.module('Editing with validation', {
 
         // act
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $cells = $(this.rowsView.element().find('tbody > tr').first().find('td'));
         const $input = getInputElements($cells).first();
@@ -13062,10 +13062,10 @@ QUnit.module('Editing with validation', {
         $($input).trigger('change');
 
         this.editCell(1, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $cells = $(this.rowsView.element().find('tbody > tr').first().find('td'));
@@ -13083,7 +13083,7 @@ QUnit.module('Editing with validation', {
         this.editCell(0, 1);
 
         getInputElements($cells).first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $cells = $(this.rowsView.element().find('tbody > tr').first().find('td'));
@@ -13116,16 +13116,16 @@ QUnit.module('Editing with validation', {
 
         // act
         that.editCell(0, 1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         const inputElement = getInputElements(testElement).first();
         inputElement.val(101);
         inputElement.trigger('change');
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.editCell(0, 2);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(editingController._getVisibleEditRowIndex(), 0, 'Correct editRowIndex');
@@ -13184,7 +13184,7 @@ QUnit.module('Editing with validation', {
 
         // act
         that.editCell(1, 1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = rowsView.element().find('td');
 
@@ -13223,7 +13223,7 @@ QUnit.module('Editing with validation', {
 
         // act
         $($addRowButton).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(that.gridContainer.find('.dx-row-inserted').length, 1, 'inserted row is rendered');
@@ -13269,7 +13269,7 @@ QUnit.module('Editing with validation', {
         inputElement.trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = rowsView.element().find('tbody > tr').first().find('td');
 
@@ -13318,21 +13318,21 @@ QUnit.module('Editing with validation', {
                 validationRules: [{ type: 'range', min: 1, max: 100 }]
             }, 'lastName']
         });
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.dataController.pageSize(2);
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.cellValue(0, 1, 101);
-        that.clock.tick();
+        that.clock.tick(10);
         that.dataController.pageIndex(1);
-        that.clock.tick();
+        that.clock.tick(10);
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.editCell(0, 1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $cell = $(that.getCellElement(0, 1));
@@ -13359,22 +13359,22 @@ QUnit.module('Editing with validation', {
                 validationRules: [{ type: 'range', min: 1, max: 100 }]
             }, 'lastName']
         });
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.dataController.pageSize(2);
-        that.clock.tick();
+        that.clock.tick(10);
         that.cellValue(0, 1, 101);
-        that.clock.tick();
+        that.clock.tick(10);
         that.dataController.pageIndex(1);
-        that.clock.tick();
+        that.clock.tick(10);
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.refresh();
-        that.clock.tick();
+        that.clock.tick(10);
         that.refresh();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $cell = $(that.getCellElement(0, 1));
@@ -13403,17 +13403,17 @@ QUnit.module('Editing with validation', {
                 validationRules: [{ type: 'range', min: 1, max: 100 }]
             }, 'lastName']
         });
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.pageSize(2);
-        that.clock.tick();
+        that.clock.tick(10);
         that.cellValue(0, 1, 101);
-        that.clock.tick();
+        that.clock.tick(10);
         that.pageIndex(1);
-        that.clock.tick();
+        that.clock.tick(10);
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(that.getVisibleRows().length, 2, 'visible row count');
@@ -13421,9 +13421,9 @@ QUnit.module('Editing with validation', {
 
         // act
         that.pageIndex(0);
-        that.clock.tick();
+        that.clock.tick(10);
         that.pageIndex(1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(that.getVisibleRows().length, 1, 'visible row count');
@@ -13473,7 +13473,7 @@ QUnit.module('Editing with validation', {
         inputElement.trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = rowsView.element().find('tbody > tr').first().find('td');
 
@@ -13544,7 +13544,7 @@ QUnit.module('Editing with validation', {
         inputElement.val(50);
         inputElement.trigger('change');
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
         that.saveEditData();
 
         // assert
@@ -13598,7 +13598,7 @@ QUnit.module('Editing with validation', {
         inputElement.trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = rowsView.element().find('tbody > tr').first().find('td');
 
@@ -13662,7 +13662,7 @@ QUnit.module('Editing with validation', {
         inputElement.trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         cells = rowsView.element().find('tbody > tr').first().find('td');
 
@@ -13998,7 +13998,7 @@ QUnit.module('Editing with validation', {
 
         // act
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $editorElements = $testElement.find('tbody > tr').first().find('td').first().find('.dx-texteditor');
@@ -14036,7 +14036,7 @@ QUnit.module('Editing with validation', {
         inputElement.val('');
         inputElement.trigger('change');
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $invalid = $formRow.find('.dx-invalid');
@@ -14110,17 +14110,17 @@ QUnit.module('Editing with validation', {
         rowsView.render(this.gridContainer);
         const $cell = this.gridContainer.find('td').first();
         $($cell).trigger('dxclick'); // Edit
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $input = getInputElements(this.gridContainer).first();
         $input.val(101);
         $($input).trigger('change');
 
         this.editingController.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         $input.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(this.gridContainer.find('.dx-revert-button').length, 'the revert button is shown');
     });
@@ -14196,7 +14196,7 @@ QUnit.module('Editing with validation', {
         $($inputElement).trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         $cellElements = $(rowsView.element().find('tbody > tr').first().find('td'));
 
@@ -14211,7 +14211,7 @@ QUnit.module('Editing with validation', {
         $($inputElement).trigger('change');
 
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         $cellElements = $(rowsView.element().find('tbody > tr').eq(1).find('td'));
 
@@ -14286,7 +14286,7 @@ QUnit.module('Editing with validation', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $cellElement = $(rowsView.element().find('tbody > tr.dx-row-inserted').first().children().first());
@@ -14321,7 +14321,7 @@ QUnit.module('Editing with validation', {
             .val('')
             .trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const cells = rowsView.element().find('tbody > tr').first().find('td');
@@ -14357,7 +14357,7 @@ QUnit.module('Editing with validation', {
         // act
         this.editingController.editRow(0);
         this.gridContainer.find('.dx-checkbox').first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.gridContainer.find('.dx-invalid-message.dx-overlay').length, 1, 'validation message should be shown');
@@ -14394,7 +14394,7 @@ QUnit.module('Editing with validation', {
             .val('')
             .trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-invalid-message.dx-invalid-message-always.dx-overlay').length, 0, 'Validation message is not shown');
@@ -14431,15 +14431,15 @@ QUnit.module('Editing with validation', {
             rowsView.render(that.gridContainer);
 
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             this.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             $cellElements = that.gridContainer.find('.dx-row-inserted').children();
             $selectBoxInput = $cellElements.find('.dx-texteditor-input').first();
             $selectBoxInput.trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual($cellElements.first().find('.dx-overlay.dx-datagrid-invalid-message').length, 1, 'has invalid message');
@@ -14447,9 +14447,9 @@ QUnit.module('Editing with validation', {
 
             // act
             $cellElements.find('.dx-texteditor-input').last().trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
             $cellElements.find('.dx-texteditor-input').last().focus();
-            this.clock.tick();
+            this.clock.tick(10);
             $cellElements.find('.dx-texteditor-input').last().trigger('dxclick');
 
             // assert
@@ -14519,7 +14519,7 @@ QUnit.module('Editing with validation', {
 
         // act
         that.editCell(1, 1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual($(rowsView.getCellElement(1, 1)).find('.dx-overlay.dx-datagrid-invalid-message').length, 1, 'has invalid message');
@@ -14527,7 +14527,7 @@ QUnit.module('Editing with validation', {
 
         // act
         that.closeEditCell();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual($(rowsView.getCellElement(1, 2)).find('.dx-overlay.dx-datagrid-invalid-message').length, 0, 'hasn\'t invalid message');
@@ -14565,7 +14565,7 @@ QUnit.module('Editing with validation', {
 
         // act
         that.editCell(0, 1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const overlayInstance = $(rowsView.getCellElement(0, 1)).find('.dx-overlay.dx-datagrid-invalid-message').dxOverlay('instance');
@@ -14609,11 +14609,11 @@ QUnit.module('Editing with validation', {
         });
 
         rowsView.scrollTo({ x: 100 });
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.editCell(0, 1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const overlayInstance = $(rowsView.getCellElement(0, 1)).find('.dx-overlay.dx-datagrid-invalid-message').dxOverlay('instance');
@@ -14665,11 +14665,11 @@ QUnit.module('Editing with validation', {
             ]
         });
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.editCell(0, 1);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const overlayInstance = $(rowsView.getCellElement(0, 1)).find('.dx-overlay.dx-datagrid-invalid-message').dxOverlay('instance');
@@ -14722,12 +14722,12 @@ QUnit.module('Editing with validation', {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         for(let i = 0; i < 4; i++) {
             this.editCell(0, i);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $cell = $(rowsView.getCellElement(0, i));
             const inputElement = getInputElements($cell).first();
@@ -14736,7 +14736,7 @@ QUnit.module('Editing with validation', {
             inputElement.val('');
             inputElement.trigger('change');
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($cell.find('.dx-datagrid-revert-tooltip').length, `revert button is rendered in the [0, ${i}] cell`);
@@ -14744,7 +14744,7 @@ QUnit.module('Editing with validation', {
 
             // act
             this.cancelEditData();
-            this.clock.tick();
+            this.clock.tick(10);
         }
     });
 
@@ -14968,7 +14968,7 @@ QUnit.module('Editing with validation', {
         });
 
         this.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
         const rowKey = this.getKeyByRowIndex(0);
 
         let result = this.validatingController.getCellValidationResult({ rowKey, columnIndex: 0 });
@@ -15008,7 +15008,7 @@ QUnit.module('Editing with validation', {
         });
 
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         const rowKey = this.getKeyByRowIndex(0);
         this.validatingController.setDisableApplyValidationResults(true);
         const deferred = new Deferred();
@@ -15060,7 +15060,7 @@ QUnit.module('Editing with validation', {
         });
 
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         const rowKey = this.getKeyByRowIndex(0);
 
         const $firstCell = $(this.getCellElement(0, 0));
@@ -15070,7 +15070,7 @@ QUnit.module('Editing with validation', {
             data: {},
             type: 'update'
         }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let result = this.validatingController.getCellValidationResult({ rowKey, columnIndex: 0 });
 
@@ -15103,7 +15103,7 @@ QUnit.module('Editing with validation', {
         });
 
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         const rowKey = this.getKeyByRowIndex(0);
 
         const $firstCell = $(this.getCellElement(0, 0));
@@ -15113,7 +15113,7 @@ QUnit.module('Editing with validation', {
             data: {},
             type: 'update'
         }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let result = this.validatingController.getCellValidationResult({ rowKey, columnIndex: 0 });
 
@@ -15152,11 +15152,11 @@ QUnit.module('Editing with validation', {
         });
 
         this.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
         const rowKey = this.getKeyByRowIndex(0);
         this.cellValue(0, 0, '');
         this.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         let result1 = this.validatingController.getCellValidationResult({ rowKey, columnIndex: 0 });
         let result2 = this.validatingController.getCellValidationResult({ rowKey, columnIndex: 1 });
@@ -15205,7 +15205,7 @@ QUnit.module('Editing with validation', {
         });
 
         this.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
         const rowKey = this.getKeyByRowIndex(0);
 
         const $secondCell = $(this.getCellElement(0, 1));
@@ -15253,7 +15253,7 @@ QUnit.module('Editing with validation', {
 
             // act
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             visibleRows = this.getVisibleRows();
@@ -15264,7 +15264,7 @@ QUnit.module('Editing with validation', {
 
             // act
             this.deleteRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             if(withConfirm) {
                 // assert
@@ -15318,7 +15318,7 @@ QUnit.module('Editing with validation', {
 
             // act
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             visibleRows = this.getVisibleRows();
@@ -15329,7 +15329,7 @@ QUnit.module('Editing with validation', {
 
             // act
             this.deleteRow(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             if(withConfirm) {
@@ -15379,7 +15379,7 @@ QUnit.module('Editing with validation', {
                 assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
 
                 this.focus($secondCell);
-                this.clock.tick();
+                this.clock.tick(10);
                 $secondCell = $(this.getCellElement(0, 1));
 
                 // assert
@@ -15422,7 +15422,7 @@ QUnit.module('Editing with validation', {
                 assert.notOk($secondCell.hasClass('dx-validator'), 'cell should not have validator');
 
                 this.focus($secondCell);
-                this.clock.tick();
+                this.clock.tick(10);
                 $secondCell = $(this.getCellElement(0, 1));
 
                 // assert
@@ -15498,14 +15498,14 @@ QUnit.module('Editing with validation', {
         rowsView.render(testElement);
         this.applyOptions(gridConfig);
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $inputElement = getInputElements(testElement).first();
         $inputElement
             .val('testa')
             .trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.saveEditData();
 
         const $secondCell = $(this.getCellElement(0, 1));
@@ -15553,14 +15553,14 @@ QUnit.module('Editing with validation', {
         rowsView.render(testElement);
         this.applyOptions(gridConfig);
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $inputElement = getInputElements(testElement).first();
         $inputElement
             .val('testa')
             .trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.saveEditData();
 
         const $secondCell = $(this.getCellElement(0, 1));
@@ -15604,14 +15604,14 @@ QUnit.module('Editing with validation', {
         rowsView.render(testElement);
         this.applyOptions(gridConfig);
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $inputElement = getInputElements(testElement).first();
         $inputElement
             .val('testa')
             .trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.saveEditData();
 
         const $secondCell = $(this.getCellElement(0, 1));
@@ -15658,14 +15658,14 @@ QUnit.module('Editing with validation', {
         rowsView.render(testElement);
         this.applyOptions(gridConfig);
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $inputElement = getInputElements(testElement).first();
         $inputElement
             .val('testa')
             .trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.saveEditData();
 
         const $secondCell = $(this.getCellElement(0, 1));
@@ -15711,7 +15711,7 @@ QUnit.module('Editing with validation', {
         const $checkboxElement = $(rowsView.getCellElement(0, 0)).find('.dx-checkbox').first();
         $($checkboxElement).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(rowsView.getCellElement(0, 0)).hasClass('dx-cell-modified'), 'cell is not marked as modified');
@@ -15753,7 +15753,7 @@ QUnit.module('Editing with validation', {
         const $checkboxElement = $(rowsView.getCellElement(0, 0)).find('.dx-checkbox').first();
         $($checkboxElement).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(rowsView.getCellElement(0, 0)).hasClass('dx-cell-modified'), 'cell is not marked as modified');
@@ -15789,7 +15789,7 @@ QUnit.module('Editing with validation', {
         this.editCell(0, 0);
         $testElement.find('input').val('new value').trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(validationCallback.callCount, 1, 'validation callback was called');
@@ -15869,7 +15869,7 @@ QUnit.module('Editing with validation', {
             });
 
             this.editCell(0, 0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.deepEqual(this.editingController._getOldData(1), { id: 1, name: 'test', description: 'test2' }, 'correct data');
@@ -15906,7 +15906,7 @@ QUnit.module('Editing with validation', {
 
             // act
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             let newRowCount = this.getVisibleRows().filter(r => r.isNewRow).length;
 
             // assert
@@ -15914,7 +15914,7 @@ QUnit.module('Editing with validation', {
 
             // act
             this.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
             newRowCount = this.getVisibleRows().filter(r => r.isNewRow).length;
 
             // assert
@@ -15980,7 +15980,7 @@ QUnit.module('Editing with validation', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 const newRow = this.getVisibleRows()[0];
@@ -15988,7 +15988,7 @@ QUnit.module('Editing with validation', {
 
                 // act
                 this.cellValue(0, 0, '');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.strictEqual(getCellText(0, 0), '', 'text of the first cell');
@@ -15997,7 +15997,7 @@ QUnit.module('Editing with validation', {
 
                 // act
                 this.cellValue(0, 1, '123');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.strictEqual(getCellText(0, 0), '', 'text of the first cell');
@@ -16041,7 +16041,7 @@ QUnit.module('Editing with validation', {
 
         // act
         this.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getRowElement(0)).hasClass('dx-edit-row'), 'edit row');
@@ -16050,7 +16050,7 @@ QUnit.module('Editing with validation', {
 
         // act
         this.cellValue(0, 'age', 123);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual($cellElement.get(0), $(this.getCellElement(0, 'name')).get(0), 'first cell isn\'t repainted');
@@ -16087,7 +16087,7 @@ QUnit.module('Editing with validation', {
 
         // act
         this.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getRowElement(0)).hasClass('dx-edit-row'), 'edit row');
@@ -16096,7 +16096,7 @@ QUnit.module('Editing with validation', {
 
         // act
         this.cellValue(0, 'age', '');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notDeepEqual($cellElement.get(0), $(this.getCellElement(0, 'name')).get(0), 'first cell is repainted');
@@ -16167,7 +16167,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
             const $targetElement = this.find($element, selector);
             const isLink = $targetElement.hasClass('dx-link');
             $($targetElement).trigger(isLink ? 'click' : 'dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
         };
 
     },
@@ -16192,7 +16192,7 @@ QUnit.module('Editing with real dataController with grouping, masterDetail', {
         this.rowsView.render(testElement);
         this.dataController.expandRow(this.dataController.getKeyByRowIndex(2));
         this.editingController.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
         this.selectAll();
 
         // assert
@@ -16589,7 +16589,7 @@ QUnit.module('Editing with scrolling', {
 
         // arrange
         this.rowsView.scrollTo({ y: 3500 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         items = this.dataController.items();
@@ -16598,7 +16598,7 @@ QUnit.module('Editing with scrolling', {
 
         // act
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         items = this.dataController.items();
@@ -16607,7 +16607,7 @@ QUnit.module('Editing with scrolling', {
 
         // act
         this.rowsView.scrollTo({ y: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         items = this.dataController.items();
@@ -17010,7 +17010,7 @@ QUnit.module('Editing with scrolling', {
 
         // arrange
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(that.dataController.items().length, 9, 'count items');
@@ -17165,7 +17165,7 @@ QUnit.module('Editing with scrolling', {
             this.rowsView.height(200);
             this.rowsView.resize();
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.pageIndex(5);
@@ -17211,7 +17211,7 @@ QUnit.module('Editing with scrolling', {
             this.rowsView.height(200);
             this.rowsView.resize();
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.pageIndex(5);
@@ -17384,7 +17384,7 @@ QUnit.module('Edit Form', {
         // this.click = function($element, selector) {
         //     var $targetElement = thatfind($element, selector);
         //     $targetElement.trigger('dxclick');
-        //     this.clock.tick();
+        //     this.clock.tick(10);
         // };
     },
     afterEach: function() {
@@ -17414,7 +17414,7 @@ QUnit.module('Edit Form', {
         const $links = testElement.find('.dx-row').eq(rowIndex).find('.dx-link-edit');
         assert.equal($links.length, 1, 'edit links count');
         $($links.eq(0)).trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(that.editingController.editRow.callCount, 1, 'editRow called');
@@ -17940,7 +17940,7 @@ QUnit.module('Edit Form', {
 
         testElement.find('input').eq(0).focus();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(testElement.find('.dx-row').eq(0).hasClass('dx-master-detail-row'), 'first row is master detail');
@@ -18356,10 +18356,10 @@ QUnit.module('Edit Form', {
         this.rowsView.render($('#container'));
 
         this.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.keyboardNavigationController.focus(this.getCellElement(0, 1));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $selectBoxElement = $(this.getCellElement(0, 1)).find('.dx-selectbox').first();
@@ -18368,7 +18368,7 @@ QUnit.module('Edit Form', {
         // act
         $selectBoxElement.trigger('dxpointerdown');
         $selectBoxElement.dxSelectBox('instance').option('value', 2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getCellElement(0, 1)).find('.dx-selectbox').hasClass('dx-state-focused'), 'second cell is focused');
@@ -18397,10 +18397,10 @@ QUnit.module('Edit Form', {
         this.rowsView.render($('#container'));
 
         this.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.keyboardNavigationController.focus(this.getCellElement(0, 0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $editorElement = $(this.getCellElement(0, 0)).find('.dx-numberbox').first();
@@ -18409,7 +18409,7 @@ QUnit.module('Edit Form', {
         // act
         $editorElement.trigger('dxpointerdown');
         $editorElement.dxNumberBox('instance').option('value', 2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getCellElement(0, 0)).find('.dx-numberbox').hasClass('dx-state-focused'), 'first editor is focused');
@@ -18491,14 +18491,14 @@ QUnit.module('Edit Form', {
 
             // act
             that.editRow(0);
-            that.clock.tick();
+            that.clock.tick(10);
 
             // assert
             assert.equal(testElement.find('.dx-datagrid-edit-form').length, 1, 'form is rendered');
 
             // act
             that.addRow();
-            that.clock.tick();
+            that.clock.tick(10);
 
             const $editPopup = testElement.find('.dx-datagrid-edit-popup');
             const editPopupInstance = $editPopup.dxPopup('instance');
@@ -18909,9 +18909,9 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
-        that.clock.tick();
+        that.clock.tick(10);
 
         const $editingForm = that.getEditPopupContent().find('.dx-form');
 
@@ -18937,9 +18937,9 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
-        that.clock.tick();
+        that.clock.tick(10);
 
 
         // assert
@@ -18960,7 +18960,7 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
         that.clock.tick(700);
 
@@ -18978,7 +18978,7 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         const $editingForm = that.getEditPopupContent().find('.dx-form');
@@ -18999,9 +18999,9 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
         that.cancelEditData();
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         // assert
@@ -19021,9 +19021,9 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         const $invalidValidators = that.getEditPopupContent().find('.dx-invalid');
@@ -19043,9 +19043,9 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         const $textBoxes = that.getEditPopupContent().find('.dx-textbox');
@@ -19069,13 +19069,13 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         const $textBoxes = that.getEditPopupContent().find('.dx-textbox');
 
         $textBoxes.eq(0).dxTextBox('instance').option('value', 'John');
-        that.clock.tick();
+        that.clock.tick(10);
 
         const $invalidValidators = that.getEditPopupContent().find('.dx-invalid');
 
@@ -19091,7 +19091,7 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         const $textBoxes = that.getEditPopupContent().find('.dx-textbox');
@@ -19155,7 +19155,7 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         // assert
@@ -19187,7 +19187,7 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.strictEqual(button.option('visible'), false, 'Toolbar button is not visible');
@@ -19212,7 +19212,7 @@ QUnit.module('Editing - "popup" mode', {
         that.renderRowsView();
 
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         // act
@@ -19227,13 +19227,13 @@ QUnit.module('Editing - "popup" mode', {
 
         that.setupModules(that);
         that.renderRowsView();
-        that.clock.tick();
+        that.clock.tick(10);
 
         const cancelEditDataSpy = sinon.spy(that.editingController, 'cancelEditData');
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.preparePopupHelpers();
         that.editPopupInstance.hide();
@@ -19251,11 +19251,11 @@ QUnit.module('Editing - "popup" mode', {
         that.options.onEditorPreparing = spyHandler;
         that.setupModules(that);
         that.renderRowsView();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         const spyArgs = spyHandler.getCall(0).args;
 
@@ -19273,7 +19273,7 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
         that.preparePopupHelpers();
 
         // assert
@@ -19543,7 +19543,7 @@ QUnit.module('Editing - "popup" mode', {
         this.renderRowsView();
 
         this.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(template.getCall(0).args[1].data, { name: 'Alex', age: 15, lastName: 'John', phone: '555555', room: 1 }, 'row data');
@@ -19610,11 +19610,11 @@ QUnit.module('Editing - "popup" mode', {
         that.setupModules(that);
         that.renderRowsView();
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.editRow(0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // arrange
         that.preparePopupHelpers();
@@ -19649,11 +19649,11 @@ QUnit.module('Editing - "popup" mode', {
         that.renderRowsView();
 
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         that.preparePopupHelpers();
         const $popupContent = that.editPopupInstance.$content();
@@ -19736,9 +19736,9 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
         this.preparePopupHelpers();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange
         assert.strictEqual(editCellTemplate.callCount, 1, 'editCellTemplate call count');
@@ -19754,7 +19754,7 @@ QUnit.module('Editing - "popup" mode', {
 
         // act
         this.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange
         this.editingController._editForm.repaint = spy;
@@ -19828,7 +19828,7 @@ QUnit.module('Promises in callbacks and events', {
             const $targetElement = this.find($element, selector);
             const isLink = $targetElement.hasClass('dx-link');
             $($targetElement).trigger(isLink ? 'click' : 'dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
         };
         this.editCell = function(rowIndex, columnIndex, text) {
             const testElement = $('#container');
@@ -19856,7 +19856,7 @@ QUnit.module('Promises in callbacks and events', {
 
         // act
         this.editCell(0, 0, 'Test');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $input = getInputElements(testElement).first();
@@ -19909,7 +19909,7 @@ QUnit.module('Promises in callbacks and events', {
         // act
         this.editCell(0, 0, 'Test');
         this.editingController.closeEditCell();
-        this.clock.tick();
+        this.clock.tick(10);
         this.cancelEditData();
 
         // assert
@@ -19963,7 +19963,7 @@ QUnit.module('Promises in callbacks and events', {
         // act
         this.editCell(0, 0, 'Test');
         this.editingController.closeEditCell();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('input').length, 1, 'Editor is not closed');
@@ -19993,7 +19993,7 @@ QUnit.module('Promises in callbacks and events', {
         this.deferred.reject('TestError');
         this.clock.tick(100);
         this.editingController.closeEditCell();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(this.hasEditData(), 'No edit data');
@@ -20037,7 +20037,7 @@ QUnit.module('Promises in callbacks and events', {
         that.clock.tick(500);
 
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         visibleRows = that.getVisibleRows();
 
@@ -20153,7 +20153,7 @@ QUnit.module('Promises in callbacks and events', {
         that.clock.tick(500);
 
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         visibleRows = that.getVisibleRows();
 
@@ -20208,7 +20208,7 @@ QUnit.module('Promises in callbacks and events', {
         that.clock.tick(500);
 
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         visibleRows = that.getVisibleRows();
 
@@ -20261,7 +20261,7 @@ QUnit.module('Promises in callbacks and events', {
         that.clock.tick(500);
 
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         visibleRows = that.getVisibleRows();
 
@@ -20329,7 +20329,7 @@ QUnit.module('Promises in callbacks and events', {
 
         // act
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         visibleRows = that.getVisibleRows();
 
@@ -20393,7 +20393,7 @@ QUnit.module('Promises in callbacks and events', {
 
         // act
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         visibleRows = that.getVisibleRows();
 
@@ -20456,7 +20456,7 @@ QUnit.module('Promises in callbacks and events', {
 
         // act
         that.saveEditData();
-        that.clock.tick();
+        that.clock.tick(10);
 
         visibleRows = that.getVisibleRows();
 
@@ -20846,10 +20846,10 @@ QUnit.module('Editing - new row position', {
 
                 this.options.editing.newRowPosition = 'first';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.rowsView.render($testElement);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -20858,7 +20858,7 @@ QUnit.module('Editing - new row position', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -20881,14 +20881,14 @@ QUnit.module('Editing - new row position', {
                 this.options.paging.pageIndex = 2;
                 this.options.editing.newRowPosition = 'first';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.rowsView.getScrollable().container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -20897,11 +20897,11 @@ QUnit.module('Editing - new row position', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.rowsView.getScrollable().container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
                 this.contentReadyCallbacks.fire();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -20922,9 +20922,9 @@ QUnit.module('Editing - new row position', {
 
                 this.options.editing.newRowPosition = 'last';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -20933,7 +20933,7 @@ QUnit.module('Editing - new row position', {
                 // act
                 config.name === 'virtual scrolling' && this.dataController._rowsScrollController.viewportSize(rows.length);
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -20950,13 +20950,13 @@ QUnit.module('Editing - new row position', {
                 this.options.paging.pageIndex = 9;
                 this.options.editing.newRowPosition = 'last';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.rowsView.getScrollable().container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -20965,9 +20965,9 @@ QUnit.module('Editing - new row position', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.rowsView.getScrollable().container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -20984,13 +20984,13 @@ QUnit.module('Editing - new row position', {
                 this.options.editing.newRowPosition = 'pageBottom';
                 this.options.paging.pageIndex = 2;
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.rowsView.getScrollable().container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 const rowCount = config.name === 'virtual scrolling' ? 7 : 10;
@@ -21000,7 +21000,7 @@ QUnit.module('Editing - new row position', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21022,13 +21022,13 @@ QUnit.module('Editing - new row position', {
                 this.options.editing.newRowPosition = 'pageTop';
                 this.options.paging.pageIndex = 2;
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.rowsView.getScrollable().container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 const rowCount = config.name === 'virtual scrolling' ? 7 : 10;
@@ -21038,7 +21038,7 @@ QUnit.module('Editing - new row position', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21054,11 +21054,11 @@ QUnit.module('Editing - new row position', {
                 this.options.height = 200;
                 this.options.editing.newRowPosition = 'viewportBottom';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21066,7 +21066,7 @@ QUnit.module('Editing - new row position', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21083,11 +21083,11 @@ QUnit.module('Editing - new row position', {
                 this.options.height = 200;
                 this.options.editing.newRowPosition = 'viewportTop';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21097,14 +21097,14 @@ QUnit.module('Editing - new row position', {
                 const scrollable = this.rowsView.getScrollable();
                 scrollable.scrollTo({ y: 40 });
                 $(scrollable.container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.strictEqual(this.rowsView.getTopVisibleItemIndex(), isVirtualScrolling ? 0 : 1, 'top visible item index');
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21121,11 +21121,11 @@ QUnit.module('Editing - new row position', {
                 this.options.dataSource.store.data = [];
                 this.options.editing.newRowPosition = 'pageBottom';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21134,7 +21134,7 @@ QUnit.module('Editing - new row position', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21151,11 +21151,11 @@ QUnit.module('Editing - new row position', {
                 this.options.dataSource.store.data = [];
                 this.options.editing.newRowPosition = 'pageTop';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21164,7 +21164,7 @@ QUnit.module('Editing - new row position', {
 
                 // act
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21261,10 +21261,10 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
                 const $testElement = $('#container');
 
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.rowsView.render($testElement);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21272,7 +21272,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.option('editing.changes', [{ type: 'insert', insertAfterKey: 5 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21290,10 +21290,10 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
                 const $testElement = $('#container');
 
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.rowsView.render($testElement);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21301,7 +21301,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.option('editing.changes', [{ type: 'insert', insertBeforeKey: 5 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21320,12 +21320,12 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 this.options.height = 200;
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21334,7 +21334,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.option('editing.changes', [{ type: 'insert', insertAfterKey: 13 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21343,7 +21343,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.pageIndex(1);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21362,12 +21362,12 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 this.options.height = 200;
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21376,7 +21376,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.option('editing.changes', [{ type: 'insert', insertBeforeKey: 13 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21384,7 +21384,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
                 assert.strictEqual(rows.length, config.name === 'virtual scrolling' ? 7 : 10, 'row count');
                 // act
                 this.pageIndex(1);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21404,11 +21404,11 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
                 this.options.height = 200;
                 this.options.editing.newRowPosition = 'last';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21416,7 +21416,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.option('editing.changes', [{ type: 'insert', insertAfterKey: 5 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21438,13 +21438,13 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
                 this.options.paging.pageIndex = 1;
                 this.options.editing.newRowPosition = 'first';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.rowsView.getScrollable().container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21453,7 +21453,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.option('editing.changes', [{ type: 'insert', insertAfterKey: 15 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21474,11 +21474,11 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
                 this.options.height = 200;
                 this.options.editing.newRowPosition = 'last';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21486,7 +21486,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.option('editing.changes', [{ type: 'insert', insertBeforeKey: 5 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21508,13 +21508,13 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
                 this.options.paging.pageIndex = 1;
                 this.options.editing.newRowPosition = 'first';
                 this.setupModules();
-                this.clock.tick();
+                this.clock.tick(10);
                 this.rowsView.render($testElement);
                 this.rowsView.height(200);
                 this.rowsView.resize();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.rowsView.getScrollable().container()).trigger('scroll');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 let rows = this.getVisibleRows();
@@ -21523,7 +21523,7 @@ QUnit.module('Editing - changes with insertBeforeKey/insertAfterKey', {
 
                 // act
                 this.option('editing.changes', [{ type: 'insert', insertBeforeKey: 15 }]);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 rows = this.getVisibleRows();
@@ -21612,7 +21612,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
             } else {
                 this.editRow(0);
             }
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const args = editCellTemplateSpy.getCall(0).args[1];
@@ -21660,7 +21660,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
 
             this.setupModules();
             this.renderRowsView();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(this.getVisibleRows().length, 4, 'count rows');
@@ -21671,7 +21671,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
                 data: { id: 123, name: 'new' },
             }]);
             this.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(this.getVisibleRows().length, 5, 'count rows');
@@ -21708,7 +21708,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
 
             this.setupModules();
             this.renderRowsView();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(this.getVisibleRows().length, 4, 'count rows');
@@ -21720,7 +21720,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
                 data: { name: 'update' }
             }]);
             this.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(this.getVisibleRows().length, 4, 'count rows');
@@ -21761,7 +21761,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
 
             this.setupModules();
             this.renderRowsView();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(this.getVisibleRows().length, 4, 'count rows');
@@ -21772,7 +21772,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
                 key: 1,
             }]);
             this.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(this.getVisibleRows().length, 3, 'count rows');
@@ -21805,7 +21805,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
                 } else {
                     this.editRow(0);
                 }
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 const args = editCellTemplateSpy.getCall(0).args[1];
@@ -21817,7 +21817,7 @@ QUnit.module('Editing - public arguments of the events/templates', {
                     if(editMode !== 'batch' && editMode !== 'cell') {
                         // act
                         $(this.getCellElement(0, 1)).find('.dx-numberbox').dxNumberBox('instance').option('value', 123);
-                        this.clock.tick();
+                        this.clock.tick(10);
 
                         // assert
                         assert.strictEqual(watchSpy.callCount, 1, 'watch update is called');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -5757,7 +5757,7 @@ QUnit.module('Editing with real dataController', {
         editor.option('value', 'test2');
         const $cell = that.getCellElement(0, 1);
         $($cell).trigger('dxclick');
-        that.clock.tick(30);
+        that.clock.tick(40);
 
         // assert
         assert.equal(saveEditDataCallCount, 1, 'save edit data called once');
@@ -5794,7 +5794,7 @@ QUnit.module('Editing with real dataController', {
         // act
         editor.option('value', 'test2');
         that.editCell(0, 1);
-        that.clock.tick(30);
+        that.clock.tick(40);
 
         // assert
         assert.strictEqual($(rowsView.getCellElement(0, 0)).find('input').val(), 'test2', 'value input');
@@ -5984,7 +5984,7 @@ QUnit.module('Editing with real dataController', {
         // act
         that.cellValue(0, 0, 'Test');
         that.editCell(0, 1);
-        this.clock.tick(100);
+        this.clock.tick(200);
 
         // assert
         assert.ok(!this.hasEditData(), 'edit data is empty');
@@ -6027,7 +6027,7 @@ QUnit.module('Editing with real dataController', {
         that.editCell(0, 0);
         that.cellValue(0, 0, 'Test');
         that.editCell(0, 1);
-        this.clock.tick(100);
+        this.clock.tick(200);
 
         // assert
         assert.ok(this.hasEditData(), 'edit data is not empty');
@@ -20317,7 +20317,7 @@ QUnit.module('Promises in callbacks and events', {
         assert.equal(visibleRows.length, 7);
 
         // act
-        that.clock.tick(500);
+        that.clock.tick(600);
 
         const $insertedRows = $('.dx-row-inserted');
 
@@ -20382,7 +20382,7 @@ QUnit.module('Promises in callbacks and events', {
         assert.equal(visibleRows.length, 7);
 
         // act
-        that.clock.tick(500);
+        that.clock.tick(600);
 
         const $insertedRow = $('.dx-row-inserted');
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editorFactory.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editorFactory.tests.js
@@ -1348,7 +1348,7 @@ QUnit.module('Focus', {
         };
 
         testElement.trigger($.Event('keydown.dxDataGridEditorFactory', { key: 'Tab' }));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(isFocused, 'cell is focused');
@@ -1362,7 +1362,7 @@ QUnit.module('Focus', {
 
         // act
         this.editorFactoryController.focus(testElement);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editorFactoryController.focus(), testElement, 'focused element');
@@ -1491,7 +1491,7 @@ QUnit.module('Focus', {
         // act
         $testElement.find('.dx-datagrid-rowsview tbody > tr').eq(1).children().eq(1).trigger('dxpointerdown');
         $testElement.find('.dx-datagrid-rowsview tbody > tr').eq(1).children().eq(1).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $cell = $testElement.find('.dx-datagrid-rowsview tbody > tr').eq(1).children().eq(1);
@@ -1502,7 +1502,7 @@ QUnit.module('Focus', {
         $testElement.find('.dx-datagrid-filter-row input').eq(1).trigger('focus');
         $testElement.find('.dx-datagrid-filter-row input').eq(1).trigger('dxpointerdown');
         $testElement.find('.dx-datagrid-filter-row input').eq(1).trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $cell = $testElement.find('.dx-datagrid-filter-row > td').eq(1);
@@ -1553,7 +1553,7 @@ QUnit.module('Focus', {
         $cell = $testElement.find('.dx-datagrid-rowsview tbody > tr').eq(0).children().eq(0);
         $cell.trigger('dxpointerdown');
         $cell.trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $cell = $testElement.find('.dx-datagrid-rowsview tbody > tr').eq(0).children().eq(0);
@@ -1600,7 +1600,7 @@ QUnit.module('Focus', {
         $cell = $testElement.find('.dx-datagrid-rowsview tbody > tr').eq(0).children().eq(0);
         $cell.trigger('dxpointerdown');
         $cell.trigger('dxclick');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         $cell = $testElement.find('.dx-datagrid-rowsview tbody > tr').eq(0).children().eq(0);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
@@ -276,10 +276,10 @@ QUnit.module('ExportController', {
         const dataProvider = this.exportController.getDataProvider();
 
         this.exportController._columnsController.columnOption('TestField4', 'visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataProvider.ready();
-        this.clock.tick();
+        this.clock.tick(10);
         const columns = dataProvider.getColumns();
 
         assert.equal(columns.length, 4, 'columns length');
@@ -385,7 +385,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataProvider.getRowsCount(), 3, 'rows count');
 
@@ -435,7 +435,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(this.getVisibleColumns().length, 11, 'visible column count');
         assert.equal(dataProvider.getColumns().length, 99, 'column count');
@@ -479,7 +479,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataProvider.getRowsCount(), 2, 'rows count');
 
@@ -511,7 +511,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataProvider.getRowsCount(), 2, 'rows count');
 
@@ -545,7 +545,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataProvider.getRowsCount(), 4, 'rows count');
         assert.equal(dataProvider.getCellData(0, 0).value, 1, 'row 1');
@@ -593,7 +593,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataProvider.getColumns().length, 1, 'columns count');
         assert.equal(dataProvider.getRowsCount(), 10, 'rows count');
@@ -631,7 +631,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act, assert
         assert.equal(dataProvider.getRowsCount(), 9, 'rows count');
@@ -668,7 +668,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act, assert
         assert.equal(dataProvider.getRowsCount(), 10, 'rows count');
@@ -713,7 +713,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act, assert
         assert.equal(dataProvider.getRowsCount(), 9, 'rows count');
@@ -762,7 +762,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act, assert
         assert.equal(dataProvider.getRowsCount(), 11, 'rows count');
@@ -820,7 +820,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getRowsCount(), 6, 'rows count');
@@ -883,7 +883,7 @@ QUnit.module('ExportController', {
         const dataProvider = this.exportController.getDataProvider();
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getRowsCount(), 4, 'rows count');
@@ -947,7 +947,7 @@ QUnit.module('ExportController', {
         const dataProvider = this.exportController.getDataProvider();
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getRowsCount(), 4, 'rows count');
@@ -1016,7 +1016,7 @@ QUnit.module('ExportController', {
         const dataProvider = this.exportController.getDataProvider();
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getRowsCount(), 0);
@@ -1077,7 +1077,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.ok(!isPrepareItemsForGroupFooters, 'summary group footer items is not generated');
@@ -1149,7 +1149,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getRowsCount(), 10, 'rows count');
@@ -1222,7 +1222,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getCellData(0, 1).value, 'Min: 1');
@@ -1285,7 +1285,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getCellData(0, 2).value, 'Max: 93% \n Min: 1');
@@ -1340,7 +1340,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const styles = dataProvider.getStyles();
 
@@ -1388,7 +1388,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const styles = dataProvider.getStyles();
         assert.deepEqual(styles[dataProvider.getStyleId(1, 0)], {
@@ -1491,7 +1491,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.strictEqual(dataProvider.getCellType(0, 0), 'string', 'header row 1 cell type');
@@ -1537,7 +1537,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getCellType(0, 0), 'number', 'col 1');
@@ -1562,7 +1562,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getCellType(0, 0), 'string', 'col 1');
@@ -1599,7 +1599,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getColumns().length, 1, 'columns count');
@@ -1626,7 +1626,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert, act
         assert.equal(dataProvider.getCellType(0, 0), 'string', 'col 1 row1');
@@ -1676,7 +1676,7 @@ QUnit.module('ExportController', {
         const dataProvider = this.exportController.getDataProvider();
         dataProvider.ready();
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         assert.deepEqual(_sourceItems[1].values, [101, [{
             alignByColumn: true,
@@ -1734,7 +1734,7 @@ QUnit.module('ExportController', {
         const dataProvider = this.exportController.getDataProvider();
         dataProvider.ready();
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         assert.deepEqual(_sourceItems[0].values, ['test 1', [
             {
@@ -1804,7 +1804,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataProvider.getRowsCount(), 2, 'rows count');
         assert.equal(dataProvider.getCellData(0, 0).value, 'test1', 'row 1 cell 1');
@@ -1957,7 +1957,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const styles = dataProvider.getStyles();
 
@@ -1983,7 +1983,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const styles = dataProvider.getStyles();
 
@@ -2011,7 +2011,7 @@ QUnit.module('ExportController', {
 
         dataProvider.ready();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const styles = dataProvider.getStyles();
 
@@ -2669,7 +2669,7 @@ QUnit.module('Real dataGrid ExportController tests', {
         };
         const dataGrid = createDataGrid(options);
 
-        this.clock.tick();
+        this.clock.tick(10);
         const dataProvider = dataGrid.getController('export').getDataProvider();
 
         dataProvider.ready();
@@ -2703,7 +2703,7 @@ QUnit.module('Real dataGrid ExportController tests', {
             }]
         };
         const dataGrid = createDataGrid(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const dataProvider = dataGrid.getController('export').getDataProvider();
 
         dataProvider.ready();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterBuilder.tests.js
@@ -322,7 +322,7 @@ QUnit.module('Real dataGrid', {
         });
 
         $('.dx-popup-content .dx-filterbuilder-item-value-text').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $('.dx-header-filter-menu.dx-popup').dxPopup('instance').hide();
 
         // assert
@@ -340,7 +340,7 @@ QUnit.module('Real dataGrid', {
             filterValue: ['field', 'anyof', ['text']],
         });
         $('.dx-popup-content .dx-filterbuilder-item-value-text').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $('.dx-header-filter-menu.dx-popup').dxPopup('instance').hide();
 
         // assert

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterPanel.tests.js
@@ -664,7 +664,7 @@ QUnit.module('Filter Panel', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(this.option('filterPanel.filterEnabled'));
@@ -685,10 +685,10 @@ QUnit.module('Filter Panel', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.option('filterPanel.filterEnabled', false);
         this.dataController.changed.fire();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.notOk(customSaveSpy.lastCall.args[0].filterPanel.filterEnabled);
     });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
@@ -948,7 +948,7 @@ QUnit.module('Filter Row', {
         const filterRowInput = $(this.columnHeadersView.element()).find('.dx-texteditor');
         filterRowInput.find('input').val(90);
         filterRowInput.find('input').trigger('keyup');
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         const $button = testElement.find('.dx-apply-button');
         assert.ok(!$button.hasClass('dx-state-disabled'), 'button is enabled');
@@ -1054,7 +1054,7 @@ QUnit.module('Filter Row', {
         const filterRowInput = $(this.columnHeadersView.element()).find('.dx-texteditor');
         filterRowInput.find('input').val(90);
         filterRowInput.find('input').trigger('keyup');
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         const $editorContainer = filterRowInput.closest('.dx-editor-container');
         const $filterCellContainer = filterRowInput.closest('.dx-editor-cell');
@@ -1083,7 +1083,7 @@ QUnit.module('Filter Row', {
         const filterRowInput = $(this.columnHeadersView.element()).find('.dx-texteditor');
         filterRowInput.find('input').val(90);
         filterRowInput.find('input').trigger('keyup');
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         $button = testElement.find('.dx-apply-button');
         $($button).trigger('dxclick');
@@ -1254,7 +1254,7 @@ QUnit.module('Filter Row', {
         const filterRowInput = $testElement.find('.dx-datagrid-filter-row .dx-texteditor input').first();
         filterRowInput.val(90);
         filterRowInput.trigger('keyup');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.headerPanel.render();
@@ -1286,7 +1286,7 @@ QUnit.module('Filter Row', {
         const $filterMenu = $('.dx-filter-menu').first();
 
         $filterMenu.trigger('focusin');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $rootMenuItem = $filterMenu.find('.dx-menu-item');
         $rootMenuItem.trigger('mouseenter');
@@ -1494,7 +1494,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
             .find('input')
             .focus();
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok($filterMenu.parent().find('input').is(':focus'), 'filter input is focused');
 
         const rootMenuItem = $filterMenu.find('.dx-menu-item').eq(0);
@@ -1510,7 +1510,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
             .find('.dx-menu-item')
             .trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok($filterMenu.parent().find('input').is(':focus'), 'filter input is focused');
     });
@@ -1530,7 +1530,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
 
         // act
         that.editorFactoryController.focus(that.gridContainer.find('td').first());
-        that.clock.tick();
+        that.clock.tick(10);
 
         assert.roughEqual(that.gridContainer.find('.dx-datagrid-focus-overlay').outerHeight(), that.gridContainer.find('td').first().outerHeight(), 1.01, 'height focus overlay');
     });
@@ -1688,7 +1688,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
 
         // act
         $($testElement.find('td').last().find('.dx-filter-range-content')).trigger('focusin');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal($('.dx-viewport').children('.dx-datagrid-filter-range-overlay').length, 1, 'has overlay wrapper');
@@ -1714,7 +1714,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
 
         // act
         $($testElement.find('td').last().find('.dx-filter-range-content')).trigger('focusin');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $startRange = $('.dx-viewport').children('.dx-datagrid-filter-range-overlay').find('.dx-numberbox').first();
@@ -1895,7 +1895,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
 
         // arrange
         $($testElement.find('td').last().find('.dx-filter-range-content')).trigger('focusin');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $startRangeInput = $('.dx-viewport').children('.dx-datagrid-filter-range-overlay').find('.dx-numberbox').first().find(TEXTEDITOR_INPUT_SELECTOR);
@@ -1937,7 +1937,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
         that.columnHeadersView.render($testElement);
 
         $($testElement.find('td').last().find('.dx-filter-range-content')).trigger('focusin');
-        that.clock.tick();
+        that.clock.tick(10);
 
         const $startRangeInput = $('.dx-viewport').children('.dx-datagrid-filter-range-overlay').find('.dx-numberbox').first().find(TEXTEDITOR_INPUT_SELECTOR);
         assert.equal($startRangeInput.length, 1, 'has input');
@@ -2177,7 +2177,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
         that.columnHeadersView.render($testElement);
 
         $($testElement.find('td').last().find('.dx-filter-range-content')).trigger('focusin');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal($('.dx-viewport').children('.dx-datagrid-filter-range-overlay').length, 1, 'has overlay wrapper');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
@@ -1358,7 +1358,7 @@ QUnit.module('Real dataGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.columnOption('field', 'filterValue'), 2);
@@ -1395,7 +1395,7 @@ QUnit.module('Real dataGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.columnOption('field', 'filterValue'), 1);
@@ -1432,7 +1432,7 @@ QUnit.module('Real dataGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.columnOption('field', 'filterValue'), 2);
@@ -1467,7 +1467,7 @@ QUnit.module('Real dataGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.columnOption('field', 'filterValue'), 2);
@@ -1502,7 +1502,7 @@ QUnit.module('Real dataGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.columnOption('field', 'filterValue'), 2);
@@ -1525,9 +1525,9 @@ QUnit.module('Real dataGrid', {
                 savingTimeout: 0
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.option('filterValue', ['field', '=', 1]);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(customSaveSpy.lastCall.args[0].filterValue, ['field', '=', 1]);
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filtering.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filtering.integration.tests.js
@@ -57,7 +57,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             filterRow: { visible: true },
             dataSource: [{ field1: '1', field2: '2' }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $menu = filterRowWrapper.getMenuElement(0);
@@ -87,7 +87,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             filterRow: { visible: true },
             dataSource: [{ field1: '1' }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $menu = filterRowWrapper.getMenuElement(0);
@@ -158,7 +158,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(onEditorPreparingCallCount, 2, 'onEditorPreparing call count');
@@ -184,11 +184,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.state({ pageIndex: 1, pageSize: 2, filterValue: ['id', '<>', 1] });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageIndex(), 1, 'pageIndex is applied');
@@ -208,7 +208,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [{ field1: 1, field2: 2 }, { field1: 3, field2: 4 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $input = $(dataGrid.$element()).find('.dx-editor-cell').first().find('.dx-texteditor-input');
         $input.focus().val('1').trigger('change');
@@ -221,7 +221,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             selectionRangeArgs.push([element, range]);
         };
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         gridCoreUtils.setSelectionRange = oldSetSelectionRange;
 
@@ -262,7 +262,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
             $filterRangeContent = $('#dataGrid').find('.dx-datagrid-filter-row').find('.dx-filter-range-content').first();
             $filterRangeContent.focus();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual($('.dx-overlay-wrapper.dx-datagrid-filter-range-overlay').length, 1, 'has overlay wrapper');
@@ -333,7 +333,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(dataGrid);
         assert.equal(contentReadyCallCount, 1, 'contentReady is called once');
         assert.equal(loadCallCount, 1, '1 load count on start');
@@ -555,7 +555,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         cellPreparedCells = [];
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(cellPreparedCells, [
@@ -580,12 +580,12 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', 'name']
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const filterValue = 'test2';
         dataGrid.option('columns', ['id', { dataField: 'name', filterValue }]);
-        this.clock.tick();
+        this.clock.tick(10);
         const visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -608,7 +608,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', 'name']
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('filterPanel.visible', true); // causes reloading a data source
@@ -620,7 +620,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         // act
         const filterValue = 'test2';
         dataGrid.option('columns', ['id', { dataField: 'name', filterValue }]);
-        this.clock.tick();
+        this.clock.tick(10);
         const visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -644,7 +644,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', { dataField: 'name', filterValue }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -653,7 +653,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('columns', ['id', { dataField: 'name', filterValue, selectedFilterOperation: '<>' }]);
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -677,7 +677,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', { dataField: 'name', filterValue }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -693,7 +693,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('columns', ['id', { dataField: 'name', filterValue, selectedFilterOperation: '<>' }]);
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -717,7 +717,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', { dataField: 'name', filterValue }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -725,7 +725,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('columns', ['id', { dataField: 'name', filterValue, allowFiltering: false }]);
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -748,7 +748,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', { dataField: 'name', filterValue }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -763,7 +763,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('columns', ['id', { dataField: 'name', filterValue, allowFiltering: false }]);
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -786,11 +786,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', 'name']
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('columns', ['id', { dataField: 'name', filterValues }]);
-        this.clock.tick();
+        this.clock.tick(10);
         const visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -814,7 +814,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', 'name']
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('filterPanel.visible', true); // causes reloading a data source
@@ -825,7 +825,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('columns', ['id', { dataField: 'name', filterValues }]);
-        this.clock.tick();
+        this.clock.tick(10);
         const visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -849,7 +849,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', { dataField: 'name', filterValues }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -858,7 +858,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('columns', ['id', { dataField: 'name', filterValues, filterType: 'exclude' }]);
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -882,7 +882,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
             columns: ['id', { dataField: 'name', filterValues }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -898,7 +898,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('columns', ['id', { dataField: 'name', filterValues, filterType: 'exclude' }]);
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -912,13 +912,13 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [{ a: 1111, b: 222 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.clearFilter();
         dataGrid.option('filterRow.visible', true);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.$element()).find('.dx-datagrid-filter-row').length, 1, 'filter row is rendered');
@@ -937,7 +937,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         });
         let filter;
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         filter = ['field1', '=', 'test1'];
@@ -948,7 +948,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.option('filterValue'), undefined, 'dataGrid\'s filter');
@@ -962,7 +962,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.option('filterValue'), undefined, 'dataGrid\'s filter');
@@ -976,7 +976,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.option('filterValue'), undefined, 'dataGrid\'s filter');
@@ -1037,14 +1037,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.pageIndex(5);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.filter(['id', '=', 666]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.getVisibleRows().length, 0, 'no rows');
@@ -1104,7 +1104,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         try {
             dataGrid.option('searchPanel.text', 'one');
-            this.clock.tick();
+            this.clock.tick(10);
         } catch(e) {
             assert.ok(false, 'error was thrown');
         }
@@ -1141,7 +1141,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleRowsBeforeSearch = dataGrid.getVisibleRows();
@@ -1149,7 +1149,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('searchPanel.text', 'three');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleRowsAfterSearch = dataGrid.getVisibleRows();
@@ -1188,7 +1188,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleRowsBeforeSearch = dataGrid.getVisibleRows();
@@ -1197,7 +1197,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('searchPanel.text', 'three');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleRowsAfterSearch = dataGrid.getVisibleRows();
@@ -1228,7 +1228,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('searchPanel.text', 'FIC1');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleRows = dataGrid.getVisibleRows();
@@ -1341,7 +1341,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataGrid.columnOption('groupIndex:0').dataField, 'Terms', 'grouped column exists');
 
@@ -1360,7 +1360,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.state(strState);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!dataGrid.columnOption('groupIndex:0'), 'no grouped columns');
@@ -1399,7 +1399,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         let $headersView;
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         $headersView = $dataGrid.find('.dx-datagrid-headers' + ' .dx-datagrid-scroll-container').first();
         $headersView.scrollLeft(200);
@@ -1547,16 +1547,16 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             remoteOperations: true,
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const selectBox = $('.dx-datagrid-filter-row').find('.dx-selectbox').eq(0).dxSelectBox('instance');
 
         selectBox.open();
-        this.clock.tick();
+        this.clock.tick(10);
 
         selectBox.option('value', 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
 
@@ -1597,22 +1597,22 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             remoteOperations: true,
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const numberBox = $('.dx-datagrid-filter-row').find('.dx-numberbox').eq(0).dxNumberBox('instance');
         const selectBox = $('.dx-datagrid-filter-row').find('.dx-selectbox').eq(0).dxSelectBox('instance');
 
         selectBox.open(); // first request on opening
-        this.clock.tick();
+        this.clock.tick(10);
 
         numberBox.option('value', 'test'); // second request because of filter changing
-        this.clock.tick();
+        this.clock.tick(10);
         numberBox.option('value', ''); // third request because of filter changing
-        this.clock.tick();
+        this.clock.tick(10);
 
         selectBox.option('value', 1); // NO request cause changing lookup filter itself
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
 
@@ -1677,7 +1677,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         $('.dx-header-filter').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $('.dx-button').eq(1).trigger('dxclick');
         this.clock.tick(600);
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/fixedColumns.tests.js
@@ -1443,7 +1443,7 @@ QUnit.module('Fixed columns', {
 
             that.editorFactoryController.focus($fixTable.find('tr').eq(1).find('td').first());
 
-            that.clock.tick();
+            that.clock.tick(10);
 
             // assert
             assert.ok(scrollableInstance, 'has scrollable');
@@ -1461,7 +1461,7 @@ QUnit.module('Fixed columns', {
 
             // act
             nativePointerMock(that.gridContainer.find('.dx-datagrid-rowsview').children('.dx-datagrid-content-fixed')).start().wheel(-30);
-            that.clock.tick();
+            that.clock.tick(10);
 
             // assert
             assert.equal(countCallScrollOffsetChanged, 1, 'count call scrollChanged');
@@ -1966,7 +1966,7 @@ QUnit.module('Fixed columns', {
         const scrollable = that.rowsView.getScrollable();
         scrollable.scrollTo(500);
         $(scrollable.container()).trigger('scroll');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.rowsView.render(that.gridContainer);
@@ -2075,7 +2075,7 @@ QUnit.module('Fixed columns', {
         const scrollable = that.rowsView.getScrollable();
         scrollable.scrollTo(600);
         $(scrollable.container()).trigger('scroll');
-        that.clock.tick();
+        that.clock.tick(10);
 
         const positionTop = $fixedTable.position().top;
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -67,7 +67,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 groupIndex: 0,
             }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const cellBackgroundColor = 'rgba(0, 0, 0, 0)';
         const $groupedRow = $(dataGrid.getRowElement(0)[0]);
@@ -97,19 +97,19 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(dataGrid.getCellElement(0, 1)).trigger(pointerEvents.down);
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.expandRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         masterDetailDataGrids[0].option('focusedRowKey', 3);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(dataGrid.getCellElement(2, 1)).trigger(pointerEvents.down);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const row = detailRowsViewWrapper.getDataRow(0);
         assert.ok(row.isFocusedRow(), 'master detail has focused row');
@@ -164,7 +164,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('focusedRowKey', 'Smith');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(rowsView.getRow(4).hasClass('dx-row-focused'), 'Focused row');
@@ -193,7 +193,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.option('focusedRowKey', 'Smith');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowIndex = dataGrid.getRowIndexByKey('Smith');
 
@@ -227,21 +227,21 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act, assert - focusedRowKey
         dataGrid.option('focusedRowKey', 'Smith');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataGrid.pageIndex(), 0, 'Page index not changed');
         assert.equal(dataGrid.option('focusedRowKey'), 'Smith', 'focusedRowKey');
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
 
         // act, assert - paging
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataGrid.pageIndex(), 1, 'Page index');
         assert.equal(dataGrid.option('focusedRowKey'), 'Smith', 'focusedRowKey');
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
 
         // act, assert - sorting
         dataGrid.columnOption('phone', { sortOrder: 'desc' });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataGrid.pageIndex(), 1, 'Page index');
         assert.equal(dataGrid.option('focusedRowKey'), 'Smith', 'focusedRowKey');
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
@@ -250,7 +250,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.clearSorting();
         // act, assert - filtering
         dataGrid.filter(['phone', 'startsWith', '454']);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataGrid.pageIndex(), 0, 'Page index changed');
         assert.equal(dataGrid.option('focusedRowKey'), 'Smith', 'focusedRowKey');
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
@@ -292,7 +292,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         }).dxDataGrid('instance');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageIndex(), 2, 'Page index changed');
@@ -324,14 +324,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act, assert - focusedRowKey
         dataGrid.option('focusedRowKey', 'Ben');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataGrid.pageIndex(), 0, 'Page index not changed');
         assert.equal(dataGrid.option('focusedRowKey'), 'Ben', 'focusedRowKey');
         assert.equal(dataGrid.option('focusedRowIndex'), 1, 'focusedRowIndex');
 
         // act, assert - paging
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataGrid.pageIndex(), 1, 'Page index');
         assert.equal(dataGrid.option('focusedRowKey'), 'Ben', 'focusedRowKey');
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
@@ -340,7 +340,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.pageIndex(2);
         dataGrid.option('focusedRowKey', 'Smith');
         dataGrid.columnOption('name', { sortOrder: 'desc' });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataGrid.pageIndex(), 2, 'Page index');
         assert.equal(dataGrid.option('focusedRowKey'), 'Smith', 'focusedRowKey');
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
@@ -349,7 +349,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.clearSorting();
         // act, assert - filtering
         dataGrid.filter(['phone', 'startsWith', '454']);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dataGrid.pageIndex(), 0, 'Page index changed');
         assert.equal(dataGrid.option('focusedRowKey'), 'Smith', 'focusedRowKey');
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
@@ -384,11 +384,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 }
             }
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption('id', 'sortOrder', 'desc');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.option('focusedRowIndex'), 0, 'focusedRowIndex');
@@ -422,14 +422,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             focusedRowEnabled: true,
             focusedRowIndex: 0,
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption(0, 'lookup.dataSource', [{}]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.option('focusedRowIndex'), 0, 'focusedRowIndex');
@@ -458,7 +458,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         const rowsView = dataGrid.getView('rowsView');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         const rowIndex = dataGrid.getRowIndexByKey('Sean');
 
         // assert
@@ -567,11 +567,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         }).dxDataGrid('instance');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 10000 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.option('focusedRowKey', 15);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 250 });
         this.clock.tick(1000);
 
@@ -600,12 +600,12 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 useNative: false
             }
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(dataGridWrapper.rowsView.isRowVisible(dataGrid.getRowIndexByKey(30), 1), 'navigated row in viewport');
 
         dataGrid.columnOption(0, 'sortOrder', 'desc');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(dataGrid.getRowIndexByKey(30), 0, 'navigated row is rendered');
         assert.ok(dataGridWrapper.rowsView.isRowVisible(dataGrid.getRowIndexByKey(30), 1), 'navigated row in viewport');
@@ -633,13 +633,13 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(dataGrid.getCellElement(7, 0))
             .trigger('dxpointerdown');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleRows()[0].key, 1, 'Visible row is not changed');
@@ -660,12 +660,12 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         const navigationController = dataGrid.getController('keyboardNavigation');
 
         $(dataGrid.getRowElement(0)).find('.dx-command-edit > .dx-link-edit').trigger(pointerEvents.up).click();
-        this.clock.tick();
+        this.clock.tick(10);
 
         navigationController._keyDownHandler({ key: 'Tab', keyName: 'tab', originalEvent: $.Event('keydown', { target: $(dataGrid.getCellElement(0, 0)) }) });
 
         $(dataGrid.getCellElement(0, 1)).trigger(pointerEvents.up);
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok($(dataGrid.getCellElement(0, 1)).hasClass('dx-focused'));
     });
@@ -700,15 +700,15 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const scrollable = dataGrid.getScrollable();
         scrollable.scrollTo({ y: 600 });
         $(scrollable.container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
         $(dataGrid.getCellElement(0, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedCellChangedCount, 1, 'onFocusedCellChanged fires count');
@@ -808,11 +808,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         }).dxDataGrid('instance');
         const rowsView = dataGrid.getView('rowsView');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('focusedRowIndex', 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.option('focusedRowIndex'), 0, 'focusedRowIndex');
@@ -838,11 +838,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 useNative: false,
             }
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 10000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getTopVisibleRowData().id, 3, 'top visible row id');
@@ -864,14 +864,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }]
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('focusedRowIndex', 0);
         dataGrid.option('focusedRowIndex', 1);
         dataGrid.option('focusedRowIndex', 2);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(data[0].id.key, 4, 'first row data was not modified');
@@ -900,10 +900,10 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             paging: { pageSize: 2 }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageIndex(), 1, 'pageIndex');
@@ -926,11 +926,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             focusedRowEnabled: true,
             scrolling: { mode: 'infinite', useNative: false }
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('focusedRowKey', 'Smith');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const rowIndex = dataGrid.getRowIndexByKey('Smith');
@@ -963,7 +963,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         // act, assert
         try {
             dataGrid.pageIndex(1);
-            this.clock.tick();
+            this.clock.tick(10);
         } catch(e) {
             assert.ok(false, e);
         }
@@ -1044,7 +1044,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.focus(dataGrid.getCellElement(1, 2));
         const keyboardController = dataGrid.getController('keyboardNavigation');
         keyboardController._keyDownHandler({ key: 'Tab', keyName: 'tab', originalEvent: $.Event('keydown', { target: $(':focus').get(0) }) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell = $(dataGrid.element()).find('.dx-focused');
 
@@ -1077,17 +1077,17 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 $(container).append(tr);
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const input = $(dataGrid.getRowElement(0)).find('.dx-texteditor-input').eq(0);
         const keyboard = keyboardMock(input);
 
         input.trigger('focus');
-        this.clock.tick();
+        this.clock.tick(10);
 
         keyboard.keyDown('tab');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(keyboard.event._defaultPrevented, 'event should not be prevented');
@@ -1111,7 +1111,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             .val('test')
             .trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $search = $($(dataGrid.$element()).find('.dx-datagrid-search-panel'));
@@ -1133,11 +1133,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             focusedRowIndex: 1
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const focusedRowElement = dataGrid.getView('rowsView').getRow(1);
@@ -1159,7 +1159,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             focusedRowIndex: 0
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('focusedRowKey', '2');
@@ -1180,11 +1180,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [{ id: 1 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('focusedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedRowChangedCallCount, 1, 'focusedRowChangedCallCount');
@@ -1259,7 +1259,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedRowChangedCallCount, 1, 'focusedRowChangedCallCount');
@@ -1276,7 +1276,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             dataSource: [{ id: 1 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedRowChangedCallCount, 0, 'focusedRowChangedCallCount');
@@ -1333,7 +1333,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }).dxDataGrid('instance');
 
             dataGrid.editRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.ok(true, 'no exception');
         });
@@ -1353,7 +1353,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }).dxDataGrid('instance');
 
             dataGrid.focus(dataGrid.getCellElement(0, 0));
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.ok(true, 'no exception');
         });
@@ -1378,14 +1378,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.option('focusedRowIndex'), -1, 'there is no focused row');
 
         const $firstCell = $(dataGrid.getCellElement(0, 1));
         $firstCell.trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $firstRow = $(dataGrid.getRowElement(0));
 
@@ -1419,11 +1419,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             columns: [{ type: 'buttons' }, 'name', 'phone']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(dataGrid.getRowElement(0)).find('.dx-command-edit > .dx-link-edit').trigger(pointerEvents.up).click();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.getRowElement(0)).find('.dx-editor-cell').eq(0).hasClass('dx-focused'), 'first editable cell is active');
@@ -1464,7 +1464,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(onFocusedRowChangedSpy.callCount, 1, 'onFocusedRowChanged is fired');
@@ -1486,7 +1486,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(onFocusedRowChangedSpy.callCount, 1, 'onFocusedRowChanged is fired');
@@ -1511,7 +1511,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(onFocusedRowChangedSpy.callCount, 1, 'onFocusedRowChanged is fired');
@@ -1582,7 +1582,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         $input.val(1);
         $input.trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
 
@@ -1651,12 +1651,12 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             columns: ['id']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('dataSource', []);
         dataGrid.columnOption(0, 'caption', 'test');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.getVisibleRows().length, 0, 'no rows');
@@ -1721,7 +1721,7 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
             .val(1)
             .trigger('change');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok($('.dx-datagrid-filter-row .dx-texteditor-input').eq(0).is(':focus'), 'filter row\'s cell is focused');
     });
@@ -1772,7 +1772,7 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange
         const dataController = dataGrid.getController('data');
@@ -1780,7 +1780,7 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
 
         // act
         dataGrid.option('focusedRowKey', 5);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(dataController._getLastItemIndex.callCount > 0, '_getLastItemIndex has called after set focusedRowKey');
@@ -1826,7 +1826,7 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
         // act
         const scrollable = dataGrid.getScrollable();
         scrollable.scrollBy(400);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const firstVisibleRowKey = dataGrid.getVisibleRows()[0].key;
         const scrollTop = scrollable.scrollTop();
@@ -1835,9 +1835,9 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
         const $checkBox = $cell.find('.dx-checkbox').eq(0);
 
         $checkBox.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
         $checkBox.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleRows()[0].key, firstVisibleRowKey, 'first visible row key');
@@ -1916,7 +1916,7 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
                 autoNavigateToFocusedRow: true,
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(dataGrid.option('focusedRowKey'), 80, 'focused row key');
@@ -2005,29 +2005,29 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
                 columns: ['Name', 'Description']
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             dataGrid.cellValue(0, 0, 'test');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($(dataGrid.getCellElement(0, 0)).hasClass('dx-cell-modified'), 'the first cell is modified');
 
             // act
             $(dataGrid.getCellElement(0, 1)).trigger('dxpointerdown').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.notOk($(dataGrid.getCellElement(0, 1)).hasClass('dx-cell-modified'), 'the second cell is not modified');
 
             // act
             $(dataGrid.getCellElement(1, 0)).trigger('dxpointerdown').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.notOk($(dataGrid.getCellElement(1, 0)).hasClass('dx-cell-modified'), 'the third cell is not modified');
@@ -2052,7 +2052,7 @@ QUnit.module('View\'s focus', {
 
         this.focusGridCell = function($target) {
             this.dataGrid.focus($target);
-            this.clock.tick();
+            this.clock.tick(10);
         };
     },
     afterEach: function() {
@@ -2110,13 +2110,13 @@ QUnit.module('View\'s focus', {
                 }
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataGrid.expandRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
         $(detailGrid.getCellElement(0, 0)).focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const focusOverlay = detailRowsViewWrapper.getFocusOverlay();
@@ -2135,11 +2135,11 @@ QUnit.module('View\'s focus', {
                 e.isHighlighted = false;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.dataGrid.getCellElement(0, 0))
             .trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.dataGrid.option('focusedRowIndex'), 0, 'focusedRowIndex');
@@ -2148,7 +2148,7 @@ QUnit.module('View\'s focus', {
         // act
         const navigationController = this.dataGrid.getController('keyboardNavigation');
         navigationController._keyDownHandler({ key: 'Tab', keyName: 'tab', originalEvent: $.Event('keydown', { target: $(this.dataGrid.getCellElement(0, 0)) }) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedCellChangingCount, 2, 'onFocusedCellChanging fires count');
@@ -2206,10 +2206,10 @@ QUnit.module('View\'s focus', {
             }
         });
         this.dataGrid.expandRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dateBoxInput = $(this.dataGrid.$element()).find('.internal-grid .dx-datagrid-filter-row').find('.dx-texteditor-input').first();
         $dateBoxInput.focus();
-        this.clock.tick();
+        this.clock.tick(10);
         const keyboard = keyboardMock($dateBoxInput);
 
         // act
@@ -2249,18 +2249,18 @@ QUnit.module('View\'s focus', {
             }
         });
         this.dataGrid.expandRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.keyboardNavigationController._focusedCellPosition = { rowIndex: 0, columnIndex: 1 };
         const $dateBoxInput = $(this.dataGrid.$element()).find('.internal-grid .dx-datagrid-filter-row').find('.dx-texteditor-input').first();
         $dateBoxInput.focus();
-        this.clock.tick();
+        this.clock.tick(10);
         const keyboard = keyboardMock($dateBoxInput);
 
         // act
         keyboard.keyDown('1');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { rowIndex: 0, columnIndex: 1 }, 'Master grid focusedCellPosition is not changed');
@@ -2375,7 +2375,7 @@ QUnit.module('View\'s focus', {
             onFocusedRowChanged
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['group', 'group'], 'group rows are rendered');
@@ -2385,7 +2385,7 @@ QUnit.module('View\'s focus', {
         // act
         const $command = $(dataGrid.getRowElement(1)).find('.dx-command-expand');
         $command.trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['group', 'group', 'data'], 'rows are rendered');
@@ -2421,7 +2421,7 @@ QUnit.module('View\'s focus', {
             onFocusedRowChanged
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['data', 'data'], 'data rows are rendered');
@@ -2431,7 +2431,7 @@ QUnit.module('View\'s focus', {
         // act
         const $command = $(dataGrid.getRowElement(1)).find('.dx-command-expand');
         $command.trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['data', 'data', 'detail'], 'rows are rendered');
@@ -2469,7 +2469,7 @@ QUnit.module('View\'s focus', {
             onFocusedCellChanged,
             onFocusedRowChanged
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['group', 'group'], 'group rows are rendered');
@@ -2479,7 +2479,7 @@ QUnit.module('View\'s focus', {
         // act
         const $command = $(dataGrid.getRowElement(1)).find('.dx-command-expand');
         $command.trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['group', 'group', 'data'], 'rows are rendered');
@@ -2517,7 +2517,7 @@ QUnit.module('View\'s focus', {
             onFocusedCellChanged,
             onFocusedRowChanged
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['data', 'data'], 'group rows are rendered');
@@ -2527,7 +2527,7 @@ QUnit.module('View\'s focus', {
         // act
         const $command = $(dataGrid.getRowElement(1)).find('.dx-command-expand');
         $command.trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['data', 'data', 'detail'], 'rows are rendered');
@@ -2563,7 +2563,7 @@ QUnit.module('View\'s focus', {
             onFocusedRowChanged
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['group', 'group'], 'group rows are rendered');
@@ -2573,7 +2573,7 @@ QUnit.module('View\'s focus', {
         // act
         const $command = $(dataGrid.getRowElement(1)).find('.dx-command-expand');
         $command.trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['group', 'group', 'data'], 'rows are rendered');
@@ -2609,7 +2609,7 @@ QUnit.module('View\'s focus', {
             onFocusedRowChanged
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['data', 'data'], 'group rows are rendered');
@@ -2619,7 +2619,7 @@ QUnit.module('View\'s focus', {
         // act
         const $command = $(dataGrid.getRowElement(1)).find('.dx-command-expand');
         $command.trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['data', 'data', 'detail'], 'rows are rendered');
@@ -2655,7 +2655,7 @@ QUnit.module('View\'s focus', {
             onFocusedRowChanged
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['group', 'group'], 'group rows are rendered');
@@ -2665,7 +2665,7 @@ QUnit.module('View\'s focus', {
         // act
         const $command = $(dataGrid.getRowElement(1)).find('.dx-command-expand');
         $command.trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['group', 'group', 'data'], 'rows are rendered');
@@ -2701,7 +2701,7 @@ QUnit.module('View\'s focus', {
             onFocusedRowChanged
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['data', 'data'], 'group rows are rendered');
@@ -2711,7 +2711,7 @@ QUnit.module('View\'s focus', {
         // act
         const $command = $(dataGrid.getRowElement(1)).find('.dx-command-expand');
         $command.trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getVisibleRows().map(({ rowType }) => rowType), ['data', 'data', 'detail'], 'rows are rendered');
@@ -2736,14 +2736,14 @@ QUnit.module('View\'s focus', {
             width: 120
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell0 = $(dataGrid.getCellElement(0, 0));
         $cell0.trigger(CLICK_EVENT).trigger('dxclick');
 
         let keyboard = keyboardMock($cell0);
         keyboard.keyDown('right');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell1 = $(dataGrid.getCellElement(0, 2));
 
@@ -2755,7 +2755,7 @@ QUnit.module('View\'s focus', {
 
         keyboard = keyboardMock($cell1);
         keyboard.keyDown('left');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($cell0.hasClass('dx-focused'), 'cell is focused');
@@ -2807,12 +2807,12 @@ QUnit.module('View\'s focus', {
                             { dataField: 'description', allowEditing: false }
                         ]
                     });
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // act
                     let $cell = $(dataGrid.getCellElement(rowIndex, 1));
                     $cell.trigger(CLICK_EVENT).trigger('dxclick');
-                    this.clock.tick();
+                    this.clock.tick(10);
                     let keyboard = keyboardMock($cell);
                     keyboard.keyDown('a');
                     this.clock.tick(25); // 25 because of T882996
@@ -2824,7 +2824,7 @@ QUnit.module('View\'s focus', {
                     // act
                     keyboard = keyboardMock($cell);
                     keyboard.keyDown(arrowKey);
-                    this.clock.tick();
+                    this.clock.tick(10);
                     $cell = $(dataGrid.getCellElement(rowIndex, 1));
                     const cellValue = dataGrid.cellValue(rowIndex, 1);
 
@@ -2872,12 +2872,12 @@ QUnit.module('View\'s focus', {
                     }
                 ]
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             let $cell = $(dataGrid.getCellElement(0, 0));
             $cell.trigger(CLICK_EVENT).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
             let keyboard = keyboardMock($cell);
             keyboard.keyDown('2');
             this.clock.tick(25);
@@ -2891,7 +2891,7 @@ QUnit.module('View\'s focus', {
             // act
             keyboard = keyboardMock($input);
             keyboard.keyDown('5');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($cell.hasClass('dx-editor-cell'), 'cell has an editor');
@@ -2931,14 +2931,14 @@ QUnit.module('View\'s focus', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell1_0 = $(dataGrid.getCellElement(1, 0));
         $cell1_0.trigger(CLICK_EVENT).trigger('dxclick');
 
         const keyboard = keyboardMock($cell1_0);
         keyboard.keyDown('tab', { shiftKey: true });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $lastCell = $(dataGrid.getRowElement(0)).children().last();
         const $editButton = $lastCell.find('.dx-link-edit');
@@ -2981,14 +2981,14 @@ QUnit.module('View\'s focus', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell1_0 = $(dataGrid.getCellElement(1, 0));
         $cell1_0.trigger(CLICK_EVENT).trigger('dxclick');
 
         const keyboard = keyboardMock($cell1_0);
         keyboard.keyDown('tab', { shiftKey: true });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $lastCell = $(dataGrid.getRowElement(0)).children().last();
         const $editButton = $lastCell.find('.dx-link-edit');
@@ -3024,7 +3024,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
         scrollable.scrollTo({ left: this.keyboardNavigationController._getMaxHorizontalOffset() });
@@ -3037,7 +3037,7 @@ QUnit.module('View\'s focus', {
         $firstCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($firstCell);
         keyboard.keyDown('tab');
-        this.clock.tick();
+        this.clock.tick(10);
         const $secondCell = $(this.dataGrid.getCellElement(0, 1));
 
         // assert
@@ -3073,7 +3073,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         scrollable.scrollTo({ left: 0 });
 
@@ -3085,7 +3085,7 @@ QUnit.module('View\'s focus', {
         $firstCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($firstCell);
         keyboard.keyDown('tab');
-        this.clock.tick();
+        this.clock.tick(10);
         const $secondCell = $(this.dataGrid.getCellElement(0, 1));
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
 
@@ -3121,7 +3121,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
 
         // assert
@@ -3132,7 +3132,7 @@ QUnit.module('View\'s focus', {
         $lastCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($lastCell);
         keyboard.keyDown('tab', { shiftKey: true });
-        this.clock.tick();
+        this.clock.tick(10);
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
         const $penultimateCell = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 2));
 
@@ -3169,7 +3169,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
 
@@ -3181,7 +3181,7 @@ QUnit.module('View\'s focus', {
         $lastCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($lastCell);
         keyboard.keyDown('tab', { shiftKey: true });
-        this.clock.tick();
+        this.clock.tick(10);
         const $penultimateCell = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 2));
 
         // assert
@@ -3220,14 +3220,14 @@ QUnit.module('View\'s focus', {
                     columns[16].fixed = true;
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const $cell0_last = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 1));
             $cell0_last.trigger(CLICK_EVENT).trigger('dxclick');
             const keyboard = keyboardMock($cell0_last);
             keyboard.keyDown('tab');
-            this.clock.tick();
+            this.clock.tick(10);
             const $cell1_first = $(this.dataGrid.getCellElement(1, 0));
 
             // assert
@@ -3267,14 +3267,14 @@ QUnit.module('View\'s focus', {
                     columns[16].fixed = true;
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const $cell0_last = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 1));
             $cell0_last.trigger(CLICK_EVENT).trigger('dxclick');
             const keyboard = keyboardMock($cell0_last);
             keyboard.keyDown('tab');
-            this.clock.tick();
+            this.clock.tick(10);
             const $cell1_first = $(this.dataGrid.getCellElement(1, 0));
 
             // assert
@@ -3311,14 +3311,14 @@ QUnit.module('View\'s focus', {
                     columns[16].fixed = true;
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const $cell1_first = $(this.dataGrid.getCellElement(1, 0));
             $cell1_first.trigger(CLICK_EVENT).trigger('dxclick');
             const keyboard = keyboardMock($cell1_first);
             keyboard.keyDown('tab', { shiftKey: true });
-            this.clock.tick();
+            this.clock.tick(10);
             const $cell0_last = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 1));
 
             // assert
@@ -3356,14 +3356,14 @@ QUnit.module('View\'s focus', {
                     columns[16].fixed = true;
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const $cell0_last = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 1));
             $cell0_last.trigger(CLICK_EVENT).trigger('dxclick');
             const keyboard = keyboardMock($cell0_last);
             keyboard.keyDown('tab', { shiftKey: true });
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $penultimateCell = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 2));
 
@@ -3399,7 +3399,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
         scrollable.scrollTo({ left: this.keyboardNavigationController._getMaxHorizontalOffset() });
@@ -3412,7 +3412,7 @@ QUnit.module('View\'s focus', {
         $firstCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($firstCell);
         keyboard.keyDown('right');
-        this.clock.tick();
+        this.clock.tick(10);
         const $secondCell = $(this.dataGrid.getCellElement(0, 1));
 
         // assert
@@ -3450,7 +3450,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
         scrollable.scrollTo({ left: this.keyboardNavigationController._getMaxHorizontalOffset() });
@@ -3463,7 +3463,7 @@ QUnit.module('View\'s focus', {
         $firstCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($firstCell);
         keyboard.keyDown('right');
-        this.clock.tick();
+        this.clock.tick(10);
         const $secondCell = $(this.dataGrid.getCellElement(0, 1));
 
         // assert
@@ -3499,7 +3499,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         scrollable.scrollTo({ left: 0 });
 
@@ -3511,7 +3511,7 @@ QUnit.module('View\'s focus', {
         $firstCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($firstCell);
         keyboard.keyDown('left');
-        this.clock.tick();
+        this.clock.tick(10);
         const $secondCell = $(this.dataGrid.getCellElement(0, 1));
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
 
@@ -3551,7 +3551,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         scrollable.scrollTo({ left: 0 });
 
@@ -3563,7 +3563,7 @@ QUnit.module('View\'s focus', {
         $firstCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($firstCell);
         keyboard.keyDown('left');
-        this.clock.tick();
+        this.clock.tick(10);
         const $secondCell = $(this.dataGrid.getCellElement(0, 1));
 
         // assert
@@ -3598,7 +3598,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
 
         // assert
@@ -3609,7 +3609,7 @@ QUnit.module('View\'s focus', {
         $lastCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($lastCell);
         keyboard.keyDown('left');
-        this.clock.tick();
+        this.clock.tick(10);
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
         const $penultimateCell = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 2));
 
@@ -3648,7 +3648,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
 
         // assert
@@ -3659,7 +3659,7 @@ QUnit.module('View\'s focus', {
         $lastCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($lastCell);
         keyboard.keyDown('left');
-        this.clock.tick();
+        this.clock.tick(10);
         const $penultimateCell = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 2));
 
         // assert
@@ -3695,7 +3695,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
 
@@ -3707,7 +3707,7 @@ QUnit.module('View\'s focus', {
         $lastCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($lastCell);
         keyboard.keyDown('right');
-        this.clock.tick();
+        this.clock.tick(10);
         const $penultimateCell = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 2));
 
         // assert
@@ -3746,7 +3746,7 @@ QUnit.module('View\'s focus', {
                 columns[16].fixed = true;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = this.dataGrid.getScrollable();
         const maxScrollOffset = this.keyboardNavigationController._getMaxHorizontalOffset();
 
@@ -3758,7 +3758,7 @@ QUnit.module('View\'s focus', {
         $lastCell.trigger(CLICK_EVENT).trigger('dxclick');
         const keyboard = keyboardMock($lastCell);
         keyboard.keyDown('right');
-        this.clock.tick();
+        this.clock.tick(10);
         const $penultimateCell = $(this.dataGrid.getCellElement(0, this.dataGrid.getVisibleColumns().length - 2));
 
         // assert
@@ -3789,17 +3789,17 @@ QUnit.module('View\'s focus', {
                 }
             }, 'description']
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $inputElement = $(this.dataGrid.element()).find('input');
 
         // act
         $inputElement.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
         $inputElement.focus();
-        this.clock.tick();
+        this.clock.tick(10);
         $inputElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($inputElement.is(':focus'), 'input is focused');
@@ -3816,13 +3816,13 @@ QUnit.module('View\'s focus', {
             },
             focusedRowEnabled: true,
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $checkbox = $(this.dataGrid.element()).find('.dx-datagrid-rowsview .dx-checkbox');
 
         // act
         $checkbox.trigger('dxpointerdown').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($checkbox.parents('tr').hasClass('dx-row-focused'), 'row is focused');
@@ -3857,18 +3857,18 @@ QUnit.module('View\'s focus', {
                 }
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(this.dataGrid.element()).find('.dx-datagrid-rowsview .dx-command-expand:eq(1)').trigger(CLICK_EVENT).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($(this.dataGrid.element()).find('.dx-datagrid-rowsview .dx-command-expand:eq(1)').attr('tabindex'), '0', 'tab index is set to the expanded button');
 
         // act
         $(this.dataGrid.element()).find('.myclass .dx-link-edit:eq(0)').trigger('dxpointerdown').trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($(this.dataGrid.element()).find('.dx-datagrid-rowsview .dx-command-expand:eq(1)').attr('tabindex'), '0', 'tab index is set to the expanded button');
@@ -3901,11 +3901,11 @@ QUnit.module('View\'s focus', {
                 }
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.dataGrid.expandRow(2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dataGrid.getScrollable().scrollTo({ top: this.dataGrid.getScrollable().scrollHeight() });
         const scrollTop = this.dataGrid.getScrollable().scrollTop();
@@ -3933,17 +3933,17 @@ QUnit.module('View\'s focus', {
                     }
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $inputElement = $('<input>').prependTo($('#container'));
 
             // act
             this.dataGrid.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             $inputElement.trigger('focus');
-            this.clock.tick();
+            this.clock.tick(10);
             $inputElement.trigger('dxpointerdown').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok($inputElement.is(':focus'), 'input is focused');
@@ -3979,19 +3979,19 @@ QUnit.module('View\'s focus', {
                 }
             ],
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         for(let i = 0; i < 2; i++) {
             for(let j = 0; j < 2; j++) {
                 // act
                 $(this.dataGrid.getCellElement(i, j)).trigger('dxpointerdown');
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.dataGrid.getCellElement(i, j)).trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 if(i === 0 && j === 0) {
                     $(this.dataGrid.getCellElement(i, j)).find('.dx-texteditor-input').val('').trigger('change');
-                    this.clock.tick();
+                    this.clock.tick(10);
                 }
 
                 // assert
@@ -4029,10 +4029,10 @@ QUnit.module('View\'s focus', {
                 }
             ],
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.dataGrid.element()).find('.dx-datagrid-addrow-button').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.dataGrid.getVisibleRows()[0].isNewRow, 'the first new row');
@@ -4047,9 +4047,9 @@ QUnit.module('View\'s focus', {
 
                 // act
                 $(this.dataGrid.getCellElement(i, j)).trigger('dxpointerdown');
-                this.clock.tick();
+                this.clock.tick(10);
                 $(this.dataGrid.getCellElement(i, j)).trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.ok($(this.dataGrid.getCellElement(0, 0)).hasClass('dx-datagrid-invalid'), `the first cell is rendered as invalid when the {${i}, ${j}} cell is clicked`);
@@ -4091,7 +4091,7 @@ QUnit.module('View\'s focus', {
                     e.isHighlighted = true;
                 }
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             let keyboard = keyboardMock($(this.dataGrid.getCellElement(0, 0)));
@@ -4399,18 +4399,18 @@ QUnit.module('API methods', baseModuleConfig, () => {
         const navigationController = dataGrid.getController('keyboardNavigation');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ left: 0, top: 1500 });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const rowData = dataGrid.getTopVisibleRowData();
 
         dataGrid.editCell(dataGrid.getRowIndexByKey(rowData) + 1, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(dataGrid.$element()).find('.dx-textbox').dxTextBox('instance').option('value', 'Test');
         navigationController._keyDownHandler({ key: 'Tab', keyName: 'tab', originalEvent: $.Event('keydown', { target: $(dataGrid.$element()).find('input').get(0) }) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(Math.floor(rowData.index / 20), 2, 'scroll position is on third page');
@@ -4447,17 +4447,17 @@ QUnit.module('API methods', baseModuleConfig, () => {
         const navigationController = dataGrid.getController('keyboardNavigation');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ x: 0, y: 10000 });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const rowData = dataGrid.getTopVisibleRowData();
         dataGrid.editCell(dataGrid.getRowIndexByKey(array[198]), 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(dataGrid.$element()).find('.dx-textbox').dxTextBox('instance').option('value', 'Test');
         navigationController._keyDownHandler({ key: 'Tab', keyName: 'tab', originalEvent: $.Event('keydown', { target: $(dataGrid.$element()).find('input').get(0) }) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.roughEqual(dataGrid.getTopVisibleRowData().index, rowData.index, 1.01, 'scroll position is not changed');
@@ -4487,11 +4487,11 @@ QUnit.module('API methods', baseModuleConfig, () => {
             },
             columns: ['id', { dataField: 'value', allowEditing: true }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-checkbox').eq(0).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-checkbox').eq(0).attr('aria-checked'), 'true', 'first checkbox is checked');
@@ -4643,10 +4643,10 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.focus($(dataGrid.getCellElement(0, 1)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $inputs = $($(dataGrid.$element()).find(TEXTEDITOR_INPUT_SELECTOR));
@@ -4691,7 +4691,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const editor = $(dataGrid.$element()).find('.dx-form .dx-texteditor').first().dxTextBox('instance');
         const $input = $(editor.$element().find('.dx-texteditor-input'));
@@ -4701,7 +4701,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         triggerTabPress($input);
         $($input).trigger('change');
         $(dataGrid.$element()).find('.dx-form .dx-texteditor-input').eq(1).focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $secondEditor = $(dataGrid.$element()).find('.dx-form .dx-texteditor').eq(1);
@@ -4735,7 +4735,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         assert.equal($cell.length, 1, 'editor cell exists');
 
         dataGrid.getController('editorFactory').focus($cell);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $focusOverlay = $($(dataGrid.$element()).find('.dx-datagrid-focus-overlay'));
 
@@ -4746,7 +4746,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         // act
         $(dataGrid.$element()).width(100);
         dataGrid.resize();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const newFocusWidth = $focusOverlay.width();
@@ -4769,7 +4769,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ field1: 1, field2: 2 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(dataGrid.element()).find('.dx-checkbox').first().focus();
 
@@ -4799,7 +4799,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.focus(dataGrid.getCellElement(0, 1));
 
         // assert
@@ -4809,7 +4809,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         $('.dx-link-cancel').trigger('dxpointerdown').trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $commandCell = $(dataGrid.getCellElement(0, 1));
@@ -4899,7 +4899,7 @@ QUnit.module('Column Resizing', baseModuleConfig, () => {
         resizeController._isResizing = true;
 
         dataGrid.focus(dataGrid.getCellElement(0, 0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($dataGrid.find('.dx-datagrid-focus-overlay').length, 'overlay is not rendered');
@@ -4927,7 +4927,7 @@ QUnit.module('Column Resizing', baseModuleConfig, () => {
         const $columnsSeparator = $dataGrid.find('.dx-datagrid-columns-separator');
 
         dataGrid.focus(dataGrid.getCellElement(0, 0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $overlay = $dataGrid.find('.dx-datagrid-focus-overlay');
@@ -4944,7 +4944,7 @@ QUnit.module('Column Resizing', baseModuleConfig, () => {
         // act
         resizeController._isResizing = false;
         $dataGrid.trigger($.Event('dxclick'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($overlay.length, 'overlay is rendered');
@@ -5009,14 +5009,14 @@ QUnit.module('Column Resizing', baseModuleConfig, () => {
                 }
             }],
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.getScrollable().scrollTo({ y: 10 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('#button1').trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getScrollable().scrollTop(), 10, 'scroll top is not changed');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.integration.tests.js
@@ -532,7 +532,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick(300);
+        this.clock.tick(400);
 
         // assert
         assert.equal(dataGrid.getTopVisibleRowData().id, 150, 'Focused row is visible');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
@@ -125,7 +125,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         const rowsView = this.gridView.getView('rowsView');
         rowsView.resize(150);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -134,7 +134,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         // act
         $cell = $(this.getCellElement(1, 1)).focus();
         fireKeyDown($cell, 'PageDown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -143,7 +143,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         // act
         $cell = $(this.getCellElement(1, 1)).focus();
         fireKeyDown($cell, 'PageUp');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -179,7 +179,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         const rowsView = this.gridView.getView('rowsView');
         rowsView.resize(150);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.keyboardNavigationController._focusView();
 
@@ -191,7 +191,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         $cell = $(this.getCellElement(1, 1));
         $cell.trigger(CLICK_EVENT);
         fireKeyDown($cell, 'PageDown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -201,7 +201,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         $cell = $(this.getCellElement(1, 1));
         $cell.trigger(CLICK_EVENT);
         fireKeyDown($cell, 'PageUp');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -221,7 +221,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -250,7 +250,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -262,7 +262,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         // act
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
         keyboardController._upDownKeysHandler({ key: 'ArrowUp', keyName: 'upArrow' });
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.option('focusedRowIndex'), 0, 'FocusedRowIndex is 0');
         assert.ok(rowsView.getRow(0).hasClass('dx-row-focused'), 'FocusedRow');
@@ -283,7 +283,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -292,7 +292,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         try {
             // act
             keyboardController._upDownKeysHandler({ key: 'ArrowUp', keyName: 'upArrow' });
-            this.clock.tick();
+            this.clock.tick(10);
             // assert
             assert.ok(true, 'No exception');
         } catch(e) {
@@ -313,7 +313,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -345,7 +345,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             };
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
             const rowsView = this.gridView.getView('rowsView');
             const keyboardController = this.getController('keyboardNavigation');
             keyboardController._focusedView = rowsView;
@@ -355,7 +355,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             // act
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(this.getVisibleRows().length, 3, 'count row');
@@ -363,14 +363,14 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             // act
             $(rowsView.getCellElement(1, 0)).trigger(CLICK_EVENT);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex = 1');
 
             // act
             this.triggerKeyDown('downArrow', false, false, $(rowsView.getCellElement(1, 0)));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 2, 'FocusedRowIndex is 2');
@@ -391,7 +391,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const keyboardController = this.getController('keyboardNavigation');
         let rowsView = this.gridView.getView('rowsView');
@@ -446,7 +446,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $cell = $(this.getCellElement(1, 1));
@@ -458,7 +458,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
                 .trigger(pointerEvents.down)
                 .trigger(clickEvent.name);
         }
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -482,7 +482,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), undefined, 'FocusedRowIndex is undefined');
@@ -518,7 +518,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
@@ -526,7 +526,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(this.option('focusedRowIndex'), undefined, 'FocusedRowIndex is undefined');
         // act
         $('#container [tabindex="0"]').first().trigger('focus').trigger('focusin');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(that.option('focusedRowIndex'), 0, 'focusedRowIndex');
         assert.strictEqual(rowsView.getRow(0).attr('tabindex'), undefined, 'Row 0 tabindex');
@@ -550,9 +550,9 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         };
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.triggerKeyDown('tab', false, false, $(this.getCellElement(0, 0)));
@@ -583,7 +583,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
@@ -591,7 +591,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(this.option('focusedRowIndex'), undefined, 'FocusedRowIndex is undefined');
         // act
         $('.dx-datagrid-rowsview [tabindex="0"]').first().trigger('focus').trigger('focusin');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(that.option('focusedRowIndex'), 0, 'focusedRowIndex');
         assert.strictEqual(rowsView.getRow(0).attr('tabindex'), undefined, 'Row 0 tabindex');
@@ -617,13 +617,13 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
         // assert
         assert.equal(this.option('focusedRowIndex'), undefined, 'FocusedRowIndex is undefined');
-        this.clock.tick();
+        this.clock.tick(10);
         // act
         $(rowsView.getRow(1).find('td').eq(0)).trigger(CLICK_EVENT);
         this.triggerKeyDown('leftArrow', false, false, rowsView.element().find(':focus').get(0));
@@ -653,11 +653,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), undefined, 'FocusedRowIndex is undefined');
-        this.clock.tick();
+        this.clock.tick(10);
         // act
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT).click();
         this.triggerKeyDown('rightArrow', false, false, $('#qunit-fixture').find(':focus').get(0));
@@ -684,7 +684,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
@@ -698,14 +698,14 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         this.triggerKeyDown('upArrow', false, false, $(rowsView.getCellElement(1, 0)));
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.option('focusedRowIndex'), 0, 'FocusedRowIndex');
         assert.ok(this.keyboardNavigationController.isRowFocusType(), 'Row focus type');
 
         // act
         this.triggerKeyDown('downArrow', false, false, $(rowsView.getCellElement(0, 0)));
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
         assert.ok(this.keyboardNavigationController.isRowFocusType(), 'Row focus type');
@@ -740,7 +740,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
@@ -773,14 +773,14 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(5, 0)).trigger(CLICK_EVENT).focus();
 
         // act
         this.dataController.filter('team', '=', 'public');
         this.dataController.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const visibleRows = this.dataController.getVisibleRows();
@@ -812,14 +812,14 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(5, 0)).trigger(CLICK_EVENT).focus();
 
         // act
         this.dataController.filter('team', '=', 'internal');
         this.dataController.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const visibleRows = this.dataController.getVisibleRows();
@@ -913,15 +913,15 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
         // act
         $(this.getCellElement(0, 0)).trigger(CLICK_EVENT).click();
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('rightArrow', false, false, $(':focus'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT).click();
 
@@ -951,7 +951,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
@@ -972,7 +972,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.getController('keyboardNavigation').isCellFocusType(), 'Cell focus type');
@@ -1003,13 +1003,13 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
         // assert
         assert.equal(this.option('focusedRowIndex'), undefined, 'FocusedRowIndex is undefined');
-        this.clock.tick();
+        this.clock.tick(10);
         // act
         $(rowsView.getRow(1).find('td').eq(0)).trigger(CLICK_EVENT);
         this.triggerKeyDown('rightArrow', false, false, rowsView.element().find(':focus').get(0));
@@ -1034,13 +1034,13 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
         // assert
         assert.equal(this.option('focusedRowIndex'), undefined, 'FocusedRowIndex is undefined');
-        this.clock.tick();
+        this.clock.tick(10);
         // act
         $(rowsView.getRow(1).find('td').eq(0)).trigger(CLICK_EVENT);
         this.triggerKeyDown('rightArrow', false, false, rowsView.element().find(':focus').get(0));
@@ -1079,7 +1079,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1090,7 +1090,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(this.option('focusedColumnIndex'), 1, 'FocusedColumnIndex');
         // act
         keyboardController._leftRightKeysHandler({ key: 'ArrowLeft', keyName: 'leftArrow' });
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.getController('keyboardNavigation').getVisibleColumnIndex(), 0, 'Focused column index');
         assert.equal(focusedColumnChangingCount, 1, 'onFocusedCellChanging fires count');
@@ -1133,7 +1133,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1184,7 +1184,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1232,7 +1232,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1243,7 +1243,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(this.option('focusedColumnIndex'), 1, 'FocusedColumnIndex');
         // act
         keyboardController._leftRightKeysHandler({ key: 'ArrowRight', keyName: 'rightArrow' });
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(keyboardController.getVisibleRowIndex(), 1, 'Focused row index');
         assert.equal(keyboardController.getVisibleColumnIndex(), 0, 'Focused column index');
@@ -1286,7 +1286,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1298,7 +1298,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         // act
         keyboardController._leftRightKeysHandler({ key: 'ArrowRight', keyName: 'rightArrow' });
         keyboardController._upDownKeysHandler({ key: 'ArrowDown', keyName: 'downArrow' });
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(keyboardController.getVisibleRowIndex(), 3, 'Focused row index');
         assert.equal(keyboardController.getVisibleColumnIndex(), 0, 'Focused column index');
@@ -1345,7 +1345,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1401,7 +1401,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1456,7 +1456,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const keyboardController = this.getController('keyboardNavigation');
         keyboardController._focusedView = this.gridView.getView('rowsView');
@@ -1504,10 +1504,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1564,10 +1564,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 2)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1613,10 +1613,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1684,10 +1684,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1749,10 +1749,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1763,7 +1763,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 1, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
@@ -1771,7 +1771,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.ok(this.editingController.isEditing(), 'Is editing');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 1, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 1, 'FocusedColumnIndex');
@@ -1818,10 +1818,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1832,7 +1832,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 1, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 1, 'FocusedColumnIndex');
@@ -1879,10 +1879,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1893,7 +1893,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 1, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
@@ -1901,7 +1901,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.ok(this.editingController.isEditing(), 'Is editing');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 2, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
@@ -1948,10 +1948,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -1962,7 +1962,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 2, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
@@ -2004,10 +2004,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -2018,7 +2018,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 2, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 1, 'FocusedColumnIndex');
@@ -2060,10 +2060,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -2074,7 +2074,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 1, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
@@ -2082,7 +2082,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.ok(this.editingController.isEditing(), 'Is editing');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 2, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 1, 'FocusedColumnIndex');
@@ -2121,10 +2121,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 2)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -2135,7 +2135,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(keyboardController.getColumnIndex(), 2, 'FocusedColumnIndex');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 1, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 2, 'FocusedColumnIndex');
@@ -2143,7 +2143,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.ok(this.editingController.isEditing(), 'Is editing');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 2, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
@@ -2182,10 +2182,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 2)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -2196,7 +2196,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(keyboardController.getColumnIndex(), 2, 'FocusedColumnIndex');
         // act, assert
         this.triggerKeyDown('enter', false, false, rowsView.getRow(1).find('td:focus'));
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(keyboardController.isCellFocusType(), 'Cell focus type');
         assert.equal(keyboardController.getVisibleRowIndex(), 2, 'Focused row index');
         assert.equal(keyboardController.getColumnIndex(), 0, 'FocusedColumnIndex');
@@ -2230,7 +2230,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const keyboardController = this.getController('keyboardNavigation');
         keyboardController._focusedView = this.getView('rowsView');
@@ -2270,7 +2270,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const keyboardController = this.getController('keyboardNavigation');
         keyboardController._focusedView = this.getView('rowsView');
@@ -2298,12 +2298,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const keyboardController = this.getController('keyboardNavigation');
         keyboardController._focusedView = this.getView('rowsView');
         keyboardController.focus(null);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedCellChangingCount, 1, 'onFocusedCellChanging fires count');
@@ -2321,12 +2321,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const keyboardController = this.getController('keyboardNavigation');
         keyboardController._focusedView = this.getView('rowsView');
         keyboardController.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedCellChangingCount, 1, 'onFocusedCellChanging fires count');
@@ -2366,11 +2366,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.getController('keyboardNavigation').getVisibleRowIndex(), 1, 'Focused row index is 1');
         assert.equal(focusedRowChangingCount, 1, 'onFocusedRowChanging fires count');
@@ -2407,7 +2407,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         const rowsView = this.gridView.getView('rowsView');
@@ -2452,7 +2452,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -2512,7 +2512,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         // act
         keyboardController._upDownKeysHandler({ key: 'ArrowUp', keyName: 'upArrow' });
         $scrollContainer.trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.getController('keyboardNavigation').getVisibleRowIndex(), 19, 'Focused row index is 19');
@@ -2550,7 +2550,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         const rowsView = this.gridView.getView('rowsView');
@@ -2598,10 +2598,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -2662,10 +2662,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(this.getCellElement(1, 2)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -2726,11 +2726,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(focusedRowChangingCount, 1, 'focusedRowChanging count');
         assert.equal(focusedRowChangedCount, 0, 'focusedRowChanged count');
@@ -2826,18 +2826,18 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(this.getCellElement(0, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(onFocusedRowChangedSpy.callCount, 1, 'focusedRowChanged count');
         assert.equal(this.getController('keyboardNavigation').getVisibleRowIndex(), 0, 'Focused row index is 1');
 
         this.data.reverse();
         this.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(onFocusedRowChangedSpy.callCount, 2, 'focusedRowChanged count');
@@ -2876,11 +2876,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(focusedCellChangedCount, 0, 'onFocusedCellChanged fires count');
 
@@ -2931,14 +2931,14 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         rowsView.resize();
         const scrollable = rowsView.getScrollable();
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         scrollable.scrollBy({ y: 400 });
-        that.clock.tick();
+        that.clock.tick(10);
         const visibleRow = that.getVisibleRows()[0];
         $(that.getCellElement(0, 1)).trigger(CLICK_EVENT);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(focusedCellChangedCount, 1, 'onFocusedCellChanged fires count');
@@ -2985,11 +2985,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         rowsView.height(100);
         rowsView.resize();
         const scrollable = rowsView.getScrollable();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         scrollable.scrollBy({ y: 400 });
-        that.clock.tick();
+        that.clock.tick(10);
         const visibleRow = that.getVisibleRows()[0];
         $(that.getCellElement(0, 1)).trigger(CLICK_EVENT);
         // assert
@@ -3036,7 +3036,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -3084,7 +3084,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
@@ -3131,7 +3131,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -3139,7 +3139,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         $(this.getCellElement(4, 1)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.getController('keyboardNavigation').getVisibleColumnIndex(), 1, 'Focused column index');
         assert.equal(focusedColumnChangingCount, 1, 'onFocusedCellChanging fires count');
@@ -3168,7 +3168,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -3176,7 +3176,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         $(this.getCellElement(4, 1)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.getController('keyboardNavigation').getVisibleColumnIndex(), 1, 'Focused column index');
         assert.equal(focusedColumnChangingCount, 1, 'onFocusedCellChanging fires count');
@@ -3201,7 +3201,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -3209,7 +3209,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         $(this.getCellElement(1, 1)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(focusedColumnChangingCount, 1, 'onFocusedCellChanging fires count');
         assert.equal(focusedColumnChangedCount, 1, 'focusedColumnChangedCount fires count');
@@ -3242,7 +3242,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.option('focusedRowEnabled', true);
@@ -3287,7 +3287,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const rowsView = this.gridView.getView('rowsView');
@@ -3326,7 +3326,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const rowsView = this.gridView.getView('rowsView');
@@ -3370,7 +3370,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const rowsView = this.gridView.getView('rowsView');
@@ -3432,12 +3432,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         loadSpy.reset();
         this.getController('columns').changeSortOrder(2, 'asc');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const focusedRowIndex = this.option('focusedRowIndex');
@@ -3487,7 +3487,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         };
         rowsView.height(100);
         this.gridView.component.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(rowsView.getRow(4).hasClass('dx-row-focused'), 'Focused row');
@@ -3527,7 +3527,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -3568,7 +3568,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -3595,7 +3595,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -3609,7 +3609,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.addRow();
         this.addRow();
         $(this.getRowElement(0)).find('.dx-texteditor-input').trigger(pointerEvents.up).click();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getRowElement(0)).find('.dx-texteditor-input').is(':focus'), 'input is focused');
@@ -3637,12 +3637,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
         this.gridView.render($('#container'));
         const rowsView = this.gridView.getView('rowsView');
-        this.clock.tick();
+        this.clock.tick(10);
 
         try {
             // act
             $(this.getCellElement(1, 1)).trigger(CLICK_EVENT);
-            this.clock.tick();
+            this.clock.tick(10);
             // assert
             assert.equal(focusedRowChangingCount, 1, 'focusedRowChangingCount');
             assert.notOk($(rowsView.getRow(0)).hasClass('dx-row-focused'), 'no focused row');
@@ -3670,7 +3670,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(this.getCellElement(0, 0)).removeAttr('tabindex');
@@ -3699,11 +3699,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(this.getCellElement(0, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(focusedCellChangingCount, 1, 'onFocusedCellChanging fires count');
@@ -3729,7 +3729,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         const keyboardController = this.getController('keyboardNavigation');
@@ -3737,7 +3737,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         $(this.getCellElement(0, 1)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(focusedCellChangingCount, 1, 'onFocusedCellChanging fires count');
     });
@@ -3768,12 +3768,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.option('focusedRowKey', 'Mark2');
         this.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.pageIndex(), 1, 'pageIndex 1');
@@ -3781,7 +3781,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(this.option('focusedRowKey'), 'Mark2', 'FocusedRowkey');
 
         this.pageIndex(2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.pageIndex(), 2, 'pageIndex 2');
@@ -3789,7 +3789,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         assert.equal(this.option('focusedRowKey'), 'Mark2', 'FocusedRowkey');
 
         this.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.pageIndex(), 1, 'pageIndex 1');
@@ -3828,7 +3828,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.option('focusedRowIndex', 0);
 
@@ -3839,7 +3839,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         this.pageIndex(3);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 0, 'focusedRowIndex');
@@ -3848,7 +3848,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         this.pageIndex(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 0, 'focusedRowIndex');
@@ -3893,7 +3893,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         this.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -3932,9 +3932,9 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         $(this.getCellElement(1, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
         this.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -3975,7 +3975,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         this.navigateToRow('Mark3');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 0, 'FocusedRowIndex');
@@ -4014,7 +4014,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         this.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -4050,14 +4050,14 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         $(rowsView.getCellElement(1, 1)).trigger(pointerEvents.down);
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.option('focusedRowIndex'), undefined, 'No focusedRowIndex');
         assert.equal(this.option('focusedRowKey'), undefined, 'No focusedRowKey');
 
         // act
         $(rowsView.getCellElement(1, 1)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(this.option('focusedRowIndex'), 1, 'focusedRowIndex');
         assert.equal(this.option('focusedRowKey'), 'Ben', 'focusedRowKey');
@@ -4094,7 +4094,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $cell = $(this.getCellElement(1, 1));
@@ -4110,7 +4110,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
                 .trigger(pointerEvents.down)
                 .trigger(clickEvent.name);
         }
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedRowChangingCounter, 1, 'focusedRowChangingCounter');
@@ -4157,7 +4157,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
         rowsView.height(70);
@@ -4171,14 +4171,14 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
         // act
         scrollTo(this, { y: 1000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.pageIndex(), 5, 'pageIndex');
 
         // act
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const newRowIndex = rowsView.getTopVisibleItemIndex();
@@ -4188,7 +4188,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
         // act
         onFocusedRowChangedSpy.reset();
         $(this.getRowElement(newRowIndex)).find('.dx-texteditor-input').trigger(pointerEvents.down).click();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(onFocusedRowChangedSpy.callCount, 0, 'onFocusedRowChanged event is not called for a new row');
@@ -4244,7 +4244,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
                     // act
                     this.option('focusedRowKey', 3);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.equal(this.option('focusedRowKey'), 3, 'focusedRowKey was changed');
@@ -4297,7 +4297,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
                     // act
                     this.option('focusedRowKey', 3);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.equal(this.option('focusedRowKey'), 3, 'focusedRowKey was changed');
@@ -4320,7 +4320,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             // act
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
 
@@ -4347,11 +4347,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             };
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             $(this.getCellElement(1, 1)).focus().trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(selectionChangedFiresCount, 1, 'selectionChangedFiresCount');
@@ -4386,7 +4386,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
 
@@ -4425,7 +4425,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
 
@@ -4552,7 +4552,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.gridView.render($('#container'));
 
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(dataErrors.length, 1, 'One error');
@@ -4585,12 +4585,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.option('focusedRowKey', 'Dan');
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(dataErrors.length, 1, 'One error');
@@ -4623,12 +4623,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.option('focusedRowKey', 'Dan');
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(dataErrors.length, 0, 'No error');
@@ -4656,7 +4656,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.gridView.render($('#container'));
 
             // act
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(dataErrors.length, 0, 'No error');
@@ -4699,7 +4699,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
 
@@ -4749,13 +4749,13 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.gridView.render($('#container'));
             rowsView.height(140);
             rowsView.resize();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 6, 'FocusedRowIndex');
 
             this.navigateToRow('Alice');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 6, 'FocusedRowIndex');
@@ -4786,12 +4786,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.dataController.filter('team', '=', 'public');
             this.dataController.load();
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
             const visibleRows = this.dataController.getVisibleRows();
@@ -4827,7 +4827,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 3, 'focusedRowIndex');
@@ -4836,7 +4836,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             // act
             this.dataController.filter('team', '=', 'internal0');
             this.dataController.load();
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
             const visibleRows = this.dataController.getVisibleRows();
@@ -4874,7 +4874,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
             const keyboardController = this.getController('keyboardNavigation');
@@ -4914,7 +4914,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
 
@@ -4924,7 +4924,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             // act
             this.collapseRow(['internal0']);
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.getVisibleRows().length, 7, 'visible rows count');
@@ -4959,7 +4959,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
 
@@ -4969,7 +4969,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             // act
             this.collapseRow(['internal0']);
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.getVisibleRows().length, 7, 'visible rows count');
@@ -5025,7 +5025,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.pageIndex(), 0, 'PageIndex is 0');
@@ -5075,7 +5075,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             $rowsView = $(this.gridView.getView('rowsView').element());
 
@@ -5086,7 +5086,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             // act
             this.getController('columns').changeSortOrder(2, 'asc');
-            this.clock.tick();
+            this.clock.tick(10);
             // assert
             $rowsView = $(this.gridView.getView('rowsView').element());
             const focusedRowIndex = this.option('focusedRowIndex');
@@ -5118,7 +5118,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.pageIndex(), 2, 'PageIndex is 2');
@@ -5152,7 +5152,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.pageIndex(), 0, 'PageIndex is 0');
@@ -5175,12 +5175,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             const keyboardController = this.getController('keyboardNavigation');
             keyboardController._focusedView = this.getView('rowsView');
             keyboardController.focus(null);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(focusedCellChangingCount, 0, 'No focusedCellChanging event');
@@ -5199,12 +5199,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             const keyboardController = this.getController('keyboardNavigation');
             keyboardController._focusedView = this.getView('rowsView');
             keyboardController.focus(null);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(focusedCellChangingCount, 0, 'onFocusedCellChanging fires count');
@@ -5242,7 +5242,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(focusedRowChangedCount, 1, 'onFocusedRowChanged fires count');
@@ -5269,11 +5269,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             };
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.option('focusedRowIndex', 1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(focusedRowChangedCount, 1, 'onFocusedRowChanged fires count');
@@ -5309,11 +5309,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             };
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.option('focusedRowIndex', 1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(focusedRowChangedCount, 1, 'onFocusedRowChanged fires count');
@@ -5359,17 +5359,17 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             const rowsView = this.gridView.getView('rowsView');
             rowsView.height(40);
             rowsView.resize();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // arrange, act
             const scrollable = this.getScrollable();
 
             scrollable.scrollBy(80);
-            this.clock.tick();
+            this.clock.tick(10);
             scrollable.scrollBy(80);
-            this.clock.tick();
+            this.clock.tick(10);
             this.option('focusedRowKey', 8);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowKey'), 8, 'Focused row key');
@@ -5395,7 +5395,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const rowsView = this.gridView.getView('rowsView');
@@ -5422,7 +5422,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             $(this.getRowElement(1))
@@ -5430,7 +5430,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
                 .focus();
             $(this.getCellElement(1, 1))
                 .trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.notOk(rowsViewWrapper.getFocusOverlay().isVisible(), 'has no focus overlay');
@@ -5461,7 +5461,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             const keyboardController = this.getController('keyboardNavigation');
 
@@ -5469,7 +5469,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             assert.equal(keyboardController.getVisibleRowIndex(), -1, 'Focused row index');
 
             this.navigateToRow('Zeb');
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(this.pageIndex(), 2, 'Page index');
             assert.equal(keyboardController.getVisibleRowIndex(), -1, 'Focused row index');
@@ -5507,7 +5507,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             const keyboardController = this.getController('keyboardNavigation');
 
@@ -5515,7 +5515,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             assert.equal(keyboardController.getVisibleRowIndex(), -1, 'Focused row index');
 
             this.navigateToRow('Zeb');
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(this.pageIndex(), 1, 'Page index');
             assert.equal(keyboardController.getVisibleRowIndex(), -1, 'Focused row index');
@@ -5548,7 +5548,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             const keyboardController = this.getController('keyboardNavigation');
 
@@ -5556,7 +5556,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             assert.equal(keyboardController.getVisibleRowIndex(), -1, 'Focused row index');
 
             this.navigateToRow('Zeb');
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(this.pageIndex(), 2, 'Page index');
             assert.equal(keyboardController.getVisibleRowIndex(), -1, 'Focused row index');
@@ -5595,10 +5595,10 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             const rowsView = this.gridView.getView('rowsView');
             rowsView.height(100);
             rowsView.resize();
-            this.clock.tick();
+            this.clock.tick(10);
 
             this.getController('focus').navigateToRow('Smith');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.notOk(rowsView.getRow(4).hasClass('dx-row-focused'), 'Focused row');
@@ -5637,7 +5637,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             const rowsView = this.gridView.getView('rowsView');
             rowsView.height(100);
             rowsView.resize();
-            this.clock.tick();
+            this.clock.tick(10);
 
             this.getController('focus').navigateToRow('Smith');
 
@@ -5664,11 +5664,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.gridView.component.editRow(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const rowsView = this.gridView.getView('rowsView');
 
@@ -5697,13 +5697,13 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.editCell(1, 1);
             const rowsView = this.gridView.getView('rowsView');
             $(rowsView.getRow(1).find('td').eq(1)).trigger(pointerEvents.up).click();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(rowsView.getRow(1).hasClass('dx-row-focused'), 'Row 1 is focused');
@@ -5724,7 +5724,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.gridView.render($('#container'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.notOk(this.isRowFocused('Alex'), 'isRowFocused true');
@@ -5747,7 +5747,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             try {
             // act
@@ -5780,11 +5780,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.expandRow('Dan');
-            this.clock.tick();
+            this.clock.tick(10);
             const rowsView = this.gridView.getView('rowsView');
             $(rowsView.getRow(2).find('td').first()).trigger(pointerEvents.up).click();
 
@@ -5808,7 +5808,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rowsView = this.gridView.getView('rowsView');
@@ -5859,7 +5859,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rowsView = this.gridView.getView('rowsView');
@@ -5885,7 +5885,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rowsView = this.gridView.getView('rowsView');
@@ -5908,7 +5908,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.getController('data')._dataSource.operationTypes = () => undefined;
@@ -5935,11 +5935,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.deleteRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowKey'), 'Dan', 'focusedRowKey was changed to the next row');
@@ -5959,11 +5959,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.deleteRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowKey'), 'Dan', 'focusedRowKey was changed to the next row');
@@ -5985,11 +5985,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.deleteRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowKey'), null, 'focusedRowKey was reset');
@@ -6011,11 +6011,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             this.setupModule();
             this.gridView.render($('#container'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.pageIndex(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 1, 'focusedRowIndex is normalized');
@@ -6050,9 +6050,9 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             this.setupModule();
 
             d.resolve(items, { totalCount: 8 });
-            this.clock.tick();
+            this.clock.tick(10);
             d.resolve(items);
-            this.clock.tick();
+            this.clock.tick(10);
 
             this.gridView.render($('#container'));
             const rowsView = this.gridView.getView('rowsView');
@@ -6105,12 +6105,12 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             rowsView.height(100);
             rowsView.resize();
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.option('autoNavigateToFocusedRow', false);
             this.option('focusedRowKey', 'Mark2');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), -1, 'FocusedRowIndex');
@@ -6147,7 +6147,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             rowsView.resize();
 
             // act
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -6182,11 +6182,11 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             rowsView.height(100);
             rowsView.resize();
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.option('focusedRowIndex', 1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -6223,7 +6223,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             rowsView.resize();
 
             // act
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), 1, 'FocusedRowIndex');
@@ -6266,7 +6266,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             // act
             this.pageIndex(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), -1, 'FocusedRowIndex');
@@ -6340,7 +6340,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             // act
             this.navigateToRow('Mark2');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), -1, 'FocusedRowIndex');
@@ -6382,7 +6382,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
 
             // act
             this.navigateToRow('Mark2');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.option('focusedRowIndex'), -1, 'FocusedRowIndex');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/gridView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/gridView.tests.js
@@ -1729,7 +1729,7 @@ QUnit.module('Synchronize columns', {
         assert.ok(!testElement.find('.dx-datagrid-scroll-container').length, 'no column headers');
         assert.ok(testElement.find('.dx-scrollable-content').children().width() > 300, 'horizontal scroller is shown');
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(testElement.find('.dx-scrollable-container').scrollLeft(), 100);
     });
 
@@ -1899,7 +1899,7 @@ QUnit.module('Synchronize columns', {
 
         // act
         that.addRow();
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.notOk($(that.getCellElement(0, 'field4'))[0].style.width, 'the fourth column has no width');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/grouping.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/grouping.integration.tests.js
@@ -116,17 +116,17 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 autoExpandAll: false
             }
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow([0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.expandRow([0, 0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.columnOption('cityId', 'groupIndex', undefined);
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
 
@@ -241,16 +241,16 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         }).dxDataGrid('instance');
         const $dataGrid = $(dataGrid.element());
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal($dataGrid.find('.dx-toolbar-item-invisible').length, 4, '4 toolbar items are hidden, group panel has a long message');
 
         dataGrid.columnOption('field2', 'groupIndex', 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($dataGrid.find('.dx-toolbar-item-invisible').length, 0, 'all toolbar items are visible, group panel has a group with short name');
 
         dataGrid.clearGrouping();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal($dataGrid.find('.dx-toolbar-item-invisible').length, 4, '4 toolbar items are hidden after clear grouping');
     });
 
@@ -413,7 +413,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         const adaptiveColumnsController = instance.getController('adaptiveColumns');
         let $visibleColumns;
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $visibleColumns = $(instance.$element().find('.dx-header-row td:not(.dx-datagrid-group-space)'));
 
@@ -425,7 +425,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         $('#container').width(150);
         instance.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
         $visibleColumns = $(instance.$element().find('.dx-header-row td:not(.dx-datagrid-group-space)'));
 
         // assert
@@ -485,7 +485,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const columnController = dataGrid.getController('columns');
 
@@ -517,14 +517,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }, 'field2']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const columnController = dataGrid.getController('columns');
 
         // act
         columnController.moveColumn(0, 1, 'group', 'headers');
         cellTemplateCallCount = 0;
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(cellTemplateCallCount, 2, 'cellTemplate call count');
@@ -720,7 +720,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const cell0_0 = $(dataGrid.getCellElement(0, 0)).get(0);
         const cell1_1 = $(dataGrid.getCellElement(1, 1)).get(0);
@@ -729,7 +729,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.getDataSource().store().push([
             { type: 'update', key: 1, data: { Count: 100 } }
         ]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($(dataGrid.getCellElement(0, 0)).get(0), cell0_0, 'expand cell in the first row is not re-rendered');
@@ -753,7 +753,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
         const dataGrid = createDataGrid(options);
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         options.dataSource.store().on('loading', loadingSpy);
 
@@ -764,7 +764,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         options.paging = {};
 
         dataGrid.option(options);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(loadingSpy.callCount, 1, 'loading called once');
@@ -782,12 +782,12 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             columns: [{ dataField: 'field1', showWhenGrouped: true }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $dataGrid.dxDataGrid('instance').columnOption('field1', 'groupIndex', 0);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const cols = $dataGrid.find('colgroup').first().children();
@@ -804,7 +804,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         dataGrid.option('dataSource', [{ a: 1, b: 2 }]);
         dataGrid.option('columns', ['a', { dataField: 'b', groupIndex: 0 }]);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleRows()[0].rowType, 'group', 'first row type is group');
@@ -821,11 +821,11 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption(0, { groupIndex: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $groupPanelItems = $('#dataGrid').find('.dx-group-panel-item');
@@ -849,12 +849,12 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const toolbar = dataGrid.$element().find('.dx-toolbar').dxToolbar('instance');
         toolbar.option('items', toolbar.option('items'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $groupPanelItems = $('#dataGrid').find('.dx-toolbar .dx-datagrid-drag-action');
@@ -906,12 +906,12 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             dataSource: [{ field1: '1', field2: '2' }, { field1: '3', field2: '4' }, { field1: '5', field2: '6' }]
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption(0, { groupIndex: 0 });
         dataGrid.option('grouping.autoExpandAll', false);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $groupPanelItems = $('#dataGrid').find('.dx-group-panel-item');
@@ -969,17 +969,17 @@ QUnit.module('API methods', baseModuleConfig, () => {
         const dataGrid = $dataGrid.dxDataGrid('instance');
         const columnController = dataGrid.getController('columns');
 
-        this.clock.tick();
+        this.clock.tick(10);
         // act
         const gridInitialWidth = $dataGrid.outerWidth();
 
         columnController.moveColumn(2, 0, 'headers', 'group');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const gridWidthAfterGrouping = $dataGrid.outerWidth();
 
         columnController.moveColumn(0, 1, 'group', 'headers');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const gridWidthAfterUngrouping = $dataGrid.outerWidth();
 
@@ -999,12 +999,12 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ field1: 'test1', field2: 'test2' }, { field1: 'test3', field2: 'test4' }]
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
         calculateCellValue.reset();
 
         // act
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(calculateCellValue.getCall(0).args[0], { field1: 'test1', field2: 'test2' }, 'calculateCellValue - first call arguments');
@@ -1018,11 +1018,11 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ field1: 'test1', field2: 'test2' }, { field1: 'test3', field2: 'test4' }]
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.columnOption(0, 'groupIndex'), 0, 'groupIndex was not reset');
@@ -1036,17 +1036,17 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ field1: 'test1', field2: 'test2' }, { field1: 'test3', field2: 'test4' }]
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption(0, 'groupIndex', undefined);
         dataGrid.columnOption(1, 'sortOrder', undefined);
 
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.columnOption(0, 'groupIndex'), 0, 'groupIndex was returned to default');
@@ -1150,7 +1150,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
                 assert.step(`rowExpanded rowCount: ${info.rowCount}, groupRow: ${info.groupRow}, dataRow: ${info.dataRow}`);
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(['value1']).done(() => {
@@ -1158,7 +1158,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
             assert.step(`done rowCount: ${info.rowCount}, groupRow: ${info.groupRow}, dataRow: ${info.dataRow}`);
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.verifySteps([
             'rowExpanded rowCount: 2, groupRow: true, dataRow: true',
@@ -1187,12 +1187,12 @@ QUnit.module('API methods', baseModuleConfig, () => {
             groupPanel: { visible: true },
             columnChooser: { enabled: true }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         const toolbarItems = $('.dx-toolbar-button').length;
         // act
         dataGrid.repaint();
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal($('.dx-toolbar-button').length, toolbarItems);
     });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -163,7 +163,7 @@ QUnit.module('Header Filter dataController', {
         dataSource.load().done(function(data) {
             items = data;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(items, [{ text: 'test1', value: 1 }]);
@@ -203,7 +203,7 @@ QUnit.module('Header Filter dataController', {
         dataSource.load().done(function(data) {
             items = data;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(items, [{ text: 'blank', value: null }, { field: 1, text: 'test1', value: 1 }]);
@@ -244,7 +244,7 @@ QUnit.module('Header Filter dataController', {
         dataSource.load().done(function(data) {
             items = data;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(items, [{ text: 'test1', value: 1 }, { text: 'test2', value: 2 }]);
@@ -2288,7 +2288,7 @@ QUnit.module('Header Filter', {
 
             // act
             that.headerFilterController.showHeaderFilterMenu(0);
-            that.clock.tick();
+            that.clock.tick(10);
 
             // assert
             $popupContent = that.headerFilterView.getPopupContainer().$content();
@@ -3909,7 +3909,7 @@ QUnit.module('Header Filter with real columnsController', {
 
         // act
         that.headerFilterController.getDataSource(column).load({ userData: {} });
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.deepEqual(loadOptions.customQueryParams, { param: 'test' }, 'custom query param');
@@ -3933,7 +3933,7 @@ QUnit.module('Header Filter with real columnsController', {
 
         // act
         const dataSource = that.headerFilterController.getDataSource(column);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal(dataSource.group.length, 1, 'one group parameter');
@@ -4035,7 +4035,7 @@ QUnit.module('Header Filter with real columnsController', {
         dataSourceOptions.load({ group: dataSourceOptions.group }).done(function(data) {
             items = data;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(getTreeText(items), ['1992', 'September', '6', '12', '13'], 'loaded data');
@@ -4098,7 +4098,7 @@ QUnit.module('Header Filter with real columnsController', {
                 }).done(function(data) {
                     items = data;
                 });
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.deepEqual(getTreeText(items), [
@@ -4156,7 +4156,7 @@ QUnit.module('Header Filter with real columnsController', {
         dataSourceOptions.load({}).done(function(data) {
             items = data;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(getTreeText(items), [
@@ -4402,7 +4402,7 @@ QUnit.module('Header Filter with real columnsController', {
             // act
             const list = $popupContent.find('.dx-list').dxList('instance');
             list.scrollBy(100);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             $listItemElements = $popupContent.find('.dx-list-item-content');
@@ -4494,7 +4494,7 @@ QUnit.module('Header Filter with real columnsController', {
                 displayExpr: 'value'
             }
         }];
-        
+
         this.options.dataSource = { load: loadSpy };
         this.options.syncLookupFilterValues = true;
         this.options.remoteOperations = { groupPaging: true }
@@ -4505,7 +4505,7 @@ QUnit.module('Header Filter with real columnsController', {
         this.setupDataGrid();
         this.columnHeadersView.render($testElement);
         this.headerFilterView.render($testElement);
-        
+
         // assert
         assert.strictEqual(loadSpy.callCount, 1);
         loadSpy.reset();
@@ -4524,11 +4524,11 @@ QUnit.module('Header Filter with real columnsController', {
         // assert
         assert.strictEqual(loadSpy.callCount, 1);
         loadSpy.reset();
-                
+
         // act
         const list = $popupContent.find('.dx-list').dxList('instance');
         list.option('searchValue', 'value1');
-        
+
         // assert
         $listItemElements = $popupContent.find('.dx-list-item-content');
         assert.equal($listItemElements.length, 1, 'count list item');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.accessibility.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.accessibility.tests.js
@@ -97,7 +97,7 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         this.focusCell(2, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.columnsController.getColumns()[2].type, 'buttons', 'Column type');
@@ -120,14 +120,14 @@ QUnit.module('Keyboard navigation accessibility', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('ArrowRight');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.columnsController.getColumns()[2].type, 'buttons', 'Column type');
         assert.ok($(this.getCellElement(1, 2)).hasClass('dx-focused'), 'cell focused');
 
         this.triggerKeyDown('tab', false, false, $(this.getCellElement(1, 2)));
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     testInDesktop('Focus command elements if row editing', function(assert) {
@@ -135,7 +135,7 @@ QUnit.module('Keyboard navigation accessibility', {
         let counter = 0;
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const _editingCellTabHandler = this.keyboardNavigationController._editingCellTabHandler;
         this.keyboardNavigationController._editingCellTabHandler = (eventArgs, direction) => {
@@ -150,10 +150,10 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         this.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         $(this.getCellElement(1, 1)).focus().trigger('dxclick');
         this.triggerKeyDown('tab', false, false, $(this.getCellElement(1, 1)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('#qunit-fixture').find(':focus').hasClass('dx-link'), 'focused element');
@@ -209,14 +209,14 @@ QUnit.module('Keyboard navigation accessibility', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.focusCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.triggerKeyDown('tab', false, false, $(this.getCellElement(0, 0)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('#qunit-fixture').find(':focus').hasClass('dx-editor-cell'), 'editor cell is focused');
@@ -235,18 +235,18 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         this.editCell(1, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('tab', false, false, $(this.getCellElement(1, 1)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getCellElement(1, 3)).hasClass('dx-focused'), 'cell focused');
 
         // act
         this.editCell(1, 4);
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('tab', false, false, $(this.getCellElement(1, 4)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getCellElement(2, 0)).hasClass('dx-focused'), 'cell focused');
@@ -265,18 +265,18 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         this.editCell(1, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('tab', false, false, $(this.getCellElement(1, 1)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getCellElement(1, 3)).hasClass('dx-focused'), 'cell focused');
 
         // act
         this.editCell(1, 4);
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('tab', false, false, $(this.getCellElement(1, 4)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getCellElement(2, 0)).hasClass('dx-focused'), 'cell focused');
@@ -304,15 +304,15 @@ QUnit.module('Keyboard navigation accessibility', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         $(this.getCellElement(1, 1)).focus().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('tab', false, true, $(this.getCellElement(1, 1)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.getController('editing').isEditing(), 'Is editing');
@@ -348,13 +348,13 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         fireKeyDown(headerPanelWrapper.getGroupPanelItem(0), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(keyDownFiresCount, 1, 'keyDownFiresCount');
 
         // act
         fireKeyDown(headerPanelWrapper.getGroupPanelItem(0), ' ');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(keyDownFiresCount, 2, 'keyDownFiresCount');
     });
@@ -377,7 +377,7 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         fireKeyDown(headersWrapper.getHeaderItem(0, 0), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.getController('data').getDataSource().sort(), [{ selector: 'name', desc: false }], 'Sorting');
@@ -385,7 +385,7 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         fireKeyDown(headersWrapper.getHeaderItem(0, 0), ' ');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.getController('data').getDataSource().sort(), [{ selector: 'name', desc: true }], 'Sorting');
@@ -415,7 +415,7 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         fireKeyDown(headersWrapper.getHeaderFilterItem(0, 0), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(headerFilterShownCount, 1, 'headerFilterShownCount');
@@ -423,7 +423,7 @@ QUnit.module('Keyboard navigation accessibility', {
 
         // act
         fireKeyDown(headersWrapper.getHeaderFilterItem(0, 0), ' ');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(headerFilterShownCount, 2, 'headerFilterShownCount');
@@ -453,19 +453,19 @@ QUnit.module('Keyboard navigation accessibility', {
         };
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         pagerWrapper.getPagerPageElement(0).focus();
 
         // act
         fireKeyDown(pagerWrapper.getPagerPageElement(0), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(keyDownFiresCount, 1, 'keyDownFiresCount');
 
         // act
         fireKeyDown(pagerWrapper.getPagerPageElement(0), ' ');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(keyDownFiresCount, 2, 'keyDownFiresCount');
     });
@@ -489,9 +489,9 @@ QUnit.module('Keyboard navigation accessibility', {
         // act
         headersWrapper.getHeaderFilterItem(0, 0).focus();
         fireKeyDown(headersWrapper.getHeaderFilterItem(0, 0), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.headerFilterView.hideHeaderFilterMenu();
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(headersWrapper.getHeaderFilterItem(0, 0).is(':focus'), 'Header filter icon focus state');
     });
@@ -517,14 +517,14 @@ QUnit.module('Keyboard navigation accessibility', {
         // act
         filterPanelWrapper.getIconFilter().focus();
         fireKeyDown(filterPanelWrapper.getIconFilter(), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(filterBuilderShownCount, 1, 'filterBuilderShownCount');
 
         // act
         filterPanelWrapper.getPanelText().focus();
         fireKeyDown(filterPanelWrapper.getPanelText(), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(filterBuilderShownCount, 2, 'filterBuilderShownCount');
 
@@ -534,7 +534,7 @@ QUnit.module('Keyboard navigation accessibility', {
         assert.deepEqual(this.options.filterValue, ['name', '=', 'Alex'], 'filterValue');
         // act
         fireKeyDown(filterPanelWrapper.getClearFilterButton(), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.options.filterValue, null, 'filterValue');
@@ -562,7 +562,7 @@ QUnit.module('Keyboard navigation accessibility', {
         // act
         pagerWrapper.getPagerPageSizeElement(2).trigger('focus');
         fireKeyDown($('#qunit-fixture').find(':focus'), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(pagerWrapper.isFocusedState(), 'Pager focus state');
         assert.ok(pagerWrapper.getPagerPageSizeElement(2).is(':focus'), 'Page size item focus state');
@@ -570,7 +570,7 @@ QUnit.module('Keyboard navigation accessibility', {
         // act
         pagerWrapper.getPagerPageElement(1).trigger('focus');
         fireKeyDown($('#qunit-fixture').find(':focus'), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(pagerWrapper.isFocusedState(), 'Pager focus state');
         assert.ok(pagerWrapper.getPagerPageElement(1).is(':focus'), 'Page choozer item focus state');
@@ -580,7 +580,7 @@ QUnit.module('Keyboard navigation accessibility', {
         // act
         pagerWrapper.getPrevButtonsElement().trigger('focus');
         fireKeyDown($('#qunit-fixture').find(':focus'), 'Space');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(pagerWrapper.isFocusedState(), 'Pager focus state');
         assert.ok(pagerWrapper.getPrevButtonsElement().is(':focus'), 'Page prev button focus state');
@@ -590,7 +590,7 @@ QUnit.module('Keyboard navigation accessibility', {
         // act
         pagerWrapper.getNextButtonsElement().trigger('focus');
         fireKeyDown($('#qunit-fixture').find(':focus'), 'Space');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(pagerWrapper.isFocusedState(), 'Pager focus state');
         assert.ok(pagerWrapper.getNextButtonsElement().is(':focus'), 'Page next button focus state');
@@ -632,7 +632,7 @@ QUnit.module('Keyboard navigation accessibility', {
         // act
         headerPanelWrapper.getGroupPanelItem(1).focus();
         fireKeyDown(headerPanelWrapper.getGroupPanelItem(1), 'enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(headerPanelWrapper.getElement().hasClass('dx-state-focused'), 'Group panel focus state');
@@ -783,7 +783,7 @@ QUnit.module('Keyboard navigation accessibility', {
         // arrange
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGridWrapper.headerPanel.getGroupPanelItem(0).focus();
@@ -849,7 +849,7 @@ QUnit.module('Keyboard navigation accessibility', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGridWrapper.headers.getHeaderItem(0, 0).focus();
@@ -893,7 +893,7 @@ QUnit.module('Keyboard navigation accessibility', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(document).trigger(createEvent('visibilitychange', { visibilityState: 'visible' }));

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.customization.tests.js
@@ -120,14 +120,14 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('2');
         this.clock.tick(525);
         keyboardMock($('#qunit-fixture').find(':focus')[0]).keyDown('downArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal($('.dx-selectbox-popup').length, 1, 'drop down created');
         assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { columnIndex: 2, rowIndex: 1 }, 'focusedCellPosition');
         keyboardMock($('#qunit-fixture').find(':focus')[0]).keyDown('enter');
 
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $input = $('.dx-row .dx-texteditor-container input').eq(0);
         assert.equal($input.length, 0, 'input');
@@ -140,11 +140,11 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('1');
         this.clock.tick(525);
         keyboardMock($('#qunit-fixture').find(':focus')[0]).keyDown('downArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         keyboardMock($('#qunit-fixture').find(':focus')[0]).keyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('upArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $input = $('.dx-row .dx-texteditor-container input').eq(0);
@@ -179,7 +179,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(this.keyboardNavigationController._isFastEditingStarted(), 'Is editing by char key');
@@ -201,7 +201,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is not in editing mode');
@@ -225,7 +225,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -233,7 +233,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -260,11 +260,11 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 1, 'row is editing');
@@ -272,7 +272,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter', undefined, true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -299,7 +299,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -307,7 +307,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -335,7 +335,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -343,7 +343,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -370,11 +370,11 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -382,7 +382,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter', undefined, true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -410,11 +410,11 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -422,7 +422,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter', undefined, true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -449,7 +449,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -457,7 +457,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -487,7 +487,7 @@ QUnit.module('Customize keyboard navigation', {
         this.renderGridView();
 
 
-        this.clock.tick();
+        this.clock.tick(10);
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
@@ -503,7 +503,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changedSpy.callCount, 2, 'changed count');
@@ -529,11 +529,11 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 1, 'row is editing');
@@ -541,7 +541,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter', undefined, true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -568,7 +568,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -576,7 +576,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -603,11 +603,11 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -615,7 +615,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter', undefined, true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -648,7 +648,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -678,7 +678,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -711,7 +711,7 @@ QUnit.module('Customize keyboard navigation', {
         const $input = $('.dx-row .dx-texteditor-input').eq(0);
         $input.val('Test');
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -744,7 +744,7 @@ QUnit.module('Customize keyboard navigation', {
         const $input = $('.dx-row .dx-texteditor-input').eq(0);
         $input.val('Test');
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -765,7 +765,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -776,7 +776,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -799,7 +799,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusFirstCell();
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -810,7 +810,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'row is editing');
@@ -859,7 +859,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         fireKeyDown($editor.find('.dx-texteditor-input'), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -911,7 +911,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         fireKeyDown($editor.find('.dx-texteditor-input'), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -963,7 +963,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         fireKeyDown($editor.find('.dx-texteditor-input'), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1015,7 +1015,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         fireKeyDown($editor.find('.dx-texteditor-input'), 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1067,7 +1067,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1118,7 +1118,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1170,7 +1170,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1221,7 +1221,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1273,7 +1273,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1304,7 +1304,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('D');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'row is editing');
@@ -1350,7 +1350,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('rightArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1400,7 +1400,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('leftArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1450,7 +1450,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('upArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1500,7 +1500,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('downArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $editor = $('.dx-texteditor').eq(0);
 
@@ -1548,7 +1548,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('downArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('A');
         this.clock.tick(25);
 
@@ -1560,7 +1560,7 @@ QUnit.module('Customize keyboard navigation', {
         assert.ok(this.keyboardNavigationController._isFastEditingStarted(), 'Fast editing mode');
 
         this.triggerKeyDown('downArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $editor = $('.dx-texteditor').eq(0);
@@ -1603,7 +1603,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('downArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('1');
         this.clock.tick(25);
 
@@ -1616,7 +1616,7 @@ QUnit.module('Customize keyboard navigation', {
         assert.equal($input.val(), '1', 'input value');
 
         this.triggerKeyDown('upArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $input = $('.dx-row .dx-texteditor-input').eq(0);
@@ -1687,7 +1687,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('rightArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('1');
         this.clock.tick(25);
 
@@ -1699,7 +1699,7 @@ QUnit.module('Customize keyboard navigation', {
         assert.equal($input.val(), '1', 'input value');
 
         this.triggerKeyDown('leftArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $input = $('.dx-row .dx-texteditor-container input').eq(0);
@@ -1737,7 +1737,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('downArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('1');
         this.clock.tick(25);
 
@@ -1750,7 +1750,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('upArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $input = $('.dx-row .dx-numberbox .dx-texteditor-container input').eq(0);
@@ -1788,7 +1788,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('rightArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('1');
         this.clock.tick(25);
 
@@ -1800,7 +1800,7 @@ QUnit.module('Customize keyboard navigation', {
         assert.equal($input.val(), '1', 'input value');
 
         this.triggerKeyDown('leftArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $input = $('.dx-row .dx-texteditor-input').eq(0);
@@ -1843,7 +1843,7 @@ QUnit.module('Customize keyboard navigation', {
         assert.ok(true);
 
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         let $input = $('.dx-texteditor-input').eq(0);
@@ -1854,7 +1854,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         fireKeyDown($input, 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $input = $('.dx-texteditor-input').eq(0);
@@ -1866,10 +1866,10 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('2');
-        this.clock.tick();
+        this.clock.tick(10);
         $input = $('.dx-texteditor-input').eq(0);
         fireKeyDown($input, 'ArrowUp');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $input = $('.dx-texteditor-input').eq(0);
         assert.equal($input.length, 0, 'input');
@@ -1908,7 +1908,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('1');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         let $input = $('.dx-texteditor-input').eq(0);
@@ -1919,7 +1919,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         fireKeyDown($input, 'Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $input = $('.dx-texteditor-input').eq(0);
@@ -1930,10 +1930,10 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('2');
-        this.clock.tick();
+        this.clock.tick(10);
         $input = $('.dx-texteditor-input').eq(0);
         fireKeyDown($input, 'ArrowUp');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $input = $('.dx-texteditor-input').eq(0);
         assert.equal($input.length, 0, 'input');
@@ -1982,7 +1982,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('downArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('1');
         this.clock.tick(25);
 
@@ -1994,9 +1994,9 @@ QUnit.module('Customize keyboard navigation', {
         assert.equal($input.val(), '#_1.00', 'input value');
 
         this.triggerKeyDown('upArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('upArrow');
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('1');
         this.clock.tick(25);
 
@@ -2008,7 +2008,7 @@ QUnit.module('Customize keyboard navigation', {
         assert.equal($input.val(), '#_1.00', 'input value');
 
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         $input = $('.dx-row .dx-texteditor-container input').eq(0);
@@ -2093,7 +2093,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(0, 1);
         this.triggerKeyDown('Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2101,7 +2101,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2109,7 +2109,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2117,7 +2117,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2125,7 +2125,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2213,7 +2213,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(0, 1);
         this.triggerKeyDown('Enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $input = $('.dx-texteditor-input');
@@ -2264,7 +2264,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(0, 1);
         this.triggerKeyDown('Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2272,7 +2272,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2280,7 +2280,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2288,7 +2288,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2296,7 +2296,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2345,7 +2345,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(0, 1);
         this.triggerKeyDown('Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2353,7 +2353,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2361,7 +2361,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2369,7 +2369,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2377,7 +2377,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2425,7 +2425,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(0, 1);
         this.triggerKeyDown('Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2433,7 +2433,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2441,7 +2441,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2449,7 +2449,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2457,7 +2457,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2503,7 +2503,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2522,7 +2522,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('Tab', false, false, $(input).parent());
         input = $('.dx-texteditor-input').get(1);
         this.getController('editing')._focusEditingCell(null, $(input).parent());
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(input, 'Editor input');
         assert.equal(getTextSelection(input), input.value, 'Selection');
@@ -2572,7 +2572,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2589,7 +2589,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('Tab', false, false, $(input).parent());
         input = $('.dx-texteditor-input').get(1);
         this.getController('editing')._focusEditingCell(null, $(input).parent());
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(input, 'Editor input');
         assert.notEqual(getTextSelection(input), input.value, 'Selection');
@@ -2641,7 +2641,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2660,7 +2660,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('Tab', false, false, $(input).parent());
         input = $('.dx-texteditor-input').get(1);
         this.getController('editing')._focusEditingCell(null, $(input).parent());
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(input, 'Editor input');
         assert.equal(getTextSelection(input), input.value, 'Selection');
@@ -2710,7 +2710,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2727,7 +2727,7 @@ QUnit.module('Customize keyboard navigation', {
         this.triggerKeyDown('Tab', false, false, $(input).parent());
         input = $('.dx-texteditor-input').get(1);
         this.getController('editing')._focusEditingCell(null, $(input).parent());
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(input, 'Editor input');
         assert.notEqual(getTextSelection(input), input.value, 'Selection');
@@ -2790,7 +2790,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2798,7 +2798,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(1, 1);
         this.triggerKeyDown('Enter');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2806,7 +2806,7 @@ QUnit.module('Customize keyboard navigation', {
 
         // act
         this.triggerKeyDown('Escape');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.notOk(input, 'Editor input');
@@ -2814,7 +2814,7 @@ QUnit.module('Customize keyboard navigation', {
         // act
         this.focusCell(2, 1);
         this.triggerKeyDown('F2');
-        this.clock.tick();
+        this.clock.tick(10);
         input = $('.dx-texteditor-input').get(0);
         // assert
         assert.ok(input, 'Editor input');
@@ -2842,7 +2842,7 @@ QUnit.module('Customize keyboard navigation', {
             // act
             this.focusCell(0, 0);
             this.triggerKeyDown('a');
-            this.clock.tick();
+            this.clock.tick(10);
             const $input = $('.dx-texteditor-input');
 
             // assert
@@ -2931,7 +2931,7 @@ QUnit.module('Customize keyboard navigation', {
 
             // act
             this.focusCell(0, 0);
-            this.clock.tick();
+            this.clock.tick(10);
             $(this.getCellElement(0, 0)).trigger($.Event('keydown', { key: 'b' }));
             $(this.getCellElement(0, 0)).find('.dx-texteditor-input').first().trigger($.Event('beforeinput'));
             this.clock.tick(300);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardController.tests.js
@@ -389,32 +389,32 @@ QUnit.module('Keyboard controller', {
         // act, assert
         navigationController.setFocusedCellPosition(0, 1);
         callViewsRenderCompleted(this.component._views);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(navigationController._testInteractiveElement && navigationController._testInteractiveElement.is('input'), 'Interactive element is input');
 
         // act, assert
         navigationController.setFocusedCellPosition(0, 2);
         callViewsRenderCompleted(this.component._views);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(navigationController._testInteractiveElement && navigationController._testInteractiveElement.is('textarea'), 'Interactive element is textarea');
 
         // act, assert
         navigationController.setFocusedCellPosition(0, 3);
         callViewsRenderCompleted(this.component._views);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(navigationController._testInteractiveElement && navigationController._testInteractiveElement.is('a'), 'Interactive element is link');
 
         // act, assert
         navigationController.setFocusedCellPosition(0, 4);
         callViewsRenderCompleted(this.component._views);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(navigationController._testInteractiveElement && navigationController._testInteractiveElement.is('select'), 'Interactive element is select');
 
         // T1034050
         // act, assert
         navigationController.setFocusedCellPosition(0, 5);
         callViewsRenderCompleted(this.component._views);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(navigationController._testInteractiveElement && navigationController._testInteractiveElement.is('.dx-checkbox'), 'Interactive element is select');
     });
 
@@ -691,7 +691,7 @@ QUnit.module('Keyboard controller', {
 
         callViewsRenderCompleted(this.component._views);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(!isFocused, 'cell is not focused');
         assert.ok(!$cell.attr('tabindex'), 'tabindex');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
@@ -312,7 +312,7 @@ QUnit.module('Keyboard keys', {
         this.editingController.editRow(0);
         this.editingController.cancelEditData();
         this.editingController.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-datagrid-edit-form input:focus').length, 1);
@@ -718,7 +718,7 @@ QUnit.module('Keyboard keys', {
 
         const isPreventDefaultCalled = this.triggerKeyDown('pageDown').preventDefault;
         $(this.rowsView.getScrollable().container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(that.rowsView.element().is(':focus'), 'rowsview element is focused');
@@ -1036,7 +1036,7 @@ QUnit.module('Keyboard keys', {
         this.focusCell(0, 0);
         this.triggerKeyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(testElement.find('.test .dx-texteditor.dx-state-focused').length === 1);
@@ -1088,11 +1088,11 @@ QUnit.module('Keyboard keys', {
         this.focusCell(0, 1);
         this.triggerKeyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(testElement.find('.test .dx-texteditor.dx-state-focused').length === 1);
         this.triggerKeyDown('tab', false, true, testElement.find('.test .dx-texteditor.dx-state-focused').get(0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 0, 'column index');
@@ -1144,15 +1144,15 @@ QUnit.module('Keyboard keys', {
         // act
         this.focusCell(0, 1);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(testElement.find('.dx-datagrid-edit-form').length, 1, 'editForm exists');
 
         testElement.find('.dx-button').last().focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('tab', false, false, testElement.find(':focus').get(0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $nextCell = testElement.find('.dx-data-row').eq(1).children().eq(0);
@@ -1227,10 +1227,10 @@ QUnit.module('Keyboard keys', {
         this.focusCell(0, 1);
         this.triggerKeyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('tab', false, false, testElement.find('.test .dx-texteditor.dx-state-focused').get(0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 1, 'column index');
@@ -1266,7 +1266,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.keyboardNavigationController._focusedView, 'focused view is initialized');
@@ -1303,7 +1303,7 @@ QUnit.module('Keyboard keys', {
 
         this.addRow();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $focusedEditor = testElement.find('.dx-texteditor.dx-state-focused');
         assert.equal($focusedEditor.length, 1, 'focused editor exists');
@@ -1354,10 +1354,10 @@ QUnit.module('Keyboard keys', {
         this.focusCell(0, 0);
         this.triggerKeyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('tab', false, true, testElement.find('.test .dx-texteditor.dx-state-focused').get(0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 0, 'column index');
@@ -1405,14 +1405,14 @@ QUnit.module('Keyboard keys', {
         this.focusCell(0, 0);
         this.triggerKeyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         this.focusCell(0, 1);
         this.triggerKeyDown('enter');
 
         this.triggerKeyDown('tab', false, true, testElement.find('.dx-row').get(1));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 0, 'column index');
@@ -1463,14 +1463,14 @@ QUnit.module('Keyboard keys', {
         // act
         this.focusCell(0, 0);
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $focusedEditor = testElement.find('.test .dx-texteditor.dx-state-focused input');
         assert.equal($focusedEditor.length, 1, 'focused editor in edit from exists');
 
         const e = $.Event('keydown', { key: 'Enter' });
         $($focusedEditor).trigger(e);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(testElement.find('.test .dx-texteditor.dx-state-focused').length === 0);
@@ -1522,7 +1522,7 @@ QUnit.module('Keyboard keys', {
         this.focusCell(0, 0);
         this.triggerKeyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         const $focusedEditor = testElement.find('.test .dx-texteditor.dx-state-focused input');
@@ -1530,7 +1530,7 @@ QUnit.module('Keyboard keys', {
 
         const e = $.Event('keydown', { key: 'Escape' });
         $($focusedEditor).trigger(e);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(testElement.find('.test .dx-texteditor.dx-state-focused').length === 0);
@@ -1630,7 +1630,7 @@ QUnit.module('Keyboard keys', {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $rowsView = $(this.gridView.getView('rowsView').element());
 
@@ -1663,7 +1663,7 @@ QUnit.module('Keyboard keys', {
         };
         setupModules(this);
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(this.getCellElement(0, 1)).trigger(CLICK_EVENT);
@@ -1862,7 +1862,7 @@ QUnit.module('Keyboard keys', {
             this.triggerKeyDown('rightArrow');
             this.triggerKeyDown('downArrow');
             this.triggerKeyDown('enter');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $input = $('.dx-row input').eq(1);
             assert.ok($input.length, 'input found');
@@ -1874,7 +1874,7 @@ QUnit.module('Keyboard keys', {
             const event = $.Event('change');
             $($input).trigger(event);
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(event.isDefaultPrevented(), false, 'default is not prevented');
@@ -1906,7 +1906,7 @@ QUnit.module('Keyboard keys', {
             this.focusFirstCell();
 
             this.triggerKeyDown('downArrow');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal($('td[tabIndex]').attr('tabIndex'), 0, 'tabIndex of cell');
@@ -1924,7 +1924,7 @@ QUnit.module('Keyboard keys', {
             // act
             const e = $.Event('keydown', { key: 'F8' });
             $($container.find('.dx-datagrid-rowsview')).trigger(e);
-            this.clock.tick();
+            this.clock.tick(10);
 
 
             // assert
@@ -1982,7 +1982,7 @@ QUnit.module('Keyboard keys', {
         this.gridView.render($container);
 
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.getVisibleRows().length, 1, 'row is added');
@@ -2015,7 +2015,7 @@ QUnit.module('Keyboard keys', {
         this.gridView.render($container);
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $input = $('.dx-row input').eq(0);
         assert.ok($input.length, 'input found');
@@ -2026,7 +2026,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('escape', false, false, $container.find('input')[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.editingController.isEditing(), 'editing is not active');
@@ -2047,7 +2047,7 @@ QUnit.module('Keyboard keys', {
         this.gridView.render($container);
         this.focusFirstCell();
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $input = $('.dx-row input').eq(0);
         assert.ok($input.length, 'input found');
@@ -2058,7 +2058,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('escape', false, false, $container.find('input')[0]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.editingController.isEditing(), 'editing is not active');
@@ -2118,7 +2118,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange
         const editor = dataGridWrapper.rowsView.getCell(0, 0).getEditor();
@@ -2133,7 +2133,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('enter', false, false, $input);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(inputBlurFired);
@@ -2162,7 +2162,7 @@ QUnit.module('Keyboard keys', {
             preventDefault: true,
             stopPropagation: false
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'edit row index');
@@ -2170,7 +2170,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'edit row index');
@@ -2211,7 +2211,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         const isPreventDefaultCalled = that.triggerKeyDown('tab', false, false, $('#container').find('input')).preventDefault;
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(that.editingController._getVisibleEditRowIndex(), 1, 'edit row index');
@@ -2270,7 +2270,7 @@ QUnit.module('Keyboard keys', {
         const $groupRow = $('#container').find('.dx-group-row');
 
         $groupRow.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok($groupRow.hasClass('dx-focused'), 'group row is focused');
         assert.ok($('#container .dx-datagrid-focus-overlay').filter(':visible').length, 'focus overlay is visible');
@@ -2310,7 +2310,7 @@ QUnit.module('Keyboard keys', {
         const $groupRows = $('#container').find('.dx-group-row');
 
         $groupRows.eq(0).focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.triggerKeyDown('tab', false, false, $groupRows.eq(0));
@@ -2363,7 +2363,7 @@ QUnit.module('Keyboard keys', {
         // act
         this.gridView.render($('#container'));
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell = $('#container').find('.dx-data-row').eq(0).find('td:nth-child(2)').eq(0);
 
@@ -2372,7 +2372,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('tab', false, false, $cell);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.editingController.isEditing(), 'is editing');
@@ -2531,7 +2531,7 @@ QUnit.module('Keyboard keys', {
         this.gridView.update();
 
         this.editCell(1, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok($('#container .dx-datagrid-focus-overlay').filter(':visible').length, 'focus overlay is visible');
 
@@ -2543,7 +2543,7 @@ QUnit.module('Keyboard keys', {
         // act
         this.keyboardNavigationController._isNeedFocus = false;
         const isPreventDefaultCalled = this.triggerKeyDown('tab', false, false, $lastCell).preventDefault;
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!isPreventDefaultCalled, 'preventDefault is not called');
@@ -2580,7 +2580,7 @@ QUnit.module('Keyboard keys', {
         this.gridView.update();
 
         this.editCell(1, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok($('#container .dx-datagrid-focus-overlay').filter(':visible').length, 'focus overlay is visible');
 
@@ -2589,7 +2589,7 @@ QUnit.module('Keyboard keys', {
         const $lastCell = this.rowsView.element().find('.dx-row').filter(':visible').last().find('td').eq(1);
 
         const isPreventDefaultCalled = this.triggerKeyDown('tab', false, false, $lastCell).preventDefault;
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!isPreventDefaultCalled, 'preventDefault is not called');
@@ -2631,7 +2631,7 @@ QUnit.module('Keyboard keys', {
                 this.gridView.update();
 
                 this.addRow();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 assert.ok($('#container .dx-datagrid-focus-overlay').filter(':visible').length, 'focus overlay is visible');
 
@@ -2639,7 +2639,7 @@ QUnit.module('Keyboard keys', {
 
                 // act
                 this.triggerKeyDown('tab', false, false, $firstCell);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.roughEqual($('#container .dx-datagrid-focus-overlay').outerWidth(), $('#container td').eq(1).outerWidth(), 1.01, 'focus overlay is not visible');
@@ -2666,13 +2666,13 @@ QUnit.module('Keyboard keys', {
         this.focusFirstCell();
 
         this.triggerKeyDown('rightArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('tab', false, false, $('#container').find('input'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.editingController.isEditing(), 'Cell is editing now');
@@ -2698,7 +2698,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('tab', false, false, $('#container').find('input'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.editingController.isEditing(), 'Cell is editing now');
@@ -2723,13 +2723,13 @@ QUnit.module('Keyboard keys', {
         this.focusFirstCell();
 
         this.triggerKeyDown('tab', false, false, $('#container').find('input'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.focusCell(0, 1);
 
         // act
         this.triggerKeyDown('tab', false, false, $('#container').find('.dx-datagrid-rowsview').find('table > tbody').find('td').eq(1).find('td').eq(1));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(this.editingController.isEditing(), 'Cell is editing now');
@@ -2838,7 +2838,7 @@ QUnit.module('Keyboard keys', {
             .focus()
             .trigger(CLICK_EVENT);
         let isPreventDefaultCalled = this.triggerKeyDown('tab', false, true, $cell).preventDefault;
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(isPreventDefaultCalled, 'preventDefault is called');
@@ -2847,7 +2847,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         isPreventDefaultCalled = this.triggerKeyDown('tab', false, true, $('#qunit-fixture').find(':focus')).preventDefault;
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!isPreventDefaultCalled, 'preventDefault is not called');
@@ -2856,7 +2856,7 @@ QUnit.module('Keyboard keys', {
         // act
         const $link1 = $('.link1').first().focus().trigger(pointerEvents.up);
         isPreventDefaultCalled = this.triggerKeyDown('tab', false, true, $link1).preventDefault;
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $cell = $(this.rowsView.getCellElement(0, 0));
@@ -2897,7 +2897,7 @@ QUnit.module('Keyboard keys', {
             const $cell = $(this.rowsView.getCellElement(0, 0));
             $cell.focus().trigger(CLICK_EVENT);
             const isPreventDefaultCalled = this.triggerKeyDown('tab', false, false, $cell).preventDefault;
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(isPreventDefaultCalled, 'preventDefault is called');
@@ -2923,10 +2923,10 @@ QUnit.module('Keyboard keys', {
         this.focusFirstCell();
 
         this.triggerKeyDown('rightArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.editingController.isEditing(), 'Cell is not editing now');
@@ -2950,10 +2950,10 @@ QUnit.module('Keyboard keys', {
         this.focusFirstCell();
 
         this.triggerKeyDown('rightArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('enter');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!this.editingController.isEditing(), 'Cell is not editing now');
@@ -2969,7 +2969,7 @@ QUnit.module('Keyboard keys', {
         this.gridView.render($('#container'));
 
         this.editingController.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $editRow = $('#container').find('.dx-data-row').first();
 
@@ -2978,7 +2978,7 @@ QUnit.module('Keyboard keys', {
         // act
         this.triggerKeyDown('tab', false, false, $('#container').find('input'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'edit row index');
@@ -2993,9 +2993,9 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.editingController.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         const isPreventDefaultCalled = this.triggerKeyDown('tab', false, false, $('#container').find('input'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'edit row index');
@@ -3011,10 +3011,10 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.editingController.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('tab', false, false, $('#container').find('input'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), -1, 'we are do not editing anything');
@@ -3032,10 +3032,10 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.editingController.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('tab', false, false, $('#container').find('input'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'we are do not editing anything');
@@ -3208,7 +3208,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         const isPreventDefaultCalled = this.triggerKeyDown('tab', false, false, $('#container').find('input')).preventDefault;
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 1, 'edit row index');
@@ -3238,7 +3238,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('tab', false, false, this.keyboardNavigationController._getFocusedCell());
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 1, 'edit row index');
@@ -3248,7 +3248,7 @@ QUnit.module('Keyboard keys', {
         isFocusedInput = false;
 
         this.triggerKeyDown('tab', false, false, this.keyboardNavigationController._getFocusedCell());
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(this.editingController._getVisibleEditRowIndex(), 1, 'edit row index');
@@ -3313,7 +3313,7 @@ QUnit.module('Keyboard keys', {
         this.triggerKeyDown('downArrow');
         this.triggerKeyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $groupRow = $container.find('.dx-group-row').first();
@@ -3590,7 +3590,7 @@ QUnit.module('Keyboard keys', {
             this.gridView.render($('#container'));
 
             this.editingController.editCell(0, 0);
-            this.clock.tick();
+            this.clock.tick(10);
             this.focusFirstCell();
 
             const isPreventDefaultCalled = this.triggerKeyDown('A', keyConfig).preventDefault;
@@ -3628,7 +3628,7 @@ QUnit.module('Keyboard keys', {
         this.keyboardNavigationController.setFocusedCellPosition(7, 0);
         this.editorFactoryController._$focusedElement = $('<div/>');
         callViewsRenderCompleted(this._views);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange
         assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { columnIndex: 0, rowIndex: 6 });
@@ -3662,10 +3662,10 @@ QUnit.module('Keyboard keys', {
         const $input = $testElement.find('.dx-texteditor-input').first();
 
         $($input).trigger('dxpointerdown.dxDataGridKeyboardNavigation');
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('tab', false, false, $testElement.find(':focus').get(0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!$('.dx-datagrid-edit-form-item[tabindex="0"]').length, 'tabIndex is not applied');
@@ -3767,11 +3767,11 @@ QUnit.module('Keyboard keys', {
         this.focusCell(0, 1);
         this.triggerKeyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(testElement.find('.test .dx-texteditor.dx-state-focused').length === 1);
         this.triggerKeyDown('tab', false, false, testElement.find('.test .dx-texteditor.dx-state-focused').get(0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $nextCell = testElement.find('.dx-data-row').eq(0).children().eq(0);
@@ -3860,7 +3860,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('tab', false, false, $('#container').find('input'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($testElement.find('.dx-datagrid-rowsview').find('tbody > tr').eq(1).children().eq(1).hasClass('dx-editor-cell'), 'second cell of the second row is edited');
@@ -3932,12 +3932,12 @@ QUnit.module('Keyboard keys', {
         // act
         this.triggerKeyDown('pageDown');
         $scrollContainer.trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('downArrow'); // navigation to the visible row
         this.triggerKeyDown('downArrow'); // navigation to the invisible row
         $scrollContainer.trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($('.dx-datagrid-focus-overlay').is(':visible'), 'focus overlay is visible');
@@ -3975,21 +3975,21 @@ QUnit.module('Keyboard keys', {
         this.rowsView.resize();
 
         this.focusFirstCell();
-        this.clock.tick();
+        this.clock.tick(10);
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $cell = $(this.getCellElement(0, 0));
         this.triggerKeyDown('tab', false, false, $cell);
-        this.clock.tick();
+        this.clock.tick(10);
         this.keyboardNavigationController._updateFocus = function() {
             // assert
             assert.ok(false, 'keyboardNavigation._updateFocus should not be called');
         };
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.changed.fire({ changeType: 'append' });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(true, 'keyboardNavigation._updateFocus was not called');
@@ -4017,16 +4017,16 @@ QUnit.module('Keyboard keys', {
         that.rowsView.resize();
 
         this.focusCell(0, 0); // focus the first cell of the first data row
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         this.triggerKeyDown('upArrow');
         $(that.rowsView.getScrollable().container()).trigger('scroll');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         this.triggerKeyDown('upArrow');
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.ok($('.dx-datagrid-focus-overlay').is(':visible'), 'focus overlay is visible');
@@ -4055,16 +4055,16 @@ QUnit.module('Keyboard keys', {
         const $scrollContainer = $(scrollable.container());
 
         this.focusFirstCell();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.triggerKeyDown('pageDown');
         $scrollContainer.trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('pageDown');
         $scrollContainer.trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.pageIndex(), 2, 'pageIndex');
@@ -4095,7 +4095,7 @@ QUnit.module('Keyboard keys', {
 
         const $firstGroupRow = $(this.getRowElement(0));
         $firstGroupRow.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($firstGroupRow.hasClass('dx-focused'), 'the first group row is marked as focused');
@@ -4137,7 +4137,7 @@ QUnit.module('Keyboard keys', {
 
         const $firstGroupRow = $(this.getRowElement(0));
         $firstGroupRow.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($firstGroupRow.hasClass('dx-focused'), 'the first group row is marked as focused');
@@ -4145,7 +4145,7 @@ QUnit.module('Keyboard keys', {
 
         // act
         this.triggerKeyDown('downArrow', false, false, $firstGroupRow.get(0));
-        this.clock.tick();
+        this.clock.tick(10);
         const $secondGroupRow = $(this.getRowElement(1));
 
         // assert
@@ -4212,14 +4212,14 @@ QUnit.module('Keyboard keys', {
             } else {
                 this.editingController.editRow(0);
             }
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal($('.dx-data-row').eq(0).find('td:eq(0) textarea:focus').length, 1, 'first cell is focused');
 
             // act
             this.triggerKeyDown('downArrow', true);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal($('.dx-data-row').eq(0).find('td:eq(0) textarea:focus').length, 1, 'first cell is still focused');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.realControllers.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.realControllers.tests.js
@@ -68,7 +68,7 @@ QUnit.module('Real DataController and ColumnsController', {
     setupAndRender: function() {
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
     },
     beforeEach: function() {
         this.clock = sinon.useFakeTimers();
@@ -93,7 +93,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const keyboardController = this.getController('keyboardNavigation');
         const rowsView = this.gridView.getView('rowsView');
@@ -101,9 +101,9 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // act
         $expandCell.trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('rightArrow');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(keyboardController._focusedCellPosition, { rowIndex: 0, columnIndex: 1 }, 'focusedCellPosition is a first column');
@@ -133,7 +133,7 @@ QUnit.module('Real DataController and ColumnsController', {
             this.gridView.render($('#container'));
 
             this.editingController.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             const $newRow = $('#container').find('.dx-data-row').first();
 
             assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'edit row index');
@@ -142,7 +142,7 @@ QUnit.module('Real DataController and ColumnsController', {
             // act
             this.triggerKeyDown('tab', false, false, $('#container').find('input'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'edit row index');
@@ -163,7 +163,7 @@ QUnit.module('Real DataController and ColumnsController', {
             this.gridView.render($('#container'));
 
             this.editingController.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $newRow = $('#container').find('.dx-data-row').first();
 
@@ -173,7 +173,7 @@ QUnit.module('Real DataController and ColumnsController', {
             // act
             this.triggerKeyDown('tab', false, false, $('#container').find('input'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.editingController._getVisibleEditRowIndex(), 0, 'edit row index');
@@ -249,7 +249,7 @@ QUnit.module('Real DataController and ColumnsController', {
         this.setupAndRender();
 
         $(this.getCellElement(1, 1)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const navigationController = this.getController('keyboardNavigation');
         const rowsView = this.getView('rowsView');
@@ -258,7 +258,7 @@ QUnit.module('Real DataController and ColumnsController', {
         navigationController._isNeedFocus = true;
         rowsView.render();
         navigationController._focusedView = this.getView('rowsView');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok($(this.getCellElement(1, 1)).is(':focus'), 'cell is focused');
     });
@@ -291,10 +291,10 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // act
         this.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.triggerKeyDown('tab', false, false, getActiveElement());
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(navigationController._focusedCellPosition, { rowIndex: 1, columnIndex: 1 });
         const cell = dataGridWrapper.rowsView.getDataRow(1).getCell(1);
@@ -319,7 +319,7 @@ QUnit.module('Real DataController and ColumnsController', {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.triggerKeyDown('space', false, false, this.getRowElement(0));
@@ -342,7 +342,7 @@ QUnit.module('Real DataController and ColumnsController', {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.focusCell(0, 0);
@@ -369,7 +369,7 @@ QUnit.module('Real DataController and ColumnsController', {
         this.setupModule();
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.focusCell(0, 0);
@@ -400,7 +400,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         this.option('focusedRowIndex', 1);
@@ -430,7 +430,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         this.gridView.render($('#container'));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $cell = $(this.getCellElement(0, 1));
@@ -463,7 +463,7 @@ QUnit.module('Real DataController and ColumnsController', {
         const $cell = $(this.rowsView.element().find('.dx-row').eq(1).find('td').eq(1));
         $cell.trigger(CLICK_EVENT);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!keyboardNavigationController._isHiddenFocus, 'not hidden focus');
@@ -505,7 +505,7 @@ QUnit.module('Real DataController and ColumnsController', {
         $cell = $(this.getCellElement(1, 1));
         $cell.trigger(CLICK_EVENT);
         this.editCell(1, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedCellChangingFiresCount, 1, 'onFocusedCellChanging fires count');
@@ -519,7 +519,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // act
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(focusedCellChangingFiresCount, 2, 'onFocusedCellChanging fires count');
@@ -558,16 +558,16 @@ QUnit.module('Real DataController and ColumnsController', {
         // act
         this.gridView.render($('#container'));
         $(this.getCellElement(1, 1)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('upArrow', false, false, $(':focus'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(this.getCellElement(0, 1)).hasClass('dx-focused'), 'Cell has focus overlay');
 
         // act
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(editingStartFiresCount, 1, 'onEditingStart fires count');
@@ -609,7 +609,7 @@ QUnit.module('Real DataController and ColumnsController', {
         $cell = $(this.rowsView.element().find('.dx-row').eq(1).find('td').eq(1));
         $cell.trigger(CLICK_EVENT);
         this.editCell(1, 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(editingStartCount, 1, 'onStartEditing fires count');
@@ -624,7 +624,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // act
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.notOk(keyboardNavigationController._canceledCellPosition, 'Check _canceledCellPosition');
         assert.equal(editingStartCount, 1, 'onStartEditing fires count');
@@ -660,7 +660,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.addRow();
@@ -692,7 +692,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(this.getCellElement(0, 0))
@@ -718,7 +718,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // act
         $(this.getCellElement(0, 0)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(getActiveElement()).closest('#container').length, 'focus in grid');
@@ -726,7 +726,7 @@ QUnit.module('Real DataController and ColumnsController', {
         // act
         $anotherRowsView.trigger(pointerEvents.down);
         this.rowsView.render();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(getActiveElement()).closest('#container').length, 'focus is not in grid');
@@ -755,10 +755,10 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // act
         this.editCell(0, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.triggerKeyDown('enter', false, false, $(this.rowsView.element().find('.dx-data-row:nth-child(1) td:nth-child(2)')));
         this.gridView.component.editorFactoryController._$focusedElement = undefined;
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cell = $(this.rowsView.element().find('.dx-data-row:nth-child(1) td:nth-child(2)'));
 
@@ -847,14 +847,14 @@ QUnit.module('Real DataController and ColumnsController', {
 
         const keyboardNavigationController = this.gridView.component.keyboardNavigationController;
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = this.gridView.getView('rowsView');
 
         const $expandCell = $(rowsView.element().find('td').first());
         $expandCell.trigger(CLICK_EVENT);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!keyboardNavigationController._isNeedFocus, 'is key down');
@@ -897,7 +897,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         this.triggerKeyDown('pageDown', false, false, $(':focus').get(0));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $cell = $(this.getCellElement(1, 1));
@@ -935,7 +935,7 @@ QUnit.module('Real DataController and ColumnsController', {
         let $cell = $(that.rowsView.element().find('.dx-freespace-row').eq(0).find('td').eq(1));
         $cell.trigger(CLICK_EVENT);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $cell = $(that.rowsView.element().find('.dx-freespace-row').eq(0).find('td').eq(1));
@@ -975,13 +975,13 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // act
         this.editCell(1, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         const $cell = $(that.rowsView.element().find('.dx-freespace-row').eq(0).find('td').eq(1));
 
         try {
             // act
             $cell.trigger(CLICK_EVENT);
-            this.clock.tick();
+            this.clock.tick(10);
             // assert
             assert.ok(true, 'No exception');
         } catch(e) {
@@ -1030,7 +1030,7 @@ QUnit.module('Real DataController and ColumnsController', {
         $cell = $(that.rowsView.element().find('.dx-virtual-row').eq(0).find('td').eq(1)).trigger(CLICK_EVENT);
         $cell.trigger(CLICK_EVENT);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $cell = $(that.rowsView.element().find('.dx-virtual-row').eq(0).find('td').eq(1));
@@ -1067,7 +1067,7 @@ QUnit.module('Real DataController and ColumnsController', {
         $cell.trigger(CLICK_EVENT, false, false, $(':focus').get(0));
         this.triggerKeyDown('pageDown');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange
         $cell = $(this.getCellElement(0, 1));
@@ -1119,7 +1119,7 @@ QUnit.module('Real DataController and ColumnsController', {
             .trigger('dxpointerdown.dxDataGridKeyboardNavigation')
             .click();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(getActiveElement()).val(), 'Alex', 'value of first editor');
@@ -1158,7 +1158,7 @@ QUnit.module('Real DataController and ColumnsController', {
         $testElement.find('input').focus();
         $testElement.trigger(CLICK_EVENT);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange, assert
         assert.notOk($testElement.hasClass('dx-cell-focus-disabled'), 'no keyboard interaction with cell template element');
@@ -1193,18 +1193,18 @@ QUnit.module('Real DataController and ColumnsController', {
         that.setupModule();
         that.gridView.render($('#container'));
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         const $input = $(that.getCellElement(0, 0)).find('input');
         $input.val('test').trigger('change');
-        that.clock.tick();
+        that.clock.tick(10);
 
         $input.trigger($.Event('keydown', { key: 'Enter' }));
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal($('.dx-revert-button').length, 0, 'has no revert button');
@@ -1245,7 +1245,7 @@ QUnit.module('Real DataController and ColumnsController', {
         that.saveEditData();
         that.getController('keyboardNavigation').focus(that.getCellElement(0, 1));
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.equal($('.dx-revert-button').length, 0, 'has no revert button');
@@ -1288,7 +1288,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // arrange
         that.editCell(0, 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         $inputElement = $testElement.find('.dx-texteditor-input').first();
         $inputElement.val('Bob');
@@ -1296,10 +1296,10 @@ QUnit.module('Real DataController and ColumnsController', {
         // act
         countCallCalculateCellValue = 0;
         $inputElement.change();
-        that.clock.tick();
+        that.clock.tick(10);
         $inputElement = $testElement.find('.dx-texteditor-input').first();
         $testElement.find('.dx-datagrid-rowsview').trigger($.Event('keydown', { key: 'Tab', target: $inputElement }));
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         assert.ok(countCallCalculateCellValue, 'calculateCellValue is called');
@@ -1331,7 +1331,7 @@ QUnit.module('Real DataController and ColumnsController', {
         this.setupModule();
         this.gridView.render($container);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $rowsView = this.rowsView.element();
 
@@ -1379,7 +1379,7 @@ QUnit.module('Real DataController and ColumnsController', {
         this.setupModule();
         this.gridView.render($container);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $rowsView = this.rowsView.element();
         $(this.getCellElement(0, 1)).trigger(CLICK_EVENT);
@@ -1417,7 +1417,7 @@ QUnit.module('Real DataController and ColumnsController', {
         this.setupModule();
         this.gridView.render($container);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $rowsView = this.rowsView.element();
 
@@ -1467,7 +1467,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
                 // act
                 $(this.getCellElement(0, 1)).trigger(startEditClickEventName);
-                this.clock.tick();
+                this.clock.tick(10);
                 // assert
                 assert.ok(editingController.isEditCell(0, 1), 'Cell[0, 1] is in edit mode');
 
@@ -1507,13 +1507,13 @@ QUnit.module('Real DataController and ColumnsController', {
                     .focus()
                     .removeClass('dx-cell-focus-disabled');
                 this.getController('editorFactory')._updateFocusCore();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 $selectCell
                     .trigger(pointerEvents.down)
                     .trigger(pointerEvents.up)
                     .trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.notOk($selectCell.hasClass('dx-focused'), 'Cell has no .dx-focused');
@@ -1524,13 +1524,13 @@ QUnit.module('Real DataController and ColumnsController', {
                     .focus()
                     .removeClass('dx-cell-focus-disabled');
                 this.getController('editorFactory')._updateFocusCore();
-                this.clock.tick();
+                this.clock.tick(10);
 
                 $selectCheckBox
                     .trigger(pointerEvents.down)
                     .trigger(pointerEvents.up)
                     .trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.notOk($selectCell.hasClass('dx-focused'), 'Cell has no .dx-focused');
@@ -1554,18 +1554,18 @@ QUnit.module('Real DataController and ColumnsController', {
 
         this.setupModule();
         this.gridView.render($container);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $commandCell = $(this.getCellElement(0, 0));
         $commandCell.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($commandCell.is(':focus'), 'command cell is focused');
         assert.equal($commandCell.find('.dx-datagrid-group-closed').length, 1, 'cell is rendered as collapsed');
 
         this.triggerKeyDown('enter', false, false, $commandCell);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $commandCell = $(this.getCellElement(0, 0));
 
@@ -1602,16 +1602,16 @@ QUnit.module('Real DataController and ColumnsController', {
 
         this.setupModule();
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.getVisibleRows().length, 2, 'count data row');
 
         // act
         this.expandRow('Dan');
-        this.clock.tick();
+        this.clock.tick(10);
         this.collapseRow('Dan');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const rows = this.getVisibleRows();
@@ -1621,7 +1621,7 @@ QUnit.module('Real DataController and ColumnsController', {
 
         // act
         const result = this.triggerKeyDown('tab', false, false, $(this.getCellElement(1, 1)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(result.preventDefault, 'prevent default is not called');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.rowsView.tests.js
@@ -123,7 +123,7 @@ QUnit.module('Rows view', {
         this.keyboardNavigationController._focusedCellPosition = { columnIndex: 0, rowIndex: 0 };
         this.keyboardNavigationController._focus(this.gridView.element().find('td').eq(4));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.keyboardNavigationController._focusedCellPosition = { columnIndex: 0, rowIndex: 0 };
         this.keyboardNavigationController._focus = function() {
@@ -131,7 +131,7 @@ QUnit.module('Rows view', {
         };
         this.rowsView.renderCompleted.fire();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(!isCellFocused);
@@ -158,12 +158,12 @@ QUnit.module('Rows view', {
         const testElement = $('#container');
 
         rowsView.render(testElement);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $focusable = testElement.find('[tabIndex]').first();
         $focusable.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($focusable.is('td'), 'focusable is cell');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/masterDetail.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/masterDetail.integration.tests.js
@@ -48,17 +48,17 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow({ id: 1 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.collapseRow({ id: 1 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.expandAdaptiveDetailRow({ id: 1 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.collapseAdaptiveDetailRow({ id: 1 });
         this.clock.tick(1000);
@@ -88,7 +88,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleColumns = dataGrid.getVisibleColumns();
@@ -124,7 +124,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
 
         // act
         dataGrid.expandRow('1');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('[id*=\'dx-col\']').each((_, element) => {
             id = $(element).attr('id');
@@ -198,7 +198,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
         });
         const gridInstance = $dataGrid.dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
         const key1 = gridInstance.getKeyByRowIndex(0);
         const key2 = gridInstance.getKeyByRowIndex(1);
 
@@ -264,9 +264,9 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
         });
         const $dataGrid = $($(dataGrid.$element()));
 
-        this.clock.tick();
+        this.clock.tick(10);
         $($dataGrid.find('.dx-datagrid-rowsview .dx-command-expand').first()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $masterDetail = $dataGrid.find('.dx-master-detail-row');
@@ -275,7 +275,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
 
         // act
         $($masterDetail.find('.dx-datagrid-rowsview .dx-command-expand').first()).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($dataGrid.find('.dx-datagrid-rowsview .dx-command-expand').first().find('.dx-datagrid-group-opened').length, 1, 'master detail row opened');
@@ -444,7 +444,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getCellElement(0, 0)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $($(dataGrid.$element()).find('td').eq(14)).trigger(pointerEvents.up); // check that error is not raised
 
@@ -472,11 +472,11 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow({ id: 1 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $rows = $(dataGrid.getRowElement(1));
@@ -528,11 +528,11 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $rows = $(dataGrid.getRowElement(1));
@@ -584,17 +584,17 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         nestedDataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         secondNestedDataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $rows = $(dataGrid.getRowElement(1));
@@ -608,7 +608,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
 
         // act
         secondNestedDataGrid.collapseRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($nestedRows.eq(0).height(), $nestedRows.eq(1).height(), 'nested row heights are synchronized after collapse');
@@ -648,17 +648,17 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             ...dataGridConfig
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         nestedDataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         nestedDataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $firstHeaderCells = $('.dx-header-row > .first-column');
@@ -685,11 +685,11 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ x: 0, y: 1000 });
 
         // assert
@@ -745,11 +745,11 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const expandColumn = $(dataGrid.element()).find('.dx-datagrid-rowsview .dx-command-expand').first();
         assert.ok(expandColumn.length);
         expandColumn.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(dataGrid.getCellElement(0, 0)).hasClass(CELL_UPDATED_CLASS));
@@ -778,7 +778,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
                 assert.step(`rowExpanded rowCount: ${info.rowCount}, masterRow: ${info.masterRow}, detailRow: ${info.detailRow}`);
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(1).done(() => {
@@ -786,7 +786,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
 
             assert.step(`done rowCount: ${info.rowCount}, masterRow: ${info.masterRow}, detailRow: ${info.detailRow}`);
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.verifySteps([
             'rowExpanded rowCount: 2, masterRow: true, detailRow: true',
@@ -904,11 +904,11 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $rows = $(dataGrid.element()).find('tbody.dx-row');
         assert.equal($rows.length, 4, 'row count');
@@ -947,19 +947,19 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
         });
 
         dataGrid.expandRow('Grid Item');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dateBoxInput = $('.inside-grid').find('.dx-datagrid-filter-row .dx-texteditor-input');
         $dateBoxInput.val('abc');
         $dateBoxInput.trigger('change');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($('.inside-grid').find('.dx-datagrid-filter-row > td').find('.dx-overlay.dx-invalid-message').length, 1, 'has invalid message');
 
         // act
         $dateBoxInput.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($('.inside-grid').find('.dx-datagrid-filter-row > td').find('.dx-overlay.dx-invalid-message').length, 1, 'has invalid message');
@@ -1088,13 +1088,13 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
                 }
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(2);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 400 });
 
 
@@ -1105,7 +1105,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
         // act
         const nestedGrid = $(dataGrid.getRowElement(3)).eq(1).find('.nested').dxDataGrid('instance');
         nestedGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(nestedGrid.getRowElement(1)).hasClass('dx-master-detail-row'), 'detail row of the nested grid');
@@ -1119,14 +1119,14 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
 
         // act
         dataGrid.expandRow(10);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.roughEqual(dataGrid.getScrollable().scrollHeight(), 2011, 7.5, 'scroll height2');
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 1728 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.roughEqual(dataGrid.getScrollable().scrollTop(), 1644, 5, 'scroll top3');
@@ -1172,7 +1172,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.expandRow(1);
         templateDeferred.resolve();
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/materialTheme.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/materialTheme.tests.js
@@ -22,7 +22,7 @@ QUnit.module('Material theme', baseModuleConfig, () => {
             }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         dataGridInstance.editCell(0, 0);
 
         const beforeElement = window.getComputedStyle($('.dx-placeholder').get(0), ':before');
@@ -47,7 +47,7 @@ QUnit.module('Material theme', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const scrollable = dataGridInstance.getScrollable();
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/pagerView.tests.js
@@ -132,7 +132,7 @@ QUnit.module('Pager', {
         // });
         $(testElement.find('.dx-page')[5]).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal(that.dataControllerOptions.pageIndex, '19', 'page index');
     });
@@ -160,7 +160,7 @@ QUnit.module('Pager', {
         pagerView.render(testElement);
         this.dataController.pageIndex(13);
         this.dataController.pageIndex(14);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(pagerView.getPager().option('pageIndex'), 15, 'page index');
@@ -175,7 +175,7 @@ QUnit.module('Pager', {
         // act
         pagerView.render(testElement);
         this.dataController.pageIndex('14');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(pagerView.getPager().option('pageIndex'), 15, 'page index changed');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowDragging.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowDragging.integration.tests.js
@@ -43,7 +43,7 @@ QUnit.module('Row dragging', baseModuleConfig, () => {
                 }
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             pointerMock(dataGrid.getCellElement(0, 0)).start().down().move(100, 100);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/rowsView.tests.js
@@ -1141,7 +1141,7 @@ QUnit.module('Rows view', {
 
         // act
         rowsView.render($testElement);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $cells = $testElement.find('.dx-group-row').find('td');
@@ -2910,7 +2910,7 @@ QUnit.module('Rows view', {
         // act
         rowsView.render(testElement);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(testElement.find('tbody > tr').length, 7, 'rows count: 2 main data rows + 1 main freespace row + 1 detail header row + 2 detail data rows + 1 detail freespace row');
@@ -4165,7 +4165,7 @@ QUnit.module('Rows view with real dataController and columnController', {
         nativePointerMock($targetTouchCell).start().touchStart().touchEnd();
         nativePointerMock($targetClickCell).start().click(true);
 
-        clock.tick();
+        clock.tick(10);
 
         // assert
         assert.equal(rowClickCount, 1);
@@ -5560,7 +5560,7 @@ QUnit.module('Rows view with real dataController and columnController', {
         // act
         this.setupDataGridModules();
         this.rowsView.render($testElement);
-        clock.tick();
+        clock.tick(10);
 
         let firstItem = this.dataController.items()[0];
 
@@ -5571,7 +5571,7 @@ QUnit.module('Rows view with real dataController and columnController', {
         assert.ok(firstItem.cells[1].groupContinuesMessage, 'continues text is defined');
 
         this.pageIndex(1);
-        clock.tick();
+        clock.tick(10);
 
         // act
         firstItem = this.dataController.items()[0];
@@ -5606,7 +5606,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
             this.setupDataGridModules(['data', 'columns', 'rows', 'editing', 'editingRowBased', 'editingFormBased', 'editorFactory', 'masterDetail', 'search']);
             this.rowsView.render($testElement);
-            clock.tick();
+            clock.tick(10);
 
             this.$element = () => {
                 return $testElement;
@@ -5614,7 +5614,7 @@ QUnit.module('Rows view with real dataController and columnController', {
 
             // act
             this.editRow(0);
-            clock.tick();
+            clock.tick(10);
 
             // assert
             const $form = $('.dx-form');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/scrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/scrolling.integration.tests.js
@@ -198,7 +198,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('#container').append($dataGrid);
         const dataGrid = $dataGrid.dxDataGrid('instance');
@@ -221,7 +221,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
                 store: [{ field1: '1', field2: '2' }]
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('.dx-scrollable').dxScrollable('instance').scrollLeft(), 100);
@@ -241,7 +241,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
             return scrollable.scrollWidth() - scrollable.clientWidth() - scrollable.scrollLeft();
         };
 
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = $('.dx-scrollable').dxScrollable('instance');
 
         // assert
@@ -285,7 +285,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.$element()).find('.dx-datagrid-headers').css('paddingRight'), '0px');
@@ -455,7 +455,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.navigateToRow('Zeb');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const rowsView = dataGrid.getView('rowsView');
 
@@ -487,7 +487,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         $(dataGrid.getCellElement(0, 0)).trigger(pointerEvents.up);
         dataGrid.getScrollable().scrollTo({ y: 200 });
         dataGrid.repaintRows(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getScrollable().scrollTop(), 200, 'scrollTop is not reseted');
@@ -584,7 +584,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.ok($dataGrid.width() > 200, 'grid\'s width is more then column widths sum');
@@ -623,7 +623,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         const dataGrid = $dataGrid.dxDataGrid('instance');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $headersView = $dataGrid.find('.dx-datagrid-headers' + ' .dx-datagrid-scroll-container').first();
         $headersView.scrollLeft(400);
@@ -667,7 +667,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         const dataGrid = $dataGrid.dxDataGrid('instance');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $footerView = $dataGrid.find('.dx-datagrid-total-footer .dx-datagrid-scroll-container').first();
         $footerView.scrollLeft(300);
@@ -698,7 +698,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.clock.restore();
 
         const scrollableInstance = dataGrid.getView('rowsView').getScrollable();
@@ -906,7 +906,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
                 showScrollbar: 'always'
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const scrollable = dataGrid.getScrollable();
         const content = dataGrid.$element().find('.dx-datagrid-rowsview .dx-datagrid-content')[0];
@@ -949,7 +949,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         });
         const dataGrid = $dataGrid.dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $scrollableContainer = $dataGrid.find('.dx-scrollable-container');
 
@@ -974,7 +974,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         });
         const dataGrid = $dataGrid.dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const scrollable = dataGrid.getScrollable();
 
@@ -1015,14 +1015,14 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         });
         const dataGrid = $dataGrid.dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const scrollable = dataGrid.getScrollable();
 
         // act
         scrollable.scrollTo(200);
         dataGrid.columnOption('field3', 'visible', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(scrollable.scrollLeft(), 200);
@@ -1051,7 +1051,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         // act
 
         dataGrid.focus($(dataGrid.getCellElement(0, 2)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getView('rowsView').getScrollable().scrollLeft(), 400, 'Correct offset');
@@ -1155,7 +1155,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageSize(), 10, 'pageSize from stateStoring is applied');
@@ -1225,7 +1225,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -1235,7 +1235,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 375 });
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -1255,7 +1255,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 375 });
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -1293,7 +1293,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -1303,7 +1303,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
 
         // act (scroll down to the middle)
         dataGrid.getScrollable().scrollTo({ top: 1500 });
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -1313,7 +1313,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
 
         // act (scroll down to the bottom)
         dataGrid.getScrollable().scrollTo({ top: 3050 });
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -1323,7 +1323,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
 
         // act (scroll up to the middle)
         dataGrid.getScrollable().scrollTo({ top: 1500 });
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -1333,7 +1333,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
 
         // act (scroll up to the top)
         dataGrid.getScrollable().scrollTo({ top: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -1402,7 +1402,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
 
         // act (pageSize 10)
         $(dataGrid.element()).find('.dx-pager .dx-page-sizes .dx-page-size:eq(0)').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         const $noDataElement = $(dataGrid.element()).find('.dx-datagrid-nodata');
 
         // assert
@@ -1441,20 +1441,20 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
                 },
             ],
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.getController('validating').validate(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('td').trigger('focus');
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const table = $('.dx-datagrid-rowsview .dx-datagrid-content:not(.dx-datagrid-content-fixed) tbody');
@@ -1479,7 +1479,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
                 useNative: true
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.$element().addClass('fixed-height');
 
@@ -1517,7 +1517,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
                 }
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(checkScrollWorks(dataGrid), 'scroll should not work if height is not specified');
@@ -1525,14 +1525,14 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         // act
         dataGrid.option('height', 150);
         dataGrid.expandRow(2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(checkScrollWorks(dataGrid), 'scroll should work as height is specified and content height is bigger than height');
 
         // act
         dataGrid.option('height', 'auto');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(checkScrollWorks(dataGrid), 'scroll should not work if height is \'auto\'');
@@ -1562,7 +1562,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         this.clock.tick(300);
 
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(checkScrollWorks(dataGrid), 'vertical scrollbar should work');
     });
@@ -1583,7 +1583,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         this.clock.tick(300);
 
         dataGrid.editRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(checkScrollWorks(dataGrid), 'vertical scrollbar should work');
     });
@@ -1605,7 +1605,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         this.clock.tick(300);
 
         dataGrid.expandAdaptiveDetailRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(checkScrollWorks(dataGrid), 'vertical scrollbar should work');
     });
@@ -1638,7 +1638,7 @@ QUnit.module('Scrolling', baseModuleConfig, () => {
         window.grid = dataGrid;
 
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok($('#dataGrid').height() < 150, 'second page should not have scrollbar');
     });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.integration.tests.js
@@ -130,11 +130,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             ],
             onSelectionChanged: selectionChanged
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $commandCell = $(dataGrid.getCellElement(0, 0));
         $commandCell.find('.my-class').trigger('click');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $firstRow = $(dataGrid.getRowElement(0));
 
@@ -165,11 +165,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             onSelectionChanged: onSelectionChangedHandler
         };
         const dataGrid = createDataGrid(gridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let selectedKeys;
         dataGrid.getSelectedRowKeys().done(keys => selectedKeys = keys);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(selectedKeys, [1]);
@@ -257,7 +257,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(dataGrid);
@@ -286,7 +286,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [1], 'selectedRowKeys');
@@ -316,7 +316,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [], 'selectedRowKeys');
@@ -352,7 +352,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cells = $(dataGrid.element()).find('.dx-editor-inline-block');
 
@@ -487,28 +487,28 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const $dataGridElement = $(dataGrid.element());
         const $selectAllElement = $dataGridElement.find('.dx-datagrid-headers .dx-command-select .dx-select-checkbox');
         const $checkboxElement = $(dataGrid.getCellElement(0, 0));
 
         // act
         $checkboxElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($selectAllElement.hasClass('dx-checkbox-indeterminate'));
 
         // act
         $dataGridElement.find('.dx-page').eq(1).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($selectAllElement.hasClass('dx-checkbox-indeterminate'));
 
         // act
         $dataGridElement.find('.dx-page').eq(0).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($selectAllElement.hasClass('dx-checkbox-indeterminate'));
@@ -529,14 +529,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getRowElement(0)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [1], 'first row is selected');
 
         // act
         $(dataGrid.getRowElement(1)).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [2], 'second row is selected');
@@ -562,7 +562,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.getSelectedRowKeys().done(keys => {
             selectedRowKeys = keys;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(selectedRowKeys, [1], 'first row is selected');
@@ -573,7 +573,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.getSelectedRowKeys().done(keys => {
             selectedRowKeys = keys;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(selectedRowKeys, [2], 'second row is selected');
@@ -594,14 +594,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getRowElement(0)).find('.dx-checkbox').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [1], 'first row is selected');
 
         // act
         $(dataGrid.getRowElement(1)).find('.dx-checkbox').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [1, 2], 'both rows are selected');
@@ -627,7 +627,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.getSelectedRowKeys().done(keys => {
             selectedRowKeys = keys;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(selectedRowKeys, [1], 'first row is selected');
@@ -638,7 +638,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         dataGrid.getSelectedRowKeys().done(keys => {
             selectedRowKeys = keys;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(selectedRowKeys, [1, 2], 'both rows are selected');
@@ -664,14 +664,14 @@ QUnit.module('Initialization', baseModuleConfig, () => {
                 showCheckBoxesMode: 'always'
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $checkBox = $(dataGrid.getRowElement(0)).find('.dx-checkbox');
         // act
         $checkBox.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $checkBox.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [1], 'row is selected');
@@ -745,11 +745,11 @@ QUnit.module('Virtual row rendering', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.selectAll();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleRows = dataGrid.getVisibleRows();
@@ -944,7 +944,7 @@ QUnit.module('Async render', baseModuleConfig, () => {
         });
 
         const $grid = grid.$element();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $selectCheckboxes = $grid.find('.dx-select-checkbox');
         const $inputs = $selectCheckboxes.find('input');
@@ -990,7 +990,7 @@ QUnit.module('Async render', baseModuleConfig, () => {
         });
 
         const $grid = grid.$element();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $selectCheckboxes = $grid.find('.dx-select-checkbox');
         const $inputs = $selectCheckboxes.find('input');
@@ -1023,7 +1023,7 @@ QUnit.module('Async render', baseModuleConfig, () => {
         });
 
         const $grid = grid.$element();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $selectCheckboxes = $grid.find('.dx-select-checkbox');
         const $inputs = $selectCheckboxes.find('input');
@@ -1065,14 +1065,14 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             selection: { mode: 'none' }
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.option({
             dataSource: [{ field1: 1, field2: 2, field3: 3 }],
             selection: { mode: 'none' }
         });
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.columnCount(), 3, 'columnCount after change dataSource');
@@ -1085,7 +1085,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             selection: { mode: 'multiple' }
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.option('selection.mode', 'single');
@@ -1102,7 +1102,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             selection: { mode: 'multiple' }
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         assert.equal($(dataGrid.$element()).find('.dx-select-checkboxes-hidden').length, 1, 'select checkboxes are hidden');
 
@@ -1214,7 +1214,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             dataSource: [{ a: 1111, b: 222 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option({
@@ -1226,7 +1226,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
 
         dataGrid.selectRows([{ a: 1111, b: 222 }]);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [{ a: 1111, b: 222 }], 'selected row keys');
@@ -1273,12 +1273,12 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             },
         });
         dataGrid.selectRows([1]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         let selectedKeysBefore;
         dataGrid.getSelectedRowKeys().done((keys) => selectedKeysBefore = keys);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(selectedKeysBefore, [1]);
 
         // act
@@ -1287,7 +1287,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
         // assert
         let selectedKeysAfter;
         dataGrid.getSelectedRowKeys().done((keys) => selectedKeysAfter = keys);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(selectedKeysAfter, [1]);
     });
 
@@ -1309,7 +1309,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
                 mode: 'multiple',
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option({
@@ -1380,7 +1380,7 @@ QUnit.module('columnWidth auto option', {
         const $selectAllElement = $(dataGrid.element()).find('.dx-header-row .dx-command-select');
         $selectAllElement.trigger('dxclick');
 
-        // this.clock.tick();
+        // this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getSelectedRowKeys().length, 1);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/selection.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/selection.tests.js
@@ -163,7 +163,7 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
             finalized = true;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(finalized);
@@ -493,7 +493,7 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
 
         this.selectionController.selectRows([]);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(loadingCount, 0, 'no loadings');
@@ -880,7 +880,7 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
         // act
         this.options.selectedRowKeys = [{ name: 'Dan', age: 16 }];
         this.dataController.init();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         assert.strictEqual(onSelectionChangedCounter, 0, 'onSelectionChanged not called');
@@ -1017,14 +1017,14 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
 
         this.dataController.optionChanged({ name: 'dataSource' });
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.store().on('loading', function(options) {
             loadOptions = options;
         });
 
         // act
         this.selectionController.selectAll();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(loadOptions.expand, 'testExpand', 'dataSource expand options sent correctly');
@@ -1368,7 +1368,7 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
             isSelectAllStates.push(that.selectionController.isSelectAll());
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(loadingCount, 1, 'one loading after init dataSource');
@@ -1395,13 +1395,13 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
 
         this.dataController.optionChanged({ name: 'dataSource' });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.selectRows(['Dan1', 'Dan3']);
         this.clearSelection();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(this.getSelectedRowKeys(), []);
@@ -1595,7 +1595,7 @@ QUnit.module('Selection without dataSource', { beforeEach: setupModule, afterEac
             changeCallCount++;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changeCallCount, 1);
@@ -1626,7 +1626,7 @@ QUnit.module('Selection without dataSource', { beforeEach: setupModule, afterEac
 
         selectionController.selectAll();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(selectionController.getSelectedRowKeys().length, 2);
@@ -2182,7 +2182,7 @@ QUnit.module('Multiple selection. DataSource with key', { beforeEach: setupSelec
 
         // act
         store.push([{ type: 'remove', key: 2 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.selectionController.isSelectAll(), false, 'nothing is selected');
@@ -3480,7 +3480,7 @@ QUnit.module('Selection with views', {
             const $selectCheckBox = dataRow0.getSelectCheckBox(0).getElement();
             $selectCheckBox.trigger(clickEvent.name);
 
-            clock.tick();
+            clock.tick(10);
 
             clock.restore();
         });
@@ -3980,7 +3980,7 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(!this.dataController.items()[0].isSelected);
         assert.ok(!this.dataController.items()[1].isSelected);
@@ -3997,7 +3997,7 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(!this.dataController.items()[0].isSelected);
         assert.ok(this.dataController.items()[1].isSelected);
@@ -4016,7 +4016,7 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -4036,7 +4036,7 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -4056,7 +4056,7 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -4078,7 +4078,7 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -4115,14 +4115,14 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.selectRows([1, 3, 4, 6], true);
-        this.clock.tick();
+        this.clock.tick(10);
         this.deselectRows([3, 6]);
-        this.clock.tick();
+        this.clock.tick(10);
         this.selectRows([1, 2, 4, 5]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const expectedSelectionFilter = [
@@ -4149,7 +4149,7 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.selectionController.selectRows([0]);
@@ -4181,7 +4181,7 @@ QUnit.module('Deferred selection', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.selectionController.selectionChanged.add(selectionChanged);
 
@@ -4211,7 +4211,7 @@ QUnit.module('Deferred selection', {
             onSelectionChanged: selectionChangedStub
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         selectionChangedStub.reset();
@@ -4225,7 +4225,7 @@ QUnit.module('Deferred selection', {
             selectedKeys = keys;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(selectedKeys, [6, 7]);
         assert.strictEqual(selectionChangedStub.callCount, 1);
@@ -4249,7 +4249,7 @@ QUnit.module('Deferred selection', {
             loadingCount++;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(loadingCount, 1, 'one loading count');
 
@@ -4278,7 +4278,7 @@ QUnit.module('Deferred selection', {
             selection: { mode: 'selectAll', deferred: true }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         let items = this.dataController.items();
         assert.equal(items.length, 2, 'filtered items');
@@ -4312,7 +4312,7 @@ QUnit.module('Deferred selection', {
         this.getSelectedRowsData().done((selectedData) => {
             selectedRowsData = selectedData;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(selectedRowsData.length, 5, 'selected rows data count');
@@ -4325,7 +4325,7 @@ QUnit.module('Deferred selection', {
         this.getSelectedRowsData().done((selectedData) => {
             selectedRowsData = selectedData;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(selectedRowsData.length, 5, 'selected rows data count');
@@ -4352,7 +4352,7 @@ QUnit.module('Deferred selection', {
         this.getSelectedRowsData().done((selectedData) => {
             selectedRowsData = selectedData;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(selectedRowsData.length, 5, 'selected rows data count');
@@ -4362,7 +4362,7 @@ QUnit.module('Deferred selection', {
         this.getSelectedRowsData().done((selectedData) => {
             selectedRowsData = selectedData;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(selectedRowsData.length, 0, 'selected rows data count');
@@ -4381,7 +4381,7 @@ QUnit.module('Deferred selection', {
             selection: { mode: 'multiple', deferred: true }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const items = this.dataController.items();
         assert.equal(items.length, 1, 'filtered items');
@@ -4414,7 +4414,7 @@ QUnit.module('Deferred selection', {
             selection: { mode: 'multiple', deferred: true }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.selectRows([1], true);
         this.selectionController.selectAll();
@@ -4437,15 +4437,15 @@ QUnit.module('Deferred selection', {
                 mode: 'multiple'
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const spy = sinon.spy(this.selectionController._selection._selectionStrategy, '_removeSameFilter');
         this.selectRows(data.map(data => data.id).slice(2));
         this.clock.tick(100);
         assert.equal(spy.callCount, 0, 'no extra calls');
         this.selectRows([0]);
-        this.clock.tick();
+        this.clock.tick(10);
         this.selectRows([1], true);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.notEqual(spy.callCount, 0, 'called for preserved selection');
         spy.restore();
     });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
@@ -26,7 +26,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         // act
         const $idHeaderElement = $(dataGrid.element()).find('.dx-header-row td').eq(0);
         $idHeaderElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         let sortedColumns = dataGrid.getVisibleColumns().filter(col => col.sortIndex >= 0);
 
@@ -37,7 +37,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.columnOption('id', 'groupIndex', 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         sortedColumns = dataGrid.getVisibleColumns().filter(col => col.sortIndex >= 0);
 
@@ -49,7 +49,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         // act
         const $nameHeaderElement = $(dataGrid.element()).find('.dx-header-row td').eq(1);
         $nameHeaderElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         sortedColumns = dataGrid.getVisibleColumns().filter(col => col.sortIndex >= 0);
 
@@ -60,7 +60,7 @@ QUnit.module('Initialization', baseModuleConfig, () => {
 
         // act
         dataGrid.columnOption('id', 'groupIndex', undefined);
-        this.clock.tick();
+        this.clock.tick(10);
 
         sortedColumns = dataGrid.getVisibleColumns().filter(col => col.sortIndex >= 0);
 
@@ -150,11 +150,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption(1, 'groupIndex', 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $dataGrid = $(dataGrid.$element());
@@ -190,11 +190,11 @@ QUnit.module('Initialization', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        that.clock.tick();
+        that.clock.tick(10);
 
         // act
         dataGrid.columnOption(1, 'groupIndex', 0);
-        that.clock.tick();
+        that.clock.tick(10);
 
         // assert
         const $dataGrid = $(dataGrid.$element());
@@ -265,10 +265,10 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.columnOption('FirstName', 'sortOrder', 'asc');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option({
@@ -278,7 +278,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
                 visible: true
             }]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleColumns().length, 2, 'two visible columns');
@@ -295,7 +295,7 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             columns: ['a', 'b'],
             filterSyncEnabled: true,
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption('a', 'sortOrder', 'asc');
@@ -324,16 +324,16 @@ QUnit.module('Assign options', baseModuleConfig, () => {
             columns: ['a', 'b'],
             filterSyncEnabled: true,
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.clearSorting();
         dataGrid.getDataSource().sort('a');
         dataGrid.getDataSource().load();
-        
+
         // assert
         assert.deepEqual(dataGrid.columnOption('a', 'sortOrder'), 'asc');
-        
+
         // act
         // same actions second time
         dataGrid.clearSorting();
@@ -377,16 +377,16 @@ QUnit.module('API methods', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         dataGrid.columnOption('field1', 'sortOrder', 'asc');
         dataGrid.columnOption('field2', 'groupIndex', 0);
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         dataGrid.state({});
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.columnOption('field1', 'sortOrder'), undefined, 'sorting is reseted');
@@ -425,15 +425,15 @@ QUnit.module('API methods', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         dataGrid.columnOption('field1', 'sortOrder', 'asc');
         dataGrid.columnOption('field2', 'groupIndex', 1);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.state({});
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.columnOption('id', 'sortOrder'), 'asc', 'sorting is reseted');
@@ -451,11 +451,11 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ field1: 'test1', field2: 'test2' }, { field1: 'test3', field2: 'test4' }]
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.columnOption(0, 'groupIndex'), 0, 'groupIndex was not reset');
@@ -469,14 +469,14 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ field1: 'test1', field2: 'test2' }, { field1: 'test3', field2: 'test4' }]
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption(0, 'groupIndex', undefined);
         dataGrid.columnOption(1, 'sortOrder', undefined);
 
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.columnOption(0, 'groupIndex'), 0, 'groupIndex was returned to default');
@@ -491,7 +491,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ field1: 'test1', field2: 'test2' }, { field1: 'test3', field2: 'test4' }]
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.columnOption(0, 'groupIndex', undefined);
@@ -501,7 +501,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
         dataGrid.columnOption(0, 'sortOrder', 'asc');
 
         dataGrid.state(null);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.columnOption(0, 'groupIndex'), 0, 'groupIndex was returned to default');
@@ -521,7 +521,7 @@ QUnit.module('API methods', baseModuleConfig, () => {
 
         // act
         dataGrid.columnOption(0, 'sortOrder', 'desc');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.cellValue(0, 0), 2, 'first row value');
@@ -536,12 +536,12 @@ QUnit.module('API methods', baseModuleConfig, () => {
             dataSource: [{ field1: 1, field2: 2, field3: 3 }, { field1: 4, field2: 5, field3: 6 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         try {
             // act
             dataGrid.columnOption('field2', 'sortOrder', 'desc');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(true, 'no exceptions');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.integration.tests.js
@@ -38,7 +38,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
         assert.equal(dataGrid.getController('columns').getVisibleColumns().length, 0, 'visible column count');
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleColumns = dataGrid.getController('columns').getVisibleColumns();
@@ -68,7 +68,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
             onDataErrorOccurred: dataErrorOccurred
         };
         const dataGrid = createDataGrid(gridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $headerRow = $(dataGrid.element()).find('.dx-header-row');
         const $errorRow = $(dataGrid.element()).find('.dx-error-row');
@@ -98,7 +98,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
             }
         };
         const dataGrid = createDataGrid(gridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $errorRow = $(dataGrid.element()).find('.dx-error-row');
 
@@ -124,7 +124,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
             onDataErrorOccurred: dataErrorOccurred
         };
         const dataGrid = createDataGrid(gridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $errorRow = $(dataGrid.element()).find('.dx-error-row');
 
@@ -152,7 +152,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
                 contentReadyCallCount++;
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(contentReadyCallCount, 1);
@@ -180,7 +180,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         let visibleColumns = dataGrid.getController('columns').getVisibleColumns();
@@ -190,7 +190,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
 
         // act
         dataGrid.state(null);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         visibleColumns = dataGrid.getController('columns').getVisibleColumns();
@@ -230,11 +230,11 @@ QUnit.module('State storing', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // act
         dataGrid.state({});
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         const $firstCell = $($(dataGrid.$element()).find('.dx-data-row').eq(0).children().eq(0));
@@ -264,7 +264,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         let visibleColumns = dataGrid.getController('columns').getVisibleColumns();
@@ -275,7 +275,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
 
         // act
         dataGrid.state(null);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         visibleColumns = dataGrid.getController('columns').getVisibleColumns();
@@ -295,7 +295,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.pageIndex(1);
 
         // assert
@@ -303,7 +303,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
 
         // act
         dataGrid.state(null);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageIndex(), 0, 'pageIndex');
@@ -331,7 +331,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
             columns: ['id', 'field1']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const newItems = [
@@ -359,11 +359,11 @@ QUnit.module('State storing', baseModuleConfig, () => {
             columns: ['field1', 'field2', { caption: 'Band Column', columns: ['field3', 'field4'] }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.state(null);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         columns = dataGrid.getVisibleColumns(0).map(function(column) { return column.caption; });
@@ -406,7 +406,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
 
         // act
         $('.dx-datagrid-addrow-button').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const rows = dataGrid.getVisibleRows();
@@ -433,7 +433,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
                 },
                 loadingTimeout: null
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.strictEqual(dataGrid.option('focusedRowIndex'), -1, 'focusedRowIndex');
             assert.strictEqual(dataGrid.option('focusedRowKey'), null, 'focusedRowKey');
@@ -462,7 +462,7 @@ QUnit.module('State storing', baseModuleConfig, () => {
             }]
         };
         const dataGrid = createDataGrid(gridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const visibleColumns = dataGrid.getVisibleColumns();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
@@ -34,7 +34,7 @@ QUnit.module('Local storage', {
 
         // act
         this.stateStoringController.save();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(parseInt(JSON.parse(localStorage.getItem('TestNameSpace')).testSetting), 107);
@@ -149,7 +149,7 @@ QUnit.module('Local storage', {
 
         // act
         this.stateStoringController.save();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(localStorage.getItem('TestNameSpace'), '{"testSetting1":100,"testSetting2":"test"}');
@@ -256,7 +256,7 @@ QUnit.module('Local storage', {
 
         // act
         this.stateStoringController.save();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(userState, 'TestNameSpace');
@@ -278,7 +278,7 @@ QUnit.module('Local storage', {
         this.stateStoringController.save();
         this.stateStoringController.save();
         this.stateStoringController.save();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(customSaveHandler.calledOnce, 'customSave call count');
@@ -310,7 +310,7 @@ QUnit.module('Local storage', {
         localStorage.setItem('TestNameSpace', JSON.stringify({ selectedRowKeys: testKeys }));
 
         that.stateStoringController.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(that.option('selectedRowKeys'), testKeys, 'keys rows');
     });
@@ -325,7 +325,7 @@ QUnit.module('Local storage', {
         localStorage.setItem('TestNameSpace', JSON.stringify({ selectionFilter: filter }));
 
         that.stateStoringController.load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(that.option('selectionFilter'), filter, 'selectionFilter is applied');
     });
@@ -357,7 +357,7 @@ QUnit.module('Session storage', {
 
         // act
         this.stateStoringController.save();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(parseInt(JSON.parse(sessionStorage.getItem('TestNameSpace')).testSetting), 107);
@@ -402,7 +402,7 @@ QUnit.module('Session storage', {
 
         // act
         this.stateStoringController.save();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(sessionStorage.getItem('TestNameSpace'), '{"testSetting1":100,"testSetting2":"test"}');
@@ -442,7 +442,7 @@ QUnit.module('Session storage', {
         assert.ok(stateStoringController.isLoading());
         assert.deepEqual(stateStoringController.state(), {});
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(changeCallCount, 1);
@@ -462,7 +462,7 @@ QUnit.module('State Storing with real controllers', {
             });
 
             if(!ignoreClockTick) {
-                this.clock.tick();
+                this.clock.tick(10);
             }
         };
     },
@@ -531,7 +531,7 @@ QUnit.module('State Storing with real controllers', {
         // act
         this.dataController.optionChanged({ name: 'dataSource' });
         this.stateStoringController.optionChanged({ name: 'stateStoring' });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(countCallCustomLoad, 1, 'count call customLoad');
@@ -557,7 +557,7 @@ QUnit.module('State Storing with real controllers', {
         });
 
         this.stateStoringController.optionChanged({ name: 'stateStoring' });
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // assert
@@ -586,7 +586,7 @@ QUnit.module('State Storing with real controllers', {
 
         // act
         this.state({ columns: [{ dataField: 'id', filterValues: ['2'], visible: true }] });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -614,7 +614,7 @@ QUnit.module('State Storing with real controllers', {
 
         // act
         this.state({ columns: [{ dataField: 'id', visible: true }, { dataField: 'name', filterValue: 'test2', visible: false }] });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -670,7 +670,7 @@ QUnit.module('State Storing with real controllers', {
         assert.strictEqual(this.dataController.pageSize(), 0, 'state store values will apply after');
         assert.strictEqual(this.dataController.items().length, 0, 'state store values will apply after');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(this.dataController.pageIndex(), 1);
         assert.strictEqual(this.dataController.pageSize(), 2);
@@ -922,7 +922,7 @@ QUnit.module('State Storing with real controllers', {
             pageSize: 2,
             selectedRowKeys: [1, 3]
         });
-        this.clock.tick();
+        this.clock.tick(10);
         this.dataController.optionChanged({ name: 'paging' });
 
         // assert
@@ -1149,7 +1149,7 @@ QUnit.module('State Storing with real controllers', {
 
         // act
         this.columnsController.columnOption(0, 'visibleWidth', 50);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(customSaveCallCount, 1, 'customSave call count');
@@ -1165,7 +1165,7 @@ QUnit.module('State Storing with real controllers', {
 
         // act
         this.columnsController.columnOption(0, 'width', 100);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(customSaveCallCount, 2, 'customSave call count');
@@ -1243,7 +1243,7 @@ QUnit.module('State Storing with real controllers', {
 
         // act
         this.columnOption('id', 'filterValues', [3]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(userState.columns, [{
@@ -1480,7 +1480,7 @@ QUnit.module('State Storing with real controllers', {
             });
 
             this.gridView.render(this.$element());
-            this.clock.tick();
+            this.clock.tick(10);
 
             const filterMenu = this.$element().find('.dx-menu .dx-menu-item').first();
             $(filterMenu).trigger('dxclick'); // open filter menu
@@ -1488,7 +1488,7 @@ QUnit.module('State Storing with real controllers', {
 
             // act
             filterMenuItem.trigger('dxclick'); // Reset filter
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.strictEqual(this.columnOption('id', 'filterValue'), null, 'filterValue');
@@ -1785,7 +1785,7 @@ QUnit.module('State Storing for filterPanel', {
                 }, options)
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
         };
     },
     afterEach: function() {
@@ -1942,7 +1942,7 @@ QUnit.module('State Storing for filterPanel', {
         });
 
         this.state({});
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -1970,7 +1970,7 @@ QUnit.module('State Storing for filterPanel', {
         });
 
         this.state({});
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();
@@ -1991,7 +1991,7 @@ QUnit.module('State Storing for filterPanel', {
 
         // act
         this.state({ filterValue: ['id', '=', 2] });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualColumns.tests.js
@@ -631,12 +631,12 @@ QUnit.module('Rendering', { beforeEach: setupRenderingModule, afterEach: teardow
         });
 
         this.gridView.render($('#container'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const columnsChangedSpy = sinon.spy();
         this.columnsController.columnsChanged.add(columnsChangedSpy);
         this.gridView.update();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(this.columnHeadersView.element().find('tr td').length, 11);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -1960,7 +1960,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick(300);
+        this.clock.tick(400);
 
         // act
         dataGrid.getScrollable().scrollTo(2500);
@@ -1969,7 +1969,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         assert.equal(dataGrid.getVisibleRows()[0].data.id, 1, 'first visible row is correct');
 
         // act
-        this.clock.tick(300);
+        this.clock.tick(400);
 
         // assert
         assert.equal(dataGrid.getVisibleRows()[0].data.id, 51, 'first visible row is correct');
@@ -3393,7 +3393,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.option('dataSource', generateDataSource(40));
-        this.clock.tick(500);
+        this.clock.tick(600);
 
 
         // assert
@@ -4856,7 +4856,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         assert.ok(dataGridWrapper.rowsView.isElementIntersectViewport($virtualRowElement), 'virtual row is rendered inside viewport after scrolling to bottom');
 
         // act
-        this.clock.tick(300);
+        this.clock.tick(400);
         $virtualRowElement = $(dataGrid.element()).find('.dx-virtual-row');
 
         // assert
@@ -4874,7 +4874,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         assert.notOk(dataGridWrapper.rowsView.isElementIntersectViewport($($virtualRowElement.get(1))), 'bottom virtual row is rendered outside viewport after scrolling to top');
 
         // act
-        this.clock.tick(300);
+        this.clock.tick(400);
         $virtualRowElement = $(dataGrid.element()).find('.dx-virtual-row');
 
         // assert

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -118,7 +118,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             dataSource: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const scrollTop = dataGrid.getScrollable().scrollTop();
@@ -151,14 +151,14 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             dataSource,
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = dataGrid.getScrollable();
 
         // act
         dataGrid.navigateToRow(100);
-        this.clock.tick();
+        this.clock.tick(10);
         $(scrollable.container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getSelectedRowKeys(), [100], 'selectedRowKeys is actual');
@@ -238,7 +238,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             const scrollable = dataGrid.getScrollable();
             scrollable.scrollTo({ x: 900 });
             $(scrollable.container()).trigger('scroll');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(columnController.getColumnIndexOffset(), 9, 'Column index offset');
@@ -256,7 +256,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             dataSource: [{}, {}, {}, {}]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal($(dataGrid.$element()).find('.dx-datagrid-bottom-load-panel').length, 1);
         // act
         dataGrid.option('scrolling.mode', 'virtual');
@@ -264,7 +264,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         // assert
         assert.ok(getHeight($(dataGrid.$element()).find('.dx-datagrid-rowsview')) > 0);
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(getHeight($(dataGrid.$element()).find('.dx-datagrid-rowsview')) > 0);
         assert.equal($(dataGrid.$element()).find('.dx-datagrid-bottom-load-panel').length, 0);
@@ -427,7 +427,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.navigateToRow('Zeb');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageIndex(), 2, 'Page index');
@@ -455,11 +455,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.getScrollable().scrollTo({ y: 1000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getScrollable().scrollTop(), 1000, 'scrollTop');
@@ -482,7 +482,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             scrolling: { mode: 'virtual' }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(getHeight($dataGrid.find('.dx-datagrid-rowsview')) > 300, 'rowsView has height');
@@ -522,7 +522,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         }
 
         dataGrid.getScrollable().scrollTo({ x: 1000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $cell = $(dataGrid.getCellElement(0, 0));
@@ -573,7 +573,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         const fixedColumnCount = 2;
 
         dataGrid.getScrollable().scrollTo({ x: 1000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.getCellElement(0, 0)).is($fixedCell), 'Fixed cell is not rerendered');
@@ -621,7 +621,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         const $fixedCell = $(dataGrid.getCellElement(0, 0));
 
         dataGrid.getScrollable().scrollTo({ x: 1000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(dataGrid.getCellElement(0, 0)).is($fixedCell), 'Fixed cell is rerendered');
@@ -657,7 +657,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         rowsView.scrollTo({ y: 3000 });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         row = rowsView.element().find('.dx-data-row').eq(0);
         assert.equal(row.attr('aria-rowindex'), 89, 'aria-index is correct after scrolling');
@@ -682,7 +682,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             scrolling: { mode: 'virtual' }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.find('.dx-gridbase-container').attr('aria-rowcount'), 200, 'aria-rowcount is correct');
@@ -749,7 +749,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
                 groupIndex: 0
             }, 'name']
         }).dxDataGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(rowsView.getDataRows().getElement().length, 2, 'row is expanded');
@@ -913,7 +913,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $footerView = $dataGrid.find('.dx-datagrid-total-footer');
         assert.ok($footerView.is(':visible'), 'footer view is visible');
@@ -940,7 +940,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageSize(), 20, 'pageSize from stateStoring is not applied');
@@ -969,12 +969,12 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.getDataSource().store().push([{ type: 'update', key: 1, data: { id: 1, field: 125 } }]);
 
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.equal($(dataGrid.getRowElement(0)).position().top, 0, 'first row position');
     });
@@ -1229,7 +1229,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         };
 
         createDataGrid(gridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(freeSpaceRowHeightStatuses.length);
@@ -1444,9 +1444,9 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         const $checkBox = $(dataGrid.getRowElement(4)).find('.dx-checkbox');
         $checkBox.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
         $checkBox.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.cellValue(4, 'field'), 'new value', 'cell\'s value was changed');
@@ -1495,7 +1495,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.option('dataSource', [{ test: 3 }, { test: 4 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(dataGrid.getController('data').viewportSize() > 0, 'viewportSize is assigned');
@@ -1562,7 +1562,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(loadingCount, 1, 'virtual scrolling load 1 page');
@@ -1588,7 +1588,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataGrid.$element().find('.dx-header-row').length, 1, 'header row is rendered');
     });
@@ -1658,7 +1658,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const resizingController = dataGrid.getController('resizing');
 
@@ -1903,7 +1903,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         $(dataGrid.getCellElement(rowIndex, 'id')).find('.dx-texteditor-input').val('100');
         $(dataGrid.getCellElement(rowIndex, 'id')).find('.dx-texteditor-input').trigger($.Event('keydown', { key: 'Enter' }));
         $(dataGrid.getScrollable().container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.roughEqual(dataGrid.getScrollable().scrollTop(), 55, 2, 'scrollTop');
@@ -2058,7 +2058,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $dataRows = $(dataGrid.$element()).find('.dx-data-row');
@@ -2086,11 +2086,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.state({ pageIndex: 0, pageSize: 2 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.pageIndex(), 0, 'pageIndex');
@@ -2176,11 +2176,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             columns: ['id', 'name']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataSource.store().push([{ type: 'insert', data: { id: 6, name: 'test 6' } }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.getVisibleRows().length, 6, 'one row is added');
@@ -2217,7 +2217,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             columns: [{ dataField: 'id', sortOrder: 'desc' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         for(let id = 6; id <= 10; id++) {
@@ -2494,12 +2494,12 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const scrollable = dataGrid.getScrollable();
         scrollable.scrollTo({ x: 300 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(scrollable.scrollOffset().left, 300, 'Content was scrolled');
@@ -2622,7 +2622,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         const columnController = instance.getController('columns');
         columnController.moveColumn(0, 3);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const colGroups = $('.dx-datagrid colgroup');
@@ -2712,7 +2712,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.navigateToRow(navigateRowKey);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleRows().filter(row => row.key === navigateRowKey).length, 1, 'navigated row is visible');
@@ -2747,7 +2747,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         rowsView.scrollTo({ y: 3000 });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $row = rowsView.element().find('.dx-data-row').first();
         assert.notEqual($row.attr('aria-rowindex'), 1, 'first row is changed');
@@ -2819,14 +2819,14 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         }).dxDataGrid('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 500 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.columnOption('group', 'groupIndex', 0);
-        this.clock.tick();
+        this.clock.tick(10);
         $(dataGrid.getScrollable().container()).trigger('scroll');
 
         // assert
@@ -3094,10 +3094,10 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         };
         const dataGrid = createDataGrid(gridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().on('scroll', onScrollHandler);
         dataGrid.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(onScrollHandler.called, 'onScroll handler is not called');
@@ -3245,7 +3245,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.option({ scrolling: { mode: 'virtual' } });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.deepEqual(dataGrid.getController('data').pageCount(), 2, 'pages count');
@@ -3316,11 +3316,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
                 const scrollTopPosition = 330; // top position of the 5-th data row
 
                 // act
-                this.clock.tick();
+                this.clock.tick(10);
                 dataGrid.getScrollable().scrollTo({ top: scrollTopPosition });
-                this.clock.tick();
+                this.clock.tick(10);
                 dataGrid.getScrollable().scrollTo({ top: scrollTopPosition });
-                this.clock.tick();
+                this.clock.tick(10);
 
                 // assert
                 assert.deepEqual(dataGrid.getScrollable().scrollTop(), scrollTopPosition, 'correct scroll position');
@@ -3343,11 +3343,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             },
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.pageIndex(1);
-        this.clock.tick();
+        this.clock.tick(10);
         const dataSource2 = generateDataSource(18);
         dataGrid.option('dataSource', dataSource2);
         this.clock.tick(300);
@@ -3376,7 +3376,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             columns: [{ dataField: 'name', fixed: true }, 'id']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const scrollable = dataGrid.getScrollable();
 
@@ -3424,7 +3424,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         const visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -3451,7 +3451,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         let visibleRows = dataGrid.getVisibleRows();
 
         // assert
@@ -3487,7 +3487,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('dataSource', generateDataSource(500));
@@ -3564,17 +3564,17 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.element()).find('.dx-edit-row').length, 1, 'edit row is rendered');
 
         dataGrid.getScrollable().scrollTo({ top: 250 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.element()).find('.dx-edit-row').length, 0, 'edit row is not rendered on scroll');
@@ -3620,7 +3620,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $newRow = $(dataGrid.element()).find('.dx-row-inserted');
 
@@ -3630,7 +3630,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 1650 });
-        this.clock.tick();
+        this.clock.tick(10);
         $newRow = $(dataGrid.element()).find('.dx-row-inserted');
 
         // assert
@@ -3639,7 +3639,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 3300 });
-        this.clock.tick();
+        this.clock.tick(10);
         $newRow = $(dataGrid.element()).find('.dx-row-inserted');
 
         // assert
@@ -3673,11 +3673,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         let $detailRow = $(dataGrid.getRowElement(1));
 
         // assert
@@ -3686,9 +3686,9 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 1650 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.expandRow(50);
-        this.clock.tick();
+        this.clock.tick(10);
         $detailRow = $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(50) + 1));
 
         // assert
@@ -3697,9 +3697,9 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 3300 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.expandRow(100);
-        this.clock.tick();
+        this.clock.tick(10);
         $detailRow = $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(100) + 1));
 
         // assert
@@ -3729,11 +3729,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(dataGrid.getRowElement(0)).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         let $adaptiveRow = $(dataGrid.getRowElement(1));
 
         // assert
@@ -3741,9 +3741,9 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 1650 });
-        this.clock.tick();
+        this.clock.tick(10);
         $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(50))).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $adaptiveRow = $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(50) + 1));
 
         // assert
@@ -3751,9 +3751,9 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 3300 });
-        this.clock.tick();
+        this.clock.tick(10);
         $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(100))).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $adaptiveRow = $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(100) + 1));
 
         // assert
@@ -3782,11 +3782,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(dataGrid.getRowElement(0)).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         let $adaptiveRow = $(dataGrid.getRowElement(1));
 
         // assert
@@ -3794,14 +3794,14 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 1080 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(dataGrid.element()).find('.dx-adaptive-detail-row').length, 'adaptive row is not rendered');
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
         $adaptiveRow = $(dataGrid.getRowElement(1));
 
         // assert
@@ -3876,9 +3876,9 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act (scroll down middle)
         dataGrid.getScrollable().scrollTo({ top: 1899 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 1900 }); // this call for simulating the second async scroll
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
         visibleGroupRowCount = visibleRows.filter(r => r.rowType === 'group').length;
 
@@ -3893,9 +3893,9 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act (scroll down bottom)
         dataGrid.getScrollable().scrollTo({ top: 3499 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 3500 }); // this call for simulating the second async scroll
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
         visibleGroupRowCount = visibleRows.filter(r => r.rowType === 'group').length;
 
@@ -3911,7 +3911,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act (scroll up middle)
         dataGrid.getScrollable().scrollTo({ top: 1900 });
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
         visibleGroupRowCount = visibleRows.filter(r => r.rowType === 'group').length;
 
@@ -3929,7 +3929,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act (scroll up top)
         dataGrid.getScrollable().scrollTo({ top: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
         visibleRows = dataGrid.getVisibleRows();
         visibleGroupRowCount = visibleRows.filter(r => r.rowType === 'group').length;
 
@@ -3989,7 +3989,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         let loadIndices = dataGrid.getVisibleRows().map(it => it.loadIndex);
 
         // assert
@@ -3997,7 +3997,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.expandRow(2);
-        this.clock.tick();
+        this.clock.tick(10);
         loadIndices = dataGrid.getVisibleRows().map(it => it.loadIndex);
 
         // assert
@@ -4005,7 +4005,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         $(dataGrid.getRowElement(7)).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         loadIndices = dataGrid.getVisibleRows().map(it => it.loadIndex);
 
         // assert
@@ -4013,7 +4013,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.expandRow(5);
-        this.clock.tick();
+        this.clock.tick(10);
         loadIndices = dataGrid.getVisibleRows().map(it => it.loadIndex);
 
         // assert
@@ -4025,7 +4025,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             { type: 'insert', insertBeforeKey: ['Category 2'] },
             { type: 'insert' }
         ]);
-        this.clock.tick();
+        this.clock.tick(10);
         loadIndices = dataGrid.getVisibleRows().map(it => it.loadIndex);
 
         // assert
@@ -4077,7 +4077,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         const loadIndices = dataGrid.getVisibleRows().map(it => it.loadIndex);
 
         // assert
@@ -4114,14 +4114,14 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getDataSource().on('customizeLoadResult', customizeLoadResultSpy);
         dataGrid.getScrollable().scrollTo({ top: 600 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 1300 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 3200 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(customizeLoadResultSpy.callCount, 'called');
@@ -4159,7 +4159,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleRows().length, 15, 'rendered row count');
@@ -4218,7 +4218,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.element()).find('.dx-loadpanel-content').first().is(':visible'), 'load panel is shown');
@@ -4363,11 +4363,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         // act
         const scrollable = dataGrid.getScrollable();
         scrollable.scrollTo({ top: 407 });
-        this.clock.tick();
+        this.clock.tick(10);
         scrollable.scrollTo({ top: 415 });
-        this.clock.tick();
+        this.clock.tick(10);
         scrollable.scrollTo({ top: 425 });
-        this.clock.tick();
+        this.clock.tick(10);
         scrollable.scrollTo({ top: 430 });
         this.clock.tick(500);
 
@@ -4474,7 +4474,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(dataGrid.getVisibleRows().length, 2, 'only first page items are visible');
@@ -4625,7 +4625,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         scrollable.scrollTo({ left: 500 });
         $(scrollable.container()).trigger('scroll');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const footerScrollLeft = dataGrid.getView('footerView').element().children().scrollLeft();
@@ -4634,7 +4634,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         // act
         scrollable.scrollTo({ top: 1000 });
         $(scrollable.container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.getView('footerView').element().children().scrollLeft(), footerScrollLeft, 'scrollLeft restored');
@@ -4667,14 +4667,14 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const rowHeight = parseFloat(getComputedStyle($(dataGrid.getRowElement(1)).get(0)).height);
 
         // navigate forward
         for(let i = 0; i < dataGrid.pageCount(); i++) {
             if(i > 0) {
                 $(dataGrid.element()).find(`.dx-pager .dx-page:eq(${i})`).trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
             }
 
             const scrollPosition = rowHeight * dataGrid.pageSize() * dataGrid.pageIndex();
@@ -4690,7 +4690,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         // navigate backward
         for(let i = dataGrid.pageCount() - 2; i > 0; i--) {
             $(dataGrid.element()).find(`.dx-pager .dx-page:eq(${i})`).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const scrollPosition = rowHeight * dataGrid.pageSize() * dataGrid.pageIndex();
             const topId = dataGrid.pageIndex() * dataGrid.pageSize() + 1;
@@ -4729,13 +4729,13 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // navigate forward
         [0, 750, 1500, 2250, 3000].forEach(position => {
             if(position > 0) {
                 dataGrid.getScrollable().scrollTo({ top: position });
-                this.clock.tick();
+                this.clock.tick(10);
             }
             const pageIndex = position / 750;
 
@@ -4748,7 +4748,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         // navigate backward
         [2250, 1500, 750, 0].forEach(position => {
             dataGrid.getScrollable().scrollTo({ top: position });
-            this.clock.tick();
+            this.clock.tick(10);
             const pageIndex = position / 750;
 
             // assert
@@ -5302,10 +5302,10 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         $(dataGrid.getCellElement(0, 0)).find('.dx-texteditor-input').val('').trigger('change');
         dataGrid.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.element()).find('.dx-datagrid-rowsview .dx-error-row').length, 1, 'error row is rendered');
@@ -5336,11 +5336,11 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
                 mode: 'virtual',
             },
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $('.dx-datagrid-addrow-button').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const dataRows = $('.dx-data-row');
@@ -6045,12 +6045,12 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         // act
         const lastRowKey = 30;
         dataGrid.navigateToRow(lastRowKey);
-        this.clock.tick();
+        this.clock.tick(10);
         $(scrollable.container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataGrid.deleteRow(dataGrid.getRowIndexByKey(lastRowKey));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.totalCount(), lastRowKey - 1, 'before scroll');
@@ -6059,7 +6059,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
         // scroll is triggered cause content's height is changed
         // totalCount should be correct both before scroll (before data loading) and after
         $(scrollable.container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(dataGrid.totalCount(), lastRowKey - 1, 'after scroll');
@@ -6142,7 +6142,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ x: 10000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.getCellElement(0, 0)).is($fixedCell), 'Fixed cell is not rerendered');
@@ -6205,7 +6205,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ x: 10000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(dataGrid.getCellElement(0, 0)).is($fixedCell), 'Fixed cell is not rerendered');
@@ -6261,7 +6261,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.expandRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         let $detailRow = $(dataGrid.getRowElement(1)).eq(1);
@@ -6273,7 +6273,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ x: 10000 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $detailRow = $(dataGrid.getRowElement(1)).eq(1);
@@ -6366,17 +6366,17 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
                 allowUpdating: true,
                 allowDeleting: true,
             },
-            repaintChangesOnly: true,          
+            repaintChangesOnly: true,
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.option('editing.editRowKey', 14);
 
-        this.clock.tick();
+        this.clock.tick(10);
         $(dataGrid.getScrollable().container()).triggerHandler('scroll');
         $(dataGrid.getScrollable().container()).triggerHandler('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         const $rows = $('.dx-data-row');
@@ -6389,7 +6389,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
                 assert.strictEqual($row.find('a:eq(0)').text(), 'Save')
                 assert.strictEqual($row.find('a:eq(1)').text(), 'Cancel')
                 return;
-            }   
+            }
 
             // other rows
             assert.strictEqual($row.find('a').length, 2);
@@ -6455,7 +6455,7 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
         // act
         $(dataGrid.getCellElement(0, 0)).trigger(pointerEvents.up);
         dataGrid.getScrollable().scrollTo({ y: 10000 });
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(dataGrid.getScrollable().scrollTop() > 0, 'scrollTop is not reseted');
     });
@@ -6776,7 +6776,7 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             dataSource: dataSource
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const viewportSize = dataGrid.getController('data').viewportSize();
         const itemCount = dataGrid.getController('data').items().length;
@@ -6784,7 +6784,7 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
         // act
         $('#dataGrid').height(1000);
         dataGrid.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(dataGrid.getController('data').viewportSize() > 0, 'viewport size more 0');
@@ -6841,12 +6841,12 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             dataSource: [{ a: 1111, b: 222 }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         // act
         dataGrid.option('scrolling', {
             mode: 'infinite'
         });
-        this.clock.tick();
+        this.clock.tick(10);
         // assert
         assert.ok(dataGrid.getController('data').viewportSize() > 0);
         assert.ok(!dataGrid.getController('data').dataSource().requireTotalCount());
@@ -6869,12 +6869,12 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         [930, 1100, 1400, 1600].forEach((top) => {
             dataGrid.getScrollable().scrollTo({ top });
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         // assert
@@ -6901,17 +6901,17 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         dataGrid.editRow(0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.element()).find('.dx-edit-row').length, 1, 'edit row is rendered');
 
         dataGrid.getScrollable().scrollTo({ top: 250 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($(dataGrid.element()).find('.dx-edit-row').length, 0, 'edit row is not rendered on scroll');
@@ -6959,12 +6959,12 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const scrollTo = (positions) => {
             positions.forEach(top => {
                 dataGrid.getScrollable().scrollTo({ top });
-                this.clock.tick();
+                this.clock.tick(10);
             });
         };
 
@@ -7018,18 +7018,18 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const scrollTo = (positions) => {
             positions.forEach(top => {
                 dataGrid.getScrollable().scrollTo({ top });
-                this.clock.tick();
+                this.clock.tick(10);
             });
         };
 
         // act
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         let $detailRow = $(dataGrid.getRowElement(1));
 
         // assert
@@ -7039,7 +7039,7 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
         // act
         scrollTo([1080, 1250, 1650]);
         dataGrid.expandRow(50);
-        this.clock.tick();
+        this.clock.tick(10);
         $detailRow = $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(50) + 1));
 
         // assert
@@ -7049,7 +7049,7 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
         // act
         scrollTo([1960, 2600, 3300, 3500]);
         dataGrid.expandRow(100);
-        this.clock.tick();
+        this.clock.tick(10);
         $detailRow = $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(100) + 1));
 
         // assert
@@ -7080,18 +7080,18 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const scrollTo = (positions) => {
             positions.forEach(top => {
                 dataGrid.getScrollable().scrollTo({ top });
-                this.clock.tick();
+                this.clock.tick(10);
             });
         };
 
         // act
         $(dataGrid.getRowElement(0)).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         let $adaptiveRow = $(dataGrid.getRowElement(1));
 
         // assert
@@ -7100,7 +7100,7 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
         // act
         scrollTo([1080, 1250, 1650]);
         $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(50))).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $adaptiveRow = $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(50) + 1));
 
         // assert
@@ -7109,7 +7109,7 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
         // act
         scrollTo([1960, 2600, 2700, 3400, 3500]);
         $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(100))).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         $adaptiveRow = $(dataGrid.getRowElement(dataGrid.getRowIndexByKey(100) + 1));
 
         // assert
@@ -7138,11 +7138,11 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $(dataGrid.getRowElement(0)).find('.dx-command-adaptive .dx-datagrid-adaptive-more').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         let $adaptiveRow = $(dataGrid.getRowElement(1));
 
         // assert
@@ -7150,14 +7150,14 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 1080 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($(dataGrid.element()).find('.dx-adaptive-detail-row').length, 'adaptive row is not rendered');
 
         // act
         dataGrid.getScrollable().scrollTo({ top: 0 });
-        this.clock.tick();
+        this.clock.tick(10);
         $adaptiveRow = $(dataGrid.getRowElement(1));
 
         // assert
@@ -7214,11 +7214,11 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
             }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollTo = (positions) => {
             positions.forEach(top => {
                 dataGrid.getScrollable().scrollTo({ top });
-                this.clock.tick();
+                this.clock.tick(10);
             });
         };
         let visibleRows = dataGrid.getVisibleRows();
@@ -7341,14 +7341,14 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getDataSource().on('customizeLoadResult', customizeLoadResultSpy);
         dataGrid.getScrollable().scrollTo({ top: 600 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 1150 });
-        this.clock.tick();
+        this.clock.tick(10);
         dataGrid.getScrollable().scrollTo({ top: 1800 });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(customizeLoadResultSpy.callCount, 'called');
@@ -7546,14 +7546,14 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
         this.clock.tick(300);
 
         dataGrid.option('searchPanel.text', '12345');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(store.load.lastCall.args[0].take, 10, 'only a single page is requested');
 
         // act
         dataGrid.option('searchPanel.text', '');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(store.load.lastCall.args[0].take, 10, 'only a single page is requested');
@@ -7777,17 +7777,17 @@ QUnit.module('Infinite Scrolling', baseModuleConfig, () => {
 
         });
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         const scrollable = dataGrid.getScrollable();
 
         dataGrid.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         scrollable.scrollBy(100);
-        this.clock.tick();
+        this.clock.tick(10);
 
         scrollable.scrollBy(100);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // const scrollableBottom
         // assert

--- a/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/autocomplete.tests.js
@@ -1132,7 +1132,7 @@ QUnit.module('Overlay integration', {
         const updateDimensionsSpy = sinon.spy(list, 'updateDimensions');
 
         popup.show();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(updateDimensionsSpy.callCount, 3, 'initial render + 2x dimension changed handler');
     });
 
@@ -1147,7 +1147,7 @@ QUnit.module('Overlay integration', {
         const $scrollableContainer = $popup.find('.dx-scrollable-container');
 
         popup.show();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(getOuterHeight($scrollableContainer), getHeight($popupContent));
     });
@@ -1158,7 +1158,7 @@ QUnit.module('Overlay integration', {
         fx.off = true;
         this.instance.option('value', '');
         this.keyboard.type('i');
-        this.clock.tick();
+        this.clock.tick(10);
         this.popup.dxPopup('option', 'onHidden', () => {
             assert.ok(true, 'popup is hidden');
         });
@@ -1592,13 +1592,13 @@ QUnit.module('widget sizing render', {
         const keyboard = keyboardMock($input);
 
         keyboard.type('C');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $($input.val('')).trigger('keyup');
-        this.clock.tick();
+        this.clock.tick(10);
 
         keyboard.type('Z');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $overlayContent = $('.dx-overlay-content');
         assert.ok($overlayContent.height() > 0, 'overlay height is correct');

--- a/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
@@ -959,11 +959,11 @@ QUnit.module('Keyboard navigation', {
             iterateViews((_, type) => {
                 calendar.option('zoomLevel', type);
 
-                clock.tick();
+                clock.tick(10);
                 triggerKeydown($element, LEFT_ARROW_KEY_CODE, optionConfig);
                 assert.deepEqual(calendar.option('currentDate'), expectedDates[type][0], `${name}+left arrow navigates correctly`);
 
-                clock.tick();
+                clock.tick(10);
                 triggerKeydown($element, RIGHT_ARROW_KEY_CODE, optionConfig);
                 assert.deepEqual(calendar.option('currentDate'), expectedDates[type][1], `${name}+right arrow navigates correctly`);
             });
@@ -982,7 +982,7 @@ QUnit.module('Keyboard navigation', {
             triggerKeydown($element, LEFT_ARROW_KEY_CODE, optionConfig);
             assert.deepEqual(this.calendar.option('currentDate'), new Date(2013, 10, this.value.getDate()), `${name}+left arrow navigates correctly`);
 
-            this.clock.tick();
+            this.clock.tick(10);
             triggerKeydown($element, RIGHT_ARROW_KEY_CODE, optionConfig);
             assert.deepEqual(this.calendar.option('currentDate'), new Date(2013, 9, this.value.getDate()), `${name}+right arrow navigates correctly`);
         });
@@ -1025,11 +1025,11 @@ QUnit.module('Keyboard navigation', {
         iterateViews((_, type) => {
             calendar.option('zoomLevel', type);
 
-            clock.tick();
+            clock.tick(10);
             triggerKeydown($element, PAGE_UP_KEY_CODE);
             assert.deepEqual(calendar.option('currentDate'), expectedDates[type][0], 'pageup navigates correctly');
 
-            clock.tick();
+            clock.tick(10);
             triggerKeydown($element, PAGE_DOWN_KEY_CODE);
             assert.deepEqual(calendar.option('currentDate'), expectedDates[type][1], 'pagedown navigates correctly');
         });
@@ -1052,11 +1052,11 @@ QUnit.module('Keyboard navigation', {
         iterateViews((_, type) => {
             calendar.option('zoomLevel', type);
 
-            clock.tick();
+            clock.tick(10);
             triggerKeydown($element, PAGE_UP_KEY_CODE);
             assert.deepEqual(calendar.option('currentDate'), expectedDates[type][0], 'pageUp navigates correctly');
 
-            clock.tick();
+            clock.tick(10);
             triggerKeydown($element, PAGE_DOWN_KEY_CODE);
             assert.deepEqual(calendar.option('currentDate'), expectedDates[type][1], 'pageDown navigates correctly');
         });

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -1128,7 +1128,6 @@ QUnit.module('dateView integration', {
         };
 
         this.instance.open();
-        this.clock.tick(10);
 
         this.dateView = function() {
             return getInstanceWidget(this.instance);

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -319,7 +319,7 @@ QUnit.module('datebox tests', moduleConfig, () => {
             min: new Date(2015, 3, 20, 15, 0, 0),
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const dateBox = $dateBox.dxDateBox('instance');
         const $done = $(dateBox.content()).parent().find(APPLY_BUTTON_SELECTOR);
         const $hourDown = $(dateBox.content()).parent().find(`.${NUMBERBOX_SPIN_DOWN_CLASS}`).eq(0);
@@ -392,12 +392,12 @@ QUnit.module('datebox tests', moduleConfig, () => {
 
             $input.val('');
             instance.open();
-            this.clock.tick();
+            this.clock.tick(10);
             kb.type(typedDate).press('enter');
             assert.deepEqual(instance.option('text'), typedDate, `typed value is set when useMaskBehavior:${options.useMaskBehavior}, type:${options.type}`);
 
             instance.open();
-            this.clock.tick();
+            this.clock.tick(10);
             kb
                 .keyDown('left', { ctrlKey: true })
                 .press('right')
@@ -936,7 +936,7 @@ QUnit.module('options changed callbacks', moduleConfig, () => {
         dateBox.option('value', secondValue);
         assert.deepEqual(firstValue, calendar.option('value'), 'value in calendar isn\'t changed');
         dateBox.open();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(secondValue, calendar.option('value'), 'value in calendar is changed');
     });
 
@@ -1128,7 +1128,7 @@ QUnit.module('dateView integration', {
         };
 
         this.instance.open();
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.dateView = function() {
             return getInstanceWidget(this.instance);
@@ -2664,7 +2664,7 @@ QUnit.module('datebox w/ calendar', {
         const popup = dateBox.$element().find('.dx-popup').dxPopup('instance');
         const repaintSpy = sinon.spy(popup, 'repaint');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(repaintSpy.called, 'repaint was fired on opened');
     });
@@ -3129,7 +3129,7 @@ QUnit.module('datebox with time component', {
             }).dxDateBox('instance');
 
             dateBox.option('opened', true);
-            clock.tick();
+            clock.tick(10);
 
             const $content = $(dateBox._popup.$content());
             const $timeView = $content.find('.dx-timeview-clock');
@@ -5128,7 +5128,7 @@ QUnit.module('datebox validation', {}, () => {
                     type: 'required'
                 }]
             });
-            clock.tick();
+            clock.tick(10);
             const dateBox = $dateBox.dxDateBox('instance');
             const $done = $(dateBox.content()).parent().find(APPLY_BUTTON_SELECTOR);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownBox.tests.js
@@ -599,7 +599,7 @@ QUnit.module('popup options', moduleConfig, () => {
         try {
             instance.open();
 
-            this.clock.tick();
+            this.clock.tick(10);
             const popup = $('.dx-popup').dxPopup('instance');
             const maxHeight = popup.option('maxHeight');
 
@@ -680,7 +680,7 @@ QUnit.module('popup options', moduleConfig, () => {
             $('#dd-content').height(contentHeight);
             instance.close();
             instance.open();
-            this.clock.tick();
+            this.clock.tick(10);
 
             const popup = this.$element.find('.dx-popup').dxPopup('instance');
             const maxHeight = popup.option('maxHeight');
@@ -738,7 +738,7 @@ QUnit.module('popup options', moduleConfig, () => {
 
                 instance.open();
                 $content.focus();
-                this.clock.tick();
+                this.clock.tick(10);
                 $(window).trigger('scroll');
 
                 assert.strictEqual(instance.option('opened'), isMac);
@@ -831,7 +831,7 @@ QUnit.module('keyboard navigation', moduleConfig, () => {
         const keyboard = keyboardMock($input2);
 
         keyboard.press('tab');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.notOk(instance.option('opened'), 'popup was closed');
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownEditor.tests.js
@@ -913,11 +913,11 @@ QUnit.module('Templates', () => {
 
         try {
             dropDownEditor.repaint();
-            clock.tick();
+            clock.tick(10);
         } catch(e) {
             assert.ok(false, `error is raised: ${e.message}`);
         } finally {
-            clock.tick();
+            clock.tick(10);
             clock.restore();
             assert.ok(true);
         }
@@ -1119,7 +1119,7 @@ QUnit.module('Templates', () => {
             });
 
             keyboard.type('z5');
-            this.clock.tick();
+            this.clock.tick(10);
             assert.strictEqual($input.val(), '5-_', 'Masked TextBox works fine');
         } finally {
             this.clock.restore();

--- a/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/dropDownList.tests.js
@@ -308,7 +308,7 @@ QUnit.module('displayExpr', moduleConfig, () => {
         });
 
         $dropDownList.dxDropDownList('option', 'opened', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(args, [2].concat(dataSource), 'displayExpr args is correct');
     });
@@ -442,7 +442,7 @@ QUnit.module('items & dataSource', moduleConfig, () => {
             deferRendering: false
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual($dropDownList.dxDropDownList('option', 'items'), dataSource, 'displayExpr args is correct');
     });
 
@@ -453,7 +453,7 @@ QUnit.module('items & dataSource', moduleConfig, () => {
             opened: true
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual($dropDownList.dxDropDownList('option', 'items'), items, 'rendered all items');
     });
 
@@ -528,7 +528,7 @@ QUnit.module('items & dataSource', moduleConfig, () => {
             itemTemplate: new Template($template)
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($.trim($('.dx-list-item').text()), 'test', 'template rendered');
     });
@@ -580,7 +580,7 @@ QUnit.module('items & dataSource', moduleConfig, () => {
         const dropDownList = $dropDownList.dxDropDownList('instance');
         dropDownList.option('value', { key: 0, value: 'one' });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const $input = $dropDownList.find('.' + TEXTEDITOR_INPUT_CLASS);
         assert.equal($input.val(), 'one', 'item displayed');
     });
@@ -1006,7 +1006,7 @@ QUnit.module('selectedItem', moduleConfig, () => {
             value: 1
         }).dxDropDownList('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(dropDownList.option('selectedItem'), items[0], 'selected item');
     });
@@ -1018,10 +1018,10 @@ QUnit.module('selectedItem', moduleConfig, () => {
             selectedItem: 1
         }).dxDropDownList('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dropDownList.option('items', ['a', 'b', 's', 'd']);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(dropDownList.option('value'), 1, 'value is unchanged');
         assert.strictEqual(dropDownList.option('selectedItem'), null, 'selected item was reset');
@@ -1035,10 +1035,10 @@ QUnit.module('selectedItem', moduleConfig, () => {
             selectedItem: '1'
         }).dxDropDownList('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dropDownList.option('dataSource', ['a', 'b', 's', 'd']);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(dropDownList.option('value'), '1', 'value is unchanged');
         assert.strictEqual(dropDownList.option('selectedItem'), null, 'selected item was reset');
@@ -1051,10 +1051,10 @@ QUnit.module('selectedItem', moduleConfig, () => {
             selectedItem: 2
         }).dxDropDownList('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         dropDownList.option('dataSource', [5, 2, 6, 7]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(dropDownList.option('value'), 2, 'value is correct');
         assert.strictEqual(dropDownList.option('selectedItem'), 2, 'selected item was not reset');
@@ -1110,7 +1110,7 @@ QUnit.module('selectedItem', moduleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $dropDownList.dxDropDownList('option', 'onSelectionChanged', e => {
             assert.equal(e.selectedItem, 1, 'selectedItem provided in onValueChanged');
@@ -1118,7 +1118,7 @@ QUnit.module('selectedItem', moduleConfig, () => {
 
         $dropDownList.dxDropDownList('option', 'value', 1);
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('selectedItem should be chosen synchronously if item is already loaded', function(assert) {
@@ -1142,11 +1142,11 @@ QUnit.module('selectedItem', moduleConfig, () => {
             opened: true
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $(`.${LIST_CLASS}`).dxList('_loadNextPage');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $dropDownList.dxDropDownList('option', 'value', 0);
 
@@ -1339,7 +1339,7 @@ QUnit.module('popup', moduleConfig, () => {
             done();
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.testInActiveWindow('After search and load new page scrollTop should not be changed', function(assert) {
@@ -1386,7 +1386,7 @@ QUnit.module('popup', moduleConfig, () => {
             done();
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('popup should be configured with templatesRenderAsynchronously=false (T470619)', function(assert) {
@@ -1467,7 +1467,7 @@ QUnit.module('dataSource integration', moduleConfig, function() {
             value
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual($dropDownList.dxDropDownList('option', 'selectedItem'), data[0], 'value found');
     });
@@ -1546,7 +1546,7 @@ QUnit.module('action options', moduleConfig, () => {
 
         const instance = $dropDownList.dxDropDownList('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $listItem = instance._$list.find(LIST_ITEM_SELECTOR).eq(1);
 

--- a/testing/tests/DevExpress.ui.widgets.editors/fileUploader.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/fileUploader.tests.js
@@ -915,7 +915,7 @@ QUnit.module('uploading by chunks', moduleConfig, function() {
         });
         const instance = $fileUploader.dxFileUploader('instance');
         simulateFileChoose($fileUploader, [fakeContentFile]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const expectedCallsCount = Math.ceil(fakeContentFile.size / instance.option('chunkSize'));
         assert.equal(index, expectedCallsCount, 'count of calls onProgress event is valid');
@@ -971,7 +971,7 @@ QUnit.module('uploading by chunks', moduleConfig, function() {
             }
         });
         simulateFileChoose($fileUploader, files);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(fileUploadedCount, files.length, 'Count uploaded files is correct');
         for(let i = 0; i < files.length; i++) {
@@ -992,7 +992,7 @@ QUnit.module('uploading by chunks', moduleConfig, function() {
 
         const files = [createBlobFile('fake1.png', 100023), createBlobFile('fake2.png', 5000)];
         simulateFileChoose($fileUploader, files);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(uploadedFiles.length, files.length, 'count uploaded files is valid');
         for(let i = 0; i < files.length; i++) {
@@ -1018,7 +1018,7 @@ QUnit.module('uploading by chunks', moduleConfig, function() {
         simulateFileChoose($fileUploader, files);
         assert.strictEqual(progressSpy.callCount, 1, 'only one chunk sent');
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(progressSpy.callCount, chunkCount, 'all chunks are sent');
     });
     test('abortUpload callback should not rise for not uploading files', function(assert) {
@@ -1080,7 +1080,7 @@ QUnit.module('uploading by chunks', moduleConfig, function() {
         simulateFileChoose($fileUploader, files);
         assert.strictEqual(progressSpy.callCount, 1, 'only one chunk sent');
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(progressSpy.callCount, chunkCount, 'all chunks are sent');
         assert.strictEqual($fileUploader.dxFileUploader('option', 'progress'), 100, 'progress is 100%');
     });
@@ -3345,7 +3345,7 @@ QUnit.module('keyboard navigation', moduleConfig, () => {
         $selectButton.trigger('focusin');
         keyboard.keyDown('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(stub.calledOnce, 'press on select button leads to input click');
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -2244,7 +2244,7 @@ QUnit.module('popup options', {
 
         const defaultHeight = $('.dx-overlay-content').outerHeight();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok($('.dx-overlay-content').outerHeight() > defaultHeight, 'popup height is changed when data is loaded');
     });
@@ -2343,7 +2343,7 @@ QUnit.module('popup options', {
             assert.ok(lookup.option('dropDownOptions.hideOnParentScroll'), 'is true by default');
 
             lookup.open();
-            this.clock.tick();
+            this.clock.tick(10);
             assert.ok(lookup.option('dropDownOptions.hideOnParentScroll'), 'still true after opening');
 
         } finally {
@@ -3064,7 +3064,7 @@ QUnit.module('dataSource integration', {
 
         const $input = $(toSelector(POPUP_CONTENT_CLASS) + ' ' + toSelector(TEXTEDITOR_INPUT_CLASS));
         $($input.val('o')).trigger('input');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal($('.dx-list-item').length, 2, 'filters execute on input event');
     });
 
@@ -3167,7 +3167,7 @@ QUnit.module('dataSource integration', {
         keyboard.type('1');
         this.clock.tick(loadDelay * 2);
         keyboard.type('2');
-        this.clock.tick(loadDelay / 2);
+        this.clock.tick(loadDelay / 2 + 10);
         const $loadPanel = $content.find(`.${SCROLL_VIEW_LOAD_PANEL_CLASS}`);
 
         assert.ok($loadPanel.is(':visible'), 'load panel is visible');

--- a/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/numberBoxParts/mask.tests.js
@@ -365,7 +365,7 @@ QUnit.module('format: sign and minus button', moduleConfig, () => {
         });
 
         this.keyboard.caret({ start: 0, end: 5 }).keyDown('-');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.input.val(), '-$ 0.00', 'text is correct');
         assert.deepEqual(this.keyboard.caret(), { start: 3, end: 6 }, 'caret is good');
     });
@@ -377,7 +377,7 @@ QUnit.module('format: sign and minus button', moduleConfig, () => {
         });
 
         this.keyboard.caret({ start: 0, end: 5 }).keyDown('-');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.input.val(), '-123.5', 'value is correct');
         assert.deepEqual(this.keyboard.caret(), { start: 1, end: 6 }, 'caret is good');
 
@@ -388,7 +388,7 @@ QUnit.module('format: sign and minus button', moduleConfig, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 2, end: 2 }, 'caret is good');
 
         this.keyboard.caret({ start: 0, end: 2 }).keyDown('-');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.input.val(), '5', 'value is correct');
         assert.deepEqual(this.keyboard.caret(), { start: 0, end: 1 }, 'caret is good');
 
@@ -406,7 +406,7 @@ QUnit.module('format: sign and minus button', moduleConfig, () => {
         });
 
         this.keyboard.caret({ start: 1, end: 3 }).keyDown('-');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.input.val(), '-123.4', 'value is correct');
         assert.deepEqual(this.keyboard.caret(), { start: 2, end: 4 }, 'caret is good');
 
@@ -421,7 +421,7 @@ QUnit.module('format: sign and minus button', moduleConfig, () => {
         });
 
         this.keyboard.caret({ start: 1, end: 2 }).keyDown('-');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(this.input.val(), '<<123.4>>', 'value is correct');
         assert.deepEqual(this.keyboard.caret(), { start: 3, end: 4 }, 'caret is good');
@@ -434,7 +434,7 @@ QUnit.module('format: sign and minus button', moduleConfig, () => {
         });
 
         this.keyboard.caret({ start: 1, end: 2 }).press('-').change();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(this.input.val(), '<<123.4>>', 'value is correct');
         assert.deepEqual(this.keyboard.caret(), { start: 3, end: 4 }, 'caret preserved');
@@ -477,7 +477,7 @@ QUnit.module('format: sign and minus button', moduleConfig, () => {
             .type('0.51')
             .change();
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(this.input.val(), '-0.51', 'text is correct');
         assert.strictEqual(this.instance.option('value'), -0.51, 'value is correct');
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -455,7 +455,7 @@ QUnit.module('functionality', moduleSetup, () => {
             .type('one')
             .change();
 
-        this.clock.tick();
+        this.clock.tick(10);
         selectBox.option('opened', false);
         selectBox.option('dataSource', null);
         $element.find(`.${DX_DROP_DOWN_BUTTON}`).trigger('dxclick');
@@ -687,7 +687,7 @@ QUnit.module('functionality', moduleSetup, () => {
             selectedItem: items[0]
         }).dxSelectBox('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), '', 'selected item');
         assert.strictEqual(selectBox.option('selectedItem'), null, 'selected item');
@@ -1670,11 +1670,11 @@ QUnit.module('clearButton', moduleSetup, () => {
             value: 1
         }).dxSelectBox('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         pointerMock($selectBox.find(toSelector(CLEAR_BUTTON_AREA))).click();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), '', 'text field is cleared');
         assert.strictEqual(selectBox.option('value'), null, 'value is null');
@@ -3906,7 +3906,7 @@ QUnit.module('search substitution', {
 
         try {
             listItem.trigger('dxpointerdown');
-            clock.tick();
+            clock.tick(10);
             let $input = this.$selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
 
             assert.equal($input.val(), '', 'input value should not be changed when selection is not complete');
@@ -4293,7 +4293,7 @@ QUnit.module('regressions', moduleSetup, () => {
             focusStateEnabled: true
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const selectBox = $element.dxSelectBox('instance');
         const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
@@ -4323,7 +4323,7 @@ QUnit.module('regressions', moduleSetup, () => {
             focusStateEnabled: true
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const selectBox = $element.dxSelectBox('instance');
         const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
@@ -4354,7 +4354,7 @@ QUnit.module('regressions', moduleSetup, () => {
             focusStateEnabled: true
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const selectBox = $element.dxSelectBox('instance');
         const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
@@ -4385,7 +4385,7 @@ QUnit.module('regressions', moduleSetup, () => {
             focusStateEnabled: true
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const selectBox = $element.dxSelectBox('instance');
         const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
@@ -5481,7 +5481,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
 
         keyboardMock($input).type('a');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($selectBox.dxSelectBox('option', 'opened'), true, 'value typed in input');
         assert.deepEqual($('.dx-list').dxList('option', 'items'), ['a', 'ab', 'ac'], 'items filtered');
@@ -5613,7 +5613,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
 
         $($input).trigger('dxclick');
         $($input).trigger('dxclick'); // NOTE: open again
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual($('.dx-list').dxList('option', 'items'), ['a', 'b'], 'all items');
     });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/tagBox.tests.js
@@ -682,7 +682,7 @@ QUnit.module('tags', moduleSetup, () => {
                 value: [1]
             });
             const tagBox = $tagBox.dxTagBox('instance');
-            this.clock.tick();
+            this.clock.tick(10);
             items = [{ name: 'updated', value: 1 }];
             dataSource.reload();
             tagBox.repaint();
@@ -1516,7 +1516,7 @@ QUnit.module('the \'onCustomItemCreating\' option', moduleSetup, () => {
             .type('123')
             .press('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $tags = $tagBox.find('.dx-tag');
         const $listItems = $(instance.content()).find('.dx-list-item.dx-list-item-selected');
@@ -1552,7 +1552,7 @@ QUnit.module('the \'onCustomItemCreating\' option', moduleSetup, () => {
             .type('123')
             .press('enter');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $tags = $tagBox.find('.dx-tag');
         const $listItems = $(instance.content()).find('.dx-list-item.dx-list-item-selected');
@@ -3367,7 +3367,7 @@ QUnit.module('searchEnabled', moduleSetup, () => {
             value: ['Moscow']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const $input = $tagBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         keyboardMock($input).type('Lon');
 
@@ -6394,7 +6394,7 @@ QUnit.module('dataSource integration', moduleSetup, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $tagBox.dxTagBox('option', 'value', [1]);
     });
@@ -7081,7 +7081,7 @@ QUnit.module('regression', {
         tagBox.option('value', [1]);
 
         assert.notOk(tagBox.option('selectedItems').length);
-        clock.tick();
+        clock.tick(10);
         assert.ok(tagBox.option('selectedItems').length);
         clock.restore();
     });
@@ -7255,7 +7255,7 @@ QUnit.module('regression', {
             value: [1, 2]
         }).dxTagBox('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(tagBox.option('selectedItems').length, 2, 'selectedItems contains all selected values');
 
         const $container = tagBox.$element().find('.' + TAGBOX_TAG_CONTAINER_CLASS);
@@ -7268,7 +7268,7 @@ QUnit.module('regression', {
 
         $($tagRemoveButtons.eq(1)).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(tagBox.option('selectedItems').length, 1, 'selectedItems was changed correctly');
     });

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -423,7 +423,7 @@ QUnit.module('typing', moduleConfig, () => {
         keyboard.caret(0);
 
         $input.triggerHandler('focus');
-        clock.tick();
+        clock.tick(10);
 
         keyboard.type('123').press('enter');
         assert.equal(handler.callCount, 1, '\'change\' event is fired on enter after value change');
@@ -470,7 +470,7 @@ QUnit.module('typing', moduleConfig, () => {
                 .beforeInput(testText)
                 .input();
 
-            clock.tick();
+            clock.tick(10);
             assert.strictEqual($input.val(), '+1 (555) 555', 'the mask is applied');
             assert.equal(textEditor.option('isValid'), true, 'isValid is true');
         } finally {
@@ -511,7 +511,7 @@ QUnit.module('backspace key', moduleConfig, () => {
 
         keyboard.type('x').press('backspace');
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(keyboard.caret().start, 0, 'caret moved backward');
         assert.equal($input.val(), '_', 'char was removed');
     });
@@ -535,7 +535,7 @@ QUnit.module('backspace key', moduleConfig, () => {
         assert.equal(keyboard.caret().start, 1, 'caret moved to fixed char');
 
         keyboard.press('backspace');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal($input.val(), '_-_', 'char was removed');
         assert.equal(keyboard.caret().start, 0, 'caret moved to start position');
     });
@@ -599,7 +599,7 @@ QUnit.module('backspace key', moduleConfig, () => {
             .press('backspace')
             .press('backspace');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($input.val(), '_-_x', 'chars removed correctly');
     });
@@ -624,7 +624,7 @@ QUnit.module('backspace key', moduleConfig, () => {
             .beforeInput(null, BACKSPACE_INPUT_TYPE)
             .input(null, BACKSPACE_INPUT_TYPE);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($input.val(), 'x-x_', 'char removed');
     });
@@ -668,7 +668,7 @@ QUnit.module('delete key', moduleConfig, () => {
             .caret({ start: 0, end: 3 })
             .press('del');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($input.val(), '_- x', 'letter deleted');
     });
@@ -722,7 +722,7 @@ QUnit.module('selection', moduleConfig, () => {
         keyboard.press('backspace');
 
         if(instance._maskStrategy.NAME === 'default') {
-            this.clock.tick();
+            this.clock.tick(10);
         }
 
         assert.equal($input.val(), 'x__', 'printed only one char');
@@ -810,14 +810,14 @@ QUnit.module('showMaskMode', moduleConfig, () => {
         assert.equal($input.val(), '', 'input is empty');
 
         $input.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(textEditor.option('text'), '__', 'editor is not empty');
         assert.equal($input.val(), '__', 'input is not empty');
         assert.deepEqual(keyboard.caret(), { start: 0, end: 0 }, 'caret position is on the start');
 
         $input.blur();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(textEditor.option('text'), '', 'editor is empty');
         assert.equal($input.val(), '', 'input is empty');
@@ -838,7 +838,7 @@ QUnit.module('showMaskMode', moduleConfig, () => {
         assert.equal($input.val(), '', 'input is empty');
 
         $input.focus();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(textEditor.option('text'), '_-_', 'editor is not empty');
         assert.equal($input.val(), '_-_', 'input is not empty');
         assert.deepEqual(keyboard.caret(), { start: 0, end: 0 }, 'caret position is on the start');
@@ -884,7 +884,7 @@ QUnit.module('focusing', moduleConfig, () => {
 
         keyboard.caret(0);
         $input.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(keyboard.caret().start, 1, 'caret position set before first rule');
     });
@@ -902,7 +902,7 @@ QUnit.module('focusing', moduleConfig, () => {
 
         keyboard.caret(3);
         $input.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(keyboard.caret().start, 1, 'caret position set before last fixed mask letter');
         assert.equal(keyboard.caret().end, 1, 'caret position set before last fixed mask letter');
@@ -927,7 +927,7 @@ QUnit.module('focusing', moduleConfig, () => {
         const keyboard = keyboardMock($input, true);
 
         keyboard.caret(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(keyboard.caret().start, 0, 'caret is at the start');
         assert.equal(keyboard.caret().end, 0, 'caret is at the start');
@@ -943,12 +943,12 @@ QUnit.module('focusing', moduleConfig, () => {
         const keyboard = keyboardMock($input, true);
 
         $input.focus();
-        this.clock.tick();
+        this.clock.tick(10);
         keyboard.type('1');
 
         $input.blur();
         $input.focus();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(keyboard.caret().start, 1, 'caret is at the last symbol');
         assert.equal(keyboard.caret().end, 1, 'caret is at the last symbol');
@@ -1410,7 +1410,7 @@ QUnit.module('clear button', () => {
             caretWorkaround($input);
 
             $input.trigger('focus');
-            clock.tick();
+            clock.tick(10);
 
             $clearButton.trigger('dxclick');
 
@@ -1434,7 +1434,7 @@ QUnit.module('clear button', () => {
                 .find('.dx-clear-button-area')
                 .trigger('dxclick');
 
-            clock.tick();
+            clock.tick(10);
 
             assert.expect(0);
         } finally {
@@ -1572,11 +1572,11 @@ QUnit.module('paste', moduleConfig, () => {
         const keyboard = keyboardMock($input, true);
 
         keyboard.caret(0);
-        this.clock.tick();
+        this.clock.tick(10);
         keyboard.paste('xx');
 
         // NOTE: wait for textEditor async paste handler
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(keyboard.caret(), { start: 2, end: 2 }, 'caret has correct position');
     });
@@ -1672,7 +1672,7 @@ QUnit.module('drag text', moduleConfig, () => {
 
         $input.val('(x)_').trigger('drop');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($input.val(), '(x_)', 'mask is correct');
     });
@@ -1690,7 +1690,7 @@ QUnit.module('drag text', moduleConfig, () => {
 
         $input.val('(x__y)').trigger('drop');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($input.val(), '(xy__)', 'mask is corrected');
     });
@@ -1957,7 +1957,7 @@ QUnit.module('T9', moduleConfig, () => {
             .caret({ start: 0, end: 1 })
             .input('x');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($input.val(), '(x)', 'mask works correctly');
     });
@@ -1983,10 +1983,10 @@ QUnit.module('T9', moduleConfig, () => {
             .caret({ start: 0, end: 1 })
             .input('x');
 
-        this.clock.tick();
+        this.clock.tick(10);
         keyboard.keyPress('x');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($input.val(), '(x_)', 'mask works correctly');
     });
@@ -2004,16 +2004,16 @@ QUnit.module('T9', moduleConfig, () => {
 
         this.focusAndTick($input);
         keyboard.type('xx');
-        this.clock.tick();
+        this.clock.tick(10);
 
         keyboard.press('backspace');
-        this.clock.tick();
+        this.clock.tick(10);
 
         keyboard.press('backspace');
-        this.clock.tick();
+        this.clock.tick(10);
 
         keyboard.press('backspace');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(keyboard.caret().start, 0, 'caret moved backward');
         assert.equal($input.val(), '_-_', 'chars was removed');

--- a/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/validator.tests.js
@@ -383,7 +383,7 @@ QUnit.module('Validator specific tests', {
         });
 
         validator.validate();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(validator.option('isValid'));
     });

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/api.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/api.tests.js
@@ -391,9 +391,9 @@ testModule('API', moduleConfig, () => {
 
         this.instance.on('valueChanged', valueChangeStub);
         this.instance.option('value', '<p>First row</p><p>Second row</p>');
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('value', 'New text');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(valueChangeStub.lastCall.args[0].value, '<p>New text</p>');
         assert.strictEqual(updateContentSpy.callCount, 2, 'value changed twice -> update content two times');
@@ -406,7 +406,7 @@ testModule('API', moduleConfig, () => {
 
         this.instance.on('valueChanged', valueChangeStub);
         this.instance.option('value', '<p>new markup</p><p></p>');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(valueChangeStub.callCount, 1);
         assert.strictEqual(valueChangeStub.getCall(0).args[0].value, '<p>new markup</p>', 'markup optimized');
@@ -419,7 +419,7 @@ testModule('API', moduleConfig, () => {
 
         this.instance.on('valueChanged', valueChangeStub);
         this.instance.option('value', '<p>markup</p><p></p>');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(valueChangeStub.callCount, 0);
     });
@@ -467,14 +467,14 @@ testModule('API', moduleConfig, () => {
         };
         this.createEditor();
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     test('onContentReady event should trigger after editor without transcluded content rendered', function(assert) {
         this.options.onContentReady = sinon.stub();
         this.createEditor();
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(this.options.onContentReady.calledOnce, 'onContentReady has been called once');
     });
 
@@ -482,7 +482,7 @@ testModule('API', moduleConfig, () => {
         this.options = { onContentReady: sinon.stub() };
         this.createEditor();
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(this.options.onContentReady.calledOnce, 'onContentReady has been called once');
     });
 
@@ -491,7 +491,7 @@ testModule('API', moduleConfig, () => {
         this.options = { onContentReady: sinon.stub() };
         this.createEditor();
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(this.options.onContentReady.calledOnce, 'onContentReady has been called once');
     });
 });

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/dropImageModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/dropImageModule.tests.js
@@ -73,7 +73,7 @@ QUnit.module('DropImage module', moduleConfig, () => {
             }
         }));
         this.$element.trigger(event);
-        clock.tick();
+        clock.tick(10);
 
         const { mozilla, chrome, version } = browser;
         if(mozilla || chrome && version > 82) {

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/mentionIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/mentionIntegration.tests.js
@@ -82,7 +82,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('popup position', function(assert) {
@@ -91,7 +91,7 @@ export default function() {
             const fixtureLeft = $fixture.css('left');
             const valueChangeSpy = sinon.spy(() => {
                 this.instance.setSelection(0, 1);
-                this.clock.tick();
+                this.clock.tick(10);
                 const { bottom, left } = getSelection().getRangeAt(0).getBoundingClientRect();
                 const overlayRect = $(`.${SUGGESTION_LIST_CLASS}`).closest(`.${OVERLAY_CONTENT_CLASS}`).get(0).getBoundingClientRect();
 
@@ -112,7 +112,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('set up mentions for existed editor', function(assert) {
@@ -134,7 +134,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('reset mentions option for existed editor', function(assert) {
@@ -153,7 +153,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('change mentions marker', function(assert) {
@@ -177,7 +177,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('#');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('list isn\'t shown for wrong marker', function(assert) {
@@ -196,7 +196,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('several mention markers: first mention', function(assert) {
@@ -221,7 +221,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('several mention markers: second mention', function(assert) {
@@ -246,7 +246,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('#');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('reduce mention markers', function(assert) {
@@ -277,7 +277,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('*');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('old marker doesn\'t work after reduce mention markers', function(assert) {
@@ -307,7 +307,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('#');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.skipInShadowDomMode('new mention should be selected after press \'enter\' key', function(assert) {
@@ -315,11 +315,11 @@ export default function() {
             const expectedMention = '<p><span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="John" data-id="John"><span contenteditable="false"><span>@</span>John</span></span> </p>';
             const valueChangeSpy = sinon.spy(({ value }) => {
                 if(valueChangeSpy.calledOnce) {
-                    this.clock.tick();
+                    this.clock.tick(10);
                     const $content = this.$element.find(`.${HTML_EDITOR_CONTENT}`);
                     KeyEventsMock.simulateEvent($content.get(0), 'keydown', { keyCode: KEY_CODES.ARROW_DOWN });
                     KeyEventsMock.simulateEvent($content.get(0), 'keydown', { keyCode: KEY_CODES.ENTER });
-                    this.clock.tick();
+                    this.clock.tick(10);
                 } else {
                     assert.strictEqual(prepareEmbedValue(value), expectedMention, 'mention has been added');
                     done();
@@ -330,14 +330,14 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('navigation keys don\'t change a caret position when suggestion list is visible', function(assert) {
             const done = assert.async();
             const valueChangeSpy = sinon.spy(() => {
                 if(valueChangeSpy.calledOnce) {
-                    this.clock.tick();
+                    this.clock.tick(10);
                     const $content = this.$element.find(`.${HTML_EDITOR_CONTENT}`);
                     const range = this.instance.getSelection();
 
@@ -354,7 +354,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('list should show relevant items on typing text', function(assert) {
@@ -363,7 +363,7 @@ export default function() {
                 if(valueChangeSpy.calledOnce) {
                     const element = this.$element.find('p').get(0);
                     element.innerText += 'F';
-                    this.clock.tick();
+                    this.clock.tick(10);
                 } else {
                     this.clock.tick(POPUP_TIMEOUT);
                     const $items = this.getItems();
@@ -379,7 +379,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('first list item should be focused on filtering', function(assert) {
@@ -389,7 +389,7 @@ export default function() {
                     const element = this.$element.find('p').get(0);
 
                     element.innerText += 'F';
-                    this.clock.tick();
+                    this.clock.tick(10);
                 } else {
                     this.clock.tick(POPUP_TIMEOUT);
                     const $items = this.getItems();
@@ -404,7 +404,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('input text should be removed after item select', function(assert) {
@@ -416,7 +416,7 @@ export default function() {
                 switch(valueChangeSpy.callCount) {
                     case 1:
                         element.innerText += 'F';
-                        this.clock.tick();
+                        this.clock.tick(10);
                         break;
                     case 2:
                         this.clock.tick(POPUP_TIMEOUT);
@@ -434,7 +434,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('search timeout', function(assert) {
@@ -446,7 +446,7 @@ export default function() {
                     const element = this.$element.find('p').get(0);
 
                     element.innerText += 'F';
-                    this.clock.tick();
+                    this.clock.tick(10);
                     assert.strictEqual(this.getItems().length, 4, 'dataSource isn\'t filtered');
                 } else {
                     this.clock.tick(TIMEOUT);
@@ -463,7 +463,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('minimal search length', function(assert) {
@@ -473,12 +473,12 @@ export default function() {
                 let $items;
                 if(valueChangeSpy.calledOnce) {
                     getParagraph().innerText += 'F';
-                    this.clock.tick();
+                    this.clock.tick(10);
                     const $items = this.getItems();
                     assert.strictEqual($items.length, 4, 'dataSource isn\'t filtered');
                 } else if(valueChangeSpy.calledTwice) {
                     getParagraph().innerText += 'r';
-                    this.clock.tick();
+                    this.clock.tick(10);
                 } else {
                     this.clock.tick(POPUP_TIMEOUT);
                     $items = this.getItems();
@@ -494,7 +494,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('search expression', function(assert) {
@@ -505,7 +505,7 @@ export default function() {
                     const element = this.$element.find('p').get(0);
 
                     element.innerText += 'A';
-                    this.clock.tick();
+                    this.clock.tick(10);
                 } else {
                     this.clock.tick(POPUP_TIMEOUT);
                     $items = this.getItems();
@@ -530,7 +530,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('template', function(assert) {
@@ -540,7 +540,7 @@ export default function() {
                 if(valueChangeSpy.calledOnce) {
                     $(`.${SUGGESTION_LIST_CLASS} .${LIST_ITEM_CLASS}`).eq(1).trigger('dxclick');
 
-                    this.clock.tick();
+                    this.clock.tick(10);
                 } else {
                     assert.strictEqual(prepareEmbedValue(value), expectedMention, 'mention has been added');
                     done();
@@ -555,7 +555,7 @@ export default function() {
             this.createWidget();
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('template for existed value', function(assert) {
@@ -580,7 +580,7 @@ export default function() {
                 if(valueChangeSpy.calledOnce) {
                     $(`.${SUGGESTION_LIST_CLASS} .${LIST_ITEM_CLASS}`).eq(1).trigger('dxclick');
 
-                    this.clock.tick();
+                    this.clock.tick(10);
                 } else {
                     assert.strictEqual(prepareEmbedValue(value), expectedMention, 'mention has been added');
                     done();
@@ -602,7 +602,7 @@ export default function() {
 
             this.instance.focus();
             this.$element.find('p').first().text('@');
-            this.clock.tick();
+            this.clock.tick(10);
         });
     });
 }

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/mentionModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/mentionModule.tests.js
@@ -309,11 +309,11 @@ QUnit.module('Mentions module', moduleConfig, () => {
         const removeWord = { ops: [{ delete: 3 }] };
 
         mention.onTextChange(addMarker, {}, 'user');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(hidePopupSpy.notCalled);
 
         mention.onTextChange(removeWord, {}, 'user');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(hidePopupSpy.calledOnce);
     });
 
@@ -325,10 +325,10 @@ QUnit.module('Mentions module', moduleConfig, () => {
         const removeMarker = { ops: [{ delete: 1 }] };
 
         mention.onTextChange(addMarker, {}, 'user');
-        this.clock.tick();
+        this.clock.tick(10);
         mention.onTextChange(removeMarker, {}, 'user');
         mention.onTextChange(addMarker, {}, 'user');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(filterListSpy.notCalled);
     });
@@ -409,7 +409,7 @@ QUnit.module('Mentions module', moduleConfig, () => {
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
 
-        this.clock.tick();
+        this.clock.tick(10);
         const $list = $(`.${SUGGESTION_LIST_CLASS}`);
         const isListFocused = $list.hasClass(FOCUSED_STATE_CLASS);
         const isFirstListItemFocused = $list.find(`.${LIST_ITEM_CLASS}`).first().hasClass(FOCUSED_STATE_CLASS);
@@ -424,7 +424,7 @@ QUnit.module('Mentions module', moduleConfig, () => {
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.$element.trigger($.Event('keydown', { key: 'ArrowDown', which: KEY_CODES.ARROW_DOWN }));
 
         const $list = $(`.${SUGGESTION_LIST_CLASS}`);
@@ -465,12 +465,13 @@ QUnit.module('Mentions module', moduleConfig, () => {
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $items = $(`.${SUGGESTION_LIST_CLASS} .${LIST_ITEM_CLASS}`);
         assert.strictEqual($items.length, 50);
 
         this.$element.trigger($.Event('keydown', { key: 'ArrowUp', which: KEY_CODES.ARROW_UP }));
+
         $items = $(`.${SUGGESTION_LIST_CLASS} .${LIST_ITEM_CLASS}`);
         const isLastItemOnPageFocused = $items.eq(49).hasClass(FOCUSED_STATE_CLASS);
 
@@ -484,7 +485,7 @@ QUnit.module('Mentions module', moduleConfig, () => {
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.$element.trigger($.Event('keydown', { key: 'ArrowUp', which: KEY_CODES.ARROW_UP }));
 
@@ -502,7 +503,7 @@ QUnit.module('Mentions module', moduleConfig, () => {
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.$element.trigger($.Event('keydown', { key: 'ArrowUp', which: KEY_CODES.ARROW_UP }));
 
@@ -528,10 +529,10 @@ QUnit.module('Mentions module', moduleConfig, () => {
 
             mention.savePosition(0);
             mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
-            this.clock.tick();
+            this.clock.tick(10);
 
             this.$element.trigger($.Event('keydown', { key, which: code }));
-            this.clock.tick();
+            this.clock.tick(10);
 
             const expectedDelta = new this.Delta()
                 .delete(1)
@@ -552,7 +553,7 @@ QUnit.module('Mentions module', moduleConfig, () => {
 
             mention.savePosition(0);
             mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
-            this.clock.tick();
+            this.clock.tick(10);
 
             mention.onTextChange(INSERT_TEXT_DELTA, {}, 'user');
             this.clock.tick(POPUP_HIDING_TIMEOUT);
@@ -572,7 +573,7 @@ QUnit.module('Mentions module', moduleConfig, () => {
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $list = $(`.${SUGGESTION_LIST_CLASS}`);
 
@@ -630,7 +631,7 @@ QUnit.module('Mentions module', moduleConfig, () => {
         const mention = new Mentions(this.quillMock, this.options);
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('#qunit-fixture').triggerHandler('scroll');
 
@@ -643,7 +644,7 @@ QUnit.module('Mentions module', moduleConfig, () => {
 
         mention.savePosition(0);
         mention.onTextChange(INSERT_DEFAULT_MENTION_DELTA, {}, 'user');
-        this.clock.tick();
+        this.clock.tick(10);
         mention.onTextChange({ ops: [{ insert: 'A' }] }, {}, 'user');
         this.clock.tick(POPUP_HIDING_TIMEOUT);
 

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/popupModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/popupModule.tests.js
@@ -52,7 +52,7 @@ QUnit.module('Popup module', moduleConfig, () => {
         const insertEmbedContent = sinon.spy(popupModule, 'insertEmbedContent');
 
         popupModule.showPopup();
-        this.clock.tick();
+        this.clock.tick(10);
         const $suggestionList = $(`.${SUGGESTION_LIST_CLASS}`);
         const $suggestionListWrapper = $suggestionList.closest(`.${SUGGESTION_LIST_WRAPPER_CLASS}`);
 
@@ -96,7 +96,7 @@ QUnit.module('Popup module', moduleConfig, () => {
         const popupModule = new PopupModule({}, this.options);
 
         popupModule.showPopup();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $wrapper = $(popupModule._popup.$wrapper());
 

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/tableContextMenuIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/tableContextMenuIntegration.tests.js
@@ -58,7 +58,7 @@ module('Table context menu integration', {
             this.quillInstance.setSelection(50, 1);
             const $tableElement = this.$element.find('td').eq(5);
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             return $(CONTEXT_MENU_OVERLAY_SELECTOR);
         };
@@ -68,7 +68,7 @@ module('Table context menu integration', {
 
             const $ItemsHasSubmenu = $contextMenu.find(`.${ITEM_HAS_SUBMENU_CLASS}`);
             $ItemsHasSubmenu.eq(firstMenuItemIndex).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
             return $contextMenu.find(SUBMENU_ITEMS_SELECTOR);
         };
     },
@@ -83,7 +83,7 @@ module('Table context menu integration', {
 
             const $tableElement = this.$element.find('td').eq(0);
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
 
             assert.ok($contextMenu.length);
@@ -93,7 +93,7 @@ module('Table context menu integration', {
             this.createWidget();
 
             this.$element.find('p').eq(0).trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
 
             assert.strictEqual($contextMenu.length, 0);
@@ -106,7 +106,7 @@ module('Table context menu integration', {
             const $tableElement = this.$element.find('td').eq(5);
             eventsEngine.trigger($tableElement, createEvent('dxcontextmenu', clickCoordinates));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const startPosition = this.instance._getQuillContainer().get(0).getBoundingClientRect();
             const contextMenuPosition = this.instance.getModule('tableContextMenu')._contextMenu.option('position');
@@ -188,15 +188,15 @@ module('Table context menu integration', {
             const $tableElement = this.$element.find('td').eq(0);
 
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             this.$element.trigger('dxclick');
 
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
 
@@ -210,7 +210,7 @@ module('Table context menu integration', {
             const $tableElement = this.$element.find('td').eq(0);
 
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
 
@@ -228,14 +228,14 @@ module('Table context menu integration', {
             const $tableElement = this.$element.find('td').eq(0);
 
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
 
             const $ItemsHasSubmenu = $contextMenu.find(`.${ITEM_HAS_SUBMENU_CLASS}`);
 
             $ItemsHasSubmenu.eq(0).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $submenuItems = $contextMenu.find(SUBMENU_ITEMS_SELECTOR);
 
@@ -248,14 +248,14 @@ module('Table context menu integration', {
             const $tableElement = this.$element.find('td').eq(0);
 
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
 
             const $ItemsHasSubmenu = $contextMenu.find(`.${ITEM_HAS_SUBMENU_CLASS}`);
 
             $ItemsHasSubmenu.eq(1).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $submenuItems = $contextMenu.find(SUBMENU_ITEMS_SELECTOR);
 
@@ -268,7 +268,7 @@ module('Table context menu integration', {
             const $tableElement = this.$element.find('td').eq(0);
 
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
 
@@ -528,7 +528,7 @@ module('Table context menu integration', {
             const $menuItems = $contextMenu.find(`.${ITEM_HAS_TEXT_CLASS}`);
 
             $menuItems.eq(0).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $table = this.$element.find('table');
 
@@ -548,7 +548,7 @@ module('Table context menu integration', {
             this.quillInstance.setSelection(50, 1);
             const $tableElement = this.$element.find('td').eq(5);
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
             const $menuItems = $contextMenu.find(`.${ITEM_HAS_TEXT_CLASS}`);
@@ -598,7 +598,7 @@ module('Table context menu integration', {
             this.quillInstance.setSelection(50, 1);
             const $tableElement = this.$element.find('td').eq(5);
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
             const $menuItems = $contextMenu.find(`.${ITEM_HAS_TEXT_CLASS}`);
@@ -633,13 +633,13 @@ module('Table context menu integration', {
             this.quillInstance.setSelection(50, 1);
             const $tableElement = this.$element.find('td').eq(5);
             $tableElement.trigger('dxcontextmenu');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $contextMenu = $(CONTEXT_MENU_OVERLAY_SELECTOR);
             const $menuItems = $contextMenu.find(`.${ITEM_HAS_TEXT_CLASS}`);
 
             $menuItems.eq(1).trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $toolbarFormatRight = this.$element.find('.dx-alignright-format');
 

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/tableProperties.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/tableProperties.tests.js
@@ -125,7 +125,7 @@ module('Table properties forms', {
             const $button = $('.dx-popup-bottom .dx-button:visible').eq(buttonIndex);
             $button.trigger('dxclick');
 
-            this.clock.tick();
+            this.clock.tick(10);
         };
 
         this.getFormInstance = () => {
@@ -144,7 +144,7 @@ module('Table properties forms', {
             const $tableElement = this.$element.find('table').eq(0);
 
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const $form = $('.dx-form:not(.dx-formdialog-form)');
             const $scrollView = $form.closest('.dx-scrollview');
 
@@ -161,7 +161,7 @@ module('Table properties forms', {
             this.quillInstance.setSelection(50, 1);
 
             showCellPropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
             const tableBorderColor = $tableElement.css('borderTopColor');
             const tableBackgroundColor = $tableElement.css('backgroundColor');
@@ -191,7 +191,7 @@ module('Table properties forms', {
             this.quillInstance.setSelection(50, 1);
 
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const formInstance = this.getFormInstance();
 
@@ -226,7 +226,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(0, 2);
             showCellPropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const formInstance = this.getFormInstance();
             const backgroundColorEditor = formInstance.$element().find(`.${COLOR_BOX_CLASS}`).eq(1).dxColorBox('instance');
@@ -243,7 +243,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(0, 2);
             showCellPropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
 
             this.applyFormChanges();
 
@@ -260,7 +260,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(50, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -278,7 +278,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(50, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const heightEditor = formInstance.getEditor('height');
@@ -303,7 +303,7 @@ module('Table properties forms', {
 
             showCellPropertiesForm(this.instance, $targetCell);
 
-            this.clock.tick();
+            this.clock.tick(10);
             const $form = $('.dx-form:not(.dx-formdialog-form)');
             const $scrollView = $form.closest('.dx-scrollview');
 
@@ -326,7 +326,7 @@ module('Table properties forms', {
 
                 showCellPropertiesForm(this.instance, $targetCell);
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.applyFormChanges(buttonConfig.index);
 
@@ -334,7 +334,7 @@ module('Table properties forms', {
                 const formatHelpers = getFormatHandlers(contextMenuModule);
                 formatHelpers['link'](this.$element);
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const formItemsCount = $(`.${FORM_CLASS} .${FIELD_ITEM_CLASS}`).length;
 
@@ -351,7 +351,7 @@ module('Table properties forms', {
             this.quillInstance.setSelection(50, 1);
 
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const borderStyleEditor = formInstance.getEditor('borderStyle');
@@ -385,7 +385,7 @@ module('Table properties forms', {
             this.quillInstance.setSelection(50, 1);
 
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const borderStyleEditor = formInstance.getEditor('borderStyle');
@@ -434,7 +434,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(50, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -457,7 +457,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(50, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const heightEditor = formInstance.getEditor('height');
@@ -491,7 +491,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(3, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const heightEditor = formInstance.getEditor('height');
@@ -523,7 +523,7 @@ module('Table properties forms', {
             const $tableElement = this.$element.find('table').eq(0);
 
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const formInstance = this.getFormInstance();
             const width = formInstance.getEditor('width').option('value');
@@ -541,7 +541,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $cellElement);
-            this.clock.tick();
+            this.clock.tick(10);
 
 
             const cellPropertiesFormInstance = this.getFormInstance();
@@ -549,7 +549,7 @@ module('Table properties forms', {
             this.applyFormChanges();
 
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const tablePropertiesFormInstance = this.getFormInstance();
             const width = tablePropertiesFormInstance.getEditor('width').option('value');
@@ -579,7 +579,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -610,7 +610,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -633,7 +633,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -662,7 +662,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -693,7 +693,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -728,7 +728,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -763,7 +763,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -786,7 +786,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -808,7 +808,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             let formInstance = this.getFormInstance();
 
             let widthEditor = formInstance.getEditor('width');
@@ -820,7 +820,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
 
             formInstance = this.getFormInstance();
 
@@ -843,7 +843,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(50, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             let formInstance = this.getFormInstance();
 
             let widthEditor = formInstance.getEditor('width');
@@ -855,7 +855,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(50, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             formInstance = this.getFormInstance();
 
             widthEditor = formInstance.getEditor('width');
@@ -885,7 +885,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const heightEditor = formInstance.getEditor('height');
@@ -907,7 +907,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(17, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const heightEditor = formInstance.getEditor('height');
@@ -931,7 +931,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const heightEditor = formInstance.getEditor('height');
@@ -954,7 +954,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const heightEditor = formInstance.getEditor('height');
@@ -980,7 +980,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -1015,7 +1015,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -1039,7 +1039,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             const formInstance = this.getFormInstance();
 
             const widthEditor = formInstance.getEditor('width');
@@ -1075,7 +1075,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             let formInstance = this.getFormInstance();
 
             let widthEditor = formInstance.getEditor('width');
@@ -1085,7 +1085,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             formInstance = this.getFormInstance();
 
             widthEditor = formInstance.getEditor('width');
@@ -1108,7 +1108,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showCellPropertiesForm(this.instance, $targetCell);
-            this.clock.tick();
+            this.clock.tick(10);
             let formInstance = this.getFormInstance();
 
             let widthEditor = formInstance.getEditor('width');
@@ -1118,7 +1118,7 @@ module('Table properties forms', {
 
             this.quillInstance.setSelection(5, 1);
             showTablePropertiesForm(this.instance, $tableElement);
-            this.clock.tick();
+            this.clock.tick(10);
             formInstance = this.getFormInstance();
 
             widthEditor = formInstance.getEditor('width');

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/tableResizingModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/tableResizingModule.tests.js
@@ -82,7 +82,7 @@ module('Table resizing module', moduleConfig, () => {
     test('create module instance with default options', function(assert) {
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(this.$element.find(`.${DX_COLUMN_RESIZE_FRAME_CLASS}`).length, 0, 'There is no resize frame element');
         assert.notOk(resizingInstance.enabled, 'module disabled by default');
     });
@@ -91,7 +91,7 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(this.$element.find(`.${DX_COLUMN_RESIZE_FRAME_CLASS}`).length, 1, 'There is resize frame element');
         assert.ok(resizingInstance.enabled, 'module disabled by default');
     });
@@ -99,12 +99,12 @@ module('Table resizing module', moduleConfig, () => {
     test('module should attach events', function(assert) {
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.attachSpies(resizingInstance);
         resizingInstance.option('enabled', true);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(this.attachEventsSpy.callCount, 1, 'Events are attached on module initialization');
         assert.strictEqual(this.detachEventsSpy.callCount, 0, 'Events are not detached on module initialization');
@@ -114,12 +114,12 @@ module('Table resizing module', moduleConfig, () => {
     test('module should detach events on clean', function(assert) {
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.attachSpies(resizingInstance);
         resizingInstance.option('enabled', true);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         resizingInstance.clean();
 
@@ -130,12 +130,12 @@ module('Table resizing module', moduleConfig, () => {
     test('module should detach events on tableResizng disabling at runtime', function(assert) {
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.attachSpies(resizingInstance);
         resizingInstance.option('enabled', true);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         resizingInstance.option('enabled', false);
 
@@ -147,18 +147,18 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         try {
             resizeCallbacks.fire();
 
             resizingInstance.option('enabled', true);
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             resizingInstance.option('enabled', false);
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             resizingInstance.option('enabled', true);
 
@@ -172,7 +172,7 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         resizeCallbacks.fire();
 
@@ -183,7 +183,7 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         resizeCallbacks.fire();
 
@@ -197,7 +197,7 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.attachSpies(resizingInstance);
         resizingInstance.option('minColumnWidth', 55);
@@ -210,7 +210,7 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.attachSpies(resizingInstance);
         resizingInstance.option('minColumnWidth', -20);
@@ -224,7 +224,7 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.attachSpies(resizingInstance);
         resizingInstance.option('minRowHeight', 45);
@@ -237,7 +237,7 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.attachSpies(resizingInstance);
         resizingInstance.option('tableResizing', { minColumnWidth: 55, minRowHeight: 45 });
@@ -251,7 +251,7 @@ module('Table resizing module', moduleConfig, () => {
         this.options.enabled = true;
         const resizingInstance = new TableResizing(this.quillMock, this.options);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.attachSpies(resizingInstance);
         resizingInstance.option('tableResizing', { enabled: false });

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/toolbarIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/toolbarIntegration.tests.js
@@ -436,8 +436,8 @@ export default function() {
                 .change();
 
             $okDialogButton.trigger('dxclick');
-            this.clock.tick();
-            this.clock.tick();
+            this.clock.tick(10);
+            this.clock.tick(10);
         });
 
         test('Add a link with empty text', function(assert) {
@@ -670,7 +670,7 @@ export default function() {
             $linkFormatButton.trigger('dxclick');
 
             const $textInput = $(`.${DIALOG_FORM_CLASS} .${INPUT_CLASS}`).last();
-            
+
             assert.strictEqual(linkText, $textInput.val());
         });
 
@@ -788,7 +788,7 @@ export default function() {
                 }
             }).dxHtmlEditor('instance');
 
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('history buttons are inactive when editor has initial value', function(assert) {
@@ -840,9 +840,9 @@ export default function() {
                 }
             }).dxHtmlEditor('instance');
 
-            this.clock.tick();
+            this.clock.tick(10);
             instance.option('width', 100);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const toolbarWidth = $container.find(`.${TOOLBAR_CLASS}`).width();
             const beforeContainerWidth = $container.find('.dx-toolbar-before').width();
@@ -926,7 +926,7 @@ export default function() {
                 .trigger('dxclick');
 
             $('.dx-suggestion-list .dx-list-item').trigger('dxclick');
-            this.clock.tick();
+            this.clock.tick(10);
         });
     });
 }

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/valueRendering.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/valueRendering.tests.js
@@ -180,7 +180,7 @@ export default function() {
                 });
             }
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(instance.option('value'), '<h1>Hi!</h1><p>Test</p>');
             assert.equal(markup, '<h1>Hi!</h1><p>Test</p>');
@@ -196,7 +196,7 @@ export default function() {
             const $element = instance.$element();
             const markup = $element.find(getSelector(CONTENT_CLASS)).html();
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(instance.option('value'), '<p>Test1</p><p>Test2</p>');
             assert.equal(markup, '<p>Test1</p><p>Test2</p>');
@@ -284,7 +284,7 @@ export default function() {
                 .dxHtmlEditor()
                 .dxHtmlEditor('instance');
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $element = instance.$element();
             const markup = $element.find(getSelector(CONTENT_CLASS)).html();
@@ -301,7 +301,7 @@ export default function() {
                 .dxHtmlEditor()
                 .dxHtmlEditor('instance');
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $element = instance.$element();
             const markup = $element.find(getSelector(CONTENT_CLASS)).html();
@@ -323,12 +323,12 @@ export default function() {
                 })
                 .dxHtmlEditor('instance');
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.expect(1);
             instance.setSelection(0, 4);
             instance.format('align', 'center');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('editor should respect attributes of the single formatted line', function(assert) {
@@ -344,12 +344,12 @@ export default function() {
                 })
                 .dxHtmlEditor('instance');
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.expect(1);
             instance.setSelection(1, 0);
             instance.format('align', 'center');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('editor should have an empty string value when all content has been removed', function(assert) {
@@ -427,7 +427,7 @@ export default function() {
                 .dxHtmlEditor({ 'value': expected })
                 .dxHtmlEditor('instance');
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.strictEqual(instance.option('value'), expected);
         });
@@ -658,7 +658,7 @@ export default function() {
                 .dxHtmlEditor('instance');
 
             instance.insertEmbed(0, 'extendedImage', { src: 'http://test.test/test.jpg', width: 100, height: 100, alt: 'altering' });
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         test('render link', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/variablesModule.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/variablesModule.tests.js
@@ -133,7 +133,7 @@ QUnit.module('Variables module', moduleConfig, () => {
         variables.showPopup();
         $(`.${SUGGESTION_LIST_CLASS} .dx-item`).first().trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(this.log, [{
             format: 'variable',

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/export.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/export.tests.js
@@ -141,7 +141,7 @@ QUnit.module('dxPivotGrid', {
         this.dataProvider = this.pivotGrid.getDataProvider();
         this.items = this.pivotGrid._getAllItems(columnsInfo, rowsInfo, cellsInfo);
         this.dataProvider.ready();
-        this.clock.tick();
+        this.clock.tick(10);
     },
     afterEach: function() {
         this.clock.restore();
@@ -235,7 +235,7 @@ QUnit.module('dxPivotGrid', {
 
         const showingBeforeReady = spyEnd.callCount === 0 && spyBegin.callCount === 1;
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(spyBegin.callCount, 1, 'beginLoadingChanged was called once');
         assert.strictEqual(spyEnd.callCount, 1, 'endLoadingChanged was called once');
@@ -274,7 +274,7 @@ QUnit.module('dxPivotGrid', {
 
         $($dataArea.find('tr').eq(1).find('td').eq(3)).trigger('dxcontextmenu');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($('.dx-menu-item-text').eq(1).text(), 'Export to Excel file');
 
@@ -289,7 +289,7 @@ QUnit.module('dxPivotGrid', {
 
         $($dataArea.find('tr').eq(1).find('td').eq(3)).trigger('dxcontextmenu');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal($('.dx-menu-item-text').eq(1).text(), '');
     });

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/fieldChooser.tests.js
@@ -2580,7 +2580,7 @@ QUnit.module('FieldChooser encodeHtml', {
                 }
             }, options));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             return this.pivotGrid;
         };

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.markup.tests.js
@@ -76,7 +76,7 @@ QUnit.module('PivotGrid markup tests', () => {
             }
         });
 
-        clock.tick();
+        clock.tick(10);
 
         // assert
         assert.ok(pivotGrid.$element().hasClass('dx-pivotgrid'), 'has dx-pivotgrid class');

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
@@ -6098,7 +6098,7 @@ QUnit.module('Vertical headers', {
     });
 
     // T696415
-    QUnit.test('headers and data columns has same width', function(assert) {
+    QUnit.skip('headers and data columns has same width', function(assert) {
         const fields = [
             { area: 'row', dataField: 'row1' },
             { area: 'column', dataField: 'col1' }

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
@@ -186,7 +186,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
         const pivotGrid = createPivotGrid(testOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $columnCell = pivotGrid.$element().find('.dx-area-column-cell');
         const $rowCell = pivotGrid.$element().find('.dx-area-row-cell');
@@ -205,7 +205,7 @@ QUnit.module('dxPivotGrid', {
         $pivotGridElement.show();
 
         triggerShownEvent($pivotGridElement);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $noDataElement = $(pivotGrid.$element().find('.dx-pivotgrid-nodata'));
         const dataAreaCell = $(`.${DATA_AREA_CELL_CLASS}`);
@@ -288,7 +288,7 @@ QUnit.module('dxPivotGrid', {
 
         assert.roughEqual(loadIndicatorElementOffset.top - dataAreaGroupElementOffset.top, (dataAreaGroupElementOffset.top + getHeight(dataAreaGroupElement)) - (loadIndicatorElementOffset.top + getOuterHeight(loadIndicatorElement)), 2.1, 'loading element position');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(onContentReadyCallback.calledOnce, 'contentReady should be called once');
         assert.ok(!pivotGrid._loadPanel.option('visible'), 'loadPanel should not be visible');
@@ -343,7 +343,7 @@ QUnit.module('dxPivotGrid', {
 
         d.resolve([{ sum: 100 }]);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(loadMessages, ['80%', 'Loading...', '85%', '87%', '90%', '95%', '97%', '100%']);
         assert.deepEqual(progresses, [1]);
@@ -377,7 +377,7 @@ QUnit.module('dxPivotGrid', {
 
         $($expandedSpan).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual($('#pivotGrid').find('.dx-pivotgrid-expanded').length, 0);
         assert.strictEqual($('#pivotGrid').find('.dx-pivotgrid-collapsed').length, 2);
@@ -403,7 +403,7 @@ QUnit.module('dxPivotGrid', {
 
         $($collapsedSpan).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(expandValueChangingArgs, {
             area: 'column',
@@ -431,7 +431,7 @@ QUnit.module('dxPivotGrid', {
 
         $($collapsedSpan).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(expandValueChangingArgs, undefined);
     });
@@ -454,7 +454,7 @@ QUnit.module('dxPivotGrid', {
 
         $($collapsedSpan).trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(expandValueChangingArgs, {
             area: 'column',
@@ -485,7 +485,7 @@ QUnit.module('dxPivotGrid', {
         const $dataArea = $('#pivotGrid').find('.dx-pivotgrid-area-data');
         const $fieldsArea = $('#pivotGrid').find('.dx-pivotgrid-fields-area');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $($dataArea.find('tr').eq(1).find('td').eq(3)).trigger('dxclick');
         $($dataArea.find('tr').eq(2).find('td').eq(4)).trigger('dxclick');
@@ -530,7 +530,7 @@ QUnit.module('dxPivotGrid', {
                 cellClickArgs.push(e);
             }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         pivotGrid.resize();
 
@@ -575,7 +575,7 @@ QUnit.module('dxPivotGrid', {
 
         assert.ok(!$('.dx-fieldchooser-popup').is(':visible'), 'fieldChooser popup is not visible');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $fieldChooserButton = $('#pivotGrid').find('.dx-pivotgrid-field-chooser-button');
         assert.strictEqual($fieldChooserButton.length, 1, 'fieldChooser button is rendered');
@@ -610,7 +610,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldPanelInstance = pivotGrid.$element().dxPivotGridFieldChooserBase('instance');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.notOk(fieldPanelInstance.option('visible'), 'fieldPanel in invisible');
         assert.ok(pivotGrid.$element().hasClass('dx-state-invisible'), 'pivot grid saves invisible styles');
@@ -630,7 +630,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldChooserPopup = pivotGrid.getFieldChooserPopup();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldChooserPopup.show();
         this.clock.tick(500);
@@ -653,7 +653,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldChooserPopup = pivotGrid.getFieldChooserPopup();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldChooserPopup.show();
         this.clock.tick(500);
@@ -689,7 +689,7 @@ QUnit.module('dxPivotGrid', {
             }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         pivotGrid.getFieldChooserPopup().show();
         this.clock.tick(500);
@@ -740,7 +740,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('#pivotGrid').find('.dx-header-filter').first().trigger('dxclick');
         this.clock.tick(500);
@@ -758,7 +758,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldChooserPopup = pivotGrid.getFieldChooserPopup();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldChooserPopup.show();
         this.clock.tick(500);
@@ -778,7 +778,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldChooserPopup = pivotGrid.getFieldChooserPopup();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldChooserPopup.show();
         this.clock.tick(500);
@@ -808,7 +808,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldChooserPopup = pivotGrid.getFieldChooserPopup();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldChooserPopup.show();
         this.clock.tick(500);
@@ -837,7 +837,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('#pivotGrid').find('.dx-header-filter').first().trigger('dxclick');
         this.clock.tick(500);
@@ -865,7 +865,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldChooserPopup = pivotGrid.getFieldChooserPopup();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldChooserPopup.show();
         this.clock.tick(500);
@@ -896,7 +896,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('#pivotGrid').find('.dx-header-filter').first().trigger('dxclick');
         this.clock.tick(500);
@@ -918,7 +918,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldChooserPopup = pivotGrid.getFieldChooserPopup();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldChooserPopup.show();
         this.clock.tick(500);
@@ -943,7 +943,7 @@ QUnit.module('dxPivotGrid', {
         });
         const fieldChooserPopup = pivotGrid.getFieldChooserPopup();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         fieldChooserPopup.show();
         this.clock.tick(500);
@@ -1001,13 +1001,13 @@ QUnit.module('dxPivotGrid', {
 
         pivotGrid.exportTo = sinon.spy();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $exportButton = $('#pivotGrid').find('.dx-pivotgrid-export-button');
         assert.equal($exportButton.length, 0, 'no export button');
 
         pivotGrid.option('export.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         $exportButton = $('#pivotGrid').find('.dx-pivotgrid-export-button');
         assert.equal($exportButton.length, 1, 'export button exists');
@@ -1029,7 +1029,7 @@ QUnit.module('dxPivotGrid', {
         });
 
         pivotGrid.getFieldChooserPopup().show();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok($('.dx-fieldchooser-popup').is(':visible'), 'fieldChooser popup is visible');
 
         pivotGrid.option('dataSource', this.testOptions.dataSource);
@@ -1056,7 +1056,7 @@ QUnit.module('dxPivotGrid', {
 
         const $descriptionCell = $('#pivotGrid').find('td').first();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $($descriptionCell).trigger('dxclick');
 
@@ -1073,7 +1073,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         pivotGrid.getFieldChooserPopup().show();
         this.clock.tick(500);
@@ -1103,7 +1103,7 @@ QUnit.module('dxPivotGrid', {
             rtlEnabled: true
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         pivotGrid.getFieldChooserPopup().show();
 
@@ -1130,7 +1130,7 @@ QUnit.module('dxPivotGrid', {
             rtlEnabled: true
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         pivotGrid._fieldChooserPopup.show();
 
@@ -1411,7 +1411,7 @@ QUnit.module('dxPivotGrid', {
 
         const $dataArea = $('#pivotGrid').find('.dx-pivotgrid-area-data');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $($dataArea.find('tr').eq(1).find('td').eq(3)).trigger('dxcontextmenu');
 
@@ -1459,7 +1459,7 @@ QUnit.module('dxPivotGrid', {
             onContextMenuPreparing: contextMenuPreparing
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         pivotGrid.getFieldChooserPopup().show();
 
@@ -1488,7 +1488,7 @@ QUnit.module('dxPivotGrid', {
 
         pivotGrid.on('contextMenuPreparing', contextMenuPreparing);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('.dx-pivotgrid-vertical-headers .dx-pivotgrid-expanded').trigger('dxcontextmenu');
         $('.dx-pivotgrid-vertical-headers .dx-pivotgrid-collapsed').trigger('dxcontextmenu');
@@ -1522,7 +1522,7 @@ QUnit.module('dxPivotGrid', {
 
         pivotGrid.on('contextMenuPreparing', contextMenuPreparing);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('.dx-pivotgrid-vertical-headers .dx-pivotgrid-expanded').trigger('dxcontextmenu');
 
@@ -1565,7 +1565,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const $dataArea = $('#pivotGrid').find('.dx-pivotgrid-area-data');
 
         $($dataArea.children().eq(0)).trigger('dxcontextmenu');
@@ -1769,7 +1769,7 @@ QUnit.module('dxPivotGrid', {
         const pivotGrid = createPivotGrid({});
 
         pivotGrid.option('dataSource', dataSource);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let isLoaded = false;
 
@@ -1777,7 +1777,7 @@ QUnit.module('dxPivotGrid', {
         dataSource.load().done(function() {
             isLoaded = true;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(isLoaded, 'data source is loaded');
     });
@@ -2750,7 +2750,7 @@ QUnit.module('dxPivotGrid', {
         testElement.width(800);
         testElement.height(300);
         const pivotGrid = createPivotGrid(this.testOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const dataAreaElement = testElement.find('.dx-pivotgrid-area-data table');
         const rows = dataAreaElement[0].rows;
         const colsElement = dataAreaElement.find('col');
@@ -2789,7 +2789,7 @@ QUnit.module('dxPivotGrid', {
         const pivotGrid = createPivotGrid({
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
         const columnWidths = pivotGrid._columnsArea.getColumnsWidth();
 
@@ -2813,7 +2813,7 @@ QUnit.module('dxPivotGrid', {
         const pivotGrid = createPivotGrid({
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
 
         assert.deepEqual(pivotGrid.getScrollPath('column'), ['2010', '1']);
@@ -2837,7 +2837,7 @@ QUnit.module('dxPivotGrid', {
             },
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
 
         const scrollable = pivotGrid._dataArea.groupElement().dxScrollable('instance');
@@ -2884,7 +2884,7 @@ QUnit.module('dxPivotGrid', {
             dataSource: this.dataSource
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(pivotGrid._columnsArea.hasScroll(), 'columns area scroll');
         assert.ok(pivotGrid._rowsArea.hasScroll(), 'rows area scroll');
@@ -2920,7 +2920,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         let contentReadyCallCount = 0;
 
@@ -2930,7 +2930,7 @@ QUnit.module('dxPivotGrid', {
 
         pivotGrid.getDataSource().expandHeaderItem('row', [1]);
         pivotGrid.getDataSource().load();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(contentReadyCallCount, 1);
     });
@@ -2947,7 +2947,7 @@ QUnit.module('dxPivotGrid', {
             },
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const dataAreaScrollable = pivotGrid._dataArea._getScrollable();
         const columnAreaScrollable = pivotGrid._columnsArea._getScrollable();
@@ -2975,7 +2975,7 @@ QUnit.module('dxPivotGrid', {
             },
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
 
         const dataAreaScrollable = pivotGrid._dataArea._getScrollable();
@@ -3017,7 +3017,7 @@ QUnit.module('dxPivotGrid', {
             },
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
 
         const dataAreaScrollable = pivotGrid._dataArea._getScrollable();
@@ -3057,7 +3057,7 @@ QUnit.module('dxPivotGrid', {
             },
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const dataAreaScrollable = pivotGrid._dataArea._getScrollable();
 
@@ -3124,7 +3124,7 @@ QUnit.module('dxPivotGrid', {
         const pivotGrid = createPivotGrid({
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const columnWidths = pivotGrid._columnsArea.getColumnsWidth();
         const scrollable = pivotGrid._dataArea.groupElement().dxScrollable('instance');
@@ -3156,7 +3156,7 @@ QUnit.module('dxPivotGrid', {
             },
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
         const columnHeights = pivotGrid._rowsArea.getRowsHeight();
 
@@ -3188,7 +3188,7 @@ QUnit.module('dxPivotGrid', {
             },
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
         const columnWidth = pivotGrid._columnsArea.getColumnsWidth();
 
@@ -3239,7 +3239,7 @@ QUnit.module('dxPivotGrid', {
                             ]
                         }
                     }).dxPivotGrid('instance');
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     $('#wrapper').css('display', 'block');
                     grid.updateDimensions();
@@ -3266,7 +3266,7 @@ QUnit.module('dxPivotGrid', {
 
             dataSource: this.dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
         const columnHeights = pivotGrid._rowsArea.getRowsHeight();
 
@@ -3358,7 +3358,7 @@ QUnit.module('dxPivotGrid', {
 
         const pivotGrid = createPivotGrid(createPivotGridOptions({ width: 1005, height: 250 }));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(pivotGrid);
         const columnsArea = pivotGrid._columnsArea;
@@ -3435,7 +3435,7 @@ QUnit.module('dxPivotGrid', {
 
         const pivotGrid = createPivotGrid(createPivotGridOptions({ width: 1020, height: 250 }));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(pivotGrid);
         const columnsArea = pivotGrid._columnsArea;
@@ -3495,7 +3495,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
         const columnsArea = pivotGrid._columnsArea;
         assert.ok(!pivotGrid._rowsArea.hasScroll());
@@ -3561,7 +3561,7 @@ QUnit.module('dxPivotGrid', {
 
         const pivotGrid = createPivotGrid(createPivotGridOptions({ width: 1020, height: 250 }));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const columnsArea = pivotGrid._columnsArea;
         assert.ok(!columnsArea.hasScroll(), 'no columnAreaScroll');
@@ -3625,11 +3625,11 @@ QUnit.module('dxPivotGrid', {
 
         const pivotGrid = createPivotGrid(createPivotGridOptions({ width: 1050, height: 250 }));
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('#pivotGrid').css({ height: 1000 });
         pivotGrid.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(pivotGrid);
         const columnsArea = pivotGrid._columnsArea;
@@ -3700,7 +3700,7 @@ QUnit.module('dxPivotGrid', {
         };
 
         const pivotGrid = createPivotGrid(pivotGridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(pivotGrid);
         const getRealHeight = function(element) {
             return window.getComputedStyle ? parseFloat(window.getComputedStyle(element).height) : element.clientHeight;
@@ -3722,7 +3722,7 @@ QUnit.module('dxPivotGrid', {
             width: 150
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const dataArea = pivotGrid._dataArea;
         assert.strictEqual(parseFloat(dataArea.groupElement()[0].style.width).toFixed(2), getWidth(dataArea.tableElement()).toFixed(2));
     });
@@ -3744,7 +3744,7 @@ QUnit.module('dxPivotGrid', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(getWidth($(pivotGrid.element()).find('table').first()), 300);
     });
@@ -3801,7 +3801,7 @@ QUnit.module('dxPivotGrid', {
         };
 
         const pivotGrid = createPivotGrid(pivotGridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(pivotGrid);
         const getRealHeight = function(element) {
@@ -3866,7 +3866,7 @@ QUnit.module('dxPivotGrid', {
         };
 
         const pivotGrid = createPivotGrid(pivotGridOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         pivotGrid.option('showBorders', true);
 
@@ -3901,7 +3901,7 @@ QUnit.module('dxPivotGrid', {
 
         widget.updateDimensions();
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(dataAreaScrollable.scrollTop(), 10);
         assert.strictEqual(dataAreaScrollable.scrollLeft(), 15);
@@ -3951,7 +3951,7 @@ QUnit.module('dxPivotGrid', {
                 }]
             }
         }, assert);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(pivotGrid);
 
@@ -3986,11 +3986,11 @@ QUnit.module('dxPivotGrid', {
             allowSortingBySummary: true,
             width: 200
         }, assert);
-        this.clock.tick();
+        this.clock.tick(10);
 
         getHeaderElement().trigger('dxcontextmenu');
         $('.dx-context-menu.dx-pivotgrid').find('.dx-menu-item').eq(0).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $header = getHeaderElement();
         assert.ok($header.hasClass('dx-pivotgrid-sorted'));
@@ -4020,7 +4020,7 @@ QUnit.module('dxPivotGrid', {
                 }]
             },
         }, assert);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(customizeTextSpy.callCount, 1, 'customizeText call count');
 
@@ -4851,7 +4851,7 @@ QUnit.module('Field Panel', {
                             }
                         });
 
-                        clock.tick();
+                        clock.tick(10);
                         eventsEngine.trigger(pivotGrid.element(), 'dxresize');
 
                         const $dataAreaCell = pivotGrid.$element().find(`.${DATA_AREA_CELL_CLASS}`).first();
@@ -4949,7 +4949,7 @@ QUnit.module('Tests with stubs', {
         that.horizontalArea.on.returns(that.horizontalArea);
         that.horizontalArea.off.returns(that.horizontalArea);
 
-        sinon.stub(HeadersAreaModule, 'HorizontalHeadersArea', function() {
+        sinon.stub(HeadersAreaModule, 'HorizontalHeadersArea').callsFake(function() {
             return that.horizontalArea;
         });
 
@@ -4962,7 +4962,7 @@ QUnit.module('Tests with stubs', {
         that.verticalArea.on.returns(that.verticalArea);
         that.verticalArea.off.returns(that.verticalArea);
 
-        sinon.stub(HeadersAreaModule, 'VerticalHeadersArea', function() {
+        sinon.stub(HeadersAreaModule, 'VerticalHeadersArea').callsFake(function() {
             return that.verticalArea;
         });
 
@@ -4976,7 +4976,7 @@ QUnit.module('Tests with stubs', {
         that.dataArea.on.returns(that.dataArea);
         that.dataArea.off.returns(that.dataArea);
 
-        sinon.stub(DataAreaModule, 'DataArea', function() {
+        sinon.stub(DataAreaModule, 'DataArea').callsFake(function() {
             return that.dataArea;
         });
 
@@ -5014,7 +5014,7 @@ QUnit.module('Tests with stubs', {
         that.dataController.getColumnsInfo.returns([]);
         that.dataController.getRowsInfo.returns([]);
 
-        sinon.stub(DataControllerModule, 'DataController', function(options) {
+        sinon.stub(DataControllerModule, 'DataController').callsFake(function(options) {
             const dataController = that.dataController;
             const dataSource = createMockDataSource(options.dataSource);
 
@@ -5195,7 +5195,7 @@ QUnit.module('Tests with stubs', {
             height: 1000,
             contentLeft: 30,
             contentTop: 15
-        }).reset();
+        });
 
         createPivotGrid({
             dataSource: this.testOptions.dataSource,
@@ -5263,7 +5263,7 @@ QUnit.module('Tests with stubs', {
             height: 1000,
             contentLeft: 30,
             contentTop: 15
-        }).reset();
+        });
 
         createPivotGrid({
             dataSource: this.testOptions.dataSource,
@@ -6098,7 +6098,7 @@ QUnit.module('Vertical headers', {
     });
 
     // T696415
-    QUnit.skip('headers and data columns has same width', function(assert) {
+    QUnit.test('headers and data columns has same width', function(assert) {
         const fields = [
             { area: 'row', dataField: 'row1' },
             { area: 'column', dataField: 'col1' }
@@ -6119,7 +6119,7 @@ QUnit.module('Vertical headers', {
                 ]
             }
         }).dxPivotGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
         grid.$element().css('zoom', 1.35);
         grid.repaint();
 
@@ -6157,7 +6157,7 @@ QUnit.module('Vertical headers', {
                             ]
                         }
                     }).dxPivotGrid('instance');
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     grid.$element().css('zoom', 1.35);
                     grid.repaint();
@@ -6221,7 +6221,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.deepEqual($(grid._dataArea.element()).text(), 'No data');
         });
@@ -6242,7 +6242,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.deepEqual($(grid._dataArea.element()).text(), 'No data');
         });
@@ -6264,7 +6264,7 @@ QUnit.module('Vertical headers', {
                 }
             }
         }).dxPivotGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual($(grid._dataArea.element()).text(), '10');
     });
@@ -6285,7 +6285,7 @@ QUnit.module('Vertical headers', {
                 }
             }
         }).dxPivotGrid('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual($(grid._dataArea.element()).text(), '10');
     });
@@ -6336,7 +6336,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data], remoteOperations = false. Resolve data as object. JQuery promise', function(assert) {
@@ -6361,7 +6361,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data], remoteOperations = false. Resolve data as object. Native promise. Retrieve fields as simple array', function(assert) {
@@ -6386,7 +6386,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data], remoteOperations = false. Resolve data as object. Native promise', function(assert) {
@@ -6411,7 +6411,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data]. remoteOperations = true. Resolve data as arguments list. JQuery promise', function(assert) {
@@ -6443,7 +6443,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data]. remoteOperations = true. Resolve data as object. JQuery promise', function(assert) {
@@ -6475,7 +6475,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data]. remoteOperations = true. Resolve data as object. Native promise', function(assert) {
@@ -6507,7 +6507,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data]. remoteOperations = true. Resolve data as object. Native promise. Retrieve fields as simple array', function(assert) {
@@ -6539,7 +6539,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data]. remoteOperations = true. displayText is specified. Resolve data as arguments list. JQuery promise', function(assert) {
@@ -6571,7 +6571,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data]. remoteOperations = true. displayText is specified. Resolve data as object. JQuery promise', function(assert) {
@@ -6603,7 +6603,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data]. remoteOperations = true. displayText is specified. Resolve data as object. Native promise', function(assert) {
@@ -6635,7 +6635,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('PivotGrid. [col x row x data]. remoteOperations = true. displayText is specified. Resolve data as object. Native promise. Retrieve fields as simple array', function(assert) {
@@ -6667,7 +6667,7 @@ QUnit.module('Vertical headers', {
                     }
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
         });
     });
 
@@ -6696,10 +6696,10 @@ QUnit.module('Vertical headers', {
                         }]
                     }
                 }).dxPivotGrid('instance');
-                clock.tick();
+                clock.tick(10);
 
                 grid.getDataSource().expandHeaderItem(changedArea, [`${changedArea}1`]);
-                clock.tick();
+                clock.tick(10);
 
                 grid.getFieldChooserPopup().show().done(() => {
                     const fieldChooser = grid.getFieldChooserPopup().$content().dxPivotGridFieldChooser('instance');
@@ -6827,7 +6827,7 @@ QUnit.module('Vertical headers', {
                     }]
                 }
             }).dxPivotGrid('instance');
-            clock.tick();
+            clock.tick(10);
 
             grid.getFieldChooserPopup().show().done(() => {
                 const fieldChooser = grid.getFieldChooserPopup().$content().dxPivotGridFieldChooser('instance');
@@ -6841,14 +6841,14 @@ QUnit.module('Vertical headers', {
             createGridAndTestFieldChooser((grid, fieldChooser, clock) => {
                 const fields = grid.getDataSource().state().fields;
                 fieldChooser.option('state', { rowExpandedPaths: [['row1']], columnExpandedPaths: [['column1']], fields: fields });
-                clock.tick();
+                clock.tick(10);
 
                 let dataSourceState = grid.getDataSource().state();
                 assert.deepEqual(dataSourceState.rowExpandedPaths, applyChangesMode === 'instantly' ? [['row1']] : []);
                 assert.deepEqual(dataSourceState.columnExpandedPaths, applyChangesMode === 'instantly' ? [['column1']] : []);
 
                 fieldChooser.applyChanges();
-                clock.tick();
+                clock.tick(10);
 
                 dataSourceState = grid.getDataSource().state();
                 const optionState = fieldChooser.option('state');
@@ -6865,14 +6865,14 @@ QUnit.module('Vertical headers', {
             createGridAndTestFieldChooser((grid, fieldChooser, clock) => {
                 const fields = grid.getDataSource().state().fields;
                 fieldChooser.option('state', { rowExpandedPaths: [['row1']], columnExpandedPaths: [['column1']], fields: fields });
-                clock.tick();
+                clock.tick(10);
 
                 let dataSourceState = grid.getDataSource().state();
                 assert.deepEqual(dataSourceState.rowExpandedPaths, applyChangesMode === 'instantly' ? [['row1']] : []);
                 assert.deepEqual(dataSourceState.columnExpandedPaths, applyChangesMode === 'instantly' ? [['column1']] : []);
 
                 fieldChooser.cancelChanges();
-                clock.tick();
+                clock.tick(10);
 
                 dataSourceState = grid.getDataSource().state();
                 const optionState = fieldChooser.option('state');
@@ -6895,7 +6895,7 @@ QUnit.module('Vertical headers', {
                 });
 
                 grid.getDataSource()._eventsStrategy.fireEvent('changed');
-                clock.tick();
+                clock.tick(10);
 
                 assert.equal(isEventTriggered, true, 'event is triggered');
             });
@@ -6912,7 +6912,7 @@ QUnit.module('Vertical headers', {
                 fieldChooser.option('state', state);
                 fieldChooser.option('state', state);
                 fieldChooser.option('state', state);
-                clock.tick();
+                clock.tick(10);
 
                 if(applyChangesMode === 'instantly') {
                     assert.equal(dataSourceEventsCount, 1, 'dataSource is reloaded only once');
@@ -6948,11 +6948,11 @@ QUnit.module('Vertical headers', {
                         : new PivotGridDataSource(dataSource);
 
                     const grid = $('#pivotGrid').dxPivotGrid(gridOptions).dxPivotGrid('instance');
-                    this.clock.tick();
+                    this.clock.tick(10);
                     getFields(grid).forEach(field => assert.strictEqual(field[option], isEnabledInGrid, 'option is initialized correctly'));
 
                     grid.option(option, !isEnabledInGrid);
-                    this.clock.tick();
+                    this.clock.tick(10);
                     getFields(grid).forEach(field => assert.strictEqual(field[option], !isEnabledInGrid, 'option is changed'));
                 });
 
@@ -6969,11 +6969,11 @@ QUnit.module('Vertical headers', {
                             : new PivotGridDataSource(dataSource);
 
                         const grid = $('#pivotGrid').dxPivotGrid(gridOptions).dxPivotGrid('instance');
-                        this.clock.tick();
+                        this.clock.tick(10);
                         getFields(grid).forEach(field => assert.strictEqual(field[option], isEnabledInField, 'option is initialized correctly'));
 
                         grid.option(option, !isEnabledInGrid);
-                        this.clock.tick();
+                        this.clock.tick(10);
                         getFields(grid).forEach(field => assert.strictEqual(field[option], isEnabledInField, 'option is not changed'));
                     });
                 });
@@ -7508,7 +7508,7 @@ QUnit.module('Data area', () => {
                     store: [ { row1: 'r1', col1: 'c1', amount: 5 } ]
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(dataAreaCellPreparedCallCount, 0, 'cellPreparedCallback call count');
             assert.equal(getDataAreaVisibleText(pivot), 'No data', 'No data message is rendered');
@@ -7533,11 +7533,11 @@ QUnit.module('Data area', () => {
                     store: [ { row1: 'r1', col1: 'c1', amount: 5 } ]
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
 
             pivot.getDataSource().field('amount', { visible: true });
             pivot.getDataSource().load();
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(dataAreaCellPreparedCallCount, 4, 'cellPreparedCallback call count');
             assert.equal(getDataAreaVisibleText(pivot), '5555', 'Valid message is rendered');
@@ -7562,7 +7562,7 @@ QUnit.module('Data area', () => {
                     store: [ { row1: 'r1', col1: 'c1', amount: 5 } ]
                 }
             }).dxPivotGrid('instance');
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(dataAreaCellPreparedCallCount, 4, 'cellPreparedCallback call count');
             assert.equal(getDataAreaVisibleText(pivot), '5555', 'Valid message is rendered');

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.themes.sharedTests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.themes.sharedTests.js
@@ -46,7 +46,7 @@ export const runThemesSharedTests = function(moduleNamePostfix) {
                 height: 400,
                 showRowGrandTotals: true
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             const cellElement = pivotGridElement.querySelector(`.${PIVOTGRID_EXPANDED_CLASS}`);
             const cellTextElement = cellElement.lastChild;

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/sortable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/sortable.tests.js
@@ -1905,7 +1905,7 @@ QUnit.module('Scroll group content', {
             .down()
             .move(offset.left + $item.width() / 2 + 10, offset.top);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(!this.onScroll.called);
     });

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/store.local.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/store.local.tests.js
@@ -221,7 +221,7 @@ QUnit.module('Array Local Store', moduleConfig, () => {
         assert.notOk(doneCalled, 'load is not completed');
 
         // act
-        clock.tick();
+        clock.tick(10);
 
         // assert
         assert.ok(doneCalled, 'load is completed');

--- a/testing/tests/DevExpress.ui.widgets.scheduler/allDayAppointments.common-1.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/allDayAppointments.common-1.tests.js
@@ -208,7 +208,7 @@ module('All day appointments common', config, () => {
                     width: 600
                 });
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const spy = sinon.spy(scheduler.instance, 'showAppointmentPopup');
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/allDayAppointments.dragging.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/allDayAppointments.dragging.tests.js
@@ -64,7 +64,7 @@ module('All day appointments dragging', config, () => {
         let pointer = pointerMock($appointment).start().down().move(10, 10);
         triggerDragEnter($element.find('.dx-scheduler-all-day-table-cell'), $appointment);
         pointer.up();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $allDayAppointment = $element.find('.dx-scheduler-all-day-appointments .dx-scheduler-appointment');
 
@@ -96,7 +96,7 @@ module('All day appointments dragging', config, () => {
         let pointer = pointerMock($appointment).start().down().move(10, 10);
         triggerDragEnter($element.find('.dx-scheduler-all-day-table-cell').eq(3), $appointment);
         pointer.up();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $allDayAppointment = $element.find('.dx-scheduler-all-day-appointments .dx-scheduler-appointment');
 
@@ -131,7 +131,7 @@ module('All day appointments dragging', config, () => {
         triggerDragEnter($(scheduler.instance.$element()).find('.dx-scheduler-date-table-cell').eq(0), $appointment);
         pointer.up();
 
-        this.clock.tick();
+        this.clock.tick(10);
         const appointmentData = dataUtils.data($(scheduler.instance.$element()).find('.dx-scheduler-appointment').get(0), 'dxItemData');
 
         assert.deepEqual(appointmentData.startDate, new Date(2015, 1, 8, 0, 0), 'Start date is correct');
@@ -160,7 +160,7 @@ module('All day appointments dragging', config, () => {
         const pointer = pointerMock($appointment).start().down().move(10, 10);
         triggerDragEnter($element.find('.dx-scheduler-all-day-table-cell'), $appointment);
         pointer.up();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(workspace.option('allDayExpanded'), true);
     });
@@ -184,7 +184,7 @@ module('All day appointments dragging', config, () => {
         const pointer = pointerMock($appointment).start().down().move(10, 10);
         triggerDragEnter($element.find('.dx-scheduler-all-day-table-cell'), $appointment);
         pointer.up();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $allDayCell = $(scheduler.instance.$element()).find('.dx-scheduler-all-day-table-cell').eq(0);
         const $allDayAppointment = $element.find('.dx-scheduler-all-day-appointment').eq(0);
@@ -212,7 +212,7 @@ module('All day appointments dragging', config, () => {
         triggerDragEnter($(scheduler.instance.$element()).find('.dx-scheduler-date-table-cell').eq(0), $appointment);
         pointer.up();
 
-        this.clock.tick();
+        this.clock.tick(10);
         const workspace = $(scheduler.instance.$element()).find('.dx-scheduler-work-space').dxSchedulerWorkSpaceWeek('instance');
 
         assert.equal(workspace.option('allDayExpanded'), false);

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointment.editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointment.editing.tests.js
@@ -136,7 +136,7 @@ module('Integration: Appointment editing', {
                     currentView: 'timelineMonth'
                 });
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const updateAppointment = scheduler.instance._updateAppointment;
                 const spy = sinon.spy(noop);
@@ -165,7 +165,7 @@ module('Integration: Appointment editing', {
 
                 const scheduler = this.createInstance({ currentDate: new Date(2015, 1, 9), dataSource: data, editing: true });
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const updateAppointment = scheduler.instance._updateAppointment;
                 const spy = sinon.spy(noop);
@@ -296,7 +296,7 @@ module('Integration: Appointment editing', {
 
                 const scheduler = this.createInstance({ currentDate: new Date(2015, 1, 9), dataSource: data });
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const updateAppointment = scheduler.instance.updateAppointment;
                 const spy = sinon.spy(() => new Deferred());

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointment.monthView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointment.monthView.tests.js
@@ -180,7 +180,7 @@ module('Integration: Appointments in Month view', {
                     currentView: 'month',
                     height: 800
                 }, this.clock);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const cellHeight = scheduler.workSpace.getCellHeight();
                 const cellWidth = scheduler.workSpace.getCellWidth();
@@ -202,7 +202,7 @@ module('Integration: Appointments in Month view', {
                     views: ['day', 'week', 'month'],
                     height: 800
                 }, this.clock);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 scheduler.instance.option('currentView', 'month');
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointment.templates.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointment.templates.tests.js
@@ -11,14 +11,6 @@ import {
 import 'ui/scheduler/ui.scheduler';
 import 'ui/switch';
 
-const {
-    module
-} = QUnit;
-
-const test = (description, callback) => {
-    return QUnit.test(description, sinon.test(callback));
-};
-
 QUnit.testStart(() => initTestMarkup());
 
 const APPOINTMENT_CLASS = 'dx-scheduler-appointment';
@@ -35,12 +27,14 @@ const createInstance = (options, clock) => {
     return scheduler;
 };
 
-module('Integration: Appointment templates', {
+QUnit.module('Integration: Appointment templates', {
     beforeEach: function() {
+        this.clock = sinon.useFakeTimers();
         fx.off = true;
     },
     afterEach: function() {
         fx.off = false;
+        this.clock.restore();
     }
 }, () => {
     let eventCallCount = 0;
@@ -200,22 +194,22 @@ module('Integration: Appointment templates', {
         recurrenceRule: 'FREQ=HOURLY;COUNT=5'
     }];
 
-    module('appointmentTemplate', () => {
-        test('model.targetedAppointmentData argument should have current appointment data', function(assert) {
+    QUnit.module('appointmentTemplate', () => {
+        QUnit.test('model.targetedAppointmentData argument should have current appointment data', function(assert) {
             const scheduler = createScheduler(commonData);
             scheduler.option({ appointmentTemplate: createTestForCommonData(assert) });
 
             assert.strictEqual(eventCallCount, 5, 'appointmentTemplate should be raised');
         });
 
-        test('model.targetedAppointmentData argument should have current appointment data in case recurrence', function(assert) {
+        QUnit.test('model.targetedAppointmentData argument should have current appointment data in case recurrence', function(assert) {
             const scheduler = createScheduler(recurrenceData);
             scheduler.option({ appointmentTemplate: createTestForRecurrenceData(assert, scheduler) });
 
             assert.strictEqual(eventCallCount, 5, 'appointmentTemplate should be raised');
         });
 
-        test('model.targetedAppointmentData argument should have current appointment data in case recurrence and custom data properties', function(assert) {
+        QUnit.test('model.targetedAppointmentData argument should have current appointment data in case recurrence and custom data properties', function(assert) {
             const scheduler = createScheduler(recurrenceDataWithCustomNames, {
                 textExpr: 'textCustom',
                 startDateExpr: 'startDateCustom',
@@ -226,7 +220,7 @@ module('Integration: Appointment templates', {
             assert.strictEqual(eventCallCount, 5, 'appointmentTemplate should be raised');
         });
 
-        test('appointmentTemplate option should be passed to the Task module', function(assert) {
+        QUnit.test('appointmentTemplate option should be passed to the Task module', function(assert) {
             const data = new DataSource({
                 store: [
                     {
@@ -247,7 +241,7 @@ module('Integration: Appointment templates', {
             assert.deepEqual(scheduler.instance.$element().find('.' + APPOINTMENT_CLASS).eq(0).text(), 'Task Template', 'Tasks itemTemplate option is correct');
         });
 
-        test('DOM element should be rendered by render function', function(assert) {
+        QUnit.test('DOM element should be rendered by render function', function(assert) {
             const startDate = new Date(2015, 1, 4, 1);
             const endDate = new Date(2015, 1, 4, 2);
             const appointment = {
@@ -284,7 +278,7 @@ module('Integration: Appointment templates', {
         });
     });
 
-    module('appointmentTooltipTemplate', () => {
+    QUnit.module('appointmentTooltipTemplate', () => {
         [
             {
                 data: commonData,
@@ -297,7 +291,7 @@ module('Integration: Appointment templates', {
                 name: 'recurrence'
             },
         ].forEach(testCase => {
-            test(`Appointment click - model.targetedAppointmentData argument should be equal to the current appointmentData, ${testCase.name} case`, function(assert) {
+            QUnit.test(`Appointment click - model.targetedAppointmentData argument should be equal to the current appointmentData, ${testCase.name} case`, function(assert) {
                 const scheduler = createScheduler(testCase.data, testCase.options);
                 const DoubleClickTimeout = 300;
                 const appointmentAmount = 5;
@@ -362,7 +356,7 @@ module('Integration: Appointment templates', {
             name: 'hourly recurrence in collector, custom timezone is set',
             testCollector: true
         }].forEach(testCase => {
-            test(`Appointment tooltip click - model.targetedAppointmentData argument should be equal to the current appointmentData, ${testCase.name} case`, function(assert) {
+            QUnit.test(`Appointment tooltip click - model.targetedAppointmentData argument should be equal to the current appointmentData, ${testCase.name} case`, function(assert) {
                 const scheduler = createScheduler(testCase.data, testCase.options);
                 const doubleClickTimeout = 300;
                 const appointmentAmount = 5;

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointment.week.based.views.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointment.week.based.views.tests.js
@@ -110,7 +110,7 @@ module('Integration: Appointment Day, Week views', {
                 cellDuration: 15
             }, this.clock);
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $appointment = $(scheduler.instance.$element()).find('.' + APPOINTMENT_CLASS).eq(0);
 
@@ -208,7 +208,7 @@ module('Integration: Appointment Day, Week views', {
                 ];
 
                 const scheduler = createInstance({ dataSource: appointments, currentDate: new Date(2015, 1, 9) }, this.clock);
-                this.clock.tick();
+                this.clock.tick(10);
                 const cellHeight = scheduler.instance.$element().find('.' + DATE_TABLE_CELL_CLASS).eq(0).get(0).getBoundingClientRect().height;
                 const resultHeight = cellHeight * 2;
 
@@ -233,7 +233,7 @@ module('Integration: Appointment Day, Week views', {
                     height: 1500
                 }, this.clock);
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const spy = sinon.spy(scheduler.instance._appointmentPopup, 'show');
 
@@ -266,7 +266,7 @@ module('Integration: Appointment Day, Week views', {
                     currentDate: new Date(2015, 3, 23)
                 }, this.clock);
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 scheduler.instance.showAppointmentPopup(task);
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointmentPopup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointmentPopup.tests.js
@@ -543,7 +543,7 @@ QUnit.module('Appointment popup form', moduleConfig, () => {
             });
 
             scheduler.instance.deleteAppointment(data[0]);
-            clock.tick();
+            clock.tick(10);
 
             assert.notOk(scheduler.appointmentPopup.hasLoadPanel(), 'Has no load panel');
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/appointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/appointments.tests.js
@@ -1006,7 +1006,7 @@ QUnit.module('Appointments Keyboard Navigation', moduleOptions, () => {
 
         instance.focus();
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(focusSpy.called, 'focus is called');
         sinon.restore();
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.events.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.events.tests.js
@@ -190,7 +190,7 @@ QUnit.module('Events', {
             endDate: new Date(2015, 1, 13, 20),
             text: 'caption2'
         });
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('All appointments should be rerendered after cellDuration changed', function(assert) {
@@ -220,7 +220,7 @@ QUnit.module('Events', {
         const initialItems = appointments.option('items');
 
         scheduler.instance.option('cellDuration', 100);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const changedItems = appointments.option('items');
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.initialization.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.initialization.tests.js
@@ -73,7 +73,7 @@ QUnit.module('Initialization', {
         } finally {
             $('#scheduler').show();
             triggerShownEvent($('#scheduler'));
-            this.clock.tick();
+            this.clock.tick(10);
             assert.equal(scheduler.instance.$element().find('.dx-scheduler-appointment').length, 1, 'Appointment is rendered');
         }
     });

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.methods.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.methods.tests.js
@@ -49,10 +49,10 @@ QUnit.module('Methods', {
             dataSource: data
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         scheduler.instance.addAppointment({ startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17), text: 'caption' });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(scheduler.instance.option('dataSource').items().length, 3, 'new item is added');
     });
 
@@ -66,10 +66,10 @@ QUnit.module('Methods', {
             dataSource: data
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         scheduler.instance.addAppointment({ startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17) });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(scheduler.instance.option('dataSource').items()[2].text, '', 'new item was added with correct text');
     });
 
@@ -98,12 +98,12 @@ QUnit.module('Methods', {
             dataSource: data
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const newTask = { startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17), text: 'caption' };
 
         scheduler.instance.updateAppointment(this.tasks[0], newTask);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(scheduler.instance.option('dataSource').items()[0], newTask, 'item is updated');
     });
@@ -118,7 +118,7 @@ QUnit.module('Methods', {
             dataSource: data
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const newTask = {
             text: 'Task 11',
@@ -130,7 +130,7 @@ QUnit.module('Methods', {
             assert.ok(true, 'Updated item was rerendered');
         });
         scheduler.instance.updateAppointment(this.tasks[0], newTask);
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('Updated item should be rerendered if it\'s coordinates weren\'t changed (T650811)', function(assert) {
@@ -143,7 +143,7 @@ QUnit.module('Methods', {
             dataSource: data
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const newTask = {
             allDay: undefined,
@@ -158,7 +158,7 @@ QUnit.module('Methods', {
 
         scheduler.instance.updateAppointment(this.tasks[0], newTask);
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('Other appointments should not be rerendered after update item', function(assert) {
@@ -171,7 +171,7 @@ QUnit.module('Methods', {
             dataSource: data
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const newTask = { startDate: new Date(2015, 1, 9, 2, 0), endDate: new Date(2015, 1, 9, 3, 0), text: 'caption' };
         let counter = 0;
@@ -181,7 +181,7 @@ QUnit.module('Methods', {
         } });
 
         scheduler.instance.updateAppointment(this.tasks[0], newTask);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(scheduler.instance.option('dataSource').items()[0], newTask, 'item is updated');
         assert.equal(counter, 1, 'Only updated appointment was rerendered');
@@ -198,12 +198,12 @@ QUnit.module('Methods', {
             timeZone: 5
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const newTask = { startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17), text: 'caption' };
 
         scheduler.instance.updateAppointment(this.tasks[0], newTask);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(scheduler.instance.option('dataSource').items()[0], newTask, 'item is updated');
     });
@@ -219,12 +219,12 @@ QUnit.module('Methods', {
             timeZone: 'Asia/Muscat'
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const newTask = { startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17), text: 'caption' };
 
         scheduler.instance.updateAppointment(this.tasks[0], newTask);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual(scheduler.instance.option('dataSource').items()[0], newTask, 'item is updated');
     });
@@ -322,7 +322,7 @@ QUnit.module('Methods', {
             dataSource: dataSource
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         scheduler.instance.updateAppointment(data[0], {});
     });
@@ -346,7 +346,7 @@ QUnit.module('Methods', {
             currentDate: new Date(2015, 1, 9),
             dataSource: dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         scheduler.instance.updateAppointment(data[0], {});
     });
@@ -361,12 +361,12 @@ QUnit.module('Methods', {
             dataSource: data
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const lastTask = this.tasks[1];
 
         scheduler.instance.deleteAppointment(this.tasks[0]);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(scheduler.instance.option('dataSource').items(), [lastTask], 'Task is removed');
     });
 
@@ -379,7 +379,7 @@ QUnit.module('Methods', {
             currentDate: new Date(2015, 1, 9),
             dataSource: data
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const lastTask = this.tasks[1];
 
@@ -388,7 +388,7 @@ QUnit.module('Methods', {
         } });
 
         scheduler.instance.deleteAppointment(this.tasks[0]);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(scheduler.instance.option('dataSource').items(), [lastTask], 'Task is removed');
     });
 
@@ -412,7 +412,7 @@ QUnit.module('Methods', {
             currentDate: new Date(2015, 1, 9),
             dataSource: dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         scheduler.instance.deleteAppointment(data[0]);
     });
@@ -436,7 +436,7 @@ QUnit.module('Methods', {
             currentDate: new Date(2015, 1, 9),
             dataSource: dataSource
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         scheduler.instance.deleteAppointment(data[0]);
     });

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.options.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.options.tests.js
@@ -143,7 +143,7 @@ QUnit.module('Options', {
         });
 
         scheduler.instance.option('startDateExpr', 'StartDate');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(scheduler.instance.$element().find('.dx-scheduler-appointment').length, 1, 'Appointment is rendered');
     });
 
@@ -420,7 +420,7 @@ QUnit.module('Options', {
         const initialAppointmentHeight = getOuterHeight(scheduler.instance.$element().find('.dx-scheduler-appointment').eq(0));
 
         scheduler.instance.option('height', 200);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.notEqual(getOuterHeight(scheduler.instance.$element().find('.dx-scheduler-appointment').eq(0)), initialAppointmentHeight, 'Appointment was repainted');
     });
@@ -446,7 +446,7 @@ QUnit.module('Options', {
         scheduler.instance.option('height', 400);
         $('#scheduler').show();
         triggerShownEvent($('#scheduler'));
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.notEqual(getOuterHeight(scheduler.instance.$element().find('.dx-scheduler-appointment').eq(0)), initialAppointmentHeight, 'Appointment was repainted');
     });

--- a/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
@@ -382,7 +382,7 @@ QUnit.module('Small size', {
             triggerShownEvent($('#scheduler'));
             const schedulerInstance = $('#scheduler').dxScheduler('instance');
             schedulerInstance.option('width', 600);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $appointment = $(schedulerInstance.$element().find('.dx-scheduler-appointment'));
             assert.roughEqual($appointment.position().left, 0, 1.001, 'Appointment is rendered correctly');

--- a/testing/tests/DevExpress.ui.widgets.scheduler/dataSource.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/dataSource.tests.js
@@ -56,7 +56,7 @@ module('Events', {
             };
 
             scheduler.instance.addAppointment(newAppointment);
-            this.clock.tick();
+            this.clock.tick(10);
 
 
             const args = addingSpy.getCall(0).args[0];
@@ -80,7 +80,7 @@ module('Events', {
             });
 
             scheduler.instance.addAppointment({ startDate: new Date(), text: 'Appointment 1' });
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.strictEqual(dataSource.items().length, 0, 'Insert operation is canceled');
         });
@@ -142,7 +142,7 @@ module('Events', {
             const newAppointment = { startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17), text: 'caption' };
 
             scheduler.instance.addAppointment(newAppointment);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const args = addedSpy.getCall(0).args[0];
 
@@ -169,7 +169,7 @@ module('Events', {
             });
 
             scheduler.instance.addAppointment({ startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17), text: 'caption' });
-            this.clock.tick();
+            this.clock.tick(10);
 
             const error = addedSpy.getCall(0).args[0].error;
 
@@ -215,7 +215,7 @@ module('Events', {
             });
 
             scheduler.instance.updateAppointment($.extend({}, oldData[0]), newData);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const args = updatingSpy.getCall(0).args[0];
 
@@ -242,7 +242,7 @@ module('Events', {
             });
 
             scheduler.instance.updateAppointment(appointments[0], { startDate: new Date(), text: 'Appointment 1' });
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.deepEqual(dataSource.items(), [{ startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17), text: 'caption' }], 'Update operation is canceled');
         });
@@ -268,7 +268,7 @@ module('Events', {
                 scheduler.instance.showAppointmentPopup(appointments[0]);
                 $('.dx-scheduler-appointment-popup .dx-popup-done').trigger('dxclick');
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const appointmentForm = scheduler.instance._appointmentPopup.form;
 
@@ -505,7 +505,7 @@ module('Events', {
             });
 
             scheduler.instance.updateAppointment(oldData[0], newData);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const args = updatedSpy.getCall(0).args[0];
 
@@ -538,7 +538,7 @@ module('Events', {
             });
 
             scheduler.instance.updateAppointment(oldData[0], newData);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const error = updatedSpy.getCall(0).args[0].error;
 
@@ -595,7 +595,7 @@ module('Events', {
             });
 
             scheduler.instance.deleteAppointment(appointments[0]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const args = deletingSpy.getCall(0).args[0];
 
@@ -621,7 +621,7 @@ module('Events', {
             });
 
             scheduler.instance.deleteAppointment(appointments[0]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.deepEqual(dataSource.items(), [{ startDate: new Date(2015, 1, 9, 16), endDate: new Date(2015, 1, 9, 17), text: 'caption' }], 'Delete operation is canceled');
         });
@@ -687,7 +687,7 @@ module('Events', {
             });
 
             scheduler.instance.deleteAppointment(appointments[0]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             const args = deletedSpy.getCall(0).args[0];
             assert.ok(deletedSpy.calledOnce, 'onAppointmentDeleted was called');
@@ -713,7 +713,7 @@ module('Events', {
             });
 
             scheduler.instance.deleteAppointment({});
-            this.clock.tick();
+            this.clock.tick(10);
 
             const error = deletedSpy.getCall(0).args[0].error;
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/desktopTooltip.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/desktopTooltip.tests.js
@@ -43,14 +43,14 @@ const environment = {
         isButtonClick: false,
     },
     afterEach: function() {
-        stubCreateComponent.reset();
-        stubComponent.option.reset();
-        stubShowAppointmentPopup.reset();
-        stubAddDefaultTemplates.reset();
-        stubGetAppointmentTemplate.reset();
-        stubCreateFormattedDateText.reset();
-        stubCreateFormattedDateText.reset();
-        stubCheckAndDeleteAppointment.reset();
+        stubCreateComponent.resetHistory();
+        stubComponent.option.resetHistory();
+        stubShowAppointmentPopup.resetHistory();
+        stubAddDefaultTemplates.resetHistory();
+        stubGetAppointmentTemplate.resetHistory();
+        stubCreateFormattedDateText.resetHistory();
+        stubCreateFormattedDateText.resetHistory();
+        stubCheckAndDeleteAppointment.resetHistory();
     }
 };
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/dragAndDropAppointments.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/dragAndDropAppointments.tests.js
@@ -2535,7 +2535,7 @@ module('Appointment dragging', {
                     }]
                 });
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const updatedItem = {
                     'text': 'Google AdWords Strategy',
@@ -2549,7 +2549,7 @@ module('Appointment dragging', {
 
                 const dataSourceItem = this.instance.option('dataSource').items()[0];
 
-                this.clock.tick();
+                this.clock.tick(10);
                 assert.deepEqual(dataSourceItem.startDate, updatedItem.startDate, 'New data is correct');
                 assert.deepEqual(dataSourceItem.endDate, updatedItem.endDate, 'New data is correct');
             });
@@ -2574,7 +2574,7 @@ module('Appointment dragging', {
 
                 this.scheduler.appointmentList[0].drag.toCell(8);
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const appointmentData = dataUtils.data(this.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
@@ -2603,7 +2603,7 @@ module('Appointment dragging', {
 
                 this.scheduler.appointmentList[0].drag.toCell(9);
 
-                this.clock.tick();
+                this.clock.tick(10);
                 const appointmentData = dataUtils.data(this.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
                 assert.deepEqual(appointmentData.startDate, new Date(2015, 1, 10, 8, 0), 'Start date is correct');
@@ -2633,7 +2633,7 @@ module('Appointment dragging', {
 
                 this.scheduler.appointmentList[0].drag.toCell(16);
 
-                this.clock.tick();
+                this.clock.tick(10);
                 const appointmentData = dataUtils.data(this.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
                 assert.deepEqual(appointmentData.startDate, new Date(2015, 4, 12, 10), 'Start date is correct');
@@ -2663,7 +2663,7 @@ module('Appointment dragging', {
 
                 this.scheduler.appointmentList[0].drag.toCell(16);
 
-                this.clock.tick();
+                this.clock.tick(10);
                 const appointmentData = dataUtils.data(this.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
                 assert.deepEqual(appointmentData.startDate, new Date(2015, 4, 12, 8), 'Start date is correct');
@@ -2678,7 +2678,7 @@ module('Appointment dragging', {
 
                 this.createInstance({ currentDate: new Date(2015, 1, 9), dataSource: data, editing: true });
 
-                this.clock.tick();
+                this.clock.tick(10);
 
                 const updatedItem = {
                     text: 'Task 1',
@@ -2691,7 +2691,7 @@ module('Appointment dragging', {
 
                 const dataSourceItem = this.instance.option('dataSource').items()[0];
 
-                this.clock.tick();
+                this.clock.tick(10);
                 assert.equal(dataSourceItem.text, updatedItem.text, 'New data is correct');
                 assert.equal(dataSourceItem.allDay, updatedItem.allDay, 'New data is correct');
                 assert.deepEqual(dataSourceItem.startDate, updatedItem.startDate, 'New data is correct');
@@ -2722,7 +2722,7 @@ module('Appointment dragging', {
                             allDayExpr: 'AllDay'
                         });
 
-                        this.clock.tick();
+                        this.clock.tick(10);
 
                         const updatedItem = {
                             text: 'Task 1',
@@ -2733,7 +2733,7 @@ module('Appointment dragging', {
 
                         this.scheduler.appointmentList[0].drag.toCell(5);
 
-                        this.clock.tick();
+                        this.clock.tick(10);
 
                         const dataSourceItem = this.instance.option('dataSource').items()[0];
 
@@ -2775,7 +2775,7 @@ module('Appointment dragging', {
 
                 this.scheduler.appointmentList[0].drag.toCell(7);
 
-                this.clock.tick();
+                this.clock.tick(10);
                 const appointmentData = dataUtils.data(this.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
                 assert.deepEqual(appointmentData.startDate, new Date(2015, 6, 5, 0), 'Start date is correct');
@@ -2838,7 +2838,7 @@ module('Appointment dragging', {
                 $(this.instance.$element().find('.' + DATE_TABLE_CELL_CLASS)).eq(7).trigger(dragEvents.enter);
                 pointer.up();
 
-                this.clock.tick();
+                this.clock.tick(10);
                 const appointmentData = dataUtils.data(this.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
                 assert.deepEqual(appointmentData.startDate, new Date(2015, 6, 5, 9, 30), 'Start date is correct');
@@ -2891,7 +2891,7 @@ module('Appointment dragging', {
                 $(this.instance.$element().find('.dx-scheduler-all-day-table-cell')).eq(11).trigger(dragEvents.enter);
                 pointer.up();
 
-                this.clock.tick();
+                this.clock.tick(10);
                 const appointmentData = dataUtils.data(this.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
                 assert.deepEqual(appointmentData.startDate, new Date(2015, 6, 9, 0), 'Start date is correct');
@@ -2941,7 +2941,7 @@ module('Appointment dragging', {
 
                 assert.deepEqual(oldAppointmentCoords, newAppointmentCoords, 'Appointment has correct coords');
 
-                this.clock.tick();
+                this.clock.tick(10);
             });
 
             test('Appointment should push correct data to the onAppointmentUpdating event on changing group by dragging', function(assert) {
@@ -2982,7 +2982,7 @@ module('Appointment dragging', {
                 assert.equal(result.oldData.priorityId, 1, 'Appointment was located in the first group');
                 assert.equal(result.newData.priorityId, 2, 'Appointment located in the second group now');
 
-                this.clock.tick();
+                this.clock.tick(10);
             });
 
             test('Appointment should not be updated if it is dropped to the initial cell (week view)', function(assert) {
@@ -2999,7 +2999,7 @@ module('Appointment dragging', {
 
                 this.scheduler.appointmentList[0].drag.toCell(1);
 
-                this.clock.tick();
+                this.clock.tick(10);
                 const appointmentData = dataUtils.data(this.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
                 assert.deepEqual(appointmentData.startDate, new Date(2015, 1, 9, 0, 7), 'Start date is correct');

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
@@ -287,7 +287,7 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
         });
 
         const scheduler = createScheduler({ currentDate: new Date(2015, 1, 9), dataSource: data, rtlEnabled: true });
-        this.clock.tick();
+        this.clock.tick(10);
 
         scheduler.appointments.click(1);
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentsVertical.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentsVertical.tests.js
@@ -1077,7 +1077,7 @@ QUnit.module('Integration: Appointments on vertical views (day, week, workWeek)'
 
         scheduler.appointmentList[0].drag.toCell(10);
 
-        this.clock.tick();
+        this.clock.tick(10);
         const appointmentData = dataUtils.data(scheduler.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
         assert.deepEqual(appointmentData.startDate, new Date(2018, 2, 1, 13), 'Start date is correct');
@@ -1118,7 +1118,7 @@ QUnit.module('Integration: Appointments on vertical views (day, week, workWeek)'
 
         scheduler.appointmentList[0].drag.toCell(75);
 
-        this.clock.tick();
+        this.clock.tick(10);
         const appointmentData = dataUtils.data(scheduler.instance.$element().find('.' + APPOINTMENT_CLASS).get(0), 'dxItemData');
 
         assert.deepEqual(appointmentData.startDate, new Date(2018, 2, 16, 13), 'Start date is correct');

--- a/testing/tests/DevExpress.ui.widgets.scheduler/integration.resources.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/integration.resources.tests.js
@@ -239,7 +239,7 @@ QUnit.module('Integration: Resources', moduleConfig, () => {
             currentDate: new Date(2015, 1, 9)
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         scheduler.instance.showAppointmentPopup(task1);
 
         let taskDetailsView = scheduler.instance.getAppointmentDetailsForm();
@@ -301,7 +301,7 @@ QUnit.module('Integration: Resources', moduleConfig, () => {
             currentDate: new Date(2015, 1, 9)
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         scheduler.instance.showAppointmentPopup(task);
 
         const taskDetailsView = scheduler.instance.getAppointmentDetailsForm();
@@ -352,7 +352,7 @@ QUnit.module('Integration: Resources', moduleConfig, () => {
             currentDate: new Date(2015, 4, 24)
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         scheduler.instance.showAppointmentPopup(appointment);
 
         const taskDetailsView = scheduler.instance.getAppointmentDetailsForm();

--- a/testing/tests/DevExpress.ui.widgets.scheduler/layoutManager.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/layoutManager.tests.js
@@ -1568,7 +1568,7 @@ QUnit.test('Focus shouldn\'t be prevent when last appointment is reached', funct
 
     const $appointments = $(this.instance.$element().find('.dx-scheduler-appointment'));
     $($appointments.eq(3)).trigger('focusin');
-    this.clock.tick();
+    this.clock.tick(10);
 
     const keyboard = keyboardMock($appointments.eq(3));
 
@@ -1597,7 +1597,7 @@ QUnit.testInActiveWindow('Apps should be focused in right order', function(asser
     const apptInstance = this.instance.getAppointmentsInstance();
 
     $($appointments.eq(0)).trigger('focusin');
-    this.clock.tick();
+    this.clock.tick(10);
 
     const keyboard = keyboardMock($appointments.eq(0));
     keyboard.keyDown('tab');
@@ -1631,7 +1631,7 @@ QUnit.testInActiveWindow('Apps should be focused in right order on month view wi
     const apptInstance = this.instance.getAppointmentsInstance();
 
     $($appointments.eq(0)).trigger('focusin');
-    this.clock.tick();
+    this.clock.tick(10);
 
     const keyboard = keyboardMock($appointments.eq(0));
     keyboard.keyDown('tab');
@@ -1657,7 +1657,7 @@ QUnit.testInActiveWindow('Apps should be focused in back order while press shift
     const keyboard = keyboardMock($appointments.eq(0));
 
     $($appointments.eq(3)).trigger('focusin');
-    this.clock.tick();
+    this.clock.tick(10);
 
     keyboard.keyDown('tab', { shiftKey: true });
     assert.deepEqual($appointments.get(2), $(apptInstance.option('focusedElement')).get(0), 'app 1 in focus');

--- a/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.integration.tests.js
@@ -24,7 +24,7 @@ const test = (description, callback) => {
     const testFunc = !isDesktopEnvironment()
         ? QUnit.skip
         : QUnit.test;
-    return testFunc(description, sinon.test(callback));
+    return testFunc(description, callback);
 };
 
 testStart(() => initTestMarkup());

--- a/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.monthView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.monthView.tests.js
@@ -20,7 +20,7 @@ const test = (description, callback) => {
         ? QUnit.skip
         : QUnit.test;
 
-    return testFunc(description, sinon.test(callback));
+    return testFunc(description, callback);
 };
 const printOffset = offset => [
     offset.x >= 0 ? `offset.x: ${offset.x}` : '',

--- a/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.tests.js
@@ -5,12 +5,9 @@ import eventsEngine from 'events/core/events_engine';
 import { addNamespace } from 'events/utils/index';
 
 const {
-    module
+    module,
+    test
 } = QUnit;
-
-const test = (description, callback) => {
-    return QUnit.test(description, sinon.test(callback));
-};
 
 module('Virtual Scrolling', {
     beforeEach: function() {
@@ -71,6 +68,14 @@ module('Virtual Scrolling', {
     },
     afterEach: function() {
         this.virtualScrollingDispatcher.dispose();
+
+        if (typeof eventsEngine.on.restore === 'function') {
+            eventsEngine.on.restore();
+        }
+
+        if (typeof eventsEngine.off.restore === 'function') {
+            eventsEngine.off.restore();
+        }
     }
 },
 () => {
@@ -98,7 +103,7 @@ module('Virtual Scrolling', {
             test('document scroll event should be subscribed correctly if heigth option is undefined', function(assert) {
                 const SCROLL_EVENT_NAME = addNamespace('scroll', 'dxSchedulerVirtualScrolling');
 
-                const spyEventsOn = this.spy(eventsEngine, 'on');
+                const spyEventsOn = sinon.spy(eventsEngine, 'on');
 
                 this.prepareInstance({ height: null });
 
@@ -109,7 +114,7 @@ module('Virtual Scrolling', {
 
             test('document scroll event should be unsubscribed correctly if heigth option is undefined', function(assert) {
                 const SCROLL_EVENT_NAME = addNamespace('scroll', 'dxSchedulerVirtualScrolling');
-                const spyEventsOff = this.spy(eventsEngine, 'off');
+                const spyEventsOff = sinon.spy(eventsEngine, 'off');
 
                 this.prepareInstance({ height: null });
 
@@ -125,8 +130,8 @@ module('Virtual Scrolling', {
             test('It should call getTotalRowCount with correct parameters', function(assert) {
                 this.prepareInstance();
 
-                const getTotalRowCountSpy = this.spy(this.verticalVirtualScrolling.options, 'getTotalRowCount');
-                const isVerticalGroupingSpy = this.spy(this.verticalVirtualScrolling.options, 'isVerticalGrouping');
+                const getTotalRowCountSpy = sinon.spy(this.verticalVirtualScrolling.options, 'getTotalRowCount');
+                const isVerticalGroupingSpy = sinon.spy(this.verticalVirtualScrolling.options, 'isVerticalGrouping');
 
                 // TODO
                 this.verticalVirtualScrolling.updateState(200);
@@ -175,7 +180,7 @@ module('Virtual Scrolling', {
             });
 
             test('document scroll event should not been subscribed if the "width" option is not defined', function(assert) {
-                const spyEventsOn = this.spy(eventsEngine, 'on');
+                const spyEventsOn = sinon.spy(eventsEngine, 'on');
 
                 this.prepareInstance({ width: null });
 
@@ -185,8 +190,8 @@ module('Virtual Scrolling', {
             test('It should call getTotalCellCount with correct parameters', function(assert) {
                 this.prepareInstance();
 
-                const getTotalCellCountSpy = this.spy(this.horizontalVirtualScrolling.options, 'getTotalCellCount');
-                const isVerticalGroupingSpy = this.spy(this.horizontalVirtualScrolling.options, 'isVerticalGrouping');
+                const getTotalCellCountSpy = sinon.spy(this.horizontalVirtualScrolling.options, 'getTotalCellCount');
+                const isVerticalGroupingSpy = sinon.spy(this.horizontalVirtualScrolling.options, 'isVerticalGrouping');
 
                 this.horizontalVirtualScrolling.updateState(600);
 
@@ -356,8 +361,8 @@ module('Virtual Scrolling', {
             test(`it should not call virtual scrolling instances if scrollOffset is "${offset}"`, function(assert) {
                 this.prepareInstance();
 
-                const spyUpdateVerticalState = this.spy(this.verticalVirtualScrolling, 'updateState');
-                const spyUpdateHorizontalState = this.spy(this.horizontalVirtualScrolling, 'updateState');
+                const spyUpdateVerticalState = sinon.spy(this.verticalVirtualScrolling, 'updateState');
+                const spyUpdateHorizontalState = sinon.spy(this.horizontalVirtualScrolling, 'updateState');
 
                 this.virtualScrollingDispatcher.handleOnScrollEvent({
                     left: offset,
@@ -372,7 +377,7 @@ module('Virtual Scrolling', {
         test('it should not update render if scroll position has not been changed', function(assert) {
             this.prepareInstance();
 
-            const spy = this.spy(this.options, 'updateRender');
+            const spy = sinon.spy(this.options, 'updateRender');
 
             const scrollOffset = { left: 300, top: 200 };
 
@@ -396,7 +401,7 @@ module('Virtual Scrolling', {
 
             this.virtualScrollingDispatcher.getCellHeight = () => 200;
 
-            const spy = this.spy(this.virtualScrollingDispatcher.verticalVirtualScrolling, 'reinitState');
+            const spy = sinon.spy(this.virtualScrollingDispatcher.verticalVirtualScrolling, 'reinitState');
             this.virtualScrollingDispatcher.updateDimensions();
 
             assert.ok(spy.calledOnce, 'reinitState called once');
@@ -409,7 +414,7 @@ module('Virtual Scrolling', {
 
             this.virtualScrollingDispatcher.getCellWidth = () => 200;
 
-            const spy = this.spy(this.virtualScrollingDispatcher.horizontalVirtualScrolling, 'reinitState');
+            const spy = sinon.spy(this.virtualScrollingDispatcher.horizontalVirtualScrolling, 'reinitState');
             this.virtualScrollingDispatcher.updateDimensions();
 
             assert.ok(spy.calledOnce, 'reinitState called once');
@@ -422,8 +427,8 @@ module('Virtual Scrolling', {
 
             this.virtualScrollingDispatcher.getCellWidth = () => 200;
 
-            const spyHorizontalReinit = this.spy(this.horizontalVirtualScrolling, 'reinitState');
-            const spyVerticalReinit = this.spy(this.verticalVirtualScrolling, 'reinitState');
+            const spyHorizontalReinit = sinon.spy(this.horizontalVirtualScrolling, 'reinitState');
+            const spyVerticalReinit = sinon.spy(this.verticalVirtualScrolling, 'reinitState');
 
             this.virtualScrollingDispatcher.updateDimensions();
 
@@ -761,7 +766,7 @@ module('Virtual Scrolling', {
 
             test('Scroll event position should be checked correctly before update state', function(assert) {
                 this.prepareInstance();
-                const spy = this.spy(this.verticalVirtualScrolling, 'needUpdateState');
+                const spy = sinon.spy(this.verticalVirtualScrolling, 'needUpdateState');
 
                 [
                     { y: 0, expectedNeedUpdate: true },
@@ -873,7 +878,7 @@ module('Virtual Scrolling', {
 
                 this.prepareInstance();
 
-                const spy = this.spy(this.horizontalVirtualScrolling, 'needUpdateState');
+                const spy = sinon.spy(this.horizontalVirtualScrolling, 'needUpdateState');
 
                 [
                     { left: 0, expectedNeedUpdate: true },

--- a/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.timeline.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.timeline.tests.js
@@ -18,7 +18,7 @@ const test = (description, callback) => {
         ? QUnit.skip
         : QUnit.test;
 
-    return testFunc(description, sinon.test(callback));
+    return testFunc(description, callback);
 };
 const printOffset = offset => [
     offset.x >= 0 ? `offset.x: ${offset.x}` : '',

--- a/testing/tests/DevExpress.ui.widgets.treeList/adaptiveColumns.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/adaptiveColumns.tests.js
@@ -66,11 +66,11 @@ QUnit.module('API', {
         setupTreeList(this);
         this.rowsView.render($('#container'));
         this.resizingController.updateDimensions();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         this.adaptiveColumnsController.expandAdaptiveDetailRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const rows = this.getVisibleRows();

--- a/testing/tests/DevExpress.ui.widgets.treeList/dataController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/dataController.tests.js
@@ -651,7 +651,7 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         try {
             this.getDataSource().filter(['id', '=', 2]);
             this.getDataSource().load();
-            clock.tick();
+            clock.tick(10);
         } catch(e) {
             assert.ok(false, e);
         }
@@ -1753,14 +1753,14 @@ QUnit.module('Remote Operations', { beforeEach: function() {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(loadingArgs.length, 2, 'two loading on init');
 
         // act
         loadingArgs = [];
         this.collapseRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const items = this.dataController.items();

--- a/testing/tests/DevExpress.ui.widgets.treeList/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/editing.tests.js
@@ -387,7 +387,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
             // act
             this.addRow(2);
             this.dataController.optionChanged({ name: 'expandedRowKeys', value: [1, 2], previousValue: [1, 2] }); // simulate the call from ngDoCheck hook
-            this.clock.tick(30);
+            this.clock.tick(100);
 
             // assert
             const rows = this.getVisibleRows();

--- a/testing/tests/DevExpress.ui.widgets.treeList/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/editing.tests.js
@@ -258,7 +258,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             $testElement.find('.dx-command-edit .dx-link-add').trigger('click');
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.ok(this.editingController.addRow.calledOnce, 'addRow is called');
@@ -277,7 +277,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.addRow(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rows = this.getVisibleRows();
@@ -297,7 +297,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             this.setupTreeList();
             this.rowsView.render($('#treeList'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.getVisibleRows().length, 1, 'one visible row');
@@ -307,7 +307,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
             this.addRow(1).done(() => {
                 doneExecuteCount++;
             });
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.equal(doneExecuteCount, 1, 'done was executed');
             assert.equal(this.getVisibleRows().length, 3, 'parent was expanded and one more row was added');
@@ -324,7 +324,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             this.setupTreeList();
             this.rowsView.render($('#treeList'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.equal(this.getVisibleRows().length, 1, '1 visible row');
@@ -345,7 +345,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             addRowAfterDeferredResolve([1, 2], 0);
 
-            this.clock.tick();
+            this.clock.tick(10);
         });
 
         QUnit.test('AddRow method returns Deferred with using promise in onInitNewRow (T844118)', function(assert) {
@@ -358,17 +358,17 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             this.setupTreeList();
             this.rowsView.render($('#treeList'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             let isAddRowDone = false;
             this.addRow(1).done(() => isAddRowDone = true);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             assert.notOk(isAddRowDone, 'done method has not executed yet');
             deferred.resolve();
-            this.clock.tick();
+            this.clock.tick(10);
             assert.ok(isAddRowDone, 'done method has executed');
         });
 
@@ -413,7 +413,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rows = this.getVisibleRows();
@@ -439,7 +439,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rows = this.getVisibleRows();
@@ -463,7 +463,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
                 // act
                 this.addRowViaMethodOrChanges(addRowWay, 1);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.collapseRow(1);
 
@@ -497,7 +497,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
                 // act
                 this.addRowViaMethodOrChanges(addRowWay, 1);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.columnOption('field2', 'sortOrder', 'desc');
 
@@ -533,7 +533,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
                 // act
                 this.addRowViaMethodOrChanges(addRowWay, 1);
-                this.clock.tick();
+                this.clock.tick(10);
 
                 this.filter([]);
 
@@ -566,7 +566,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.addRowViaChanges(undefined, { insertAfterKey: 2 });
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rows = this.getVisibleRows();
@@ -586,11 +586,11 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             this.setupTreeList();
             this.rowsView.render($('#treeList'));
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const items = this.getVisibleRows();
@@ -960,11 +960,11 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
             { id: 3, parentId: 2, field1: 'test3', field2: 3, field3: new Date(2003, 2, 3) }
         ];
         this.setupTreeList();
-        this.clock.tick();
+        this.clock.tick(10);
         this.rowsView.render($testElement);
 
         this.editCell(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($(this.getCellElement(0, 0)).find('.dx-texteditor').length, 1, 'has editor');
@@ -972,7 +972,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
         // act
         $(this.getCellElement(1, 0)).find('.dx-treelist-collapsed').trigger('dxpointerdown');
         $(this.getCellElement(1, 0)).find('.dx-treelist-collapsed').trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual($(this.getCellElement(0, 0)).find('.dx-texteditor').length, 0, 'hasn\'t editor');
@@ -1077,7 +1077,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
         // act
         this.addRow();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         let $newRowElement = $testElement.find('tbody > .dx-data-row').first();
@@ -1085,7 +1085,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
         // act
         $newRowElement.find('td').eq(1).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         $newRowElement = $testElement.find('tbody > .dx-data-row').first();
@@ -1207,7 +1207,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.addRow(2);
-            this.clock.tick();
+            this.clock.tick(10);
             this.cellValue(2, 'field1', 'added');
             this.saveEditData();
 
@@ -1229,7 +1229,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.addRow();
-            this.clock.tick();
+            this.clock.tick(10);
             this.cellValue(0, 'field1', 'added');
             this.saveEditData();
 
@@ -1250,7 +1250,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.deleteRow(1);
-            this.clock.tick();
+            this.clock.tick(10);
             this.saveEditData();
 
             // assert
@@ -1271,7 +1271,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.deleteRow(0);
-            this.clock.tick();
+            this.clock.tick(10);
             this.saveEditData();
 
             // assert
@@ -1309,7 +1309,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.getDataSource().store().push([{ type: 'insert', data: { id: 3, parentId: 1, field1: 'test3', hasItems: false }, index: 0 }]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rows = this.getVisibleRows();
@@ -1328,7 +1328,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.getDataSource().store().push([{ type: 'insert', data: { id: 3, parentId: 1, field1: 'test3', hasItems: false }, index: -1 }]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rows = this.getVisibleRows();
@@ -1347,7 +1347,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.getDataSource().store().push([{ type: 'insert', data: { id: 3, parentId: 1, field1: 'test3', hasItems: false }, index: 10 }]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             const rows = this.getVisibleRows();
@@ -1367,9 +1367,9 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.getDataSource().store().push([{ type: 'insert', data: { id: 2, field1: 'test2' }, index: 2 }]);
-            this.clock.tick();
+            this.clock.tick(10);
             this.getDataSource().store().push([{ type: 'insert', data: { id: 3, field1: 'test3', parentId: 2 }, index: 3 }]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             let rows = this.getVisibleRows();
@@ -1379,7 +1379,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.expandRow(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             rows = this.getVisibleRows();
@@ -1395,7 +1395,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.getDataSource().store().push([{ type: 'insert', data: { id: 2, field1: 'test2', parentId: 1 } }]);
-            this.clock.tick();
+            this.clock.tick(10);
             // assert
             let rows = this.getVisibleRows();
             assert.strictEqual(rows.length, 1);
@@ -1404,7 +1404,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.expandRow(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // assert
             rows = this.getVisibleRows();
@@ -1412,7 +1412,7 @@ QUnit.module('Editing', { beforeEach: setupModule, afterEach: teardownModule }, 
 
             // act
             this.getDataSource().store().push([{ type: 'insert', data: { id: 3, field1: 'test3', parentId: 1 } }]);
-            this.clock.tick();
+            this.clock.tick(10);
 
             rows = this.getVisibleRows();
             assert.strictEqual(rows.length, 3);

--- a/testing/tests/DevExpress.ui.widgets.treeList/selection.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/selection.integration.tests.js
@@ -77,10 +77,10 @@ QUnit.module('Selection', baseModuleConfig, () => {
             treeList.editCell(1, 'text');
             treeList.cellValue(1, 'text', '123');
             treeList.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             treeList.saveEditData();
-            this.clock.tick();
+            this.clock.tick(10);
 
             const loadCallsBeforeSelection = loadCalls;
 

--- a/testing/tests/DevExpress.ui.widgets.treeList/selection.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/selection.tests.js
@@ -402,7 +402,7 @@ QUnit.module('Selection', { beforeEach: setupModule, afterEach: teardownModule }
         // act
         const $checkbox = $('.dx-header-row').find('.dx-checkbox');
         $checkbox.trigger('dxclick');
-        clock.tick();
+        clock.tick(10);
 
         // assert
         assert.equal($checkbox.dxCheckBox('instance').option('value'), true, 'SelectAll checkbox value is OK');
@@ -549,7 +549,7 @@ QUnit.module('Selection', { beforeEach: setupModule, afterEach: teardownModule }
         const $selectCheckbox = $expandableCell.find('.dx-select-checkbox').first();
 
         $selectCheckbox.focus();
-        clock.tick();
+        clock.tick(10);
 
         // assert
         assert.ok(!$expandableCell.hasClass('dx-focused'));
@@ -1300,7 +1300,7 @@ QUnit.module('Recursive selection', {
         this.options.loadingTimeout = 0;
         this.options.selectedRowKeys = [1];
         this.setupTreeList();
-        clock.tick();
+        clock.tick(10);
 
         this.rowsView.render($testElement);
 
@@ -1309,7 +1309,7 @@ QUnit.module('Recursive selection', {
 
         // act
         this.loadDescendants();
-        clock.tick();
+        clock.tick(10);
 
         // assert
         assert.deepEqual(this.getSelectedRowKeys('leavesOnly'), [2, 3, 4], 'leaves');

--- a/testing/tests/DevExpress.ui.widgets.treeList/stateStoring.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/stateStoring.tests.js
@@ -40,7 +40,7 @@ QUnit.module('State Storing', {
                     }
                 }, options)
             });
-            this.clock.tick();
+            this.clock.tick(10);
         };
     },
     afterEach: function() {
@@ -176,12 +176,12 @@ QUnit.module('State Storing', {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(customSaveCallCount, 0, 'customSave is not called');
 
         // act
         this.expandRow(2);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(customSaveCallCount, 1, 'customSave is called once after expandRow');
@@ -209,7 +209,7 @@ QUnit.module('State Storing', {
 
         // act
         this.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         let expandedRowKeys = this.option('expandedRowKeys');
@@ -219,7 +219,7 @@ QUnit.module('State Storing', {
 
         // act
         this.collapseRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         expandedRowKeys = this.option('expandedRowKeys');

--- a/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.treeList/treeList.tests.js
@@ -83,13 +83,13 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $headerCell = $(treeList.$element().find('.dx-header-row td').first());
 
         $($headerCell).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $dataRows = $(treeList.$element().find('.dx-data-row'));
@@ -109,7 +109,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $rowElement = $(treeList.getRowElement(0));
@@ -249,7 +249,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.option('scrolling.mode'), 'virtual', 'scrolling mode is virtual');
@@ -276,21 +276,21 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
         const navigationController = treeList.getController('keyboardNavigation');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         treeList.focus($(treeList.getCellElement(1, 0)));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         navigationController._keyDownHandler({ keyName: 'rightArrow', key: 'ArrowRight', ctrl: true, originalEvent: $.Event('keydown', { target: treeList.getCellElement(1, 0), ctrlKey: true }) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(treeList.isRowExpanded(2), 'second row is expanded');
 
         // act
         navigationController._keyDownHandler({ keyName: 'leftArrow', key: 'ArrowLeft', ctrl: true, originalEvent: $.Event('keydown', { target: treeList.getCellElement(1, 0), ctrlKey: true }) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(treeList.isRowExpanded(2), 'second row is collapsed');
@@ -315,16 +315,16 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             expandedRowKeys: [1]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $target = $(treeList.getCellElement(1, 0)).find('.dx-select-checkbox');
 
         treeList.focus($target.get(0));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         $target.trigger(createEvent('keydown', { target: $target.get(0), key: ' ' }));
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $checkBoxes = treeList.$element().find('.dx-select-checkbox');
@@ -348,11 +348,11 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $('.dx-treelist-collapsed').trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $checkBoxes = treeList.$element().find('.dx-select-checkbox');
@@ -377,7 +377,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.$element().find('.dx-data-row').length, 2, 'two filtered rows are rendered');
@@ -399,7 +399,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         const $filterMenuElement = $(treeList.$element().find('.dx-treelist-filter-row').find('.dx-menu').first().find('.dx-menu-item'));
@@ -425,7 +425,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.$element().find('.dx-data-row').length, 2, 'two filtered rows are rendered');
@@ -449,15 +449,15 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(treeList.$element().find('.dx-data-row').length, 3, 'filtered rows are rendered');
         treeList.filter('gender', '=', 'male');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(treeList.$element().find('.dx-data-row').length, 3, 'filtered rows are rendered');
 
         // act
         treeList.clearFilter();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.$element().find('.dx-data-row').length, 6, 'six filtered rows are rendered');
@@ -480,12 +480,12 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(treeList.$element().find('.dx-data-row').length, 3, 'filtered rows are rendered');
 
         // act
         treeList.clearFilter();
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.$element().find('.dx-data-row').length, 2, 'two rows are rendered');
@@ -506,7 +506,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
 
         // assert
@@ -530,7 +530,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.option('selection.showCheckBoxesMode'), 'always', 'showCheckBoxesMode is always');
@@ -550,10 +550,10 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
         const $selectCheckbox = $('#treeList').find('.dx-treelist-cell-expandable').eq(0).find('.dx-select-checkbox').eq(0);
         $($selectCheckbox).trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk($('#treeList').find('.dx-texteditor').length, 'Editing textEditor wasn\'t rendered');
@@ -594,7 +594,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         this.clock.tick(500);
 
         treeList.saveEditData();
-        this.clock.tick();
+        this.clock.tick(10);
 
         visibleRows = treeList.getVisibleRows();
 
@@ -623,7 +623,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $firstDataCell = $(treeList.getCellElement(0, 0));
@@ -644,7 +644,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
         });
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal($('#treeList').find('.dx-treelist-filter-row').length, 1, 'filter row is rendered');
@@ -664,7 +664,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             expandedRowKeys: [1]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $treeList = $(treeList.$element());
@@ -709,7 +709,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             }
         });
 
-        clock.tick();
+        clock.tick(10);
 
         // assert
         columnsWrapper.getCommandButtons().each((_, button) => {
@@ -741,7 +741,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $cellElement = $(treeList.getCellElement(0, 0));
         $cellElement.trigger('contextmenu');
@@ -800,7 +800,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             columns: [{ dataField: 'field' }]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(treeList.$element().find('.dx-treelist-filter-panel').is(':visible'), 'filter panel is visible');
@@ -827,7 +827,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $treeListElement = $(treeList.$element());
@@ -849,7 +849,7 @@ QUnit.module('Initialization', defaultModuleConfig, () => {
             columns: ['test']
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const $treeList = $(treeList.$element());
         const $headerPanel = $treeList.find('.dx-treelist-header-panel');
 
@@ -958,7 +958,7 @@ QUnit.module('Option Changed', defaultModuleConfig, () => {
             dataSource: generateData(20),
             selectedRowKeys: [1]
         });
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(treeList.getVisibleRows().length, 40, 'row count');
@@ -997,7 +997,7 @@ QUnit.module('Option Changed', defaultModuleConfig, () => {
             ]
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.$element().find('.dx-treelist-headers .dx-header-row').length, 1, 'header row is rendered');
@@ -1022,7 +1022,7 @@ QUnit.module('Option Changed', defaultModuleConfig, () => {
             }
         });
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.getVisibleColumns().length, 6, 'visible column count');
@@ -1259,7 +1259,7 @@ QUnit.module('Expand/Collapse rows', () => {
         try {
             scrollable.scrollTo({ y: 300 }); // scroll to the last page
             isNativeScrolling && $(scrollable.container()).trigger('scroll');
-            clock.tick();
+            clock.tick(10);
 
             const topVisibleRowData = treeList.getTopVisibleRowData();
 
@@ -1416,7 +1416,7 @@ QUnit.module('Expand/Collapse rows', () => {
                 repaintChangesOnly: true
             });
 
-            clock.tick();
+            clock.tick(10);
             let $rowElement = $(treeList.getRowElement(treeList.getRowIndexByKey(1)));
 
             // assert
@@ -1424,7 +1424,7 @@ QUnit.module('Expand/Collapse rows', () => {
 
             // act
             treeList.expandRow(1);
-            clock.tick();
+            clock.tick(10);
             $rowElement = $(treeList.getRowElement(treeList.getRowIndexByKey(1)));
 
             // assert
@@ -1432,7 +1432,7 @@ QUnit.module('Expand/Collapse rows', () => {
 
             // act
             treeList.collapseRow(1);
-            clock.tick();
+            clock.tick(10);
             $rowElement = $(treeList.getRowElement(treeList.getRowIndexByKey(1)));
 
             // assert
@@ -1453,7 +1453,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
             focusedRowIndex: 0
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok($(treeList.getRowElement(0)).hasClass('dx-row-focused'), 'first row is focused');
@@ -1475,7 +1475,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.pageIndex(), 1, 'page is changed');
@@ -1500,7 +1500,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.pageIndex(), 1, 'page is changed');
@@ -1528,7 +1528,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
             focusedRowKey: 5
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange
         const childrenNodes = treeList.getNodeByKey(1).children;
@@ -1548,12 +1548,12 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
             focusedRowKey: 4
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         treeList.collapseRow(3);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(treeList.isRowExpanded(3), false, 'parent node collapsed');
@@ -1570,7 +1570,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
             focusedRowKey: 3
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const rowIndex = treeList.getRowIndexByKey(3);
@@ -1578,7 +1578,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
 
         // act
         $(treeList.getCellElement(4, 1)).trigger(CLICK_EVENT);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.notOk(rowsViewWrapper.getDataRow(rowIndex).isFocusedRow(), 'Row 3 is not a focused row');
@@ -1605,7 +1605,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
         const d = treeList.navigateToRow(12);
         d.done(callback);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(d.state(), 'resolved', 'promise is resolved');
@@ -1628,12 +1628,12 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
         const callback = sinon.spy();
 
         // act
-        this.clock.tick();
+        this.clock.tick(10);
 
         const d = treeList.navigateToRow(2);
         d.done(callback);
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(d.state(), 'resolved', 'promise is resolved');
@@ -1670,7 +1670,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
         d.done(callback);
 
         $(treeList.getScrollable().container()).trigger('scroll');
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.strictEqual(d.state(), 'resolved', 'promise is resolved');
@@ -1704,13 +1704,13 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
 
         const treeList = createTreeList(options);
 
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         options.dataSource.store().on('loading', loadingSpy);
 
         // act
         treeList.option(options);
-        this.clock.tick(0);
+        this.clock.tick(10);
 
         // assert
         assert.equal(loadingSpy.callCount, 1, 'loading called once');
@@ -1739,14 +1739,14 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
         try {
             // act
             createTreeList(options);
-            this.clock.tick();
+            this.clock.tick(10);
 
             // arrange
             options.selection.mode = 'multiple';
 
             // act
             createTreeList(options);
-            this.clock.tick();
+            this.clock.tick(10);
         } catch(e) {
             // assert
             assert.ok(false, e.message);
@@ -1868,7 +1868,7 @@ QUnit.module('Focused Row', defaultModuleConfig, () => {
         // act
         treeList.focus(treeList.getCellElement(0, 0));
         treeList.addRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         const $firstCellInAddedRow = $(treeList.getCellElement(1, 0));
@@ -2151,7 +2151,7 @@ QUnit.module('Scroll', defaultModuleConfig, () => {
 
         // act
         treeList.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
         const $row = $(treeList.getRowElement(2));
 
         // assert
@@ -2175,14 +2175,14 @@ QUnit.module('Scroll', defaultModuleConfig, () => {
             columns: ['Name'],
             expandedRowKeys: [1]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         treeList.getDataSource().store().push([{
             type: 'insert',
             data: { ID: 2, Head_ID: 1, Name: 'Alex' }
         }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // arrange
         const $row = $(treeList.getRowElement(1));
@@ -2208,11 +2208,11 @@ QUnit.module('Scroll', defaultModuleConfig, () => {
             expandedRowKeys: [],
             onNodesInitialized: onNodesInitializedSpy
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         treeList.expandRow(1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.equal(onNodesInitializedSpy.callCount, 1, 'data did not reshape');
@@ -2236,11 +2236,11 @@ QUnit.module('Scroll', defaultModuleConfig, () => {
             keyExpr: 'id',
             parentIdExpr: 'parentId',
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         // act
         store.push([{ type: 'remove', key: 100 }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         // assert
         assert.ok(true, 'exception does not occur');
@@ -2335,7 +2335,7 @@ QUnit.module('Row dragging', defaultModuleConfig, () => {
                 }
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             pointerMock(treeList.getCellElement(0, 0)).start().down().move(100, 100);
@@ -2393,7 +2393,7 @@ QUnit.module('Selection', defaultModuleConfig, () => {
                 }
             });
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             // act
             const $selectCheckBoxes = $('.dx-select-checkbox');

--- a/testing/tests/DevExpress.ui.widgets/button.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/button.tests.js
@@ -318,7 +318,7 @@ QUnit.module('Button', function() {
             const pointer = pointerMock($inkButton);
 
             pointer.start('touch').down();
-            clock.tick();
+            clock.tick(10);
             pointer.start('touch').up();
             assert.strictEqual($inkButton.find(`.${INK_RIPPLE_CLASS}`).length, 1, 'inkRipple element was rendered');
 
@@ -326,13 +326,13 @@ QUnit.module('Button', function() {
             assert.strictEqual($inkButton.find(`.${INK_RIPPLE_CLASS}`).length, 0, 'inkRipple element was removed');
 
             pointer.start('touch').down();
-            clock.tick();
+            clock.tick(10);
             pointer.start('touch').up();
             assert.strictEqual($inkButton.find(`.${INK_RIPPLE_CLASS}`).length, 0, 'inkRipple element was removed is still removed after click');
 
             inkButton.option('useInkRipple', true);
             pointer.start('touch').down();
-            clock.tick();
+            clock.tick(10);
             pointer.start('touch').up();
             assert.strictEqual($inkButton.find(`.${INK_RIPPLE_CLASS}`).length, 1, 'inkRipple element was rendered');
 
@@ -426,7 +426,7 @@ QUnit.module('Button', function() {
             this.$form = $('#form');
             this.clickButton = function() {
                 this.$element.trigger('dxclick');
-                this.clock.tick();
+                this.clock.tick(10);
             };
         },
         afterEach: function() {

--- a/testing/tests/DevExpress.ui.widgets/drawer.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/drawer.tests.js
@@ -1260,7 +1260,7 @@ QUnit.module('CloseOnOutsideClick', {
         const $shader = drawer.$element().find('.' + DRAWER_SHADER_CLASS);
 
         $($content).trigger('dxclick');
-        clock.tick();
+        clock.tick(10);
 
         assert.equal(drawer.option('opened'), false, 'drawer is hidden');
         assert.ok($shader.is(':hidden'), 'shader is hidden');

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.markup.tests.js
@@ -497,7 +497,7 @@ QUnit.module('deferred datasource', {
             items: [{ id: 1, text: 'Item 1' }, { id: 2, text: 'Item 2' }]
         });
         dropDownButton.option('selectedItemKey', 2);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(getActionButton(dropDownButton).text(), 'Item 2', 'action button has been changed');
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/dropDownButton.tests.js
@@ -1802,7 +1802,7 @@ QUnit.module('deferred datasource', {
             items: [{ id: 1, text: 'Item 1' }, { id: 2, text: 'Item 2' }]
         });
         dropDownButton.option('selectedItemKey', 2);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(getList(dropDownButton).option('selectedItemKeys')[0], 2, 'selectedItemKeys is correct');
     });
 

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/arrayProvider.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/arrayProvider.tests.js
@@ -53,7 +53,7 @@ const moduleConfig = {
 
         this.rootItem = new FileSystemItem('', true);
 
-        sinon.stub(fileSaver, 'saveAs', (fileName, format, data) => {
+        sinon.stub(fileSaver, 'saveAs').callsFake((fileName, format, data) => {
             if(fileSaver._onTestSaveAs) {
                 fileSaver._onTestSaveAs(fileName, format, data);
             }

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
@@ -606,7 +606,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
             }),
             upload: { chunkSize }
         });
-        this.clock.tick(400);
+        this.clock.tick(500);
 
         this.wrapper.getToolbarButton('Upload').filter(':visible').trigger('dxclick');
 
@@ -671,7 +671,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
             }),
             upload: { chunkSize }
         });
-        this.clock.tick(400);
+        this.clock.tick(500);
 
         this.wrapper.getToolbarButton('Upload').filter(':visible').trigger('dxclick');
 
@@ -1367,19 +1367,19 @@ QUnit.module('Editing operations', moduleConfig, () => {
                 showFolders: true
             }
         });
-        this.clock.tick(400);
+        this.clock.tick(500);
 
         // Select folder 'Folder 1/Folder 1.1/File 1-1.txt'
         this.wrapper.getColumnCellsInDetailsView(2).eq(1).trigger(CLICK_EVENT).click();
-        this.clock.tick(400);
+        this.clock.tick(500);
         // Invoke copy dialog
         this.wrapper.getToolbarButton('Copy to').trigger('dxclick');
-        this.clock.tick(400);
+        this.clock.tick(500);
         // Select destination directory 'Folder 1/Folder 1.2'
         this.wrapper.getFolderNodes(true).eq(4).trigger('dxclick');
         this.wrapper.getDialogButton('Copy').trigger('dxclick');
 
-        this.clock.tick(operationDelay + 1);
+        this.clock.tick(operationDelay + 100);
         fileManager.refresh();
 
         this.clock.tick(operationDelay);

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
@@ -613,7 +613,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
         const emptyFiles = createUploaderFiles(3, 0);
         this.wrapper.setUploadInputFile(emptyFiles);
 
-        this.clock.tick(operationDelay + 1);
+        this.clock.tick(operationDelay + 100);
         assert.strictEqual(uploadChunkSpy.callCount, 2, '2 empty files are uploaded, and 1 isn\'t started');
 
         let infos = this.progressPanelWrapper.getInfos();

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/editing.tests.js
@@ -636,7 +636,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
             }
         }
 
-        this.clock.tick(operationDelay + 1);
+        this.clock.tick(operationDelay + 100);
         assert.strictEqual(uploadChunkSpy.callCount, 3, 'all files are uploaded');
 
         infos = this.progressPanelWrapper.getInfos();
@@ -679,7 +679,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
         const file = createUploaderFiles(3, chunkSize * 2)[2];
         this.wrapper.setUploadInputFile([ ...emptyFiles, file ]);
 
-        this.clock.tick(operationDelay + 1);
+        this.clock.tick(operationDelay + 100);
         assert.strictEqual(uploadChunkSpy.callCount, 2, 'empty files are uploaded, and 0 % of regular file is uploaded');
 
         let infos = this.progressPanelWrapper.getInfos();
@@ -702,7 +702,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
             }
         }
 
-        this.clock.tick(operationDelay + 1);
+        this.clock.tick(operationDelay + 100);
         assert.strictEqual(uploadChunkSpy.callCount, 3, 'empty files are uploaded, and 50 % of regular file is uploaded');
 
         infos = this.progressPanelWrapper.getInfos();
@@ -725,7 +725,7 @@ QUnit.module('Editing operations', moduleConfig, () => {
             }
         }
 
-        this.clock.tick(operationDelay + 1);
+        this.clock.tick(operationDelay + 100);
         assert.strictEqual(uploadChunkSpy.callCount, 4, 'all files are uploaded');
 
         infos = this.progressPanelWrapper.getInfos();

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/editingEvents.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/editingEvents.tests.js
@@ -42,7 +42,7 @@ const moduleConfig = {
         this.dialogResult = { };
 
         const showDialog = () => new Deferred().resolve(this.dialogResult).promise();
-        sinon.stub(this.fileManager._editing, '_showDialog', showDialog);
+        sinon.stub(this.fileManager._editing, '_showDialog').callsFake(showDialog);
     },
 
     afterEach: function() {

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/editingProgress.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/editingProgress.tests.js
@@ -25,7 +25,7 @@ const moduleConfig = {
     },
 
     afterEach: function() {
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.clock.restore();
         fx.off = false;
@@ -836,7 +836,7 @@ QUnit.module('Editing progress tests', moduleConfig, () => {
 
         this.logger.clear();
         this.notificationControl.tryShowProgressPanel();
-        this.clock.tick();
+        this.clock.tick(10);
         const expectedEntries = [ { message: '', status: 'default', type: 'notification-onActionProgress' } ];
         assert.deepEqual(this.logger.getEntries(), expectedEntries, 'success status removed');
     });
@@ -853,7 +853,7 @@ QUnit.module('Editing progress tests', moduleConfig, () => {
 
         this.logger.clear();
         this.notificationControl.tryShowProgressPanel();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(this.logger.getEntries(), [], 'error status persisted');
 
         const panel = this.notificationControl._getNotificationManager()._progressPanel;
@@ -876,7 +876,7 @@ QUnit.module('Editing progress tests', moduleConfig, () => {
 
         this.logger.clear();
         this.notificationControl.tryShowProgressPanel();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(this.logger.getEntries(), [], 'error status persisted');
 
         const panel = this.notificationControl._getNotificationManager()._progressPanel;
@@ -884,7 +884,7 @@ QUnit.module('Editing progress tests', moduleConfig, () => {
         assert.deepEqual(this.logger.getEntries(), []);
 
         this.notificationControl.tryShowProgressPanel();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.deepEqual(this.logger.getEntries(), [], 'error status persisted');
 
         panel._closeOperation(panel.getStoredInfos()[1]);

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
@@ -1170,7 +1170,7 @@ QUnit.module('Navigation operations', moduleConfig, () => {
             ],
             currentPath: targetPath
         });
-        this.clock.tick(400);
+        this.clock.tick(500);
 
         currentPath = this.fileManager.option('currentPath');
         currentPathKeys = this.fileManager.option('currentPathKeys');
@@ -1338,7 +1338,7 @@ QUnit.module('Navigation operations', moduleConfig, () => {
                 })
             }),
         });
-        this.clock.tick(operationDelay * 2 + 1);
+        this.clock.tick(operationDelay * 2 + 100);
 
         currentPath = this.fileManager.option('currentPath');
         currentPathKeys = this.fileManager.option('currentPathKeys');

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/navigation.tests.js
@@ -1281,7 +1281,7 @@ QUnit.module('Navigation operations', moduleConfig, () => {
             }),
             currentPath: targetPath
         });
-        this.clock.tick(operationDelay * 2 + 1);
+        this.clock.tick(operationDelay * 2 + 100);
 
         currentPath = this.fileManager.option('currentPath');
         currentPathKeys = this.fileManager.option('currentPathKeys');

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/progressPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/progressPanel.tests.js
@@ -23,7 +23,7 @@ const moduleConfig = {
     },
 
     afterEach: function() {
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.clock.restore();
         fx.off = false;

--- a/testing/tests/DevExpress.ui.widgets/fileManagerParts/progressPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/fileManagerParts/progressPanel.tests.js
@@ -766,13 +766,13 @@ QUnit.module('Progress panel integration tests', integrationModuleConfig, () => 
                 showPanel: false
             }
         });
-        this.clock.tick(400);
+        this.clock.tick(500);
 
         assert.equal(this.progressPanelWrapper.getInfos().length, 0, 'there is no operations');
 
         this.wrapper.setUploadInputFile(createUploaderFiles(1));
 
-        this.clock.tick(operationDelay * 2 + 1);
+        this.clock.tick(operationDelay * 2 + 100);
         assert.strictEqual(uploadChunkSpy.callCount, 2, 'file is uploaded');
         assert.ok(this.wrapper.getNotificationPopup().is(':visible'), 'notification popup is visible');
 

--- a/testing/tests/DevExpress.ui.widgets/gallery.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/gallery.tests.js
@@ -172,7 +172,7 @@ QUnit.module('behavior', {
         const $galleryItems = $gallery.find(`.${GALLERY_ITEM_CLASS}`);
 
         $galleryItems.eq(1).trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(calculateItemPosition($galleryItems.eq(0), $gallery), 0);
     });

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/actions.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/actions.tests.js
@@ -20,38 +20,38 @@ const moduleConfig = {
 QUnit.module('Actions', moduleConfig, () => {
     test('expand', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
     });
     test('collapse', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
         const collapsedElement = this.$element.find(Consts.TREELIST_COLLAPSED_SELECTOR).first();
         collapsedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
     });
     test('expand/collapse All', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance._collapseAll();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance._expandAll();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
     });
     test('collapse and expand after inserting', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         const newStart = new Date('2019-02-21');
@@ -65,7 +65,7 @@ QUnit.module('Actions', moduleConfig, () => {
             parentId: '2'
         };
         getGanttViewCore(this.instance).commandManager.createTaskCommand.execute(taskData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, tasksCount + 1, 'new task was created in ds');
         const createdTask = data.tasks[data.tasks.length - 1];
@@ -75,12 +75,12 @@ QUnit.module('Actions', moduleConfig, () => {
 
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).eq(1);
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 2);
 
         const collapsedElement = this.$element.find(Consts.TREELIST_COLLAPSED_SELECTOR).first();
         collapsedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
     });
 
@@ -88,7 +88,7 @@ QUnit.module('Actions', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('validation.autoUpdateParentTasks', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         const newStart = new Date('2019-02-21');
@@ -102,7 +102,7 @@ QUnit.module('Actions', moduleConfig, () => {
             parentId: '2'
         };
         getGanttViewCore(this.instance).commandManager.createTaskCommand.execute(taskData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, tasksCount + 1, 'new task was created in ds');
         const createdTask = data.tasks[data.tasks.length - 1];
@@ -112,23 +112,23 @@ QUnit.module('Actions', moduleConfig, () => {
 
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).eq(1);
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 2);
 
         const collapsedElement = this.$element.find(Consts.TREELIST_COLLAPSED_SELECTOR).first();
         collapsedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
     });
 
     test('collapse and check state after validation option changed (T997932)', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).eq(1);
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 2);
 
         this.instance.option('validation.autoUpdateParentTasks', true);
@@ -144,7 +144,7 @@ QUnit.module('Actions', moduleConfig, () => {
 
     test('move splitter', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const splitterWrapper = this.$element.find(Consts.SPLITTER_WRAPPER_SELECTOR);
         const splitter = this.$element.find(Consts.SPLITTER_SELECTOR);
@@ -206,7 +206,7 @@ QUnit.module('Actions', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         const $element2 = $('<div>').attr('id', 'gantt2').appendTo('#qunit-fixture');
         const instance2 = $element2.dxGantt().dxGantt('instance');
-        this.clock.tick();
+        this.clock.tick(10);
 
         [this.$element, $element2].forEach(($element, index) => {
             const splitterWrapper = $element.find(Consts.SPLITTER_WRAPPER_SELECTOR);
@@ -271,41 +271,41 @@ QUnit.module('Actions', moduleConfig, () => {
     });
     test('expand api', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.collapseAll();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
 
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.expandAll();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
 
         this.instance.expandAllToLevel(1);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 2);
 
         this.instance.expandToTask(7);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
 
         this.instance.expandToTask(2);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 2);
 
         this.instance.expandTask(2);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
 
         this.instance.collapseTask(2);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 2);
     });
     test('showResources()', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_RESOURCES_SELECTOR).length, data.resourceAssignments.length);
         this.instance.showResources(false);
         assert.equal(this.$element.find(Consts.TASK_RESOURCES_SELECTOR).length, 0);
@@ -314,7 +314,7 @@ QUnit.module('Actions', moduleConfig, () => {
     });
     test('showDependencies()', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_ARROW_SELECTOR).length, data.dependencies.length);
         this.instance.showDependencies(false);
         assert.equal(this.$element.find(Consts.TASK_ARROW_SELECTOR).length, 0);
@@ -340,10 +340,10 @@ QUnit.module('Actions', moduleConfig, () => {
         };
 
         this.createInstance(taskOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 2);
         this.instance._collapseAll();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
 
         const customText = 'new';
@@ -374,10 +374,10 @@ QUnit.module('Actions', moduleConfig, () => {
         };
 
         this.createInstance(taskOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 2);
         this.instance._collapseAll();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
 
         const customText = 'new';

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/clientSideEvents.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/clientSideEvents.tests.js
@@ -22,7 +22,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('task inserting - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         this.instance.option('onTaskInserting', (e) => {
@@ -30,13 +30,13 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         });
 
         getGanttViewCore(this.instance).commandManager.createTaskCommand.execute(null);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount, 'new task was not created in ds');
     });
     test('task inserting - update args', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         const newStart = new Date('2019-02-23');
@@ -56,7 +56,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         });
 
         getGanttViewCore(this.instance).commandManager.createTaskCommand.execute(taskData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, tasksCount + 1, 'new task was created in ds');
         const createdTask = data.tasks[data.tasks.length - 1];
@@ -68,7 +68,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('task inserted', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const text = 'My text';
         const newStart = new Date('2019-02-23');
@@ -125,7 +125,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
             e.values['ItemName'] = 'new item text';
             e.values['CustomText'] = 'new custom text';
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             ParentId: 0,
@@ -138,7 +138,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         };
 
         this.instance.insertTask(data);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(tasks[1].CustomText, 'new custom text', 'task cust field  is updated');
         assert.equal(tasks[1].ItemName, 'new item text', 'task cust field  is updated');
         assert.equal(tasks[1].TaskColor, 'red', 'task color field  is updated');
@@ -146,7 +146,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('task deleting - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         let values;
@@ -159,7 +159,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         const taskToDelete = data.tasks[data.tasks.length - 1];
         this.instance.option('selectedRowKey', taskToDelete.id.toString());
         getGanttViewCore(this.instance).commandManager.removeTaskCommand.execute(taskToDelete.id.toString(), false);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount, 'new task was not deleted');
         assert.equal(values['parentId'], taskToDelete.parentId, 'check values parentId');
         assert.equal(values['title'], taskToDelete.title, 'check values title');
@@ -170,7 +170,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('task deleted', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let key;
         let values;
@@ -191,7 +191,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('task updating - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskToUpdate = data.tasks[0];
         const dataToUpdate = {
@@ -205,7 +205,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         });
 
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(taskToUpdate.id.toString(), dataToUpdate);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.notEqual(taskToUpdate.title, dataToUpdate.title, 'task title is not updated');
         assert.notEqual(taskToUpdate.start, dataToUpdate.start, 'new task start is not updated');
         assert.notEqual(taskToUpdate.end, dataToUpdate.end, 'new task end is not updated');
@@ -213,7 +213,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('task updating - change args', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskToUpdate = data.tasks[0];
         const newStart = new Date('2019-02-25');
@@ -243,7 +243,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(taskToUpdate.id.toString(), dataToUpdate);
         assert.ok(keyIsDefined, 'key defined');
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(taskToUpdate.title, newTitle, 'task title is updated');
         assert.equal(taskToUpdate.start, newStart, 'new task start is updated');
         assert.equal(taskToUpdate.end, newEnd, 'new task end is updated');
@@ -279,7 +279,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
             e.newValues['ItemName'] = 'new item text';
             e.newValues['CustomText'] = 'new custom text';
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             CustomText: 'new',
@@ -287,7 +287,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         };
 
         this.instance.updateTask(task.Id, data);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(task.CustomText, 'new custom text', 'task cust field  is updated');
         assert.equal(task.ItemName, 'new item text', 'task cust field  is updated');
     });
@@ -320,7 +320,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
 
         let values;
         this.instance.option('onTaskUpdated', (e) => { values = e.values; });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             CustomText: 'new',
@@ -328,7 +328,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         };
 
         this.instance.updateTask(task.Id, data);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.CustomText, values.CustomText, 'task cust field  is updated');
         assert.equal(data.ItemName, values.ItemName, 'task cust field  is updated');
     });
@@ -339,9 +339,9 @@ QUnit.module('Client side edit events', moduleConfig, () => {
 
         this.instance.option('onTaskEditDialogShowing', (e) => { e.cancel = true; });
 
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 0, 'dialog is not shown');
     });
@@ -364,9 +364,9 @@ QUnit.module('Client side edit events', moduleConfig, () => {
             keyIsDefined = !!e.key;
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
         const $inputs = $dialog.find('.dx-texteditor-input');
@@ -388,9 +388,9 @@ QUnit.module('Client side edit events', moduleConfig, () => {
             e.readOnlyFields.push('progress');
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
         const inputs = $dialog.find('.dx-texteditor-input');
@@ -400,15 +400,15 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         let inputs = $dialog.find('.dx-texteditor-input');
         const count = inputs.length;
         const $okButton = $dialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.instance.option('onTaskEditDialogShowing', (e) => {
             e.hiddenFields.push('title');
@@ -416,9 +416,9 @@ QUnit.module('Client side edit events', moduleConfig, () => {
             e.hiddenFields.push('end');
             e.hiddenFields.push('progress');
         });
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
 
         inputs = $dialog.find('.dx-texteditor-input');
         assert.equal(inputs.length, count - 4, 'all inputs is hidden');
@@ -427,11 +427,11 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('dependency inserting - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
         const count = data.dependencies.length;
         this.instance.option('onDependencyInserting', (e) => { e.cancel = true; });
         getGanttViewCore(this.instance).commandManager.createDependencyCommand.execute('0', '1', '2');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.dependencies.length, count, 'new dependency was not created');
     });
     test('dependency inserted', function(assert) {
@@ -448,7 +448,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
 
         this.createInstance(dependenciesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let values;
         let key;
@@ -459,7 +459,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
 
         const data = { 'predecessorId': 2, 'successorId': 3, 'type': 0 };
         this.instance.insertDependency(data);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(!!key, 'key created');
         assert.equal(values['predecessorId'], data['predecessorId'], 'new predecessorId is right');
@@ -469,7 +469,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('dependency deleting - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.dependencies.length;
         const dependencyToDelete = data.dependencies[count - 1];
@@ -481,7 +481,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
             key = e.key;
         });
         getGanttViewCore(this.instance).commandManager.removeDependencyCommand.execute(dependencyToDelete.id.toString(), false);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.dependencies.length, count, 'new dependency was not deleted');
         assert.equal(values['predecessorId'], dependencyToDelete.predecessorId, 'check values predecessorId');
         assert.equal(values['successorId'], dependencyToDelete.successorId, 'check values successorId');
@@ -502,7 +502,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
 
         this.createInstance(dependenciesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let key;
         let values;
@@ -516,7 +516,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         const $confirmDialog = $('body').find(Consts.POPUP_SELECTOR);
         const $yesButton = $confirmDialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $yesButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(key, 0, 'key is right');
         assert.equal(values.predecessorId, dependencyToDelete.predecessorId, 'check values predecessorId');
         assert.equal(values.successorId, dependencyToDelete.successorId, 'check values successorId');
@@ -525,7 +525,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('resource inserting - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resources.length;
         this.instance.option('onResourceInserting', (e) => {
@@ -533,19 +533,19 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         });
 
         getGanttViewCore(this.instance).commandManager.createResourceCommand.execute('text');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.resources.length, count, 'new resource was not created');
     });
     test('resource inserting - update text', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resources.length;
         this.instance.option('onResourceInserting', (e) => { e.values['text'] = 'My text'; });
 
         getGanttViewCore(this.instance).commandManager.createResourceCommand.execute('text');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.resources.length, count + 1, 'new resource was created');
         const newResource = data.resources[data.resources.length - 1];
         this.instance.option('onResourceAssigning', (e) => { });
@@ -554,7 +554,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('resource deleting - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resources.length;
         const resourceToDelete = data.resources[count - 1];
@@ -566,7 +566,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
             key = e.key;
         });
         getGanttViewCore(this.instance).commandManager.removeResourceCommand.execute(resourceToDelete.id.toString());
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.resources.length, count, 'resource was not deleted');
         assert.equal(values['text'], resourceToDelete.text, 'check values text');
         assert.equal(key, resourceToDelete.id, 'check key');
@@ -574,19 +574,19 @@ QUnit.module('Client side edit events', moduleConfig, () => {
     test('resource assigning - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resourceAssignments.length;
         this.instance.option('onResourceAssigning', (e) => { e.cancel = true; });
 
         getGanttViewCore(this.instance).commandManager.assignResourceCommand.execute('1', '2');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.resourceAssignments.length, count, 'new resource was not assigned');
     });
     test('resource un assigning - canceling', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resourceAssignments.length;
         const toDelete = data.resourceAssignments[count - 1];
@@ -594,15 +594,15 @@ QUnit.module('Client side edit events', moduleConfig, () => {
 
         // eslint-disable-next-line spellcheck/spell-checker
         getGanttViewCore(this.instance).commandManager.deassignResourceCommand.execute(toDelete.id.toString());
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.resourceAssignments.length, count, 'resource was not deassigned');
     });
     test('resource manager showing', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.showResourceManagerDialog();
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
         const expectedResourceTitleText = messageLocalization.format('dxGantt-dialogResourceManagerTitle');
@@ -613,9 +613,9 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('onResourceManagerDialogShowing', (e) => { e.cancel = true; });
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.showResourceManagerDialog();
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 0, 'dialog is not shown');
     });
@@ -637,7 +637,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         this.instance.option('onTaskUpdating', (e) => {
             e.newValues['CustomText'] = 'new custom text';
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             title: 'new'
@@ -646,7 +646,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         assert.equal(dependencies.length, 6);
         getGanttViewCore(this.instance).commandManager.removeDependencyCommand.execute('0', false);
 
-        this.clock.tick();
+        this.clock.tick(10);
         dependencies = getDependencyElements(this.$element, 0);
         assert.equal(dependencies.length, 0, 'dependency has been deleted');
         this.instance.updateTask('1', data);
@@ -669,7 +669,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         this.createInstance(dependenciesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('columns', [{ dataField: 'CustomText', caption: 'Task' }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             'CustomText': 'new'
@@ -678,7 +678,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         assert.equal(dependencies.length, 6);
         getGanttViewCore(this.instance).commandManager.removeDependencyCommand.execute('1', false);
 
-        this.clock.tick();
+        this.clock.tick(10);
         dependencies = getDependencyElements(this.$element, '1');
         assert.equal(dependencies.length, 0, 'dependency has been deleted');
         this.instance.updateTask('1', data);
@@ -704,7 +704,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         };
 
         this.createInstance(taskOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const customText = 'new';
         const data = {
             'CustomText': customText
@@ -727,7 +727,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('onTaskUpdated', (e) => { e.component.collapseAll(); });
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, data.tasks.length - 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, data.tasks.length);
@@ -741,7 +741,7 @@ QUnit.module('Client side edit events', moduleConfig, () => {
         this.instance.option('editing.enabled', true);
         this.instance.option('validation.autoUpdateParentTasks', true);
         this.instance.option('onTaskUpdated', (e) => { e.component.collapseAll(); });
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length > 5);
         assert.ok(this.instance._treeList.getVisibleRows().length, data.tasks.length > 5);

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/constraintViolationDialog.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/constraintViolationDialog.tests.js
@@ -70,9 +70,9 @@ const moduleConfig = {
 QUnit.module('ConstraintViolationDialog', moduleConfig, () => {
     test('FS, critical errors', function(assert) {
         this.createInstance(dependency_options);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask('3', { start: new Date(2019, 0, 14) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
@@ -81,9 +81,9 @@ QUnit.module('ConstraintViolationDialog', moduleConfig, () => {
     });
     test('FS, no critical errors', function(assert) {
         this.createInstance(dependency_options);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask('3', { start: new Date(2019, 0, 16) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
@@ -92,9 +92,9 @@ QUnit.module('ConstraintViolationDialog', moduleConfig, () => {
     });
     test('SS, critical errors', function(assert) {
         this.createInstance(dependency_options);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask('6', { start: new Date(2019, 0, 12) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
@@ -103,9 +103,9 @@ QUnit.module('ConstraintViolationDialog', moduleConfig, () => {
     });
     test('SS, no critical errors', function(assert) {
         this.createInstance(dependency_options);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask('6', { start: new Date(2019, 0, 14) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
@@ -114,9 +114,9 @@ QUnit.module('ConstraintViolationDialog', moduleConfig, () => {
     });
     test('FF, critical errors', function(assert) {
         this.createInstance(dependency_options);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask('9', { end: new Date(2019, 0, 19) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
@@ -125,9 +125,9 @@ QUnit.module('ConstraintViolationDialog', moduleConfig, () => {
     });
     test('FF, no critical errors', function(assert) {
         this.createInstance(dependency_options);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask('9', { end: new Date(2019, 0, 22) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
@@ -136,9 +136,9 @@ QUnit.module('ConstraintViolationDialog', moduleConfig, () => {
     });
     test('SF, critical errors', function(assert) {
         this.createInstance(dependency_options);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask('12', { end: new Date(2019, 0, 13) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
@@ -147,9 +147,9 @@ QUnit.module('ConstraintViolationDialog', moduleConfig, () => {
     });
     test('SF, no critical errors', function(assert) {
         this.createInstance(dependency_options);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask('12', { end: new Date(2019, 0, 15) });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/contextMenu.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/contextMenu.tests.js
@@ -21,7 +21,7 @@ const moduleConfig = {
 QUnit.module('Context Menu', moduleConfig, () => {
     test('showing', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const getContextMenuElement = () => {
             return $('body').find(Consts.OVERLAY_WRAPPER_SELECTOR).find(Consts.CONTEXT_MENU_SELECTOR);
@@ -32,7 +32,7 @@ QUnit.module('Context Menu', moduleConfig, () => {
     });
     test('tree list context menu', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const getContextMenuElement = () => {
             return $('body').find(Consts.OVERLAY_WRAPPER_SELECTOR).find(Consts.CONTEXT_MENU_SELECTOR);
@@ -44,7 +44,7 @@ QUnit.module('Context Menu', moduleConfig, () => {
     });
     test('shown at correct position', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const oldTop = $('#qunit-fixture').css('top');
         const oldLeft = $('#qunit-fixture').css('left');
         $('#qunit-fixture').css('top', '0');
@@ -60,14 +60,14 @@ QUnit.module('Context Menu', moduleConfig, () => {
         const contextMenuElement = getContextMenuElement();
         assert.equal(contextMenuElement.length, 1, 'menu is visible after right click');
         assert.roughEqual(contextMenuElement.position().top, boundsMax - contextMenuElement.height(), 0.9, 'menu has been shown at correct position');
-        this.clock.tick();
+        this.clock.tick(10);
         $('#qunit-fixture').css('top', oldTop);
         $('#qunit-fixture').css('left', oldLeft);
 
     });
     test('enabled', function(assert) {
         this.createInstance(extend(options.tasksOnlyOptions, { contextMenu: { enabled: false } }));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const getContextMenuElement = () => {
             return $('body').find(Consts.OVERLAY_WRAPPER_SELECTOR).find(Consts.CONTEXT_MENU_SELECTOR);
@@ -92,7 +92,7 @@ QUnit.module('Context Menu', moduleConfig, () => {
             }
         };
         this.createInstance(extend(options.tasksOnlyOptions, contextMenuOptions));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const getContextMenuElement = () => {
             return $('body').find(Consts.OVERLAY_WRAPPER_SELECTOR).find(Consts.CONTEXT_MENU_SELECTOR);
@@ -110,7 +110,7 @@ QUnit.module('Context Menu', moduleConfig, () => {
     });
     test('cancel ContextMenuPreparing', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const getContextMenuElement = () => {
             return $('body').find(Consts.OVERLAY_WRAPPER_SELECTOR).find(Consts.CONTEXT_MENU_SELECTOR);
@@ -118,13 +118,13 @@ QUnit.module('Context Menu', moduleConfig, () => {
         this.instance.option('onContextMenuPreparing', (e) => {
             e.cancel = true;
         });
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance._showPopupMenu({ position: { x: 0, y: 0 } });
         assert.equal(getContextMenuElement().length, 0, 'menu is hidden after right click');
     });
     test('add item in ContextMenuPreparing', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const getContextMenuElement = () => {
             return $('body').find(Consts.OVERLAY_WRAPPER_SELECTOR).find(Consts.CONTEXT_MENU_SELECTOR);
@@ -141,7 +141,7 @@ QUnit.module('Context Menu', moduleConfig, () => {
             contextMenu: { items: [ 'addSubTask' ] }
         };
         this.createInstance(extend(options.tasksOnlyOptions, contextMenuOptions));
-        this.clock.tick();
+        this.clock.tick(10);
 
         const getContextMenuElement = () => {
             return $('body').find(Consts.OVERLAY_WRAPPER_SELECTOR).find(Consts.CONTEXT_MENU_SELECTOR);

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/dataSource.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/dataSource.tests.js
@@ -21,7 +21,7 @@ QUnit.module('DataSources', moduleConfig, () => {
     test('inserting', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         const taskData = {
@@ -32,7 +32,7 @@ QUnit.module('DataSources', moduleConfig, () => {
             parentId: '1'
         };
         getGanttViewCore(this.instance).commandManager.createTaskCommand.execute(taskData);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount + 1, 'new task was created in ds');
         const createdTask = data.tasks[data.tasks.length - 1];
         assert.equal(createdTask.title, taskData.title, 'new task title is right');
@@ -42,7 +42,7 @@ QUnit.module('DataSources', moduleConfig, () => {
     test('updating', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTaskId = 3;
         const dataToUpdate = {
@@ -51,7 +51,7 @@ QUnit.module('DataSources', moduleConfig, () => {
             title: 'New'
         };
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(updatedTaskId.toString(), dataToUpdate);
-        this.clock.tick();
+        this.clock.tick(10);
         const updatedTask = data.tasks.filter((t) => t.id === updatedTaskId)[0];
         assert.equal(updatedTask.title, dataToUpdate.title, 'task title is updated');
         assert.equal(updatedTask.start, dataToUpdate.start, 'new task start is updated');
@@ -61,12 +61,12 @@ QUnit.module('DataSources', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('selectedRowKey', 3);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const removedTaskId = 3;
         const tasksCount = data.tasks.length;
         getGanttViewCore(this.instance).commandManager.removeTaskCommand.execute(removedTaskId.toString(), false);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount - 1, 'tasks less');
         const removedTask = data.tasks.filter((t) => t.id === removedTaskId)[0];
         assert.equal(removedTask, undefined, 'task was removed');
@@ -77,10 +77,10 @@ QUnit.module('DataSources', moduleConfig, () => {
             tasks: { dataSource: [] },
             validation: { autoUpdateParentTasks: true }
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.instance.option('tasks.dataSource', data.tasks);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.instance._treeList.option('expandedRowKeys').length, 2, 'each task is loaded and expanded');
     });
     test('incorrect tasks data', function(assert) {
@@ -95,7 +95,7 @@ QUnit.module('DataSources', moduleConfig, () => {
             tasks: { dataSource: failTasks },
             validation: { autoUpdateParentTasks: true }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         let keys = this.instance.getVisibleTaskKeys();
         assert.equal(keys.length, 3, 'incorrect keys filtered');
         assert.equal(keys[0], 1, 'correct key');
@@ -103,7 +103,7 @@ QUnit.module('DataSources', moduleConfig, () => {
         assert.equal(keys[2], 3, 'correct key');
 
         this.instance.option('validation.autoUpdateParentTasks', false);
-        this.clock.tick();
+        this.clock.tick(10);
         keys = this.instance.getVisibleTaskKeys();
         assert.equal(keys.length, 3, 'incorrect keys filtered');
         assert.equal(keys[0], 1, 'correct key');
@@ -119,7 +119,7 @@ QUnit.module('DataSources', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('columns', columns);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
         const taskData = {
             start: new Date('2019-02-21'),
             end: new Date('2019-02-22'),
@@ -128,7 +128,7 @@ QUnit.module('DataSources', moduleConfig, () => {
             parentId: '1'
         };
         getGanttViewCore(this.instance).commandManager.createTaskCommand.execute(taskData);
-        this.clock.tick();
+        this.clock.tick(10);
         const titleText = $(this.instance._treeList.getCellElement(data.tasks.length - 1, 0)).text();
         const progress = $(this.instance._treeList.getCellElement(data.tasks.length - 1, 1)).text();
         const endDate = new Date($(this.instance._treeList.getCellElement(data.tasks.length - 1, 2)).text());
@@ -151,7 +151,7 @@ QUnit.module('DataSources', moduleConfig, () => {
                 { dataField: 'end', caption: 'End Date' }
             ]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             start: new Date('2019-02-21'),
@@ -159,7 +159,7 @@ QUnit.module('DataSources', moduleConfig, () => {
             title: 'New'
         };
         this.instance.updateTask(tasks[2].id, data);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const titleText = $(this.instance._treeList.getCellElement(2, 0)).text();
         const startDate = new Date($(this.instance._treeList.getCellElement(2, 1)).text());

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/dialogs.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/dialogs.tests.js
@@ -22,12 +22,12 @@ QUnit.module('Dialogs', moduleConfig, () => {
     test('common', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
         assert.equal($('body').find(Consts.POPUP_SELECTOR).length, 1, 'dialog is shown');
         this.instance.repaint();
         assert.equal($('body').find(Consts.POPUP_SELECTOR).length, 0, 'dialog is missed after widget repainting');
-        this.clock.tick();
+        this.clock.tick(10);
 
         showTaskEditDialog(this.instance);
         assert.equal($('body').find(Consts.POPUP_SELECTOR).length, 1, 'dialog is shown');
@@ -38,9 +38,9 @@ QUnit.module('Dialogs', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         let $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
 
@@ -84,9 +84,9 @@ QUnit.module('Dialogs', moduleConfig, () => {
     test('showTaskDetailsDialog', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.showTaskDetailsDialog(1);
-        this.clock.tick();
+        this.clock.tick(10);
         let $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
 
@@ -116,7 +116,7 @@ QUnit.module('Dialogs', moduleConfig, () => {
         assert.ok(isValidStartTextBox, 'not empty start validation');
         assert.ok(isValidEndTextBox, 'not empty end validation');
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         const firstTreeListTitleText = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).first().find('td').eq(2).text();
         assert.equal(firstTreeListTitleText, testTitle, 'title text was modified');
 
@@ -131,9 +131,9 @@ QUnit.module('Dialogs', moduleConfig, () => {
     test('resources editing', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
         getGanttViewCore(this.instance).commandManager.showResourcesDialog.execute();
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
 
@@ -158,12 +158,12 @@ QUnit.module('Dialogs', moduleConfig, () => {
 
         const $okButton = $dialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $confirmDialog = $('body').find(Consts.POPUP_SELECTOR);
         const $yesButton = $confirmDialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $yesButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.resources[0].text, secondResourceText, 'first resource removed from ds');
         assert.equal(data.resources[1].text, thirdResourceText, 'second resource ds');
@@ -173,9 +173,9 @@ QUnit.module('Dialogs', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
 
@@ -188,14 +188,14 @@ QUnit.module('Dialogs', moduleConfig, () => {
         titleTextBox.option('value', testTitle);
         const $okButton = $dialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks[0].progress, 31, 'progress reset');
     });
     test('showing taskEditDialog after resources dialog is closed', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         showTaskEditDialog(this.instance);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
@@ -206,7 +206,7 @@ QUnit.module('Dialogs', moduleConfig, () => {
 
         const $showResourcesButton = $dialog.find('.dx-texteditor-buttons-container').find('.dx-button').eq(0);
         $showResourcesButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const expectedResourceTitleText = messageLocalization.format('dxGantt-dialogResourceManagerTitle');
         popupTitleText = $dialog.find('.dx-popup-title').text();
@@ -214,7 +214,7 @@ QUnit.module('Dialogs', moduleConfig, () => {
 
         const $okButton = $dialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         popupTitleText = $dialog.find('.dx-popup-title').text();
         assert.equal(expectedTaskEditTitleText, popupTitleText, 'taskEditPopup title shown again');
@@ -225,7 +225,7 @@ QUnit.module('Dialogs', moduleConfig, () => {
         this.instance.option('editing.allowTaskResourceUpdating', false);
 
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         showTaskEditDialog(this.instance);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
@@ -239,7 +239,7 @@ QUnit.module('Dialogs', moduleConfig, () => {
         this.instance.option('editing.allowResourceDeleting', false);
 
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         showTaskEditDialog(this.instance);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
@@ -264,7 +264,7 @@ QUnit.module('Dialogs', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         showTaskEditDialog(this.instance);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/editApi.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/editApi.tests.js
@@ -21,7 +21,7 @@ QUnit.module('Edit api', moduleConfig, () => {
     test('task insert', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskData = {
             title: 'My text',
@@ -32,7 +32,7 @@ QUnit.module('Edit api', moduleConfig, () => {
 
         const tasksCount = data.tasks.length;
         this.instance.insertTask(taskData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, tasksCount + 1, 'new task was created in ds');
         const createdTask = data.tasks[data.tasks.length - 1];
@@ -56,7 +56,7 @@ QUnit.module('Edit api', moduleConfig, () => {
             editing: { enabled: true }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             title: 'My text',
@@ -67,7 +67,7 @@ QUnit.module('Edit api', moduleConfig, () => {
 
         const tasksCount = myTasks.length;
         this.instance.insertTask(data);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(myTasks.length, tasksCount + 1, 'new task was created in ds');
         const createdTask = myTasks[myTasks.length - 1];
@@ -76,12 +76,12 @@ QUnit.module('Edit api', moduleConfig, () => {
     test('task delete', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         const taskToDelete = data.tasks[tasksCount - 1];
         this.instance.deleteTask(taskToDelete.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, tasksCount - 1, 'new task was deleted');
         const removedTask = data.tasks.filter((t) => t.id === taskToDelete.id)[0];
@@ -90,7 +90,7 @@ QUnit.module('Edit api', moduleConfig, () => {
     test('taskUpdate', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskToUpdate = data.tasks[0];
         const taskData = {
@@ -101,7 +101,7 @@ QUnit.module('Edit api', moduleConfig, () => {
         };
 
         this.instance.updateTask(taskToUpdate.id, taskData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(taskToUpdate.title, taskData.title, 'task title is updated');
         assert.equal(taskToUpdate.start, taskData.start, 'new task start is updated');
@@ -134,7 +134,7 @@ QUnit.module('Edit api', moduleConfig, () => {
         };
         this.instance.option('tasks', tasksMap);
         this.instance.option('columns', [{ dataField: 'CustomText', caption: 'Task' }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             ItemName: 'New',
@@ -142,7 +142,7 @@ QUnit.module('Edit api', moduleConfig, () => {
         };
 
         this.instance.updateTask(task.Id, data);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(task.ItemName, data.ItemName, 'task title is updated');
         assert.equal(task.CustomText, data.CustomText, 'task cust field  is updated');
@@ -184,14 +184,14 @@ QUnit.module('Edit api', moduleConfig, () => {
             columns: [{ dataField: 'ItemName', caption: 'Task' }]
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             ItemName: 'New',
             TaskColor: 'yellow'
         };
         this.instance.updateTask(1, data);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const firstTreeListTitleText = $(this.instance._treeList.getCellElement(0, 0)).text();
         assert.equal(firstTreeListTitleText, data.ItemName, 'title text was modified');
@@ -225,7 +225,7 @@ QUnit.module('Edit api', moduleConfig, () => {
         this.instance.option('tasks', tasksMap);
         this.instance.option('onTaskUpdated', (e) => { values = e.values; });
         this.instance.option('columns', [{ dataField: 'CustomText', caption: 'Task' }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             CustomText: 'new text'
@@ -240,12 +240,12 @@ QUnit.module('Edit api', moduleConfig, () => {
     test('insertDependency', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.dependencies.length;
         const dependencyData = { 'predecessorId': 2, 'successorId': 4, 'type': 0 };
         this.instance.insertDependency(dependencyData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.dependencies.length, count + 1, 'new dependency was not created');
         const createdDependency = data.dependencies[data.dependencies.length - 1];
@@ -260,17 +260,17 @@ QUnit.module('Edit api', moduleConfig, () => {
         this.instance.option('editing.enabled', true);
         this.instance.option('validation.validateDependencies', true);
         this.instance.option('validation.autoUpdateParentTasks', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = dependencies.length;
         let dependencyData = { 'predecessorId': 2, 'successorId': 4, 'type': 0 };
         this.instance.insertDependency(dependencyData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dependencies.length, count, 'new dependency was not created');
         dependencyData = { 'predecessorId': 6, 'successorId': 7, 'type': 0 };
         this.instance.insertDependency(dependencyData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dependencies.length, count + 1, 'new dependency was created');
         const createdDependency = dependencies[dependencies.length - 1];
@@ -281,17 +281,17 @@ QUnit.module('Edit api', moduleConfig, () => {
     test('deleteDependency', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.dependencies.length;
         const dependencyToDelete = data.dependencies[count - 1];
         this.instance.deleteDependency(dependencyToDelete.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $confirmDialog = $('body').find(Consts.POPUP_SELECTOR);
         const $yesButton = $confirmDialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $yesButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.dependencies.length, count - 1, 'new dependency was deleted');
         const removedDependency = data.dependencies.filter((t) => t.id === dependencyToDelete.id)[0];
@@ -306,13 +306,13 @@ QUnit.module('Edit api', moduleConfig, () => {
             values = e.values;
             keyExists = !!e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const resourcesCount = data.resources.length;
         const assignmentsCount = data.resourceAssignments.length;
         const resourceData = { text: 'My text' };
         this.instance.insertResource(resourceData, [2]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.resources.length, resourcesCount + 1, 'new resource was created');
         assert.equal(data.resourceAssignments.length, assignmentsCount + 1, 'new assignment was created');
@@ -339,11 +339,11 @@ QUnit.module('Edit api', moduleConfig, () => {
             assignedValues = e.values;
             assignmentKey = !!e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = { text: 'My text' };
         this.instance.insertResource(data, [2]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(assignmentKey, 'key created');
         assert.equal(assigningValues.taskId, 2, 'assigning task key');
@@ -365,7 +365,7 @@ QUnit.module('Edit api', moduleConfig, () => {
             assignedValues = e.values;
             assignmentKey = !!e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = { text: 'My text' };
         this.instance.insertResource(data);
@@ -389,12 +389,12 @@ QUnit.module('Edit api', moduleConfig, () => {
             key = e.key;
             values = e.values;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resources.length;
         const resourceToDelete = data.resources[count - 1];
         this.instance.deleteResource(resourceToDelete.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.resources.length, count - 1, 'resources was deleted');
         const removedResource = data.resources.filter((t) => t.id === resourceToDelete.id)[0];
@@ -411,13 +411,13 @@ QUnit.module('Edit api', moduleConfig, () => {
             values = e.values;
             keyExists = !!e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resourceAssignments.length;
         const taskToAssign = data.tasks[data.tasks.length - 1];
         const resourceToAssign = data.resources[data.resources.length - 1];
         this.instance.assignResourceToTask(resourceToAssign.id, taskToAssign.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.resourceAssignments.length, count + 1, 'resource was assigned');
         const newAssignment = data.resourceAssignments[data.resourceAssignments.length - 1];
@@ -437,13 +437,13 @@ QUnit.module('Edit api', moduleConfig, () => {
             values = e.values;
             key = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resourceAssignments.length;
         const toDelete = data.resourceAssignments[count - 1];
         // eslint-disable-next-line spellcheck/spell-checker
         this.instance.unassignResourceFromTask(toDelete.resourceId, toDelete.taskId);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.resourceAssignments.length, count - 1, 'resource was not deassigned');
         const removedAssignment = data.resourceAssignments.filter((t) => t.id === toDelete.id)[0];
@@ -460,13 +460,13 @@ QUnit.module('Edit api', moduleConfig, () => {
         this.instance.option('onResourceUnassigned', (e) => {
             values = e.values;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resourceAssignments.length;
         const toDelete = data.resourceAssignments[count - 1];
         // eslint-disable-next-line spellcheck/spell-checker
         this.instance.unassignAllResourcesFromTask(toDelete.taskId);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.resourceAssignments.length, count - 2, 'resources were deassigned');
         const removedAssignments = data.resourceAssignments.filter((t) => t.taskId === toDelete.taskId);
@@ -495,7 +495,7 @@ QUnit.module('Edit api', moduleConfig, () => {
             progressExpr: 'TaskProgress'
         };
         this.instance.option('tasks', tasksMap);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskData = this.instance.getTaskData(1);
         assert.equal(taskData['ItemName'], task['ItemName'], 'title');
@@ -519,10 +519,10 @@ QUnit.module('Edit api', moduleConfig, () => {
         };
         this.createInstance(options.tasksOnlyOptions);
         this.instance.option('dependencies', dependencyMap);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const dependencyData = this.instance.getDependencyData(1);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(dependencyData['PredecessorTask'], dependency['PredecessorTask'], 'PredecessorTask');
         assert.equal(dependencyData['SuccessorTask'], dependency['SuccessorTask'], 'SuccessorTask');
         assert.equal(dependencyData['DependencyType'], dependency['DependencyType'], 'DependencyType');
@@ -537,7 +537,7 @@ QUnit.module('Edit api', moduleConfig, () => {
             colorExpr: 'ResourceColor'
         };
         this.instance.option('resources', resourceMap);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const resourceData = this.instance.getResourceData(1);
         assert.equal(resourceData['ResourceText'], resource['ResourceText'], 'ResourceText');
@@ -553,7 +553,7 @@ QUnit.module('Edit api', moduleConfig, () => {
             resourceIdExpr: 'ResourceKey'
         };
         this.instance.option('resourceAssignments', assignmentMap);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const assignmentData = this.instance.getResourceAssignmentData(1);
         assert.equal(assignmentData['TaskKey'], assignment['TaskKey'], 'TaskKey');
@@ -583,7 +583,7 @@ QUnit.module('Edit api', moduleConfig, () => {
         };
         this.instance.option('resources', resourceMap);
         this.instance.option('resourceAssignments', assignmentMap);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskResources = this.instance.getTaskResources(1);
         assert.equal(taskResources.length, 2, 'length');
@@ -629,7 +629,7 @@ QUnit.module('Edit api', moduleConfig, () => {
         };
 
         this.createInstance(my_allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(this.instance.getVisibleTaskKeys().length, my_tasks.length, 'task keys');
         assert.equal(this.instance.getVisibleDependencyKeys().length, my_dependencies.length, 'dependencies keys');
@@ -640,7 +640,7 @@ QUnit.module('Edit api', moduleConfig, () => {
         this.instance.option('dependencies', { dataSource: [] });
         this.instance.option('resources', { dataSource: [] });
         this.instance.option('resourceAssignments', { dataSource: [] });
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(this.instance.getVisibleTaskKeys().length, 0, 'task keys');
         assert.equal(this.instance.getVisibleDependencyKeys().length, 0, 'dependencies keys');
@@ -662,7 +662,7 @@ QUnit.module('Edit api', moduleConfig, () => {
             editing: { enabled: true }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             title: 'My text',
@@ -674,7 +674,7 @@ QUnit.module('Edit api', moduleConfig, () => {
         const tasksCount = myTasks.length;
         this.instance.insertTask(data);
         this.instance.insertTask(data);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(myTasks.length, tasksCount + 2, 'new task was created in ds');
     });
     test('taskUpdate with only custom field and update custom field in onTaskUpdating should trigger onTaskUpdated', function(assert) {
@@ -704,12 +704,12 @@ QUnit.module('Edit api', moduleConfig, () => {
         this.instance.option('tasks', tasksMap);
         this.instance.option('onTaskUpdated', (e) => { values = e.values; });
         this.instance.option('columns', [{ dataField: 'CustomText', caption: 'Task' }]);
-        this.clock.tick();
+        this.clock.tick(10);
         const onTaskUpdatingText = 'new custom text';
         this.instance.option('onTaskUpdating', (e) => {
             e.newValues['CustomText'] = onTaskUpdatingText;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = {
             CustomText: 'new text'
@@ -745,10 +745,10 @@ QUnit.module('Edit api', moduleConfig, () => {
             progressExpr: 'TaskProgress'
         };
         this.instance.option('tasks', tasksMap);
-        this.clock.tick();
+        this.clock.tick(10);
         let receivedValues;
         this.instance.option('onTaskUpdating', (e) => { receivedValues = e.newValues; });
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.instance.updateTask(task.Id);
         this.clock.tick(300);
@@ -808,13 +808,13 @@ QUnit.module('Edit api', moduleConfig, () => {
         this.instance.option('tasks', tasksMap);
         this.instance.option('onTaskUpdated', (e) => { updatedEventTriggered = true; });
         this.instance.option('columns', [{ dataField: 'CustomText', caption: 'Task' }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.instance.option('onTaskUpdating', (e) => {
             updatingEventTriggered = true;
             e.cancel = true;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const data = { CustomText: 'new text' };
         this.instance.updateTask(task.Id, data);

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/editDataSources.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/editDataSources.tests.js
@@ -39,13 +39,13 @@ QUnit.module('Edit data sources (T887281)', moduleConfig, () => {
             validation: { autoUpdateParentTasks: true }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTaskId = 3;
         const updatedStart = new Date('2019-02-21');
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(updatedTaskId.toString(), { start: updatedStart });
         this.instance._ganttTreeList.updateDataSource();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask = tasks.filter((t) => t.my_id === updatedTaskId)[0];
         assert.equal(updatedTask.start, updatedStart, 'new task start is updated');
@@ -68,13 +68,13 @@ QUnit.module('Edit data sources (T887281)', moduleConfig, () => {
             validation: { autoUpdateParentTasks: false }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTaskId = 3;
         const updatedStart = new Date('2019-02-21');
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(updatedTaskId.toString(), { start: updatedStart });
         this.instance._ganttTreeList.updateDataSource();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask = tasks.filter((t) => t.my_id === updatedTaskId)[0];
         assert.equal(updatedTask.start, updatedStart, 'new task start is updated');
@@ -121,13 +121,13 @@ QUnit.module('Edit data sources (T887281)', moduleConfig, () => {
             validation: { autoUpdateParentTasks: true }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTaskId = 3;
         const updatedStart = new Date('2019-02-21');
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(updatedTaskId.toString(), { start: updatedStart });
         this.instance._ganttTreeList.updateDataSource();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask = tasks.filter((t) => t.my_id === updatedTaskId)[0];
         assert.equal(updatedTask.start, updatedStart, 'new task start is updated');
@@ -174,13 +174,13 @@ QUnit.module('Edit data sources (T887281)', moduleConfig, () => {
             validation: { autoUpdateParentTasks: false }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTaskId = 3;
         const updatedStart = new Date('2019-02-21');
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(updatedTaskId.toString(), { start: updatedStart });
         this.instance._ganttTreeList.updateDataSource();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask = tasks.filter((t) => t.my_id === updatedTaskId)[0];
         assert.equal(updatedTask.start, updatedStart, 'new task start is updated');
@@ -227,13 +227,13 @@ QUnit.module('Edit data sources (T887281)', moduleConfig, () => {
             validation: { autoUpdateParentTasks: true }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTaskId = 3;
         const updatedStart = new Date('2019-02-21');
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(updatedTaskId.toString(), { start: updatedStart });
         this.instance._ganttTreeList.updateDataSource();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask = tasks.filter((t) => t.my_id === updatedTaskId)[0];
         assert.equal(updatedTask.start, updatedStart, 'new task start is updated');
@@ -280,13 +280,13 @@ QUnit.module('Edit data sources (T887281)', moduleConfig, () => {
             validation: { autoUpdateParentTasks: false }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTaskId = 3;
         const updatedStart = new Date('2019-02-21');
         getGanttViewCore(this.instance).commandManager.updateTaskCommand.execute(updatedTaskId.toString(), { start: updatedStart });
         this.instance._ganttTreeList.updateDataSource();
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask = tasks.filter((t) => t.my_id === updatedTaskId)[0];
         assert.equal(updatedTask.start, updatedStart, 'new task start is updated');
@@ -311,10 +311,10 @@ QUnit.module('Edit data sources (T887281)', moduleConfig, () => {
             tasks: { dataSource: tasksDataSource },
             editing: { enabled: true }
         });
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.instance._treeList.getVisibleRows().length, 4, 'tasks filtered');
         this.instance.deleteTask('4');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.instance._treeList.getVisibleRows().length, 3, 'tasks removed');
     });
     test('check render for ds with delay T1024748', function(assert) {
@@ -350,7 +350,7 @@ QUnit.module('Edit data sources (T887281)', moduleConfig, () => {
             validation: { autoUpdateParentTasks: true }
         };
         this.createInstance(options);
-        this.clock.tick(200);
+        this.clock.tick(300);
 
         const titleText = $(this.instance._treeList.getCellElement(0, 0)).text();
         assert.equal(titleText, tasks[0].title, 'title cell text is right');

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/events.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/events.tests.js
@@ -30,18 +30,18 @@ QUnit.module('Events', moduleConfig, () => {
             }
         };
         this.createInstance(extend(options.tasksOnlyOptions, eventsOptions));
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.instance._showPopupMenu({ position: { x: 0, y: 0 } });
         const popupItem = $('body').find(Consts.OVERLAY_WRAPPER_SELECTOR).find(Consts.CONTEXT_MENU_SELECTOR).find(Consts.CONTEXT_MENU_ITEM_SELECTOR).eq(0);
         popupItem.trigger('dxclick');
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(executedCommandName, eventsOptions.contextMenu.items[0].name, 'onCustomCommand was raised');
     });
     test('selection changed', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const key = 2;
         let keyFromEvent;
@@ -49,7 +49,7 @@ QUnit.module('Events', moduleConfig, () => {
             keyFromEvent = e.selectedRowKey;
         });
         this.instance.option('selectedRowKey', key);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(keyFromEvent, key);
     });
     test('onContentReady', function(assert) {
@@ -61,13 +61,13 @@ QUnit.module('Events', moduleConfig, () => {
             onContentReady: onContentReadyHandler
         };
         this.createInstance(eventsOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(onContentReadyHandler.callCount, 1, 'onContentReadyHandler was called 1 times');
     });
     test('task click', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const key = 2;
         let keyFromEvent;
@@ -76,13 +76,13 @@ QUnit.module('Events', moduleConfig, () => {
         });
         const $cellElement = $(this.instance._treeList.getCellElement(key - 1, 0));
         $cellElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(keyFromEvent, key);
     });
 
     test('task double click', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const key = 2;
         let keyFromEvent;
@@ -92,7 +92,7 @@ QUnit.module('Events', moduleConfig, () => {
         });
         const $cellElement = $(this.instance._treeList.getCellElement(key - 1, 0));
         $cellElement.trigger('dxdblclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(keyFromEvent, key);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 0, 'dialog is not shown');
@@ -114,7 +114,7 @@ QUnit.module('Events', moduleConfig, () => {
             }
         };
         this.createInstance(my_options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $top_item = $('#qunit-fixture').find('.gst_item');
         assert.ok($top_item.length > 0, 'top items customized');

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/filtering.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/filtering.tests.js
@@ -46,7 +46,7 @@ QUnit.module('Filtering', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $filterRow = this.$element.find(Consts.TREELIST_FILTER_ROW_SELECTOR);
         assert.equal($filterRow.length, 1);
@@ -91,7 +91,7 @@ QUnit.module('Filtering', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_SELECTOR).length, 2);
         this.instance._treeList.clearFilter();
         this.clock.tick(300);
@@ -128,7 +128,7 @@ QUnit.module('Filtering', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const treeListIdText1 = $(this.instance._treeList.getCellElement(0, 0)).text();
         const treeListTitleText1 = $(this.instance._treeList.getCellElement(0, 1)).text();
@@ -257,11 +257,11 @@ QUnit.module('Filtering', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
 
@@ -277,7 +277,7 @@ QUnit.module('Filtering', moduleConfig, () => {
 
         expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
 

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/firstDayOfWeek.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/firstDayOfWeek.tests.js
@@ -22,31 +22,31 @@ QUnit.module('First day of week', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('scaleType', 'days');
         this.instance.option('firstDayOfWeek', 0);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(getGanttViewCore(this.instance).range.start.getDay(), 0, 'incorrect first day');
 
         this.instance.option('firstDayOfWeek', 1);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(getGanttViewCore(this.instance).range.start.getDay(), 1, 'incorrect first day');
 
         this.instance.option('firstDayOfWeek', 2);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(getGanttViewCore(this.instance).range.start.getDay(), 2, 'incorrect first day');
 
         this.instance.option('firstDayOfWeek', 3);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(getGanttViewCore(this.instance).range.start.getDay(), 3, 'incorrect first day');
 
         this.instance.option('firstDayOfWeek', 4);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(getGanttViewCore(this.instance).range.start.getDay(), 4, 'incorrect first day');
 
         this.instance.option('firstDayOfWeek', 5);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(getGanttViewCore(this.instance).range.start.getDay(), 5, 'incorrect first day');
 
         this.instance.option('firstDayOfWeek', 6);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(getGanttViewCore(this.instance).range.start.getDay(), 6, 'incorrect first day');
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/fullScreenMode.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/fullScreenMode.tests.js
@@ -21,15 +21,15 @@ const moduleConfig = {
 QUnit.module('FullScreen Mode', moduleConfig, () => {
     test('FullScreen is switching', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('height', 200);
-        this.clock.tick();
+        this.clock.tick(10);
         const fullScreenCommand = getGanttViewCore(this.instance).commandManager.getCommand(10);
 
         assert.strictEqual(getGanttViewCore(this.instance).fullScreenModeHelper.isInFullScreenMode, false, 'Normal mode is enabled');
-        this.clock.tick();
+        this.clock.tick(10);
         fullScreenCommand.executeInternal();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.strictEqual(getGanttViewCore(this.instance).fullScreenModeHelper.isInFullScreenMode, true, 'FullScreen mode is enabled');
         fullScreenCommand.execute();
         assert.strictEqual(getGanttViewCore(this.instance).fullScreenModeHelper.isInFullScreenMode, false, 'Normal mode is enabled after FullScreen mode');
@@ -37,11 +37,11 @@ QUnit.module('FullScreen Mode', moduleConfig, () => {
     });
     test('is taking up entire screen', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('height', 200);
         this.instance.option('width', 400);
         this.instance.option('taskListWidth', 200);
-        this.clock.tick();
+        this.clock.tick(10);
         const fullScreenCommand = getGanttViewCore(this.instance).commandManager.getCommand(10);
         assert.ok(getHeight(this.instance.$element()) < getHeight($(window)), '1.normalMode: gantt height < window height');
         assert.ok(getWidth(this.instance.$element()) < getWidth($(window)), '1.normalMode: gantt width < window width');
@@ -49,7 +49,7 @@ QUnit.module('FullScreen Mode', moduleConfig, () => {
         assert.equal(getHeight(this.instance.$element()), getHeight($(window)), '1.fullScreenMode: gantt height == window height');
         assert.equal(getWidth(this.instance.$element()), getWidth($(window)), '1.fullScreenMode: gantt width == window width');
         fullScreenCommand.execute();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(getHeight(this.instance.$element()) < getHeight($(window)), '2.normalMode: gantt height < window height');
         assert.ok(getWidth(this.instance.$element()) < getWidth($(window)), '2.normalMode: gantt width < window width');
         fullScreenCommand.execute();
@@ -62,12 +62,12 @@ QUnit.module('FullScreen Mode', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
         const fullScreenCommand = getGanttViewCore(this.instance).commandManager.getCommand(10);
         fullScreenCommand.execute();
         assert.strictEqual(getGanttViewCore(this.instance).fullScreenModeHelper.isInFullScreenMode, true, 'FullScreen mode is enabled');
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         let $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
 
@@ -82,7 +82,7 @@ QUnit.module('FullScreen Mode', moduleConfig, () => {
         titleTextBox.option('value', testTitle);
         const $okButton = $dialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         const firstTreeListTitleText = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).first().find('td').eq(2).text();
         assert.equal(firstTreeListTitleText, testTitle, 'title text was modified');
 
@@ -96,16 +96,16 @@ QUnit.module('FullScreen Mode', moduleConfig, () => {
     });
     test('panel sizes are the same', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const fullScreenCommand = getGanttViewCore(this.instance).commandManager.getCommand(10);
         let leftPanelWidth = this.instance._splitter._leftPanelPercentageWidth;
         fullScreenCommand.execute();
         assert.equal(Math.floor(leftPanelWidth), Math.floor(this.instance._splitter._leftPanelPercentageWidth), 'left Panel Width is not changed in FullScreen');
         fullScreenCommand.execute();
-        this.clock.tick();
+        this.clock.tick(10);
         const diff = Math.abs(leftPanelWidth - Math.floor(this.instance._splitter._leftPanelPercentageWidth));
         assert.ok(diff < 2, 'left Panel Width is not changed in NormalMode');
-        this.clock.tick();
+        this.clock.tick(10);
         fullScreenCommand.execute();
         const splitterWrapper = this.$element.find(Consts.SPLITTER_WRAPPER_SELECTOR);
         const splitter = this.$element.find(Consts.SPLITTER_SELECTOR);

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/markup.tests.js
@@ -26,46 +26,46 @@ QUnit.module('Markup', moduleConfig, () => {
     });
     test('should render task wrapper for each task', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const elements = this.$element.find(Consts.TASK_WRAPPER_SELECTOR);
         assert.equal(elements.length, data.tasks.length - 1);
     });
     test('should render dependencies', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const element = this.$element.find(Consts.TASK_ARROW_SELECTOR);
         assert.equal(element.length, data.dependencies.length);
     });
     test('should render resources', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const element = this.$element.find(Consts.TASK_RESOURCES_SELECTOR);
         assert.equal(element.length, data.resourceAssignments.length);
     });
     test('row heights', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListRowElement = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).last().get(0);
         const ganttViewRowElement = this.$element.find(Consts.GANTT_VIEW_ROW_SELECTOR).get(0);
         assert.roughEqual(treeListRowElement.getBoundingClientRect().height, ganttViewRowElement.getBoundingClientRect().height, 0.01, 'row heights are equal');
     });
     test('auto height', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const initHeight = this.$element.height();
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(initHeight > this.$element.height(), 'collapsed height');
     });
     test('fixed height', function(assert) {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('height', 800);
-        this.clock.tick();
+        this.clock.tick(10);
         const initHeight = this.$element.height();
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.roughEqual(initHeight, this.$element.height(), 1, 'collapsed height');
     });
     test('invalid start or end dates', function(assert) {
@@ -86,7 +86,7 @@ QUnit.module('Markup', moduleConfig, () => {
             dependencies: { dataSource: customDependencies }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListElements = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR);
         assert.strictEqual(treeListElements.length, 5);
 
@@ -105,7 +105,7 @@ QUnit.module('Markup', moduleConfig, () => {
             tasks: { dataSource: testTasks }
         });
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
         const data = {
             start: new Date('2019-02-21'),
             end: new Date('2019-02-22'),
@@ -115,7 +115,7 @@ QUnit.module('Markup', moduleConfig, () => {
         };
 
         this.instance.insertTask(data);
-        this.clock.tick();
+        this.clock.tick(10);
         $('.dx-gantt .dx-row').css({ height: '63px' });
         this.instance._sizeHelper.updateGanttRowHeights();
         assert.equal(testTasks.length, 1, 'first new task was created in ds');
@@ -124,10 +124,10 @@ QUnit.module('Markup', moduleConfig, () => {
         let treeListRowElementHeight = treeListRowElement.getBoundingClientRect().height;
         assert.roughEqual(treeListRowElementHeight, rowHeight, 1.1, 'row heights are equal');
         this.instance.insertTask(data);
-        this.clock.tick();
+        this.clock.tick(10);
         $('.dx-gantt .dx-row').css({ height: '63px' });
         this.instance._sizeHelper.updateGanttRowHeights();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(testTasks.length, 2, 'second new task was created in ds');
         rowHeight = this.instance._getGanttViewOption('rowHeight');
         treeListRowElement = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).last().get(0);
@@ -155,7 +155,7 @@ QUnit.module('Markup', moduleConfig, () => {
             tasks: { dataSource: testTasks }
         });
         this.instance.option('editing.enabled', true);
-        this.clock.tick();
+        this.clock.tick(10);
         const data = {
             start: new Date('2021-04-21'),
             end: new Date('2021-04-22'),
@@ -165,13 +165,13 @@ QUnit.module('Markup', moduleConfig, () => {
         };
 
         this.instance.insertTask(data);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(testTasks.length, 3, 'first new task was created in ds');
         let selectedTask = this.$element.find(Consts.TASK_SELECTED_SELECTOR);
         let selectedTaskIndex = selectedTask.eq(0).attr('task-index');
         assert.equal(selectedTaskIndex, 2, 'first new added task is selected');
         this.instance.insertTask(data);
-        this.clock.tick();
+        this.clock.tick(10);
         selectedTask = this.$element.find(Consts.TASK_SELECTED_SELECTOR);
         selectedTaskIndex = selectedTask.eq(0).attr('task-index');
         assert.equal(selectedTaskIndex, 3, 'second new added task is selected');
@@ -190,7 +190,7 @@ QUnit.module('Markup', moduleConfig, () => {
             }
         };
         this.createInstance(my_options);
-        this.clock.tick();
+        this.clock.tick(10);
     });
     test('12 format check (T1130809)', function(assert) {
         localization.locale('en-US');
@@ -205,6 +205,6 @@ QUnit.module('Markup', moduleConfig, () => {
             }
         };
         this.createInstance(my_options);
-        this.clock.tick();
+        this.clock.tick(10);
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/options.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/options.tests.js
@@ -20,7 +20,7 @@ const moduleConfig = {
 QUnit.module('Options', moduleConfig, () => {
     test('taskListWidth', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('width', 1000);
         const treeListWrapperElement = this.$element.find(Consts.TREELIST_WRAPPER_SELECTOR);
         const splitterWrapper = this.$element.find(Consts.SPLITTER_WRAPPER_SELECTOR);
@@ -43,7 +43,7 @@ QUnit.module('Options', moduleConfig, () => {
     });
     test('showResources', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_RESOURCES_SELECTOR).length, data.resourceAssignments.length);
         this.instance.option('showResources', false);
         assert.equal(this.$element.find(Consts.TASK_RESOURCES_SELECTOR).length, 0);
@@ -52,7 +52,7 @@ QUnit.module('Options', moduleConfig, () => {
     });
     test('showDependencies', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_ARROW_SELECTOR).length, data.dependencies.length);
         this.instance.option('showDependencies', false);
         assert.equal(this.$element.find(Consts.TASK_ARROW_SELECTOR).length, 0);
@@ -61,7 +61,7 @@ QUnit.module('Options', moduleConfig, () => {
     });
     test('taskTitlePosition', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const milestoneCount = data.tasks.reduce((count, t) => {
             return t.start.getTime() === t.end.getTime() ? count + 1 : count;
         }, 0);
@@ -116,7 +116,7 @@ QUnit.module('Options', moduleConfig, () => {
             columns: ['t']
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const taskWrapperElements = this.$element.find(Consts.TASK_WRAPPER_SELECTOR);
         assert.equal(taskWrapperElements.length, tasksDS.length);
         const firstTitle = taskWrapperElements.first().children().children().first().text();
@@ -145,7 +145,7 @@ QUnit.module('Options', moduleConfig, () => {
             ]
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         let $treeListHeaderRow = this.$element.find(Consts.TREELIST_HEADER_ROW_SELECTOR);
         assert.equal($treeListHeaderRow.children().length, 2, 'treeList has 2 columns');
         assert.equal($treeListHeaderRow.children().eq(0).text(), 'Subject', 'first column title is checked');
@@ -168,7 +168,7 @@ QUnit.module('Options', moduleConfig, () => {
             selectedRowKey: selectedRowKey
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListSelectedRowKeys = this.instance._treeList.option('selectedRowKeys');
         assert.equal(treeListSelectedRowKeys.length, 1, 'only one treeList row is selected');
         assert.equal(treeListSelectedRowKeys, selectedRowKey, 'second treeList row is selected');
@@ -177,12 +177,12 @@ QUnit.module('Options', moduleConfig, () => {
         this.instance.option('selectedRowKey', 1);
         assert.equal(this.$element.find(Consts.SELECTION_SELECTOR).length, 1);
         this.instance.option('selectedRowKey', undefined);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.SELECTION_SELECTOR).length, 0);
     });
     test('allowSelection', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('selectedRowKey', 1);
         assert.equal(this.$element.find(Consts.SELECTION_SELECTOR).length, 1);
         this.instance.option('allowSelection', false);
@@ -190,7 +190,7 @@ QUnit.module('Options', moduleConfig, () => {
     });
     test('showRowLines', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(this.$element.find(Consts.GANTT_VIEW_HORIZONTAL_BORDER_SELECTOR).length > 0, 'ganttView has borders by default');
         assert.equal(this.instance._treeList.option('showRowLines'), true, 'treeList has borders by default');
         this.instance.option('showRowLines', false);
@@ -202,7 +202,7 @@ QUnit.module('Options', moduleConfig, () => {
     });
     test('editing', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         let coreEditingSettings = getGanttViewCore(this.instance).settings.editing;
         assert.equal(coreEditingSettings.enabled, false, 'editing is prohibited by default');
         assert.equal(coreEditingSettings.allowTaskInsert, true, 'task adding allowed by default');
@@ -245,7 +245,7 @@ QUnit.module('Options', moduleConfig, () => {
             return this.$element.find('.dx-gantt-tsa').eq(1).find('.dx-gantt-si').text().indexOf(text) > -1;
         };
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(isHeaderContainsText('January'), 'is months scale type (auto)');
         this.instance.option('scaleType', 'minutes');
@@ -271,7 +271,7 @@ QUnit.module('Options', moduleConfig, () => {
     test('calculateCellValue for key', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
         this.instance.option('columns', [{ dataField: 'id' }]);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const columns = this.instance._treeList.getVisibleColumns();
 

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/parentAutoCalculation.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/parentAutoCalculation.tests.js
@@ -25,7 +25,7 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
             validation: { autoUpdateParentTasks: true }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $stripLines = this.$element.find(Consts.PARENT_TASK_SELECTOR);
         assert.ok($stripLines.length > 0, 'parent tasks has className');
@@ -44,14 +44,14 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
             validation: { autoUpdateParentTasks: true }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let dataToCheck = [];
         this.instance._onParentTasksRecalculated = (data) => {
             dataToCheck = data;
         };
         getGanttViewCore(this.instance).viewModel.updateModel(true);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(dataToCheck.length, 3, 'length');
         assert.equal(dataToCheck[0].start, start, 'parent 0 start date');
@@ -81,13 +81,13 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
         this.instance._onParentTasksRecalculated = (data) => {
             dataToCheck = data;
         };
-        this.clock.tick();
+        this.clock.tick(10);
         let $parentTasks = this.$element.find(Consts.PARENT_TASK_SELECTOR);
         assert.equal(dataToCheck.length, 0, 'length');
         assert.equal($parentTasks.length, 0, 'parent tasks exists');
 
         this.instance.option('validation.autoUpdateParentTasks', true);
-        this.clock.tick();
+        this.clock.tick(10);
         $parentTasks = this.$element.find(Consts.PARENT_TASK_SELECTOR);
         assert.equal($parentTasks.length, 2, 'parent tasks not exists');
         assert.equal(dataToCheck.length, 3, 'length');
@@ -103,7 +103,7 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
 
         dataToCheck = [];
         this.instance.option('validation.autoUpdateParentTasks', false);
-        this.clock.tick();
+        this.clock.tick(10);
         $parentTasks = this.$element.find(Consts.PARENT_TASK_SELECTOR);
         assert.equal(dataToCheck.length, 0, 'length');
         assert.equal($parentTasks.length, 0, 'parent tasks exists');
@@ -126,7 +126,7 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
             }]
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const customCellText0 = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).first().find('td').first().text();
         const customCellText1 = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).eq(1).find('td').first().text();
@@ -151,10 +151,10 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
         };
         this.createInstance(options);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
 
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         const $inputs = $dialog.find(Consts.INPUT_TEXT_EDITOR_SELECTOR);
         assert.equal($inputs.eq(0).val(), tasks[0].title, 'title text is shown');
@@ -163,7 +163,7 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
         titleTextBox.option('value', testTitle);
         const $okButton = $dialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         const firstTreeListTitleText = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).first().find('td').eq(2).text();
         assert.equal(firstTreeListTitleText, testTitle, 'title text was modified');
     });
@@ -189,7 +189,7 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
         };
         this.createInstance(options);
         this.instance.option('onTaskUpdated', (e) => { values = e.values; });
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.deleteTask(4);
         this.clock.tick(500);
 
@@ -217,7 +217,7 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
         };
         this.createInstance(options);
         this.instance.option('onTaskUpdated', (e) => { values = e.values; });
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask(4, { 'end': new Date('2020-02-20') });
         this.clock.tick(500);
 
@@ -250,7 +250,7 @@ QUnit.module('Parent auto calculation', moduleConfig, () => {
             }
             extend(updated[e.key], e.values);
         });
-        this.clock.tick();
+        this.clock.tick(10);
         const newEnd = new Date('2020-02-27');
         this.instance.updateTask(4, { 'end': newEnd });
         this.clock.tick(500);

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/refresh.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/refresh.tests.js
@@ -23,17 +23,17 @@ const moduleConfig = {
 QUnit.module('Refresh', moduleConfig, () => {
     test('should render treeList after refresh()', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListElements = this.$element.find(Consts.TREELIST_SELECTOR);
         assert.strictEqual(treeListElements.length, 1);
     });
     test('should render task wrapper for each task after refresh()', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
         const elements = this.$element.find(Consts.TASK_WRAPPER_SELECTOR);
         assert.equal(elements.length, data.tasks.length - 1);
     });
@@ -41,9 +41,9 @@ QUnit.module('Refresh', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
 
@@ -58,12 +58,12 @@ QUnit.module('Refresh', moduleConfig, () => {
         titleTextBox.option('value', testTitle);
         const $okButton = $dialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         let firstTreeListTitleText = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).first().find('td').eq(2).text();
         assert.equal(firstTreeListTitleText, testTitle, 'title text was modified');
 
         this.instance.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
         firstTreeListTitleText = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).first().find('td').eq(2).text();
         assert.equal(firstTreeListTitleText, testTitle, 'title text is the same after repaint()');
     });
@@ -94,17 +94,17 @@ QUnit.module('Refresh', moduleConfig, () => {
                 { dataField: 'end', caption: 'End Date' }
             ]
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         dataLoaded = false;
         const oldTitle = task.title;
         task.title = 'test';
         this.instance.repaint();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.notOk(dataLoaded);
         assert.equal(this.instance.getTaskData(1).title, oldTitle);
         this.instance.refresh();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(dataLoaded);
         assert.equal(this.instance.getTaskData(1).title, 'test');
     });

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/repaint.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/repaint.tests.js
@@ -20,17 +20,17 @@ const moduleConfig = {
 QUnit.module('Repaint', moduleConfig, () => {
     test('should render treeList after repaint()', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.repaint();
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListElements = this.$element.find(Consts.TREELIST_SELECTOR);
         assert.strictEqual(treeListElements.length, 1);
     });
     test('should render task wrapper for each task after repaint()', function(assert) {
         this.createInstance(options.allSourcesOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.repaint();
-        this.clock.tick();
+        this.clock.tick(10);
         const elements = this.$element.find(Consts.TASK_WRAPPER_SELECTOR);
         assert.equal(elements.length, data.tasks.length - 1);
     });
@@ -38,9 +38,9 @@ QUnit.module('Repaint', moduleConfig, () => {
         this.createInstance(options.allSourcesOptions);
         this.instance.option('editing.enabled', true);
         this.instance.option('selectedRowKey', 1);
-        this.clock.tick();
+        this.clock.tick(10);
         showTaskEditDialog(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         const $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
 
@@ -55,12 +55,12 @@ QUnit.module('Repaint', moduleConfig, () => {
         titleTextBox.option('value', testTitle);
         const $okButton = $dialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $okButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         let firstTreeListTitleText = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).first().find('td').eq(2).text();
         assert.equal(firstTreeListTitleText, testTitle, 'title text was modified');
 
         this.instance.repaint();
-        this.clock.tick();
+        this.clock.tick(10);
         firstTreeListTitleText = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR).first().find('td').eq(2).text();
         assert.equal(firstTreeListTitleText, testTitle, 'title text is the same after repaint()');
     });

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/rootValue.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/rootValue.tests.js
@@ -28,7 +28,7 @@ QUnit.module('Root Value', moduleConfig, () => {
             tasks: { dataSource: customTasks }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListElements = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR);
         assert.strictEqual(treeListElements.length, 3);
     });
@@ -42,7 +42,7 @@ QUnit.module('Root Value', moduleConfig, () => {
             tasks: { dataSource: customTasks }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListElements = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR);
         assert.strictEqual(treeListElements.length, 3);
     });
@@ -57,7 +57,7 @@ QUnit.module('Root Value', moduleConfig, () => {
             rootValue: 0
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListElements = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR);
         assert.strictEqual(treeListElements.length, 3);
     });
@@ -72,7 +72,7 @@ QUnit.module('Root Value', moduleConfig, () => {
             rootValue: undefined
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListElements = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR);
         assert.strictEqual(treeListElements.length, 3);
     });
@@ -87,7 +87,7 @@ QUnit.module('Root Value', moduleConfig, () => {
             rootValue: null
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const treeListElements = this.$element.find(Consts.TREELIST_DATA_ROW_SELECTOR);
         assert.strictEqual(treeListElements.length, 3);
     });

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/sorting.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/sorting.tests.js
@@ -42,7 +42,7 @@ QUnit.module('Sorting', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let treeListIdText1 = $(this.instance._treeList.getCellElement(0, 0)).text();
         let treeListTitleText1 = $(this.instance._treeList.getCellElement(0, 1)).text();
@@ -192,7 +192,7 @@ QUnit.module('Sorting', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.instance.insertTask(task1);
         this.clock.tick(500);
@@ -324,7 +324,7 @@ QUnit.module('Sorting', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.instance.insertTask(task1);
         this.clock.tick(500);
@@ -444,7 +444,7 @@ QUnit.module('Sorting', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let treeListIdText1 = $(this.instance._treeList.getCellElement(0, 0)).text();
         let treeListTitleText1 = $(this.instance._treeList.getCellElement(0, 1)).text();
@@ -509,7 +509,7 @@ QUnit.module('Sorting', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 3);
         assert.equal(this.instance._treeList.getVisibleRows().length, 3);

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/stripLines.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/stripLines.tests.js
@@ -29,7 +29,7 @@ QUnit.module('Strip Lines', moduleConfig, () => {
             stripLines: stripLines
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $stripLines = this.$element.find(Consts.TIME_MARKER_SELECTOR);
         assert.equal($stripLines.length, 2, 'all strip lines are rendered');
@@ -40,7 +40,7 @@ QUnit.module('Strip Lines', moduleConfig, () => {
     });
     test('changing', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $stripLines = this.$element.find(Consts.TIME_MARKER_SELECTOR);
         assert.equal($stripLines.length, 0, 'gantt has no strip lines');

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/taskTemplate.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/taskTemplate.tests.js
@@ -20,7 +20,7 @@ const moduleConfig = {
 QUnit.module('Task Template', moduleConfig, () => {
     test('common', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const taskText = this.$element.find(Consts.TASK_SELECTOR)[0].textContent;
         const taskTitle = data.tasks[0].title;
         assert.equal(taskText.indexOf(taskTitle), 0, 'Default task works correctly');
@@ -41,10 +41,10 @@ QUnit.module('Task Template', moduleConfig, () => {
             taskContentTemplate: customTaskFunction
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const elements = this.$element.find(Consts.TASK_WRAPPER_SELECTOR);
         assert.equal(elements.length, customTasks.length, 'Should render task wrapper for each task');
-        this.clock.tick();
+        this.clock.tick(10);
         const taskText = this.$element.find(Consts.TASK_WRAPPER_SELECTOR).first().text();
         assert.equal(taskText, customTaskText, 'Custom task text works correctly');
     });
@@ -61,7 +61,7 @@ QUnit.module('Task Template', moduleConfig, () => {
             taskContentTemplate: customTaskFunction
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const taskText = this.$element.find(Consts.TASK_WRAPPER_SELECTOR).first().text();
         assert.equal(taskText, customTaskText, 'Custom template with jQuery works correctly');
     });
@@ -91,7 +91,7 @@ QUnit.module('Task Template', moduleConfig, () => {
             taskContentTemplate: customTaskFunction
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const taskWrapperElements = this.$element.find(Consts.TASK_WRAPPER_SELECTOR);
         const taskText = taskWrapperElements[1].textContent;
         assert.equal(taskText, customTaskText, 'Custom task text works correctly');

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/toolbar.tests.js
@@ -42,7 +42,7 @@ QUnit.module('Toolbar', moduleConfig, () => {
             toolbar: { items: items }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         assert.equal($items.length, items.length, 'All items were rendered');
@@ -60,7 +60,7 @@ QUnit.module('Toolbar', moduleConfig, () => {
             toolbar: { items: items }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         let $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         assert.equal($items.length, items.length, 'All items were rendered');
@@ -98,7 +98,7 @@ QUnit.module('Toolbar', moduleConfig, () => {
             toolbar: { items: items }
         };
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         assert.equal($items.length, items.length, 'All items were rendered');
@@ -114,7 +114,7 @@ QUnit.module('Toolbar', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         assert.equal($items.length, items.length, 'All items were rendered');

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/tooltipTemplate.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/tooltipTemplate.tests.js
@@ -20,13 +20,13 @@ const moduleConfig = {
 QUnit.module('Tooltip Template', moduleConfig, () => {
     test('common', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const ganttCore = getGanttViewCore(this.instance);
         ganttCore.taskEditController.show(0);
         ganttCore.taskEditController.showTaskInfo(0, 0);
 
-        this.clock.tick();
+        this.clock.tick(10);
         const tooltip = this.$element.find(Consts.TOOLTIP_SELECTOR);
         let tooltipText = tooltip.text();
         const taskTitle = data.tasks[0].title;
@@ -43,7 +43,7 @@ QUnit.module('Tooltip Template', moduleConfig, () => {
     });
     test('custom text', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const customTooltipText = 'TestTooltipText';
         const customTooltipFunction = (item, container) => {
             return customTooltipText;
@@ -56,16 +56,16 @@ QUnit.module('Tooltip Template', moduleConfig, () => {
         const customProgressTooltipFunction = (item, container) => {
             return customProgressTooltipText;
         };
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('taskTooltipContentTemplate', customTooltipFunction);
         this.instance.option('taskTimeTooltipContentTemplate', customTimeTooltipFunction);
         this.instance.option('taskProgressTooltipContentTemplate', customProgressTooltipFunction);
-        this.clock.tick();
+        this.clock.tick(10);
         const ganttCore = getGanttViewCore(this.instance);
         ganttCore.taskEditController.show(0);
         ganttCore.taskEditController.showTaskInfo(0, 0);
 
-        this.clock.tick();
+        this.clock.tick(10);
         const tooltip = this.$element.find(Consts.TOOLTIP_SELECTOR);
         let tooltipText = tooltip.text();
         assert.equal(tooltipText, customTooltipText, 'Custom template text works correctly');
@@ -78,24 +78,24 @@ QUnit.module('Tooltip Template', moduleConfig, () => {
     });
     test('custom jQuery', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const customTooltipText = 'TestCustomTooltipJQuery';
         const customTooltipJQuery = $('<div>' + customTooltipText + '</div>');
         const customTimeTooltipText = 'TestCustomTimeTooltipJQuery';
         const customTimeTooltipJQuery = $('<div>' + customTimeTooltipText + '</div>');
         const customProgressTooltipText = 'TestCustomProgressTooltipJQuery';
         const customProgressTooltipJQuery = $('<div>' + customProgressTooltipText + '</div>');
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('taskTooltipContentTemplate', customTooltipJQuery);
         this.instance.option('taskTimeTooltipContentTemplate', customTimeTooltipJQuery);
         this.instance.option('taskProgressTooltipContentTemplate', customProgressTooltipJQuery);
 
-        this.clock.tick();
+        this.clock.tick(10);
         const ganttCore = getGanttViewCore(this.instance);
         ganttCore.taskEditController.show(0);
         ganttCore.taskEditController.showTaskInfo(0, 0);
 
-        this.clock.tick();
+        this.clock.tick(10);
         const tooltip = this.$element.find(Consts.TOOLTIP_SELECTOR);
         let tooltipText = tooltip.text();
         assert.equal(tooltipText, customTooltipText, 'Custom template with jQuery works correctly');
@@ -108,7 +108,7 @@ QUnit.module('Tooltip Template', moduleConfig, () => {
     });
     test('different tooltips for tasks', function(assert) {
         this.createInstance(options.tasksOnlyOptions);
-        this.clock.tick();
+        this.clock.tick(10);
         const customTooltipText = 'TestTooltipText';
         const customTooltipFunction = (task, container) => {
             if(task.id === 3 || task.id === 4) {
@@ -116,21 +116,21 @@ QUnit.module('Tooltip Template', moduleConfig, () => {
             }
             return;
         };
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('taskTooltipContentTemplate', customTooltipFunction);
-        this.clock.tick();
+        this.clock.tick(10);
         const ganttCore = getGanttViewCore(this.instance);
-        this.clock.tick();
+        this.clock.tick(10);
         ganttCore.taskEditController.show(1);
         ganttCore.taskEditController.showTaskInfo(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         const tooltipDisplayStyle = this.$element.find(Consts.TOOLTIP_SELECTOR)[0].style.display;
         assert.equal(tooltipDisplayStyle, 'none', 'Empty content template doesnt show tooltip');
         ganttCore.taskEditController.tooltip.hide();
-        this.clock.tick();
+        this.clock.tick(10);
         ganttCore.taskEditController.show(2);
         ganttCore.taskEditController.showTaskInfo(0, 0);
-        this.clock.tick();
+        this.clock.tick(10);
         const tooltipText = this.$element.find(Consts.TOOLTIP_SELECTOR).text();
         assert.equal(tooltipText, customTooltipText, 'Custom template text works correctly');
     });

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/treeListExpanding.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/treeListExpanding.tests.js
@@ -35,13 +35,13 @@ QUnit.module('Expand state T1105252', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.updateTask(1, { progress: tasks[0].progress + 1 });
         this.clock.tick(1000);
 
@@ -55,13 +55,13 @@ QUnit.module('Expand state T1105252', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('tasks', { dataSource: tasks.slice() });
         this.clock.tick(1000);
 
@@ -81,13 +81,13 @@ QUnit.module('Expand state T1105252', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('tasks', { dataSource: my_tasks.slice(0, my_tasks.length) });
         this.clock.tick(1000);
 
@@ -107,13 +107,13 @@ QUnit.module('Expand state T1105252', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.option('tasks', { dataSource: my_tasks.slice(0, my_tasks.length - 1) });
         this.clock.tick(1000);
 
@@ -133,13 +133,13 @@ QUnit.module('Expand state T1105252', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         my_tasks.push({ 'id': 5, 'parentId': 0, 'title': 'New task 1', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-07-04T12:00:00.000Z'), 'progress': 31, 'color': 'red' });
         my_tasks.push({ 'id': 6, 'parentId': 5, 'title': 'New task 2', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-07-04T12:00:00.000Z'), 'progress': 31, 'color': 'red' });
         my_tasks.push({ 'id': 7, 'parentId': 6, 'title': 'New task 3', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-07-04T12:00:00.000Z'), 'progress': 31, 'color': 'red' });
@@ -161,10 +161,10 @@ QUnit.module('Expand state T1105252', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 4);
         assert.equal(this.instance._treeList.getVisibleRows().length, 4);
-        this.clock.tick();
+        this.clock.tick(10);
         my_tasks.push({ 'id': 5, 'parentId': 0, 'title': 'New task 1', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-07-04T12:00:00.000Z'), 'progress': 31, 'color': 'red' });
         my_tasks.push({ 'id': 6, 'parentId': 5, 'title': 'New task 2', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-07-04T12:00:00.000Z'), 'progress': 31, 'color': 'red' });
         my_tasks.push({ 'id': 7, 'parentId': 6, 'title': 'New task 3', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-07-04T12:00:00.000Z'), 'progress': 31, 'color': 'red' });
@@ -186,15 +186,15 @@ QUnit.module('Expand state T1105252', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 4);
         assert.equal(this.instance._treeList.getVisibleRows().length, 4);
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         const new_tasks = [
             { 'id': 1, 'parentId': 0, 'title': 'Software Development', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-07-04T12:00:00.000Z'), 'progress': 31, 'color': 'red' },
             { 'id': 2, 'parentId': 1, 'title': 'Scope', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-02-26T09:00:00.000Z'), 'progress': 60 },
@@ -222,15 +222,15 @@ QUnit.module('Expand state T1105252', moduleConfig, () => {
         };
 
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 4);
         assert.equal(this.instance._treeList.getVisibleRows().length, 4);
         const expandedElement = this.$element.find(Consts.TREELIST_EXPANDED_SELECTOR).first();
         expandedElement.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(this.$element.find(Consts.TASK_WRAPPER_SELECTOR).length, 1);
         assert.equal(this.instance._treeList.getVisibleRows().length, 1);
-        this.clock.tick();
+        this.clock.tick(10);
         const new_tasks = [
             { 'id': 1, 'parentId': 0, 'title': 'Software Development', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-07-04T12:00:00.000Z'), 'progress': 31, 'color': 'red' },
             { 'id': 3, 'parentId': 1, 'title': 'Scope', 'start': new Date('2019-02-21T05:00:00.000Z'), 'end': new Date('2019-02-26T09:00:00.000Z'), 'progress': 60 },

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/undo.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/undo.tests.js
@@ -71,7 +71,7 @@ const moduleConfig = {
 QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
     test('task insert', function(assert) {
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskData = {
             title: 'My text',
@@ -82,7 +82,7 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
 
         const tasksCount = data.tasks.length;
         this.instance.insertTask(taskData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, tasksCount + 1, 'new task was created in ds');
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
@@ -91,107 +91,107 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
 
         const $undo = $items.first();
         $undo.children().first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount, 'new task removed');
 
         this.fireRedo();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount + 1, 'new task restored');
     });
     test('task delete', function(assert) {
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         const taskToDelete = data.tasks[tasksCount - 1];
         this.instance.deleteTask(taskToDelete.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, tasksCount - 1, 'new task was deleted');
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         const $undo = $items.first();
         $undo.children().first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount, 'task restored');
 
         this.fireRedo();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount - 1, 'task restored');
     });
     test('insertDependency', function(assert) {
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.dependencies.length;
         const dependencyData = { 'predecessorId': 2, 'successorId': 4, 'type': 0 };
         this.instance.insertDependency(dependencyData);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.dependencies.length, count + 1, 'new dependency was  created');
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         const $undo = $items.first();
         $undo.children().first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.dependencies.length, count, 'dependency removed');
 
         this.fireRedo();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.dependencies.length, count + 1, 'dependency restored');
     });
     test('deleteDependency', function(assert) {
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.dependencies.length;
         const dependencyToDelete = data.dependencies[count - 1];
         this.instance.deleteDependency(dependencyToDelete.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const $confirmDialog = $('body').find(Consts.POPUP_SELECTOR);
         const $yesButton = $confirmDialog.find('.dx-popup-bottom').find('.dx-button').eq(0);
         $yesButton.trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.dependencies.length, count - 1, 'new dependency was deleted');
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         const $undo = $items.first();
         $undo.children().first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.dependencies.length, count, 'dependency restored');
 
         this.fireRedo();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.dependencies.length, count - 1, 'dependency removed');
     });
     test('deleteResource + unassign', function(assert) {
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const count = data.resources.length;
         const resourceToDelete = data.resources[1];
         const assignmentCount = data.resourceAssignments.length;
         const assignmentToDelete = data.resourceAssignments.filter(a => a.resourceId === resourceToDelete.id).length;
         this.instance.deleteResource(resourceToDelete.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.resources.length, count - 1, 'resources was deleted');
         assert.equal(data.resourceAssignments.length, assignmentCount - assignmentToDelete, 'resources was unassigned');
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         const $undo = $items.first();
         $undo.children().first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.resources.length, count, 'resource restored');
         assert.equal(data.resourceAssignments.length, assignmentCount, 'assignments restored');
         assert.equal(data.resources[data.resources.length - 1].id, data.resourceAssignments[data.resourceAssignments.length - 1].resourceId, 'checl restored key');
 
         this.fireRedo();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.resources.length, count - 1, 'resources was deleted');
         assert.equal(data.resourceAssignments.length, assignmentCount - assignmentToDelete, 'resources was unassigned');
     });
     test('task delete with relations', function(assert) {
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         const taskToDelete = data.tasks[5];
@@ -201,7 +201,7 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
         const dependenciesToDelete = data.dependencies.filter(d => d.predecessorId === taskToDelete.id || d.successorId === taskToDelete.id).length;
 
         this.instance.deleteTask(taskToDelete.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, tasksCount - 1, 'new task was deleted');
         assert.equal(data.resourceAssignments.length, assignmentCount - assignmentToDelete, 'tasks was unassigned');
@@ -209,7 +209,7 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         const $undo = $items.first();
         $undo.children().first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount, 'task restored');
         assert.equal(data.resourceAssignments.length, assignmentCount, 'assignments restored');
         assert.equal(data.dependencies.length, dependencyCount, 'dependency restored');
@@ -217,7 +217,7 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
         assert.equal(data.tasks[data.tasks.length - 1].id, data.dependencies[data.dependencies.length - 1].successorId, 'check dependency restored task key');
 
         this.fireRedo();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount - 1, 'new task was deleted');
         assert.equal(data.resourceAssignments.length, assignmentCount - assignmentToDelete, 'tasks was unassigned');
         assert.equal(data.dependencies.length, dependencyCount - dependenciesToDelete, 'dependency deleted');
@@ -225,7 +225,7 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
 
     test('task delete with relations and children', function(assert) {
         this.createInstance(options);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tasksCount = data.tasks.length;
         const taskToDelete = data.tasks[1];
@@ -234,7 +234,7 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
         const assignmentCount = data.resourceAssignments.length;
 
         this.instance.deleteTask(taskToDelete.id);
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(data.tasks.length, 1, 'task deleted with children');
         assert.ok(data.resourceAssignments.length < assignmentCount, 'tasks was unassigned');
@@ -243,7 +243,7 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
         const $items = this.$element.find(Consts.TOOLBAR_ITEM_SELECTOR);
         const $undo = $items.first();
         $undo.children().first().trigger('dxclick');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, tasksCount, 'tasks restored');
         assert.equal(data.resourceAssignments.length, assignmentCount, 'assignments restored');
         assert.equal(data.dependencies.length, dependencyCount, 'dependency restored');
@@ -253,7 +253,7 @@ QUnit.module('Undo tests (T1099868)', moduleConfig, () => {
         assert.notEqual(data.tasks[1].id, oldTasks[1].id, 'check key');
 
         this.fireRedo();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(data.tasks.length, 1, 'task deleted with children');
         assert.ok(data.resourceAssignments.length < assignmentCount, 'tasks was unassigned');
         assert.ok(data.dependencies.length < dependencyCount, 'dependency deleted');

--- a/testing/tests/DevExpress.ui.widgets/ganttParts/validateDependencies.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/ganttParts/validateDependencies.tests.js
@@ -36,7 +36,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -56,12 +56,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -90,7 +90,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -110,12 +110,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -144,7 +144,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -164,12 +164,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -198,7 +198,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -218,12 +218,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -252,7 +252,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -272,12 +272,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -307,7 +307,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -327,12 +327,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -363,7 +363,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -383,12 +383,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -418,7 +418,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -438,12 +438,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -473,7 +473,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -493,12 +493,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -529,7 +529,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -549,12 +549,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -585,7 +585,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -605,12 +605,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -640,7 +640,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -660,12 +660,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -694,7 +694,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -714,12 +714,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -748,7 +748,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -768,12 +768,12 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
@@ -802,7 +802,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -825,17 +825,17 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         const newEnd = new Date('2019-05-24T09:00:00.000Z');
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskData = getGanttViewCore(this.instance).getTaskByPublicId(globalPrevInsertedKey);
         const taskMoveCommand = getGanttViewCore(this.instance).commandManager.updateTaskCommand;
         taskMoveCommand.execute(taskData.internalId, { start: newStart, end: newEnd });
-        this.clock.tick();
+        this.clock.tick(10);
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
 
@@ -864,7 +864,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -887,17 +887,17 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         const newEnd = new Date('2019-01-24T09:00:00.000Z');
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskData = getGanttViewCore(this.instance).getTaskByPublicId(globalPrevInsertedKey);
         const taskMoveCommand = getGanttViewCore(this.instance).commandManager.updateTaskCommand;
         taskMoveCommand.execute(taskData.internalId, { start: newStart, end: newEnd });
-        this.clock.tick();
+        this.clock.tick(10);
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
 
@@ -926,7 +926,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -949,17 +949,17 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         const newEnd = new Date('2019-01-24T09:00:00.000Z');
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         const taskData = getGanttViewCore(this.instance).getTaskByPublicId(globalPrevInsertedKey);
         const taskMoveCommand = getGanttViewCore(this.instance).commandManager.updateTaskCommand;
         taskMoveCommand.execute(taskData.internalId, { start: newStart, end: newEnd });
-        this.clock.tick();
+        this.clock.tick(10);
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
 
@@ -988,7 +988,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -1011,17 +1011,17 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         const newEnd = new Date('2019-01-24T09:00:00.000Z');
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
         getGanttViewCore(this.instance).validationController.lockPredecessorToSuccessor = false;
         const taskData = getGanttViewCore(this.instance).getTaskByPublicId(globalPrevInsertedKey);
         const taskMoveCommand = getGanttViewCore(this.instance).commandManager.updateTaskCommand;
         taskMoveCommand.execute(taskData.internalId, { start: newStart, end: newEnd });
-        this.clock.tick();
+        this.clock.tick(10);
         const updatedTask1 = this.instance.getTaskData(globalPrevInsertedKey);
         const updatedTask2 = this.instance.getTaskData(globalLastInsertedKey);
 
@@ -1050,7 +1050,7 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
             globalPrevInsertedKey = globalLastInsertedKey;
             globalLastInsertedKey = e.key;
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         const task1 = {
             'my_id': 1000,
@@ -1070,15 +1070,15 @@ QUnit.module('Validate Dependencies', moduleConfig, () => {
         };
 
         this.instance.insertTask(task1);
-        this.clock.tick();
+        this.clock.tick(10);
         this.instance.insertTask(task2);
         this.clock.tick(500);
         const dependency = { predecessorId: globalPrevInsertedKey, successorId: globalLastInsertedKey, type: globalDependencyType };
         this.instance.insertDependency(dependency);
-        this.clock.tick();
+        this.clock.tick(10);
 
         this.instance.showTaskDetailsDialog(globalLastInsertedKey);
-        this.clock.tick();
+        this.clock.tick(10);
         let $dialog = $('body').find(Consts.POPUP_SELECTOR);
         assert.equal($dialog.length, 1, 'dialog is shown');
 

--- a/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
@@ -577,7 +577,7 @@ QUnit.module('collapsible groups', moduleSetup, () => {
 
             instance.collapseGroup(0);
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             const $groups = $element.find('.' + LIST_GROUP_CLASS);
             assert.equal($groups.length, 2, 'second group was loaded');
@@ -677,7 +677,7 @@ QUnit.module('collapsible groups', moduleSetup, () => {
 
             instance.collapseGroup(1);
 
-            this.clock.tick();
+            this.clock.tick(10);
             assert.ok(instance.$element().find('.dx-list-next-button').length, 'button was not removed');
         } finally {
             fx.off = false;
@@ -713,7 +713,7 @@ QUnit.module('collapsible groups', moduleSetup, () => {
 
             instance.collapseGroup(1);
 
-            this.clock.tick();
+            this.clock.tick(10);
             assert.ok(instance.$element().find('.dx-list-next-button').length, 'button was not removed');
         } finally {
             fx.off = false;
@@ -2012,10 +2012,10 @@ QUnit.module('events', moduleSetup, () => {
         const $item = $element.find(toSelector(LIST_ITEM_CLASS));
 
         $item.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
         keyboardMock($element).keyDown('enter');
     });
-    
+
     QUnit.test('onItemHold should be fired when item is held', function(assert) {
         let actionFired;
         let actionData;
@@ -2282,7 +2282,7 @@ QUnit.module('dataSource integration', moduleSetup, () => {
         });
 
         const scrollView = element.dxScrollView('instance');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(scrollView._loading, false, 'scrollView not in loading state');
     });
 
@@ -2310,7 +2310,7 @@ QUnit.module('dataSource integration', moduleSetup, () => {
         assert.equal(scrollView._loading, false, 'scrollview not in loading state after first data load');
 
         dataSource.load();
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(scrollView._loading, true, 'scrollview loading started on data reload');
 
         this.clock.tick(dataSourceLoadTime);
@@ -2816,7 +2816,7 @@ QUnit.module('infinite list scenario', moduleSetup, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual($element.dxList('option', 'items'), [1, 2], 'only first page is loaded');
     });
@@ -2835,10 +2835,10 @@ QUnit.module('infinite list scenario', moduleSetup, () => {
             }
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         $element.show().triggerHandler('dxshown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.deepEqual($element.dxList('option', 'items'), [1, 2, 3, 4], 'all data loaded');
     });
@@ -3430,14 +3430,14 @@ QUnit.module('scrollView integration', {
             pageLoadMode: 'scrollBottom'
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const getListItemsCount = () => $(toSelector(LIST_ITEM_CLASS), $list).length;
 
         assert.strictEqual(getListItemsCount(), 5, 'first page loaded');
 
         $container.height(listHeight * 10);
         resizeCallbacks.fire();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(getListItemsCount(), 10, 'second page loaded');
     });
@@ -3459,14 +3459,14 @@ QUnit.module('scrollView integration', {
             pageLoadMode: 'scrollBottom'
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         const getListItemsCount = () => $(toSelector(LIST_ITEM_CLASS), $list).length;
 
         assert.strictEqual(getListItemsCount(), 5, 'first page loaded');
 
         $container.height(listHeight * 2);
         resizeCallbacks.fire();
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.strictEqual(getListItemsCount(), 5, 'new page has not been loaded');
     });
@@ -3623,7 +3623,7 @@ QUnit.module('keyboard navigation', {
         let $item = $element.find(toSelector(LIST_ITEM_CLASS)).eq(2).trigger('dxpointerdown');
         let keyboard = keyboardMock($element);
         const itemHeight = $item.outerHeight();
-        this.clock.tick();
+        this.clock.tick(10);
 
         instance.option('height', itemHeight * 3);
 
@@ -3632,7 +3632,7 @@ QUnit.module('keyboard navigation', {
 
         $item = $element.find(toSelector(LIST_ITEM_CLASS)).eq(1);
         $item.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
         keyboard = keyboardMock($element);
         keyboard.keyDown('up');
         assert.equal(instance.scrollTop(), 0, 'item scrolled to visible area at top when up arrow were pressed');
@@ -3657,10 +3657,10 @@ QUnit.module('keyboard navigation', {
         const $firstItem = $element.find(toSelector(LIST_ITEM_CLASS)).eq(0);
 
         $firstItem.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         keyboard.keyDown('up');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok($selectAllItem.hasClass('dx-state-focused'), 'selectAll checkbox is focused');
 
         $element.trigger($.Event('keydown', { key: 'Enter' }));
@@ -3691,24 +3691,24 @@ QUnit.module('keyboard navigation', {
         const $lastItem = $element.find(toSelector(LIST_ITEM_CLASS)).eq(4);
 
         $firstItem.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         keyboard.keyDown('up');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok($selectAllCheckBox.hasClass('dx-state-focused'), 'selectAll checkbox is focused');
 
         keyboard.keyDown('up');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(!$selectAllCheckBox.hasClass('dx-state-focused'), 'selectAll checkbox isn\'t focused');
         assert.ok($lastItem.hasClass('dx-state-focused'), 'last item is focused');
 
         keyboard.keyDown('down');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok($selectAllCheckBox.hasClass('dx-state-focused'), 'selectAll checkbox is focused');
 
         keyboard.keyDown('down');
-        this.clock.tick();
+        this.clock.tick(10);
         assert.ok(!$selectAllCheckBox.hasClass('dx-state-focused'), 'selectAll checkbox isn\'t focused');
         assert.ok($firstItem.hasClass('dx-state-focused'), 'first item is focused');
     });
@@ -3747,7 +3747,7 @@ QUnit.module('keyboard navigation', {
         assert.equal(instance.scrollTop(), 0, 'list scrolled to zero');
 
         $item.trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(instance.scrollTop(), 0, 'item was not scrolled to half-visible item by click on it');
     });
@@ -4129,7 +4129,7 @@ if(devices.real().deviceType === 'desktop') {
                 const $item_2 = $(helper.getItems().eq(2));
                 eventsEngine.trigger($item_2, 'dxclick');
                 eventsEngine.trigger($item_2, 'dxpointerdown');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 helper.checkAttributes(searchEnabled ? helper.$itemContainer : helper.$widget, { role: 'listbox', 'aria-activedescendant': helper.focusedItemId, tabindex: '0' });
                 helper.checkItemsAttributes([2], { attributes: ['aria-selected'], focusedItemIndex: 2, role: 'option' });
@@ -4148,7 +4148,7 @@ if(devices.real().deviceType === 'desktop') {
                 const $item_1 = $(helper.getItems().eq(1));
                 eventsEngine.trigger($item_1, 'dxclick');
                 eventsEngine.trigger($item_1, 'dxpointerdown');
-                this.clock.tick();
+                this.clock.tick(10);
 
                 helper.checkAttributes(searchEnabled ? helper.$itemContainer : helper.$widget, { role: 'listbox', 'aria-activedescendant': helper.focusedItemId, tabindex: '0' });
                 helper.checkItemsAttributes([0, 1, 2], { attributes: ['aria-selected'], focusedItemIndex: 1, role: 'option' });
@@ -4204,7 +4204,7 @@ if(QUnit.urlParams['nojquery'] && QUnit.urlParams['shadowDom']) {
             $(this.root).trigger(this.createEvent('mousedown'));
             $(this.root).trigger(this.createEvent('touchstart'));
 
-            this.clock.tick();
+            this.clock.tick(10);
 
             assert.ok(this.getItems().eq(1).hasClass('dx-state-focused'));
         });

--- a/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
@@ -1771,7 +1771,7 @@ QUnit.module('selection', moduleSetup, () => {
             }
         });
 
-        clock.tick(0);
+        clock.tick(10);
     });
 
     QUnit.test('selection should not be removed after second click if selectionMode is single', function(assert) {
@@ -2208,7 +2208,7 @@ QUnit.module('dataSource integration', moduleSetup, () => {
             pageLoadMode: 'scrollBottom'
         });
 
-        this.clock.tick(300);
+        this.clock.tick(400);
 
         assert.equal($.trim($list.find('.dx-list-item').text()), '012');
     });

--- a/testing/tests/DevExpress.ui.widgets/listParts/editingTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/editingTests.js
@@ -297,7 +297,7 @@ QUnit.test('items reordering by keyboard', function(assert) {
     let $lastItem = $list.find('.' + LIST_ITEM_CLASS).eq(2);
 
     $lastItem.trigger('dxpointerdown');
-    this.clock.tick();
+    this.clock.tick(10);
     $lastItem.trigger($.Event('keydown', { key: 'ArrowUp', shiftKey: true }));
 
     assert.deepEqual(list.option('items'), items, 'reordering by keyboard is impossible if \'itemDragging.allowReordering\' = false ');
@@ -306,7 +306,7 @@ QUnit.test('items reordering by keyboard', function(assert) {
 
     $lastItem = $list.find('.' + LIST_ITEM_CLASS).eq(2);
     $lastItem.trigger('dxpointerdown');
-    this.clock.tick();
+    this.clock.tick(10);
     $list.trigger($.Event('keydown', { key: 'ArrowUp', shiftKey: true }));
 
     assert.deepEqual(list.option('items'), ['1', '3', '2'], 'items were reordered');

--- a/testing/tests/DevExpress.ui.widgets/listParts/editingUITests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/editingUITests.js
@@ -2645,7 +2645,7 @@ QUnit.test('reordering class should be present on item during drag', function(as
     const pointer = reorderingPointerMock($item, this.clock, true);
 
     pointer.dragStart().drag(10);
-    this.clock.tick();
+    this.clock.tick(10);
     assert.ok($item.hasClass(REORDERING_ITEM_CLASS), 'class was added');
     pointer.dragEnd();
     assert.ok(!$item.hasClass(REORDERING_ITEM_CLASS), 'class was removed');
@@ -2675,7 +2675,7 @@ QUnit.test('list item should be duplicated on drag start', function(assert) {
 
     pointer.dragStart().drag(10);
 
-    this.clock.tick();
+    this.clock.tick(10);
     let $ghostItem = $list.find(toSelector(REORDERING_ITEM_GHOST_CLASS));
     assert.strictEqual($ghostItem.text(), $item.text(), 'correct item was duplicated');
     assert.strictEqual($ghostItem.offset().top, $item.offset().top + 10, 'correct ghost position');
@@ -2700,7 +2700,7 @@ QUnit.test('list item duplicate should inherit direction (rtl)', function(assert
 
     pointer.dragStart().drag(10);
 
-    this.clock.tick();
+    this.clock.tick(10);
     let $ghostItem = $list.find(toSelector(REORDERING_ITEM_GHOST_CLASS));
     assert.strictEqual($ghostItem.text(), $item.text(), 'correct item was duplicated');
     assert.strictEqual($ghostItem.offset().top, $item.offset().top + 10, 'correct ghost position');
@@ -2724,7 +2724,7 @@ QUnit.test('cached items doesn\'t contains a ghost item after reordering', funct
     const pointer = reorderingPointerMock($items.first(), this.clock);
 
     pointer.dragStart(0.5).drag(0.6);
-    this.clock.tick();
+    this.clock.tick(10);
     pointer.dragEnd();
 
     const cachedItems = list._itemElements();
@@ -2744,7 +2744,7 @@ QUnit.test('ghost item should be moved by drag', function(assert) {
 
     pointer.dragStart().drag(10);
 
-    this.clock.tick();
+    this.clock.tick(10);
     const $ghostItem = $list.find(toSelector(REORDERING_ITEM_GHOST_CLASS));
     const startPosition = topTranslation($ghostItem.parent());
 
@@ -2882,7 +2882,7 @@ QUnit.test('drop item should reorder list items with correct indexes', function(
     const pointer = reorderingPointerMock($item1, this.clock);
 
     pointer.dragStart(0.5).drag(1);
-    this.clock.tick();
+    this.clock.tick(10);
     pointer.dragEnd();
 });
 
@@ -2913,7 +2913,7 @@ QUnit.test('reordering should correctly handle items contains List widget', func
     const pointer = reorderingPointerMock($item1, this.clock);
 
     pointer.dragStart(0.5).drag(2);
-    this.clock.tick();
+    this.clock.tick(10);
     pointer.dragEnd();
 });
 

--- a/testing/tests/DevExpress.ui.widgets/loadPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/loadPanel.tests.js
@@ -58,7 +58,7 @@ QUnit.module('init', {
 
             assert.strictEqual(instance.option('templatesRenderAsynchronously'), true, 'templatesRenderAsynchronously option can be reassigned (T896267)');
             assert.strictEqual(onShowingSpy.called, false);
-            clock.tick();
+            clock.tick(10);
             assert.strictEqual(onShowingSpy.called, true);
         } finally {
             clock.restore();

--- a/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -211,7 +211,7 @@ testModule('render', moduleConfig, () => {
             });
 
             assert.strictEqual(onShowingSpy.called, false);
-            clock.tick();
+            clock.tick(10);
             assert.strictEqual(onShowingSpy.called, true);
         } finally {
             clock.restore();
@@ -261,7 +261,7 @@ testModule('render', moduleConfig, () => {
                 visible: true
             });
             overlay.hide();
-            clock.tick();
+            clock.tick(10);
             assert.strictEqual(overlay.$content().is(':visible'), false);
         } finally {
             clock.restore();

--- a/testing/tests/DevExpress.ui.widgets/scrollView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollView.tests.js
@@ -707,7 +707,7 @@ QUnit.module('dynamic', moduleConfig, () => {
             inertiaEnabled: false,
             onPullDown: function() {
                 $scrollView.dxScrollView('release');
-                clock.tick();
+                clock.tick(10);
             },
             onEnd: function() {
                 assert.equal($topPocket.children().eq(0).hasClass(SCROLLVIEW_PULLDOWN_LOADING_CLASS), false, 'scrollview-pull-down-loading class removed');
@@ -935,7 +935,7 @@ QUnit.module('dynamic', moduleConfig, () => {
             inertiaEnabled: false,
             onReachBottom: function() {
                 this.release();
-                clock.tick();
+                clock.tick(10);
             },
             onEnd: function() {
                 const location = getScrollOffset($scrollView);
@@ -1123,7 +1123,7 @@ QUnit.module('api', moduleConfig, () => {
             inertiaEnabled: false,
             onPullDown: function() {
                 this.release();
-                clock.tick();
+                clock.tick(10);
             },
             onEnd: function() {
                 const location = getScrollOffset($scrollView);
@@ -1157,7 +1157,7 @@ QUnit.module('api', moduleConfig, () => {
             assert.ok($reachBottom.is(':hidden'), 'reach bottom is hidden');
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('release with preventReachBottom', function(assert) {
@@ -1170,7 +1170,7 @@ QUnit.module('api', moduleConfig, () => {
             inertiaEnabled: false,
             onPullDown: function() {
                 this.release(true);
-                clock.tick();
+                clock.tick(10);
             },
             onEnd: function() {
                 const $bottomPocketLoading = $scrollView.find('.' + SCROLLVIEW_REACHBOTTOM_CLASS);
@@ -1200,7 +1200,7 @@ QUnit.module('api', moduleConfig, () => {
                 assert.ok(true, 'release without loading fails');
             });
 
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('release fires update', function(assert) {
@@ -1214,7 +1214,7 @@ QUnit.module('api', moduleConfig, () => {
 
         $scrollView.dxScrollView('release');
 
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.equal(onUpdatedHandler.callCount, isRenovatedScrollView ? 0 : 1, 'update fired');
     });

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.dynamic.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.dynamic.tests.js
@@ -221,7 +221,7 @@ QUnit.test('scrollbar is hidden on stop', function(assert) {
         .move(0, -10)
         .up();
 
-    this.clock.tick(10);
+    this.clock.tick(100);
 
     const $scroll = $scrollable.find('.dx-scrollable-scroll');
     assert.ok($scroll.hasClass('dx-state-invisible'), 'scroll was hidden');
@@ -303,7 +303,7 @@ QUnit.test('bounce up', function(assert) {
         .move(0, 100)
         .up();
 
-    this.clock.tick(10);
+    this.clock.tick(100);
 });
 
 QUnit.test('stop bounce on click', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.dynamic.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.dynamic.tests.js
@@ -196,7 +196,7 @@ QUnit.test('stop inertia on click', function(assert) {
         .down()
         .up();
 
-    this.clock.tick();
+    this.clock.tick(10);
 
     const location = getScrollOffset($scrollable);
     assert.notEqual(Math.round(location.top), Math.round(distance), 'scroll was stopped');
@@ -221,7 +221,7 @@ QUnit.test('scrollbar is hidden on stop', function(assert) {
         .move(0, -10)
         .up();
 
-    this.clock.tick();
+    this.clock.tick(10);
 
     const $scroll = $scrollable.find('.dx-scrollable-scroll');
     assert.ok($scroll.hasClass('dx-state-invisible'), 'scroll was hidden');
@@ -303,7 +303,7 @@ QUnit.test('bounce up', function(assert) {
         .move(0, 100)
         .up();
 
-    this.clock.tick();
+    this.clock.tick(10);
 });
 
 QUnit.test('stop bounce on click', function(assert) {
@@ -333,7 +333,7 @@ QUnit.test('stop bounce on click', function(assert) {
         .up()
         .down();
 
-    this.clock.tick();
+    this.clock.tick(10);
 
     const location = getScrollOffset($scrollable);
     assert.notEqual(location.top, 0, 'bounced stopped');
@@ -368,7 +368,7 @@ QUnit.test('stop inertia bounce on after mouse up', function(assert) {
     mouse
         .down();
 
-    this.clock.tick();
+    this.clock.tick(10);
 
     const location = getScrollOffset($scrollable);
     assert.notEqual(location.top, 0, 'bounced stopped');
@@ -492,7 +492,7 @@ QUnit.test('inertia stopped on the bound when bounce is disabled', function(asse
         .move(0, moveDistance)
         .up();
 
-    this.clock.tick();
+    this.clock.tick(10);
 });
 
 QUnit.test('inertia is stopped when bound is reached', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.main.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.main.tests.js
@@ -130,7 +130,7 @@ QUnit.test('horizontal inertia calc distance', function(assert) {
         .move(moveDistance, 0)
         .up();
 
-    this.clock.tick();
+    this.clock.tick(10);
 });
 
 QUnit.test('reset unused position after change direction', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets/selection.test.js
+++ b/testing/tests/DevExpress.ui.widgets/selection.test.js
@@ -451,7 +451,7 @@ QUnit.test('clearSelection should work if it call after select', function(assert
 
     // act
     selection.clearSelection();
-    this.clock.tick();
+    this.clock.tick(10);
 
     // assert
     assert.deepEqual(selection.getSelectedItemKeys(), [], 'selection is cleared');
@@ -799,7 +799,7 @@ QUnit.test('selection should work with custom store without filter implementatio
 
         dataSource.load();
         selection.selectedItemKeys(2);
-        clock.tick();
+        clock.tick(10);
     } finally {
         clock.restore();
     }

--- a/testing/tests/DevExpress.ui.widgets/sortable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/sortable.tests.js
@@ -2740,7 +2740,7 @@ QUnit.module('With scroll', getModuleConfigForTestsWithScroll('#itemsWithScroll'
 
                     // act
                     scrollView.scrollTo({ y: 100 });
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     assert.ok($(scrollView.container()).scrollTop() > 0, 'scrollTop > 0');
@@ -2748,17 +2748,17 @@ QUnit.module('With scroll', getModuleConfigForTestsWithScroll('#itemsWithScroll'
                     // act
                     let items = $(this.$element).children();
                     const pointer = pointerMock(items.last()).start().down().move(0, -200);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     scrollView.scrollTo({ y: 0 });
                     $(scrollView.content()).trigger('scroll');
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     pointer.move(0, -25);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     pointer.up();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     items = $(this.$element).children();
@@ -2793,16 +2793,16 @@ QUnit.module('With scroll', getModuleConfigForTestsWithScroll('#itemsWithScroll'
                     // act
                     let items = $(this.$element).children();
                     const pointer = pointerMock(items.first()).start().down().move(0, 200);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     scrollView.scrollTo({ y: 100 });
                     this.clock.tick(100);
 
                     pointer.move(0, 40);
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     pointer.up();
-                    this.clock.tick();
+                    this.clock.tick(10);
 
                     // assert
                     items = $(this.$element).children();

--- a/testing/tests/DevExpress.ui.widgets/tabPanel.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabPanel.tests.js
@@ -83,7 +83,7 @@ QUnit.module('rendering', {
             const $container = $tabPanel.find('.' + TABPANEL_CONTAINER_CLASS);
             const $tabs = $tabPanel.find('.' + TABS_CLASS);
 
-            clock.tick();
+            clock.tick(10);
 
             assert.roughEqual(parseFloat($container.css('padding-top')), $tabs.outerHeight(), 0.5, 'padding correct');
             assert.roughEqual(parseFloat($container.css('margin-top')), -$tabs.outerHeight(), 0.5, 'margin correct');
@@ -103,7 +103,7 @@ QUnit.module('rendering', {
             const $container = $tabPanel.find('.' + TABPANEL_CONTAINER_CLASS);
             const $tabs = $tabPanel.find('.' + TABS_CLASS);
 
-            clock.tick();
+            clock.tick(10);
 
             assert.roughEqual(parseFloat($container.css('padding-top')), $tabs.outerHeight(), 0.5, 'padding correct');
             assert.roughEqual(parseFloat($container.css('margin-top')), -$tabs.outerHeight(), 0.5, 'margin correct');
@@ -589,7 +589,7 @@ QUnit.module('keyboard navigation', {
 
         this.instance.focus();
         $(toSelector(MULTIVIEW_ITEM_CLASS)).eq(1).trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const multiViewFocusedIndex = $(this.instance.option('focusedElement')).index();
 
@@ -604,7 +604,7 @@ QUnit.module('keyboard navigation', {
 
         this.instance.focus();
         $(toSelector(TABS_ITEM_CLASS)).eq(1).trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         const tabsFocusedIndex = $(this.instance.option('focusedElement')).index();
         assert.equal(isRenderer(this.instance.option('focusedElement')), !!config().useJQuery, 'focusedElement is correct');

--- a/testing/tests/DevExpress.ui.widgets/tabs.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabs.tests.js
@@ -941,7 +941,7 @@ QUnit.module('Async templates', {
 }, () => {
     QUnit.test('render tabs', function() {
         const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 290 });
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.checkTabsWithoutScrollable();
         testWrapper.checkNavigationButtons(false);
     });
@@ -953,7 +953,7 @@ QUnit.module('Async templates', {
             itemTemplate: null
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.checkTabsWithoutScrollable();
         testWrapper.checkNavigationButtons(false);
     });
@@ -966,7 +966,7 @@ QUnit.module('Async templates', {
             itemTemplate: null
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.checkTabsWithScrollable();
         testWrapper.checkNavigationButtons(false);
     });
@@ -979,28 +979,28 @@ QUnit.module('Async templates', {
             itemTemplate: null
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.checkTabsWithScrollable();
         testWrapper.checkNavigationButtons(true);
     });
 
     QUnit.test('render tabs with scrollable', function() {
         const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 150, showNavButtons: false });
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.checkTabsWithScrollable();
         testWrapper.checkNavigationButtons(false);
     });
 
     QUnit.test('render tabs with scrollable and navigation buttons', function() {
         const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 150, showNavButtons: true });
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.checkTabsWithScrollable();
         testWrapper.checkNavigationButtons(true);
     });
 
     QUnit.test('Add scrollable when width is changed from large to small', function() {
         const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 220, showNavButtons: false });
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.width = 150;
         testWrapper.checkTabsWithScrollable();
         testWrapper.checkNavigationButtons(false);
@@ -1008,7 +1008,7 @@ QUnit.module('Async templates', {
 
     QUnit.test('Add scrollable and navigation buttons when width is changed from large to small', function() {
         const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 220, showNavButtons: true });
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.width = 150;
         testWrapper.checkTabsWithScrollable();
         testWrapper.checkNavigationButtons(true);
@@ -1016,7 +1016,7 @@ QUnit.module('Async templates', {
 
     QUnit.test('Remove scrollable when width is changed from small to large', function() {
         const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 150, showNavButtons: false });
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.width = 290;
         testWrapper.checkTabsWithoutScrollable();
         testWrapper.checkNavigationButtons(false);
@@ -1024,7 +1024,7 @@ QUnit.module('Async templates', {
 
     QUnit.test('Remove scrollable and navigation buttons when width is changed from small to large', function() {
         const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 150, showNavButtons: true });
-        this.clock.tick();
+        this.clock.tick(10);
         testWrapper.width = 290;
         testWrapper.checkTabsWithoutScrollable();
         testWrapper.checkNavigationButtons(false);
@@ -1034,9 +1034,9 @@ QUnit.module('Async templates', {
         QUnit.test(`Add scrollable when items are changed from 5 to 10, repaintChangesOnly: ${repaintChangesOnly}`, function() {
             const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 290, showNavButtons: false, repaintChangesOnly });
 
-            this.clock.tick();
+            this.clock.tick(10);
             testWrapper.setItemsByCount(10);
-            this.clock.tick();
+            this.clock.tick(10);
 
             testWrapper.checkTabsWithScrollable();
             testWrapper.checkNavigationButtons(false);
@@ -1045,9 +1045,9 @@ QUnit.module('Async templates', {
         QUnit.test(`Add scrollable and navigation buttons when items are changed from 5 to 10, repaintChangesOnly: ${repaintChangesOnly}`, function() {
             const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 290, showNavButtons: true, repaintChangesOnly });
 
-            this.clock.tick();
+            this.clock.tick(10);
             testWrapper.setItemsByCount(10);
-            this.clock.tick();
+            this.clock.tick(10);
 
             testWrapper.checkTabsWithScrollable();
             testWrapper.checkNavigationButtons(true);
@@ -1056,9 +1056,9 @@ QUnit.module('Async templates', {
         QUnit.test(`Remove scrollable when items are changed from 10 to 5, repaintChangesOnly: ${repaintChangesOnly}`, function() {
             const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 290, showNavButtons: false, repaintChangesOnly, itemsCount: 10 });
 
-            this.clock.tick();
+            this.clock.tick(10);
             testWrapper.setItemsByCount(5);
-            this.clock.tick();
+            this.clock.tick(10);
 
             testWrapper.checkTabsWithoutScrollable();
             testWrapper.checkNavigationButtons(false);
@@ -1067,9 +1067,9 @@ QUnit.module('Async templates', {
         QUnit.test(`Remove scrollable and navigation buttons when items are changed from 10 to 5, repaintChangesOnly: ${repaintChangesOnly}`, function() {
             const testWrapper = new TestAsyncTabsWrapper($('#tabs'), { width: 290, showNavButtons: true, repaintChangesOnly, itemsCount: 10 });
 
-            this.clock.tick();
+            this.clock.tick(10);
             testWrapper.setItemsByCount(5);
-            this.clock.tick();
+            this.clock.tick(10);
 
             testWrapper.checkTabsWithoutScrollable();
             testWrapper.checkNavigationButtons(false);

--- a/testing/tests/DevExpress.ui.widgets/tileView.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tileView.tests.js
@@ -521,7 +521,7 @@ QUnit.module('keyboard navigation', {
         const keyboard = this.keyboard;
 
         $element.find(TILEVIEW_ITEM_SELECTOR).eq(5).trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
         keyboard.keyDown('home');
 
         assert.ok($element.find(TILEVIEW_ITEM_SELECTOR).first().hasClass('dx-state-focused'), 'first element obtained dx-state-focused after press home');
@@ -532,7 +532,7 @@ QUnit.module('keyboard navigation', {
         const keyboard = this.keyboard;
 
         $element.find(TILEVIEW_ITEM_SELECTOR).eq(5).trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
         keyboard.keyDown('end');
 
         assert.ok($element.find(TILEVIEW_ITEM_SELECTOR).last().hasClass('dx-state-focused'), 'last element obtained dx-state-focused after press end');
@@ -567,7 +567,7 @@ $.each(configs, function(direction, config) {
             const instance = $('#widget').dxTileView('instance');
 
             $element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.start).trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
             keyboard.keyDown('right');
 
             assert.equal(isRenderer(instance.option('focusedElement')), !!globalConfig().useJQuery, 'focusedElement is correct');
@@ -584,7 +584,7 @@ $.each(configs, function(direction, config) {
             const keyboard = this.keyboard;
 
             $element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.start).trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
             keyboard.keyDown('left');
 
             assert.ok($element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.end).hasClass('dx-state-focused'), 'left element obtained dx-state-focused after press left arrow');
@@ -600,7 +600,7 @@ $.each(configs, function(direction, config) {
             const keyboard = this.keyboard;
 
             $element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.start).trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
             keyboard.keyDown('down');
 
             assert.ok($element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.end).hasClass('dx-state-focused'), 'down element obtained dx-state-focused after press down arrow');
@@ -616,7 +616,7 @@ $.each(configs, function(direction, config) {
             const keyboard = this.keyboard;
 
             $element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.start).trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
             keyboard.keyDown('pageDown');
 
             assert.ok($element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.end).hasClass('dx-state-focused'), 'pageDown element obtained dx-state-focused after press pageDown arrow');
@@ -632,7 +632,7 @@ $.each(configs, function(direction, config) {
             const keyboard = this.keyboard;
 
             $element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.start).trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
             keyboard.keyDown('up');
 
             assert.ok($element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.end).hasClass('dx-state-focused'), 'up element obtained dx-state-focused after press up arrow');
@@ -648,7 +648,7 @@ $.each(configs, function(direction, config) {
             const keyboard = this.keyboard;
 
             $element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.start).trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
             keyboard.keyDown('pageUp');
 
             assert.ok($element.find(TILEVIEW_ITEM_SELECTOR).eq(testConfig.end).hasClass('dx-state-focused'), 'up element obtained dx-state-focused after press pageUp');
@@ -672,7 +672,7 @@ $.each(configs, function(direction, config) {
             assert.equal(instance.scrollPosition(), 0, 'scrollPosition equal zero on init');
 
             $element.find(TILEVIEW_ITEM_SELECTOR).first().trigger('dxpointerdown');
-            this.clock.tick();
+            this.clock.tick(10);
             keyboard.keyDown(testConfig.forward);
             assert.equal(instance.scrollPosition(), 80, 'scrollPosition equal 80 after press forward arrow (item num 7)');
 

--- a/testing/tests/DevExpress.ui.widgets/toast.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toast.tests.js
@@ -296,7 +296,7 @@ QUnit.module('overlay integration', moduleConfig, () => {
             return $('<div>');
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         assert.equal(hideSpy.callCount, 0, 'Toast didn\'t hide');
     });
 });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -1364,7 +1364,7 @@ QUnit.module('adaptivity', moduleConfig, () => {
         const $item2 = $('.dx-list-item').eq(1);
 
         $($item2).trigger('dxpointerdown');
-        this.clock.tick();
+        this.clock.tick(10);
 
         assert.ok(!$item2.hasClass('dx-state-focused'), 'only item2 is focused');
         assert.ok(!$item1.hasClass('dx-state-focused'), 'only item2 is focused');
@@ -1771,7 +1771,7 @@ QUnit.module('Waiting fonts for material theme', moduleConfig, () => {
             height: 50
         });
 
-        this.clock.tick();
+        this.clock.tick(10);
         themes.isMaterial = origIsMaterial;
     });
 

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/accessibility.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/accessibility.js
@@ -81,14 +81,14 @@ let helper;
 
             helper.createWidget({ items: this.items, selectionMode: 'single' });
             helper.widget.collapseItem(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             helper.checkAttributes(searchEnabled ? helper.$itemContainer : helper.$widget, { role: 'tree', tabindex: '0' });
             helper.checkAttributes(searchEnabled ? helper.$widget : helper.widget._itemContainer(true), { });
             helper.checkItemsAttributes([1], { });
 
             helper.widget.expandItem(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             helper.checkAttributes(searchEnabled ? helper.$itemContainer : helper.$widget, { role: 'tree', tabindex: '0' });
             helper.checkAttributes(searchEnabled ? helper.$widget : helper.widget._itemContainer(true), { });
@@ -101,14 +101,14 @@ let helper;
 
             helper.createWidget({ items: this.items, selectionMode: 'single' });
             helper.widget.expandItem(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             helper.checkAttributes(searchEnabled ? helper.$itemContainer : helper.$widget, { role: 'tree', tabindex: '0' });
             helper.checkAttributes(searchEnabled ? helper.$widget : helper.widget._itemContainer(true), { });
             helper.checkItemsAttributes([0], { });
 
             helper.widget.collapseItem(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             helper.checkAttributes(searchEnabled ? helper.$itemContainer : helper.$widget, { role: 'tree', tabindex: '0' });
             helper.checkAttributes(searchEnabled ? helper.$widget : helper.widget._itemContainer(true), { });
@@ -120,14 +120,14 @@ let helper;
 
             helper.createWidget({ items: this.items, selectionMode: 'single' });
             helper.widget.collapseItem(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             helper.checkAttributes(searchEnabled ? helper.$itemContainer : helper.$widget, { role: 'tree', tabindex: '0' });
             helper.checkAttributes(searchEnabled ? helper.$widget : helper.widget._itemContainer(true), { });
             helper.checkItemsAttributes([1], { });
 
             helper.widget.expandItem(1);
-            this.clock.tick();
+            this.clock.tick(10);
 
             helper.checkAttributes(searchEnabled ? helper.$itemContainer : helper.$widget, { role: 'tree', tabindex: '0' });
             helper.checkAttributes(searchEnabled ? helper.$widget : helper.widget._itemContainer(true), { });

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/focusing.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/focusing.js
@@ -206,7 +206,7 @@ QUnit.test('Scroll should not jump down when focusing on item (T492496)', functi
         assert.equal(scrollable.scrollTop(), 0, 'scroll top position');
 
         $items.first().trigger('dxpointerdown');
-        clock.tick();
+        clock.tick(10);
         assert.equal(scrollable.scrollTop(), 0, 'scroll top position');
     } finally {
         clock.restore();
@@ -230,7 +230,7 @@ QUnit.test('First node should not has been focused when focusing on SelectAll it
 
     try {
         $selectAllItem.trigger('focusin');
-        clock.tick();
+        clock.tick(10);
 
         assert.notOk($firstItem.hasClass(FOCUSED_STATE_CLASS), 'first item has not focus state class');
     } finally {
@@ -261,7 +261,7 @@ QUnit.test('Scroll should not jump down when focusing on Select All (T517945)', 
         assert.equal(scrollable.scrollTop(), 0, 'scroll top position');
 
         $treeView.find('.' + SELECT_ALL_ITEM_CLASS).first().trigger('dxpointerdown');
-        clock.tick();
+        clock.tick(10);
         assert.equal(scrollable.scrollTop(), 0, 'scroll top position');
     } finally {
         clock.restore();

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/keyboardNavigation.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/keyboardNavigation.js
@@ -815,7 +815,7 @@ QUnit.testInActiveWindow('First list item should be focused on the \'tab\' key p
     const $searchEditor = $treeView.children('.dx-treeview-search');
 
     $searchEditor.find('input').focus();
-    this.clock.tick();
+    this.clock.tick(10);
 
     $searchEditor.on('keydown', function(e) {
         if(e.key === 'Tab') {
@@ -824,7 +824,7 @@ QUnit.testInActiveWindow('First list item should be focused on the \'tab\' key p
     });
 
     $searchEditor.trigger($.Event('keydown', { key: 'Tab' }));
-    this.clock.tick();
+    this.clock.tick(10);
 
     assert.ok($treeView.find('.' + internals.NODE_CLASS).first().hasClass('dx-state-focused'), 'first node is focused');
     assert.ok($treeView.hasClass('dx-state-focused'), 'treeview is focused');

--- a/testing/tests/DevExpress.ui.widgets/treeViewParts/scrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/treeViewParts/scrolling.tests.js
@@ -109,7 +109,7 @@ QUnit.module('scrollToItem', {
                         done();
                     });
                 }
-                this.clock.tick();
+                this.clock.tick(10);
             });
         });
 
@@ -130,7 +130,7 @@ QUnit.module('scrollToItem', {
                             done();
                         });
                     }
-                    this.clock.tick();
+                    this.clock.tick(10);
                 });
             });
         });
@@ -152,7 +152,7 @@ QUnit.module('scrollToItem', {
             wrapper.checkNodeIsInVisibleArea(key);
             done();
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         wrapper.instance.getScrollable().scrollTo({ left: 0, top: 0 });
         const node = wrapper.getElement().find('[data-item-id="item1_1_1"]').get(0);
@@ -160,7 +160,7 @@ QUnit.module('scrollToItem', {
             wrapper.checkNodeIsInVisibleArea(node.getAttribute('data-item-id'));
             done();
         });
-        this.clock.tick();
+        this.clock.tick(10);
 
         wrapper.instance.getScrollable().scrollTo({ left: 0, top: 0 });
         const itemData = wrapper.instance.option('items')[0].items[0].items[0];
@@ -168,7 +168,7 @@ QUnit.module('scrollToItem', {
             wrapper.checkNodeIsInVisibleArea(itemData.id);
             done();
         });
-        this.clock.tick();
+        this.clock.tick(10);
     });
 
     QUnit.test('scrollToItem(not exists key)', function(assert) {
@@ -177,11 +177,11 @@ QUnit.module('scrollToItem', {
 
         const done = assert.async(3);
         wrapper.instance.scrollToItem('12345').fail(() => { assert.ok('scroll must fail, node not found for this key'); done(); });
-        this.clock.tick();
+        this.clock.tick(10);
         wrapper.instance.scrollToItem($('<div/>').get(0)).fail(() => { assert.ok('scroll must fail, node not found for this itemElement'); done(); });
-        this.clock.tick();
+        this.clock.tick(10);
         wrapper.instance.scrollToItem({}).fail(() => { assert.ok('scroll must fail, node not found for this itemData'); done(); });
-        this.clock.tick();
+        this.clock.tick(10);
     });
 });
 

--- a/testing/tests/DevExpress.viz.charts/chart.integration.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chart.integration.tests.js
@@ -3097,7 +3097,7 @@ QUnit.module('Option changing in onDrawn after zooming', {
     beforeEach: function() {
         this.legendShiftSpy = sinon.spy(legendModule.Legend.prototype, 'move');
         this.titleShiftSpy = sinon.spy(titleModule.Title.prototype, 'move');
-        sinon.spy(rendererModule, 'Renderer', function() {
+        sinon.stub(rendererModule, 'Renderer').callsFake(function() {
             return new vizMocks.Renderer();
         });
     },

--- a/testing/tests/DevExpress.viz.charts/chart.part5.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chart.part5.tests.js
@@ -550,8 +550,8 @@ QUnit.test('ScrollBar option changed', function(assert) {
     });
     const scrollBar = scrollBarClassModule.ScrollBar.lastCall.returnValue;
 
-    scrollBar.init.reset();
-    scrollBar.setPosition.reset();
+    scrollBar.init.resetHistory();
+    scrollBar.setPosition.resetHistory();
 
     this.themeManager.getOptions.withArgs('scrollBar').returns({
         visible: true,

--- a/testing/tests/DevExpress.viz.charts/chartAxisDrawing.tests.js
+++ b/testing/tests/DevExpress.viz.charts/chartAxisDrawing.tests.js
@@ -28,7 +28,7 @@ const environment = {
             getMargins: sinon.stub()
         };
 
-        this.scrollBarStub = sinon.stub(scrollBarModule, 'ScrollBar', function(renderer, group) {
+        this.scrollBarStub = sinon.stub(scrollBarModule, 'ScrollBar').callsFake(function(renderer, group) {
             const scrollBar = new originalScrollBar(renderer, group);
             const originalUpdateSize = scrollBar.updateSize;
 
@@ -44,7 +44,7 @@ const environment = {
         let axisIndex = 0;
         const originalAxis = axisModule.Axis;
 
-        this.axisStub = sinon.stub(axisModule, 'Axis', function(renderingSettings) {
+        this.axisStub = sinon.stub(axisModule, 'Axis').callsFake(function(renderingSettings) {
             const axis = new originalAxis(renderingSettings);
 
             for(const stubName in axesStubs[axisIndex]) {
@@ -73,7 +73,7 @@ const environment = {
     },
     afterEach: function() {
         this.renderer = null;
-        rendererModule.Renderer.reset();
+        rendererModule.Renderer.resetHistory();
         this.axisStub.restore();
         this.scrollBarStub && this.scrollBarStub.restore();
         this.legendStub.restore();
@@ -110,8 +110,8 @@ function createAxisStubs() {
 
 function resetAxisStubs(axis) {
     axis.draw.reset();
-    axis.getMargins.reset();
-    axis.estimateMargins.reset();
+    axis.getMargins.resetHistory();
+    axis.estimateMargins.resetHistory();
     axis.updateSize.reset();
     axis.shift.reset();
     axis.createTicks.reset();

--- a/testing/tests/DevExpress.viz.charts/polarChart.tests.js
+++ b/testing/tests/DevExpress.viz.charts/polarChart.tests.js
@@ -309,7 +309,7 @@ QUnit.test('create series with correct theme and renderer', function(assert) {
     assert.ok(this.createSeries.args[0][0].renderer instanceof vizMocks.Renderer);
 
     assert.strictEqual(this.createSeries.args[0][1].rotated, undefined);
-    assert.deepEqual(this.createSeries.args[0][1], this.themeManager.getOptions.withArgs('series').lastCall.args[1]);
+    assert.deepEqual(this.createSeries.args[0][1], this.themeManager.getOptions.withArgs('series').returnValues[0]);
 });
 
 QUnit.test('create spider series', function(assert) {

--- a/testing/tests/DevExpress.viz.charts/polarChart.tests.js
+++ b/testing/tests/DevExpress.viz.charts/polarChart.tests.js
@@ -150,7 +150,7 @@ const environment = {
         that.$container = $('#chartContainer');
 
         this.createThemeManager = sinon.stub(chartThemeManagerModule, 'ThemeManager').callsFake(function() {
-            // resetStub(stubThemeManager);
+            resetStub(stubThemeManager);
             that.themeManager = stubThemeManager;
             return stubThemeManager;
         });

--- a/testing/tests/DevExpress.viz.charts/polarChart.tests.js
+++ b/testing/tests/DevExpress.viz.charts/polarChart.tests.js
@@ -309,7 +309,7 @@ QUnit.test('create series with correct theme and renderer', function(assert) {
     assert.ok(this.createSeries.args[0][0].renderer instanceof vizMocks.Renderer);
 
     assert.strictEqual(this.createSeries.args[0][1].rotated, undefined);
-    assert.deepEqual(this.createSeries.args[0][1], this.themeManager.getOptions.withArgs('series').returnValues[0]);
+    assert.deepEqual(this.createSeries.args[0][1], this.themeManager.getOptions.withArgs('series').lastCall.args[1]);
 });
 
 QUnit.test('create spider series', function(assert) {

--- a/testing/tests/DevExpress.viz.charts/polarChart.tests.js
+++ b/testing/tests/DevExpress.viz.charts/polarChart.tests.js
@@ -55,7 +55,13 @@ stubExport();
 
 function resetStub(stub) {
     $.each(stub, function(_, stubFunc) {
-        stubFunc && stubFunc.reset && stubFunc.reset();
+        if (stubFunc) {
+            if(stubFunc.resetHistory) {
+                stubFunc.resetHistory();
+            } else if(stubFunc.reset) {
+                stubFunc.reset();
+            }
+        }
     });
 }
 function createStubThemeManager() {
@@ -143,8 +149,8 @@ const environment = {
 
         that.$container = $('#chartContainer');
 
-        this.createThemeManager = sinon.stub(chartThemeManagerModule, 'ThemeManager', function() {
-            resetStub(stubThemeManager);
+        this.createThemeManager = sinon.stub(chartThemeManagerModule, 'ThemeManager').callsFake(function() {
+            // resetStub(stubThemeManager);
             that.themeManager = stubThemeManager;
             return stubThemeManager;
         });
@@ -160,25 +166,25 @@ const environment = {
             };
         };
 
-        that.createRenderer = sinon.stub(rendererModule, 'Renderer', function() {
+        that.createRenderer = sinon.stub(rendererModule, 'Renderer').callsFake(function() {
             const stubRenderer = new vizMocks.Renderer();
             stubRenderer.clipCircle = that.clipFunc;
             stubRenderer.clipRect = that.clipFunc;
             return stubRenderer;
         });
 
-        that.createTooltip = sinon.stub(tooltipModule, 'Tooltip', function() {
+        that.createTooltip = sinon.stub(tooltipModule, 'Tooltip').callsFake(function() {
             resetStub(stubTooltip);
             return stubTooltip;
         });
 
-        that.range = sinon.stub(rangeModule, 'Range', function() {
+        that.range = sinon.stub(rangeModule, 'Range').callsFake(function() {
             resetStub(stubRange);
             stubRange.addRange = function() { this.min = 2; };
             return stubRange;
         });
 
-        that.createSeries = sinon.stub(seriesModule, 'Series', function(settings, seriesTheme) {
+        that.createSeries = sinon.stub(seriesModule, 'Series').callsFake(function(settings, seriesTheme) {
             resetStub(stubSeries[seriesIndex]);
             stubSeries[seriesIndex].getValueAxis.returns(settings.valueAxis);
             if(seriesTheme.valueErrorBar) {
@@ -187,7 +193,7 @@ const environment = {
             return $.extend(true, stubSeries[seriesIndex++], seriesTheme);
         });
 
-        that.createAxis = sinon.stub(axisModule, 'Axis', function() {
+        that.createAxis = sinon.stub(axisModule, 'Axis').callsFake(function() {
             resetStub(stubAxes[axesIndex]);
 
             stubAxes[axesIndex].getMargins.returns({
@@ -200,12 +206,12 @@ const environment = {
             return stubAxes[axesIndex++];
         });
 
-        that.createSeriesFamily = sinon.stub(seriesFamilyModule, 'SeriesFamily', function() {
+        that.createSeriesFamily = sinon.stub(seriesFamilyModule, 'SeriesFamily').callsFake(function() {
             resetStub(stubSeriesFamily);
             return stubSeriesFamily;
         });
 
-        that.createLayoutManager = sinon.stub(layoutManagerModule, 'LayoutManager', function() {
+        that.createLayoutManager = sinon.stub(layoutManagerModule, 'LayoutManager').callsFake(function() {
             resetStub(stubLayoutManager);
             return stubLayoutManager;
         });
@@ -218,28 +224,28 @@ const environment = {
         });
     },
     afterEach: function() {
-        this.createThemeManager.reset();
+        this.createThemeManager.resetHistory();
         this.createThemeManager.restore();
 
-        this.createSeries.reset();
+        this.createSeries.resetHistory();
         this.createSeries.restore();
 
-        this.createRenderer.reset();
+        this.createRenderer.resetHistory();
         this.createRenderer.restore();
 
-        this.range.reset();
+        this.range.resetHistory();
         this.range.restore();
 
-        this.createTooltip.reset();
+        this.createTooltip.resetHistory();
         this.createTooltip.restore();
 
-        this.createAxis.reset();
+        this.createAxis.resetHistory();
         this.createAxis.restore();
 
-        this.createSeriesFamily.reset();
+        this.createSeriesFamily.resetHistory();
         this.createSeriesFamily.restore();
 
-        this.createLayoutManager.reset();
+        this.createLayoutManager.resetHistory();
         this.createLayoutManager.restore();
 
         trackerModule.ChartTracker.reset();
@@ -279,7 +285,7 @@ QUnit.test('create series with panes', function(assert) {
 });
 
 QUnit.test('give series in groups to data validator', function(assert) {
-    const validateData = sinon.stub(dataValidatorModule, 'validateData', function(data) {
+    const validateData = sinon.stub(dataValidatorModule, 'validateData').callsFake(function(data) {
         return data || [];
     });
     try {

--- a/testing/tests/DevExpress.viz.charts/scrollBar.tests.js
+++ b/testing/tests/DevExpress.viz.charts/scrollBar.tests.js
@@ -237,12 +237,13 @@ QUnit.test('setPosition by arguments. Discrete axis. stick false', function(asse
 
     scrollTranslator.translate.withArgs('40', -1).returns(40);
     scrollTranslator.translate.withArgs('40', +1).returns(50);
-    scrollTranslator.translate.withArgs('40').returns(45);
-
+    // sinon ignores more specific range of arguments
+    // scrollTranslator.translate.withArgs('40').returns(45);
 
     scrollTranslator.translate.withArgs('70', -1).returns(70);
     scrollTranslator.translate.withArgs('70', +1).returns(80);
-    scrollTranslator.translate.withArgs('70').returns(75);
+    // sinon ignores more specific range of arguments
+    // scrollTranslator.translate.withArgs('70').returns(75);
 
     scrollTranslator.getCanvasVisibleArea.returns({
         min: 10,

--- a/testing/tests/DevExpress.viz.charts/scrollBar.tests.js
+++ b/testing/tests/DevExpress.viz.charts/scrollBar.tests.js
@@ -238,12 +238,12 @@ QUnit.test('setPosition by arguments. Discrete axis. stick false', function(asse
     scrollTranslator.translate.withArgs('40', -1).returns(40);
     scrollTranslator.translate.withArgs('40', +1).returns(50);
     // sinon ignores more specific range of arguments
-    // scrollTranslator.translate.withArgs('40').returns(45);
+    scrollTranslator.translate.withArgs('40').returns(45);
 
     scrollTranslator.translate.withArgs('70', -1).returns(70);
     scrollTranslator.translate.withArgs('70', +1).returns(80);
     // sinon ignores more specific range of arguments
-    // scrollTranslator.translate.withArgs('70').returns(75);
+    scrollTranslator.translate.withArgs('70').returns(75);
 
     scrollTranslator.getCanvasVisibleArea.returns({
         min: 10,

--- a/testing/tests/DevExpress.viz.charts/scrollBar.tests.js
+++ b/testing/tests/DevExpress.viz.charts/scrollBar.tests.js
@@ -30,7 +30,7 @@ const environment = {
 
         this.group = this.renderer.g();
 
-        sinon.stub(translator2DModule, 'Translator2D', function() {
+        sinon.stub(translator2DModule, 'Translator2D').callsFake(function() {
             const stub = new Translator();
             stub.getScale = sinon.stub().returns(1);
             stub.stub('getCanvasVisibleArea');

--- a/testing/tests/DevExpress.viz.charts/scrollBar.tests.js
+++ b/testing/tests/DevExpress.viz.charts/scrollBar.tests.js
@@ -237,12 +237,11 @@ QUnit.test('setPosition by arguments. Discrete axis. stick false', function(asse
 
     scrollTranslator.translate.withArgs('40', -1).returns(40);
     scrollTranslator.translate.withArgs('40', +1).returns(50);
-    // sinon ignores more specific range of arguments
     scrollTranslator.translate.withArgs('40').returns(45);
+
 
     scrollTranslator.translate.withArgs('70', -1).returns(70);
     scrollTranslator.translate.withArgs('70', +1).returns(80);
-    // sinon ignores more specific range of arguments
     scrollTranslator.translate.withArgs('70').returns(75);
 
     scrollTranslator.getCanvasVisibleArea.returns({

--- a/testing/tests/DevExpress.viz.charts/tracker.tests.js
+++ b/testing/tests/DevExpress.viz.charts/tracker.tests.js
@@ -2057,8 +2057,8 @@ QUnit.test('repairTooltip', function(assert) {
     const point = createPoint(this.series);
 
     $(this.options.seriesGroup.element).trigger(getEvent('showpointtooltip'), point);
-    this.options.tooltip.show.reset();
-    point.getTooltipParams.reset();
+    this.options.tooltip.show.resetHistory();
+    point.getTooltipParams.resetHistory().returns({ x: 200, y: 100 });
 
     // act
     this.tracker.repairTooltip();
@@ -2686,8 +2686,8 @@ QUnit.test('Tooltip is disabled. Show tooltip on point, stopCurrentHandling, sho
 
 QUnit.test('show Tooltip event when there is tooltip on another point. TooltipHidden fired, TooltipShown fired', function(assert) {
     this.environment.options.seriesGroup.trigger(getEvent('showpointtooltip'), this.environment.point2);
-    this.tooltip.stub('hide').reset();
-    this.tooltip.stub('show').reset();
+    this.tooltip.stub('hide').resetHistory();
+    this.tooltip.stub('show').resetHistory();
 
     // act
     this.environment.options.seriesGroup.trigger(getEvent('showpointtooltip'), this.environment.point1);

--- a/testing/tests/DevExpress.viz.charts/tracker.tests.js
+++ b/testing/tests/DevExpress.viz.charts/tracker.tests.js
@@ -2058,7 +2058,7 @@ QUnit.test('repairTooltip', function(assert) {
 
     $(this.options.seriesGroup.element).trigger(getEvent('showpointtooltip'), point);
     this.options.tooltip.show.resetHistory();
-    point.getTooltipParams.resetHistory().returns({ x: 200, y: 100 });
+    point.getTooltipParams.resetHistory();
 
     // act
     this.tracker.repairTooltip();

--- a/testing/tests/DevExpress.viz.core.series/pieSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/pieSeries.tests.js
@@ -60,7 +60,13 @@ const createPoint = function(series, data) {
 
 function resetStub(stub) {
     $.each(stub, function(_, stubFunc) {
-        stubFunc && stubFunc.reset && stubFunc.reset();
+        if(stubFunc) {
+            if (stubFunc.resetHistory) {
+                stubFunc.resetHistory();
+            } else if(stubFunc.reset) {
+                stubFunc.reset();
+            }
+        }
     });
 }
 

--- a/testing/tests/DevExpress.viz.core.series/polarPoint.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/polarPoint.tests.js
@@ -58,7 +58,7 @@ const environment = {
         series._argumentChecker.returns(true);
         series._valueChecker.returns(true);
 
-        this.createLabel = sinon.stub(labelModule, 'Label', function() {
+        this.createLabel = sinon.stub(labelModule, 'Label').callsFake(function() {
             label.getBoundingRect.returns({ x: 1, y: 2, width: 20, height: 10 });
             label.getLayoutOptions.returns({ alignment: 'center', radialOffset: 0 });
             resetStub(label);
@@ -75,7 +75,13 @@ const environment = {
 
 function resetStub(stub) {
     $.each(stub, function(_, stubFunc) {
-        stubFunc && stubFunc.reset && stubFunc.reset();
+        if (stubFunc) {
+            if (stubFunc.resetHistory) {
+                stubFunc.resetHistory();
+            } else if (stubFunc.reset) {
+                stubFunc.reset();
+            }
+        }
     });
 }
 

--- a/testing/tests/DevExpress.viz.core.series/scatterSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/scatterSeries.tests.js
@@ -65,7 +65,13 @@ const mockPoints = [createPoint(), createPoint(), createPoint(), createPoint(), 
 
 function resetStub(stub) {
     $.each(stub, function(_, stubFunc) {
-        stubFunc && stubFunc.reset && stubFunc.reset();
+        if(stubFunc) {
+            if (stubFunc.resetHistory) {
+                stubFunc.resetHistory();
+            } else if(stubFunc.reset) {
+                stubFunc.reset();
+            }
+        }
     });
 }
 

--- a/testing/tests/DevExpress.viz.core/annotations.plugins.tests.js
+++ b/testing/tests/DevExpress.viz.core/annotations.plugins.tests.js
@@ -1044,7 +1044,7 @@ QUnit.module('Lifecycle', {
         ];
         const chart = this.chart(annotationOptions, items);
         this.createAnnotationStub.getCall(0).returnValue[0].draw.reset();
-        this.createAnnotationStub.reset();
+        this.createAnnotationStub.resetHistory();
 
         const newItems = [
             { some: 'newItem' }
@@ -1075,7 +1075,7 @@ QUnit.module('Lifecycle', {
         ];
         const chart = this.chart(annotationOptions, items);
         this.createAnnotationStub.getCall(0).returnValue[0].draw.reset();
-        this.createAnnotationStub.reset();
+        this.createAnnotationStub.resetHistory();
 
         const newAnnotationOptions = {
             some: 'otherOptions'
@@ -1234,7 +1234,7 @@ QUnit.module('Lifecycle', {
         ];
         const polarChart = this.polarChart(annotationOptions, items);
         this.createAnnotationStub.getCall(0).returnValue[0].draw.reset();
-        this.createAnnotationStub.reset();
+        this.createAnnotationStub.resetHistory();
 
         const newItems = [
             { some: 'newItem' }
@@ -1265,7 +1265,7 @@ QUnit.module('Lifecycle', {
         ];
         const polarChart = this.polarChart(annotationOptions, items);
         this.createAnnotationStub.getCall(0).returnValue[0].draw.reset();
-        this.createAnnotationStub.reset();
+        this.createAnnotationStub.resetHistory();
 
         const newAnnotationOptions = {
             some: 'otherOptions'

--- a/testing/tests/DevExpress.viz.core/title.integration.tests.js
+++ b/testing/tests/DevExpress.viz.core/title.integration.tests.js
@@ -49,7 +49,7 @@ QUnit.test('Options and canvas', function(assert) {
 
 QUnit.test('Depends on theme', function(assert) {
     const widget = this.createWidget();
-    this.title.update.reset();
+    this.title.update.resetHistory();
 
     widget.option('theme', 'test-theme');
 
@@ -63,7 +63,7 @@ QUnit.test('title / size is changed', function(assert) {
         title: 'title-options'
     });
     this.title.stub('update').returns(true);
-    this.title.measure.reset();
+    this.title.measure.resetHistory();
 
     widget.option({ title: 'new-title-options' });
 
@@ -78,7 +78,7 @@ QUnit.test('title / size is not changed', function(assert) {
         title: 'title-options'
     });
     this.title.stub('update').returns(false);
-    this.title.measure.reset();
+    this.title.measure.resetHistory();
 
     widget.option({ title: 'new-title-options' });
 

--- a/testing/tests/DevExpress.viz.vectorMap/mapLayer.strategies.tests.js
+++ b/testing/tests/DevExpress.viz.vectorMap/mapLayer.strategies.tests.js
@@ -287,7 +287,7 @@ QUnit.test('Perform grouping', function(assert) {
     assert.deepEqual(callback({ attribute: stub }, 'test-arg'), 'test-data', 'value callback');
     assert.deepEqual(stub.lastCall.args, ['test-arg'], 'attribute');
 
-    valuesCallback.reset();
+    valuesCallback.resetHistory();
     set.reset();
     callback = sinon.spy();
     performGrouping(context, [1, 2, 3], 'test-field-2', callback, valuesCallback);
@@ -305,7 +305,7 @@ QUnit.test('Perform grouping', function(assert) {
         defaultColor: 'default color'
     }], 'data is set 2');
 
-    valuesCallback.reset();
+    valuesCallback.resetHistory();
     set.reset();
     performGrouping(context, { tag: 'test' }, 'test-field-3', 'data-field', valuesCallback);
 


### PR DESCRIPTION
I chose v2 version, not the latest, because it's the first version that avoids using of eval. Our primary goal is to use the lib without insecure functions.

List of changes:

- Stub behaviour defining API has changes
```
// Old
sinon.stub(obj, "meth", fn);
// New
sinon.stub(obj, "meth").callsFake(fn);
```
- Stub reset API has changed
```
// Old
stub.reset();
// New
stub.resetHistory();
```
- A lot of modifying of timers (using `clock.tick(ms)`)

Changes in tests were mostly motivated by this PR: https://github.com/DevExpress/DevExtreme/pull/20528