### PR TITLE
CI: Setup npm deps scanner

### DIFF
--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run deps scanner
         run: |
           ./deps-scanner/exe/npmDepsScanner.exe scan_cache ${{ github.workspace }} reportGithub.json
-          mkdir -p ./artifatcs/deps-scanner
+          mkdir -p ./artifacts/deps-scanner
           cp reportGithub.json ./artifacts/deps-scanner/
 
       - name: Build artifacts package

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -60,12 +60,8 @@ jobs:
       - name: Run deps scanner
         run: |
           ./deps-scanner/exe/npmDepsScanner.exe scan_cache ${{ github.workspace }} reportGithub.json
-
-      #      - name: Copy scanner artifacts
-      #        shell: bash
-      #        run: |
-      #          mkdir -p ./artifacts/deps-scanner
-      #          cp reportGithub.json ./artifacts/deps-scanner
+          mkdir -p ./artifatcs/deps-scanner
+          cp reportGithub.json ./artifacts/deps-scanner/
 
       - name: Build artifacts package
         run: npx ts-node tools/scripts/make-artifacts-package
@@ -81,7 +77,6 @@ jobs:
         working-directory: artifacts/npm
         shell: bash
         run: ls *.tgz | grep -E -i "$FILTER" | sed -r 's/^(.*).tgz$/"\1"/g' | paste -sd "," - | sed -r 's/(.*)/packages=[\1]/' >> "$GITHUB_OUTPUT"
-
 
 #  publish:
 #    name: Publish package

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -23,7 +23,6 @@ env:
   MOVE_STABLE_TAG: ${{ inputs.tag == 'stable' }}
 
 jobs:
-
   build:
     name: Build packages
     runs-on: windows-latest
@@ -78,89 +77,89 @@ jobs:
         shell: bash
         run: ls *.tgz | grep -E -i "$FILTER" | sed -r 's/^(.*).tgz$/"\1"/g' | paste -sd "," - | sed -r 's/(.*)/packages=[\1]/' >> "$GITHUB_OUTPUT"
 
