### PR TITLE
Fix R1 editor css classes map

### DIFF
--- a/packages/devextreme/js/renovation/ui/editors/common/editor.tsx
+++ b/packages/devextreme/js/renovation/ui/editors/common/editor.tsx
@@ -28,7 +28,7 @@ const getCssClasses = (model: EditorPropsType): string => {
   const classesMap = {
     'dx-state-readonly': !!readOnly,
     'dx-invalid': !isValid,
-    [`${classes}`]: !!classes,
+    [String(classes)]: !!classes,
   };
   return combineClasses(classesMap);
 };


### PR DESCRIPTION
### Practical Value
This is required to fix run-time error:

```
Error: Failed to execute 'remove' on 'DOMTokenList': The token provided ('
') contains HTML space characters, which are not valid in tokens.
        at DOMTokenList.remove (http://...)
        at http://...
        at Array.forEach (<anonymous>)
        at Widget.InfernoWrapperComponent.componentDidUpdate (http://...)
        at Array.<anonymous> (http://...)
        at fastApply (http://...)
        at value (http://...)
        at callAll (http://...)
        at __render (http://...)
        at render (http://...)
```

### Details

Error occurs due to incorrect R1 generation. In my opinion `String(value)` has exactly the same meaning and is correctly treated by R1 generator.

### Before

String interpolation is broken:

```ts
get cssClasses() {
    return `${(model=>{const{classes:classes,isValid:isValid,readOnly:readOnly}=model;const classesMap={"dx-state-readonly":!!readOnly,"dx-invalid":!isValid,[`
    $ {
        classes
    }
    `]:!!classes};return(0,_combine_classes.combineClasses)(classesMap)})(_extends({},this.props,{value:void 0!==this.props.value?this.props.value:this.state.value}))}`
}
```

### After

```ts
get cssClasses() {
    return `${(model=>{const{classes:classes,isValid:isValid,readOnly:readOnly}=model;const classesMap={"dx-state-readonly":!!readOnly,"dx-invalid":!isValid,[String(classes)]:!!classes};return(0,_combine_classes.combineClasses)(classesMap)})(_extends({},this.props,{value:void 0!==this.props.value?this.props.value:this.state.value}))}`
}
```