### PR TITLE
Build TS: fixed regular expression removing code.

### DIFF
--- a/build/gulp/compression-pipes.js
+++ b/build/gulp/compression-pipes.js
@@ -9,8 +9,15 @@ const prettify = require('gulp-jsbeautifier');
 
 const context = require('./context.js');
 
+// NOTE:
+// Removes the #DEBUG section from the code in the production build.
+// E.g. removes the next code:
+// //#DEBUG
+// // some code.
+// //#ENDDEBUG
+// Between comment slashes (/) and # may be space symbols (count doesn't matter).
 const removeDebug = lazyPipe().pipe(function() {
-    return replace(/\/{2,}#DEBUG[\s\S]*?\/{2,}#ENDDEBUG/g, '');
+    return replace(/\/{2,}\s{0,}#DEBUG[\s\S]*?\/{2,}\s{0,}#ENDDEBUG/g, '');
 });
 
 function saveLicenseComments(node, comment) {


### PR DESCRIPTION
**Problem:**
If the comment slashes ```//``` has a space before the ```#``` symbol debug section wasn't removed.
E.g. the next code still exists in the prod build:
```typescript
// #DEBUG
console.log('test');
// #ENDDEBUG
```

**Solution:**
Added optional spaces to regexp removing the debug section.