### PR TITLE
Add minor corrections for recent transpiling update

### DIFF
--- a/apps/demos/utils/bundle/index.js
+++ b/apps/demos/utils/bundle/index.js
@@ -76,7 +76,6 @@ const getDefaultBuilderConfig = (framework, additionPaths, map) => ({
   },
   paths: {
     'devextreme/*': '../../node_modules/devextreme/cjs/*',
-    "devextreme/bundles/dx.custom.config.js": "../../node_modules/devextreme/bundles/dx.custom.config.js",
     'devexpress-gantt': '../../node_modules/devexpress-gantt/dist/dx-gantt.min.js',
     'devexpress-diagram': '../../node_modules/devexpress-diagram/dist/dx-diagram.min.js',
     [`devextreme-${framework}/*`]: `../../node_modules/devextreme-${framework}/${['react', 'vue'].includes(framework) ? 'cjs/*' : '*'}`,

--- a/apps/demos/utils/bundle/index.js
+++ b/apps/demos/utils/bundle/index.js
@@ -58,10 +58,10 @@ const getDefaultBuilderConfig = (framework, additionPaths, map) => ({
   meta: {
     '*': {
       build: false,
+      transpile: true,
     },
     'devextreme/*': {
       build: true,
-      transpile: true,
     },
     'devexpress-gantt': {
       build: true,

--- a/packages/devextreme-angular/tsconfig.json
+++ b/packages/devextreme-angular/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2017",
     "module": "ES2015",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,

--- a/packages/devextreme-vue/tsconfig.json
+++ b/packages/devextreme-vue/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ]
+    "skipLibCheck": true
   },
   "include": [
     "src/core/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     },
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "jsx": "react",
     "noEmitOnError": true,
@@ -40,9 +40,6 @@
     "noUnusedParameters": true,
     "strictNullChecks": true,
     "lib": [
-      "esnext",
-      "es2015",
-      "es2015.iterable",
       "dom"
     ]
   },


### PR DESCRIPTION
- fixes missing `hideTopOverlay` issues in demos bundles
- brings back transpiling for platform packages (#27342)