### PR TITLE
DataGrid/TreeList - Navigation via the Tab key should work when cellRender/cellComponent is used (T1207684)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -2638,7 +2638,9 @@ export const keyboardNavigationModule: import('../m_types').Module = {
 
         renderDelayedTemplates(change) {
           this.callBase.apply(this, arguments);
-          this._renderFocusByChange(change);
+          this.waitAsyncTemplates().done(() => {
+            this._renderFocusByChange(change);
+          });
         },
         _renderFocusByChange(change) {
           const { operationTypes, repaintChangesOnly } = change ?? {};


### PR DESCRIPTION
See #26499