### PR TITLE
DataGrid - ColumnChooser - Height and width types do not include String (T1214374)

### DIFF
--- a/packages/devextreme-angular/src/ui/data-grid/index.ts
+++ b/packages/devextreme-angular/src/ui/data-grid/index.ts
@@ -246,10 +246,10 @@ export class DxDataGridComponent<TRowData = any, TKey = any> extends DxComponent
     
      */
     @Input()
-    get columnChooser(): { allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number } {
+    get columnChooser(): { allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number | string, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number | string } {
         return this._getOption('columnChooser');
     }
-    set columnChooser(value: { allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number }) {
+    set columnChooser(value: { allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number | string, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number | string }) {
         this._setOption('columnChooser', value);
     }
 
@@ -610,10 +610,10 @@ export class DxDataGridComponent<TRowData = any, TKey = any> extends DxComponent
     
      */
     @Input()
-    get headerFilter(): { allowSearch?: boolean, allowSelectAll?: boolean, height?: number, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number } {
+    get headerFilter(): { allowSearch?: boolean, allowSelectAll?: boolean, height?: number | string, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number | string } {
         return this._getOption('headerFilter');
     }
-    set headerFilter(value: { allowSearch?: boolean, allowSelectAll?: boolean, height?: number, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number }) {
+    set headerFilter(value: { allowSearch?: boolean, allowSelectAll?: boolean, height?: number | string, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number | string }) {
         this._setOption('headerFilter', value);
     }
 
@@ -701,10 +701,10 @@ export class DxDataGridComponent<TRowData = any, TKey = any> extends DxComponent
     
      */
     @Input()
-    get loadPanel(): { enabled?: Mode | boolean, height?: number, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number } {
+    get loadPanel(): { enabled?: Mode | boolean, height?: number | string, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number | string } {
         return this._getOption('loadPanel');
     }
-    set loadPanel(value: { enabled?: Mode | boolean, height?: number, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number }) {
+    set loadPanel(value: { enabled?: Mode | boolean, height?: number | string, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number | string }) {
         this._setOption('loadPanel', value);
     }
 
@@ -1502,7 +1502,7 @@ export class DxDataGridComponent<TRowData = any, TKey = any> extends DxComponent
      * This member supports the internal infrastructure and is not intended to be used directly from your code.
     
      */
-    @Output() columnChooserChange: EventEmitter<{ allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number }>;
+    @Output() columnChooserChange: EventEmitter<{ allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number | string, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number | string }>;
 
     /**
     
@@ -1698,7 +1698,7 @@ export class DxDataGridComponent<TRowData = any, TKey = any> extends DxComponent
      * This member supports the internal infrastructure and is not intended to be used directly from your code.
     
      */
-    @Output() headerFilterChange: EventEmitter<{ allowSearch?: boolean, allowSelectAll?: boolean, height?: number, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number }>;
+    @Output() headerFilterChange: EventEmitter<{ allowSearch?: boolean, allowSelectAll?: boolean, height?: number | string, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number | string }>;
 
     /**
     
@@ -1747,7 +1747,7 @@ export class DxDataGridComponent<TRowData = any, TKey = any> extends DxComponent
      * This member supports the internal infrastructure and is not intended to be used directly from your code.
     
      */
-    @Output() loadPanelChange: EventEmitter<{ enabled?: Mode | boolean, height?: number, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number }>;
+    @Output() loadPanelChange: EventEmitter<{ enabled?: Mode | boolean, height?: number | string, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number | string }>;
 
     /**
     

--- a/packages/devextreme-angular/src/ui/nested/base/data-grid-column-dxi.ts
+++ b/packages/devextreme-angular/src/ui/nested/base/data-grid-column-dxi.ts
@@ -306,10 +306,10 @@ export abstract class DxiDataGridColumn extends CollectionNestedOption {
         this._setOption('headerCellTemplate', value);
     }
 
-    get headerFilter(): { allowSearch?: boolean, allowSelectAll?: boolean, dataSource?: DataSourceOptions | Store | Function | null | undefined | Array<any>, groupInterval?: HeaderFilterGroupInterval | number | undefined, height?: number | undefined, search?: ColumnHeaderFilterSearchConfig, searchMode?: SearchMode, width?: number | undefined } {
+    get headerFilter(): { allowSearch?: boolean, allowSelectAll?: boolean, dataSource?: DataSourceOptions | Store | Function | null | undefined | Array<any>, groupInterval?: HeaderFilterGroupInterval | number | undefined, height?: number | string | undefined, search?: ColumnHeaderFilterSearchConfig, searchMode?: SearchMode, width?: number | string | undefined } {
         return this._getOption('headerFilter');
     }
-    set headerFilter(value: { allowSearch?: boolean, allowSelectAll?: boolean, dataSource?: DataSourceOptions | Store | Function | null | undefined | Array<any>, groupInterval?: HeaderFilterGroupInterval | number | undefined, height?: number | undefined, search?: ColumnHeaderFilterSearchConfig, searchMode?: SearchMode, width?: number | undefined }) {
+    set headerFilter(value: { allowSearch?: boolean, allowSelectAll?: boolean, dataSource?: DataSourceOptions | Store | Function | null | undefined | Array<any>, groupInterval?: HeaderFilterGroupInterval | number | undefined, height?: number | string | undefined, search?: ColumnHeaderFilterSearchConfig, searchMode?: SearchMode, width?: number | string | undefined }) {
         this._setOption('headerFilter', value);
     }
 

--- a/packages/devextreme-angular/src/ui/nested/base/gantt-header-filter.ts
+++ b/packages/devextreme-angular/src/ui/nested/base/gantt-header-filter.ts
@@ -43,10 +43,10 @@ export abstract class DxoGanttHeaderFilter extends NestedOption {
         this._setOption('groupInterval', value);
     }
 
-    get height(): number | undefined {
+    get height(): number | string | undefined {
         return this._getOption('height');
     }
-    set height(value: number | undefined) {
+    set height(value: number | string | undefined) {
         this._setOption('height', value);
     }
 
@@ -64,10 +64,10 @@ export abstract class DxoGanttHeaderFilter extends NestedOption {
         this._setOption('searchMode', value);
     }
 
-    get width(): number | undefined {
+    get width(): number | string | undefined {
         return this._getOption('width');
     }
-    set width(value: number | undefined) {
+    set width(value: number | string | undefined) {
         this._setOption('width', value);
     }
 

--- a/packages/devextreme-angular/src/ui/nested/column-chooser.ts
+++ b/packages/devextreme-angular/src/ui/nested/column-chooser.ts
@@ -65,10 +65,10 @@ export class DxoColumnChooserComponent extends NestedOption implements OnDestroy
     }
 
     @Input()
-    get height(): number {
+    get height(): number | string {
         return this._getOption('height');
     }
-    set height(value: number) {
+    set height(value: number | string) {
         this._setOption('height', value);
     }
 
@@ -129,10 +129,10 @@ export class DxoColumnChooserComponent extends NestedOption implements OnDestroy
     }
 
     @Input()
-    get width(): number {
+    get width(): number | string {
         return this._getOption('width');
     }
-    set width(value: number) {
+    set width(value: number | string) {
         this._setOption('width', value);
     }
 

--- a/packages/devextreme-angular/src/ui/nested/load-panel.ts
+++ b/packages/devextreme-angular/src/ui/nested/load-panel.ts
@@ -38,10 +38,10 @@ export class DxoLoadPanelComponent extends NestedOption implements OnDestroy, On
     }
 
     @Input()
-    get height(): number {
+    get height(): number | string {
         return this._getOption('height');
     }
-    set height(value: number) {
+    set height(value: number | string) {
         this._setOption('height', value);
     }
 
@@ -94,10 +94,10 @@ export class DxoLoadPanelComponent extends NestedOption implements OnDestroy, On
     }
 
     @Input()
-    get width(): number {
+    get width(): number | string {
         return this._getOption('width');
     }
-    set width(value: number) {
+    set width(value: number | string) {
         this._setOption('width', value);
     }
 

--- a/packages/devextreme-angular/src/ui/tree-list/index.ts
+++ b/packages/devextreme-angular/src/ui/tree-list/index.ts
@@ -248,10 +248,10 @@ export class DxTreeListComponent<TRowData = any, TKey = any> extends DxComponent
     
      */
     @Input()
-    get columnChooser(): { allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number } {
+    get columnChooser(): { allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number | string, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number | string } {
         return this._getOption('columnChooser');
     }
-    set columnChooser(value: { allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number }) {
+    set columnChooser(value: { allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number | string, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number | string }) {
         this._setOption('columnChooser', value);
     }
 
@@ -625,10 +625,10 @@ export class DxTreeListComponent<TRowData = any, TKey = any> extends DxComponent
     
      */
     @Input()
-    get headerFilter(): { allowSearch?: boolean, allowSelectAll?: boolean, height?: number, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number } {
+    get headerFilter(): { allowSearch?: boolean, allowSelectAll?: boolean, height?: number | string, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number | string } {
         return this._getOption('headerFilter');
     }
-    set headerFilter(value: { allowSearch?: boolean, allowSelectAll?: boolean, height?: number, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number }) {
+    set headerFilter(value: { allowSearch?: boolean, allowSelectAll?: boolean, height?: number | string, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number | string }) {
         this._setOption('headerFilter', value);
     }
 
@@ -729,10 +729,10 @@ export class DxTreeListComponent<TRowData = any, TKey = any> extends DxComponent
     
      */
     @Input()
-    get loadPanel(): { enabled?: Mode | boolean, height?: number, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number } {
+    get loadPanel(): { enabled?: Mode | boolean, height?: number | string, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number | string } {
         return this._getOption('loadPanel');
     }
-    set loadPanel(value: { enabled?: Mode | boolean, height?: number, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number }) {
+    set loadPanel(value: { enabled?: Mode | boolean, height?: number | string, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number | string }) {
         this._setOption('loadPanel', value);
     }
 
@@ -1496,7 +1496,7 @@ export class DxTreeListComponent<TRowData = any, TKey = any> extends DxComponent
      * This member supports the internal infrastructure and is not intended to be used directly from your code.
     
      */
-    @Output() columnChooserChange: EventEmitter<{ allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number }>;
+    @Output() columnChooserChange: EventEmitter<{ allowSearch?: boolean, container?: string | UserDefinedElement | undefined, emptyPanelText?: string, enabled?: boolean, height?: number | string, mode?: ColumnChooserMode, position?: PositionConfig | undefined, search?: ColumnChooserSearchConfig, searchTimeout?: number, selection?: ColumnChooserSelectionConfig, sortOrder?: SortOrder | undefined, title?: string, width?: number | string }>;
 
     /**
     
@@ -1699,7 +1699,7 @@ export class DxTreeListComponent<TRowData = any, TKey = any> extends DxComponent
      * This member supports the internal infrastructure and is not intended to be used directly from your code.
     
      */
-    @Output() headerFilterChange: EventEmitter<{ allowSearch?: boolean, allowSelectAll?: boolean, height?: number, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number }>;
+    @Output() headerFilterChange: EventEmitter<{ allowSearch?: boolean, allowSelectAll?: boolean, height?: number | string, search?: HeaderFilterSearchConfig, searchTimeout?: number, texts?: { cancel?: string, emptyValue?: string, ok?: string }, visible?: boolean, width?: number | string }>;
 
     /**
     
@@ -1755,7 +1755,7 @@ export class DxTreeListComponent<TRowData = any, TKey = any> extends DxComponent
      * This member supports the internal infrastructure and is not intended to be used directly from your code.
     
      */
-    @Output() loadPanelChange: EventEmitter<{ enabled?: Mode | boolean, height?: number, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number }>;
+    @Output() loadPanelChange: EventEmitter<{ enabled?: Mode | boolean, height?: number | string, indicatorSrc?: string, shading?: boolean, shadingColor?: string, showIndicator?: boolean, showPane?: boolean, text?: string, width?: number | string }>;
 
     /**
     

--- a/packages/devextreme-react/src/data-grid.ts
+++ b/packages/devextreme-react/src/data-grid.ts
@@ -508,10 +508,10 @@ type IColumnProps = React.PropsWithChildren<{
     allowSelectAll?: boolean;
     dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
     groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-    height?: number;
+    height?: number | string;
     search?: ColumnHeaderFilterSearchConfig;
     searchMode?: "contains" | "startswith" | "equals";
-    width?: number;
+    width?: number | string;
   };
   hidingPriority?: number;
   isBand?: boolean;
@@ -631,7 +631,7 @@ type IColumnChooserProps = React.PropsWithChildren<{
   container?: any | string;
   emptyPanelText?: string;
   enabled?: boolean;
-  height?: number;
+  height?: number | string;
   mode?: "dragAndDrop" | "select";
   position?: PositionConfig;
   search?: ColumnChooserSearchConfig;
@@ -639,7 +639,7 @@ type IColumnChooserProps = React.PropsWithChildren<{
   selection?: ColumnChooserSelectionConfig;
   sortOrder?: "asc" | "desc";
   title?: string;
-  width?: number;
+  width?: number | string;
 }>
 class ColumnChooser extends NestedOption<IColumnChooserProps> {
   public static OptionName = "columnChooser";
@@ -712,10 +712,10 @@ type IColumnHeaderFilterProps = React.PropsWithChildren<{
   allowSelectAll?: boolean;
   dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
   groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-  height?: number;
+  height?: number | string;
   search?: ColumnHeaderFilterSearchConfig;
   searchMode?: "contains" | "startswith" | "equals";
-  width?: number;
+  width?: number | string;
 }>
 class ColumnHeaderFilter extends NestedOption<IColumnHeaderFilterProps> {
   public static OptionName = "headerFilter";
@@ -828,7 +828,7 @@ class CustomRule extends NestedOption<ICustomRuleProps> {
 type IDataGridHeaderFilterProps = React.PropsWithChildren<{
   allowSearch?: boolean;
   allowSelectAll?: boolean;
-  height?: number;
+  height?: number | string;
   search?: HeaderFilterSearchConfig;
   searchTimeout?: number;
   texts?: Record<string, any> | {
@@ -837,7 +837,7 @@ type IDataGridHeaderFilterProps = React.PropsWithChildren<{
     ok?: string;
   };
   visible?: boolean;
-  width?: number;
+  width?: number | string;
 }>
 class DataGridHeaderFilter extends NestedOption<IDataGridHeaderFilterProps> {
   public static OptionName = "headerFilter";
@@ -1543,10 +1543,10 @@ type IHeaderFilterProps = React.PropsWithChildren<{
   allowSelectAll?: boolean;
   dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
   groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-  height?: number;
+  height?: number | string;
   search?: ColumnHeaderFilterSearchConfig | HeaderFilterSearchConfig;
   searchMode?: "contains" | "startswith" | "equals";
-  width?: number;
+  width?: number | string;
   searchTimeout?: number;
   texts?: Record<string, any> | {
     cancel?: string;
@@ -1659,14 +1659,14 @@ class Label extends NestedOption<ILabelProps> {
 // DataGrid
 type ILoadPanelProps = React.PropsWithChildren<{
   enabled?: boolean | "auto";
-  height?: number;
+  height?: number | string;
   indicatorSrc?: string;
   shading?: boolean;
   shadingColor?: string;
   showIndicator?: boolean;
   showPane?: boolean;
   text?: string;
-  width?: number;
+  width?: number | string;
 }>
 class LoadPanel extends NestedOption<ILoadPanelProps> {
   public static OptionName = "loadPanel";

--- a/packages/devextreme-react/src/gantt.ts
+++ b/packages/devextreme-react/src/gantt.ts
@@ -258,10 +258,10 @@ type IColumnProps = React.PropsWithChildren<{
     allowSelectAll?: boolean;
     dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
     groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-    height?: number;
+    height?: number | string;
     search?: ColumnHeaderFilterSearchConfig;
     searchMode?: "contains" | "startswith" | "equals";
-    width?: number;
+    width?: number | string;
   };
   minWidth?: number;
   selectedFilterOperation?: "<" | "<=" | "<>" | "=" | ">" | ">=" | "between" | "contains" | "endswith" | "notcontains" | "startswith";
@@ -330,10 +330,10 @@ type IColumnHeaderFilterProps = React.PropsWithChildren<{
   allowSelectAll?: boolean;
   dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
   groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-  height?: number;
+  height?: number | string;
   search?: ColumnHeaderFilterSearchConfig;
   searchMode?: "contains" | "startswith" | "equals";
-  width?: number;
+  width?: number | string;
 }>
 class ColumnHeaderFilter extends NestedOption<IColumnHeaderFilterProps> {
   public static OptionName = "headerFilter";
@@ -503,10 +503,10 @@ type IHeaderFilterProps = React.PropsWithChildren<{
   allowSelectAll?: boolean;
   dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
   groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-  height?: number;
+  height?: number | string;
   search?: ColumnHeaderFilterSearchConfig | HeaderFilterSearchConfig;
   searchMode?: "contains" | "startswith" | "equals";
-  width?: number;
+  width?: number | string;
   searchTimeout?: number;
   texts?: dxGanttHeaderFilterTexts;
   visible?: boolean;

--- a/packages/devextreme-react/src/tree-list.ts
+++ b/packages/devextreme-react/src/tree-list.ts
@@ -489,10 +489,10 @@ type IColumnProps = React.PropsWithChildren<{
     allowSelectAll?: boolean;
     dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
     groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-    height?: number;
+    height?: number | string;
     search?: ColumnHeaderFilterSearchConfig;
     searchMode?: "contains" | "startswith" | "equals";
-    width?: number;
+    width?: number | string;
   };
   hidingPriority?: number;
   isBand?: boolean;
@@ -600,7 +600,7 @@ type IColumnChooserProps = React.PropsWithChildren<{
   container?: any | string;
   emptyPanelText?: string;
   enabled?: boolean;
-  height?: number;
+  height?: number | string;
   mode?: "dragAndDrop" | "select";
   position?: PositionConfig;
   search?: ColumnChooserSearchConfig;
@@ -608,7 +608,7 @@ type IColumnChooserProps = React.PropsWithChildren<{
   selection?: ColumnChooserSelectionConfig;
   sortOrder?: "asc" | "desc";
   title?: string;
-  width?: number;
+  width?: number | string;
 }>
 class ColumnChooser extends NestedOption<IColumnChooserProps> {
   public static OptionName = "columnChooser";
@@ -681,10 +681,10 @@ type IColumnHeaderFilterProps = React.PropsWithChildren<{
   allowSelectAll?: boolean;
   dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
   groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-  height?: number;
+  height?: number | string;
   search?: ColumnHeaderFilterSearchConfig;
   searchMode?: "contains" | "startswith" | "equals";
-  width?: number;
+  width?: number | string;
 }>
 class ColumnHeaderFilter extends NestedOption<IColumnHeaderFilterProps> {
   public static OptionName = "headerFilter";
@@ -1346,10 +1346,10 @@ type IHeaderFilterProps = React.PropsWithChildren<{
   allowSelectAll?: boolean;
   dataSource?: Array<any> | DataSourceOptions | ((options: { component: Record<string, any>, dataSource: DataSourceOptions | null }) => void) | null | Store;
   groupInterval?: number | "day" | "hour" | "minute" | "month" | "quarter" | "second" | "year";
-  height?: number;
+  height?: number | string;
   search?: ColumnHeaderFilterSearchConfig | HeaderFilterSearchConfig;
   searchMode?: "contains" | "startswith" | "equals";
-  width?: number;
+  width?: number | string;
   searchTimeout?: number;
   texts?: Record<string, any> | {
     cancel?: string;
@@ -1462,14 +1462,14 @@ class Label extends NestedOption<ILabelProps> {
 // TreeList
 type ILoadPanelProps = React.PropsWithChildren<{
   enabled?: boolean | "auto";
-  height?: number;
+  height?: number | string;
   indicatorSrc?: string;
   shading?: boolean;
   shadingColor?: string;
   showIndicator?: boolean;
   showPane?: boolean;
   text?: string;
-  width?: number;
+  width?: number | string;
 }>
 class LoadPanel extends NestedOption<ILoadPanelProps> {
   public static OptionName = "loadPanel";
@@ -2050,7 +2050,7 @@ class ToolbarItem extends NestedOption<IToolbarItemProps> {
 type ITreeListHeaderFilterProps = React.PropsWithChildren<{
   allowSearch?: boolean;
   allowSelectAll?: boolean;
-  height?: number;
+  height?: number | string;
   search?: HeaderFilterSearchConfig;
   searchTimeout?: number;
   texts?: Record<string, any> | {
@@ -2059,7 +2059,7 @@ type ITreeListHeaderFilterProps = React.PropsWithChildren<{
     ok?: string;
   };
   visible?: boolean;
-  width?: number;
+  width?: number | string;
 }>
 class TreeListHeaderFilter extends NestedOption<ITreeListHeaderFilterProps> {
   public static OptionName = "headerFilter";

--- a/packages/devextreme-vue/src/data-grid.ts
+++ b/packages/devextreme-vue/src/data-grid.ts
@@ -726,7 +726,7 @@ const DxColumnChooser = createConfigurationComponent({
     container: {},
     emptyPanelText: String,
     enabled: Boolean,
-    height: Number,
+    height: [Number, String],
     mode: String,
     position: Object,
     search: Object,
@@ -734,7 +734,7 @@ const DxColumnChooser = createConfigurationComponent({
     selection: Object,
     sortOrder: String,
     title: String,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxColumnChooser as any).$_optionName = "columnChooser";
@@ -827,10 +827,10 @@ const DxColumnHeaderFilter = createConfigurationComponent({
     allowSelectAll: Boolean,
     dataSource: {},
     groupInterval: [Number, String],
-    height: Number,
+    height: [Number, String],
     search: Object,
     searchMode: String,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxColumnHeaderFilter as any).$_optionName = "headerFilter";
@@ -977,12 +977,12 @@ const DxDataGridHeaderFilter = createConfigurationComponent({
   props: {
     allowSearch: Boolean,
     allowSelectAll: Boolean,
-    height: Number,
+    height: [Number, String],
     search: Object,
     searchTimeout: Number,
     texts: Object,
     visible: Boolean,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxDataGridHeaderFilter as any).$_optionName = "headerFilter";
@@ -1831,13 +1831,13 @@ const DxHeaderFilter = createConfigurationComponent({
     allowSelectAll: Boolean,
     dataSource: {},
     groupInterval: [Number, String],
-    height: Number,
+    height: [Number, String],
     search: Object,
     searchMode: String,
     searchTimeout: Number,
     texts: Object,
     visible: Boolean,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxHeaderFilter as any).$_optionName = "headerFilter";
@@ -1964,14 +1964,14 @@ const DxLoadPanel = createConfigurationComponent({
   },
   props: {
     enabled: [Boolean, String],
-    height: Number,
+    height: [Number, String],
     indicatorSrc: String,
     shading: Boolean,
     shadingColor: String,
     showIndicator: Boolean,
     showPane: Boolean,
     text: String,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxLoadPanel as any).$_optionName = "loadPanel";

--- a/packages/devextreme-vue/src/gantt.ts
+++ b/packages/devextreme-vue/src/gantt.ts
@@ -367,10 +367,10 @@ const DxColumnHeaderFilter = createConfigurationComponent({
     allowSelectAll: Boolean,
     dataSource: {},
     groupInterval: [Number, String],
-    height: Number,
+    height: [Number, String],
     search: Object,
     searchMode: String,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxColumnHeaderFilter as any).$_optionName = "headerFilter";
@@ -609,13 +609,13 @@ const DxHeaderFilter = createConfigurationComponent({
     allowSelectAll: Boolean,
     dataSource: {},
     groupInterval: [Number, String],
-    height: Number,
+    height: [Number, String],
     search: Object,
     searchMode: String,
     searchTimeout: Number,
     texts: Object,
     visible: Boolean,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxHeaderFilter as any).$_optionName = "headerFilter";

--- a/packages/devextreme-vue/src/tree-list.ts
+++ b/packages/devextreme-vue/src/tree-list.ts
@@ -706,7 +706,7 @@ const DxColumnChooser = createConfigurationComponent({
     container: {},
     emptyPanelText: String,
     enabled: Boolean,
-    height: Number,
+    height: [Number, String],
     mode: String,
     position: Object,
     search: Object,
@@ -714,7 +714,7 @@ const DxColumnChooser = createConfigurationComponent({
     selection: Object,
     sortOrder: String,
     title: String,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxColumnChooser as any).$_optionName = "columnChooser";
@@ -807,10 +807,10 @@ const DxColumnHeaderFilter = createConfigurationComponent({
     allowSelectAll: Boolean,
     dataSource: {},
     groupInterval: [Number, String],
-    height: Number,
+    height: [Number, String],
     search: Object,
     searchMode: String,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxColumnHeaderFilter as any).$_optionName = "headerFilter";
@@ -1603,13 +1603,13 @@ const DxHeaderFilter = createConfigurationComponent({
     allowSelectAll: Boolean,
     dataSource: {},
     groupInterval: [Number, String],
-    height: Number,
+    height: [Number, String],
     search: Object,
     searchMode: String,
     searchTimeout: Number,
     texts: Object,
     visible: Boolean,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxHeaderFilter as any).$_optionName = "headerFilter";
@@ -1736,14 +1736,14 @@ const DxLoadPanel = createConfigurationComponent({
   },
   props: {
     enabled: [Boolean, String],
-    height: Number,
+    height: [Number, String],
     indicatorSrc: String,
     shading: Boolean,
     shadingColor: String,
     showIndicator: Boolean,
     showPane: Boolean,
     text: String,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxLoadPanel as any).$_optionName = "loadPanel";
@@ -2479,12 +2479,12 @@ const DxTreeListHeaderFilter = createConfigurationComponent({
   props: {
     allowSearch: Boolean,
     allowSelectAll: Boolean,
-    height: Number,
+    height: [Number, String],
     search: Object,
     searchTimeout: Number,
     texts: Object,
     visible: Boolean,
-    width: Number
+    width: [Number, String]
   }
 });
 (DxTreeListHeaderFilter as any).$_optionName = "headerFilter";

--- a/packages/devextreme/js/common/grids.d.ts
+++ b/packages/devextreme/js/common/grids.d.ts
@@ -498,7 +498,7 @@ export type ColumnChooser = {
    * @docid GridBaseOptions.columnChooser.height
    * @default 260
    */
-  height?: number;
+  height?: number | string;
   /**
    * @docid GridBaseOptions.columnChooser.mode
    * @default "dragAndDrop"
@@ -532,7 +532,7 @@ export type ColumnChooser = {
    * @docid GridBaseOptions.columnChooser.width
    * @default 250
    */
-  width?: number;
+  width?: number | string;
   /**
    * @docid GridBaseOptions.columnChooser.sortOrder
    * @default undefined
@@ -681,7 +681,7 @@ export type ColumnHeaderFilter = {
    * @docid GridBaseColumn.headerFilter.height
    * @default undefined
    */
-  height?: number;
+  height?: number | string;
   /**
    * @docid GridBaseColumn.headerFilter.search
    */
@@ -696,7 +696,7 @@ export type ColumnHeaderFilter = {
    * @docid GridBaseColumn.headerFilter.width
    * @default undefined
    */
-  width?: number;
+  width?: number | string;
 };
 
 /**
@@ -1232,7 +1232,7 @@ export type HeaderFilter = {
    * @default 315 &for(Fluent)
    * @default 325
    */
-  height?: number;
+  height?: number | string;
   /**
    * @docid GridBaseOptions.headerFilter.search
    */
@@ -1257,7 +1257,7 @@ export type HeaderFilter = {
    * @docid GridBaseOptions.headerFilter.width
    * @default 252
    */
-  width?: number;
+  width?: number | string;
 };
 
 /**
@@ -2381,7 +2381,7 @@ export type LoadPanel = {
    * @docid GridBaseOptions.loadPanel.height
    * @default 90
    */
-  height?: number;
+  height?: number | string;
   /**
    * @docid GridBaseOptions.loadPanel.indicatorSrc
    * @default ""
@@ -2416,7 +2416,7 @@ export type LoadPanel = {
    * @docid GridBaseOptions.loadPanel.width
    * @default 200
    */
-  width?: number;
+  width?: number | string;
 };
 
 /**

--- a/packages/devextreme/testing/testcafe/model/dataGrid/headers/headerFilter.ts
+++ b/packages/devextreme/testing/testcafe/model/dataGrid/headers/headerFilter.ts
@@ -3,6 +3,7 @@ import List from '../../list';
 
 const CLASS = {
   filterMenu: 'dx-header-filter-menu',
+  content: 'dx-overlay-content',
   list: 'dx-list',
   button: 'dx-button',
 };
@@ -18,5 +19,9 @@ export default class HeaderFilter {
 
   getButtons(): Selector {
     return this.element.find(`.${CLASS.button}`);
+  }
+
+  getContent(): Selector {
+    return this.element.find(`.${CLASS.content}`);
   }
 }

--- a/packages/devextreme/testing/testcafe/model/dataGrid/index.ts
+++ b/packages/devextreme/testing/testcafe/model/dataGrid/index.ts
@@ -49,6 +49,7 @@ export const CLASS = {
 
   overlayContent: 'dx-overlay-content',
   overlayWrapper: 'dx-overlay-wrapper',
+  loadPanelWrapper: 'dx-loadpanel-wrapper',
   revertTooltip: 'revert-tooltip',
   invalidMessage: 'invalid-message',
 
@@ -195,6 +196,10 @@ export default class DataGrid extends Widget {
 
   getOverlay(): Overlay {
     return new Overlay(this.element.find(`.${CLASS.overlayWrapper}`));
+  }
+
+  getLoadPanel(): Overlay {
+    return new Overlay(this.element.find(`.${CLASS.loadPanelWrapper}`));
   }
 
   getConfirmDeletionButton(): Selector {
@@ -545,6 +550,16 @@ export default class DataGrid extends Widget {
           getInstance,
         },
       },
+    )();
+  }
+
+  apiBeginCustomLoading(messageText: string): Promise<void> {
+    const { getInstance } = this;
+    return ClientFunction(
+      () => {
+        (getInstance() as DataGridInstance).beginCustomLoading(messageText);
+      },
+      { dependencies: { getInstance, messageText } },
     )();
   }
 

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/columnChooser.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/columnChooser.ts
@@ -110,3 +110,29 @@ test('Column chooser checkboxes should be aligned correctly with tree structure'
     },
   },
 }));
+
+test('Column chooser should support string height and width', async (t) => {
+  const dataGrid = new DataGrid('#container');
+
+  await t
+    .click(dataGrid.getHeaderPanel().getColumnChooserButton());
+
+  const columnChooserContent = dataGrid.getColumnChooser().content;
+
+  await t
+    .expect(columnChooserContent.getStyleProperty('height'))
+    .eql('400px')
+    .expect(columnChooserContent.getStyleProperty('width'))
+    .eql('330px');
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: [],
+  columns: [
+    'field1', 'field2', 'field3',
+  ],
+  width: 700,
+  columnChooser: {
+    enabled: true,
+    height: '400px',
+    width: '330px',
+  },
+}));

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/headerFilter/headerFilter.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/headerFilter/headerFilter.ts
@@ -133,3 +133,38 @@ test('Should correctly change values (T1161941)', async (t) => {
   },
   columns: ['Name', 'Amount'],
 }));
+
+test('Header filter should support string height and width', async (t) => {
+  const dataGrid = new DataGrid('#container');
+  const firstFilterIcon = dataGrid.getHeaders().getHeaderRow(0).getHeaderCell(0).getFilterIcon();
+  const thirdFilterIcon = dataGrid.getHeaders().getHeaderRow(0).getHeaderCell(2).getFilterIcon();
+
+  await t
+    .click(firstFilterIcon)
+    .expect(new HeaderFilter().getContent().getStyleProperty('height'))
+    .eql('400px')
+    .expect(new HeaderFilter().getContent().getStyleProperty('width'))
+    .eql('330px')
+    .click(thirdFilterIcon)
+    .expect(new HeaderFilter().getContent().getStyleProperty('height'))
+    .eql('450px')
+    .expect(new HeaderFilter().getContent().getStyleProperty('width'))
+    .eql('380px');
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: [],
+  columns: [
+    'field1', 'field2', {
+      dataField: 'field3',
+      headerFilter: {
+        height: '450px',
+        width: '380px',
+      },
+    },
+  ],
+  width: 700,
+  headerFilter: {
+    visible: true,
+    height: '400px',
+    width: '330px',
+  },
+}));

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/markup/markup.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/markup/markup.ts
@@ -1,0 +1,28 @@
+import url from '../../../helpers/getPageUrl';
+import { createWidget } from '../../../helpers/createWidget';
+import DataGrid from '../../../model/dataGrid';
+
+fixture.disablePageReloads`Icon Sizes`
+  .page(url(__dirname, '../../container.html'));
+
+test('Load panel should support string height and width', async (t) => {
+  const dataGrid = new DataGrid('#container');
+  await dataGrid.apiBeginCustomLoading('test');
+
+  await t
+    .expect(dataGrid.getLoadPanel().content.getStyleProperty('height'))
+    .eql('400px')
+    .expect(dataGrid.getLoadPanel().content.getStyleProperty('width'))
+    .eql('330px');
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: [],
+  columns: [
+    'field1', 'field2', 'field3',
+  ],
+  width: 700,
+  loadPanel: {
+    enabled: true,
+    height: '400px',
+    width: '330px',
+  },
+}));

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -2874,7 +2874,7 @@ declare module DevExpress.common.grids {
     /**
      * [descr:GridBaseOptions.columnChooser.height]
      */
-    height?: number;
+    height?: number | string;
     /**
      * [descr:GridBaseOptions.columnChooser.mode]
      */
@@ -2903,7 +2903,7 @@ declare module DevExpress.common.grids {
     /**
      * [descr:GridBaseOptions.columnChooser.width]
      */
-    width?: number;
+    width?: number | string;
     /**
      * [descr:GridBaseOptions.columnChooser.sortOrder]
      */
@@ -3010,7 +3010,7 @@ declare module DevExpress.common.grids {
     /**
      * [descr:GridBaseColumn.headerFilter.height]
      */
-    height?: number;
+    height?: number | string;
     /**
      * [descr:GridBaseColumn.headerFilter.search]
      */
@@ -3023,7 +3023,7 @@ declare module DevExpress.common.grids {
     /**
      * [descr:GridBaseColumn.headerFilter.width]
      */
-    width?: number;
+    width?: number | string;
   };
   /**
    * [descr:ColumnHeaderFilterSearchConfig]
@@ -4072,7 +4072,7 @@ declare module DevExpress.common.grids {
     /**
      * [descr:GridBaseOptions.headerFilter.height]
      */
-    height?: number;
+    height?: number | string;
     /**
      * [descr:GridBaseOptions.headerFilter.search]
      */
@@ -4093,7 +4093,7 @@ declare module DevExpress.common.grids {
     /**
      * [descr:GridBaseOptions.headerFilter.width]
      */
-    width?: number;
+    width?: number | string;
   };
   export type HeaderFilterGroupInterval =
     | 'day'
@@ -4183,7 +4183,7 @@ declare module DevExpress.common.grids {
     /**
      * [descr:GridBaseOptions.loadPanel.height]
      */
-    height?: number;
+    height?: number | string;
     /**
      * [descr:GridBaseOptions.loadPanel.indicatorSrc]
      */
@@ -4211,7 +4211,7 @@ declare module DevExpress.common.grids {
     /**
      * [descr:GridBaseOptions.loadPanel.width]
      */
-    width?: number;
+    width?: number | string;
   };
   /**
    * [descr:NewRowInfo]


### PR DESCRIPTION
See https://supportcenter.devexpress.com/ticket/details/t1214374/datagrid-columnchooser-height-and-width-types-do-not-include-string