### PR TITLE
ToolbarMenu: import Popup without Toolbar

### DIFF
--- a/packages/devextreme/js/__internal/ui/toolbar/internal/m_toolbar.menu.ts
+++ b/packages/devextreme/js/__internal/ui/toolbar/internal/m_toolbar.menu.ts
@@ -232,6 +232,7 @@ export default class DropDownMenu extends Widget<Properties> {
           .addClass(DROP_DOWN_MENU_POPUP_CLASS);
       },
       deferRendering: false,
+      preventScrollEvents: false,
       contentTemplate: (contentElement) => this._renderList(contentElement),
       _ignoreFunctionValueDeprecation: true,
       maxHeight: () => this._getMaxHeight(),


### PR DESCRIPTION
The first part of the change is here: https://github.com/DevExpress/DevExtreme/pull/27603. Instead of the Popup with Toolbar version, we should use the base version with the preventScrollEvents option set to false. This preserves the initial behavior, the same as in Popup.full.