### PR TITLE
Сore: Replace "new Function" by JSON.parse

### DIFF
--- a/js/core/config.js
+++ b/js/core/config.js
@@ -44,13 +44,24 @@ const config = {
         if(optionsString.trim().charAt(0) !== '{') {
             optionsString = '{' + optionsString + '}';
         }
+
         try {
-            // eslint-disable-next-line no-new-func
-            return (new Function('return ' + optionsString))();
+            return JSON.parse(optionsString);
         } catch(ex) {
-            throw errors.Error('E3018', ex, optionsString);
+            try {
+                return JSON.parse(normalizeToJSONString(optionsString));
+            } catch(exNormalize) {
+                throw errors.Error('E3018', ex, optionsString);
+            }
         }
-    }
+    },
+};
+
+const normalizeToJSONString = (optionsString) => {
+    return optionsString
+        .replace(/'/g, '"') // replace all ' to "
+        .replace(/,\s*([\]}])/g, '$1') // remove trailing commas
+        .replace(/([{,])\s*([^":\s]+)\s*:/g, '$1"$2":'); // add quotes for unquoted keys
 };
 
 const deprecatedFields = [ 'decimalSeparator', 'thousandsSeparator' ];

--- a/testing/tests/DevExpress.core/config.tests.js
+++ b/testing/tests/DevExpress.core/config.tests.js
@@ -88,3 +88,39 @@ QUnit.test('deprecated fields', function(assert) {
         errors.log = originalLog;
     }
 });
+
+QUnit.test('DevExpress.config.optionsParser works correct', function(assert) {
+    const optionsParser = DevExpress.config().optionsParser;
+
+    const testData = [
+        [
+            'dxTemplate: { "name": "title" }',
+            { 'dxTemplate': { 'name': 'title' } },
+        ],
+        [
+            `'dxTemplate': {
+               name: "title",
+               test: {
+                arr: ['a1', 'a2'],
+               },
+              }`,
+            { 'dxTemplate': { 'name': 'title', test: { arr: ['a1', 'a2'] } } },
+        ],
+        [
+            '"dxTemplate": { "name": "title" }',
+            { 'dxTemplate': { 'name': 'title' } }
+        ],
+        [
+            `{
+              "dxTemplate": {
+                "name": "title"
+               }
+              }`,
+            { 'dxTemplate': { 'name': 'title' } }
+        ]
+    ];
+
+    testData.forEach(([optionsString, etalon]) => {
+        assert.deepEqual(optionsParser(optionsString), etalon);
+    });
+});

--- a/testing/tests/DevExpress.core/config.tests.js
+++ b/testing/tests/DevExpress.core/config.tests.js
@@ -100,11 +100,13 @@ QUnit.test('DevExpress.config.optionsParser works correct', function(assert) {
         [
             `'dxTemplate': {
                name: "title",
+               max-count: 123,
+               isOpen: true,
                test: {
-                arr: ['a1', 'a2'],
+                arr: ['a1', 'a2', true, 123],
                },
               }`,
-            { 'dxTemplate': { 'name': 'title', test: { arr: ['a1', 'a2'] } } },
+            { 'dxTemplate': { name: 'title', 'max-count': 123, isOpen: true, test: { arr: ['a1', 'a2', true, 123] } } },
         ],
         [
             '"dxTemplate": { "name": "title" }',


### PR DESCRIPTION
Replace "new Function" by JSON.parse for CSP restrictions script-src=unsafe-eval