### PR TITLE
Skip unstable dataGrid, pivotGrid and scheduler TestCafe tests

### DIFF
--- a/packages/devextreme/testing/testcafe/tests/dataGrid/exportButton.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/exportButton.ts
@@ -131,7 +131,7 @@ safeSizeTest('Export is disabled when no data columns is in grid header, menu: f
   },
 }));
 
-safeSizeTest('Export is disabled when no data columns is in grid header, menu: true', async (t) => {
+/* safeSizeTest */test.skip('Export is disabled when no data columns is in grid header, menu: true', async (t) => {
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
 
   const dataGrid = new DataGrid('#container');
@@ -144,7 +144,7 @@ safeSizeTest('Export is disabled when no data columns is in grid header, menu: t
     .ok()
     .expect(compareResults.isValid())
     .ok(compareResults.errorMessages());
-}, [800, 800]).before(async () => createWidget('dxDataGrid', {
+}/* , [800, 800] */).before(async () => createWidget('dxDataGrid', {
   dataSource: [{ value: 1 }],
   columns: [
     { dataField: 'value', visible: false },

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -2205,7 +2205,7 @@ test('Empty row should lose focus on Tab (T941246)', async (t) => {
     });
   });
 
-  test(`The first cell should be focused on pressing shift and tab keys after clicking on the document when command column is ${isCommandColumnFixed ? 'fixed' : 'unfixed'} and on the right side (T951849)`, async (t) => {
+  test.skip(`The first cell should be focused on pressing shift and tab keys after clicking on the document when command column is ${isCommandColumnFixed ? 'fixed' : 'unfixed'} and on the right side (T951849)`, async (t) => {
     const dataGrid = new DataGrid('#container');
     const headers = dataGrid.getHeaders();
     const dataGridOffsetBottom = await dataGrid.element.getBoundingClientRectProperty('bottom');

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/pager.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/pager.ts
@@ -66,7 +66,7 @@ safeSizeTest('Full size pager', async (t) => {
     .ok();
 }).before(async () => createDataGridWithPager());
 
-safeSizeTest('Compact pager', async (t) => {
+/* safeSizeTest */test.skip('Compact pager', async (t) => {
   const dataGrid = new DataGrid('#container');
   const pager = dataGrid.getPager();
   const pageSizeWidget = new SelectBox(pager.getPageSizeSelect() as any);
@@ -82,7 +82,7 @@ safeSizeTest('Compact pager', async (t) => {
     .eql('69')
     .expect(await compareScreenshot(t, 'pager-compact.png'))
     .ok();
-}, [350, 600]).before(async () => createDataGridWithPager());
+}/* , [350, 600] */).before(async () => createDataGridWithPager());
 
 safeSizeTest('Resize', async (t) => {
   const dataGrid = new DataGrid('#container');
@@ -134,7 +134,11 @@ safeSizeTest('Resize without navigation buttons', async (t) => {
 }).before(async () => createDataGridWithPager());
 
 ['generic.light', 'generic.light.compact', 'material.blue.light', 'material.blue.light.compact'].forEach((theme) => {
-  safeSizeTest(`Compact pager in the ${theme} theme (T1057735)`, async (t) => {
+  const [testCase, extra]: [typeof test | typeof safeSizeTest, [number, number][]] = theme === 'material.blue.light'
+    ? [test.skip, []]
+    : [safeSizeTest, [[700, 600]]];
+
+  testCase(`Compact pager in the ${theme} theme (T1057735)`, async (t) => {
     const dataGrid = new DataGrid('#container');
     const pagerElement = dataGrid.getPager().element;
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
@@ -144,7 +148,7 @@ safeSizeTest('Resize without navigation buttons', async (t) => {
       .ok()
       .expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }, [700, 600])
+  }, ...extra)
     .before(async () => {
       await changeTheme(theme);
       await createWidget('dxDataGrid', {

--- a/packages/devextreme/testing/testcafe/tests/pivotGrid/headerFilter.ts
+++ b/packages/devextreme/testing/testcafe/tests/pivotGrid/headerFilter.ts
@@ -8,7 +8,7 @@ import { sales } from './data';
 fixture.disablePageReloads`pivotGrid_headerFilter`
   .page(url(__dirname, '../container.html'));
 
-test('Header filter popup', async (t) => {
+test.skip('Header filter popup', async (t) => {
   const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
   const pivotGrid = new PivotGrid('#container');
 

--- a/packages/devextreme/testing/testcafe/tests/scheduler/layout/resources/base/generic.ts
+++ b/packages/devextreme/testing/testcafe/tests/scheduler/layout/resources/base/generic.ts
@@ -49,7 +49,8 @@ const resources = [{
 
 [undefined, resources].forEach((resourcesValue) => {
   ['timelineDay', 'timelineWeek', 'timelineWorkWeek', 'timelineMonth'].forEach((view) => {
-    test(`Timeline views layout test in generic theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
+    const testCase = resourcesValue != null && view === 'timelineWorkWeek' ? test.skip : test;
+    testCase(`Timeline views layout test in generic theme with resources(view='${view})', resource=${!!resourcesValue}`, async (t) => {
       const scheduler = new Scheduler('#container');
 
       await t.click(scheduler.getAppointment('1 appointment', 0).element);

--- a/packages/devextreme/testing/testcafe/tests/scheduler/tooltipBehaviour/tooltipBehavior.ts
+++ b/packages/devextreme/testing/testcafe/tests/scheduler/tooltipBehaviour/tooltipBehavior.ts
@@ -91,7 +91,7 @@ safeSizeTest('The tooltip should hide after manually scrolling in the browser', 
   false,
   true,
 ].forEach((adaptivityEnabled) => {
-  safeSizeTest('The tooltip screenshot', async (t) => {
+  /* safeSizeTest */test.skip('The tooltip screenshot', async (t) => {
     const { takeScreenshot, compareResults } = createScreenshotsComparer(t);
     const scheduler = new Scheduler('#container');
     const appointment = scheduler.getAppointment('Brochure Design Review');
@@ -110,7 +110,7 @@ safeSizeTest('The tooltip should hide after manually scrolling in the browser', 
       .ok()
       .expect(compareResults.isValid())
       .ok(compareResults.errorMessages());
-  }, [600, 400]).before(async () => createScheduler({
+  }/* , [600, 400] */).before(async () => createScheduler({
     views: ['week'],
     currentView: 'week',
     dataSource,


### PR DESCRIPTION
Skipped tests for TestCafe tests / scheduler:

- Appointment tooltip behavior during scrolling in the Scheduler (T755449) - The tooltip screenshot (18 failures in 2 days)
- Scheduler: Generic theme layout - Timeline views layout test in generic theme with resources(view='timelineWorkWeek)', resource=true (3 failures in 2 days)

Skipped tests for TestCafe tests / dataGrid:

- Pager - Compact pager [in the material.blue.light theme (T1057735)] (4 failures in 2 days)
- Export button - Export is disabled when no data columns is in grid header, menu: true (8 failures in 2 days)
- Keyboard Navigation - common - The first cell should be focused on pressing shift and tab keys after clicking on the document when command column is fixed and on the right side (T951849) (8 failures in 2 days)

Skipped tests for TestCafe tests / pivotGrid:

- pivotGrid_headerFilter - Header filter popup (7 failures in 2 days)