### PR TITLE
Add pointerEventStrategy option to GlobalConfig for setting EventStrategy

### DIFF
--- a/packages/devextreme/js/common.d.ts
+++ b/packages/devextreme/js/common.d.ts
@@ -344,6 +344,7 @@ export type GlobalConfig = {
    * @public
    */
   oDataFilterToLower?: boolean;
+  pointerEventsStrategy?: 'mouse-and-touch' | 'mouse' | 'touch';
   /**
    * @docid
    * @default false

--- a/packages/devextreme/js/common.d.ts
+++ b/packages/devextreme/js/common.d.ts
@@ -344,7 +344,7 @@ export type GlobalConfig = {
    * @public
    */
   oDataFilterToLower?: boolean;
-  pointerEventsStrategy?: 'mouse-and-touch' | 'mouse' | 'touch';
+  pointerEventStrategy?: 'mouse-and-touch' | 'mouse' | 'touch';
   /**
    * @docid
    * @default false

--- a/packages/devextreme/js/events/pointer.js
+++ b/packages/devextreme/js/events/pointer.js
@@ -100,8 +100,7 @@ const pointer = {
 };
 
 function getStrategyFromGlobalConfig(name) {
-    const config = GlobalConfig();
-    const eventStrategyName = config.pointerEventStrategy;
+    const eventStrategyName = GlobalConfig().pointerEventStrategy;
 
     return {
         'mouse-and-touch': MouseAndTouchStrategy,

--- a/packages/devextreme/js/events/pointer.js
+++ b/packages/devextreme/js/events/pointer.js
@@ -1,3 +1,4 @@
+import GlobalConfig from '../core/config';
 import * as support from '../core/utils/support';
 import { each } from '../core/utils/iterator';
 import devices from '../core/devices';
@@ -63,8 +64,13 @@ import MouseAndTouchStrategy from './pointer/mouse_and_touch';
   * @module events/pointer
 */
 
-const getStrategy = (support, device) => {
-    const { tablet, phone } = device;
+const getStrategy = (support, { tablet, phone }) => {
+    const pointerEventsStrategy = getStrategyFromGlobalConfig();
+
+    if(pointerEventsStrategy) {
+        return pointerEventsStrategy;
+    }
+
     if(support.touch && !(tablet || phone)) {
         return MouseAndTouchStrategy;
     }
@@ -92,6 +98,17 @@ const pointer = {
     over: 'dxpointerover',
     out: 'dxpointerout'
 };
+
+function getStrategyFromGlobalConfig(name) {
+    const config = GlobalConfig();
+    const eventsStrategyName = config.pointerEventsStrategy;
+
+    return {
+        'mouse-and-touch': MouseAndTouchStrategy,
+        'touch': TouchStrategy,
+        'mouse': MouseStrategy,
+    }[eventsStrategyName];
+}
 
 ///#DEBUG
 pointer.getStrategy = getStrategy;

--- a/packages/devextreme/js/events/pointer.js
+++ b/packages/devextreme/js/events/pointer.js
@@ -99,7 +99,7 @@ const pointer = {
     out: 'dxpointerout'
 };
 
-function getStrategyFromGlobalConfig(name) {
+function getStrategyFromGlobalConfig() {
     const eventStrategyName = GlobalConfig().pointerEventStrategy;
 
     return {

--- a/packages/devextreme/js/events/pointer.js
+++ b/packages/devextreme/js/events/pointer.js
@@ -65,10 +65,10 @@ import MouseAndTouchStrategy from './pointer/mouse_and_touch';
 */
 
 const getStrategy = (support, { tablet, phone }) => {
-    const pointerEventsStrategy = getStrategyFromGlobalConfig();
+    const pointerEventStrategy = getStrategyFromGlobalConfig();
 
-    if(pointerEventsStrategy) {
-        return pointerEventsStrategy;
+    if(pointerEventStrategy) {
+        return pointerEventStrategy;
     }
 
     if(support.touch && !(tablet || phone)) {
@@ -101,13 +101,13 @@ const pointer = {
 
 function getStrategyFromGlobalConfig(name) {
     const config = GlobalConfig();
-    const eventsStrategyName = config.pointerEventsStrategy;
+    const eventStrategyName = config.pointerEventStrategy;
 
     return {
         'mouse-and-touch': MouseAndTouchStrategy,
         'touch': TouchStrategy,
         'mouse': MouseStrategy,
-    }[eventsStrategyName];
+    }[eventStrategyName];
 }
 
 ///#DEBUG

--- a/packages/devextreme/testing/tests/DevExpress.ui.events/pointerParts/strategySelectionTests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.events/pointerParts/strategySelectionTests.js
@@ -8,12 +8,12 @@ const { test } = QUnit;
 
 QUnit.module('Strategy selection', () => {
     test('Use strategy from GlobalConfig', function(assert) {
-        GlobalConfig({ pointerEventsStrategy: 'mouse-and-touch' });
+        GlobalConfig({ pointerEventStrategy: 'mouse-and-touch' });
 
         const strategy = getStrategy({}, {}, {});
 
         assert.strictEqual(strategy, MouseAndTouchStrategy);
-        GlobalConfig({ pointerEventsStrategy: null });
+        GlobalConfig({ pointerEventStrategy: null });
     });
 
     test('Use the Mouse strategy by default', function(assert) {

--- a/packages/devextreme/testing/tests/DevExpress.ui.events/pointerParts/strategySelectionTests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.events/pointerParts/strategySelectionTests.js
@@ -1,3 +1,4 @@
+import GlobalConfig from 'core/config';
 import { getStrategy } from 'events/pointer';
 import TouchStrategy from 'events/pointer/touch';
 import MouseStrategy from 'events/pointer/mouse';
@@ -6,6 +7,15 @@ import MouseAndTouchStrategy from 'events/pointer/mouse_and_touch';
 const { test } = QUnit;
 
 QUnit.module('Strategy selection', () => {
+    test('Use strategy from GlobalConfig', function(assert) {
+        GlobalConfig({ pointerEventsStrategy: 'mouse-and-touch' });
+
+        const strategy = getStrategy({}, {}, {});
+
+        assert.strictEqual(strategy, MouseAndTouchStrategy);
+        GlobalConfig({ pointerEventsStrategy: null });
+    });
+
     test('Use the Mouse strategy by default', function(assert) {
         const strategy = getStrategy({}, {}, {});
 

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -1507,6 +1507,7 @@ declare module DevExpress.common {
      * [descr:GlobalConfig.oDataFilterToLower]
      */
     oDataFilterToLower?: boolean;
+    pointerEventStrategy?: 'mouse-and-touch' | 'mouse' | 'touch';
     /**
      * [descr:GlobalConfig.rtlEnabled]
      */


### PR DESCRIPTION
Add pointerEventStrategy option to GlobalConfig for setting EventStrategy. We need a way to set eventStrategy manually.

<!--
Make sure that you've read the "Contributing Code and Content" section in CONTRIBUTING.md

If you are submitting a bug fix, the subject should contain "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What did you do? 
2. How did you do it?
3. How should we verify this?

-->
