### PR TITLE
CI: Rollback upload-artifact action to v3

### DIFF
--- a/.github/workflows/demos_visual_tests_frameworks.yml
+++ b/.github/workflows/demos_visual_tests_frameworks.yml
@@ -385,7 +385,7 @@ jobs:
 
     - name: Copy screenshots artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: screenshots-${{ steps.screenshotname.outputs.value }}-${{ matrix.THEME }}
         path: ${{ github.workspace }}/apps/demos/testing/artifacts/compared-screenshots/**/*


### PR DESCRIPTION
Rollback upload-artifact action to v3. BC in v4 doesn't allow to upload screenshots from different jobs in one folder
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
