### PR TITLE
DataGrid - The defaultSortIndex property was removed in v22.2.5 (T1160139)

### DIFF
--- a/js/common/grids.d.ts
+++ b/js/common/grids.d.ts
@@ -376,6 +376,7 @@ export interface ColumnBase<TRowData = any> {
   /**
    * @docid GridBaseColumn.sortIndex
    * @default undefined
+   * @fires GridBaseOptions.onOptionChanged
    * @public
    */
   sortIndex?: number;


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/24411