### PR TITLE
Sortable(T1158698): Drop indicator line is not visible on an attempt to drop an item to the very bottom on Chrome

### DIFF
--- a/js/ui/sortable.js
+++ b/js/ui/sortable.js
@@ -811,7 +811,13 @@ const Sortable = Draggable.inherit({
         }
 
         if(position) {
+            const isLastVerticalPosition = isVerticalOrientation && toIndex === items.length;
+            const outerPlaceholderHeight = getOuterHeight($placeholderElement);
+
             position.left = that._makeLeftCorrection(position.left);
+            position.top = isLastVerticalPosition && position.top >= outerPlaceholderHeight
+                ? position.top - outerPlaceholderHeight
+                : position.top;
 
             that._move(position, $placeholderElement);
         }
@@ -936,7 +942,7 @@ const Sortable = Draggable.inherit({
         this._getAction('onReorder')(args);
 
         return args.promise || (new Deferred()).resolve();
-    }
+    },
 });
 
 registerComponent(SORTABLE, Sortable);

--- a/testing/testcafe/tests/dataGrid/rowDragging.ts
+++ b/testing/testcafe/tests/dataGrid/rowDragging.ts
@@ -551,13 +551,18 @@ test('The placeholder should have correct position after dragging the row to the
   await dataGrid.moveRow(0, 0, 50, true);
   await dataGrid.moveRow(0, 0, 550);
 
-  await t.expect(isPlaceholderVisible()).ok();
-
   const freeSpaceRowOffset = await getFreeSpaceRowOffset();
+  const placeholderOffset = await getPlaceholderOffset();
 
-  await t
-    .expect(getPlaceholderOffset())
-    .eql(freeSpaceRowOffset);
+  const expectedPlaceholderOffset = freeSpaceRowOffset
+    ? {
+      ...freeSpaceRowOffset,
+      top: freeSpaceRowOffset.top - 2,
+    }
+    : undefined;
+
+  await t.expect(isPlaceholderVisible()).ok();
+  await t.expect(placeholderOffset).eql(expectedPlaceholderOffset);
 }).before(async (t) => {
   await t.maximizeWindow();
   return createWidget('dxDataGrid', {

--- a/testing/tests/DevExpress.ui.widgets/sortable.tests.js
+++ b/testing/tests/DevExpress.ui.widgets/sortable.tests.js
@@ -967,7 +967,7 @@ QUnit.module('placeholder and source', moduleConfig, () => {
         // assert
         $placeholderElement = $('.dx-sortable-placeholder');
         assert.ok($placeholderElement.is(':visible'), 'placeholder is visible');
-        assert.strictEqual($placeholderElement.offset().top, 60, 'placeholder position top');
+        assert.strictEqual($placeholderElement.offset().top, 58, 'placeholder position top');
         assert.strictEqual(onDragChangeSpy.getCall(0).args[0].toIndex, 2, 'toIndex');
     });
 
@@ -1018,7 +1018,7 @@ QUnit.module('placeholder and source', moduleConfig, () => {
         // assert
         const $placeholderElement = $('.dx-sortable-placeholder');
         assert.ok($placeholderElement.is(':visible'), 'placeholder is visible');
-        assert.strictEqual($placeholderElement.offset().top, 60, 'placeholder position top');
+        assert.strictEqual($placeholderElement.offset().top, 58, 'placeholder position top');
         assert.strictEqual(onDragChangeSpy.getCall(0).args[0].toIndex, 2, 'toIndex');
     });
 


### PR DESCRIPTION
See ticket: [T1158698](https://supportcenter.devexpress.com/ticket/details/t1158698/sortable-drop-indicator-line-is-not-visible-on-an-attempt-to-drop-an-item-to-the-very)