### PR TITLE
Correct @type doc tags on Event Types members

### DIFF
--- a/js/common/grids.d.ts
+++ b/js/common/grids.d.ts
@@ -77,7 +77,10 @@ import { PositionConfig } from '../animation/position';
  * @namespace DevExpress.common.grids
  */
 export type AdaptiveDetailRowPreparingInfo = {
-  /** @docid */
+  /**
+   * @docid
+   * @type object
+   */
   readonly formOptions: any;
 };
 
@@ -2412,7 +2415,10 @@ export type LoadPanel = {
  * @namespace DevExpress.common.grids
  */
 export interface NewRowInfo<TRowData = any> {
-  /** @docid */
+  /**
+   * @docid
+   * @type object
+   */
   data: TRowData;
   /**
    * @docid
@@ -2716,7 +2722,10 @@ export type RowDraggingTemplateData<TRowData = any> = {
  * @namespace DevExpress.common.grids
  */
 export type RowInsertedInfo<TRowData = any, TKey = any> = {
-  /** @docid */
+  /**
+   * @docid
+   * @type object
+   */
   readonly data: TRowData;
   /** @docid */
   readonly key: TKey;
@@ -2730,7 +2739,10 @@ export type RowInsertedInfo<TRowData = any, TKey = any> = {
  * @namespace DevExpress.common.grids
  */
 export type RowInsertingInfo<TRowData = any> = {
-  /** @docid */
+  /**
+   * @docid
+   * @type object
+   */
   data: TRowData;
   /**
    * @docid
@@ -2755,7 +2767,10 @@ export type RowKeyInfo<TKey = any> = {
  * @namespace DevExpress.common.grids
  */
 export interface RowRemovedInfo<TRowData = any, TKey = any> {
-  /** @docid */
+  /**
+   * @docid
+   * @type object
+   */
   readonly data: TRowData;
   /** @docid */
   readonly key: TKey;
@@ -2769,7 +2784,10 @@ export interface RowRemovedInfo<TRowData = any, TKey = any> {
  * @namespace DevExpress.common.grids
  */
 export interface RowRemovingInfo<TRowData = any, TKey = any> {
-  /** @docid */
+  /**
+   * @docid
+   * @type object
+   */
   readonly data: TRowData;
   /** @docid */
   readonly key: TKey;
@@ -2786,7 +2804,10 @@ export interface RowRemovingInfo<TRowData = any, TKey = any> {
  * @namespace DevExpress.common.grids
  */
 export interface RowUpdatedInfo<TRowData = any, TKey = any> {
-  /** @docid */
+  /**
+   * @docid
+   * @type object
+   */
   readonly data: TRowData;
   /** @docid */
   readonly key: TKey;

--- a/js/events/index.d.ts
+++ b/js/events/index.d.ts
@@ -20,7 +20,6 @@ export interface InitializedEventInfo<TComponent> {
     /**
      * @docid
      * @type this
-     * @default Widget
      */
     readonly component?: TComponent;
     /** @docid */
@@ -35,7 +34,6 @@ export interface EventInfo<TComponent> {
     /**
      * @docid
      * @type this
-     * @default Widget
      */
     readonly component: TComponent;
     /** @docid */
@@ -52,7 +50,6 @@ export interface NativeEventInfo<TComponent, TNativeEvent = Event> {
     /**
      * @docid
      * @type this
-     * @default Widget
      */
     readonly component: TComponent;
     /** @docid */

--- a/js/ui/data_grid.d.ts
+++ b/js/ui/data_grid.d.ts
@@ -368,10 +368,7 @@ export type CellHoverChangedEvent<TRowData = any, TKey = any> = EventInfo<dxData
    * @type object
    */
   readonly data: TRowData;
-  /**
-   * @docid _ui_data_grid_CellHoverChangedEvent.key
-   * @type any
-   */
+  /** @docid _ui_data_grid_CellHoverChangedEvent.key */
   readonly key: TKey;
   /** @docid _ui_data_grid_CellHoverChangedEvent.value */
   readonly value?: any;
@@ -411,10 +408,7 @@ export type CellPreparedEvent<TRowData = any, TKey = any> = EventInfo<dxDataGrid
    * @type object
    */
   readonly data: TRowData;
-  /**
-   * @docid _ui_data_grid_CellPreparedEvent.key
-   * @type any
-   */
+  /** @docid _ui_data_grid_CellPreparedEvent.key */
   readonly key: TKey;
   /** @docid _ui_data_grid_CellPreparedEvent.value */
   readonly value?: any;

--- a/js/ui/diagram.d.ts
+++ b/js/ui/diagram.d.ts
@@ -57,7 +57,6 @@ export type CustomCommandEvent = {
     /**
      * @docid _ui_diagram_CustomCommandEvent.component
      * @type this
-     * @default Widget
      */
     readonly component: dxDiagram;
     /** @docid _ui_diagram_CustomCommandEvent.element */

--- a/js/ui/draggable.d.ts
+++ b/js/ui/draggable.d.ts
@@ -131,15 +131,9 @@ export type DragEndEvent = Cancelable & NativeEventInfo<dxDraggable, PointerEven
     readonly itemData?: any;
     /** @docid _ui_draggable_DragEndEvent.itemElement */
     readonly itemElement?: DxElement;
-    /**
-     * @docid _ui_draggable_DragEndEvent.fromComponent
-     * @type this
-     */
+    /** @docid _ui_draggable_DragEndEvent.fromComponent */
     readonly fromComponent: dxSortable | dxDraggable;
-    /**
-     * @docid _ui_draggable_DragEndEvent.toComponent
-     * @type this
-     */
+    /** @docid _ui_draggable_DragEndEvent.toComponent */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_draggable_DragEndEvent.fromData */
     readonly fromData?: any;
@@ -158,15 +152,9 @@ export type DragMoveEvent = Cancelable & NativeEventInfo<dxDraggable, PointerEve
     readonly itemData?: any;
     /** @docid _ui_draggable_DragMoveEvent.itemElement */
     readonly itemElement?: DxElement;
-    /**
-     * @docid _ui_draggable_DragMoveEvent.fromComponent
-     * @type this
-     */
+    /** @docid _ui_draggable_DragMoveEvent.fromComponent */
     readonly fromComponent: dxSortable | dxDraggable;
-    /**
-     * @docid _ui_draggable_DragMoveEvent.toComponent
-     * @type this
-     */
+    /** @docid _ui_draggable_DragMoveEvent.toComponent */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_draggable_DragMoveEvent.fromData */
     readonly fromData?: any;

--- a/js/ui/draggable.d.ts
+++ b/js/ui/draggable.d.ts
@@ -134,13 +134,11 @@ export type DragEndEvent = Cancelable & NativeEventInfo<dxDraggable, PointerEven
     /**
      * @docid _ui_draggable_DragEndEvent.fromComponent
      * @type this
-     * @default Widget
      */
     readonly fromComponent: dxSortable | dxDraggable;
     /**
      * @docid _ui_draggable_DragEndEvent.toComponent
      * @type this
-     * @default Widget
      */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_draggable_DragEndEvent.fromData */
@@ -163,13 +161,11 @@ export type DragMoveEvent = Cancelable & NativeEventInfo<dxDraggable, PointerEve
     /**
      * @docid _ui_draggable_DragMoveEvent.fromComponent
      * @type this
-     * @default Widget
      */
     readonly fromComponent: dxSortable | dxDraggable;
     /**
      * @docid _ui_draggable_DragMoveEvent.toComponent
      * @type this
-     * @default Widget
      */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_draggable_DragMoveEvent.fromData */

--- a/js/ui/drop_down_editor/ui.drop_down_list.d.ts
+++ b/js/ui/drop_down_editor/ui.drop_down_list.d.ts
@@ -36,7 +36,10 @@ import {
  * @hidden
  */
 export interface SelectionChangedInfo<T = any> {
-    /** @docid _ui_drop_down_editor_ui_drop_down_list_SelectionChangedInfo.selectedItem */
+    /**
+     * @docid _ui_drop_down_editor_ui_drop_down_list_SelectionChangedInfo.selectedItem
+     * @type object
+     */
     readonly selectedItem: T;
 }
 

--- a/js/ui/editor/editor.d.ts
+++ b/js/ui/editor/editor.d.ts
@@ -18,9 +18,15 @@ import {
  * @hidden
  */
 export interface ValueChangedInfo {
-    /** @docid */
+    /**
+     * @docid
+     * @type object
+     */
     readonly previousValue?: any;
-    /** @docid */
+    /**
+     * @docid
+     * @type object
+     */
     readonly value?: any;
 }
 

--- a/js/ui/gantt.d.ts
+++ b/js/ui/gantt.d.ts
@@ -75,7 +75,6 @@ export type ContextMenuPreparingEvent = Cancelable & {
     /**
      * @docid _ui_gantt_ContextMenuPreparingEvent.component
      * @type this
-     * @default Widget
      */
     readonly component?: dxGantt;
     /** @docid _ui_gantt_ContextMenuPreparingEvent.element */
@@ -107,7 +106,6 @@ export type CustomCommandEvent = {
     /**
      * @docid _ui_gantt_CustomCommandEvent.component
      * @type this
-     * @default Widget
      */
     readonly component?: dxGantt;
     /** @docid _ui_gantt_CustomCommandEvent.element */

--- a/js/ui/list.d.ts
+++ b/js/ui/list.d.ts
@@ -54,7 +54,10 @@ type ItemLike = string | Item | any;
  * @hidden
  */
 export interface ListItemInfo<TItem extends ItemLike> {
-    /** @docid */
+    /**
+     * @docid
+     * @type object
+     */
     readonly itemData?: TItem;
     /** @docid */
     readonly itemElement: DxElement;
@@ -72,7 +75,10 @@ export type ListMenuMode = 'context' | 'slide';
  * @hidden
  */
 export interface ScrollInfo {
-    /** @docid */
+    /**
+     * @docid
+     * @type object
+     */
     readonly scrollOffset?: any;
     /** @docid */
     readonly reachedLeft: boolean;

--- a/js/ui/sortable.d.ts
+++ b/js/ui/sortable.d.ts
@@ -39,10 +39,7 @@ export {
  * @type object
  */
 export interface AddEvent {
-    /**
-     * @docid _ui_sortable_AddEvent.component
-     * @type this
-     */
+    /** @docid _ui_sortable_AddEvent.component */
     readonly component: dxSortable;
     /** @docid _ui_sortable_AddEvent.element */
     readonly element: DxElement;
@@ -61,15 +58,9 @@ export interface AddEvent {
     readonly fromIndex: number;
     /** @docid _ui_sortable_AddEvent.toIndex */
     readonly toIndex: number;
-    /**
-     * @docid _ui_sortable_AddEvent.fromComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_AddEvent.fromComponent */
     readonly fromComponent: dxSortable | dxDraggable;
-    /**
-     * @docid _ui_sortable_AddEvent.toComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_AddEvent.toComponent */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_AddEvent.fromData */
     readonly fromData?: any;
@@ -102,15 +93,9 @@ export type DragChangeEvent = Cancelable & NativeEventInfo<dxSortable, PointerEv
     readonly fromIndex?: number;
     /** @docid _ui_sortable_DragChangeEvent.toIndex */
     readonly toIndex?: number;
-    /**
-     * @docid _ui_sortable_DragChangeEvent.fromComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_DragChangeEvent.fromComponent */
     readonly fromComponent?: dxSortable | dxDraggable;
-    /**
-     * @docid _ui_sortable_DragChangeEvent.toComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_DragChangeEvent.toComponent */
     readonly toComponent?: dxSortable | dxDraggable;
     /** @docid _ui_sortable_DragChangeEvent.fromData */
     readonly fromData?: any;
@@ -135,15 +120,9 @@ export type DragEndEvent = Cancelable & NativeEventInfo<dxSortable, PointerEvent
     readonly fromIndex: number;
     /** @docid _ui_sortable_DragEndEvent.toIndex */
     readonly toIndex: number;
-    /**
-     * @docid _ui_sortable_DragEndEvent.fromComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_DragEndEvent.fromComponent */
     readonly fromComponent: dxSortable | dxDraggable;
-    /**
-     * @docid _ui_sortable_DragEndEvent.toComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_DragEndEvent.toComponent */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_DragEndEvent.fromData */
     readonly fromData?: any;
@@ -168,15 +147,9 @@ export type DragMoveEvent = Cancelable & NativeEventInfo<dxSortable, PointerEven
     readonly fromIndex: number;
     /** @docid _ui_sortable_DragMoveEvent.toIndex */
     readonly toIndex: number;
-    /**
-     * @docid _ui_sortable_DragMoveEvent.fromComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_DragMoveEvent.fromComponent */
     readonly fromComponent: dxSortable | dxDraggable;
-    /**
-     * @docid _ui_sortable_DragMoveEvent.toComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_DragMoveEvent.toComponent */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_DragMoveEvent.fromData */
     readonly fromData?: any;
@@ -234,15 +207,9 @@ export type RemoveEvent = NativeEventInfo<dxSortable, PointerEvent | MouseEvent 
     readonly fromIndex: number;
     /** @docid _ui_sortable_RemoveEvent.toIndex */
     readonly toIndex: number;
-    /**
-     * @docid _ui_sortable_RemoveEvent.fromComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_RemoveEvent.fromComponent */
     readonly fromComponent: dxSortable | dxDraggable;
-    /**
-     * @docid _ui_sortable_RemoveEvent.toComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_RemoveEvent.toComponent */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_RemoveEvent.fromData */
     readonly fromData?: any;
@@ -265,15 +232,9 @@ export type ReorderEvent = NativeEventInfo<dxSortable, PointerEvent | MouseEvent
     readonly fromIndex: number;
     /** @docid _ui_sortable_ReorderEvent.toIndex */
     readonly toIndex: number;
-    /**
-     * @docid _ui_sortable_ReorderEvent.fromComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_ReorderEvent.fromComponent */
     readonly fromComponent: dxSortable | dxDraggable;
-    /**
-     * @docid _ui_sortable_ReorderEvent.toComponent
-     * @type this
-     */
+    /** @docid _ui_sortable_ReorderEvent.toComponent */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_ReorderEvent.fromData */
     readonly fromData?: any;

--- a/js/ui/sortable.d.ts
+++ b/js/ui/sortable.d.ts
@@ -42,7 +42,6 @@ export interface AddEvent {
     /**
      * @docid _ui_sortable_AddEvent.component
      * @type this
-     * @default Widget
      */
     readonly component: dxSortable;
     /** @docid _ui_sortable_AddEvent.element */
@@ -65,13 +64,11 @@ export interface AddEvent {
     /**
      * @docid _ui_sortable_AddEvent.fromComponent
      * @type this
-     * @default Widget
      */
     readonly fromComponent: dxSortable | dxDraggable;
     /**
      * @docid _ui_sortable_AddEvent.toComponent
      * @type this
-     * @default Widget
      */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_AddEvent.fromData */
@@ -108,13 +105,11 @@ export type DragChangeEvent = Cancelable & NativeEventInfo<dxSortable, PointerEv
     /**
      * @docid _ui_sortable_DragChangeEvent.fromComponent
      * @type this
-     * @default Widget
      */
     readonly fromComponent?: dxSortable | dxDraggable;
     /**
      * @docid _ui_sortable_DragChangeEvent.toComponent
      * @type this
-     * @default Widget
      */
     readonly toComponent?: dxSortable | dxDraggable;
     /** @docid _ui_sortable_DragChangeEvent.fromData */
@@ -143,13 +138,11 @@ export type DragEndEvent = Cancelable & NativeEventInfo<dxSortable, PointerEvent
     /**
      * @docid _ui_sortable_DragEndEvent.fromComponent
      * @type this
-     * @default Widget
      */
     readonly fromComponent: dxSortable | dxDraggable;
     /**
      * @docid _ui_sortable_DragEndEvent.toComponent
      * @type this
-     * @default Widget
      */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_DragEndEvent.fromData */
@@ -178,13 +171,11 @@ export type DragMoveEvent = Cancelable & NativeEventInfo<dxSortable, PointerEven
     /**
      * @docid _ui_sortable_DragMoveEvent.fromComponent
      * @type this
-     * @default Widget
      */
     readonly fromComponent: dxSortable | dxDraggable;
     /**
      * @docid _ui_sortable_DragMoveEvent.toComponent
      * @type this
-     * @default Widget
      */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_DragMoveEvent.fromData */
@@ -246,13 +237,11 @@ export type RemoveEvent = NativeEventInfo<dxSortable, PointerEvent | MouseEvent 
     /**
      * @docid _ui_sortable_RemoveEvent.fromComponent
      * @type this
-     * @default Widget
      */
     readonly fromComponent: dxSortable | dxDraggable;
     /**
      * @docid _ui_sortable_RemoveEvent.toComponent
      * @type this
-     * @default Widget
      */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_RemoveEvent.fromData */
@@ -279,13 +268,11 @@ export type ReorderEvent = NativeEventInfo<dxSortable, PointerEvent | MouseEvent
     /**
      * @docid _ui_sortable_ReorderEvent.fromComponent
      * @type this
-     * @default Widget
      */
     readonly fromComponent: dxSortable | dxDraggable;
     /**
      * @docid _ui_sortable_ReorderEvent.toComponent
      * @type this
-     * @default Widget
      */
     readonly toComponent: dxSortable | dxDraggable;
     /** @docid _ui_sortable_ReorderEvent.fromData */

--- a/js/ui/tab_panel.d.ts
+++ b/js/ui/tab_panel.d.ts
@@ -32,7 +32,10 @@ type ItemLike = string | Item | any;
  * @hidden
  */
 export interface TabPanelItemInfo<TItem extends ItemLike> {
-    /** @docid */
+    /**
+     * @docid
+     * @type object
+     */
     readonly itemData?: TItem;
     /** @docid */
     readonly itemElement?: DxElement;

--- a/js/ui/tree_list.d.ts
+++ b/js/ui/tree_list.d.ts
@@ -75,7 +75,10 @@ import Widget from './widget/ui.widget';
  * @hidden
  */
 export interface CellInfo<TRowData = any, TKey = any> {
-    /** @docid */
+    /**
+     * @docid
+     * @type object
+     */
     readonly data: TRowData;
     /** @docid */
     readonly key: TKey;
@@ -482,20 +485,11 @@ export type FocusedRowChangedEvent<TRowData = any, TKey = any> = EventInfo<dxTre
  * @inherits Cancelable,NativeEventInfo
  */
 export type FocusedRowChangingEvent<TRowData = any, TKey = any> = Cancelable & NativeEventInfo<dxTreeList<TRowData, TKey>, KeyboardEvent | PointerEvent | MouseEvent | TouchEvent> & {
-    /**
-     * @docid _ui_tree_list_FocusedRowChangingEvent.rowElement
-     * @type DxElement
-     */
+    /** @docid _ui_tree_list_FocusedRowChangingEvent.rowElement */
     readonly rowElement: DxElement;
-    /**
-     * @docid _ui_tree_list_FocusedRowChangingEvent.prevRowIndex
-     * @type number
-     */
+    /** @docid _ui_tree_list_FocusedRowChangingEvent.prevRowIndex */
     readonly prevRowIndex: number;
-    /**
-     * @docid _ui_tree_list_FocusedRowChangingEvent.newRowIndex
-     * @type number
-     */
+    /** @docid _ui_tree_list_FocusedRowChangingEvent.newRowIndex */
     newRowIndex: number;
     /**
      * @docid _ui_tree_list_FocusedRowChangingEvent.rows

--- a/js/viz/bar_gauge.d.ts
+++ b/js/viz/bar_gauge.d.ts
@@ -94,9 +94,11 @@ export interface BarGaugeLegendItem extends BaseLegendItem {
  * @docid _viz_bar_gauge_TooltipInfo
  * @hidden
  */
-
 export interface TooltipInfo {
-    /** @docid _viz_bar_gauge_TooltipInfo.target */
+    /**
+     * @docid _viz_bar_gauge_TooltipInfo.target
+     * @type object
+     */
     target?: any;
 }
 

--- a/js/viz/core/base_widget.d.ts
+++ b/js/viz/core/base_widget.d.ts
@@ -63,7 +63,6 @@ export type FileSavingEventInfo<T> = Cancelable & {
   /**
    * @docid
    * @type this
-   * @default Widget
    */
   readonly component: T;
   /** @docid */

--- a/js/viz/gauges/base_gauge.d.ts
+++ b/js/viz/gauges/base_gauge.d.ts
@@ -40,7 +40,10 @@ import {
  * @hidden
  */
 export interface TooltipInfo {
-    /** @docid _viz_base_gauge_TooltipInfo.target */
+    /**
+     * @docid _viz_base_gauge_TooltipInfo.target
+     * @type object
+     */
     target: any;
 }
 

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -31938,10 +31938,10 @@ declare module DevExpress.viz {
     export type TooltipHiddenEvent = DevExpress.events.EventInfo<dxBarGauge> &
       TooltipInfo;
     /**
-      * [descr:_viz_bar_gauge_TooltipInfo]
-      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
-      */
-     export interface TooltipInfo {
+     * [descr:_viz_bar_gauge_TooltipInfo]
+     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+     */
+    export interface TooltipInfo {
       /**
        * [descr:_viz_bar_gauge_TooltipInfo.target]
        */


### PR DESCRIPTION
### Cherry-picks
- #25183

Correct @type doc tags on Event Types members (from base modules / members doc tags) after #24851 