### PR TITLE
DataGrid - Fix the issue with page index being reset when the grid is refreshed and virtual scrolling is used (T1196099)

### DIFF
--- a/js/renovation/ui/pager/pages/small.tsx
+++ b/js/renovation/ui/pager/pages/small.tsx
@@ -33,7 +33,7 @@ export const viewFunction = ({
     <NumberBox
       className={PAGER_PAGE_INDEX_CLASS}
       min={1}
-      max={pageCount}
+      max={Math.max(pageCount, value)}
       width={width}
       value={value}
       valueChange={valueChange}

--- a/testing/testcafe/model/dataGrid/index.ts
+++ b/testing/testcafe/model/dataGrid/index.ts
@@ -525,6 +525,16 @@ export default class DataGrid extends Widget {
     )();
   }
 
+  apiRefresh(): Promise<void> {
+    const { getInstance } = this;
+    return ClientFunction(
+      () => {
+        (getInstance() as DataGridInstance).refresh().catch(() => {});
+      },
+      { dependencies: { getInstance } },
+    )();
+  }
+
   apiToggleKeyboardNavigation(value: boolean): Promise<void> {
     const { getInstance } = this;
 

--- a/testing/testcafe/tests/dataGrid/pager.ts
+++ b/testing/testcafe/tests/dataGrid/pager.ts
@@ -205,3 +205,32 @@ test('Changing pageSize to \'all\' with rowRenderingMode=\'virtual\' should work
     },
     height: 400,
   }));
+
+test('Page index should not reset when scrolling while the grid is being refreshed (T1196099)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+
+  await t
+    .expect(dataGrid.option('paging.pageIndex'))
+    .eql(2);
+
+  await dataGrid.apiRefresh();
+  await dataGrid.scrollBy({ y: 20 });
+
+  await t
+    .expect(dataGrid.option('paging.pageIndex'))
+    .eql(2);
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: [...new Array(100).keys()].map((i) => ({ id: i })),
+  keyExpr: 'id',
+  showBorders: true,
+  scrolling: {
+    mode: 'standard',
+    rowRenderingMode: 'virtual',
+  },
+  paging: { pageIndex: 2 },
+  pager: {
+    visible: true,
+    displayMode: 'compact',
+  },
+  height: 440,
+}));


### PR DESCRIPTION
See #25978