### PR TITLE
DataGrid: Fix the "Cannot read properties of undefined (reading 'selector')" error occurs when a column's dataField is not specified and repaintChangesOnly is enabled in popup edit mode (T1198534)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_form_based.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_form_based.ts
@@ -318,7 +318,7 @@ const editingControllerExtender = (Base: ModuleType<EditingController>) => class
   }
 
   getFormEditorTemplate(cellOptions, item) {
-    const column = this.component.columnOption(item.dataField);
+    const column = this.component.columnOption(item.name || item.dataField);
 
     return (options, container) => {
       const $container = $(container);

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -19841,6 +19841,28 @@ QUnit.module('Editing - "popup" mode', {
         // assert
         assert.equal(spy.callCount, 1, 'Edit form has repainted only once');
     });
+
+    // T1198534
+    QUnit.test('No exceptions on editing row whene there is unbound column', function(assert) {
+        // arrange
+        this.options.repaintChangesOnly = true;
+        this.columns.push({ name: 'test' });
+        this.setupModules(this);
+        this.renderRowsView();
+
+        try {
+            // act
+            this.editRow(0);
+            this.clock.tick(10);
+
+            // assert
+            this.preparePopupHelpers();
+            assert.ok(this.isEditingPopupVisible(), 'Edit popup is visible');
+        } catch(e) {
+            // assert
+            assert.ok(false, 'exception');
+        }
+    });
 });
 
 QUnit.module('Promises in callbacks and events', {


### PR DESCRIPTION
See https://devexpress.com/issue=T1198534