### PR TITLE
DateBox types: the public DateBox class shouldn't have a generic type (revert after migration to TS)

### DIFF
--- a/packages/devextreme/js/__internal/ui/date_range_box/m_multiselect_date_box.ts
+++ b/packages/devextreme/js/__internal/ui/date_range_box/m_multiselect_date_box.ts
@@ -1,9 +1,10 @@
+// eslint-disable-next-line max-classes-per-file
 import $ from '@js/core/renderer';
 import { getWidth } from '@js/core/utils/size';
 import eventsEngine from '@js/events/core/events_engine';
 import { addNamespace } from '@js/events/utils';
 import type { Properties } from '@js/ui/date_box';
-import DateBox from '@js/ui/date_box';
+import { DateBoxBase } from '@js/ui/date_box';
 import type Popup from '@js/ui/popup';
 
 import { getDeserializedDate, monthDifference } from './m_date_range.utils';
@@ -17,7 +18,11 @@ export interface MultiselectDateBoxProperties extends Properties {
   _showValidationMessage?: boolean;
 }
 
-class MultiselectDateBox extends DateBox<MultiselectDateBoxProperties> {
+declare class DateBox<TProperties = MultiselectDateBoxProperties> extends DateBoxBase<TProperties> {
+  reset(value?: Date | number | string | null): void;
+}
+
+class MultiselectDateBox extends DateBox {
   // Temporary solution. Move to component level
   public NAME!: string;
 

--- a/packages/devextreme/js/__internal/ui/date_range_box/m_multiselect_date_box.ts
+++ b/packages/devextreme/js/__internal/ui/date_range_box/m_multiselect_date_box.ts
@@ -4,7 +4,7 @@ import { getWidth } from '@js/core/utils/size';
 import eventsEngine from '@js/events/core/events_engine';
 import { addNamespace } from '@js/events/utils';
 import type { Properties } from '@js/ui/date_box';
-import { DateBoxBase } from '@js/ui/date_box';
+import DateBox, { DateBoxBase } from '@js/ui/date_box';
 import type Popup from '@js/ui/popup';
 
 import { getDeserializedDate, monthDifference } from './m_date_range.utils';
@@ -18,11 +18,13 @@ export interface MultiselectDateBoxProperties extends Properties {
   _showValidationMessage?: boolean;
 }
 
-declare class DateBox<TProperties = MultiselectDateBoxProperties> extends DateBoxBase<TProperties> {
+declare class ExtendedDateBox extends DateBoxBase<MultiselectDateBoxProperties> {
   reset(value?: Date | number | string | null): void;
 }
 
-class MultiselectDateBox extends DateBox {
+const TypedDateBox: typeof ExtendedDateBox = DateBox as any;
+
+class MultiselectDateBox extends TypedDateBox {
   // Temporary solution. Move to component level
   public NAME!: string;
 

--- a/packages/devextreme/js/ui/date_box.d.ts
+++ b/packages/devextreme/js/ui/date_box.d.ts
@@ -377,7 +377,7 @@ export class DateBoxBase<TProperties = Properties> extends dxDropDownEditor<TPro
  * @namespace DevExpress.ui
  * @public
  */
-export default class dxDateBox<TProperties = Properties> extends DateBoxBase<TProperties> {
+export default class dxDateBox extends DateBoxBase<Properties> {
     /**
      * @docid
      * @publicName reset(value)

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -12155,9 +12155,7 @@ declare module DevExpress.ui {
   /**
    * [descr:dxDateBox]
    */
-  export class dxDateBox<
-    TProperties = DevExpress.ui.dxDateBox.Properties
-  > extends DateBoxBase<TProperties> {
+  export class dxDateBox extends DateBoxBase<DevExpress.ui.dxDateBox.Properties> {
     /**
      * [descr:dxDateBox.reset(value)]
      */


### PR DESCRIPTION
https://github.com/DevExpress/DevExtreme/pull/27347/