### PR TITLE
PivotGrid(T1178847): shows CSP errors in the console when jQuery is referenced 

### DIFF
--- a/packages/devextreme/js/__internal/grids/pivot_grid/area_item/m_area_item.ts
+++ b/packages/devextreme/js/__internal/grids/pivot_grid/area_item/m_area_item.ts
@@ -575,7 +575,7 @@ const AreaItem = Class.inherit({
       } catch (e) {
         that._tableElement.empty();
       }
-      that._tableElement.attr('style', '');
+      that._tableElement.removeAttr('style');
     } else {
       that._groupElement = that._createGroupElement();
       that._tableElement = that._createTableElement();

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
@@ -7035,6 +7035,30 @@ QUnit.module('Data area', () => {
         assert.strictEqual(dataArea.groupElement().css('position'), 'relative');
     });
 
+    // Covers the CSP issue T1178847
+    QUnit.test('Should remove data area table\'s styles during render', function(assert) {
+        const dataArea = createDataArea();
+        const $testElement = $('#pivotArea');
+
+        dataArea.render($testElement, [
+            [
+                { columnType: 'D', rowType: 'D', text: '1' },
+            ],
+        ]);
+
+        const $table = $testElement.find('table');
+        $table.css({ 'box-shadow': '0 0 #ff0000' });
+
+        dataArea.render($testElement, [
+            [
+                { columnType: 'D', rowType: 'D', text: '2' },
+            ],
+        ]);
+
+        const expectedCss = $table.css('box-shadow');
+        assert.equal(expectedCss, 'none', 'box-shadow style was reset');
+    });
+
     QUnit.test('Render when data area is not empty', function(assert) {
         const dataArea = createDataArea();
         let rows;


### PR DESCRIPTION
Change the unsafe ```attr('style', '')``` with the safe ```removeAttr``` function.
And add the QUnit that covers this case.