### PR TITLE
DataGrid(T1172034): DataGrid: stateStoring does not restore default behavior after an exception. (#24917)

### DIFF
--- a/js/__internal/grids/grid_core/state_storing/m_state_storing_core.ts
+++ b/js/__internal/grids/grid_core/state_storing/m_state_storing_core.ts
@@ -52,7 +52,7 @@ const StateStoringController = modules.ViewController.inherit((function () {
         // @ts-expect-error
         return JSON.parse(getStorage(options).getItem(getUniqueStorageKey(options)));
       } catch (e: any) {
-        errors.log(e.message);
+        errors.log('W1022', 'State storing', e.message);
       }
     },
 

--- a/js/ui/widget/ui.errors.js
+++ b/js/ui/widget/ui.errors.js
@@ -344,5 +344,10 @@ export default errorUtils(errors.ERROR_MESSAGES, {
     /**
     * @name ErrorsUIWidgets.W1021
     */
-    W1021: 'The \'{0}\' is not rendered because none of the DOM elements match the value of the "container" property.'
+    W1021: 'The \'{0}\' is not rendered because none of the DOM elements match the value of the "container" property.',
+
+    /**
+     * @name ErrorsUIWidgets.W1022
+     */
+    W1022: '{0} JSON parsing error: \'{1}\''
 });

--- a/testing/testcafe/tests/dataGrid/stateStoring/stateStoring.ts
+++ b/testing/testcafe/tests/dataGrid/stateStoring/stateStoring.ts
@@ -1,0 +1,36 @@
+import { ClientFunction } from 'testcafe';
+import url from '../../../helpers/getPageUrl';
+import createWidget from '../../../helpers/createWidget';
+import DataGrid from '../../../model/dataGrid';
+
+fixture.disablePageReloads`State Storing`
+  .page(url(__dirname, '../../container.html'));
+
+const GRID_CONTAINER = '#container';
+
+const makeLocalStorageJsonInvalid = ClientFunction(() => {
+  window.localStorage.testStorageKey = '{]';
+});
+
+test('The Grid should load if JSON in localStorage is invalid and stateStoring enabled', async (t) => {
+  const dataGrid = new DataGrid(GRID_CONTAINER);
+  const secondCell = dataGrid.getDataCell(1, 1);
+  const consoleMessages = await t.getBrowserConsoleMessages();
+
+  await t.expect(secondCell.element().innerText).eql('5');
+  const isWarningExist = !!consoleMessages.warn.find((message) => message.startsWith('W1022'));
+  await t.expect(isWarningExist).ok();
+}).before(async () => {
+  await makeLocalStorageJsonInvalid();
+  await createWidget('dxDataGrid', {
+    dataSource: [
+      { A: 1, B: 2, C: 3 },
+      { A: 4, B: 5, C: 6 },
+      { A: 7, B: 8, C: 9 },
+    ],
+    stateStoring: {
+      enabled: true,
+      storageKey: 'testStorageKey',
+    },
+  });
+});


### PR DESCRIPTION
Cherry-pick of the https://github.com/DevExpress/DevExtreme/pull/24917 PR