### PR TITLE
Fix deprecated "set-output" command in workflows (#25607)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,9 +67,8 @@ jobs:
     steps:
       - name: Get Date
         id: get-date
-        run: |
-          echo "::set-output name=date::$(/bin/date -u "+%s")"
         shell: bash
+        run: echo "date=$(/bin/date -u "+%s")" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: notify-cache


### PR DESCRIPTION
Cherry-pick of https://github.com/DevExpress/DevExtreme/pull/25607