### PR TITLE
SelectBox: should not throw an error if its detached template is re-mounted by a framework (T1178295)

### DIFF
--- a/js/ui/drop_down_editor/ui.drop_down_editor.js
+++ b/js/ui/drop_down_editor/ui.drop_down_editor.js
@@ -337,8 +337,6 @@ const DropDownEditor = TextBox.inherit({
     },
 
     _renderTemplatedField: function(fieldTemplate, data) {
-        this._fieldRenderQueueLength = (this._fieldRenderQueueLength ?? 0) + 1;
-
         const isFocused = focused(this._input());
         const $container = this._$container;
 
@@ -354,8 +352,9 @@ const DropDownEditor = TextBox.inherit({
             model: data,
             container: getPublicElement($templateWrapper),
             onRendered: () => {
-                this._fieldRenderQueueLength--;
-                if(this._fieldRenderQueueLength !== 0) {
+                const isRenderedInRoot = !!this.$element().find($templateWrapper).length;
+
+                if(!isRenderedInRoot) {
                     return;
                 }
 


### PR DESCRIPTION
Cherry-picking https://github.com/DevExpress/DevExtreme/pull/25467
