### PR TITLE
DataGrid - Pager's editors don't have the "aria-label" attribute in compact mode (T1156999)

### DIFF
--- a/js/localization/messages/ar.json
+++ b/js/localization/messages/ar.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "الإجمالي الكلي",
         "dxPivotGrid-total": "{0} المجموع",

--- a/js/localization/messages/ca.json
+++ b/js/localization/messages/ca.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Pàgina anterior",
         "dxPager-nextPage": "Pàgina següent",
         "dxPager-ariaLabel": "Navegació de pàgina",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Total Imal",
         "dxPivotGrid-total": "{0} total",

--- a/js/localization/messages/cs.json
+++ b/js/localization/messages/cs.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Celkem",
         "dxPivotGrid-total": "{0} Celkem",

--- a/js/localization/messages/de.json
+++ b/js/localization/messages/de.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Vorherige Seite",
         "dxPager-nextPage": "Nächste Seite",
         "dxPager-ariaLabel": "Seitennavigation",
+        "dxPager-ariaPageSize": "Seitenlänge",
+        "dxPager-ariaPageNumber": "Seitennummer",
 
         "dxPivotGrid-grandTotal": "Gesamt",
         "dxPivotGrid-total": "{0} Gesamt",

--- a/js/localization/messages/el.json
+++ b/js/localization/messages/el.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Σύνολο",
         "dxPivotGrid-total": "{0} Σύνολο",

--- a/js/localization/messages/en.json
+++ b/js/localization/messages/en.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Grand Total",
         "dxPivotGrid-total": "{0} Total",

--- a/js/localization/messages/es.json
+++ b/js/localization/messages/es.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Gran Total",
         "dxPivotGrid-total": "{0} Total",

--- a/js/localization/messages/fi.json
+++ b/js/localization/messages/fi.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Loppusumma",
         "dxPivotGrid-total": "{0} Summa",

--- a/js/localization/messages/fr.json
+++ b/js/localization/messages/fr.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Total général",
         "dxPivotGrid-total": "Total {0}",

--- a/js/localization/messages/hu.json
+++ b/js/localization/messages/hu.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Teljes összeg",
         "dxPivotGrid-total": "{0} Összeg",

--- a/js/localization/messages/it.json
+++ b/js/localization/messages/it.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Pagina precedente",
         "dxPager-nextPage": "Pagina successiva",
         "dxPager-ariaLabel": "Navigazione pagine",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Totale",
         "dxPivotGrid-total": "{0} Totale",

--- a/js/localization/messages/ja.json
+++ b/js/localization/messages/ja.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "前のページ",
         "dxPager-nextPage": "次のページ",
         "dxPager-ariaLabel": "ページ ナビゲーション",
+        "dxPager-ariaPageSize": "ページ サイズ",
+        "dxPager-ariaPageNumber": "ページ番号",
 
         "dxPivotGrid-grandTotal": "総計",
         "dxPivotGrid-total": "{0} 合計",

--- a/js/localization/messages/lt.json
+++ b/js/localization/messages/lt.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Ankstesnis puslapis",
         "dxPager-nextPage": "Kitas puslapis",
         "dxPager-ariaLabel": "Puslapio naršymas",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Iš viso",
         "dxPivotGrid-total": "{0} iš viso",

--- a/js/localization/messages/nb.json
+++ b/js/localization/messages/nb.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Totalsum",
         "dxPivotGrid-total": "{0} Totalt",

--- a/js/localization/messages/nl.json
+++ b/js/localization/messages/nl.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Eindtotaal",
         "dxPivotGrid-total": "{0} Totaal",

--- a/js/localization/messages/pt.json
+++ b/js/localization/messages/pt.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Grande Total",
         "dxPivotGrid-total": "{0} Total",

--- a/js/localization/messages/ro.json
+++ b/js/localization/messages/ro.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Total general",
         "dxPivotGrid-total": "{0} Total",

--- a/js/localization/messages/ru.json
+++ b/js/localization/messages/ru.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Предыдущая страница",
         "dxPager-nextPage": "Следующая страница",
         "dxPager-ariaLabel": "Навигация по страницам",
+        "dxPager-ariaPageSize": "Размер страницы",
+        "dxPager-ariaPageNumber": "Номер страницы",
 
         "dxPivotGrid-grandTotal": "Итого",
         "dxPivotGrid-total": "{0} Всего",

--- a/js/localization/messages/sl.json
+++ b/js/localization/messages/sl.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Skupna vsota",
         "dxPivotGrid-total": "{0} skupaj",

