### PR TITLE
DataGrid - Cell focus in edit mode does not work correctly if a cell has a disabled editor (T1177434)

### DIFF
--- a/js/__internal/grids/grid_core/editing/const.ts
+++ b/js/__internal/grids/grid_core/editing/const.ts
@@ -17,7 +17,7 @@ export const EDITING_EDITCOLUMNNAME_OPTION_NAME = 'editing.editColumnName';
 export const TARGET_COMPONENT_NAME = 'targetComponent';
 
 export const EDITORS_INPUT_SELECTOR = 'input:not([type=\'hidden\'])';
-export const FOCUSABLE_ELEMENT_SELECTOR = `[tabindex], ${EDITORS_INPUT_SELECTOR}`;
+export const FOCUSABLE_ELEMENT_SELECTOR = `[tabindex]:not([disabled]), ${EDITORS_INPUT_SELECTOR}:not([disabled])`;
 
 export const EDIT_MODE_BATCH = 'batch';
 export const EDIT_MODE_ROW = 'row';

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1352,10 +1352,7 @@ export class KeyboardNavigationController extends modules.ViewController {
       let $cell = this._getFocusedCell();
       const isEditing = this._editingController.isEditing();
 
-      if (
-        $cell
-        && !(this._isMasterDetailCell($cell) && !this._isRowEditMode())
-      ) {
+      if (!this._isMasterDetailCell($cell) || this._isRowEditMode()) {
         if (this._hasSkipRow($cell.parent())) {
           const direction = this._focusedCellPosition && this._focusedCellPosition.rowIndex > 0
             ? 'upArrow'
@@ -1402,7 +1399,7 @@ export class KeyboardNavigationController extends modules.ViewController {
     });
   }
 
-  _needFocusEditingCell() {
+  private _needFocusEditingCell() {
     const isCellEditMode = this._editingController.getEditMode() === EDIT_MODE_CELL;
     const isBatchEditMode = this._editingController.getEditMode() === EDIT_MODE_BATCH;
 
@@ -1411,8 +1408,7 @@ export class KeyboardNavigationController extends modules.ViewController {
     const $cell = this._getFocusedCell();
 
     return (
-      !isElementDefined($cell)
-      || $cell.children().length === 0
+      $cell.children().length === 0
       || $cell.find(FOCUSABLE_ELEMENT_SELECTOR).length > 0
     ) && (cellEditModeHasChanges || isNewRowBatchEditMode);
   }

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -31,6 +31,7 @@ import {
   EDIT_MODE_FORM,
   EDIT_MODE_ROW,
   EDITOR_CELL_CLASS,
+  FOCUSABLE_ELEMENT_SELECTOR,
   ROW_CLASS,
 } from '../editing/const';
 import modules from '../m_modules';
@@ -1344,7 +1345,19 @@ export class KeyboardNavigationController extends modules.ViewController {
   _updateFocus(isRenderView?) {
     this._updateFocusTimeout = setTimeout(() => {
       const editingController = this._editingController;
+      const isCellEditMode = editingController.getEditMode() === EDIT_MODE_CELL;
+      const isBatchEditMode = editingController.getEditMode() === EDIT_MODE_BATCH;
       let $cell = this._getFocusedCell();
+
+      const cellEditModeHasChanges = isCellEditMode && editingController.hasChanges();
+      const isNewRowBatchEditMode = isBatchEditMode && editingController.isNewRowInEditMode();
+      const cellHasFocusableElements = $cell.find(FOCUSABLE_ELEMENT_SELECTOR).length > 0;
+
+      if (cellHasFocusableElements && (cellEditModeHasChanges || isNewRowBatchEditMode)) {
+        editingController._focusEditingCell();
+        return;
+      }
+
       const isEditing = editingController.isEditing();
 
       if (

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1344,22 +1344,14 @@ export class KeyboardNavigationController extends modules.ViewController {
 
   _updateFocus(isRenderView?) {
     this._updateFocusTimeout = setTimeout(() => {
-      const editingController = this._editingController;
-      const isCellEditMode = editingController.getEditMode() === EDIT_MODE_CELL;
-      const isBatchEditMode = editingController.getEditMode() === EDIT_MODE_BATCH;
-      let $cell = this._getFocusedCell();
+      const isEditing = this._editingController.isEditing();
 
-      const cellEditModeHasChanges = isCellEditMode && editingController.hasChanges();
-      const isNewRowBatchEditMode = isBatchEditMode && editingController.isNewRowInEditMode();
-      const cellHasFocusableElements = $cell.find(FOCUSABLE_ELEMENT_SELECTOR).length > 0;
-
-      if (cellHasFocusableElements && (cellEditModeHasChanges || isNewRowBatchEditMode)) {
-        editingController._focusEditingCell();
+      if (this._needFocusEditingCell()) {
+        this._editingController._focusEditingCell();
         return;
       }
 
-      const isEditing = editingController.isEditing();
-
+      let $cell = this._getFocusedCell();
       if (
         $cell
         && !(this._isMasterDetailCell($cell) && !this._isRowEditMode())
@@ -1408,6 +1400,21 @@ export class KeyboardNavigationController extends modules.ViewController {
         }
       }
     });
+  }
+
+  _needFocusEditingCell() {
+    const isCellEditMode = this._editingController.getEditMode() === EDIT_MODE_CELL;
+    const isBatchEditMode = this._editingController.getEditMode() === EDIT_MODE_BATCH;
+
+    const cellEditModeHasChanges = isCellEditMode && this._editingController.hasChanges();
+    const isNewRowBatchEditMode = isBatchEditMode && this._editingController.isNewRowInEditMode();
+    const $cell = this._getFocusedCell();
+
+    return (
+      !isElementDefined($cell)
+      || $cell.children().length === 0
+      || $cell.find(FOCUSABLE_ELEMENT_SELECTOR).length > 0
+    ) && (cellEditModeHasChanges || isNewRowBatchEditMode);
   }
 
   _getFocusedCell() {

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1344,17 +1344,6 @@ export class KeyboardNavigationController extends modules.ViewController {
   _updateFocus(isRenderView?) {
     this._updateFocusTimeout = setTimeout(() => {
       const editingController = this._editingController;
-      const isCellEditMode = editingController.getEditMode() === EDIT_MODE_CELL;
-      const isBatchEditMode = editingController.getEditMode() === EDIT_MODE_BATCH;
-
-      if (
-        (isCellEditMode && editingController.hasChanges())
-        || (isBatchEditMode && editingController.isNewRowInEditMode())
-      ) {
-        editingController._focusEditingCell();
-        return;
-      }
-
       let $cell = this._getFocusedCell();
       const isEditing = editingController.isEditing();
 

--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1344,14 +1344,14 @@ export class KeyboardNavigationController extends modules.ViewController {
 
   _updateFocus(isRenderView?) {
     this._updateFocusTimeout = setTimeout(() => {
-      const isEditing = this._editingController.isEditing();
-
       if (this._needFocusEditingCell()) {
         this._editingController._focusEditingCell();
         return;
       }
 
       let $cell = this._getFocusedCell();
+      const isEditing = this._editingController.isEditing();
+
       if (
         $cell
         && !(this._isMasterDetailCell($cell) && !this._isRowEditMode())

--- a/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4047,6 +4047,7 @@ test('DataGrid - "Maximum call stack size exceeded" error occurs on navigating s
     pageSize: 3,
   },
 }));
+
 test('DataGrid - focusedRowIndex is -1 when the first data cell is focused with the keyboard (T1175896)', async (t) => {
   const dataGrid = new DataGrid('#container');
   await t
@@ -4069,5 +4070,41 @@ test('DataGrid - focusedRowIndex is -1 when the first data cell is focused with 
       const focusedRowIndex = e.component.option('focusedRowIndex');
       ($('#otherContainer') as any).text(focusedRowIndex);
     }
+  },
+}));
+
+test('DataGrid - Cell focus in edit mode does not work correctly if a cell has a disabled editor (T1177434)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+
+  await t
+    .click(dataGrid.getToolbar().getItem(0))
+    .pressKey('tab')
+
+    .expect(Selector(':focus').tagName)
+    .eql('td')
+    .expect(Selector(':focus').getAttribute('aria-colindex'))
+    .eql('3');
+}).before(async () => createWidget('dxDataGrid', {
+  onEditorPreparing(e) {
+    if (e.dataField === 'field_1') { e.editorOptions.disabled = true; }
+  },
+  dataSource: getData(3, 3),
+  showBorders: true,
+  editing: {
+    mode: 'cell',
+    allowUpdating: true,
+    allowAdding: true,
+    allowDeleting: true,
+  },
+  selection: {
+    mode: 'multiple',
+  },
+  toolbar: {
+    items: [
+      {
+        name: 'addRowButton',
+        showText: 'always',
+      },
+    ],
   },
 }));


### PR DESCRIPTION
See https://supportcenter.devexpress.com/ticket/details/t1177434/datagrid-cell-focus-in-edit-mode-does-not-work-correctly-if-a-cell-has-a-disabled-editor