### PR TITLE
Accessibility: DataGrid - Fix the 'ARIA commands must have an accessible name' error in the filter row's search icon (T1047481)

### DIFF
--- a/js/__internal/grids/grid_core/filter/m_filter_row.ts
+++ b/js/__internal/grids/grid_core/filter/m_filter_row.ts
@@ -552,13 +552,15 @@ const ColumnHeadersViewFilterRowExtender = (function () {
         cssClass: `${that.getWidgetContainerClass()} ${CELL_FOCUS_DISABLED_CLASS} ${FILTER_MENU}`,
         showFirstSubmenuMode: 'onHover',
         hideSubmenuOnMouseLeave: true,
-        elementAttr: { 'aria-label': ARIA_SEARCH_BOX },
         items: [{
           disabled: !(column.filterOperations && column.filterOperations.length),
           icon: OPERATION_ICONS[getColumnSelectedFilterOperation(that, column) || 'default'],
           selectable: false,
           items: that._getFilterOperationMenuItems(column),
         }],
+        onItemRendered({ itemElement }) {
+          this.setAria('label', ARIA_SEARCH_BOX, $(itemElement));
+        },
         onItemClick(properties) {
           const selectedFilterOperation = properties.itemData.name;
           const columnSelectedFilterOperation = getColumnSelectedFilterOperation(that, column);

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/filterRow.tests.js
@@ -2804,7 +2804,7 @@ QUnit.module('Filter Row with real dataController and columnsController', {
         this.columnHeadersView.render($testElement);
 
         // assert
-        assert.equal(this.columnHeadersView.element().find('.dx-menu').first().attr('aria-label'), 'Search box');
+        assert.equal(this.columnHeadersView.element().find('.dx-menu-item').first().attr('aria-label'), 'Search box');
     });
 
     if(device.deviceType === 'desktop') {


### PR DESCRIPTION
Cherry-pick from #25419