### PR TITLE
PivotGrid(T1157878): throws JS errors on an attempt to import a module in RequireJS

### DIFF
--- a/js/__internal/tsconfig.json
+++ b/js/__internal/tsconfig.json
@@ -38,7 +38,7 @@
   },
   "tsc-alias": {
     "verbose": false,
-    "resolveFullPaths": true,
+    "resolveFullPaths": false,
     "fileExtensions": {
       "inputGlob": "js,ts",
       "outputCheck": ["js", "ts"]


### PR DESCRIPTION
See the ticket: [T1157878](https://supportcenter.devexpress.com/ticket/details/t1157878/pivotgrid-throws-js-errors-on-an-attempt-to-import-a-module-in-requirejs)