--- a/js/localization/messages/sv.json
+++ b/js/localization/messages/sv.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Totalsumma",
         "dxPivotGrid-total": "{0} Summa",

--- a/js/localization/messages/tr.json
+++ b/js/localization/messages/tr.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Genel Toplam",
         "dxPivotGrid-total": "{0} Toplam",

--- a/js/localization/messages/vi.json
+++ b/js/localization/messages/vi.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "Tổng tất cả",
         "dxPivotGrid-total": "{0} Tổng",

--- a/js/localization/messages/zh-tw.json
+++ b/js/localization/messages/zh-tw.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "合計",
         "dxPivotGrid-total": "{0} 總計",

--- a/js/localization/messages/zh.json
+++ b/js/localization/messages/zh.json
@@ -179,6 +179,8 @@
         "dxPager-prevPage": "Previous Page",
         "dxPager-nextPage": "Next Page",
         "dxPager-ariaLabel": "Page Navigation",
+        "dxPager-ariaPageSize": "Page size",
+        "dxPager-ariaPageNumber": "Page number",
 
         "dxPivotGrid-grandTotal": "合计",
         "dxPivotGrid-total": "{0} 总计",

--- a/js/renovation/ui/editors/common/editor.tsx
+++ b/js/renovation/ui/editors/common/editor.tsx
@@ -118,6 +118,8 @@ export class EditorProps extends BaseWidgetProps {
 
   @OneWay() isValid = true;
 
+  @OneWay() inputAttr = {};
+
   // private
   @Event() onFocusIn?: (e: Event) => void;
 }

--- a/js/renovation/ui/pager/__tests__/content.test.tsx
+++ b/js/renovation/ui/pager/__tests__/content.test.tsx
@@ -12,6 +12,8 @@ import { InfoText } from '../info';
 import { Widget } from '../../common/widget';
 import { registerKeyboardAction } from '../../../../ui/shared/accessibility';
 import messageLocalization from '../../../../localization/message';
+import { PageSizeSmall, PageSizeSmallProps } from '../page_size/small';
+import { PagesSmall, PagerSmallProps } from '../pages/small';
 
 let mockInstance: Record<string, AbstractFunction> = {};
 
@@ -236,7 +238,7 @@ describe('PagerContent', () => {
       } as PagerContentProps);
       component.widgetRootElementRef = createTestRef(rootElement);
       component.keyboardAction.registerKeyboardAction(element, action);
