### PR TITLE
Scheduler treats the America/Monterrey timezone as if it has DST (T1209314)

### DIFF
--- a/packages/devextreme/js/__internal/scheduler/timezones/timezones_data.ts
+++ b/packages/devextreme/js/__internal/scheduler/timezones/timezones_data.ts
@@ -980,9 +980,9 @@ export default {
     },
     {
       id: 'America/Monterrey',
-      untils: '-p1u7c0|ykt480|ast80|3vppg0|afuk0|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|9q2s0|7k580|9q2s0|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|Infinity',
+      untils: '-p1u7c0|ykt480|ast80|3vppg0|afuk0|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|9q2s0|7k580|9q2s0|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|7x9g0|ast80|8a840|afuk0|8a840|afuk0|8a840|ast80|7x9g0|ast80|Infinity',
       offsets: '401.2667|360|300',
-      offsetIndices: '0121212121212121212121212121212121212121212121212121212121212121212121212121212121212121',
+      offsetIndices: '0121212121212121212121212121212121212121212121212121212121',
     },
     {
       id: 'America/Montevideo',


### PR DESCRIPTION
See https://supportcenter.devexpress.com/ticket/details/t1209314/scheduler-treats-the-america-monterrey-timezone-as-if-it-has-dst