### PR TITLE
jQuery playground: fix path to the axe script.

### DIFF
--- a/packages/devextreme/playground/jquery.html
+++ b/packages/devextreme/playground/jquery.html
@@ -30,7 +30,7 @@
     -->
 
     <script type="text/javascript" src="../artifacts/js/dx.all.debug.js" charset="utf-8"></script>
-    <script type="text/javascript" src="../node_modules/axe-core/axe.min.js"></script>
+    <script type="text/javascript" src="../../../node_modules/axe-core/axe.min.js"></script>
 </head>
 <body>
     <div role="main">


### PR DESCRIPTION
Fixed the axe script path in the jQuery.html after the mono repo migration