-#  publish:
-#    name: Publish package
-#    runs-on: ubuntu-latest
-#    needs: build
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        package: ${{ fromJSON(needs.build.outputs.packages) }}
-#    steps:
-#      - name: Get sources
-#        uses: actions/checkout@v4
-#        with:
-#          sparse-checkout: |
-#            /tools
-#            /packages/devextreme-monorepo-tools
-#            package.json
-#          sparse-checkout-cone-mode: false
-#
-#      - name: Download artifacts
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: packages
-#
-#      - name: Install dependencies
-#        run: npm install --no-audit --no-fund --legacy-peer-deps --ignore-scripts
-#
-#      - name: Change package scope
-#        id: scopedPackage
-#        env:
-#          PACKAGE: ${{ matrix.package }}
-#        run: |
-#          SCOPE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]');
-#          PACKAGE_DIR=$(npx ts-node tools/scripts/change-package-scope --tgz $PACKAGE.tgz --scope $SCOPE)
-#          echo "packageDir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT";
-#          cd $PACKAGE_DIR;
-#          npm pkg get name --workspaces=false | tr -d '"' | sed -r 's/(.*)/name=\1/' >> "$GITHUB_OUTPUT";
-#          npm pkg get version --workspaces=false | tr -d '"' | sed -r 's/(.*)/version=\1/' >> "$GITHUB_OUTPUT";
-#          npm pkg get version --workspaces=false | tr -d '"' | sed -r 's/([0-9]+\.[0-9]+).*/majorVersion=\1/' >> "$GITHUB_OUTPUT";
-#
-#        # --ignore-scripts is required for publishing devextreme-angular which fails with error:
-#        # 'Trying to publish a package that has been compiled by Ivy in full compilation mode.'
-#        # Should be removed.
-#      - name: Publish to npm.pkg.github.com
-#        working-directory: ${{ steps.scopedPackage.outputs.packageDir }}
-#        env:
-#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN";
-#          npm publish --quiet --ignore-scripts --registry https://npm.pkg.github.com;
-#
-#      - name: Move 'daily' tag
-#        if: ${{ env.MOVE_DAILY_TAG == 'true' }}
-#        env:
-#          PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
-#          PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
-#          PACKAGE_VERSION_MAJOR: ${{ steps.scopedPackage.outputs.majorVersion }}
-#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
-#          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-daily
-#
-#      - name: Move 'stable' tag
-#        if: ${{ env.MOVE_STABLE_TAG == 'true' }}
-#        env:
-#          PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
-#          PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
-#          PACKAGE_VERSION_MAJOR: ${{ steps.scopedPackage.outputs.majorVersion }}
-#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
-#          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-stable
-#
-#
-#  notify:
-#    runs-on: devextreme-shr2
-#    name: Send notifications
-#    needs: [ build, publish ]
-#    if: failure()
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: DevExpress/github-actions/send-teams-notification@main
-#        with:
-#          hook_url: ${{secrets.TEAMS_ALERT}}
-#          bearer_token: ${{secrets.GITHUB_TOKEN}}
-#          specific_repo: DevExpress/DevExtreme
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.build.outputs.packages) }}
+    steps:
+      - name: Get sources
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            /tools
+            /packages/devextreme-monorepo-tools
+            package.json
+          sparse-checkout-cone-mode: false
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund --legacy-peer-deps --ignore-scripts
+
+      - name: Change package scope
+        id: scopedPackage
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          SCOPE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]');
+          PACKAGE_DIR=$(npx ts-node tools/scripts/change-package-scope --tgz $PACKAGE.tgz --scope $SCOPE)
+          echo "packageDir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT";
+          cd $PACKAGE_DIR;
+          npm pkg get name --workspaces=false | tr -d '"' | sed -r 's/(.*)/name=\1/' >> "$GITHUB_OUTPUT";
+          npm pkg get version --workspaces=false | tr -d '"' | sed -r 's/(.*)/version=\1/' >> "$GITHUB_OUTPUT";
+          npm pkg get version --workspaces=false | tr -d '"' | sed -r 's/([0-9]+\.[0-9]+).*/majorVersion=\1/' >> "$GITHUB_OUTPUT";
+
+        # --ignore-scripts is required for publishing devextreme-angular which fails with error:
+        # 'Trying to publish a package that has been compiled by Ivy in full compilation mode.'
+        # Should be removed.
+      - name: Publish to npm.pkg.github.com
+        working-directory: ${{ steps.scopedPackage.outputs.packageDir }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN";
+          npm publish --quiet --ignore-scripts --registry https://npm.pkg.github.com;
+
+      - name: Move 'daily' tag
+        if: ${{ env.MOVE_DAILY_TAG == 'true' }}
+        env:
+          PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
+          PACKAGE_VERSION_MAJOR: ${{ steps.scopedPackage.outputs.majorVersion }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
+          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-daily
+
+      - name: Move 'stable' tag
+        if: ${{ env.MOVE_STABLE_TAG == 'true' }}
+        env:
+          PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
+          PACKAGE_VERSION_MAJOR: ${{ steps.scopedPackage.outputs.majorVersion }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
+          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-stable
+
+
+  notify:
+    runs-on: devextreme-shr2
+    name: Send notifications
+    needs: [ build, publish ]
+    if: failure()
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DevExpress/github-actions/send-teams-notification@main
+        with:
+          hook_url: ${{secrets.TEAMS_ALERT}}
+          bearer_token: ${{secrets.GITHUB_TOKEN}}
+          specific_repo: DevExpress/DevExtreme

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -57,12 +57,15 @@ jobs:
           token: ${{ secrets.NPM_DEPS_SCANNER_PAT }}
           path: deps-scanner
 
-      - name: Build and run deps scanner
-        working-directory: deps-scanner
+      - name: Run deps scanner
         run: |
-          dotnet build -c Release -o ../
-          cd ../
-          dotnet npmDepsScanner.dll scan_cache reportGithub.json
+          ./deps-scanner/exe/npmDepsScanner.exe scan_cache ${{ github.workspace }} reportGithub.json
+
+      #      - name: Copy scanner artifacts
+      #        shell: bash
+      #        run: |
+      #          mkdir -p ./artifacts/deps-scanner
+      #          cp reportGithub.json ./artifacts/deps-scanner
 
       - name: Build artifacts package
         run: npx ts-node tools/scripts/make-artifacts-package
@@ -73,10 +76,11 @@ jobs:
           path: artifacts/npm/*.tgz
           retention-days: 2
 
-#      - name: Filter packages
-#        id: filter
-#        working-directory: artifacts/npm
-#        run: ls *.tgz | grep -E -i "$FILTER" | sed -r 's/^(.*).tgz$/"\1"/g' | paste -sd "," - | sed -r 's/(.*)/packages=[\1]/' >> "$GITHUB_OUTPUT"
+      - name: Filter packages
+        id: filter
+        working-directory: artifacts/npm
+        shell: bash
+        run: ls *.tgz | grep -E -i "$FILTER" | sed -r 's/^(.*).tgz$/"\1"/g' | paste -sd "," - | sed -r 's/(.*)/packages=[\1]/' >> "$GITHUB_OUTPUT"
 
 
 #  publish:

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -26,7 +26,7 @@ jobs:
 
   build:
     name: Build packages
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     outputs:
       packages: ${{ steps.filter.outputs.packages }}
     steps:
@@ -50,6 +50,20 @@ jobs:
           BUILD_INTERNAL_PACKAGE: true
         run: npm run all:build
 
+      - name: Clone deps scanner
+        uses: actions/checkout@v4
+        with:
+          repository: DevExpress/npmdeps-scanner
+          token: ${{ secrets.NPM_DEPS_SCANNER_PAT }}
+          path: deps-scanner
+
+      - name: Build and run deps scanner
+        working-directory: deps-scanner
+        run: |
+          dotnet build -c Release -o ../
+          cd ../
+          dotnet npmDepsScanner.dll scan_cache reportGithub.json
+
       - name: Build artifacts package
         run: npx ts-node tools/scripts/make-artifacts-package
 
@@ -59,95 +73,95 @@ jobs:
           path: artifacts/npm/*.tgz
           retention-days: 2
 
-      - name: Filter packages
-        id: filter
-        working-directory: artifacts/npm
-        run: ls *.tgz | grep -E -i "$FILTER" | sed -r 's/^(.*).tgz$/"\1"/g' | paste -sd "," - | sed -r 's/(.*)/packages=[\1]/' >> "$GITHUB_OUTPUT"
+#      - name: Filter packages
+#        id: filter
+#        working-directory: artifacts/npm
+#        run: ls *.tgz | grep -E -i "$FILTER" | sed -r 's/^(.*).tgz$/"\1"/g' | paste -sd "," - | sed -r 's/(.*)/packages=[\1]/' >> "$GITHUB_OUTPUT"
 
 
-  publish:
-    name: Publish package
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        package: ${{ fromJSON(needs.build.outputs.packages) }}
-    steps:
-      - name: Get sources
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            /tools
-            /packages/devextreme-monorepo-tools
-            package.json
-          sparse-checkout-cone-mode: false
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: packages
-
-      - name: Install dependencies
-        run: npm install --no-audit --no-fund --legacy-peer-deps --ignore-scripts
-
-      - name: Change package scope
-        id: scopedPackage
-        env:
-          PACKAGE: ${{ matrix.package }}
-        run: |
-          SCOPE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]');
-          PACKAGE_DIR=$(npx ts-node tools/scripts/change-package-scope --tgz $PACKAGE.tgz --scope $SCOPE)
-          echo "packageDir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT";
-          cd $PACKAGE_DIR;
-          npm pkg get name --workspaces=false | tr -d '"' | sed -r 's/(.*)/name=\1/' >> "$GITHUB_OUTPUT";
-          npm pkg get version --workspaces=false | tr -d '"' | sed -r 's/(.*)/version=\1/' >> "$GITHUB_OUTPUT";
-          npm pkg get version --workspaces=false | tr -d '"' | sed -r 's/([0-9]+\.[0-9]+).*/majorVersion=\1/' >> "$GITHUB_OUTPUT";
-
-        # --ignore-scripts is required for publishing devextreme-angular which fails with error:
-        # 'Trying to publish a package that has been compiled by Ivy in full compilation mode.'
-        # Should be removed.
-      - name: Publish to npm.pkg.github.com
-        working-directory: ${{ steps.scopedPackage.outputs.packageDir }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN";
-          npm publish --quiet --ignore-scripts --registry https://npm.pkg.github.com;
-
-      - name: Move 'daily' tag
-        if: ${{ env.MOVE_DAILY_TAG == 'true' }}
-        env:
-          PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
-          PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
-          PACKAGE_VERSION_MAJOR: ${{ steps.scopedPackage.outputs.majorVersion }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
-          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-daily
-
-      - name: Move 'stable' tag
-        if: ${{ env.MOVE_STABLE_TAG == 'true' }}
-        env:
-          PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
-          PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
-          PACKAGE_VERSION_MAJOR: ${{ steps.scopedPackage.outputs.majorVersion }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
-          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-stable
-
-
-  notify:
-    runs-on: devextreme-shr2
-    name: Send notifications
-    needs: [ build, publish ]
-    if: failure()
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
-        with:
-          hook_url: ${{secrets.TEAMS_ALERT}}
-          bearer_token: ${{secrets.GITHUB_TOKEN}}
-          specific_repo: DevExpress/DevExtreme
+#  publish:
+#    name: Publish package
+#    runs-on: ubuntu-latest
+#    needs: build
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        package: ${{ fromJSON(needs.build.outputs.packages) }}
+#    steps:
+#      - name: Get sources
+#        uses: actions/checkout@v4
+#        with:
+#          sparse-checkout: |
+#            /tools
+#            /packages/devextreme-monorepo-tools
+#            package.json
+#          sparse-checkout-cone-mode: false
+#
+#      - name: Download artifacts
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: packages
+#
+#      - name: Install dependencies
+#        run: npm install --no-audit --no-fund --legacy-peer-deps --ignore-scripts
+#
+#      - name: Change package scope
+#        id: scopedPackage
+#        env:
+#          PACKAGE: ${{ matrix.package }}
+#        run: |
+#          SCOPE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]');
+#          PACKAGE_DIR=$(npx ts-node tools/scripts/change-package-scope --tgz $PACKAGE.tgz --scope $SCOPE)
+#          echo "packageDir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT";
+#          cd $PACKAGE_DIR;
+#          npm pkg get name --workspaces=false | tr -d '"' | sed -r 's/(.*)/name=\1/' >> "$GITHUB_OUTPUT";
+#          npm pkg get version --workspaces=false | tr -d '"' | sed -r 's/(.*)/version=\1/' >> "$GITHUB_OUTPUT";
+#          npm pkg get version --workspaces=false | tr -d '"' | sed -r 's/([0-9]+\.[0-9]+).*/majorVersion=\1/' >> "$GITHUB_OUTPUT";
+#
+#        # --ignore-scripts is required for publishing devextreme-angular which fails with error:
+#        # 'Trying to publish a package that has been compiled by Ivy in full compilation mode.'
+#        # Should be removed.
+#      - name: Publish to npm.pkg.github.com
+#        working-directory: ${{ steps.scopedPackage.outputs.packageDir }}
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN";
+#          npm publish --quiet --ignore-scripts --registry https://npm.pkg.github.com;
+#
+#      - name: Move 'daily' tag
+#        if: ${{ env.MOVE_DAILY_TAG == 'true' }}
+#        env:
+#          PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
+#          PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
+#          PACKAGE_VERSION_MAJOR: ${{ steps.scopedPackage.outputs.majorVersion }}
+#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
+#          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-daily
+#
+#      - name: Move 'stable' tag
+#        if: ${{ env.MOVE_STABLE_TAG == 'true' }}
+#        env:
+#          PACKAGE_NAME: ${{ steps.scopedPackage.outputs.name }}
+#          PACKAGE_VERSION: ${{ steps.scopedPackage.outputs.version }}
+#          PACKAGE_VERSION_MAJOR: ${{ steps.scopedPackage.outputs.majorVersion }}
+#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          npm set //npm.pkg.github.com/:_authToken="$NODE_AUTH_TOKEN"
+#          npm --registry=https://npm.pkg.github.com dist-tag add $PACKAGE_NAME@$PACKAGE_VERSION $PACKAGE_VERSION_MAJOR-stable
+#
+#
+#  notify:
+#    runs-on: devextreme-shr2
+#    name: Send notifications
+#    needs: [ build, publish ]
+#    if: failure()
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: DevExpress/github-actions/send-teams-notification@main
+#        with:
+#          hook_url: ${{secrets.TEAMS_ALERT}}
+#          bearer_token: ${{secrets.GITHUB_TOKEN}}
+#          specific_repo: DevExpress/DevExtreme

--- a/tools/scripts/common/paths.ts
+++ b/tools/scripts/common/paths.ts
@@ -6,4 +6,5 @@ export const INTERNAL_TOOLS_ARTIFACTS = path.join(ARTIFACTS_DIR, 'internal-tools
 export const TS_ARTIFACTS = path.join(ARTIFACTS_DIR, 'ts');
 export const JS_ARTIFACTS = path.join(ARTIFACTS_DIR, 'js');
 export const CSS_ARTIFACTS = path.join(ARTIFACTS_DIR, 'css');
+export const DEPS_SCANNER_ARTIFACTS = path.join(ARTIFACTS_DIR, 'deps-scanner');
 export const NPM_DIR = path.join(ARTIFACTS_DIR, 'npm');

--- a/tools/scripts/make-artifacts-package.ts
+++ b/tools/scripts/make-artifacts-package.ts
@@ -1,7 +1,7 @@
 import sh from 'shelljs';
 import path from 'path';
 
-import { ARTIFACTS_DIR, INTERNAL_TOOLS_ARTIFACTS, JS_ARTIFACTS, TS_ARTIFACTS, CSS_ARTIFACTS } from './common/paths';
+import { ARTIFACTS_DIR, INTERNAL_TOOLS_ARTIFACTS, JS_ARTIFACTS, TS_ARTIFACTS, CSS_ARTIFACTS, DEPS_SCANNER_ARTIFACTS } from './common/paths';
 import { ensureEmptyDir } from './common/monorepo-tools';
 
 import { version, license, author } from '../../package.json';
@@ -11,11 +11,11 @@ const ARTIFACTS_PACKAGE_DIR = path.join(ARTIFACTS_DIR, 'devextreme-artifacts');
 
 ensureEmptyDir(ARTIFACTS_PACKAGE_DIR);
 
-sh.cp('-r', [INTERNAL_TOOLS_ARTIFACTS, JS_ARTIFACTS, TS_ARTIFACTS, CSS_ARTIFACTS], ARTIFACTS_PACKAGE_DIR);
+sh.cp('-r', [INTERNAL_TOOLS_ARTIFACTS, JS_ARTIFACTS, TS_ARTIFACTS, CSS_ARTIFACTS, DEPS_SCANNER_ARTIFACTS], ARTIFACTS_PACKAGE_DIR);
 sh.pushd(ARTIFACTS_PACKAGE_DIR);
 {
   npm.initEmpty();
   npm.pkg.set({ name: 'devextreme-artifacts', version, license, author });
-  npm.pack({destination: '../npm'});
+  npm.pack({ destination: '../npm' });
 }
 sh.popd();


### PR DESCRIPTION
Scan npm cache with deps-scanner tool to collect deps list. We have to use windows-latest runner to run deps-scanner.