### PR TITLE
DataGrid - Display pending changes when recreating editors while scrolling back and forth with virtual scrolling (T1145698) 

### DIFF
--- a/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
+++ b/js/ui/grid_core/ui.grid_core.virtual_scrolling.js
@@ -1432,11 +1432,16 @@ export const virtualScrollingModule = {
 
                             const loadingItemsStarted = this._loadItems(checkLoading, !viewportIsNotFilled);
 
-                            if(!loadingItemsStarted && !(this._isLoading && checkLoading) && !checkLoadedParamsOnly) {
+                            const needToUpdateItems = !(loadingItemsStarted
+                                || this._isLoading && checkLoading
+                                || checkLoadedParamsOnly);
+
+                            if(needToUpdateItems) {
+                                const noPendingChangesInEditing = !this.getController('editing')?.getChanges()?.length;
                                 this.updateItems({
                                     repaintChangesOnly: true,
                                     needUpdateDimensions: true,
-                                    useProcessedItemsCache: true,
+                                    useProcessedItemsCache: noPendingChangesInEditing,
                                     cancelEmptyChanges: true
                                 });
                             }

--- a/testing/testcafe/tests/dataGrid/scrolling.ts
+++ b/testing/testcafe/tests/dataGrid/scrolling.ts
@@ -1351,3 +1351,56 @@ test('New virtual mode. Navigation to the last row if new row is added (T1069849
     await t.wait(300);
   });
 });
+
+test('Editors should keep changes after being scrolled out of sight (T1145698)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+
+  // act
+  await t.wait(200)
+    .click(dataGrid.getDataCell(0, 0).element)
+    .pressKey('ctrl+a')
+    .typeText(dataGrid.getDataCell(0, 0).element, 'test')
+    .click(dataGrid.getDataCell(1, 0).element)
+    .pressKey('ctrl+a')
+    .typeText(dataGrid.getDataCell(1, 0).element, 'test')
+    .pressKey('enter');
+
+  await dataGrid.scrollTo({ y: 500 });
+  await dataGrid.scrollTo({ y: 0 });
+
+  // assert
+  await t.wait(300)
+    .expect(dataGrid.apiGetCellValue(0, 0))
+    .eql('test')
+    .expect(dataGrid.apiGetCellValue(1, 0))
+    .eql('test');
+}).before(async () => {
+  const getItems = (): Record<string, unknown>[] => {
+    const items: Record<string, unknown>[] = [];
+    for (let i = 0; i < 65; i += 1) {
+      items.push({
+        ID: i + 1,
+        Name: `Name ${i + 1}`,
+      });
+    }
+    return items;
+  };
+
+  return createWidget('dxDataGrid', {
+    dataSource: getItems(),
+    keyExpr: 'ID',
+    columns: [{
+      dataField: 'Name',
+      showEditorAlways: true,
+    }],
+    scrolling: {
+      mode: 'virtual',
+    },
+    height: 300,
+    editing: {
+      mode: 'batch',
+      allowUpdating: true,
+      allowAdding: true,
+    },
+  });
+});


### PR DESCRIPTION
cherrypicked from https://github.com/DevExpress/DevExtreme/pull/24218