### PR TITLE
DataGrid - "Maximum call stack size exceeded" error occurs on navigating summary items in the group footer via arrow keys (T1175253)

### DIFF
--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -55,7 +55,6 @@ import {
   FOCUS_TYPE_ROW,
   FREESPACE_ROW_CLASS,
   FUNCTIONAL_KEYS,
-  GROUP_FOOTER_CLASS,
   INTERACTIVE_ELEMENTS_SELECTOR,
   MASTER_DETAIL_CELL_CLASS,
   NON_FOCUSABLE_ELEMENTS_SELECTOR,
@@ -71,6 +70,7 @@ import {
   isEditorCell,
   isElementDefined,
   isFixedColumnIndexOffsetRequired,
+  isGroupFooterRow,
   isGroupRow,
   isMobile,
   isNotFocusedRow,
@@ -1286,7 +1286,7 @@ export class KeyboardNavigationController extends modules.ViewController {
 
     this._isHiddenFocus = disableFocus;
 
-    const isRowFocus = isGroupRow($row) || this.isRowFocusType();
+    const isRowFocus = isGroupRow($row) || isGroupFooterRow($row) || this.isRowFocusType();
 
     if (isRowFocus) {
       $focusElement = $row;
@@ -2223,7 +2223,6 @@ export class KeyboardNavigationController extends modules.ViewController {
     return (
       row
       && (row.style.display === 'none'
-        || $row.hasClass(this.addWidgetPrefix(GROUP_FOOTER_CLASS))
         || (isDetailRow($row)
           && !$row.hasClass(this.addWidgetPrefix(EDIT_FORM_CLASS))))
     );

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation_utils.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation_utils.ts
@@ -3,12 +3,17 @@ import { isDefined } from '@js/core/utils/type';
 
 import { EDITOR_CELL_CLASS } from '../editing/const';
 import {
-  COMMAND_SELECT_CLASS, FREESPACE_ROW_CLASS, GROUP_ROW_CLASS, HEADER_ROW_CLASS,
+  COMMAND_SELECT_CLASS, DATA_ROW_CLASS, FREESPACE_ROW_CLASS, GROUP_ROW_CLASS, HEADER_ROW_CLASS,
   MASTER_DETAIL_ROW_CLASS, VIRTUAL_ROW_CLASS,
 } from './const';
 
+const DATAGRID_GROUP_FOOTER_CLASS = 'dx-datagrid-group-footer';
+
 export function isGroupRow($row) {
   return $row && $row.hasClass(GROUP_ROW_CLASS);
+}
+export function isGroupFooterRow($row) {
+  return $row && $row.hasClass(DATAGRID_GROUP_FOOTER_CLASS);
 }
 
 export function isDetailRow($row) {
@@ -16,7 +21,7 @@ export function isDetailRow($row) {
 }
 
 export function isDataRow($row) {
-  return $row && !isGroupRow($row) && !isDetailRow($row);
+  return $row && $row.hasClass(DATA_ROW_CLASS);
 }
 
 export function isNotFocusedRow($row) {

--- a/testing/testcafe/model/dataGrid/index.ts
+++ b/testing/testcafe/model/dataGrid/index.ts
@@ -17,11 +17,13 @@ import { Overlay } from './overlay';
 import MasterRow from './masterRow';
 import AdaptiveDetailRow from './adaptiveDetailRow';
 import ColumnChooser from './columnChooser';
+import TextBox from '../textBox';
 
 export const CLASS = {
   dataGrid: 'dx-datagrid',
   headers: 'headers',
   headerPanel: 'header-panel',
+  searchBox: 'dx-searchbox',
   dataRow: 'dx-data-row',
   groupRow: 'dx-group-row',
   focusedRow: 'dx-row-focused',
@@ -38,6 +40,7 @@ export const CLASS = {
 
   headerRow: 'dx-header-row',
   footerRow: 'dx-footer-row',
+  groupFooterRow: 'group-footer',
 
   columnChooser: 'column-chooser',
 
@@ -174,6 +177,10 @@ export default class DataGrid extends Widget {
     return new EditorType(this.getHeaders().getFilterRow().getFilterCell(columnIndex).getEditor());
   }
 
+  getSearchBox(): TextBox {
+    return new TextBox(this.element.find(`.${CLASS.searchBox}`));
+  }
+
   getOverlay(): Overlay {
     return new Overlay(this.element.find(`.${CLASS.overlayWrapper}`));
   }
@@ -192,6 +199,10 @@ export default class DataGrid extends Widget {
 
   getFooterRow(): Selector {
     return this.element.find(`.${CLASS.footerRow}`);
+  }
+
+  getGroupFooterRow(): Selector {
+    return this.element.find(`.${CLASS.dataGrid}-${CLASS.groupFooterRow}`);
   }
 
   getColumnChooser(): ColumnChooser {

--- a/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4,6 +4,7 @@ import createWidget from '../../../helpers/createWidget';
 import DataGrid from '../../../model/dataGrid';
 import CommandCell from '../../../model/dataGrid/commandCell';
 import { ClassNames } from '../../../model/dataGrid/classNames';
+import { getData } from '../helpers/generateDataSourceData';
 
 const CLASS = ClassNames;
 
@@ -2493,7 +2494,7 @@ test('New mode. A cell should be focused when the PageDow/Up key is pressed (T89
     .expect(dataGrid.option('focusedColumnIndex'))
     .eql(0);
 }).before(async () => {
-  const getData = (): Record<string, unknown>[] => {
+  const getTestData = (): Record<string, unknown>[] => {
     const items: Record<string, unknown>[] = [];
     for (let i = 0; i < 100; i += 1) {
       items.push({
@@ -2505,7 +2506,7 @@ test('New mode. A cell should be focused when the PageDow/Up key is pressed (T89
     return items;
   };
   await createWidget('dxDataGrid', {
-    dataSource: getData(),
+    dataSource: getTestData(),
     keyExpr: 'ID',
     remoteOperations: true,
     height: 300,
@@ -2601,6 +2602,15 @@ test('All rows should be focused on arrow-up/down when virtual scrolling enabled
 
   // assert
   await t
+    .expect(dataGrid.getGroupFooterRow().focused)
+    .ok();
+
+  // act
+  await t
+    .pressKey('down');
+
+  // assert
+  await t
     .expect(dataGrid.getGroupRow(1).element.focused)
     .ok()
     .expect(dataGrid.getGroupRow(1).isFocused)
@@ -2626,6 +2636,15 @@ test('All rows should be focused on arrow-up/down when virtual scrolling enabled
     .expect(dataGrid.getGroupRow(1).element.focused)
     .ok()
     .expect(dataGrid.getGroupRow(1).isFocused)
+    .ok();
+
+  // act
+  await t
+    .pressKey('up');
+
+  // assert
+  await t
+    .expect(dataGrid.getGroupFooterRow().focused)
     .ok();
 
   // act
@@ -3974,5 +3993,57 @@ test('DataGrid - An exception should not throw after pressing the space key in a
   },
   selection: {
     mode: 'single',
+  },
+}));
+
+test('DataGrid - "Maximum call stack size exceeded" error occurs on navigating summary items in the group footer via arrow keys (T1175253)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+
+  // act
+  await t
+    .click(dataGrid.getSearchBox().input)
+    .pressKey('tab tab tab tab tab tab tab tab tab tab');
+
+  // assert
+  await t
+    .expect(Selector(':focus').innerText)
+    .eql('2');
+
+  // act
+  await t
+    .click(dataGrid.getGroupFooterRow())
+    .pressKey('left left left tab shift+tab');
+
+  // assert
+  await t
+    .expect((await Selector(':focus').innerText).trim())
+    .eql('Total: 1');
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: getData(3, 3),
+  keyExpr: 'field_0',
+  showBorders: true,
+  columns: [{
+    dataField: 'field_0',
+    groupIndex: 0,
+  }, {
+    dataField: 'field_1',
+  }, {
+    dataField: 'field_2',
+  }],
+  summary: {
+    groupItems: [{
+      column: 'field_2',
+      summaryType: 'count',
+      displayFormat: 'Total: {0}',
+      showInGroupFooter: true,
+    }],
+  },
+  searchPanel: {
+    visible: true,
+    width: 240,
+    placeholder: 'Search...',
+  },
+  paging: {
+    pageSize: 3,
   },
 }));

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/keyboardNavigation.keyboardKeys.tests.js
@@ -244,8 +244,8 @@ QUnit.module('Keyboard keys', {
         // assert
         const rowIndex = this.keyboardNavigationController._focusedCellPosition.rowIndex;
         assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 1, 'cellIndex');
-        assert.equal(rowIndex, 8, 'rowIndex');
-        assert.ok(!this.rowsView.element().find('.dx-row').eq(rowIndex).hasClass('dx-datagrid-group-footer'), 'not group footer');
+        assert.equal(rowIndex, 7, 'rowIndex');
+        assert.ok(this.rowsView.element().find('.dx-row').eq(rowIndex).hasClass('dx-datagrid-group-footer'), 'group footer');
     });
 
     QUnit.testInActiveWindow('Up arrow to group footer', function(assert) {
@@ -261,8 +261,8 @@ QUnit.module('Keyboard keys', {
         // assert
         const rowIndex = this.keyboardNavigationController._focusedCellPosition.rowIndex;
         assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 1, 'cellIndex');
-        assert.equal(rowIndex, 6, 'rowIndex');
-        assert.ok(!this.rowsView.element().find('.dx-row').eq(rowIndex).hasClass('dx-datagrid-group-footer'), 'not group footer');
+        assert.equal(rowIndex, 7, 'rowIndex');
+        assert.ok(this.rowsView.element().find('.dx-row').eq(rowIndex).hasClass('dx-datagrid-group-footer'), 'group footer');
     });
 
     QUnit.testInActiveWindow('Ctrl+RightArrow do not expand master detail row if master detail is not enabled (T576946)', function(assert) {
@@ -600,11 +600,10 @@ QUnit.module('Keyboard keys', {
         };
 
         this.triggerKeyDown('downArrow');
-        this.triggerKeyDown('rightArrow');
 
         // assert
-        assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 1, 'cellIndex');
-        assert.equal(this.keyboardNavigationController._focusedCellPosition.rowIndex, 2, 'rowIndex');
+        assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 0, 'cellIndex');
+        assert.equal(this.keyboardNavigationController._focusedCellPosition.rowIndex, 4, 'rowIndex');
     });
 
     // T1069664
@@ -3613,23 +3612,6 @@ QUnit.module('Keyboard keys', {
 
         // assert
         assert.equal(this.keyboardNavigationController._focusedCellPosition.columnIndex, 0, 'columnIndex of focusedCellPosition');
-    });
-
-    QUnit.testInActiveWindow('Move up when a focused cell is located on invalid position', function(assert) {
-        // arrange
-        setupModules(this);
-        this.gridView.render($('#container'));
-        this.keyboardNavigationController._focusedView = this.rowsView;
-        this.keyboardNavigationController._isNeedFocus = true;
-
-        // act
-        this.keyboardNavigationController.setFocusedCellPosition(7, 0);
-        this.editorFactoryController._$focusedElement = $('<div/>');
-        callViewsRenderCompleted(this._views);
-        this.clock.tick(10);
-
-        // arrange
-        assert.deepEqual(this.keyboardNavigationController._focusedCellPosition, { columnIndex: 0, rowIndex: 6 });
     });
 
     QUnit.testInActiveWindow('Tab index is not applied when focus is located inside edit form and master detail is enabled', function(assert) {


### PR DESCRIPTION
See https://supportcenter.devexpress.com/ticket/details/t1175253/datagrid-maximum-call-stack-size-exceeded-error-occurs-on-navigating-summary-items-in