### PR TITLE
Widget: aria-hidden should not be set if visible=false while "display:none" is used

### DIFF
--- a/js/ui/widget/ui.widget.js
+++ b/js/ui/widget/ui.widget.js
@@ -187,7 +187,6 @@ const Widget = DOMComponent.inherit({
 
     _toggleVisibility(visible) {
         this.$element().toggleClass('dx-state-invisible', !visible);
-        this.setAria('hidden', !visible || void 0);
     },
 
     _renderFocusState() {

--- a/testing/tests/DevExpress.ui/widget.tests.js
+++ b/testing/tests/DevExpress.ui/widget.tests.js
@@ -1541,6 +1541,13 @@ QUnit.module('aria accessibility', {}, () => {
         assert.equal($element.attr('aria-disabled'), undefined, 'attribute test on option change');
     });
 
+    QUnit.test('aria-hidden', function(assert) {
+        const $element = $('#widget').dxWidget({ visible: false });
+
+        // NOTE: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden
+        assert.strictEqual($element.attr('aria-hidden'), undefined, 'attribute should not be set while element has "display:none"');
+    });
+
     QUnit.test('setAria function', function(assert) {
         const $element = $('#widget').dxWidget();
         const instance = $element.dxWidget('instance');

--- a/testing/tests/DevExpress.ui/widget.tests.js
+++ b/testing/tests/DevExpress.ui/widget.tests.js
@@ -1541,16 +1541,6 @@ QUnit.module('aria accessibility', {}, () => {
         assert.equal($element.attr('aria-disabled'), undefined, 'attribute test on option change');
     });
 
-    QUnit.test('aria-hidden', function(assert) {
-        const $element = $('#widget').dxWidget({ visible: false });
-        const instance = $element.dxWidget('instance');
-
-        assert.equal($element.attr('aria-hidden'), 'true', 'attribute test on init');
-
-        instance.option('visible', true);
-        assert.equal($element.attr('aria-hidden'), undefined, 'attribute test on option change');
-    });
-
     QUnit.test('setAria function', function(assert) {
         const $element = $('#widget').dxWidget();
         const instance = $element.dxWidget('instance');


### PR DESCRIPTION
```markdown
aria-hidden="true" should not be added when:

The HTML [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) attribute is present
The element or the element's ancestor is hidden with [display: none](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
The element or the element's ancestor is hidden with [visibility: hidden](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility)
```
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden