### PR TITLE
Fix axe accessibility issues in demos / index.html

### DIFF
--- a/apps/demos/Demos/DataGrid/Overview/jQuery/index.html
+++ b/apps/demos/Demos/DataGrid/Overview/jQuery/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head>
     <title>DevExtreme Demo</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
     <script src="../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../../node_modules/cldrjs/dist/cldr.js"></script>
     <script src="../../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
@@ -16,8 +16,11 @@
     <script src="index.js"></script>
   </head>
   <body class="dx-viewport">
-    <div class="demo-container">
-      <div id="gridContainer"></div>
-    </div>
+    <main>
+      <h1 style="position: fixed; left: 0; top: 0; clip: rect(1px, 1px, 1px, 1px);">DataGrid Overview</h1>
+      <div class="demo-container">
+        <div id="gridContainer"></div>
+      </div>
+  </main>
   </body>
 </html>


### PR DESCRIPTION
ReOpened at #27513

Fixes the following axe-core found 4 violations in a standalone (nested into a WidgetsGallery iframe) demo html page / file:

1	Document should have one main landmark	landmark-one-main	Best practice	moderate	1
2	Zooming and scaling must not be disabled	meta-viewport	WCAG 2 Level AA, WCAG 1.4.4	critical	1
3	Page should contain a level-one heading	page-has-heading-one	Best practice	moderate	1
4	All page content should be contained by landmarks	region	Best practice	moderate	1

The inclusively hidden (h1) is copied from:
https://github.com/DevExpress/DevExtreme/blob/24_1/packages/devextreme/playground/jquery.html