### PR TITLE
DataGrid: Fix disabled state for export button when using the `toolbar|items|disabled` option (T1189621)

### DIFF
--- a/js/__internal/grids/grid_core/header_panel/m_header_panel.ts
+++ b/js/__internal/grids/grid_core/header_panel/m_header_panel.ts
@@ -126,6 +126,13 @@ const members = {
     }
   },
 
+  _isDisabledDefinedByUser(name: string): boolean {
+    const userItems = this.option('toolbar')?.items;
+    const userItem = userItems?.find((item) => item?.name === name);
+
+    return isDefined(userItem?.disabled);
+  },
+
   init() {
     this.callBase();
     this.createAction('onToolbarPreparing', { excludeValidators: ['disabled', 'readOnly'] });
@@ -138,8 +145,9 @@ const members = {
 
   setToolbarItemDisabled(name, disabled: boolean): void {
     const toolbar = this._toolbar;
+    const isDefinedByUser = this._isDisabledDefinedByUser(name);
 
-    if (!toolbar) {
+    if (!toolbar || isDefinedByUser) {
       return;
     }
 

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/exportController.tests.js
@@ -2807,5 +2807,30 @@ QUnit.module('Real dataGrid ExportController tests', {
             }]
         ], 'PrepareItems is correct with custom Array prototype method');
     });
+
+    // T1189621
+    QUnit.test('The export button should be disabled using the `toolbar|items|disabled` option ', function(assert) {
+        // arrange, act
+        const $container = $('#container');
+
+        createDataGrid({
+            dataSource: [{ id: 0, field: 1 }],
+            export: {
+                enabled: true,
+            },
+            toolbar: {
+                items: [{
+                    name: 'exportButton',
+                    disabled: true
+                }]
+            },
+        });
+
+        this.clock.tick(50);
+
+        // assert
+        const $exportButton = $container.find('.dx-datagrid-export-button');
+        assert.ok($exportButton.closest('.dx-toolbar-item').hasClass('dx-state-disabled'), 'export button is disabled');
+    });
 });
 


### PR DESCRIPTION
See https://devexpress.com/issue=T1189621