-      expect(registerKeyboardAction).toBeCalledWith(
+      expect(registerKeyboardAction).toHaveBeenCalledWith(
         'pager',
         {
           option: expect.any(Function),
@@ -349,12 +351,21 @@ describe('PagerContent', () => {
       expect(component.pageIndexSelectorVisible).toBe(true);
     });
 
-    it('aria', () => {
-      (messageLocalization.format as jest.Mock).mockReturnValue('Page Navigation');
-      const component = new PagerContent(new PagerContentProps());
+    it('Renders aria attributes', () => {
+      const message = 'Localization';
+      (messageLocalization.format as jest.Mock).mockReturnValue(message);
+      const pagerContent = new PagerContent(new PagerContentProps());
 
-      expect(component.aria).toEqual({ role: 'navigation', label: 'Page Navigation' });
-      expect(messageLocalization.format).toBeCalledWith('dxPager-ariaLabel');
+      expect(pagerContent.aria).toEqual({ role: 'navigation', label: message });
+      expect(messageLocalization.format).toHaveBeenCalledWith('dxPager-ariaLabel');
+
+      const pagesSmall = new PagesSmall(new PagerSmallProps() as any);
+      expect(pagesSmall.props.inputAttr['aria-label']).toBe(message);
+      expect(messageLocalization.format).toHaveBeenCalledWith('dxPager-ariaPageNumber');
+
+      const pageSizeSmall = new PageSizeSmall(new PageSizeSmallProps() as any);
+      expect(pageSizeSmall.props.inputAttr['aria-label']).toBe(message);
+      expect(messageLocalization.format).toHaveBeenCalledWith('dxPager-ariaPageSize');
     });
 
     describe('className', () => {

--- a/js/renovation/ui/pager/page_size/__tests__/small.test.tsx
+++ b/js/renovation/ui/pager/page_size/__tests__/small.test.tsx
@@ -21,7 +21,7 @@ describe('Pager size selector', () => {
         pageSizeChange: jest.fn(),
         pageSizes,
       },
-    } as Partial<PageSizeSmall>;
+    } as unknown as Partial<PageSizeSmall>;
     const tree = shallow(<PageSizeSmallComponent {...props as any} /> as any);
     expect(tree.props()).toEqual({
       displayExpr: 'text',
@@ -40,7 +40,7 @@ describe('Pager size selector', () => {
       const component = new PageSizeSmall({ parentRef, pageSizes: [...pageSizes, { text: '1000', value: 1000 }] } as any);
       component.updateWidth();
       expect(component.width).toBe(42 + 10 * 4);
-      expect(getElementComputedStyle as jest.Mock).toBeCalledWith(parentRef.current);
+      expect(getElementComputedStyle as jest.Mock).toHaveBeenCalledWith(parentRef.current);
     });
 
     it('Effect updateWidth, default width', () => {

--- a/js/renovation/ui/pager/page_size/small.tsx
+++ b/js/renovation/ui/pager/page_size/small.tsx
@@ -9,6 +9,7 @@ import {
   RefObject,
 } from '@devextreme-generator/declarations';
 
+import messageLocalization from '../../../../localization/message';
 import { SelectBox } from '../../editors/drop_down_editors/select_box';
 import { calculateValuesFittedWidth } from '../utils/calculate_values_fitted_width';
 import { FullPageSize } from '../common/types';
@@ -18,7 +19,7 @@ import { InternalPagerProps } from '../common/pager_props';
 export const viewFunction = ({
   width,
   props: {
-    pageSize, pageSizeChange, pageSizes,
+    pageSize, pageSizeChange, pageSizes, inputAttr,
   },
 }: PageSizeSmall): JSX.Element => (
   <SelectBox
@@ -28,6 +29,7 @@ export const viewFunction = ({
     value={pageSize}
     valueChange={pageSizeChange}
     width={width}
+    inputAttr={inputAttr}
   />
 );
 
@@ -36,6 +38,8 @@ export class PageSizeSmallProps {
   @Ref() parentRef!: RefObject<HTMLElement>;
 
   @OneWay() pageSizes!: FullPageSize[];
+
+  @OneWay() inputAttr = { 'aria-label': messageLocalization.format('dxPager-ariaPageSize') };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-type-alias

--- a/js/renovation/ui/pager/pages/small.tsx
+++ b/js/renovation/ui/pager/pages/small.tsx
@@ -1,6 +1,8 @@
 import {
   Component,
+  ComponentBindings,
   JSXComponent,
+  OneWay,
   Effect,
   InternalState, RefObject, Ref,
 } from '@devextreme-generator/declarations';
@@ -25,7 +27,7 @@ export const viewFunction = ({
   width,
   value,
   pagesCountText,
-  props: { pageCount },
+  props: { pageCount, inputAttr },
 }: PagesSmall): JSX.Element => (
   <div className={LIGHT_PAGES_CLASS} ref={pageIndexRef}>
     <NumberBox
@@ -35,6 +37,7 @@ export const viewFunction = ({
       width={width}
       value={value}
       valueChange={valueChange}
+      inputAttr={inputAttr}
     />
     <span className={PAGER_INFO_TEXT_CLASS}>{pagesCountText}</span>
     <Page
@@ -45,11 +48,17 @@ export const viewFunction = ({
     />
   </div>
 );
+
+@ComponentBindings()
+export class PagerSmallProps {
+  @OneWay() inputAttr = { 'aria-label': messageLocalization.format('dxPager-ariaPageNumber') };
+}
+
 // eslint-disable-next-line @typescript-eslint/no-type-alias
-type PagerSmallProps = Pick<InternalPagerProps, 'pageCount' | 'pageIndex' | 'pageIndexChange' | 'pagesCountText'>;
+type PagerSmallPropsType = Pick<InternalPagerProps, 'pageCount' | 'pageIndex' | 'pageIndexChange' | 'pagesCountText'> & PagerSmallProps;
 
 @Component({ defaultOptionRules: null, view: viewFunction })
-export class PagesSmall extends JSXComponent<PagerSmallProps, 'pageIndexChange'>() {
+export class PagesSmall extends JSXComponent<PagerSmallPropsType, 'pageIndexChange'>() {
   @Ref() pageIndexRef!: RefObject<HTMLDivElement>;
 
   get value(): number {


### PR DESCRIPTION
Adding aria-label attributes for pager's inputs (see https://supportcenter.devexpress.com/ticket/details/t1156999/datagrid-pager-s-editors-don-t-have-the-aria-label-attribute-in-compact-mode)