### PR TITLE
DataGrid - The "Cannot read properties of undefined (reading 'values')" error is thrown when adding a new row (T1159821)

### DIFF
--- a/js/ui/grid_core/ui.grid_core.focus.js
+++ b/js/ui/grid_core/ui.grid_core.focus.js
@@ -252,27 +252,29 @@ const FocusController = core.ViewController.inherit((function() {
             }
         },
         _navigateToVirtualRow: function(key, deferred, needFocusRow) {
-            const that = this;
             const dataController = this.getController('data');
             // @ts-expect-error
             const rowsScrollController = dataController._rowsScrollController;
             const rowIndex = gridCoreUtils.getIndexByKey(key, dataController.items(true));
-            const scrollable = that.getView('rowsView').getScrollable();
+            const scrollable = this.getView('rowsView').getScrollable();
 
             if(rowsScrollController && scrollable && rowIndex >= 0) {
                 const focusedRowIndex = rowIndex + dataController.getRowIndexOffset(true);
                 const offset = rowsScrollController.getItemOffset(focusedRowIndex);
 
-                const triggerUpdateFocusedRow = function() {
-                    that.component.off('contentReady', triggerUpdateFocusedRow);
+                const triggerUpdateFocusedRow = () => {
+                    if(dataController.totalCount() && !dataController.items().length) {
+                        return;
+                    }
+                    this.component.off('contentReady', triggerUpdateFocusedRow);
 
                     if(needFocusRow) {
-                        that._triggerUpdateFocusedRow(key, deferred);
+                        this._triggerUpdateFocusedRow(key, deferred);
                     } else {
                         deferred.resolve(focusedRowIndex);
                     }
                 };
-                that.component.on('contentReady', triggerUpdateFocusedRow);
+                this.component.on('contentReady', triggerUpdateFocusedRow);
 
                 this.getView('rowsView').scrollTopPosition(offset);
             } else {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -7879,4 +7879,47 @@ QUnit.module('newRowPosition', baseModuleConfig, () => {
             assert.strictEqual($(dataGrid.getCellElement(newRowInfo.visibleIndex, 1)).find('.dx-texteditor-input').val(), '111', 'cell value in a new row is not changed');
         });
     });
+
+    ['pageBottom', 'pageTop'].forEach(newRowPosition => {
+        QUnit.test(`Adding a new row should not throw error in popup mode (newRowPosition is ${newRowPosition} and rowRenderingMode: virtual)`, function(assert) {
+            // arrange
+            const getData = () => {
+                const items = [];
+                for(let i = 0; i < 100; i += 1) {
+                    items.push({
+                        id: i + 1,
+                        name: `Name ${i + 1}`
+                    });
+                }
+                return items;
+            };
+            const dataGrid = createDataGrid({
+                height: 200,
+                dataSource: getData(),
+                keyExpr: 'id',
+                editing: {
+                    newRowPosition,
+                },
+                paging: {
+                    pageSize: 10
+                },
+                scrolling: {
+                    rowRenderingMode: 'virtual',
+                    useNative: false
+                },
+                masterDetail: {
+                    enabled: true,
+                    autoExpandAll: true,
+                }
+            });
+
+            this.clock.tick(400);
+
+            // act
+            dataGrid.addRow();
+            this.clock.tick(400);
+
+            assert.ok(true, 'no errors');
+        });
+    });
 });


### PR DESCRIPTION
Cherry pick from https://github.com/DevExpress/DevExtreme/pull/24360