### PR TITLE
DataGrid - onFocusedCellChanged's 'cellElement' parameter is not an instance of DxElement (T1170682)

### DIFF
--- a/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -1383,7 +1383,7 @@ class EditingControllerImpl extends modules.ViewController {
   }
 
   _fireOnSaving() {
-    const onSavingParams = {
+    const onSavingParams: any = {
       cancel: false,
       promise: null,
       changes: [...this.getChanges()],

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -2081,7 +2081,7 @@ export class KeyboardNavigationController extends modules.ViewController {
     const row = this._dataController.items()[localRowIndex];
     const column = this._columnsController.getVisibleColumns()[columnIndex];
     this.executeAction('onFocusedCellChanged', {
-      cellElement: getPublicElement($cell!),
+      cellElement: ($cell ? getPublicElement($cell) : undefined)!,
       columnIndex,
       rowIndex,
       row: row as any,

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1,5 +1,6 @@
 import { noop } from '@js/core//utils/common';
 import domAdapter from '@js/core/dom_adapter';
+import { getPublicElement } from '@js/core/element';
 import $, { dxElementWrapper } from '@js/core/renderer';
 import browser from '@js/core/utils/browser';
 import { Deferred, when } from '@js/core/utils/deferred';
@@ -2080,10 +2081,10 @@ export class KeyboardNavigationController extends modules.ViewController {
     const row = this._dataController.items()[localRowIndex];
     const column = this._columnsController.getVisibleColumns()[columnIndex];
     this.executeAction('onFocusedCellChanged', {
-      cellElement: $cell,
+      cellElement: getPublicElement($cell!),
       columnIndex,
       rowIndex,
-      row,
+      row: row as any,
       column,
     });
   }
@@ -2145,9 +2146,9 @@ export class KeyboardNavigationController extends modules.ViewController {
         ? undefined
         : this._rowsView.getRowElement(localRowIndex),
       rowIndex: focusedRowIndex,
-      row: focusedRowIndex < 0
+      row: (focusedRowIndex < 0
         ? undefined
-        : this._dataController.getVisibleRows()[localRowIndex],
+        : this._dataController.getVisibleRows()[localRowIndex]) as any,
     });
   }
 

--- a/js/__internal/grids/grid_core/m_types.ts
+++ b/js/__internal/grids/grid_core/m_types.ts
@@ -4,6 +4,7 @@ import { GridBase, GridBaseOptions } from '@js/common/grids';
 import { Component } from '@js/core/component';
 import { PropertyType } from '@js/core/index';
 import { dxElementWrapper } from '@js/core/renderer';
+import { Properties as DataGridOptions } from '@js/ui/data_grid';
 import Widget from '@js/ui/widget/ui.widget';
 
 type GridPropertyType<T, TProp extends string> = PropertyType<T, TProp> extends never ? never : PropertyType<T, TProp> | undefined;
@@ -60,7 +61,22 @@ export interface InternalGrid extends GridBaseType {
   ) => TComponent;
 }
 
-export interface InternalGridOptions extends GridBaseOptions<InternalGrid, unknown, unknown> {
+type TemporarlyOptionsTakenFromDataGrid = Pick<DataGridOptions,
+'onFocusedCellChanged' |
+'onRowClick' |
+'onRowDblClick' |
+'onRowPrepared' |
+'onCellPrepared' |
+'onCellClick' |
+'onCellHoverChanged' |
+'onCellDblClick' |
+'onFocusedCellChanging' |
+'onFocusedRowChanged' |
+'onFocusedRowChanging' |
+'onEditingStart'
+>;
+
+export interface InternalGridOptions extends GridBaseOptions<InternalGrid, unknown, unknown>, TemporarlyOptionsTakenFromDataGrid {
   dataRowTemplate?: any;
 
   loadingTimeout?: number;
@@ -155,6 +171,10 @@ type SilentOptionType = <TPropertyName extends string>(
   optionValue: GridPropertyType<InternalGridOptions, TPropertyName>
 ) => void;
 
+type ActionParameters<
+  TActionName extends keyof InternalGridOptions,
+> = Omit<Parameters<InternalGridOptions[TActionName]>[0], 'component' | 'element'>;
+
 export interface ClassStaticMembers {
   inherit: (obj: any) => any;
   subclassOf: (obj: any) => any;
@@ -205,7 +225,7 @@ declare class ModuleItem {
 
   createAction(...args: any[]): void;
 
-  executeAction(...args: any[]): void;
+  executeAction<T extends keyof InternalGridOptions>(actionName: T, args: ActionParameters<T>): void;
 
   dispose(): void;
 

--- a/js/__internal/grids/grid_core/m_types.ts
+++ b/js/__internal/grids/grid_core/m_types.ts
@@ -225,7 +225,10 @@ declare class ModuleItem {
 
   createAction(...args: any[]): void;
 
-  executeAction<T extends keyof InternalGridOptions>(actionName: T, args: ActionParameters<T>): void;
+  executeAction<T extends keyof InternalGridOptions>(
+    actionName: T,
+    args: ActionParameters<T>
+  ): void;
 
   dispose(): void;
 

--- a/js/core/element.d.ts
+++ b/js/core/element.d.ts
@@ -38,5 +38,5 @@ export type dxElement = DxElement<HTMLElement>;
  */
 export type dxSVGElement = DxElement<SVGElement>;
 
-export function getPublicElement(element: InternalElement<Element>): DxElement;
-export function setPublicElementWrapper(newStrategy: (element: InternalElement<Element>) => DxElement): void;
+export function getPublicElement<TElement extends Element = Element>(element: InternalElement<Element>): DxElement<TElement>;
+export function setPublicElementWrapper(newStrategy: (element: InternalElement<Element>) => DxElement<Element>): void;

--- a/js/core/element.d.ts
+++ b/js/core/element.d.ts
@@ -38,5 +38,5 @@ export type dxElement = DxElement<HTMLElement>;
  */
 export type dxSVGElement = DxElement<SVGElement>;
 
-export function getPublicElement(element: InternalElement<Element>): DxElement<Element>;
-export function setPublicElementWrapper(newStrategy: (element: InternalElement<Element>) => DxElement<Element>): void;
+export function getPublicElement(element: InternalElement<Element>): DxElement;
+export function setPublicElementWrapper(newStrategy: (element: InternalElement<Element>) => DxElement): void;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/focus.tests.js
@@ -3244,7 +3244,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             },
             onFocusedCellChanged: function(e) {
                 ++focusedCellChangedCount;
-                assert.deepEqual(e.cellElement.text(), rowsView.getRow(1).find('td').eq(1).text(), 'Cell element');
+                assert.deepEqual($(e.cellElement).text(), rowsView.getRow(1).find('td').eq(1).text(), 'Cell element');
                 assert.equal(e.columnIndex, 1, 'Column index');
                 assert.deepEqual(e.row.data, { name: 'Dan', phone: '2222222', room: 5 }, 'Row data');
                 assert.deepEqual(e.rowIndex, 1, 'Row index');
@@ -3284,7 +3284,7 @@ QUnit.module('Focused row', getModuleConfig(true), () => {
             },
             onFocusedCellChanged: function(e) {
                 ++focusedCellChangedCount;
-                assert.deepEqual(e.cellElement.text(), rowsView.getRow(3).find('td').eq(1).text(), 'Cell element');
+                assert.deepEqual($(e.cellElement).text(), rowsView.getRow(3).find('td').eq(1).text(), 'Cell element');
                 assert.equal(e.columnIndex, 1, 'Column index');
                 assert.deepEqual(e.row.data, { name: 'Sean', phone: '4545454', room: 3 }, 'Row data');
                 assert.deepEqual(e.rowIndex, 3, 'Row index');


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
