### PR TITLE
DataGrid(T1158098) - A grouping column does not keep its sorting state when it becomes a simple column

### DIFF
--- a/js/ui/grid_core/ui.grid_core.columns_controller.js
+++ b/js/ui/grid_core/ui.grid_core.columns_controller.js
@@ -684,8 +684,8 @@ export const columnsControllerModule = {
                 const columnWasGrouped = prevGroupIndex >= 0;
 
                 if(groupIndex >= 0) {
-                    if(!columnWasGrouped) {
-                        column._needResetSortingAfterUngrouping = !column.sortOrder;
+                    if(!columnWasGrouped && !column.sortOrder) {
+                        column._needResetSortingAfterUngrouping = true;
                     }
                 } else {
                     const sortMode = that.option('sorting.mode');

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/columnsController.tests.js
@@ -4900,7 +4900,7 @@ QUnit.module('Move Columns', { beforeEach: setupModule, afterEach: teardownModul
 
         // assert
         assert.strictEqual(this.columnsController.getVisibleColumns()[0].dataField, 'field1');
-        assert.strictEqual(this.columnsController.getVisibleColumns()[0].sortOrder, 'desc');
+        assert.strictEqual(this.columnsController.getVisibleColumns()[0].sortOrder, 'asc');
         assert.strictEqual(this.columnsController.getVisibleColumns()[0].groupIndex, undefined);
     });
 
@@ -4927,7 +4927,7 @@ QUnit.module('Move Columns', { beforeEach: setupModule, afterEach: teardownModul
 
         // assert
         assert.strictEqual(this.columnsController.getVisibleColumns()[1].dataField, 'field1');
-        assert.strictEqual(this.columnsController.getVisibleColumns()[1].sortOrder, 'desc');
+        assert.strictEqual(this.columnsController.getVisibleColumns()[1].sortOrder, 'asc');
         assert.strictEqual(this.columnsController.getVisibleColumns()[1].groupIndex, undefined);
     });
 
@@ -5646,13 +5646,12 @@ QUnit.module('Column Option', { beforeEach: setupModule, afterEach: teardownModu
         // assert
         assert.strictEqual(this.columnsController.getColumns()[0].groupIndex, 0, 'groupIndex');
         assert.strictEqual(this.columnsController.getColumns()[0].sortOrder, 'asc', 'sortOrder');
-        assert.strictEqual(this.columnsController.getColumns()[0].lastSortOrder, 'desc', 'sortOrder');
 
         // act
         this.columnsController.columnOption(0, 'groupIndex', -1);
 
         // assert
-        assert.strictEqual(this.columnsController.getColumns()[0].sortOrder, 'desc', 'sortOrder');
+        assert.strictEqual(this.columnsController.getColumns()[0].sortOrder, 'asc', 'sortOrder');
     });
 
     QUnit.test('Initial columns should not be changed on an attempt to manipulate columns at runtime', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/sorting.integration.tests.js
@@ -70,6 +70,28 @@ QUnit.module('Initialization', baseModuleConfig, () => {
         assert.strictEqual(sortedColumns[0].sortOrder, 'asc', 'sortOrder after ungrouping');
     });
 
+    QUnit.test('Column should not reset sorting if it was sorted while being groupped (T1158098)', function(assert) {
+        // arrange
+        const dataGrid = createDataGrid({
+            dataSource: [{ id: 1, name: 'test' }],
+            columns: ['id', 'name'],
+            loadingTimeout: null,
+        });
+
+        // act
+        dataGrid.columnOption('id', 'groupIndex', 0);
+        this.clock.tick(10);
+
+        dataGrid.columnOption('id', 'sortOrder', 'desc');
+        this.clock.tick(10);
+
+        dataGrid.columnOption('id', 'groupIndex', null);
+        this.clock.tick(10);
+
+        // assert
+        assert.strictEqual(dataGrid.columnOption('id', 'sortOrder'), 'desc');
+    });
+
     QUnit.test('Apply sort/group dataSource options', function(assert) {
         const dataGrid = $('#dataGrid').dxDataGrid({
             commonColumnSettings: {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
@@ -1077,7 +1077,7 @@ QUnit.module('State Storing with real controllers', {
     });
 
     QUnit.test('Save user state when grouping a column', function(assert) {
-    // arrange, act
+        // arrange, act
         let userState;
         let customSaveCallCount = 0;
 
@@ -1108,7 +1108,7 @@ QUnit.module('State Storing with real controllers', {
         // assert
         assert.strictEqual(customSaveCallCount, 1, 'customSave call count');
         assert.deepEqual(userState, {
-            columns: [{ groupIndex: 0, sortOrder: 'asc', lastSortOrder: 'asc', visibleIndex: 0, dataField: 'id', name: 'id', visible: true, sortIndex: 0, dataType: 'number' }],
+            columns: [{ groupIndex: 0, sortOrder: 'asc', visibleIndex: 0, dataField: 'id', name: 'id', visible: true, sortIndex: 0, dataType: 'number' }],
             pageIndex: 0,
             pageSize: 20,
             allowedPageSizes: [10, 20, 40],


### PR DESCRIPTION
See the ticket: [T1158098](https://supportcenter.devexpress.com/ticket/details/t1158098/datagrid-a-grouping-column-does-not-keep-its-sorting-state-when-it-becomes-a-simple-column)