### PR TITLE
Safe check changed option when its iterable value becomes scalar

### DIFF
--- a/packages/devextreme-angular/src/core/iterable-differ-helper.ts
+++ b/packages/devextreme-angular/src/core/iterable-differ-helper.ts
@@ -2,13 +2,15 @@ import {
   Injectable,
   SimpleChanges,
   IterableDiffers,
-  ɵisListLikeIterable,
 } from '@angular/core';
 
 import {
   DxComponent,
 } from './component';
 
+function isJsObject(o) {
+  return o !== null && (typeof o === 'function' || typeof o === 'object');
+}
 @Injectable()
 export class IterableDifferHelper {
   private _host: DxComponent;
@@ -44,7 +46,7 @@ export class IterableDifferHelper {
   }
 
   getChanges(prop: string, value: any) {
-    if (this._propertyDiffers[prop] && ɵisListLikeIterable(value)) {
+    if (this._propertyDiffers[prop] && isJsObject(value) && typeof value[Symbol.iterator] === 'function') {
       return this._propertyDiffers[prop].diff(value);
     }
   }

--- a/packages/devextreme-angular/src/core/iterable-differ-helper.ts
+++ b/packages/devextreme-angular/src/core/iterable-differ-helper.ts
@@ -8,10 +8,6 @@ import {
   DxComponent,
 } from './component';
 
-function isJsObject(o) {
-  return o !== null && (typeof o === 'function' || typeof o === 'object');
-}
-
 @Injectable()
 export class IterableDifferHelper {
   private _host: DxComponent;
@@ -57,12 +53,13 @@ export class IterableDifferHelper {
   }
 
   doCheck(prop: string) {
-    if (this._propertyDiffers[prop] && this._host.instance) {
-      const hostValue = this._host[prop];
-      const changes = hostValue && isJsObject(hostValue) && this.getChanges(prop, hostValue);
-      const isNeedHandle = changes && !this.checkChangedOptions(prop, hostValue);
+    const hostValue = this._host.instance && this._host[prop];
+    const typeOfValueOrFalse = hostValue && typeof hostValue;
 
-      if (isNeedHandle) {
+    if (typeOfValueOrFalse && (typeOfValueOrFalse === 'function' || typeOfValueOrFalse === 'object') && this._propertyDiffers[prop]) {
+      const changes = this.getChanges(prop, hostValue);
+
+      if (changes && !this.checkChangedOptions(prop, hostValue)) {
         this._host.lockWidgetUpdate();
         this._host.instance.option(prop, hostValue);
       }

--- a/packages/devextreme-angular/src/core/iterable-differ-helper.ts
+++ b/packages/devextreme-angular/src/core/iterable-differ-helper.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   SimpleChanges,
   IterableDiffers,
+  ɵisListLikeIterable,
 } from '@angular/core';
 
 import {
@@ -43,7 +44,7 @@ export class IterableDifferHelper {
   }
 
   getChanges(prop: string, value: any) {
-    if (this._propertyDiffers[prop]) {
+    if (this._propertyDiffers[prop] && ɵisListLikeIterable(value)) {
       return this._propertyDiffers[prop].diff(value);
     }
   }

--- a/packages/devextreme-angular/src/core/iterable-differ-helper.ts
+++ b/packages/devextreme-angular/src/core/iterable-differ-helper.ts
@@ -53,11 +53,9 @@ export class IterableDifferHelper {
   }
 
   doCheck(prop: string) {
-    const hostValue = this._host.instance && this._host[prop];
-    const typeOfValueOrFalse = hostValue && typeof hostValue;
-
-    if (typeOfValueOrFalse && (typeOfValueOrFalse === 'function' || typeOfValueOrFalse === 'object') && this._propertyDiffers[prop]) {
-      const changes = this.getChanges(prop, hostValue);
+    if (this._propertyDiffers[prop] && this._host.instance) {
+      const hostValue = this._host[prop];
+      const changes = hostValue && (typeof hostValue[Symbol.iterator] === 'function') && this.getChanges(prop, hostValue);
 
       if (changes && !this.checkChangedOptions(prop, hostValue)) {
         this._host.lockWidgetUpdate();

--- a/packages/devextreme-angular/src/core/iterable-differ-helper.ts
+++ b/packages/devextreme-angular/src/core/iterable-differ-helper.ts
@@ -11,6 +11,7 @@ import {
 function isJsObject(o) {
   return o !== null && (typeof o === 'function' || typeof o === 'object');
 }
+
 @Injectable()
 export class IterableDifferHelper {
   private _host: DxComponent;
@@ -46,7 +47,7 @@ export class IterableDifferHelper {
   }
 
   getChanges(prop: string, value: any) {
-    if (this._propertyDiffers[prop] && isJsObject(value) && typeof value[Symbol.iterator] === 'function') {
+    if (this._propertyDiffers[prop]) {
       return this._propertyDiffers[prop].diff(value);
     }
   }
@@ -56,10 +57,10 @@ export class IterableDifferHelper {
   }
 
   doCheck(prop: string) {
-    if (this._propertyDiffers[prop]) {
-      const hostValue = this._host[prop];
-      const isChangedOption = this.checkChangedOptions(prop, hostValue);
+    const hostValue = this._host[prop];
 
+    if (this._propertyDiffers[prop] && isJsObject(hostValue) && typeof hostValue[Symbol.iterator] === 'function') {
+      const isChangedOption = this.checkChangedOptions(prop, hostValue);
       const changes = this.getChanges(prop, hostValue);
       if (changes && this._host.instance && !isChangedOption) {
         this._host.lockWidgetUpdate();

--- a/packages/devextreme-angular/src/core/iterable-differ-helper.ts
+++ b/packages/devextreme-angular/src/core/iterable-differ-helper.ts
@@ -57,12 +57,12 @@ export class IterableDifferHelper {
   }
 
   doCheck(prop: string) {
-    const hostValue = this._host[prop];
+    if (this._propertyDiffers[prop] && this._host.instance) {
+      const hostValue = this._host[prop];
+      const changes = hostValue && isJsObject(hostValue) && this.getChanges(prop, hostValue);
+      const isNeedHandle = changes && !this.checkChangedOptions(prop, hostValue);
 
-    if (this._propertyDiffers[prop] && isJsObject(hostValue) && typeof hostValue[Symbol.iterator] === 'function') {
-      const isChangedOption = this.checkChangedOptions(prop, hostValue);
-      const changes = this.getChanges(prop, hostValue);
-      if (changes && this._host.instance && !isChangedOption) {
+      if (isNeedHandle) {
         this._host.lockWidgetUpdate();
         this._host.instance.option(prop, hostValue);
       }

--- a/packages/devextreme-angular/tests/src/ui/calendar.spec.ts
+++ b/packages/devextreme-angular/tests/src/ui/calendar.spec.ts
@@ -1,0 +1,54 @@
+/* tslint:disable:component-selector */
+
+import {
+    Component,
+    ViewChild
+} from '@angular/core';
+
+import { TestBed } from '@angular/core/testing';
+import { BrowserTransferStateModule } from '@angular/platform-browser';
+
+import {
+  DxCalendarModule,
+  DxCalendarComponent,
+} from "devextreme-angular";
+
+@Component({
+    selector: 'test-container-component',
+    template: '',
+})
+class TestContainerComponent {
+    @ViewChild(DxCalendarComponent) calendar: DxCalendarComponent;
+
+    value: any = [];
+}
+
+describe('DxCalendar', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule(
+            {
+                declarations: [TestContainerComponent],
+                imports: [DxCalendarModule, BrowserTransferStateModule]
+            });
+    });
+
+    // spec
+    it('should take iterable and no-iterable values without exception', () => {
+        TestBed.overrideComponent(TestContainerComponent, {
+            set: {
+                template: `<dx-calendar [value]="value" selectionMode="multiple"></dx-calendar>`
+            }
+        });
+
+        const fixture = TestBed.createComponent(TestContainerComponent);
+
+        fixture.detectChanges();
+
+        const calendar = fixture.componentInstance.calendar;
+
+        calendar.selectionMode = 'single';
+        calendar.instance.option('value', new Date());
+
+        fixture.detectChanges();
+    });
+});

--- a/playgrounds/angular/src/app/app.component.html
+++ b/playgrounds/angular/src/app/app.component.html
@@ -119,7 +119,13 @@
 
     <dx-date-box [(value)]="currentDate"></dx-date-box>
 
-    <dx-calendar [(value)]="currentDate"></dx-calendar>
+    <dx-calendar #calendar [value]="value" [selectionMode]="selectionMode">
+    </dx-calendar>
+    <dx-select-box
+      [dataSource]="selectionModes"
+      [(value)]="selectionMode"
+    >
+    </dx-select-box>
 
     <h2>Custom Templates</h2>
 

--- a/playgrounds/angular/src/app/app.component.ts
+++ b/playgrounds/angular/src/app/app.component.ts
@@ -99,6 +99,14 @@ import {
 })
 export class AppComponent implements OnInit, AfterViewInit {
   @ViewChild(DxPopoverComponent) popover: DxPopoverComponent;
+  
+  value: any = [
+    new Date(),
+    new Date(new Date().getTime() + 1000 * 60 * 60 * 24)
+  ];
+  selectionModes: string[] = ["single", "multiple", "range"];
+  selectionMode = "multiple";
+
   text = 'Initial text';
   formData = { email: '', password: '' };
   emailControl: AbstractControl;


### PR DESCRIPTION
Before a fix fails with:
"Only arrays and iterables are allowed"

```
at DefaultIterableDiffer.diff 
at IterableDifferHelper.getChanges
at IterableDifferHelper.doCheck
```

Moved to:
https://github.com/DevExpress/DevExtreme/pull/25855