### PR TITLE
DataGrid: Fix the 'Cannot read properties of undefined (reading 'done')' error that occurs under certain conditions (T1219612)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/views/m_grid_view.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/views/m_grid_view.ts
@@ -4,6 +4,7 @@ import type { dxElementWrapper } from '@js/core/renderer';
 import $ from '@js/core/renderer';
 import browser from '@js/core/utils/browser';
 import { deferRender, deferUpdate } from '@js/core/utils/common';
+import type { DeferredObj } from '@js/core/utils/deferred';
 import { Deferred, when } from '@js/core/utils/deferred';
 import { each } from '@js/core/utils/iterator';
 import { getBoundingRect } from '@js/core/utils/position';
@@ -646,9 +647,10 @@ export class ResizingController extends modules.ViewController {
   /**
    * @extended: virtual_scrolling
    */
-  public resize() {
+  public resize(): DeferredObj<unknown> {
     if (this.component._requireResize) {
-      return;
+      // @ts-expect-error
+      return new Deferred().resolve();
     }
 
     // @ts-expect-error

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/m_virtual_scrolling.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/m_virtual_scrolling.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import $ from '@js/core/renderer';
 import browser from '@js/core/utils/browser';
+import type { DeferredObj } from '@js/core/utils/deferred';
 import { Deferred, when } from '@js/core/utils/deferred';
 import { isElementInDom } from '@js/core/utils/dom';
 import { each } from '@js/core/utils/iterator';
@@ -1319,7 +1320,7 @@ export const resizing = (Base: ModuleType<ResizingController>) => class VirtualS
     return !!this._resizeTimeout;
   }
 
-  public resize() {
+  public resize(): DeferredObj<unknown> {
     let result;
 
     if (isVirtualMode(this) || gridCoreUtils.isVirtualRowRendering(this)) {


### PR DESCRIPTION
See https://devexpress.com/issue=T1219612