### PR TITLE
ESlint: Fix rules for QUnit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,92 @@ module.exports = {
             },
             rules: {
                 'i18n/no-russian-character': ['error', { 'includeIdentifier': true }],
+                'block-spacing': 'error',
+                'comma-spacing': 'error',
+                'computed-property-spacing': 'error',
+                'comma-style': ['error', 'last'],
+                'eqeqeq': ['error', 'allow-null'],
+                'strict': 'error',
+                'func-call-spacing': 'error',
+                'key-spacing': 'error',
+                'keyword-spacing': [
+                    'error',
+                    {
+                        'overrides': {
+                            'catch': {
+                                'after': false,
+                            },
+                            'for': {
+                                'after': false,
+                            },
+                            'if': {
+                                'after': false,
+                            },
+                            'switch': {
+                                'after': false,
+                            },
+                            'while': {
+                                'after': false,
+                            },
+                        },
+                    },
+                ],
+                'no-multiple-empty-lines': ['error', { max: 2 }],
+                'no-multi-spaces': 'error',
+                'no-trailing-spaces': 'error',
+                'no-empty': ['error', { allowEmptyCatch: true }],
+                'no-new-func': 'error',
+                'no-eval': 'error',
+                'no-undef-init': 'error',
+                'no-unused-vars': ['error', { args: 'none', ignoreRestSiblings: true }],
+                'no-extend-native': 'error',
+                'no-alert': 'error',
+                'no-console': 'error',
+                'no-restricted-syntax': ['error', 'ForOfStatement'],
+                'no-var': 'error',
+                'no-whitespace-before-property': 'error',
+                'object-curly-spacing': ['error', 'always'],
+                'one-var': ['error', 'never'],
+                'prefer-const': 'error',
+                'semi-spacing': 'error',
+                'semi': 'error',
+                'space-before-blocks': 'error',
+                'space-before-function-paren': ['error', 'never'],
+                'space-in-parens': 'error',
+                'space-infix-ops': 'error',
+                'space-unary-ops': 'error',
+                'spaced-comment': [
+                    'error',
+                    'always',
+                    {
+                        'exceptions': [
+                            '#DEBUG',
+                            '#ENDDEBUG',
+                        ],
+                        'markers': [
+                            '/',
+                        ],
+                    },
+                ],
+                'brace-style': ['error', '1tbs', { allowSingleLine: true }],
+                'curly': ['error', 'multi-line', 'consistent'],
+                'unicode-bom': ['error', 'never'],
+                'eol-last': ['error', 'always'],
+                'indent': [
+                    'error',
+                    4,
+                    {
+                        'SwitchCase': 1,
+                        'MemberExpression': 1,
+                        'CallExpression': {
+                            'arguments': 1,
+                        },
+                    },
+                ],
+                'quotes': ['error', 'single'],
+                'import/named': 2,
+                'import/default': 2,
+                'import/no-duplicates': 2,
             }
         },
         {

--- a/js/.eslintrc.js
+++ b/js/.eslintrc.js
@@ -9,8 +9,6 @@ module.exports = {
         {
             files: ['*.js'],
             rules: {
-                'import/no-commonjs': 'error',
-                'no-restricted-modules': ['error', { 'patterns': ['*.js'] }],
                 'no-restricted-imports': ['error', {
                     'paths': [
                         { 'name': 'jquery' },
@@ -20,92 +18,8 @@ module.exports = {
                     ],
                     'patterns': ['jquery/*', 'angular/*', 'knockout/*', 'globalize/*'],
                 }],
-                'block-spacing': 'error',
-                'comma-spacing': 'error',
-                'computed-property-spacing': 'error',
-                'comma-style': ['error', 'last'],
-                'eqeqeq': ['error', 'allow-null'],
-                'strict': 'error',
-                'func-call-spacing': 'error',
-                'key-spacing': 'error',
-                'keyword-spacing': [
-                    'error',
-                    {
-                        'overrides': {
-                            'catch': {
-                                'after': false,
-                            },
-                            'for': {
-                                'after': false,
-                            },
-                            'if': {
-                                'after': false,
-                            },
-                            'switch': {
-                                'after': false,
-                            },
-                            'while': {
-                                'after': false,
-                            },
-                        },
-                    },
-                ],
-                'no-multiple-empty-lines': ['error', { max: 2 }],
-                'no-multi-spaces': 'error',
-                'no-trailing-spaces': 'error',
-                'no-empty': ['error', { allowEmptyCatch: true }],
-                'no-new-func': 'error',
-                'no-eval': 'error',
-                'no-undef-init': 'error',
-                'no-unused-vars': ['error', { args: 'none', ignoreRestSiblings: true }],
-                'no-extend-native': 'error',
-                'no-alert': 'error',
-                'no-console': 'error',
-                'no-restricted-syntax': ['error', 'ForOfStatement'],
-                'no-var': 'error',
-                'no-whitespace-before-property': 'error',
-                'object-curly-spacing': ['error', 'always'],
-                'one-var': ['error', 'never'],
-                'prefer-const': 'error',
-                'semi-spacing': 'error',
-                'semi': 'error',
-                'space-before-blocks': 'error',
-                'space-before-function-paren': ['error', 'never'],
-                'space-in-parens': 'error',
-                'space-infix-ops': 'error',
-                'space-unary-ops': 'error',
-                'spaced-comment': [
-                    'error',
-                    'always',
-                    {
-                        'exceptions': [
-                            '#DEBUG',
-                            '#ENDDEBUG',
-                        ],
-                        'markers': [
-                            '/',
-                        ],
-                    },
-                ],
-                'brace-style': ['error', '1tbs', { allowSingleLine: true }],
-                'curly': ['error', 'multi-line', 'consistent'],
-                'unicode-bom': ['error', 'never'],
-                'eol-last': ['error', 'always'],
-                'indent': [
-                    'error',
-                    4,
-                    {
-                        'SwitchCase': 1,
-                        'MemberExpression': 1,
-                        'CallExpression': {
-                            'arguments': 1,
-                        },
-                    },
-                ],
-                'quotes': ['error', 'single'],
-                'import/named': 2,
-                'import/default': 2,
-                'import/no-duplicates': 2,
+                'import/no-commonjs': 'error',
+                'no-restricted-modules': ['error', { 'patterns': ['*.js'] }],
             }
         },
         {

--- a/testing/helpers/keyboardMock.js
+++ b/testing/helpers/keyboardMock.js
@@ -57,9 +57,7 @@ let focused;
                 try {
                     start = input.selectionStart;
                     end = input.selectionEnd;
-                }
-                // eslint-disable-next-line no-empty
-                catch(e) {}
+                } catch(e) {}
             }
             return { start: start, end: end };
         },
@@ -94,9 +92,7 @@ let focused;
                 } else {
                     input.setSelectionRange(start, end);
                 }
