### PR TITLE
TreeList/DataGrid - Focus indicator is not visible when the Toolbar includes a DropDownButton item (T1225005)

### DIFF
--- a/e2e/testcafe-devextreme/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4600,3 +4600,32 @@ test('Keyboard navigation should work after opening-closing master-detal', async
     enabled: true,
   },
 }));
+
+test('TreeList/DataGrid - Focus indicator is not visible when the Toolbar includes a DropDownButton item (T1225005)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+  await t
+    .click(dataGrid.getHeaders().getHeaderRow(0).getHeaderCell(1).element)
+    .pressKey('tab')
+
+    .expect(dataGrid.getFocusOverlay().exists)
+    .ok();
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: getData(1, 2),
+  toolbar: {
+    items: [
+      {
+        widget: 'dxDropDownButton',
+        location: 'before',
+        options: {
+          text: 'Clear Batch',
+          items: [
+            { text: 'Delete All Lines' },
+            { text: 'Zero All Values' },
+          ],
+        },
+      },
+    ],
+  },
+  keyExpr: 'field_0',
+  showBorders: true,
+}));

--- a/packages/devextreme/js/__internal/grids/grid_core/editor_factory/m_editor_factory.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editor_factory/m_editor_factory.ts
@@ -117,8 +117,7 @@ export class EditorFactory extends ViewControllerWithMixin {
       '.dx-lookup-field:focus',
       '.dx-checkbox:focus',
       '.dx-switch:focus',
-      '.dx-dropdownbutton',
-      '.dx-buttongroup:focus',
+      '.dx-dropdownbutton .dx-buttongroup:focus',
       '.dx-adaptive-item-text:focus'].join(',');
 
     // T181706

--- a/packages/testcafe-models/dataGrid/index.ts
+++ b/packages/testcafe-models/dataGrid/index.ts
@@ -34,6 +34,7 @@ export const CLASS = {
   filterPanel: 'filter-panel',
   filterRow: 'filter-row',
   filterRangeOverlay: 'filter-range-overlay',
+  focusOverlay: 'focus-overlay',
   pager: 'pager',
   editFormRow: 'edit-form',
   button: 'dx-button',
@@ -187,6 +188,9 @@ export default class DataGrid extends Widget {
 
   getFilterRangeOverlay(): Selector {
     return this.body.find(`.${this.addWidgetPrefix(CLASS.filterRangeOverlay)}`);
+  }
+  getFocusOverlay() {
+    return this.body.find(`.${this.addWidgetPrefix(CLASS.focusOverlay)}`);
   }
 
   getFilterEditor<T>(


### PR DESCRIPTION
See https://supportcenter.devexpress.com/ticket/details/t1225005/treelist-datagrid-focus-indicator-is-not-visible-when-the-toolbar-includes-a