### PR TITLE
Core: Fix how the Inferno template wrapper removes its children (#26050)

### DIFF
--- a/js/renovation/component_wrapper/common/__tests__/component.test.tsx
+++ b/js/renovation/component_wrapper/common/__tests__/component.test.tsx
@@ -23,6 +23,7 @@ import * as UpdatePropsImmutable from '../../utils/update_props_immutable';
 import registerEvent from '../../../../events/core/event_registrator';
 import { one } from '../../../../events';
 import KeyboardProcessor from '../../../../events/core/keyboard_processor';
+import { removeEvent } from '../../../../events/remove';
 
 const fakeEventSingleton = new class {
   handlerCount = 0;
@@ -923,18 +924,23 @@ describe('templates and slots', () => {
   });
 
   it('remove old template content between renders', () => {
+    let dxRemoveFired = false;
+
     $('#component').dxTemplatedTestWidget({
       template(data, element) {
         $(element).append(`<span>Template - ${data.simpleTemplate}</span>` as any);
       },
     });
-    const templateRoot = $('#component').children('.templates-root')[0];
+    const templateRoot = $('#component').children('.templates-root');
+
+    one(templateRoot.children()[0], removeEvent, () => { dxRemoveFired = true; });
 
     $('#component').dxTemplatedTestWidget({
       text: 'new data',
     });
 
-    expect(templateRoot.innerHTML).toBe('<span>Template - new data</span>');
+    expect(templateRoot[0].innerHTML).toBe('<span>Template - new data</span>');
+    expect(dxRemoveFired).toBeTruthy();
   });
 
   it('correctly change template at runtime', () => {

--- a/js/renovation/component_wrapper/common/template_wrapper.ts
+++ b/js/renovation/component_wrapper/common/template_wrapper.ts
@@ -103,7 +103,10 @@ function removeDifferentElements(
     const hasOldChild = !!oldChildren.find((oldElement) => newElement === oldElement);
 
     if (!hasOldChild && newElement.parentNode) {
-      newElement.parentNode.removeChild(newElement);
+      // @ts-expect-error The renderer's remove() function requires an argument in .d.ts.
+      // We currenlty suppress the error if we don't need the argument (see Grids).
+      // We should change the .d.ts (maybe make the parameter optional).
+      $(newElement).remove();
     }
   });
 }

--- a/testing/tests/DevExpress.ui.events/remove.tests.js
+++ b/testing/tests/DevExpress.ui.events/remove.tests.js
@@ -22,6 +22,8 @@ QUnit.test('dxremove event should be fired on element removing', function(assert
 });
 
 QUnit.test('dxremove event should be fired for nested removing element', function(assert) {
+    assert.expect(2);
+
     $('#inner')
         .data('testData', true)
         .on(removeEvent, function(e) {


### PR DESCRIPTION
Cherry-pick https://github.com/DevExpress/DevExtreme/pull/26050