### PR TITLE
Scheduler: Fix unstable testcafe test.

### DIFF
--- a/testing/testcafe/tests/scheduler/dataSource/load.ts
+++ b/testing/testcafe/tests/scheduler/dataSource/load.ts
@@ -142,9 +142,10 @@ test('it should not call additional DataSource loads after repaint', async (t) =
   await repaint();
 
   await pushDataToStore(0, {});
+  await t.wait(200);
 
   const testClientData = await getWindow();
-  await t.expect(testClientData?.loadCount).eql(2);
+  await t.expect(testClientData.loadCount).eql(2);
 }).before(async () => ClientFunction(() => {
   window.testOptions = {
     loadCount: 0,


### PR DESCRIPTION
Add timeout to wait until the all DataSource async queue will be processed.