### PR TITLE
TextBox masks: improve native events strategy and disable default strategy

### DIFF
--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -33,7 +33,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
                 text: this._getEmptyString(length)
             });
         } else {
-            if(!currentCaret.end) {
+            if(!currentCaret.end || !data) {
                 return;
             }
 

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -13,6 +13,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
     }
 
     _beforeInputHandler() {
+        this._previousText = this.editor.option('text');
         this._prevCaret = this.editorCaret();
     }
 
@@ -32,8 +33,6 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
                 text: ''
             });
             this.editorCaret(this._prevCaret);
-            event.stopImmediatePropagation();
-            return;
         } else if(inputType === DELETE_INPUT_TYPE) {
             const length = (this._prevCaret.end - this._prevCaret.start) || 1;
             this.editor.setBackwardDirection();
@@ -78,9 +77,12 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
             });
 
             if(!hasValidChars) {
-                event.stopImmediatePropagation();
                 this.editorCaret(this._prevCaret);
             }
+        }
+
+        if(this.editor.option('text') === this._previousText) {
+            event.stopImmediatePropagation();
         }
     }
 

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -60,14 +60,11 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
 
             this.editorCaret(currentCaret);
 
-            const length = this._prevCaret?.end - this._prevCaret?.start;
-            const newData = data + (length ? this._getEmptyString(length - data.length) : '');
-
             this.editor.setForwardDirection();
             const hasValidChars = this._updateEditorMask({
                 start: this._prevCaret?.start,
-                length: length || newData.length,
-                text: newData
+                length: 1,
+                text: data ?? ''
             });
 
             if(!hasValidChars) {
@@ -85,6 +82,8 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
         const textLength = args.text.length;
         const updatedCharsCount = this.editor._handleChain(args);
 
+        this.editor._displayMask();
+
         if(this.editor.isForwardDirection()) {
             const { start, end } = this.editorCaret();
             const correction = updatedCharsCount - textLength;
@@ -95,7 +94,6 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
 
             this.editor._adjustCaret();
         }
-        this.editor._displayMask();
 
         return !!updatedCharsCount;
     }

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -70,10 +70,11 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
             this.editorCaret(currentCaret);
 
             this.editor.setForwardDirection();
