### PR TITLE
GridCore(T1179824): It is not possible to navigate via keyboard from the header to the data rows in certain use cases

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/row_dragging/dom.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/row_dragging/dom.ts
@@ -6,11 +6,11 @@ import $ from '@js/core/renderer';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports,
 // eslint-disable-next-line forbidden-imports/no-restricted-imports
 import gridCoreUtils from '../m_utils';
-import { ATTRIBUTES, CLASSES } from './const';
+import { CLASSES } from './const';
 
 const createHandleTemplateFunc = (addWidgetPrefix) => (container, options) => {
   const $container = $(container);
-  $container.attr(ATTRIBUTES.dragCell, '');
+
   if (options.rowType === 'data') {
     $container.addClass(CLASSES.cellFocusDisabled);
     return $('<span>').addClass(addWidgetPrefix(CLASSES.handleIcon));

--- a/packages/devextreme/js/__internal/grids/grid_core/row_dragging/m_row_dragging.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/row_dragging/m_row_dragging.ts
@@ -5,7 +5,7 @@ import { getWidth, setWidth } from '@js/core/utils/size';
 import Sortable from '@js/ui/sortable';
 
 import gridCoreUtils from '../m_utils';
-import { CLASSES } from './const';
+import { ATTRIBUTES, CLASSES } from './const';
 import { GridCoreRowDraggingDom } from './dom';
 
 const RowDraggingExtender = {
@@ -26,18 +26,19 @@ const RowDraggingExtender = {
     const columnsController = this._columnsController;
     const isHandleColumnVisible = allowReordering && rowDragging.showDragIcons;
 
-    columnsController && columnsController.addCommandColumn({
+    columnsController?.addCommandColumn({
       type: 'drag',
       command: 'drag',
       visibleIndex: -2,
       alignment: 'center',
+      elementAttr: [{ name: ATTRIBUTES.dragCell, value: '' }],
       cssClass: CLASSES.commandDrag,
       width: 'auto',
       cellTemplate: this._getHandleTemplate(),
       visible: isHandleColumnVisible,
     });
 
-    columnsController.columnOption('type:drag', 'visible', isHandleColumnVisible);
+    columnsController?.columnOption('type:drag', 'visible', isHandleColumnVisible);
   },
 
   _renderContent() {

--- a/packages/devextreme/js/__internal/grids/grid_core/views/m_columns_view.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/views/m_columns_view.ts
@@ -226,6 +226,12 @@ export class ColumnsView extends viewWithColumnStateMixin {
       $cell.addClass(column.cssClass);
     }
 
+    if (Array.isArray(column.elementAttr)) {
+      column.elementAttr.forEach(({ name, value }) => {
+        $cell.attr(name, value);
+      });
+    }
+
     if (column.command === 'expand') {
       $cell.addClass(column.cssClass);
       $cell.addClass(this.addWidgetPrefix(GROUP_SPACE_CLASS));
@@ -1025,9 +1031,11 @@ export class ColumnsView extends viewWithColumnStateMixin {
     const result: number[] = [];
     const cellElements = $cellElements.toArray();
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     (cellElements as HTMLElement[]).forEach((cell) => {
       let width = cell.offsetWidth;
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       if ((cell as any).getBoundingClientRect) {
         const rect = getBoundingRect(cell);
 

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/skipDragCell.functional.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/skipDragCell.functional.ts
@@ -8,24 +8,25 @@ fixture
   .page(url(__dirname, '../../container.html'));
 
 const DATA_GRID_SELECTOR = '#container';
+const DATA_SOURCE = [
+  {
+    id: 1,
+    columnA: 'A_0',
+    columnB: 'B_0',
+  },
+  {
+    id: 2,
+    columnA: 'A_1',
+    columnB: 'B_1',
+  },
+  {
+    id: 3,
+    columnA: 'A_2',
+    columnB: 'B_2',
+  },
+];
 const createDataGrid = async () => createWidget('dxDataGrid', {
-  dataSource: [
-    {
-      id: 1,
-      columnA: 'A_0',
-      columnB: 'B_0',
-    },
-    {
-      id: 2,
-      columnA: 'A_1',
-      columnB: 'B_1',
-    },
-    {
-      id: 3,
-      columnA: 'A_2',
-      columnB: 'B_2',
-    },
-  ],
+  dataSource: DATA_SOURCE,
   keyExpr: 'id',
   columns: ['id', 'columnA', 'columnB'],
   rowDragging: {
@@ -34,6 +35,19 @@ const createDataGrid = async () => createWidget('dxDataGrid', {
   sorting: {
     mode: 'none',
   },
+});
+
+const createDataGridRenderAsyncWithButtons = async () => createWidget('dxDataGrid', {
+  dataSource: DATA_SOURCE,
+  keyExpr: 'id',
+  columns: ['id', 'columnA', 'columnB', { type: 'buttons' }],
+  rowDragging: {
+    allowReordering: true,
+  },
+  sorting: {
+    mode: 'none',
+  },
+  renderAsync: true,
 });
 
 test('The drag cell should be skipped when navigating from the header cell by tab keypress', async (t) => {
@@ -46,6 +60,18 @@ test('The drag cell should be skipped when navigating from the header cell by ta
     .expect(expectedFocusedCell.isFocused)
     .ok();
 }).before(async () => createDataGrid());
+
+test('The drag cell should be skipped when navigating from the header cell by tab keypress'
+  + ' with buttons column and renderAsync: true', async (t) => {
+  const dataGrid = new DataGrid(DATA_GRID_SELECTOR);
+  const expectedFocusedCell = dataGrid.getDataCell(0, 1);
+  const cellToStartNavigation = dataGrid.getHeaders().getHeaderRow(0).getHeaderCell(3);
+
+  await t.click(cellToStartNavigation.element)
+    .pressKey('tab')
+    .expect(expectedFocusedCell.isFocused)
+    .ok();
+}).before(async () => createDataGridRenderAsyncWithButtons());
 
 test('The drag cell should be skipped when navigating to the header cell by shift+tab keypress', async (t) => {
   const dataGrid = new DataGrid(DATA_GRID_SELECTOR);

--- a/packages/devextreme/testing/testcafe/tests/treeList/keyboardNavigation/skipDragCell.functional.ts
+++ b/packages/devextreme/testing/testcafe/tests/treeList/keyboardNavigation/skipDragCell.functional.ts
@@ -8,27 +8,29 @@ fixture
   .page(url(__dirname, '../../container.html'));
 
 const TREE_LIST_SELECTOR = '#container';
+const DATA_SOURCE = [
+  {
+    id: 1,
+    parentId: 0,
+    columnA: 'A_0',
+    columnB: 'B_0',
+  },
+  {
+    id: 2,
+    parentId: 0,
+    columnA: 'A_1',
+    columnB: 'B_1',
+  },
+  {
+    id: 3,
+    parentId: 0,
+    columnA: 'A_2',
+    columnB: 'B_2',
+  },
+];
+
 const createTreeList = async () => createWidget('dxTreeList', {
-  dataSource: [
-    {
-      id: 1,
-      parentId: 0,
-      columnA: 'A_0',
-      columnB: 'B_0',
-    },
-    {
-      id: 2,
-      parentId: 0,
-      columnA: 'A_1',
-      columnB: 'B_1',
-    },
-    {
-      id: 3,
-      parentId: 0,
-      columnA: 'A_2',
-      columnB: 'B_2',
-    },
-  ],
+  dataSource: DATA_SOURCE,
   keyExpr: 'id',
   parentIdExpr: 'parentId',
   columns: ['id', 'columnA', 'columnB'],
@@ -38,6 +40,20 @@ const createTreeList = async () => createWidget('dxTreeList', {
   sorting: {
     mode: 'none',
   },
+});
+
+const createTreeListRenderAsyncWithButtons = async () => createWidget('dxTreeList', {
+  dataSource: DATA_SOURCE,
+  keyExpr: 'id',
+  parentIdExpr: 'parentId',
+  columns: ['id', 'columnA', 'columnB', { type: 'buttons' }],
+  rowDragging: {
+    allowReordering: true,
+  },
+  sorting: {
+    mode: 'none',
+  },
+  renderAsync: true,
 });
 
 test('The drag cell should be skipped when navigating from the header cell by tab keypress', async (t) => {
@@ -50,6 +66,18 @@ test('The drag cell should be skipped when navigating from the header cell by ta
     .expect(expectedFocusedCell.isFocused)
     .ok();
 }).before(async () => createTreeList());
+
+test('The drag cell should be skipped when navigating from the header cell by tab keypress'
+  + ' with buttons column and renderAsync: true', async (t) => {
+  const treeList = new TreeList(TREE_LIST_SELECTOR);
+  const expectedFocusedCell = treeList.getDataCell(0, 1);
+  const cellToStartNavigation = treeList.getHeaders().getHeaderRow(0).getHeaderCell(3);
+
+  await t.click(cellToStartNavigation.element)
+    .pressKey('tab')
+    .expect(expectedFocusedCell.isFocused)
+    .ok();
+}).before(async () => createTreeListRenderAsyncWithButtons());
 
 test('The drag cell should be skipped when navigating to the header cell by shift+tab keypress', async (t) => {
   const treeList = new TreeList(TREE_LIST_SELECTOR);


### PR DESCRIPTION
Moved the HTML attribute creation directly to the cell markup creation.
Before the attribute sets in the template and that causes the issue with the ```renderAsync: true``` option.