### PR TITLE
Angular: Remove steps containing code generation from npm pack task

### DIFF
--- a/.github/workflows/devextreme_angular_tests.yml
+++ b/.github/workflows/devextreme_angular_tests.yml
@@ -64,6 +64,10 @@ jobs:
       working-directory: ./packages/devextreme-angular
       run: npm run test:dev
 
+    - name: Check packing
+      working-directory: ./packages/devextreme-angular
+      run: npm run pack
+
     - name: Archive internal-tools artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/packages/devextreme-angular/LICENSE
+++ b/packages/devextreme-angular/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Developer Express Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/devextreme-angular/README.md
+++ b/packages/devextreme-angular/README.md
@@ -1,0 +1,26 @@
+[![CircleCI](https://img.shields.io/circleci/project/github/DevExpress/devextreme-angular/master.svg)](https://circleci.com/gh/DevExpress/devextreme-angular) [![npm version](https://badge.fury.io/js/devextreme-angular.svg)](https://badge.fury.io/js/devextreme-angular)
+
+
+# DevExtreme Angular UI Components #
+
+This project allows you to use [DevExtreme widgets](http://js.devexpress.com/Demos/WidgetsGallery/) in [Angular](https://angular.io/) applications.
+
+* [Documentation](https://js.devexpress.com/Documentation/Guide/Angular_Components/DevExtreme_Angular_Components/)
+* [Technical Demos](https://js.devexpress.com/Demos/WidgetsGallery/Demo/DataGrid/Overview/Angular/Light/)
+* Real-World Application Demos
+    * [Sales Viewer](https://github.com/DevExpress/SalesViewer)
+    * [Golf Club](https://github.com/DevExpress/golfclub)
+    * [DX Election](https://github.com/DevExpress/dx-election)
+* [API Reference](http://js.devexpress.com/Documentation/ApiReference/)
+
+## License ##
+
+**DevExtreme Angular UI Components are released as a MIT-licensed (free and open-source) add-on to DevExtreme.**
+
+Familiarize yourself with the [DevExtreme License](https://js.devexpress.com/Licensing/). [Free trial is available!](http://js.devexpress.com/Buy/)
+
+## Support & Feedback ##
+
+If you have questions regarding Angular functionality, consult [Angular docs](https://angular.io/docs).
+
+If you want to report a bug, request a feature, or ask a question, submit an [issue](https://github.com/DevExpress/devextreme-angular/issues) to this repo. Alternatively, you can contact us at the [DevExpress Support Center](https://www.devexpress.com/Support/Center) if you own an active DevExtreme license.

--- a/packages/devextreme-angular/build.config.js
+++ b/packages/devextreme-angular/build.config.js
@@ -79,6 +79,6 @@ module.exports = {
     },
     npm: {
         distPath: "npm/dist",
-        content: [ "../../LICENSE", "../../README.md" ]
+        content: [ "./LICENSE", "./README.md" ]
     }
 };

--- a/packages/devextreme-angular/gulpfile.js
+++ b/packages/devextreme-angular/gulpfile.js
@@ -140,13 +140,19 @@ gulp.task('build.components', gulp.series('generate.facades',
 
 //------------npm------------
 
-gulp.task('npm.content', gulp.series('build.components', function() {
-    var npmConfig = buildConfig.npm,
-        cmpConfig = buildConfig.components;
+gulp.task('npm.content', gulp.series(
+    'build.copy-sources',
+    'build.license-headers',
+    'build.ngc',
+    'build.remove-unusable-variable',
+    function() {
+        var npmConfig = buildConfig.npm,
+            cmpConfig = buildConfig.components;
 
-    return gulp.src([cmpConfig.outputPath + '/**/collection.json', ...npmConfig.content])
-        .pipe(gulp.dest(npmConfig.distPath));
-}));
+        return gulp.src([cmpConfig.outputPath + '/**/collection.json', ...npmConfig.content])
+            .pipe(gulp.dest(npmConfig.distPath));
+    })
+);
 
 gulp.task('npm.pack', gulp.series(
     'npm.content',


### PR DESCRIPTION
Remove steps containing code generation from npm pack task. Copy readme and license from old repo