### PR TITLE
[Duplicate] Git hooks: hide warnings from eslint pre-commit check.

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
 {
     "**/*.{css,scss}": "stylelint",
-    "packages/devextreme/**/*.{js,ts,tsx}": "eslint"
+    "packages/devextreme/**/*.{js,ts,tsx}": "eslint --quiet"
 }


### PR DESCRIPTION
Cherry-pick of the https://github.com/DevExpress/DevExtreme/pull/25751 PR