### PR TITLE
CI - allow to download package-lock from artifacts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -197,7 +197,7 @@ jobs:
         retention-days: 1  
 
     - name: Check package-lock
-        git diff --exit-code package-lock.json
+      run: git diff --exit-code package-lock.json
 
   component_exports:
     runs-on: devextreme-shr2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -183,11 +183,20 @@ jobs:
       with:
         node-version: '20'
 
-    - name: Check package-lock
+    - name: Update package-lock
       run: |
         node -v
         npm -v
         npm install --no-audit --no-fund --ignore-scripts
+
+    - name: Upload package-lock
+      uses: actions/upload-artifact@v3
+      with:
+        name: package-lock.json
+        path: ./package-lock.json
+        retention-days: 1  
+
+    - name: Check package-lock
         git diff --exit-code package-lock.json
 
   component_exports:


### PR DESCRIPTION
Generation of package-lock on different machines can be different. We have CI task to check that package-lock is actual, but sometimes it fail because of different machines

This PR allows to download package-lock from CI to push it to PR