### PR TITLE
DataGrid: Fix memory leak occurs when changes are pushed and 'repaintChangesOnly' is enabled (T1196383)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/adaptivity/m_adaptivity.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/adaptivity/m_adaptivity.ts
@@ -9,6 +9,7 @@ import { getWidth } from '@js/core/utils/size';
 import { isDefined, isString } from '@js/core/utils/type';
 import { name as clickEventName } from '@js/events/click';
 import eventsEngine from '@js/events/core/events_engine';
+import { removeEvent } from '@js/events/remove';
 import { addNamespace } from '@js/events/utils/index';
 import messageLocalization from '@js/localization/message';
 import Form from '@js/ui/form';
@@ -177,15 +178,20 @@ const adaptiveColumnsControllerMembers: Partial<import('../adaptivity/m_adaptivi
       };
 
       renderFormTemplate();
-      templateOptions.watch && templateOptions.watch(() => ({
-        isItemEdited: that._isItemEdited(item),
-        value: cellOptions.row.values[columnIndex],
-      }), () => {
-        // @ts-expect-error
-        $container.contents().remove();
-        $container.removeClass(ADAPTIVE_ITEM_TEXT_CLASS);
-        renderFormTemplate();
-      });
+
+      if (templateOptions.watch) {
+        const dispose = templateOptions.watch(() => ({
+          isItemEdited: that._isItemEdited(item),
+          value: cellOptions.row.values[columnIndex],
+        }), () => {
+          // @ts-expect-error
+          $container.contents().remove();
+          $container.removeClass(ADAPTIVE_ITEM_TEXT_CLASS);
+          renderFormTemplate();
+        });
+
+        eventsEngine.on($container, removeEvent, dispose);
+      }
     };
   },
 

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -21,6 +21,7 @@ import { createObjectWithChanges } from '@js/data/array_utils';
 import { name as clickEventName } from '@js/events/click';
 import eventsEngine from '@js/events/core/events_engine';
 import pointerEvents from '@js/events/pointer';
+import { removeEvent } from '@js/events/remove';
 import { addNamespace } from '@js/events/utils/index';
 import messageLocalization from '@js/localization/message';
 import { confirm } from '@js/ui/dialog';
@@ -400,16 +401,20 @@ class EditingControllerImpl extends modules.ViewController {
 
         this._renderEditingButtons($container, buttons, options, change);
 
-        options.watch && options.watch(
-          () => buttons.map((button) => ({
-            visible: this._isButtonVisible(button, options),
-            disabled: this._isButtonDisabled(button, options),
-          })),
-          () => {
-            $container.empty();
-            this._renderEditingButtons($container, buttons, options);
-          },
-        );
+        if (options.watch) {
+          const dispose = options.watch(
+            () => buttons.map((button) => ({
+              visible: this._isButtonVisible(button, options),
+              disabled: this._isButtonDisabled(button, options),
+            })),
+            () => {
+              $container.empty();
+              this._renderEditingButtons($container, buttons, options);
+            },
+          );
+
+          eventsEngine.on($container, removeEvent, dispose);
+        }
       } else {
         gridCoreUtils.setEmptyText($container);
       }

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_form_based.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_form_based.ts
@@ -8,6 +8,7 @@ import { extend } from '@js/core/utils/extend';
 import { each } from '@js/core/utils/iterator';
 import { isDefined, isString } from '@js/core/utils/type';
 import eventsEngine from '@js/events/core/events_engine';
+import { removeEvent } from '@js/events/remove';
 import Button from '@js/ui/button';
 import Form from '@js/ui/form';
 import Popup from '@js/ui/popup/ui.popup';
@@ -322,25 +323,30 @@ const editingControllerExtender = (Base: ModuleType<EditingController>) => class
 
     return (options, container) => {
       const $container = $(container);
+      const { row } = cellOptions;
 
-      cellOptions.row.watch?.(() => column.selector(cellOptions.row.data), () => {
-        let $editorElement: any = $container.find('.dx-widget').first();
-        let validator: any = $editorElement.data('dxValidator');
-        const validatorOptions = validator?.option();
+      if (row?.watch) {
+        const dispose = row.watch(() => column.selector(row.data), () => {
+          let $editorElement: any = $container.find('.dx-widget').first();
+          let validator: any = $editorElement.data('dxValidator');
+          const validatorOptions = validator?.option();
 
-        ($container.contents() as any).remove();
-        cellOptions = this.renderFormEditorTemplate.bind(this)(cellOptions, item, options, $container);
+          ($container.contents() as any).remove();
+          cellOptions = this.renderFormEditorTemplate.bind(this)(cellOptions, item, options, $container);
 
-        $editorElement = $container.find('.dx-widget').first();
-        validator = $editorElement.data('dxValidator');
-        if (validatorOptions && !validator) {
-          $editorElement.dxValidator({
-            validationRules: validatorOptions.validationRules,
-            validationGroup: validatorOptions.validationGroup,
-            dataGetter: validatorOptions.dataGetter,
-          });
-        }
-      });
+          $editorElement = $container.find('.dx-widget').first();
+          validator = $editorElement.data('dxValidator');
+          if (validatorOptions && !validator) {
+            $editorElement.dxValidator({
+              validationRules: validatorOptions.validationRules,
+              validationGroup: validatorOptions.validationGroup,
+              dataGetter: validatorOptions.dataGetter,
+            });
+          }
+        });
+
+        eventsEngine.on($container, removeEvent, dispose);
+      }
 
       cellOptions = this.renderFormEditorTemplate.bind(this)(cellOptions, item, options, $container);
     };

--- a/packages/devextreme/js/__internal/grids/grid_core/views/m_rows_view.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/views/m_rows_view.ts
@@ -45,7 +45,7 @@ function isGroupRow({ rowType, column }) {
     && !column.showWhenGrouped && !column.command;
 }
 
