### PR TITLE
Revert: "add fake generic type params for affected narrowed events"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@types/yargs": "^17.0.32",
         "cheerio": "1.0.0-rc.10",
         "codelyzer": "^6.0.2",
-        "devextreme-internal-tools": "14.0.0-beta.4",
+        "devextreme-internal-tools": "14.0.0-beta.5",
         "eslint": "8.57.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-airbnb-typescript": "17.1.0",
@@ -26035,9 +26035,9 @@
       "link": true
     },
     "node_modules/devextreme-internal-tools": {
-      "version": "14.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-14.0.0-beta.4.tgz",
-      "integrity": "sha512-bSsJI1duDOxfAKsnlaJK7O/lLLlv/EEPEq4Knd5sf7ScwsLdGMrSwIOLlc6+epm9A5rY4D7sRKXaWVo0pLPQ+A==",
+      "version": "14.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-14.0.0-beta.5.tgz",
+      "integrity": "sha512-HuswhGy8ZwCNmafGw5M+DlUvTSloNR2QK006Kvy7kOBdw814O81XG8lw4XlUJN5SZ6hq+Mi8ls1NLLoQtpbbDQ==",
       "dev": true,
       "dependencies": {
         "dasherize": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/yargs": "^17.0.32",
     "cheerio": "1.0.0-rc.10",
     "codelyzer": "^6.0.2",
-    "devextreme-internal-tools": "14.0.0-beta.4",
+    "devextreme-internal-tools": "14.0.0-beta.5",
     "eslint": "8.57.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-airbnb-typescript": "17.1.0",

--- a/packages/devextreme-react/src/splitter.ts
+++ b/packages/devextreme-react/src/splitter.ts
@@ -26,9 +26,9 @@ type ISplitterOptionsNarrowedEvents<TItem = any, TKey = any> = {
   onItemContextMenu?: ((e: ItemContextMenuEvent<TItem, TKey>) => void);
   onItemExpanded?: ((e: ItemExpandedEvent<TItem, TKey>) => void);
   onItemRendered?: ((e: ItemRenderedEvent<TItem, TKey>) => void);
-  onResize?: ((e: ResizeEvent<TItem, TKey>) => void);
-  onResizeEnd?: ((e: ResizeEndEvent<TItem, TKey>) => void);
-  onResizeStart?: ((e: ResizeStartEvent<TItem, TKey>) => void);
+  onResize?: ((e: ResizeEvent<TKey>) => void);
+  onResizeEnd?: ((e: ResizeEndEvent<TKey>) => void);
+  onResizeStart?: ((e: ResizeStartEvent<TKey>) => void);
 }
 
 type ISplitterOptions<TItem = any, TKey = any> = React.PropsWithChildren<ReplaceFieldTypes<Properties<TItem, TKey>, ISplitterOptionsNarrowedEvents<TItem, TKey>> & IHtmlOptions & {

--- a/packages/devextreme/js/ui/splitter.d.ts
+++ b/packages/devextreme/js/ui/splitter.d.ts
@@ -101,7 +101,7 @@ export type OptionChangedEvent<TItem extends ItemLike<TKey> = any, TKey = any> =
  * @type object
  * @inherits Cancelable,NativeEventInfo,_ui_splitter_ResizeInfo
  */
-export type ResizeEvent<TItem extends ItemLike<TKey> = any, TKey = any> = Cancelable & NativeEventInfo<dxSplitter<TKey>, KeyboardEvent | PointerEvent | MouseEvent | TouchEvent> & ResizeInfo;
+export type ResizeEvent<TKey = any> = Cancelable & NativeEventInfo<dxSplitter<TKey>, KeyboardEvent | PointerEvent | MouseEvent | TouchEvent> & ResizeInfo;
 
 /**
  * @docid _ui_splitter_ResizeStartEvent
@@ -109,7 +109,7 @@ export type ResizeEvent<TItem extends ItemLike<TKey> = any, TKey = any> = Cancel
  * @type object
  * @inherits Cancelable,NativeEventInfo,_ui_splitter_ResizeInfo
  */
-export type ResizeStartEvent<TItem extends ItemLike<TKey> = any, TKey = any> = Cancelable & NativeEventInfo<dxSplitter<TKey>, KeyboardEvent | PointerEvent | MouseEvent | TouchEvent> & ResizeInfo;
+export type ResizeStartEvent<TKey = any> = Cancelable & NativeEventInfo<dxSplitter<TKey>, KeyboardEvent | PointerEvent | MouseEvent | TouchEvent> & ResizeInfo;
 
 /**
  * @docid _ui_splitter_ResizeEndEvent
@@ -117,7 +117,7 @@ export type ResizeStartEvent<TItem extends ItemLike<TKey> = any, TKey = any> = C
  * @type object
  * @inherits Cancelable,NativeEventInfo,_ui_splitter_ResizeInfo
  */
-export type ResizeEndEvent<TItem extends ItemLike<TKey> = any, TKey = any> = Cancelable & NativeEventInfo<dxSplitter<TKey>, KeyboardEvent | PointerEvent | MouseEvent | TouchEvent> & ResizeInfo;
+export type ResizeEndEvent<TKey = any> = Cancelable & NativeEventInfo<dxSplitter<TKey>, KeyboardEvent | PointerEvent | MouseEvent | TouchEvent> & ResizeInfo;
 
 /**
  * @docid _ui_splitter_ItemCollapsedEvent

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -25610,10 +25610,7 @@ declare module DevExpress.ui {
     /**
      * [descr:_ui_splitter_ResizeEndEvent]
      */
-    export type ResizeEndEvent<
-      TItem extends ItemLike<TKey> = any,
-      TKey = any
-    > = DevExpress.events.Cancelable &
+    export type ResizeEndEvent<TKey = any> = DevExpress.events.Cancelable &
       DevExpress.events.NativeEventInfo<
         dxSplitter<TKey>,
         KeyboardEvent | PointerEvent | MouseEvent | TouchEvent
@@ -25622,10 +25619,7 @@ declare module DevExpress.ui {
     /**
      * [descr:_ui_splitter_ResizeEvent]
      */
-    export type ResizeEvent<
-      TItem extends ItemLike<TKey> = any,
-      TKey = any
-    > = DevExpress.events.Cancelable &
+    export type ResizeEvent<TKey = any> = DevExpress.events.Cancelable &
       DevExpress.events.NativeEventInfo<
         dxSplitter<TKey>,
         KeyboardEvent | PointerEvent | MouseEvent | TouchEvent
@@ -25644,10 +25638,7 @@ declare module DevExpress.ui {
     /**
      * [descr:_ui_splitter_ResizeStartEvent]
      */
-    export type ResizeStartEvent<
-      TItem extends ItemLike<TKey> = any,
-      TKey = any
-    > = DevExpress.events.Cancelable &
+    export type ResizeStartEvent<TKey = any> = DevExpress.events.Cancelable &
       DevExpress.events.NativeEventInfo<
         dxSplitter<TKey>,
         KeyboardEvent | PointerEvent | MouseEvent | TouchEvent


### PR DESCRIPTION
The new version of the devextreme-internal-tools supports generic type parameters for narrowed events (previously, we used parameters from the component options). Now we can revert [the workaround](https://github.com/DevExpress/DevExtreme/pull/26655/commits/1b25cf65c3149a34ead662986ab91ede19017bbf) with fake type params.