### PR TITLE
Arrange dxToolbarItem type import in Angular toolbar component

### DIFF
--- a/packages/devextreme-angular/src/ui/toolbar/index.ts
+++ b/packages/devextreme-angular/src/ui/toolbar/index.ts
@@ -27,8 +27,7 @@ export { ExplicitTypes } from 'devextreme/ui/toolbar';
 import { ToolbarItemComponent, ToolbarItemLocation } from 'devextreme/common';
 import { Store } from 'devextreme/data';
 import DataSource, { Options as DataSourceOptions } from 'devextreme/data/data_source';
-import { ContentReadyEvent, DisposingEvent, InitializedEvent, ItemClickEvent, ItemContextMenuEvent, ItemHoldEvent, ItemRenderedEvent, LocateInMenuMode, OptionChangedEvent, ShowTextMode } from 'devextreme/ui/toolbar';
-import { dxToolbarItem } from 'devextreme/ui/toolbar/ui.toolbar';
+import { ContentReadyEvent, DisposingEvent, dxToolbarItem, InitializedEvent, ItemClickEvent, ItemContextMenuEvent, ItemHoldEvent, ItemRenderedEvent, LocateInMenuMode, OptionChangedEvent, ShowTextMode } from 'devextreme/ui/toolbar';
 
 import DxToolbar from 'devextreme/ui/toolbar';
 

--- a/packages/devextreme/js/ui/toolbar.js
+++ b/packages/devextreme/js/ui/toolbar.js
@@ -1,3 +1,9 @@
 import Toolbar from './toolbar/ui.toolbar';
 
 export default Toolbar;
+
+/**
+ * @name dxToolbarItem
+ * @inherits CollectionWidgetItem
+ * @type object
+ */

--- a/packages/devextreme/js/ui/toolbar/ui.toolbar.js
+++ b/packages/devextreme/js/ui/toolbar/ui.toolbar.js
@@ -253,9 +253,3 @@ class Toolbar extends ToolbarBase {
 registerComponent('dxToolbar', Toolbar);
 
 export default Toolbar;
-
-/**
- * @name dxToolbarItem
- * @inherits CollectionWidgetItem
- * @type object
- */


### PR DESCRIPTION
Fixes:
`
/node_modules/devextreme-angular/ui/toolbar/index.d.ts:26:31 - error TS7016: Could not find a declaration file for module 'devextreme/ui/toolbar/ui.toolbar'. '.../node_modules/devextreme/cjs/ui/toolbar/ui.toolbar.js' implicitly has an 'any' type.
`

`
import { dxToolbarItem } from 'devextreme/ui/toolbar/ui.toolbar';
`

Patch for #27248
A single? CollectionWidgetItem descendant was define in a deeply nested js module:
`"Uid": "ui/toolbar/ui.toolbar:dxToolbarItem"`

The other CollectionWidgetItem descendants are defined in the related js module(s) and their declarations have the following Uids:
`"Uid": "ui/accordion:dxAccordionItem",`
`"Uid": "ui/box:dxBoxItem",`
etc.