### PR TITLE
Add 'use client' for NextJS compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/shelljs": "0.8.13",
         "cheerio": "1.0.0-rc.10",
         "codelyzer": "^6.0.2",
-        "devextreme-internal-tools": "12.0.0-beta.8",
+        "devextreme-internal-tools": "12.0.0-beta.9",
         "eslint": "8.47.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-airbnb-typescript": "17.0.0",
@@ -13548,9 +13548,9 @@
       "link": true
     },
     "node_modules/devextreme-internal-tools": {
-      "version": "12.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-12.0.0-beta.8.tgz",
-      "integrity": "sha512-NsOI5hAPlrptAVn3mnC4sFGWEOw9SWNuDT0dHMipjTk+idSJ6z4q73g8rDDtAAwMbQJbti0/4lBbRmgBAHIcaw==",
+      "version": "12.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-12.0.0-beta.9.tgz",
+      "integrity": "sha512-TB2v8cA/5+qm2/b8z7smsvJU/yVoYpzOD5WDnObO/3KKY89lMU+P53gcxQAPB/5bgaM5LtpZu4g14hEDoC1uAQ==",
       "dev": true,
       "dependencies": {
         "dasherize": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/shelljs": "0.8.13",
     "cheerio": "1.0.0-rc.10",
     "codelyzer": "^6.0.2",
-    "devextreme-internal-tools": "12.0.0-beta.8",
+    "devextreme-internal-tools": "12.0.0-beta.9",
     "eslint": "8.47.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-airbnb-typescript": "17.0.0",

--- a/packages/devextreme-react/src/accordion.ts
+++ b/packages/devextreme-react/src/accordion.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/accordion";
 import dxAccordion, {
     Properties

--- a/packages/devextreme-react/src/action-sheet.ts
+++ b/packages/devextreme-react/src/action-sheet.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/action_sheet";
 import dxActionSheet, {
     Properties

--- a/packages/devextreme-react/src/autocomplete.ts
+++ b/packages/devextreme-react/src/autocomplete.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxAutocomplete, {
     Properties
 } from "devextreme/ui/autocomplete";

--- a/packages/devextreme-react/src/bar-gauge.ts
+++ b/packages/devextreme-react/src/bar-gauge.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxBarGauge, {
     Properties
 } from "devextreme/viz/bar_gauge";

--- a/packages/devextreme-react/src/box.ts
+++ b/packages/devextreme-react/src/box.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/box";
 import dxBox, {
     Properties

--- a/packages/devextreme-react/src/bullet.ts
+++ b/packages/devextreme-react/src/bullet.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxBullet, {
     Properties
 } from "devextreme/viz/bullet";

--- a/packages/devextreme-react/src/button-group.ts
+++ b/packages/devextreme-react/src/button-group.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxButtonGroup, {
     Properties
 } from "devextreme/ui/button_group";

--- a/packages/devextreme-react/src/button.ts
+++ b/packages/devextreme-react/src/button.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxButton, {
     Properties
 } from "devextreme/ui/button";

--- a/packages/devextreme-react/src/calendar.ts
+++ b/packages/devextreme-react/src/calendar.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxCalendar, {
     Properties
 } from "devextreme/ui/calendar";

--- a/packages/devextreme-react/src/chart.ts
+++ b/packages/devextreme-react/src/chart.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxChart, {
     Properties
 } from "devextreme/viz/chart";

--- a/packages/devextreme-react/src/check-box.ts
+++ b/packages/devextreme-react/src/check-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxCheckBox, {
     Properties
 } from "devextreme/ui/check_box";

--- a/packages/devextreme-react/src/circular-gauge.ts
+++ b/packages/devextreme-react/src/circular-gauge.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxCircularGauge, {
     Properties
 } from "devextreme/viz/circular_gauge";

--- a/packages/devextreme-react/src/color-box.ts
+++ b/packages/devextreme-react/src/color-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxColorBox, {
     Properties
 } from "devextreme/ui/color_box";

--- a/packages/devextreme-react/src/context-menu.ts
+++ b/packages/devextreme-react/src/context-menu.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/context_menu";
 import dxContextMenu, {
     Properties

--- a/packages/devextreme-react/src/data-grid.ts
+++ b/packages/devextreme-react/src/data-grid.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/data_grid";
 import dxDataGrid, {
     Properties

--- a/packages/devextreme-react/src/date-box.ts
+++ b/packages/devextreme-react/src/date-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxDateBox, {
     Properties
 } from "devextreme/ui/date_box";

--- a/packages/devextreme-react/src/date-range-box.ts
+++ b/packages/devextreme-react/src/date-range-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxDateRangeBox, {
     Properties
 } from "devextreme/ui/date_range_box";

--- a/packages/devextreme-react/src/defer-rendering.ts
+++ b/packages/devextreme-react/src/defer-rendering.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxDeferRendering, {
     Properties
 } from "devextreme/ui/defer_rendering";

--- a/packages/devextreme-react/src/diagram.ts
+++ b/packages/devextreme-react/src/diagram.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxDiagram, {
     Properties
 } from "devextreme/ui/diagram";

--- a/packages/devextreme-react/src/draggable.ts
+++ b/packages/devextreme-react/src/draggable.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxDraggable, {
     Properties
 } from "devextreme/ui/draggable";

--- a/packages/devextreme-react/src/drawer.ts
+++ b/packages/devextreme-react/src/drawer.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxDrawer, {
     Properties
 } from "devextreme/ui/drawer";

--- a/packages/devextreme-react/src/drop-down-box.ts
+++ b/packages/devextreme-react/src/drop-down-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxDropDownBox, {
     Properties
 } from "devextreme/ui/drop_down_box";

--- a/packages/devextreme-react/src/drop-down-button.ts
+++ b/packages/devextreme-react/src/drop-down-button.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxDropDownButton, {
     Properties
 } from "devextreme/ui/drop_down_button";

--- a/packages/devextreme-react/src/file-manager.ts
+++ b/packages/devextreme-react/src/file-manager.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxFileManager, {
     Properties
 } from "devextreme/ui/file_manager";

--- a/packages/devextreme-react/src/file-uploader.ts
+++ b/packages/devextreme-react/src/file-uploader.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxFileUploader, {
     Properties
 } from "devextreme/ui/file_uploader";

--- a/packages/devextreme-react/src/filter-builder.ts
+++ b/packages/devextreme-react/src/filter-builder.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxFilterBuilder, {
     Properties
 } from "devextreme/ui/filter_builder";

--- a/packages/devextreme-react/src/form.ts
+++ b/packages/devextreme-react/src/form.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxForm, {
     Properties
 } from "devextreme/ui/form";

--- a/packages/devextreme-react/src/funnel.ts
+++ b/packages/devextreme-react/src/funnel.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxFunnel, {
     Properties
 } from "devextreme/viz/funnel";

--- a/packages/devextreme-react/src/gallery.ts
+++ b/packages/devextreme-react/src/gallery.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/gallery";
 import dxGallery, {
     Properties

--- a/packages/devextreme-react/src/gantt.ts
+++ b/packages/devextreme-react/src/gantt.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxGantt, {
     Properties
 } from "devextreme/ui/gantt";

--- a/packages/devextreme-react/src/html-editor.ts
+++ b/packages/devextreme-react/src/html-editor.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxHtmlEditor, {
     Properties
 } from "devextreme/ui/html_editor";

--- a/packages/devextreme-react/src/linear-gauge.ts
+++ b/packages/devextreme-react/src/linear-gauge.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxLinearGauge, {
     Properties
 } from "devextreme/viz/linear_gauge";

--- a/packages/devextreme-react/src/list.ts
+++ b/packages/devextreme-react/src/list.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/list";
 import dxList, {
     Properties

--- a/packages/devextreme-react/src/load-indicator.ts
+++ b/packages/devextreme-react/src/load-indicator.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxLoadIndicator, {
     Properties
 } from "devextreme/ui/load_indicator";

--- a/packages/devextreme-react/src/load-panel.ts
+++ b/packages/devextreme-react/src/load-panel.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxLoadPanel, {
     Properties
 } from "devextreme/ui/load_panel";

--- a/packages/devextreme-react/src/lookup.ts
+++ b/packages/devextreme-react/src/lookup.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxLookup, {
     Properties
 } from "devextreme/ui/lookup";

--- a/packages/devextreme-react/src/map.ts
+++ b/packages/devextreme-react/src/map.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxMap, {
     Properties
 } from "devextreme/ui/map";

--- a/packages/devextreme-react/src/menu.ts
+++ b/packages/devextreme-react/src/menu.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/menu";
 import dxMenu, {
     Properties

--- a/packages/devextreme-react/src/multi-view.ts
+++ b/packages/devextreme-react/src/multi-view.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/multi_view";
 import dxMultiView, {
     Properties

--- a/packages/devextreme-react/src/number-box.ts
+++ b/packages/devextreme-react/src/number-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxNumberBox, {
     Properties
 } from "devextreme/ui/number_box";

--- a/packages/devextreme-react/src/pie-chart.ts
+++ b/packages/devextreme-react/src/pie-chart.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxPieChart, {
     Properties
 } from "devextreme/viz/pie_chart";

--- a/packages/devextreme-react/src/pivot-grid-field-chooser.ts
+++ b/packages/devextreme-react/src/pivot-grid-field-chooser.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxPivotGridFieldChooser, {
     Properties
 } from "devextreme/ui/pivot_grid_field_chooser";

--- a/packages/devextreme-react/src/pivot-grid.ts
+++ b/packages/devextreme-react/src/pivot-grid.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxPivotGrid, {
     Properties
 } from "devextreme/ui/pivot_grid";

--- a/packages/devextreme-react/src/polar-chart.ts
+++ b/packages/devextreme-react/src/polar-chart.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxPolarChart, {
     Properties
 } from "devextreme/viz/polar_chart";

--- a/packages/devextreme-react/src/popover.ts
+++ b/packages/devextreme-react/src/popover.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxPopover, {
     Properties
 } from "devextreme/ui/popover";

--- a/packages/devextreme-react/src/popup.ts
+++ b/packages/devextreme-react/src/popup.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxPopup, {
     Properties
 } from "devextreme/ui/popup";

--- a/packages/devextreme-react/src/progress-bar.ts
+++ b/packages/devextreme-react/src/progress-bar.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxProgressBar, {
     Properties
 } from "devextreme/ui/progress_bar";

--- a/packages/devextreme-react/src/radio-group.ts
+++ b/packages/devextreme-react/src/radio-group.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxRadioGroup, {
     Properties
 } from "devextreme/ui/radio_group";

--- a/packages/devextreme-react/src/range-selector.ts
+++ b/packages/devextreme-react/src/range-selector.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxRangeSelector, {
     Properties
 } from "devextreme/viz/range_selector";

--- a/packages/devextreme-react/src/range-slider.ts
+++ b/packages/devextreme-react/src/range-slider.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxRangeSlider, {
     Properties
 } from "devextreme/ui/range_slider";

--- a/packages/devextreme-react/src/recurrence-editor.ts
+++ b/packages/devextreme-react/src/recurrence-editor.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxRecurrenceEditor, {
     Properties
 } from "devextreme/ui/recurrence_editor";

--- a/packages/devextreme-react/src/resizable.ts
+++ b/packages/devextreme-react/src/resizable.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxResizable, {
     Properties
 } from "devextreme/ui/resizable";

--- a/packages/devextreme-react/src/responsive-box.ts
+++ b/packages/devextreme-react/src/responsive-box.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/responsive_box";
 import dxResponsiveBox, {
     Properties

--- a/packages/devextreme-react/src/sankey.ts
+++ b/packages/devextreme-react/src/sankey.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxSankey, {
     Properties
 } from "devextreme/viz/sankey";

--- a/packages/devextreme-react/src/scheduler.ts
+++ b/packages/devextreme-react/src/scheduler.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxScheduler, {
     Properties
 } from "devextreme/ui/scheduler";

--- a/packages/devextreme-react/src/scroll-view.ts
+++ b/packages/devextreme-react/src/scroll-view.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxScrollView, {
     Properties
 } from "devextreme/ui/scroll_view";

--- a/packages/devextreme-react/src/select-box.ts
+++ b/packages/devextreme-react/src/select-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxSelectBox, {
     Properties
 } from "devextreme/ui/select_box";

--- a/packages/devextreme-react/src/slider.ts
+++ b/packages/devextreme-react/src/slider.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxSlider, {
     Properties
 } from "devextreme/ui/slider";

--- a/packages/devextreme-react/src/sortable.ts
+++ b/packages/devextreme-react/src/sortable.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxSortable, {
     Properties
 } from "devextreme/ui/sortable";

--- a/packages/devextreme-react/src/sparkline.ts
+++ b/packages/devextreme-react/src/sparkline.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxSparkline, {
     Properties
 } from "devextreme/viz/sparkline";

--- a/packages/devextreme-react/src/speed-dial-action.ts
+++ b/packages/devextreme-react/src/speed-dial-action.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxSpeedDialAction, {
     Properties
 } from "devextreme/ui/speed_dial_action";

--- a/packages/devextreme-react/src/switch.ts
+++ b/packages/devextreme-react/src/switch.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxSwitch, {
     Properties
 } from "devextreme/ui/switch";

--- a/packages/devextreme-react/src/tab-panel.ts
+++ b/packages/devextreme-react/src/tab-panel.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/tab_panel";
 import dxTabPanel, {
     Properties

--- a/packages/devextreme-react/src/tabs.ts
+++ b/packages/devextreme-react/src/tabs.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/tabs";
 import dxTabs, {
     Properties

--- a/packages/devextreme-react/src/tag-box.ts
+++ b/packages/devextreme-react/src/tag-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxTagBox, {
     Properties
 } from "devextreme/ui/tag_box";

--- a/packages/devextreme-react/src/text-area.ts
+++ b/packages/devextreme-react/src/text-area.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxTextArea, {
     Properties
 } from "devextreme/ui/text_area";

--- a/packages/devextreme-react/src/text-box.ts
+++ b/packages/devextreme-react/src/text-box.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxTextBox, {
     Properties
 } from "devextreme/ui/text_box";

--- a/packages/devextreme-react/src/tile-view.ts
+++ b/packages/devextreme-react/src/tile-view.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/tile_view";
 import dxTileView, {
     Properties

--- a/packages/devextreme-react/src/toast.ts
+++ b/packages/devextreme-react/src/toast.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxToast, {
     Properties
 } from "devextreme/ui/toast";

--- a/packages/devextreme-react/src/toolbar.ts
+++ b/packages/devextreme-react/src/toolbar.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/toolbar";
 import dxToolbar, {
     Properties

--- a/packages/devextreme-react/src/tooltip.ts
+++ b/packages/devextreme-react/src/tooltip.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxTooltip, {
     Properties
 } from "devextreme/ui/tooltip";

--- a/packages/devextreme-react/src/tree-list.ts
+++ b/packages/devextreme-react/src/tree-list.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/tree_list";
 import dxTreeList, {
     Properties

--- a/packages/devextreme-react/src/tree-map.ts
+++ b/packages/devextreme-react/src/tree-map.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxTreeMap, {
     Properties
 } from "devextreme/viz/tree_map";

--- a/packages/devextreme-react/src/tree-view.ts
+++ b/packages/devextreme-react/src/tree-view.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/tree_view";
 import dxTreeView, {
     Properties

--- a/packages/devextreme-react/src/validation-group.ts
+++ b/packages/devextreme-react/src/validation-group.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxValidationGroup, {
     Properties
 } from "devextreme/ui/validation_group";

--- a/packages/devextreme-react/src/validation-summary.ts
+++ b/packages/devextreme-react/src/validation-summary.ts
@@ -1,3 +1,4 @@
+"use client"
 export { ExplicitTypes } from "devextreme/ui/validation_summary";
 import dxValidationSummary, {
     Properties

--- a/packages/devextreme-react/src/validator.ts
+++ b/packages/devextreme-react/src/validator.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxValidator, {
     Properties
 } from "devextreme/ui/validator";

--- a/packages/devextreme-react/src/vector-map.ts
+++ b/packages/devextreme-react/src/vector-map.ts
@@ -1,3 +1,4 @@
+"use client"
 import dxVectorMap, {
     Properties
 } from "devextreme/viz/vector_map";


### PR DESCRIPTION
Adds the 'use client' instruction at the top of the file according to:
https://nextjs.org/docs/messages/class-component-in-server-component