### PR TITLE
PivotGrid - Simple Array demo - 'Sales' variable is not used

### DIFF
--- a/apps/demos/Demos/PivotGrid/SimpleArray/Angular/app/app.component.ts
+++ b/apps/demos/Demos/PivotGrid/SimpleArray/Angular/app/app.component.ts
@@ -18,8 +18,6 @@ if (!/localhost/.test(document.location.host)) {
   providers: [Service],
 })
 export class AppComponent {
-  sales: Sale[];
-
   dataSource: DataSourceConfig;
 
   constructor(service: Service) {


### PR DESCRIPTION

Removed unused variable
"sales: Sale[];"

in app.component.ts