### PR TITLE
TypeScript - CustomStore onLoaded result own param type

### DIFF
--- a/js/data/custom_store.d.ts
+++ b/js/data/custom_store.d.ts
@@ -70,6 +70,14 @@ export interface CustomStoreOptions<
     loadMode?: 'processed' | 'raw';
     /**
      * @docid
+     * @type_function_param1 result:LoadResult
+     * @type_function_param2 loadOptions:LoadOptions
+     * @action
+     * @public
+     */
+    onLoaded?: ((result: LoadResult<TItem>, loadOptions: LoadOptions<TItem>) => void);
+    /**
+     * @docid
      * @type_function_param1 key:object|string|number
      * @type_function_return Promise<void>
      * @public

--- a/js/data/odata/store.d.ts
+++ b/js/data/odata/store.d.ts
@@ -1,6 +1,5 @@
 import { DxPromise } from '../../core/utils/deferred';
 import Store, { Options as StoreOptions } from '../abstract_store';
-import { LoadOptions } from '../index';
 import { Query } from '../query';
 import { ODataRequestOptions } from './context';
 

--- a/js/data/odata/store.d.ts
+++ b/js/data/odata/store.d.ts
@@ -66,13 +66,6 @@ export interface ODataStoreOptions<
     keyType?: 'String' | 'Int32' | 'Int64' | 'Guid' | 'Boolean' | 'Single' | 'Decimal' | any;
     /**
      * @docid
-     * @type_function_param1 loadOptions:LoadOptions
-     * @action
-     * @public
-     */
-    onLoading?: ((loadOptions: LoadOptions<TItem>) => void);
-    /**
-     * @docid
      * @public
      */
     url?: string;

--- a/ts/dx.all.d.ts
+++ b/ts/dx.all.d.ts
@@ -5173,6 +5173,13 @@ declare module DevExpress.data {
      */
     loadMode?: 'processed' | 'raw';
     /**
+     * [descr:CustomStoreOptions.onLoaded]
+     */
+    onLoaded?: (
+      result: DevExpress.common.LoadResult<TItem>,
+      loadOptions: LoadOptions<TItem>
+    ) => void;
+    /**
      * [descr:CustomStoreOptions.remove]
      */
     remove?: (key: TKey) => PromiseLike<void>;
@@ -5900,10 +5907,6 @@ declare module DevExpress.data {
       | 'Single'
       | 'Decimal'
       | any;
-    /**
-     * [descr:ODataStoreOptions.onLoading]
-     */
-    onLoading?: (loadOptions: LoadOptions<TItem>) => void;
     /**
      * [descr:ODataStoreOptions.url]
      */


### PR DESCRIPTION
Cherry-pick of #26244

A lightweight version of the 23.2 fix via shadowing members (without moving types through modules):
- Remove the excessive onLoading member with the same signature from ODataStoreOptions.
- Define the CustomStoreOptions.onLoaded member with the correct signature.

A proposed Docs generation result:
https://github.com/DevExpress/devextreme-documentation/pull/5882