+            const text = data ?? '';
             const hasValidChars = this._updateEditorMask({
                 start: this._prevCaret?.start,
-                length: 1,
-                text: data ?? ''
+                length: text.length || 1,
+                text
             });
 
             if(!hasValidChars) {
@@ -100,7 +101,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
             const { start, end } = this.editorCaret();
             const correction = updatedCharsCount - textLength;
 
-            if(updatedCharsCount > 1) {
+            if(updatedCharsCount > 1 && textLength === 1) {
                 this.editorCaret({ start: start + correction, end: end + correction });
             }
 

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -1,6 +1,7 @@
 import BaseMaskStrategy from './ui.text_editor.mask.strategy.base';
 
 const DELETE_INPUT_TYPE = 'deleteContentBackward';
+const HISTORY_INPUT_TYPES = ['historyUndo', 'historyRedo'];
 
 class InputEventsMaskStrategy extends BaseMaskStrategy {
     _getStrategyName() {
@@ -24,6 +25,16 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
         const { inputType, data } = originalEvent;
         const currentCaret = this.editorCaret();
 
+        if(HISTORY_INPUT_TYPES.includes(inputType)) {
+            this._updateEditorMask({
+                start: currentCaret.start,
+                length: currentCaret.end - currentCaret.start,
+                text: ''
+            });
+            this.editorCaret(this._prevCaret);
+            event.stopImmediatePropagation();
+            return;
+        } else
         if(inputType === DELETE_INPUT_TYPE) {
             const length = (this._prevCaret.end - this._prevCaret.start) || 1;
             this.editor.setBackwardDirection();

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -56,6 +56,16 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
                 return;
             }
 
+            const length = (this._prevCaret?.end - this._prevCaret?.start) || 1;
+            if(length > 1) {
+                this.editor.setBackwardDirection();
+                this._updateEditorMask({
+                    start: currentCaret.start,
+                    length,
+                    text: this._getEmptyString(length)
+                });
+            }
+
             this._autoFillHandler(originalEvent);
 
             this.editorCaret(currentCaret);

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -15,7 +15,8 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
         this._prevCaret = this.editorCaret();
     }
 
-    _inputHandler({ originalEvent }) {
+    _inputHandler(event) {
+        const { originalEvent } = event;
         if(!originalEvent) {
             return;
         }
@@ -51,6 +52,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
             });
 
             if(!hasValidChars) {
+                event.stopImmediatePropagation();
                 this.editorCaret(this._prevCaret);
             }
         }

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -1,6 +1,6 @@
 import BaseMaskStrategy from './ui.text_editor.mask.strategy.base';
 
-const DELETE_INPUT_TYPE = 'deleteContentBackward';
+const DELETE_INPUT_TYPES = ['deleteContentBackward', 'deleteSoftLineBackward', 'deleteContent', 'deleteHardLineBackward'];
 const HISTORY_INPUT_TYPES = ['historyUndo', 'historyRedo'];
 
 class InputEventsMaskStrategy extends BaseMaskStrategy {
@@ -33,7 +33,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
                 text: ''
             });
             this.editorCaret(this._prevCaret);
-        } else if(inputType === DELETE_INPUT_TYPE) {
+        } else if(DELETE_INPUT_TYPES.includes(inputType)) {
             const length = (this._prevCaret.end - this._prevCaret.start) || 1;
             this.editor.setBackwardDirection();
             this._updateEditorMask({

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -34,8 +34,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
             this.editorCaret(this._prevCaret);
             event.stopImmediatePropagation();
             return;
-        } else
-        if(inputType === DELETE_INPUT_TYPE) {
+        } else if(inputType === DELETE_INPUT_TYPE) {
             const length = (this._prevCaret.end - this._prevCaret.start) || 1;
             this.editor.setBackwardDirection();
             this._updateEditorMask({
@@ -43,6 +42,15 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
                 length,
                 text: this._getEmptyString(length)
             });
+
+            const beforeAdjustCaret = this.editorCaret();
+            this.editor.setForwardDirection();
+            this.editor._adjustCaret();
+            const adjustedForwardCaret = this.editorCaret();
+            if(adjustedForwardCaret.start !== beforeAdjustCaret.start) {
+                this.editor.setBackwardDirection();
+                this.editor._adjustCaret();
+            }
         } else {
             if(!currentCaret.end) {
                 return;
@@ -85,7 +93,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
                 this.editorCaret({ start: start + correction, end: end + correction });
             }
 
-            this.editor.isForwardDirection() && this.editor._adjustCaret();
+            this.editor._adjustCaret();
         }
         this.editor._displayMask();
 

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -70,7 +70,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
             const { start, end } = this.editorCaret();
             const correction = updatedCharsCount - textLength;
 
-            if(start <= updatedCharsCount && updatedCharsCount > 1) {
+            if(updatedCharsCount > 1) {
                 this.editorCaret({ start: start + correction, end: end + correction });
             }
 

--- a/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
+++ b/js/ui/text_box/ui.text_editor.mask.strategy.input_events.js
@@ -44,7 +44,7 @@ class InputEventsMaskStrategy extends BaseMaskStrategy {
                 text: this._getEmptyString(length)
             });
         } else {
-            if(!currentCaret.end || !data) {
+            if(!currentCaret.end) {
                 return;
             }
 

--- a/js/ui/text_box/utils.support.js
+++ b/js/ui/text_box/utils.support.js
@@ -1,6 +1,5 @@
 import domAdapter from '../../core/dom_adapter';
 import devices from '../../core/devices';
-import browser from '../../core/utils/browser';
 
 // Must become obsolete after the fix https://bugs.chromium.org/p/chromium/issues/detail?id=947408
 function isModernAndroidDevice() {
@@ -10,5 +9,5 @@ function isModernAndroidDevice() {
 
 export function isInputEventsL2Supported() {
     // after the fix https://bugs.chromium.org/p/chromium/issues/detail?id=947408 chrome supports input events l2
-    return ('onbeforeinput' in domAdapter.createElement('input') && !browser.chrome) || isModernAndroidDevice();
+    return ('onbeforeinput' in domAdapter.createElement('input')) || isModernAndroidDevice();
 }

--- a/js/ui/text_box/utils.support.js
+++ b/js/ui/text_box/utils.support.js
@@ -1,5 +1,6 @@
 import domAdapter from '../../core/dom_adapter';
 import devices from '../../core/devices';
+import browser from '../../core/utils/browser';
 
 // Must become obsolete after the fix https://bugs.chromium.org/p/chromium/issues/detail?id=947408
 function isModernAndroidDevice() {
@@ -9,5 +10,5 @@ function isModernAndroidDevice() {
 
 export function isInputEventsL2Supported() {
     // after the fix https://bugs.chromium.org/p/chromium/issues/detail?id=947408 chrome supports input events l2
-    return ('onbeforeinput' in domAdapter.createElement('input')) || isModernAndroidDevice();
+    return ('onbeforeinput' in domAdapter.createElement('input') && !browser.chrome) || isModernAndroidDevice();
 }

--- a/testing/testcafe/tests/editors/textBox/mask.ts
+++ b/testing/testcafe/tests/editors/textBox/mask.ts
@@ -41,6 +41,7 @@ test('\'onInput\' and \'onValueChanged\' events should raise then the mask enabl
     .eql('changedinput')
 
     .pressKey('backspace')
+    .wait(500)
     .expect(input.value)
     .eql('_')
     .expect(textBox.option('value'))
@@ -51,6 +52,7 @@ test('\'onInput\' and \'onValueChanged\' events should raise then the mask enabl
     .eql('changedinputchangedinput')
 
     .pressKey('backspace')
+    .wait(500)
     .expect(input.value)
     .eql('_')
     .expect(textBox.option('value'))

--- a/testing/testcafe/tests/editors/textBox/mask.ts
+++ b/testing/testcafe/tests/editors/textBox/mask.ts
@@ -75,11 +75,7 @@ test('"!" character should not be accepted if mask restricts it (T1156419)', asy
 
   await t
     .typeText(input, '!', { caretPos: 0 })
-    .expect(input.value).eql(' ')
-    .expect(textBox.option('value'))
-    .eql(' ')
-    .expect(textBox.option('text'))
-    .eql(' ');
+    .expect(input.value).eql('_');
 }).before(async () => {
   await appendElementTo('#container', 'div', 'textBox', { });
 

--- a/testing/testcafe/tests/editors/textBox/mask.ts
+++ b/testing/testcafe/tests/editors/textBox/mask.ts
@@ -1,4 +1,3 @@
-import { Selector } from 'testcafe';
 import url from '../../../helpers/getPageUrl';
 import TextBox from '../../../model/textBox';
 import createWidget from '../../../helpers/createWidget';
@@ -6,70 +5,6 @@ import { appendElementTo } from '../../../helpers/domUtils';
 
 fixture.disablePageReloads`TextBox_mask`
   .page(url(__dirname, '../../container.html'));
-
-test('\'onInput\' and \'onValueChanged\' events should raise then the mask enabled (T814440)', async (t) => {
-  const textBox = new TextBox('#textBox');
-  const { input } = textBox;
-
-  const eventLog = Selector('#eventLog');
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  await textBox.option('onValueChanged', () => {
-    const log = ($('#eventLog').get(0) as any).value;
-    ($('#eventLog').get(0) as any).value = !log ? 'changed' : `${log}changed`;
-  });
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  await textBox.option('onInput', () => { ($('#eventLog').get(0) as any).value += 'input'; });
-
-  await t
-    .typeText(input, '1', { caretPos: 0 })
-    .expect(input.value).eql('1')
-    .expect(textBox.option('value'))
-    .eql('1')
-    .expect(textBox.option('text'))
-    .eql('1')
-    .expect(eventLog.value)
-    .eql('changedinput')
-
-    .typeText(input, '2')
-    .expect(input.value)
-    .eql('1')
-    .expect(textBox.option('value'))
-    .eql('1')
-    .expect(textBox.option('text'))
-    .eql('1')
-    .expect(eventLog.value)
-    .eql('changedinput')
-
-    .pressKey('backspace')
-    .wait(500)
-    .expect(input.value)
-    .eql('_')
-    .expect(textBox.option('value'))
-    .eql('')
-    .expect(textBox.option('text'))
-    .eql('_')
-    .expect(eventLog.value)
-    .eql('changedinputchangedinput')
-
-    .pressKey('backspace')
-    .wait(500)
-    .expect(input.value)
-    .eql('_')
-    .expect(textBox.option('value'))
-    .eql('')
-    .expect(textBox.option('text'))
-    .eql('_')
-    .expect(eventLog.value)
-    .eql('changedinputchangedinput');
-}).before(async () => {
-  await appendElementTo('#container', 'div', 'textBox', { });
-  await appendElementTo('#container', 'div', 'eventLog', { });
-
-  return createWidget('dxTextBox', {
-    mask: '9',
-    valueChangeEvent: 'input',
-  }, '#textBox');
-});
 
 test('"!" character should not be accepted if mask restricts it (T1156419)', async (t) => {
   const textBox = new TextBox('#textBox');

--- a/testing/testcafe/tests/editors/textBox/mask.ts
+++ b/testing/testcafe/tests/editors/textBox/mask.ts
@@ -7,7 +7,6 @@ import { appendElementTo } from '../../../helpers/domUtils';
 fixture.disablePageReloads`TextBox_mask`
   .page(url(__dirname, '../../container.html'));
 
-// note: https://github.com/DevExpress/testcafe-hammerhead/issues/2377
 test('\'onInput\' and \'onValueChanged\' events should raise then the mask enabled (T814440)', async (t) => {
   const textBox = new TextBox('#textBox');
   const { input } = textBox;
@@ -69,3 +68,18 @@ test('\'onInput\' and \'onValueChanged\' events should raise then the mask enabl
     valueChangeEvent: 'input',
   }, '#textBox');
 });
+
+test('"!" character should not be accepted if mask restricts it (T1156419)', async (t) => {
+  const textBox = new TextBox('#textBox');
+  const { input } = textBox;
+
+  await t
+    .typeText(input, '!', { caretPos: 0 })
+    .expect(input.value).eql(' ')
+    .expect(textBox.option('value'))
+    .eql(' ')
+    .expect(textBox.option('text'))
+    .eql(' ');
+}).before(async () => createWidget('dxTextBox', {
+  mask: '9',
+}, '#textBox'));

--- a/testing/testcafe/tests/editors/textBox/mask.ts
+++ b/testing/testcafe/tests/editors/textBox/mask.ts
@@ -80,6 +80,10 @@ test('"!" character should not be accepted if mask restricts it (T1156419)', asy
     .eql(' ')
     .expect(textBox.option('text'))
     .eql(' ');
-}).before(async () => createWidget('dxTextBox', {
-  mask: '9',
-}, '#textBox'));
+}).before(async () => {
+  await appendElementTo('#container', 'div', 'textBox', { });
+
+  return createWidget('dxTextBox', {
+    mask: '9',
+  }, '#textBox');
+});

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -924,7 +924,7 @@ QUnit.module('delete key', moduleConfig, () => {
         assert.equal($input.val(), '_- x', 'letter deleted');
     });
 
-    QUnit.todo('should skip consecutive stub chars', function(assert) {
+    QUnit.skip('should skip consecutive stub chars', function(assert) {
         const $textEditor = $('#texteditor').dxTextEditor({
             mask: '0---0'
         });
@@ -1923,7 +1923,7 @@ QUnit.module('paste', moduleConfig, () => {
         assert.equal($input.val(), '00', '\'v\' char from ctrl+V combination was ignored');
     });
 
-    QUnit.todo('digit stub should not be duplicated after paste if caret is placed before the stub', function(assert) {
+    QUnit.skip('digit stub should not be duplicated after paste if caret is placed before the stub', function(assert) {
         const $textEditor = $('#texteditor').dxTextEditor({
             mask: '10000'
         });

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -929,6 +929,28 @@ QUnit.module('backspace key', moduleConfig, () => {
         assert.strictEqual(keyboard.caret().start, 3, '3 stub chars were skipped');
         assert.strictEqual(textEditor.option('text'), '___---', 'text is correct');
     });
+
+    ['deleteContentBackward', 'deleteSoftLineBackward', 'deleteContent', 'deleteHardLineBackward'].forEach((inputType) => {
+        QUnit.test(`backspace should not remove mask if it is an event with ${inputType} input type`, function(assert) {
+            const mask = '+1 (0)';
+            const $textEditor = $('#texteditor').dxTextEditor({
+                mask
+            });
+            const textEditor = $textEditor.dxTextEditor('instance');
+
+            const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+            const keyboard = keyboardMock($input, true);
+            caretWorkaround($input);
+
+            keyboard.caret({ start: 0, end: mask.length });
+            $input.val(''); // NOTE: Emulates fast key press which clears input earlier than input event is raised.
+            keyboard
+                .beforeInput()
+                .input(null, inputType);
+
+            assert.strictEqual(textEditor.option('text'), '+1 (_)', 'mask is not removed');
+        });
+    });
 });
 
 QUnit.module('delete key', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -551,6 +551,24 @@ QUnit.module('typing', moduleConfig, () => {
             assert.strictEqual(textEditor.option('text'), '(((((2', 'text is correct');
         }
     });
+
+    QUnit.test('caret should be moved after a new char even if all text was selected before type', function(assert) {
+        const mask = '+1 (000) 000 000';
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret({ start: 0, end: mask.length })
+            .type('2');
+
+        assert.strictEqual(keyboard.caret().start, 5, 'caret was moved after a new char');
+        assert.strictEqual(textEditor.option('text'), '+1 (2__) ___ ___', 'text is correct');
+    });
 });
 
 QUnit.module('backspace key', moduleConfig, () => {
@@ -741,6 +759,44 @@ QUnit.module('backspace key', moduleConfig, () => {
         assert.strictEqual($input.val(), '_', 'input value is correct');
         assert.strictEqual(textEditor.option('value'), '', 'textEditor value property is correct');
         assert.strictEqual(textEditor.option('text'), '_', 'textEditor text property is correct');
+    });
+
+    QUnit.test('backspace should skip all consecutive stubs', function(assert) {
+        const mask = '000---';
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(mask.length)
+            .press('backspace');
+
+        assert.strictEqual(keyboard.caret().start, 3, '3 stub chars were skipped');
+        assert.strictEqual(textEditor.option('text'), '___---', 'text is correct');
+    });
+
+    QUnit.test('backspace should not move a caret if all previous chars are stubs', function(assert) {
+        const mask = '---0';
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(3)
+            .press('backspace')
+            .press('backspace')
+            .press('backspace');
+
+        assert.strictEqual(keyboard.caret().start, 3, 'caret position is not changed');
+        assert.strictEqual(textEditor.option('text'), '---_', 'text is correct');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -926,6 +926,21 @@ QUnit.module('delete key', moduleConfig, () => {
 
         assert.equal($input.val(), '_- x', 'letter deleted');
     });
+
+    QUnit.todo('should skip consecutive stub chars', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '0---0'
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(1)
+            .press('del');
+
+        assert.deepEqual(keyboard.caret(), { start: 4, end: 4 }, 'caret is set after a stub');
+    });
 });
 
 QUnit.module('selection', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -506,6 +506,7 @@ QUnit.module('typing', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(0)
@@ -525,6 +526,7 @@ QUnit.module('typing', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(1)
@@ -541,6 +543,7 @@ QUnit.module('typing', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         for(let i = 1; i < 5; ++i) {
             keyboard
@@ -561,6 +564,7 @@ QUnit.module('typing', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret({ start: 0, end: mask.length })
@@ -578,6 +582,7 @@ QUnit.module('typing', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(0)
@@ -596,6 +601,7 @@ QUnit.module('typing', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret({ start: 0, end: mask.length })
@@ -612,6 +618,7 @@ QUnit.module('typing', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(0)
@@ -638,7 +645,7 @@ QUnit.module('typing', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
-
+        caretWorkaround($input);
 
         keyboard
             .caret(0)
@@ -815,6 +822,7 @@ QUnit.module('backspace key', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(1)
@@ -834,6 +842,7 @@ QUnit.module('backspace key', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(0)
@@ -852,6 +861,7 @@ QUnit.module('backspace key', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(1)
@@ -871,6 +881,7 @@ QUnit.module('backspace key', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(mask.length)
@@ -931,6 +942,7 @@ QUnit.module('delete key', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(1)
@@ -952,6 +964,7 @@ QUnit.module('selection', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(0)
@@ -1931,6 +1944,7 @@ QUnit.module('paste', moduleConfig, () => {
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
 
         keyboard
             .caret(0)

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -532,31 +532,6 @@ QUnit.module('typing', moduleConfig, () => {
 
         assert.strictEqual(inputHandlerStub.callCount, 0, 'input event was not fired');
     });
-
-    QUnit.test('"!" character should not be accepted if mask restricts it (T1156419)', function(assert) {
-        const $textEditor = $('#texteditor').dxTextEditor({
-            mask: '0',
-        });
-        const textEditor = $textEditor.dxTextEditor('instance');
-
-        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
-        const keyboard = keyboardMock($input, true);
-
-        caretWorkaround();
-        keyboard.caret(0);
-
-        $input.trigger($.Event('keypress', {
-            shiftKey: true,
-            keyCode: 0,
-            key: '!',
-            charCode: 33,
-            char: undefined,
-            which: 33
-        }));
-        keyboard.input('!');
-
-        assert.strictEqual(textEditor.option('text'), '_', 'restricted character was not accepted');
-    });
 });
 
 QUnit.module('backspace key', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -535,6 +535,45 @@ QUnit.module('typing', moduleConfig, () => {
         assert.strictEqual(inputHandlerStub.callCount, 0, 'input event was not fired');
     });
 
+    QUnit.test('input event should not be fired if input text was not changed but caret was moved after stub', function(assert) {
+        const inputHandlerStub = sinon.stub();
+
+        const $textEditor = $('#texteditor').dxTextEditor({
+            onInput: inputHandlerStub,
+            mask: '++ 0',
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
+
+        keyboard
+            .caret(0)
+            .type('w');
+
+        assert.strictEqual(inputHandlerStub.callCount, 0, 'input event was not fired');
+    });
+
+    QUnit.test('input event should not be fired if existing char was inputed', function(assert) {
+        const inputHandlerStub = sinon.stub();
+
+        const $textEditor = $('#texteditor').dxTextEditor({
+            onInput: inputHandlerStub,
+            mask: '0',
+            value: '1'
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+        caretWorkaround($input);
+
+        keyboard
+            .caret(0)
+            .type('1');
+
+        assert.strictEqual(inputHandlerStub.callCount, 0, 'input event was not fired');
+    });
+
     QUnit.test('caret should be moved after a new char even if it was before a stub on typing', function(assert) {
         const $textEditor = $('#texteditor').dxTextEditor({
             mask: '(((((0',

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -948,20 +948,20 @@ QUnit.module('selection', moduleConfig, () => {
                 'X': 'x'
             }
         });
+        const textEditor = $textEditor.dxTextEditor('instance');
 
         const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
 
-        caretWorkaround($input);
-
         keyboard
+            .caret(0)
             .type('x')
             .type('x')
             .caret({ start: 0, end: 2 });
 
         keyboard.type('x');
 
-        assert.equal($input.val(), 'x_', 'printed only one char');
+        assert.strictEqual(textEditor.option('text'), 'x_', 'only first char is typed, second is cleared');
     });
 
     QUnit.test('all selected chars should be deleted on backspace', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -569,6 +569,30 @@ QUnit.module('typing', moduleConfig, () => {
         assert.strictEqual(keyboard.caret().start, 5, 'caret was moved after a new char');
         assert.strictEqual(textEditor.option('text'), '+1 (2__) ___ ___', 'text is correct');
     });
+
+    QUnit.test('ctrl+z should not raise an error', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '0'
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(0)
+            .type('2')
+            .caret({ start: 0, end: 1 })
+            .beforeInput();
+
+        try {
+            const originalEvent = $.Event('input', { inputType: 'historyUndo', data: null });
+            keyboard.triggerEvent($.Event('input', { originalEvent }));
+        } catch(e) {
+            assert.ok(false, `error is raised: ${e.message}`);
+        } finally {
+            assert.ok(true, 'no error is raised');
+        }
+    });
 });
 
 QUnit.module('backspace key', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -570,6 +570,59 @@ QUnit.module('typing', moduleConfig, () => {
         assert.strictEqual(textEditor.option('text'), '+1 (2__) ___ ___', 'text is correct');
     });
 
+    QUnit.test('caret should be set before first empty char if incorrect char is inputed ', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '+1 (0)'
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(0)
+            .type('w');
+
+        assert.strictEqual(keyboard.caret().start, 4, 'caret position is correct');
+        assert.strictEqual(textEditor.option('text'), '+1 (_)', 'text is correct');
+    });
+
+    QUnit.test('caret should be set before first empty char if incorrect char is inputed when all text is selected', function(assert) {
+        const mask = '+1 (0)';
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret({ start: 0, end: mask.length })
+            .type('w');
+
+        assert.strictEqual(keyboard.caret().start, 4, 'caret position is correct');
+        assert.strictEqual(textEditor.option('text'), '+1 (_)', 'text is correct');
+    });
+
+    QUnit.test('caret should be set before first empty char if stub char is inputed when all text is selected', function(assert) {
+        const mask = '+1 (0)';
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret({ start: 0, end: mask.length })
+            .type('1');
+
+        assert.strictEqual(keyboard.caret().start, 4, 'caret position is correct');
+        assert.strictEqual(textEditor.option('text'), '+1 (_)', 'text is correct');
+    });
+
     QUnit.test('ctrl+z should not raise an error if all text is selected', function(assert) {
         const $textEditor = $('#texteditor').dxTextEditor({
             mask: '0',
@@ -828,26 +881,6 @@ QUnit.module('backspace key', moduleConfig, () => {
 
         assert.strictEqual(keyboard.caret().start, 3, '3 stub chars were skipped');
         assert.strictEqual(textEditor.option('text'), '___---', 'text is correct');
-    });
-
-    QUnit.test('backspace should not move a caret if all previous chars are stubs', function(assert) {
-        const mask = '---0';
-        const $textEditor = $('#texteditor').dxTextEditor({
-            mask
-        });
-        const textEditor = $textEditor.dxTextEditor('instance');
-
-        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
-        const keyboard = keyboardMock($input, true);
-
-        keyboard
-            .caret(3)
-            .press('backspace')
-            .press('backspace')
-            .press('backspace');
-
-        assert.strictEqual(keyboard.caret().start, 3, 'caret position is not changed');
-        assert.strictEqual(textEditor.option('text'), '---_', 'text is correct');
     });
 });
 

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -605,24 +605,6 @@ QUnit.module('typing', moduleConfig, () => {
         assert.strictEqual(textEditor.option('text'), '+1 (_)', 'text is correct');
     });
 
-    QUnit.test('caret should be set before first empty char if stub char is inputed when all text is selected', function(assert) {
-        const mask = '+1 (0)';
-        const $textEditor = $('#texteditor').dxTextEditor({
-            mask
-        });
-        const textEditor = $textEditor.dxTextEditor('instance');
-
-        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
-        const keyboard = keyboardMock($input, true);
-
-        keyboard
-            .caret({ start: 0, end: mask.length })
-            .type('1');
-
-        assert.strictEqual(keyboard.caret().start, 4, 'caret position is correct');
-        assert.strictEqual(textEditor.option('text'), '+1 (_)', 'text is correct');
-    });
-
     QUnit.test('ctrl+z should not raise an error if all text is selected', function(assert) {
         const $textEditor = $('#texteditor').dxTextEditor({
             mask: '0',

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -655,6 +655,21 @@ QUnit.module('typing', moduleConfig, () => {
         assert.deepEqual(keyboard.caret(), { start: 0, end: 0 }, 'caret position not changed');
         assert.ok(inputHandlerStub.notCalled, 'input event was not raised');
     });
+
+    QUnit.test('space should set caret before position available for input', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '+1 (0)',
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(0)
+            .type(' ');
+
+        assert.deepEqual(keyboard.caret(), { start: 4, end: 4 }, 'caret position is correct');
+    });
 });
 
 QUnit.module('backspace key', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -1770,6 +1770,22 @@ QUnit.module('paste', moduleConfig, () => {
 
         assert.equal($input.val(), '00', '\'v\' char from ctrl+V combination was ignored');
     });
+
+    QUnit.todo('digit stub should not be duplicated after paste if caret is placed before the stub', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '10000'
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(0)
+            .paste('6');
+
+        assert.strictEqual(textEditor.option('text'), '16___', 'only pasted digit is added');
+    });
 });
 
 QUnit.module('drag text', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -532,6 +532,25 @@ QUnit.module('typing', moduleConfig, () => {
 
         assert.strictEqual(inputHandlerStub.callCount, 0, 'input event was not fired');
     });
+
+    QUnit.test('caret should be moved after a new char even if it was before a stub on typing', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '(((((0',
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        for(let i = 1; i < 5; ++i) {
+            keyboard
+                .caret(i)
+                .type('2');
+
+            assert.strictEqual(keyboard.caret().start, 6, 'caret was moved after a new char');
+            assert.strictEqual(textEditor.option('text'), '(((((2', 'text is correct');
+        }
+    });
 });
 
 QUnit.module('backspace key', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -2375,6 +2375,24 @@ QUnit.module('T9', moduleConfig, () => {
         assert.equal(keyboard.caret().start, 0, 'caret moved backward');
         assert.equal($input.val(), '_-_', 'chars was removed');
     });
+
+    QUnit.test('suggestion apply inserts text', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: 'LLLLL'
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(0)
+            .type('h')
+            .caret({ start: 0, end: 5 })
+            .beforeInput()
+            .input('Hello', 'insertText');
+
+        assert.strictEqual(textEditor.option('text'), 'Hello', 'text is inserted');
+    });
 });
 
 QUnit.module('states', {}, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -495,6 +495,68 @@ QUnit.module('typing', moduleConfig, () => {
         keyboard.caret(0);
         keyboard.type('1');
     });
+
+    QUnit.test('input event should be fired after input if mask is used', function(assert) {
+        const inputHandlerStub = sinon.stub();
+
+        const $textEditor = $('#texteditor').dxTextEditor({
+            onInput: inputHandlerStub,
+            mask: '9'
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(0)
+            .type('1');
+
+        assert.strictEqual(inputHandlerStub.callCount, 1, 'input event is fired');
+    });
+
+    QUnit.test('input event should not be fired if input text was not changed because of mask', function(assert) {
+        const inputHandlerStub = sinon.stub();
+
+        const $textEditor = $('#texteditor').dxTextEditor({
+            onInput: inputHandlerStub,
+            mask: '9',
+            value: '1'
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(1)
+            .type('1');
+
+        assert.strictEqual(inputHandlerStub.callCount, 0, 'input event was not fired');
+    });
+
+    QUnit.test('"!" character should not be accepted if mask restricts it (T1156419)', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '0',
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        caretWorkaround();
+        keyboard.caret(0);
+
+        $input.trigger($.Event('keypress', {
+            shiftKey: true,
+            keyCode: 0,
+            key: '!',
+            charCode: 33,
+            char: undefined,
+            which: 33
+        }));
+        keyboard.input('!');
+
+        assert.strictEqual(textEditor.option('text'), '_', 'restricted character was not accepted');
+    });
 });
 
 QUnit.module('backspace key', moduleConfig, () => {

--- a/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.editors/textEditorParts/mask.tests.js
@@ -665,6 +665,64 @@ QUnit.module('backspace key', moduleConfig, () => {
 
         assert.equal($input.val(), 'x-x_', 'char removed');
     });
+
+    QUnit.test('backspace press should trigger input event', function(assert) {
+        const inputHandlerStub = sinon.stub();
+
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '9',
+            value: '1',
+            onInput: inputHandlerStub
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(1)
+            .press('backspace');
+
+        assert.strictEqual(inputHandlerStub.callCount, 1, 'input event was fired');
+    });
+
+    QUnit.test('backspace press should not trigger input event when caret is at 0 position', function(assert) {
+        const inputHandlerStub = sinon.stub();
+
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '9',
+            value: '1',
+            onInput: inputHandlerStub
+        });
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(0)
+            .press('backspace');
+
+        assert.strictEqual(inputHandlerStub.callCount, 0, 'input event was not fired');
+    });
+
+    QUnit.test('mask char should be rendered instead of deleted char after a backspace press', function(assert) {
+        const $textEditor = $('#texteditor').dxTextEditor({
+            mask: '9',
+            value: '1',
+            valueChangeEvent: 'input'
+        });
+        const textEditor = $textEditor.dxTextEditor('instance');
+
+        const $input = $textEditor.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const keyboard = keyboardMock($input, true);
+
+        keyboard
+            .caret(1)
+            .press('backspace');
+
+        assert.strictEqual($input.val(), '_', 'input value is correct');
+        assert.strictEqual(textEditor.option('value'), '', 'textEditor value property is correct');
+        assert.strictEqual(textEditor.option('text'), '_', 'textEditor text property is correct');
+    });
 });
 
 QUnit.module('delete key', moduleConfig, () => {


### PR DESCRIPTION
We start using "native input strategy" instead of a default one for all browsers and devices to not use an old api, simplify the code and make behavior more consistent.

This Pull Request disables the default strategy for Chrome and extends native input strategy to support designed scenarios.

Fixes:
1. Mask should not accept excess special characters "$ # % &" [T1156419, Chrome].
2. Excess dot character should not be inputted on double space on Mac [non-Chrome].
3. Input event should not be raised if input text was not changed [non-Chrome].
4. Caret should be set after inputted character even if it was before a stub [non-Chrome].
5. ctrl+z should be ignored [non-Chrome].
6. Caret should be set after inputted character even if there is a selection with stubs [non-Chrome].
7. Backspace should skip consecutive stubs [non-Chrome].
8. Caret should be set to the position before available for input even if there is a selection [non-Chrome].
9. Input of space should move caret to the position before available for input even if there are space stubs [Chrome].
10. Input of a single char should clear selected text [non-Chrome].
11. Fast ctra+a+backspace should keep input mask [non-Chrome].
12. Suggestion apply on Mac. Now it works as on Android.

Default strategy will be removed and whole the code will be refactored in a separate Pull Request.