-function watch({
+function setWatcher({
   element, watch, getter, callBack,
 }) {
   if (watch) {
@@ -198,7 +198,7 @@ class RowsView extends ColumnsView {
       if (this.option('rowAlternationEnabled')) {
         this._isAltRow(row) && $row.addClass(ROW_ALTERNATION_CLASS);
 
-        watch({
+        setWatcher({
           element: $row.get(0),
           watch: rowOptions.watch,
           getter: () => this._isAltRow(row),
@@ -210,7 +210,7 @@ class RowsView extends ColumnsView {
 
       this._setAriaRowIndex(rowOptions, $row);
 
-      watch({
+      setWatcher({
         element: $row.get(0),
         watch: rowOptions.watch,
         getter: () => rowOptions.rowIndex,

--- a/packages/devextreme/js/__internal/grids/grid_core/views/m_rows_view.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/views/m_rows_view.ts
@@ -45,6 +45,16 @@ function isGroupRow({ rowType, column }) {
     && !column.showWhenGrouped && !column.command;
 }
 
+function watch({
+  element, watch, getter, callBack,
+}) {
+  if (watch) {
+    const dispose = watch(getter, callBack);
+
+    eventsEngine.on(element, removeEvent, dispose);
+  }
+}
+
 const defaultCellTemplate = function ($container, options) {
   const isDataTextEmpty = isEmpty(options.text) && options.rowType === 'data';
   const { text } = options;
@@ -187,13 +197,25 @@ class RowsView extends ColumnsView {
     if (rowOptions.rowType === 'data') {
       if (this.option('rowAlternationEnabled')) {
         this._isAltRow(row) && $row.addClass(ROW_ALTERNATION_CLASS);
-        rowOptions.watch && rowOptions.watch(() => this._isAltRow(row), (value) => {
-          $row.toggleClass(ROW_ALTERNATION_CLASS, value);
+
+        watch({
+          element: $row.get(0),
+          watch: rowOptions.watch,
+          getter: () => this._isAltRow(row),
+          callBack: (value) => {
+            $row.toggleClass(ROW_ALTERNATION_CLASS, value);
+          },
         });
       }
 
       this._setAriaRowIndex(rowOptions, $row);
-      rowOptions.watch && rowOptions.watch(() => rowOptions.rowIndex, () => this._setAriaRowIndex(rowOptions, $row));
+
+      watch({
+        element: $row.get(0),
+        watch: rowOptions.watch,
+        getter: () => rowOptions.rowIndex,
+        callBack: () => this._setAriaRowIndex(rowOptions, $row),
+      });
     }
 
     super._rowPrepared.apply(this, arguments as any);

--- a/packages/devextreme/js/__internal/grids/tree_list/rows/m_rows.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/rows/m_rows.ts
@@ -1,5 +1,7 @@
 import $ from '@js/core/renderer';
 import { isDefined } from '@js/core/utils/type';
+import eventsEngine from '@js/events/core/events_engine';
+import { removeEvent } from '@js/events/remove';
 import { rowsModule } from '@ts/grids/grid_core/views/m_rows_view';
 
 import treeListCore from '../m_core';
@@ -37,10 +39,18 @@ export const RowsView = rowsModule.views.rowsView.inherit((function () {
         .addClass(TREELIST_EXPAND_ICON_CONTAINER_CLASS)
         .appendTo($container);
 
-      options.watch && options.watch(() => [options.row.level, options.row.isExpanded, options.row.node.hasChildren], () => {
-        $iconContainer.empty();
-        this._renderIcons($iconContainer, options);
-      });
+      if (options.watch) {
+        const dispose = options.watch(() => [
+          options.row.level,
+          options.row.isExpanded,
+          options.row.node.hasChildren,
+        ], () => {
+          $iconContainer.empty();
+          this._renderIcons($iconContainer, options);
+        });
+
+        eventsEngine.on($iconContainer, removeEvent, dispose);
+      }
 
       $container.addClass(TREELIST_CELL_EXPANDABLE_CLASS);
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -18949,6 +18949,50 @@ QUnit.module('Edit Form', {
             oldValue = newValue;
         }
     });
+
+    // T1196383
+    QUnit.test('Watchers should be destroyed after repainting the edit row when repaintChangesOnly is enabled', function(assert) {
+        // arrange
+        let disposeFuncs = [];
+        const $testElement = $('#container');
+
+        this.options.repaintChangesOnly = true;
+        this.setupModules(this);
+
+        sinon.stub(this.rowsView, '_addWatchMethod').callsFake((options, row) => {
+            const source = row || options;
+
+            source.watch = () => {
+                disposeFuncs.push(sinon.spy());
+
+                return disposeFuncs[disposeFuncs.length - 1];
+            };
+            source.update = commonUtils.noop;
+
+            if(source !== options) {
+                options.watch = source.watch.bind(source);
+            }
+        });
+
+        this.rowsView.render($testElement);
+        disposeFuncs = [];
+
+        // act
+        this.editRow(0);
+
+        // assert
+        assert.strictEqual(disposeFuncs.length, 5, 'count dispose function');
+        assert.notOk(disposeFuncs.some((dispose) => dispose.called), 'dispose functions were not called');
+
+        // arrange
+        const prevDisposeFuncs = disposeFuncs.slice();
+
+        // act
+        this.rowsView.render($testElement);
+
+        // assert
+        assert.ok(prevDisposeFuncs.every((dispose) => dispose.called), 'dispose functions were called');
+    });
 });
 
 QUnit.module('Editing - "popup" mode', {


### PR DESCRIPTION
See https://devexpress.com/issue=T1196383