### PR TITLE
DataGrid briefly shows and then removes the 'minus' sign if you press the minus key to start editing a cell with a numeric value (T1201166)

### DIFF
--- a/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -2039,7 +2039,8 @@ export class KeyboardNavigationController extends modules.ViewController {
       if (!keyPressEvent.isDefaultPrevented()) {
         const timeout = browser.mozilla ? 25 : 0; // T882996
         setTimeout(() => {
-          $input.val(editorValue);
+          const inputValue = this._getKeyPressInputValue($input, editorValue);
+          $input.val(inputValue);
 
           const $widgetContainer = $input.closest(`.${WIDGET_CLASS}`);
           // @ts-expect-error
@@ -2054,6 +2055,24 @@ export class KeyboardNavigationController extends modules.ViewController {
         }, timeout);
       }
     }
+  }
+
+  /*
+  * NOTE: See the T1203026 ticket.
+  * The method is created for cases where the editor in the column is formatted according to the 'decimal' type.
+  * After the native event 'keydown', the '-' sign is formatted by the editor into '-0'.
+  * Subsequent assignment of '-' to the editor's value is treated as a text change, causing the inversion of the value from '-0' to '0'.
+  * To prevent this inversion, it is necessary to assign to the value the same content as in the editor: '-0'.
+  */
+  _getKeyPressInputValue(
+    $input: dxElementWrapper,
+    editorValue: any,
+  ): any {
+    const inputCurrentValue: any = $input.val();
+
+    return editorValue === '-' && inputCurrentValue === '-0'
+      ? '-0'
+      : editorValue;
   }
 
   // #endregion Editing

--- a/testing/testcafe/tests/dataGrid/keyboardNavigation/startEditing.functional.ts
+++ b/testing/testcafe/tests/dataGrid/keyboardNavigation/startEditing.functional.ts
@@ -35,3 +35,42 @@ test('Editing should start by pressing enter after scrolling content with scroll
     height: 300,
   });
 });
+
+test('DataGrid should not remove the minus symbol when editing started (T1201166)', async (t) => {
+  const dataGrid = new DataGrid(DATA_GRID_SELECTOR);
+
+  await t
+    .click(dataGrid.getDataCell(0, 0).element)
+    .pressKey('- 1')
+    .pressKey('enter')
+    .expect(dataGrid.getDataCell(0, 0).element.innerText)
+    .eql('-1');
+}).before(async () => {
+  await createWidget('dxDataGrid', {
+    dataSource: [
+      { id: undefined, text: '1' },
+      { id: 2, text: '2' },
+      { id: 3, text: '3' },
+    ],
+    columns: [{
+      dataField: 'id',
+      dataType: 'number',
+      editorOptions: {
+        format: { type: 'decimal' },
+      },
+    },
+    'text',
+    ],
+    editing: {
+      allowUpdating: true,
+      selectTextOnEditStart: true,
+      mode: 'batch',
+      startEditAction: 'dblClick',
+    },
+    keyboardNavigation: {
+      editOnKeyPress: true,
+      enterKeyAction: 'moveFocus',
+      enterKeyDirection: 'column',
+    },
+  });
+});


### PR DESCRIPTION
Cherry pick https://github.com/DevExpress/DevExtreme/pull/26249