-            }
-            // eslint-disable-next-line no-empty
-            catch(e) { }
+            } catch(e) { }
         }
     };
 

--- a/testing/testcafe/.eslintrc.js
+++ b/testing/testcafe/.eslintrc.js
@@ -5,4 +5,4 @@ module.exports = {
         files: ['*.ts'],
         extends: ['devextreme/testcafe'],
     }],
-}
+};

--- a/testing/tests/DevExpress.core/utils.dom.tests.js
+++ b/testing/tests/DevExpress.core/utils.dom.tests.js
@@ -108,11 +108,11 @@ QUnit.test('it correctly detect the body element', function(assert) {
 
 QUnit.test('it does not raise error if element is a href', function(assert) {
     const hrefElement = $('<a>')
-            .attr({ href: 'text' })
-            .get(0);
+        .attr({ href: 'text' })
+        .get(0);
 
     try {
-        domUtils.contains(document, hrefElement)
+        domUtils.contains(document, hrefElement);
     } catch(e) {
         assert.ok(false, `error is raised: ${e.message}`);
     } finally {

--- a/testing/tests/DevExpress.core/utils.variableWrapper.tests.js
+++ b/testing/tests/DevExpress.core/utils.variableWrapper.tests.js
@@ -1,12 +1,12 @@
 const variableWrapper = require('core/utils/variable_wrapper');
-const { logger } = require('core/utils/console')
+const { logger } = require('core/utils/console');
 
 QUnit.test('Base wrapper methods', function(assert) {
     assert.strictEqual(variableWrapper.isWrapped(3), false, 'isWrapped method');
     assert.strictEqual(variableWrapper.wrap(3), 3, 'wrap method');
     assert.strictEqual(variableWrapper.unwrap(3), 3, 'unwrap method');
     const loggerErrorSpy = sinon.spy(logger, 'error');
-    variableWrapper.assign({}, 3)
+    variableWrapper.assign({}, 3);
     assert.strictEqual(loggerErrorSpy.callCount, 1, 'assign method');
 });
 

--- a/testing/tests/DevExpress.exporter/pdfCreator.tests.js
+++ b/testing/tests/DevExpress.exporter/pdfCreator.tests.js
@@ -15,7 +15,7 @@ const contentTestEnv = {
         sinon.stub(imageCreator, 'getImageData', (markup) => {
             const def = $.Deferred();
             def.resolve(this.imageDataSample || '_test_' + markup + '_string_');
-            return def; 
+            return def;
         });
     },
     afterEach: function() {

--- a/testing/tests/DevExpress.knockout/variableWrapperUtils.tests.js
+++ b/testing/tests/DevExpress.knockout/variableWrapperUtils.tests.js
@@ -1,6 +1,6 @@
 const ko = require('knockout');
 const variableWrapper = require('core/utils/variable_wrapper');
-const { logger } = require('core/utils/console')
+const { logger } = require('core/utils/console');
 
 require('integration/knockout');
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -8810,14 +8810,14 @@ QUnit.module('Editing with real dataController', {
         };
 
         class Data {
-            prop1
+            prop1;
         }
         class Prop1 {
-            prop2
+            prop2;
         }
 
         class Prop2 {
-            name
+            name;
         }
 
         const dataSource = [{
@@ -10634,9 +10634,9 @@ QUnit.module('Refresh modes', {
             {
                 type: 'buttons',
                 buttons: [
-                    { name: 'edit',   icon: 'active-icon', visible: e => e.row.data.state === 'active' },
-                    { name: 'delete', icon: 'remove',      visible: e => e.row.data.state !== 'active' },
-                    { name: 'custom', icon: 'custom',     disabled: e => e.row.data.state !== 'active' },
+                    { name: 'edit', icon: 'active-icon', visible: e => e.row.data.state === 'active' },
+                    { name: 'delete', icon: 'remove', visible: e => e.row.data.state !== 'active' },
+                    { name: 'custom', icon: 'custom', disabled: e => e.row.data.state !== 'active' },
                 ]
             },
             'state'
@@ -10677,9 +10677,9 @@ QUnit.module('Refresh modes', {
             {
                 type: 'buttons',
                 buttons: [
-                    { name: 'edit',   icon: 'active-icon', visible: e => e.row.data.state === 'active' },
-                    { name: 'delete', icon: 'remove',      visible: e => e.row.data.state !== 'active' },
-                    { name: 'custom', icon: 'custom',     disabled: e => e.row.data.state !== 'active' },
+                    { name: 'edit', icon: 'active-icon', visible: e => e.row.data.state === 'active' },
+                    { name: 'delete', icon: 'remove', visible: e => e.row.data.state !== 'active' },
+                    { name: 'custom', icon: 'custom', disabled: e => e.row.data.state !== 'active' },
                 ]
             },
             'state'
@@ -10709,9 +10709,9 @@ QUnit.module('Refresh modes', {
         // act
         this.options.dataSource.store().push([
             {
-              type: 'update',
-              key: 1,
-              data: { state: 'disabled'}
+                type: 'update',
+                key: 1,
+                data: { state: 'disabled' }
             }
         ]);
         this.clock.tick(10);
@@ -10871,13 +10871,13 @@ QUnit.module('Editing with validation', {
                 dataField: 'name',
                 editorOptions: { disabled: true },
                 validationRules: [{
-                    type: "async",
+                    type: 'async',
                     validationCallback: disabledEditorValidationCallback
                 }]
             }, {
                 dataField: 'age',
                 validationRules: [{
-                    type: "async",
+                    type: 'async',
                     validationCallback: enabledEditorValidationCallback
                 }]
             }]

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/headerFilter.tests.js
@@ -4495,7 +4495,7 @@ QUnit.module('Header Filter with real columnsController', {
 
         this.options.dataSource = { load: loadSpy };
         this.options.syncLookupFilterValues = true;
-        this.options.remoteOperations = { groupPaging: true }
+        this.options.remoteOperations = { groupPaging: true };
         this.options.headerFilter.allowSearch = true;
 
         const $testElement = $('#container');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -6350,7 +6350,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
     QUnit.test('Editing buttons should rerender correctly after scrolling if repaintChangesOnly=true', function(assert) {
         // arrange
         const data = [...new Array(14)].map((_, i) => ({
-            id: i+1
+            id: i + 1
         }));
 
         const dataGrid = createDataGrid({
@@ -6384,18 +6384,18 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
 
         Array.from($rows).forEach((row, i) => {
             const $row = $(row);
-            if (i === 5) { // editing row
+            if(i === 5) { // editing row
                 assert.strictEqual($row.find('a').length, 2);
-                assert.strictEqual($row.find('a:eq(0)').text(), 'Save')
-                assert.strictEqual($row.find('a:eq(1)').text(), 'Cancel')
+                assert.strictEqual($row.find('a:eq(0)').text(), 'Save');
+                assert.strictEqual($row.find('a:eq(1)').text(), 'Cancel');
                 return;
             }
 
             // other rows
             assert.strictEqual($row.find('a').length, 2);
-            assert.strictEqual($row.find('a:eq(0)').text(), 'Edit')
-            assert.strictEqual($row.find('a:eq(1)').text(), 'Delete')
-        })
+            assert.strictEqual($row.find('a:eq(0)').text(), 'Edit');
+            assert.strictEqual($row.find('a:eq(1)').text(), 'Delete');
+        });
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
@@ -1454,14 +1454,14 @@ module('Caret moving', setupModule, () => {
         assert.deepEqual(this.keyboard.caret(), { start: 5, end: 7 }, 'caret was moved to month');
     });
 
-    test(`Caret should not be moved to next group after type hour "1" when "hh" time format is used`, function(assert) {
+    test('Caret should not be moved to next group after type hour "1" when "hh" time format is used', function(assert) {
         this.instance.option({
             value: new Date(2021, 9, 17, 16, 6),
             displayFormat: 'hh:mm a'
         });
 
         this.keyboard.type('1');
-        assert.strictEqual(this.instance.option('text'), `01:06 PM`, 'text is correct');
+        assert.strictEqual(this.instance.option('text'), '01:06 PM', 'text is correct');
         assert.deepEqual(this.keyboard.caret(), { start: 0, end: 2 }, 'caret position is correct');
     });
 
@@ -1471,7 +1471,7 @@ module('Caret moving', setupModule, () => {
                 value: new Date(2021, 9, 17, 16, 6),
                 displayFormat: 'hh:mm a'
             });
-    
+
             this.keyboard.type(`${hour}`);
             assert.strictEqual(this.instance.option('text'), `0${hour}:06 PM`, 'text is correct');
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, 'caret position is correct');
@@ -1484,7 +1484,7 @@ module('Caret moving', setupModule, () => {
                 value: new Date(2021, 9, 17, 16, 6),
                 displayFormat: 'hh:mm a'
             });
-    
+
             this.keyboard.type(`${hour}`);
             assert.strictEqual(this.instance.option('text'), `${hour}:06 PM`, 'text is correct');
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, 'caret was moved to month');
@@ -1497,7 +1497,7 @@ module('Caret moving', setupModule, () => {
                 value: new Date(2021, 9, 17, 16, 6),
                 displayFormat: 'hh:mm a'
             });
-    
+
             this.keyboard.type(`${hour}`);
             assert.strictEqual(this.instance.option('text'), `0${hour.toString()[1]}:06 PM`, 'text is correct');
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, 'caret position is correct');
@@ -1510,7 +1510,7 @@ module('Caret moving', setupModule, () => {
                 value: new Date(2021, 9, 17, 16, 6),
                 displayFormat: 'HH:mm a'
             });
-    
+
             this.keyboard.type(`${hour}`);
             assert.strictEqual(this.instance.option('text'), `0${hour}:06 AM`, 'text is correct');
             assert.deepEqual(this.keyboard.caret(), { start: 0, end: 2 }, 'caret position is correct');
@@ -1523,7 +1523,7 @@ module('Caret moving', setupModule, () => {
                 value: new Date(2021, 9, 17, 16, 6),
                 displayFormat: 'HH:mm a'
             });
-    
+
             this.keyboard.type(`${hour}`);
             assert.strictEqual(this.instance.option('text'), `0${hour}:06 AM`, 'text is correct');
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, 'caret position is correct');
@@ -1536,7 +1536,7 @@ module('Caret moving', setupModule, () => {
                 value: new Date(2021, 9, 17, 16, 6),
                 displayFormat: 'HH:mm a'
             });
-    
+
             this.keyboard.type(`${hour}`);
             assert.strictEqual(this.instance.option('text'), `${hour}:06 AM`, 'text is correct');
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, 'caret position is correct');
@@ -1549,7 +1549,7 @@ module('Caret moving', setupModule, () => {
                 value: new Date(2021, 9, 17, 16, 6),
                 displayFormat: 'HH:mm a'
             });
-    
+
             this.keyboard.type(`${hour}`);
             assert.strictEqual(this.instance.option('text'), `${hour}:06 PM`, 'text is correct');
             assert.deepEqual(this.keyboard.caret(), { start: 3, end: 5 }, 'caret position is correct');

--- a/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/datebox.tests.js
@@ -4944,10 +4944,10 @@ QUnit.module('Popup open state', () => {
 
                 dateBox.open();
                 keyboard.keyDown('tab');
-        
+
                 assert.strictEqual(dateBox.option('opened'), false, 'popup is closed');
             });
-        })
+        });
     });
 
     ['date', 'time', 'datetime'].forEach(type => {
@@ -4965,10 +4965,10 @@ QUnit.module('Popup open state', () => {
 
                 dateBox.open();
                 keyboard.keyDown('tab');
-        
+
                 assert.strictEqual(dateBox.option('opened'), true, 'popup is still opened');
             });
-        })
+        });
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -1135,7 +1135,7 @@ QUnit.module('Lookup', {
                 dropDownOptions: {
                     onShowing: (e) => {
                         const $overlayContent = e.component.$content().parent();
-                        $overlayContent.attr("role", "custom-role");
+                        $overlayContent.attr('role', 'custom-role');
                     }
                 }
             }).dxLookup('instance');

--- a/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -2726,10 +2726,7 @@ QUnit.module('editing', moduleSetup, () => {
 
         try {
             keyboard.change();
-        }
-        // eslint-disable-next-line no-empty
-        catch(e) {
-        }
+        } catch(e) { }
 
         assert.equal($input.val(), '1', 'input value is correct');
         assert.equal($selectBox.dxSelectBox('option', 'value'), '1', 'widget value is correct');

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/markup.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/markup.tests.js
@@ -128,7 +128,7 @@ export default function() {
             config({
                 editorStylingMode: 'filled',
             });
-        }, 
+        },
         afterEach() {
             config({
                 editorStylingMode: 'outlined',

--- a/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/toolbarIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/toolbarIntegration.tests.js
@@ -619,7 +619,7 @@ export default function() {
             });
             const linkHref = $container.find('a').attr('href');
 
-            assert.strictEqual(linkHref, '')
+            assert.strictEqual(linkHref, '');
         });
 
         test('href should be empty on empty URL input submit (T1134100)', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/chartIntegration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/chartIntegration.tests.js
@@ -90,7 +90,6 @@ QUnit.module('Chart Binding', {
     });
 
     QUnit.test('Bind chart instance to pivotGrid', function(assert) {
-        console.log('here');
         const pivotGrid = createPivotGrid(this.pivotGridOptions);
         const chart = createChart();
         const chartBinding = pivotGrid.bindChart(chart);

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/summaryDisplayModes.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/summaryDisplayModes.tests.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import summaryDisplayModes, {
     applyDisplaySummaryMode,
     applyRunningTotal,
-    summaryDictionary ,
+    summaryDictionary,
 } from '__internal/grids/pivot_grid/summary_display_modes/module'; // arguments: description, data
 import pivotGridUtils from '__internal/grids/pivot_grid/module_widget_utils';
 

--- a/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.scheduler/virtual_scrolling.tests.js
@@ -69,11 +69,11 @@ module('Virtual Scrolling', {
     afterEach: function() {
         this.virtualScrollingDispatcher.dispose();
 
-        if (typeof eventsEngine.on.restore === 'function') {
+        if(typeof eventsEngine.on.restore === 'function') {
             eventsEngine.on.restore();
         }
 
-        if (typeof eventsEngine.off.restore === 'function') {
+        if(typeof eventsEngine.off.restore === 'function') {
             eventsEngine.off.restore();
         }
     }

--- a/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
+++ b/testing/tests/DevExpress.ui.widgets/listParts/commonTests.js
@@ -2001,7 +2001,7 @@ QUnit.module('events', moduleSetup, () => {
         }
 
         const $element = this.element.dxList({
-            items:[{
+            items: [{
                 text: 'item 1',
                 onClick: () => {
                     assert.ok('onClick was fired');

--- a/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
@@ -340,7 +340,7 @@ QUnit.module('Menu rendering', () => {
                 items: [{ text: 'Item text', url }]
             });
             const content = menuBase.element.find(`.${DX_MENU_ITEM_TEXT_CLASS}`).children()[0];
-    
+
             assert.strictEqual(content.tagName, 'A');
             assert.strictEqual(content.getAttribute('href'), url);
             assert.strictEqual(content.text, 'Item text');
@@ -356,7 +356,7 @@ QUnit.module('Menu rendering', () => {
         assert.ok(!content.children()[0]);
         assert.strictEqual(content.text(), 'Item text');
     });
-    
+
     QUnit.test('should update item link after update item option with new url', function(assert) {
         const menuBase = createMenu({
             items: [{ text: 'Item text', url: 'http://some_url' }]

--- a/testing/tests/DevExpress.ui.widgets/popover.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/popover.tests.js
@@ -2302,7 +2302,7 @@ QUnit.module('aria accessibility', {
 
     QUnit.test('role="dialog" attribute should be set if popover has toolbarItems', function(assert) {
         const $popover = $('#what');
-        new Popover($popover, { toolbarItems: [{ text: "Title", location: "before" }]});
+        new Popover($popover, { toolbarItems: [{ text: 'Title', location: 'before' }] });
         const $overlay = $(`.${OVERLAY_CONTENT_CLASS}`);
 
         assert.strictEqual($overlay.attr('role'), 'dialog');

--- a/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.main.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/scrollableParts/scrollable.main.tests.js
@@ -725,9 +725,9 @@ QUnit.test('useNative false in simulator', function(assert) {
         if(forceDevice) {
             window.top['dx-force-device'] = forceDevice;
         } else {
-            try { delete window.top['dx-force-device']; }
-            // eslint-disable-next-line no-empty
-            catch(e) { }
+            try {
+                delete window.top['dx-force-device'];
+            } catch(e) { }
         }
     }
 });

--- a/testing/tests/DevExpress.ui.widgets/speedDialAction.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/speedDialAction.tests.js
@@ -63,9 +63,7 @@ QUnit.module('maxSpeedDialActionCount option', () => {
                     .appendTo($container)
                     .dxSpeedDialAction({ icon: 'favorites' })
                     .dxSpeedDialAction('instance'));
-            }
-            // eslint-disable-next-line no-empty
-            catch(error) {}
+            } catch(error) { }
         }
 
         assert.equal($(FAB_MAIN_SELECTOR).length, 1, 'one main fab is created');

--- a/testing/tests/DevExpress.ui.widgets/tabPanel.repaintChangesOnly.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/tabPanel.repaintChangesOnly.tests.js
@@ -30,9 +30,7 @@ QUnit.module('repaintChangesOnly', {
         this.containsElement = (id) => {
             try {
                 return this.$tabPanel.find('#id_' + id)[0].textContent;
-            }
-            // eslint-disable-next-line no-empty
-            catch(e) {}
+            } catch(e) {}
         };
         this.checkNotContainsElements = (assert, idList) => {
             idList.forEach((id) => { assert.notOk(this.containsElement(id), `doesn't contain '${id}'`); });

--- a/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/toolbar.tests.js
@@ -1732,12 +1732,12 @@ QUnit.module('Toolbar disposing', () => {
 
         try {
             toolbar._dimensionChanged();
-        } catch (e) {
+        } catch(e) {
             assert.ok(false, e);
         } finally {
             assert.ok(true, 'the exception is not thrown');
         }
-    })
+    });
 });
 
 QUnit.module('Waiting fonts for material theme', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui/dialog.tests.js
+++ b/testing/tests/DevExpress.ui/dialog.tests.js
@@ -55,9 +55,9 @@ module('dialog', {
             return;
         }
 
-        custom({ 
-            messageHtml: 'text', 
-            buttons: [{ type: 'default', text: 'Ok' }] 
+        custom({
+            messageHtml: 'text',
+            buttons: [{ type: 'default', text: 'Ok' }]
         }).show();
 
         const dialogButton = this
@@ -97,30 +97,30 @@ module('dialog', {
                 assert.ok(true, 'desktop specific test');
                 return;
             }
-    
-            custom({ 
-                messageHtml: 'text', 
+
+            custom({
+                messageHtml: 'text',
                 buttons: [{ type: 'default', text: 'Ok' }],
             }).show();
-    
+
             const dialogButton = this
                 .dialog()
                 .find(`.${DIALOG_BUTTON_CLASS}`);
             const keyboard = keyboardMock(dialogButton);
 
             keyboard.keyDown('esc');
-    
+
             assert.strictEqual(this.getDialogElement().length, 1, 'dialog markup is not removed immediately');
 
             this.clock.tick(ANIMATION_TIMEOUT);
             assert.strictEqual(this.getDialogElement().length, 0, 'dialog markup is removed after animation is finished');
         });
-    
+
         test('should remove its markup after hide method call only after hiding animation is finished', function(assert) {
             const { show, hide } = custom({
                 messageHtml: 'text',
             });
-    
+
             show();
             hide();
 
@@ -129,7 +129,7 @@ module('dialog', {
             this.clock.tick(ANIMATION_TIMEOUT);
             assert.strictEqual(this.getDialogElement().length, 0, 'dialog markup is removed after animation is finished');
         });
-    })
+    });
 
     test('dialog show/hide by Escape (T686065)', function(assert) {
         if(devices.real().deviceType !== 'desktop') {

--- a/testing/tests/DevExpress.ui/themes.tests.js
+++ b/testing/tests/DevExpress.ui/themes.tests.js
@@ -37,7 +37,7 @@ function loadCss(frame, cssFileName) {
 
 // TODO: remove this wrapper after fix blinking tests
 const timeoutDoneWrapper = (done) => {
-    setTimeout(done, 200)
+    setTimeout(done, 200);
 };
 
 const defaultTimeout = 2000;

--- a/testing/tests/DevExpress.viz.charts/polarChart.tests.js
+++ b/testing/tests/DevExpress.viz.charts/polarChart.tests.js
@@ -55,7 +55,7 @@ stubExport();
 
 function resetStub(stub) {
     $.each(stub, function(_, stubFunc) {
-        if (stubFunc) {
+        if(stubFunc) {
             if(stubFunc.resetHistory) {
                 stubFunc.resetHistory();
             } else if(stubFunc.reset) {

--- a/testing/tests/DevExpress.viz.core.series/pieSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/pieSeries.tests.js
@@ -61,7 +61,7 @@ const createPoint = function(series, data) {
 function resetStub(stub) {
     $.each(stub, function(_, stubFunc) {
         if(stubFunc) {
-            if (stubFunc.resetHistory) {
+            if(stubFunc.resetHistory) {
                 stubFunc.resetHistory();
             } else if(stubFunc.reset) {
                 stubFunc.reset();

--- a/testing/tests/DevExpress.viz.core.series/polarPoint.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/polarPoint.tests.js
@@ -75,10 +75,10 @@ const environment = {
 
 function resetStub(stub) {
     $.each(stub, function(_, stubFunc) {
-        if (stubFunc) {
-            if (stubFunc.resetHistory) {
+        if(stubFunc) {
+            if(stubFunc.resetHistory) {
                 stubFunc.resetHistory();
-            } else if (stubFunc.reset) {
+            } else if(stubFunc.reset) {
                 stubFunc.reset();
             }
         }

--- a/testing/tests/DevExpress.viz.core.series/scatterSeries.tests.js
+++ b/testing/tests/DevExpress.viz.core.series/scatterSeries.tests.js
@@ -66,7 +66,7 @@ const mockPoints = [createPoint(), createPoint(), createPoint(), createPoint(), 
 function resetStub(stub) {
     $.each(stub, function(_, stubFunc) {
         if(stubFunc) {
-            if (stubFunc.resetHistory) {
+            if(stubFunc.resetHistory) {
                 stubFunc.resetHistory();
             } else if(stubFunc.reset) {
                 stubFunc.reset();

--- a/testing/tests/DevExpress.viz.gauges/barGauge.tests.js
+++ b/testing/tests/DevExpress.viz.gauges/barGauge.tests.js
@@ -582,7 +582,7 @@ QUnit.test('Connectors should be moved by turning if labels are not moved', func
         resolveLabelOverlapping: 'shift',
     });
     const group = this.getBarsGroup();
-    const line1 = group.children[2]
+    const line1 = group.children[2];
     const line2 = group.children[6];
     const text1 = group.children[3];
     const text2 = group.children[7];
@@ -607,7 +607,7 @@ QUnit.test('The connector should move without turning', function(assert) {
         resolveLabelOverlapping: 'shift',
     });
     const group = this.getBarsGroup();
-    const line1 = group.children[2]
+    const line1 = group.children[2];
     const line2 = group.children[6];
     const line3 = group.children[10];
     const text1 = group.children[3];
@@ -623,7 +623,7 @@ QUnit.test('The connector should move without turning', function(assert) {
         assert.deepEqual(line2.rotate.lastCall.args, [0], 'line 2 is shifted without rotation');
         assert.roughEqual(text2._stored_settings.x, 34, 1, 'text 2 is coord x');
         assert.roughEqual(text2._stored_settings.y, 222, 1, 'text 2 is coord y');
-        assert.deepEqual(line3._stored_settings.points, [130.8819, 197.5093, 4 , 22], 'line 3 coords');
+        assert.deepEqual(line3._stored_settings.points, [130.8819, 197.5093, 4, 22], 'line 3 coords');
         assert.deepEqual(line3.rotate.lastCall.args, [0], 'line 3 is shifted without rotation');
         assert.roughEqual(text3._stored_settings.x, 34, 1, 'text 3 is coord x');
         assert.roughEqual(text3._stored_settings.y, 222, 1, 'text 3 is coord y');
@@ -641,7 +641,7 @@ QUnit.test('Label location if the angle < 90, resolveLabelOverlapping - shift, w
         }
     });
     const group = this.getBarsGroup();
-    const line1 = group.children[2]
+    const line1 = group.children[2];
     const line2 = group.children[6];
     const line3 = group.children[10];
     const text1 = group.children[3];
@@ -669,7 +669,7 @@ QUnit.test('label location if the angle < 90, resolveLabelOverlapping - shift', 
         resolveLabelOverlapping: 'shift',
     });
     const group = this.getBarsGroup();
-    const line1 = group.children[2]
+    const line1 = group.children[2];
     const line2 = group.children[6];
     const line3 = group.children[10];
     const text1 = group.children[3];
@@ -729,7 +729,7 @@ QUnit.test('label location if the angle = 90, resolveLabelOverlapping - shift, w
         }
     });
     const group = this.getBarsGroup();
-    const line1 = group.children[2]
+    const line1 = group.children[2];
     const line2 = group.children[6];
     const line3 = group.children[10];
     const text1 = group.children[3];
@@ -757,7 +757,7 @@ QUnit.test('label location if the angle = 90, resolveLabelOverlapping - shift', 
         resolveLabelOverlapping: 'shift'
     });
     const group = this.getBarsGroup();
-    const line1 = group.children[2]
+    const line1 = group.children[2];
     const line2 = group.children[6];
     const line3 = group.children[10];
     const text1 = group.children[3];
@@ -788,7 +788,7 @@ QUnit.test('label location if the angle > 90, resolveLabelOverlapping - shift, w
         }
     });
     const group = this.getBarsGroup();
-    const line1 = group.children[2]
+    const line1 = group.children[2];
     const line2 = group.children[6];
     const line3 = group.children[10];
     const text1 = group.children[3];
@@ -816,7 +816,7 @@ QUnit.test('label location if the angle is > 90, resolveLabelOverlapping - shift
         resolveLabelOverlapping: 'shift'
     });
     const group = this.getBarsGroup();
-    const line1 = group.children[2]
+    const line1 = group.children[2];
     const line2 = group.children[6];
     const line3 = group.children[10];
     const text1 = group.children[3];

--- a/themebuilder-scss/.eslintrc.js
+++ b/themebuilder-scss/.eslintrc.js
@@ -41,4 +41,5 @@ module.exports = {
             }
         },
     ],
-}
+};
+


### PR DESCRIPTION
Return base rules for *.js files to root config to apply it to QUnit code too.
And fix eslint errors by the ```-fix``` option in the second commit.