### PR TITLE
DataGrid/TreeList - The 'container' parameter in a template's render function should be an HtmlElement when integrating a 3rd-party template engine (T1181910)

### DIFF
--- a/testing/tests/DevExpress.core/utils.template_manager.tests.js
+++ b/testing/tests/DevExpress.core/utils.template_manager.tests.js
@@ -3,7 +3,7 @@ import type from 'core/utils/type';
 import renderer from 'core/renderer';
 import {
     findTemplates, suitableTemplatesByName, addOneRenderedCall, templateKey,
-    getNormalizedTemplateArgs, validateTemplateSource,
+    getNormalizedTemplateArgs, validateTemplateSource, addPublicElementNormalization,
     defaultCreateElement, acquireIntegrationTemplate, acquireTemplate,
 } from 'core/utils/template_manager';
 import { Template } from 'core/templates/template';
@@ -11,6 +11,8 @@ import { TemplateBase } from 'core/templates/template_base';
 import { EmptyTemplate } from 'core/templates/empty_template';
 import { ChildDefaultTemplate } from 'core/templates/child_default_template';
 import devices from 'core/devices';
+import { getPublicElement } from 'core/element';
+import $ from 'jquery';
 
 QUnit.module('TemplateManager utils', {
     beforeEach: function() {
@@ -112,6 +114,20 @@ QUnit.test('#addOneRenderedCall', function(assert) {
 
     nextTemplate.render('options');
     assert.ok(render.calledWith('options'), 'should call old `render` method');
+});
+
+QUnit.test('#addPublicElementNormalization', function(assert) {
+    const render = sinon.spy(({ container }) => {
+        const comparer = QUnit.urlParams['nojquery'] ? 'isEqualNode' : 'is';
+        const expectedPublicElement = getPublicElement(wrappedElement);
+        assert.ok(container[comparer](expectedPublicElement), 'container should be a public element');
+    });
+    const template = { render };
+    const nextTemplate = addPublicElementNormalization(template);
+
+    const wrappedElement = $('<div>');
+    const options = { container: wrappedElement };
+    nextTemplate.render(options);
 });
 
 QUnit.test('#getNormalizedTemplateArgs', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -4586,7 +4586,7 @@ QUnit.module('templates', baseModuleConfig, () => {
                                         '</tr>';
 
                                 (asyncMethod === 'deferUpdate' ? deferUpdate : setTimeout)(function() {
-                                    container.append(markup);
+                                    $(container).append(markup);
                                     onRendered();
                                 });
 
@@ -4634,7 +4634,7 @@ QUnit.module('templates', baseModuleConfig, () => {
                                     '</tr>';
 
                             deferUpdate(function() {
-                                container.append(markup);
+                                $(container).append(markup);
                                 onRendered();
                             });
                             return container;

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/masterDetail.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/masterDetail.integration.tests.js
@@ -881,7 +881,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
                                     '</tr>';
 
                             commonUtils.deferUpdate(function() {
-                                container.append(markup);
+                                $(container).append(markup);
                                 onRendered();
                             });
 
@@ -893,7 +893,7 @@ QUnit.module('Master Detail', baseModuleConfig, () => {
                             const markup = '<div class="my-detail">' + model.data.text + '<div>';
 
                             commonUtils.deferUpdate(function() {
-                                container.append(markup);
+                                $(container).append(markup);
                                 onRendered();
                             });
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -2445,7 +2445,7 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
                                 .css('height', `${rowHeight}px`);
 
                             commonUtils.deferUpdate(function() {
-                                container.append(markup);
+                                $(container).append(markup);
                                 onRendered();
                             });
 


### PR DESCRIPTION
Cherry-pick from #25300