### PR TITLE
DataGrid - focusedRowIndex is -1 when the first data cell is focused with the keyboard (T1175896)

### DIFF
--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -196,7 +196,8 @@ export class KeyboardNavigationController extends modules.ViewController {
       }
 
       const isCell = $element.is('td');
-      if (isCell) {
+      const needSetFocusPosition = (this.option('focusedRowIndex') ?? -1) < 0;
+      if (isCell && needSetFocusPosition) {
         this._updateFocusedCellPosition($element);
       }
     };

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -194,6 +194,11 @@ export class KeyboardNavigationController extends modules.ViewController {
           eventsEngine.trigger($focusedCell, 'focus');
         }
       }
+
+      const isCell = $element.is('td');
+      if (isCell) {
+        this._updateFocusedCellPosition($element);
+      }
     };
 
     this._rowsView.renderCompleted.add((e) => {

--- a/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4047,3 +4047,27 @@ test('DataGrid - "Maximum call stack size exceeded" error occurs on navigating s
     pageSize: 3,
   },
 }));
+test('DataGrid - focusedRowIndex is -1 when the first data cell is focused with the keyboard (T1175896)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+  await t
+    .click(dataGrid.getSearchBox().input)
+    .pressKey('tab tab tab')
+    .pressKey('enter')
+
+    .expect(Selector('#otherContainer').innerText)
+    .eql('0');
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: getData(1, 2),
+  keyExpr: 'field_0',
+  showBorders: true,
+  searchPanel: {
+    visible: true,
+  },
+  onKeyDown(e) {
+    const eventKey = e.event.key.toLowerCase();
+    if (eventKey === 'enter') {
+      const focusedRowIndex = e.component.option('focusedRowIndex');
+      ($('#otherContainer') as any).text(focusedRowIndex);
+    }
+  },
+}));


### PR DESCRIPTION
See https://supportcenter.devexpress.com/ticket/details/T1175896/datagrid-focusedrowindex-is-1-when-the-first-data-cell-is-focused-with-the-keyboard