### PR TITLE
GH Packages: simplify the publishing workflow args, use "daily" tag instead of "next"

### DIFF
--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -19,8 +19,8 @@ on:
 env:
   FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.filter || '' }}
   SET_TIMESTAMP_VERSION:  ${{ inputs.tag == 'daily' }}
-  MOVE_DAILY_TAG: ${{ inputs.tag == 'daily }}
-  MOVE_STABLE_TAG: ${{ inputs.tag == 'stable }}
+  MOVE_DAILY_TAG: ${{ inputs.tag == 'daily' }}
+  MOVE_STABLE_TAG: ${{ inputs.tag == 'stable' }}
 
 jobs:
 

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -3,31 +3,24 @@ name: Publishing to GitHub Packages
 on:
   workflow_dispatch:
     inputs:
+      tag:
+        required: false
+        description: Use 'daily' for daily builds with timestamp version, use 'stable' for releases.
+        type: choice
+        options:
+          - daily
+          - stable
+        default: 'daily'
       filter:
         type: string
         description: Package file filter pattern
         required: false
-      timestamp-version:
-        type: boolean
-        description: Set timestamp version
-        required: false
-        default: true
-      next-tag:
-        type: boolean
-        description: Move 'next' tag
-        required: false
-        default: true
-      stable-tag:
-        type: boolean
-        description: Move 'stable' tag
-        required: false
-        default: false
 
 env:
   FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.filter || '' }}
-  SET_TIMESTAMP_VERSION: ${{ (github.event_name == 'workflow_dispatch' && inputs.timestamp-version) || (github.event_name != 'workflow_dispatch' && true) }}
-  MOVE_NEXT_TAG: ${{ (github.event_name == 'workflow_dispatch' && inputs.next-tag) || (github.event_name != 'workflow_dispatch' && true) }}
-  MOVE_STABLE_TAG: ${{ (github.event_name == 'workflow_dispatch' && inputs.stable-tag) || (github.event_name != 'workflow_dispatch' && false) }}
+  SET_TIMESTAMP_VERSION:  ${{ inputs.tag == 'daily' }}
+  MOVE_DAILY_TAG: ${{ inputs.tag == 'daily }}
+  MOVE_STABLE_TAG: ${{ inputs.tag == 'stable }}
 
 jobs:
 
@@ -121,8 +114,8 @@ jobs:
           npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN";
           npm publish --quiet --ignore-scripts --registry https://npm.pkg.github.com;
 
-      - name: Move 'next' tag
-        if: ${{ env.MOVE_NEXT_TAG == 'true' }}
+      - name: Move 'daily' tag
+        if: ${{ env.MOVE_DAILY_TAG == 'true' }}
         env:
           PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
           PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
@@ -130,7 +123,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
-          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-next
+          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-daily
 
       - name: Move 'stable' tag
         if: ${{ env.MOVE_STABLE_TAG == 'true' }}

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        required: false
-        description: Use 'daily' for daily builds with timestamp version, use 'stable' for releases.
+        description: "Choose a tag: 'daily' when publishing a daily build with a timestamp version, 'stable' when publishing a stable build from a release branch"
         type: choice
         options:
           - daily
           - stable
         default: 'daily'
+        required: false
       filter:
         type: string
         description: Package file filter pattern

--- a/.github/workflows/packages_publishing_scheduler.yml
+++ b/.github/workflows/packages_publishing_scheduler.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Publish Packages (${{ matrix.branch }})
         run: |
-          gh workflow run packages_publishing.yml --ref ${{ matrix.branch }}          
+          gh workflow run packages_publishing.yml -f tag=daily --ref ${{ matrix.branch }}          


### PR DESCRIPTION
We tagged "next" daily builds with a version containing timestamp. But the "next" tag contains uncertainty because the latest stable release also may have this tag. Also it may cause conflict with "next" tag on npm which may be published release or hotfix. So we decided to use "daily" for daily builds and leave "stable" tag for stable builds (releases).

### Cherry-picks
- #26652