### PR TITLE
DataGrid - Cell focus works incorrectly if the command column has a disabled native button element (T1179207)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/const.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/const.ts
@@ -31,7 +31,7 @@ export const FOCUSED_CLASS = 'dx-focused';
 export const FAST_EDITING_DELETE_KEY = 'delete';
 
 export const INTERACTIVE_ELEMENTS_SELECTOR = `
-  input:not([type=\\'hidden\\']):not([disabled]),
+  input:not([type="hidden"]):not([disabled]),
   textarea:not([disabled]),
   a:not([disabled]),
   select:not([disabled]),

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/const.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/const.ts
@@ -30,7 +30,15 @@ export const FOCUSED_CLASS = 'dx-focused';
 
 export const FAST_EDITING_DELETE_KEY = 'delete';
 
-export const INTERACTIVE_ELEMENTS_SELECTOR = 'input:not([type=\'hidden\']), textarea, a, select, button, [tabindex], .dx-checkbox';
+export const INTERACTIVE_ELEMENTS_SELECTOR = `
+  input:not([type=\\'hidden\\']):not([disabled]),
+  textarea:not([disabled]),
+  a:not([disabled]),
+  select:not([disabled]),
+  button:not([disabled]),
+  [tabindex]:not([disabled]),
+  .dx-checkbox:not([disabled])
+`;
 export const NON_FOCUSABLE_ELEMENTS_SELECTOR = `${INTERACTIVE_ELEMENTS_SELECTOR}, .dx-dropdowneditor-icon`;
 
 export const EDIT_MODE_FORM = 'form';

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4108,3 +4108,35 @@ test('DataGrid - Cell focus in edit mode does not work correctly if a cell has a
     ],
   },
 }));
+
+test('DataGrid - Cell focus works incorrectly if the command column has a disabled native button element (T1179207)', async (t) => {
+  await t
+    .pressKey('tab tab tab tab tab tab')
+
+    .expect(Selector(':focus').tagName)
+    .eql('td')
+    .expect(Selector(':focus').getAttribute('aria-colindex'))
+    .eql('1');
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: getData(2, 2),
+  showBorders: true,
+  editing: {
+    mode: 'cell',
+    allowUpdating: true,
+    allowDeleting: true,
+  },
+  columns: ['field_0', 'field_1', {
+    type: 'buttons',
+    buttons: [{
+      template() {
+        return $('<button>').text('Edit');
+      },
+    }, {
+      template() {
+        return $('<button>').attr({
+          disabled: true,
+        }).text('Delete');
+      },
+    }],
+  }],
+}));


### PR DESCRIPTION
See https://supportcenter.devexpress.com/ticket/details/t1179207/datagrid-cell-focus-works-incorrectly-if-the-command-column-has-a-disabled-native-button