### PR TITLE
Optimize license-check performance

### DIFF
--- a/packages/devextreme/js/__internal/core/license/rsa_bigint.ts
+++ b/packages/devextreme/js/__internal/core/license/rsa_bigint.ts
@@ -24,7 +24,7 @@ export function compareSignatures(args: Args): boolean {
         e >>= one; // eslint-disable-line no-bitwise
       }
 
-      return result % modulus;
+      return result;
     };
 
     const bigIntFromBytes = (bytes: Uint8Array): bigint => bytes.reduce(

--- a/packages/devextreme/js/__internal/core/license/rsa_bigint.ts
+++ b/packages/devextreme/js/__internal/core/license/rsa_bigint.ts
@@ -8,11 +8,27 @@ interface Args {
 export function compareSignatures(args: Args): boolean {
   try {
     const zero = BigInt(0);
+    const one = BigInt(1);
     const eight = BigInt(8);
 
+    const modExp = (base: bigint, exponent: bigint, modulus: bigint): bigint => {
+      let result = one;
+      let b = base;
+      let e = exponent;
+
+      while (e) {
+        if (e & one) { // eslint-disable-line no-bitwise
+          result = (result * b) % modulus;
+        }
+        b = (b * b) % modulus;
+        e >>= one; // eslint-disable-line no-bitwise
+      }
+
+      return result % modulus;
+    };
+
     const bigIntFromBytes = (bytes: Uint8Array): bigint => bytes.reduce(
-      // eslint-disable-next-line no-bitwise
-      (acc, cur) => (acc << eight) + BigInt(cur),
+      (acc, cur) => (acc << eight) + BigInt(cur), // eslint-disable-line no-bitwise
       zero,
     );
 
@@ -21,7 +37,7 @@ export function compareSignatures(args: Args): boolean {
     const signature = bigIntFromBytes(args.signature);
     const exponent = BigInt(args.key.e);
     const modulus = bigIntFromBytes(args.key.n);
-    const expected = (signature ** exponent) % modulus;
+    const expected = modExp(signature, exponent, modulus);
 
     return expected === actual;
   } catch {


### PR DESCRIPTION
This reduces execution time of license-check and makes it insignificant

| | Before | After |
| -- | -- | -- |
| license-check execution time | 750ms | 4ms |