### PR TITLE
DataGrid - The state of command buttons is rendered incorrectly in some situations when specific virtual scrolling options are used with repaintChangesOnly and a disabled cache (T1136896)

### DIFF
--- a/js/__internal/grids/grid_core/editing/m_editing_row_based.ts
+++ b/js/__internal/grids/grid_core/editing/m_editing_row_based.ts
@@ -1,8 +1,11 @@
+import { equalByValue } from '@js/core/utils/common';
+
 import { ModuleType } from '../m_types';
 import {
   EDIT_FORM_CLASS,
   EDIT_MODE_ROW,
   EDIT_ROW,
+  EDITING_EDITROWKEY_OPTION_NAME,
   MODES_WITH_DELAYED_FOCUS,
   ROW_SELECTED_CLASS,
 } from './const';
@@ -28,7 +31,7 @@ const editingControllerExtender = (Base: ModuleType<EditingController>) => class
 
   _isDefaultButtonVisible(button, options) {
     const isRowMode = this.isRowBasedEditMode();
-    const isEditRow = options.row && options.row.rowIndex === this._getVisibleEditRowIndex();
+    const isEditRow = options.row && equalByValue(options.row.key, this.option(EDITING_EDITROWKEY_OPTION_NAME));
 
     if (isRowMode) {
       switch (button.name) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -6369,6 +6369,58 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             $('#qunit-fixture').removeClass('qunit-fixture-static');
         }
     });
+
+    // T1136896
+    QUnit.test('Editing buttons should rerender correctly after scrolling if repaintChangesOnly=true', function(assert) {
+        // arrange
+        const data = [...new Array(14)].map((_, i) => ({
+            id: i + 1
+        }));
+
+        const dataGrid = createDataGrid({
+            height: 200,
+            loadingTimeout: null,
+            dataSource: data,
+            keyExpr: 'id',
+            scrolling: {
+                mode: 'virtual',
+            },
+            editing: {
+                mode: 'row',
+                allowUpdating: true,
+                allowDeleting: true,
+            },
+            repaintChangesOnly: true,
+        });
+        this.clock.tick();
+
+        // act
+        dataGrid.option('editing.editRowKey', 14);
+
+        this.clock.tick();
+        $(dataGrid.getScrollable().container()).triggerHandler('scroll');
+        $(dataGrid.getScrollable().container()).triggerHandler('scroll');
+        this.clock.tick();
+
+
+        const $rows = $('.dx-data-row');
+        assert.strictEqual($rows.length, 6);
+
+        Array.from($rows).forEach((row, i) => {
+            const $row = $(row);
+            if(i === 5) { // editing row
+                assert.strictEqual($row.find('a').length, 2);
+                assert.strictEqual($row.find('a:eq(0)').text(), 'Save');
+                assert.strictEqual($row.find('a:eq(1)').text(), 'Cancel');
+                return;
+            }
+
+            // other rows
+            assert.strictEqual($row.find('a').length, 2);
+            assert.strictEqual($row.find('a:eq(0)').text(), 'Edit');
+            assert.strictEqual($row.find('a:eq(1)').text(), 'Delete');
+        });
+    });
 });
 
 


### PR DESCRIPTION
Cherry-pick of: https://github.com/DevExpress/DevExtreme/pull/24142