### PR TITLE
DataGrid: Fix closing editable cell when mouse pointer is dragged to copy data to other cells of the current row (T1203250)

### DIFF
--- a/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -2549,7 +2549,7 @@ export const editingModule = {
             return isShowEditorAlways && allowEditing && editingController.editCell(e.rowIndex, columnIndex);
           }
 
-          if (eventName === 'click' && startEditAction === 'dblClick') {
+          if (eventName === 'click' && startEditAction === 'dblClick' && this._pointerDownTarget === $targetElement.get(0)) {
             const isError = false;
             const withoutSaveEditData = row?.isNewRow;
             editingController.closeEditCell(isError, withoutSaveEditData);
@@ -2560,6 +2560,7 @@ export const editingModule = {
           }
         },
         _rowPointerDown(e) {
+          this._pointerDownTarget = e.event.target;
           this._pointerDownTimeout = setTimeout(() => {
             this._editCellByClick(e, 'down');
           });

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -2705,12 +2705,45 @@ QUnit.module('Editing', {
         sinon.spy(that.editingController, 'closeEditCell');
 
         // act
+        $testElement.find('td').eq(1).trigger('dxpointerdown');
         $testElement.find('td').eq(1).trigger('dxclick');
         that.clock.tick(10);
 
         // assert
         assert.strictEqual(that.editingController.closeEditCell.callCount, 1, 'count call closeEditCell');
         assert.strictEqual(getInputElements($testElement).length, 0, 'hasn\'t input');
+    });
+
+    // T1203250
+    QUnit.test('Batch mode with startEditAction is \'dblClick\' - Editing cell should not be closed when mouse pointer is dragged to copy data to other cells of the current row', function(assert) {
+        // arrange
+        const rowsView = this.rowsView;
+        const $testElement = $('#container');
+
+        $.extend(this.options.editing, {
+            allowUpdating: true,
+            mode: 'batch',
+            startEditAction: 'dblClick'
+        });
+        sinon.spy(this.editingController, 'closeEditCell');
+
+        rowsView.render($testElement);
+
+        // act
+        $(this.getCellElement(0, 0)).trigger('dxdblclick');
+        this.clock.tick(10);
+
+        // assert
+        assert.strictEqual($(this.getCellElement(0, 0)).find('input').length, 1, 'has input');
+
+        // act
+        $(this.getCellElement(0, 0)).trigger('dxpointerdown');
+        $(this.getCellElement(0, 1)).trigger('dxclick');
+        this.clock.tick(10);
+
+        // assert
+        assert.strictEqual(this.editingController.closeEditCell.callCount, 0, 'count call closeEditCell');
+        assert.strictEqual($(this.getCellElement(0, 0)).find('input').length, 1, 'has input');
     });
 
     QUnit.test('Batch mode - Clicking on the edited cell should not close it when startEditAction is \'dblClick\'', function(assert) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/editing.tests.js
@@ -10,6 +10,8 @@ import { getHeight, getWidth, setWidth, getOffset } from 'core/utils/size';
 import typeUtils from 'core/utils/type';
 import eventsEngine from 'events/core/events_engine';
 import pointerEvents from 'events/pointer';
+import { name as clickEventName } from 'events/click';
+import { name as dblClickEventName } from 'events/dblclick';
 import { triggerResizeEvent } from 'events/visibility_change';
 import 'generic_light.css!';
 import $ from 'jquery';
@@ -2694,7 +2696,7 @@ QUnit.module('Editing', {
         rowsView.render($testElement);
 
         // act
-        $testElement.find('td').first().trigger('dxdblclick');
+        $testElement.find('td').first().trigger(dblClickEventName);
 
         // assert
         assert.strictEqual(that.editingController.editCell.callCount, 1, 'count call editCell');
@@ -2705,8 +2707,8 @@ QUnit.module('Editing', {
         sinon.spy(that.editingController, 'closeEditCell');
 
         // act
-        $testElement.find('td').eq(1).trigger('dxpointerdown');
-        $testElement.find('td').eq(1).trigger('dxclick');
+        $testElement.find('td').eq(1).trigger(pointerEvents.down);
+        $testElement.find('td').eq(1).trigger(clickEventName);
         that.clock.tick(10);
 
         // assert
@@ -2730,15 +2732,15 @@ QUnit.module('Editing', {
         rowsView.render($testElement);
 
         // act
-        $(this.getCellElement(0, 0)).trigger('dxdblclick');
+        $(this.getCellElement(0, 0)).trigger(dblClickEventName);
         this.clock.tick(10);
 
         // assert
         assert.strictEqual($(this.getCellElement(0, 0)).find('input').length, 1, 'has input');
 
         // act
-        $(this.getCellElement(0, 0)).trigger('dxpointerdown');
-        $(this.getCellElement(0, 1)).trigger('dxclick');
+        $(this.getCellElement(0, 0)).trigger(pointerEvents.down);
+        $(this.getCellElement(0, 1)).trigger(clickEventName);
         this.clock.tick(10);
 
         // assert


### PR DESCRIPTION
See https://devexpress.com/issue=T1203250