### PR TITLE
PivotGrid - Maximum call stack size exceeded error occurs when reloading a data source after changing a row's visibility - T1169225

### DIFF
--- a/js/__internal/grids/pivot_grid/module_widget_utils.ts
+++ b/js/__internal/grids/pivot_grid/module_widget_utils.ts
@@ -16,7 +16,9 @@ const setFieldProperty = function (field, property, value, isInitialization?) {
   const initProperties = field._initProperties = field._initProperties || {};
   const initValue = isInitialization ? value : field[property];
 
-  if (!Object.prototype.hasOwnProperty.call(initProperties, property) || isInitialization) {
+  const needInitProperty = !Object.prototype.hasOwnProperty.call(initProperties, property) || isInitialization;
+
+  if (needInitProperty && property !== '_initProperties') {
     initProperties[property] = initValue;
   }
 

--- a/testing/tests/DevExpress.ui.widgets.pivotGrid/dataSource_bundled.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.pivotGrid/dataSource_bundled.tests.js
@@ -2313,6 +2313,33 @@ QUnit.module('dxPivotGrid dataSource with Store', {
         }], 'load args');
     });
 
+    // T1169225
+    QUnit.test('Changed field should not contain circular \'_initProperties\' property', function(assert) {
+        // arrange
+        this.testStore.load.returns($.Deferred().reject());
+
+        const dataSource = createDataSource({
+            fields: [
+                { dataField: 'field1', area: 'row', areaIndex: 0, visible: false },
+            ],
+            store: this.testStore
+        });
+
+        // act
+        let field = dataSource.field(0);
+
+        field.visible = true;
+
+        dataSource.field(0, field);
+
+        // assert
+        field = dataSource.field(0);
+
+        const hasCircularInitProperties = Object.prototype.hasOwnProperty.call(field._initProperties, '_initProperties');
+
+        assert.ok(!hasCircularInitProperties, 'field contains circular _initProperties');
+    });
+
     QUnit.test('Reset calculated field\'s properties on changed', function(assert) {
         this.testStore.load.returns($.Deferred().reject());
 


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
