### PR TITLE
DataGrid - Master-detail - It's not possible to focus all rows after rows are expanded and collapsed (T1187124)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1742,7 +1742,7 @@ export class KeyboardNavigationController extends modules.ViewController {
 
     const lastVisibleIndex = Math.max(
       ...dataController.items()
-        .map((item, index) => (item.visible ? index : -1)),
+        .map((item, index) => (item.visible !== false ? index : -1)),
     );
 
     return rowIndex === lastVisibleIndex;

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1740,13 +1740,12 @@ export class KeyboardNavigationController extends modules.ViewController {
       return rowIndex >= (dataController as any).getMaxRowIndex();
     }
 
-    const lastVisibleIndex = dataController.items().reduce<number>(
-      (maxIndex, item, i) => Math.max(
-        maxIndex,
-        item.visible !== false ? i : -1,
-      ),
-      -1,
-    );
+    let lastVisibleIndex = -1;
+    dataController.items().forEach((item, i) => {
+      if (item.visible) {
+        lastVisibleIndex = i;
+      }
+    });
 
     return rowIndex === lastVisibleIndex;
   }

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1733,7 +1733,7 @@ export class KeyboardNavigationController extends modules.ViewController {
     return this._isCellValid($cell);
   }
 
-  private _isLastRow(rowIndex: number) {
+  private _isLastRow(rowIndex: number): boolean {
     const dataController = this._dataController;
 
     if (this._isVirtualRowRender()) {
@@ -1742,7 +1742,7 @@ export class KeyboardNavigationController extends modules.ViewController {
 
     let lastVisibleIndex = -1;
     dataController.items().forEach((item, i) => {
-      if (item.visible) {
+      if (item.visible !== false) {
         lastVisibleIndex = i;
       }
     });

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1740,12 +1740,10 @@ export class KeyboardNavigationController extends modules.ViewController {
       return rowIndex >= (dataController as any).getMaxRowIndex();
     }
 
-    let lastVisibleIndex = -1;
-    dataController.items().forEach((item, i) => {
-      if (item.visible !== false) {
-        lastVisibleIndex = i;
-      }
-    });
+    const lastVisibleIndex = Math.max(
+      ...dataController.items()
+        .map((item, index) => (item.visible ? index : -1)),
+    );
 
     return rowIndex === lastVisibleIndex;
   }

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -1733,17 +1733,22 @@ export class KeyboardNavigationController extends modules.ViewController {
     return this._isCellValid($cell);
   }
 
-  _isLastRow(rowIndex) {
-    const dataController = this._dataController as any;
-    const visibleItems = dataController
-      .items()
-      .filter((item) => item.visible !== false);
+  private _isLastRow(rowIndex: number) {
+    const dataController = this._dataController;
 
     if (this._isVirtualRowRender()) {
-      return rowIndex >= dataController.getMaxRowIndex();
+      return rowIndex >= (dataController as any).getMaxRowIndex();
     }
 
-    return rowIndex === visibleItems.length - 1;
+    const lastVisibleIndex = dataController.items().reduce<number>(
+      (maxIndex, item, i) => Math.max(
+        maxIndex,
+        item.visible !== false ? i : -1,
+      ),
+      -1,
+    );
+
+    return rowIndex === lastVisibleIndex;
   }
 
   _isFirstValidCell(cellPosition) {

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4374,3 +4374,42 @@ test('Focus second cell (via click) -> tab navigation when focusedRowEnabled is 
     },
   }, 'field2', 'field3'],
 }, undefined, { disableFxAnimation: true }));
+
+// T1187124
+test('Keyboard navigation should work after opening-closing master-detal', async (t) => {
+  const dataGrid = new DataGrid('#container');
+
+  await t.click(dataGrid.getDataRow(0).getCommandCell(0).element); // open master detail
+  await t.click(dataGrid.getDataRow(0).getCommandCell(0).element); // close master detail
+
+  await t.debug();
+
+  await t
+    .click(dataGrid.getHeaders().getHeaderRow(0).getHeaderCell(1).element)
+    .pressKey('tab')
+    .pressKey('tab')
+    .expect(dataGrid.getDataCell(0, 1).isFocused)
+    .ok();
+
+  await t
+    .pressKey('down')
+    .expect(dataGrid.getDataCell(1, 1).isFocused).ok();
+
+  await t
+    .pressKey('down')
+    .expect(dataGrid.getDataCell(2, 1).isFocused).ok();
+  await t
+    .pressKey('down')
+    .expect(dataGrid.getDataCell(3, 1).isFocused).ok();
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: [
+    { id: 1 },
+    { id: 2 },
+    { id: 3 },
+    { id: 4 },
+  ],
+  keyExpr: 'id',
+  masterDetail: {
+    enabled: true,
+  },
+}, undefined, { disableFxAnimation: true }));

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4334,7 +4334,7 @@ test('Focus first cell with dropDownButton (via tab key) -> open dropDownButton 
       });
     },
   }, 'field2', 'field3'],
-}, undefined, { disableFxAnimation: true }));
+}));
 
 // T1185341
 test('Focus second cell (via click) -> tab navigation when focusedRowEnabled is true', async (t) => {
@@ -4373,7 +4373,7 @@ test('Focus second cell (via click) -> tab navigation when focusedRowEnabled is 
       });
     },
   }, 'field2', 'field3'],
-}, undefined, { disableFxAnimation: true }));
+}));
 
 // T1187124
 test('Keyboard navigation should work after opening-closing master-detal', async (t) => {
@@ -4410,4 +4410,4 @@ test('Keyboard navigation should work after opening-closing master-detal', async
   masterDetail: {
     enabled: true,
   },
-}, undefined, { disableFxAnimation: true }));
+}));

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4382,8 +4382,6 @@ test('Keyboard navigation should work after opening-closing master-detal', async
   await t.click(dataGrid.getDataRow(0).getCommandCell(0).element); // open master detail
   await t.click(dataGrid.getDataRow(0).getCommandCell(0).element); // close master detail
 
-  await t.debug();
-
   await t
     .click(dataGrid.getHeaders().getHeaderRow(0).getHeaderCell(1).element)
     .pressKey('tab')


### PR DESCRIPTION
<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
