### PR TITLE
DataGrid: Disable row selection by shift for not loaded data when there is grouping and virtual scrolling is enabled (T1180554)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.ts
@@ -195,6 +195,7 @@ export class SelectionController extends modules.Controller {
       maxFilterLengthInRequest: (selectionOptions as any).maxFilterLengthInRequest,
       selectionFilter: this.option('selectionFilter'),
       ignoreDisabledItems: true,
+      isVirtualPaging: virtualPaging,
       allowLoadByRange() {
         const hasGroupColumns = columnsController.getGroupColumns().length > 0;
         return virtualPaging && !legacyScrollingMode && !hasGroupColumns && allowSelectAll && !deferred;

--- a/packages/devextreme/js/__internal/grids/tree_list/selection/m_selection.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/selection/m_selection.ts
@@ -84,7 +84,7 @@ treeListCore.registerModule('selection', extend(true, {}, selectionModule, {
           };
           config.isSelectableItem = (item) => !!item;
           config.getItemData = (item) => item;
-          config.allowLoadByRange = () => false;
+          config.allowLoadByRange = () => undefined;
           return config;
         },
 

--- a/packages/devextreme/js/ui/selection/selection.js
+++ b/packages/devextreme/js/ui/selection/selection.js
@@ -121,8 +121,10 @@ export default class Selection {
         const itemIsNotInLoadedRange = (index) => index >= 0 && !items.filter(it => it.loadIndex === index).length;
 
         if(isVirtualPaging && isDefined(item)) {
-            indexOffset = item.loadIndex - itemIndex;
-            itemIndex = item.loadIndex;
+            if(allowLoadByRange) {
+                indexOffset = item.loadIndex - itemIndex;
+                itemIndex = item.loadIndex;
+            }
             focusedItemNotInLoadedRange = itemIsNotInLoadedRange(this._focusedItemIndex);
             if(isDefined(this._shiftFocusedItemIndex)) {
                 shiftFocusedItemNotInLoadedRange = itemIsNotInLoadedRange(this._shiftFocusedItemIndex);
@@ -140,7 +142,7 @@ export default class Selection {
         const allowSelectByShift = keys.shift && (allowLoadByRange !== false || (!focusedItemNotInLoadedRange && !shiftFocusedItemNotInLoadedRange));
 
         if(allowSelectByShift && this.options.mode === 'multiple' && this._focusedItemIndex >= 0) {
-            if(focusedItemNotInLoadedRange || shiftFocusedItemNotInLoadedRange) {
+            if(allowLoadByRange && (focusedItemNotInLoadedRange || shiftFocusedItemNotInLoadedRange)) {
                 isSelectedItemsChanged = itemIndex !== this._shiftFocusedItemIndex || this._focusedItemIndex !== this._shiftFocusedItemIndex;
 
                 if(isSelectedItemsChanged) {

--- a/packages/devextreme/js/ui/selection/selection.js
+++ b/packages/devextreme/js/ui/selection/selection.js
@@ -112,6 +112,7 @@ export default class Selection {
         const items = this.options.plainItems();
         const item = items[itemIndex];
         let deferred;
+        const isVirtualPaging = this.options.isVirtualPaging;
         const allowLoadByRange = this.options.allowLoadByRange?.();
         let indexOffset;
         let focusedItemNotInLoadedRange = false;
@@ -119,7 +120,7 @@ export default class Selection {
 
         const itemIsNotInLoadedRange = (index) => index >= 0 && !items.filter(it => it.loadIndex === index).length;
 
-        if(allowLoadByRange && isDefined(item)) {
+        if(isVirtualPaging && isDefined(item)) {
             indexOffset = item.loadIndex - itemIndex;
             itemIndex = item.loadIndex;
             focusedItemNotInLoadedRange = itemIsNotInLoadedRange(this._focusedItemIndex);
@@ -136,8 +137,9 @@ export default class Selection {
         const itemKey = this.options.keyOf(itemData);
 
         keys = keys || {};
+        const allowSelectByShift = keys.shift && (allowLoadByRange !== false || (!focusedItemNotInLoadedRange && !shiftFocusedItemNotInLoadedRange));
 
-        if(keys.shift && this.options.mode === 'multiple' && this._focusedItemIndex >= 0) {
+        if(allowSelectByShift && this.options.mode === 'multiple' && this._focusedItemIndex >= 0) {
             if(focusedItemNotInLoadedRange || shiftFocusedItemNotInLoadedRange) {
                 isSelectedItemsChanged = itemIndex !== this._shiftFocusedItemIndex || this._focusedItemIndex !== this._shiftFocusedItemIndex;
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/virtualScrolling.integration.tests.js
@@ -5695,7 +5695,8 @@ QUnit.module('Virtual Scrolling', baseModuleConfig, () => {
             this.clock.tick(300);
 
             // assert
-            assert.deepEqual(dataGrid.getSelectedRowKeys(), [2, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40], 'selected keys after scroll down');
+            // T1180554
+            assert.deepEqual(dataGrid.getSelectedRowKeys(), [2, 51], 'selected keys after scroll down');
         });
 
         QUnit.test(`${scrollingMode} - Rows should be selected correctly with Shift not on the first page (T1070776)`, function(assert) {


### PR DESCRIPTION
See https://devexpress.com/issue=T1180554