### PR TITLE
DataGrid loses grouping after the expandAll method if a grouped column has calculateDisplayValue (T1232129) 

### DIFF
--- a/e2e/testcafe-devextreme/tests/dataGrid/grouping/grouping.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/grouping/grouping.ts
@@ -344,3 +344,37 @@ test('The collapse icon should update if repaintChangesOnly option is enabled (T
   },
   showBorders: true,
 }));
+
+const customersT1232129 = [
+  {
+    id: 1,
+    number: 2,
+    description: 'Material Description',
+    groupId: '',
+    articleGroup: 'Material',
+  },
+];
+test('DataGrid loses grouping after the expandAll method if a grouped column has calculateDisplayValue (T1232129)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+
+  await dataGrid.apiExpandAll();
+  await t
+    .expect(dataGrid.apiColumnOption('groupId', 'groupIndex'))
+    .eql(0);
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: customersT1232129,
+  keyExpr: 'id',
+  showBorders: true,
+  grouping: {
+    autoExpandAll: false,
+  },
+  columns: [
+    'number',
+    'description',
+    {
+      dataField: 'groupId',
+      calculateDisplayValue: 'articleGroup',
+      groupIndex: 0,
+    },
+  ],
+}));

--- a/packages/devextreme/js/__internal/grids/grid_core/columns_controller/m_columns_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/columns_controller/m_columns_controller.ts
@@ -1272,6 +1272,7 @@ export class ColumnsController extends modules.Controller {
 
             if (selector === column.dataField
                                   || selector === column.name
+                                  || selector === column.displayField
                                   || selector === column.selector
                                   || selector === column.calculateCellValue
                                   || selector === column.calculateGroupValue

--- a/packages/testcafe-models/dataGrid/index.ts
+++ b/packages/testcafe-models/dataGrid/index.ts
@@ -555,6 +555,19 @@ export default class DataGrid extends Widget {
     )();
   }
 
+  apiExpandAll(): Promise<void> {
+    const { getInstance } = this;
+
+    return ClientFunction(
+      () => (getInstance() as any).expandAll(),
+      {
+        dependencies: {
+          getInstance,
+        },
+      },
+    )();
+  }
+
   apiCollapseAllGroups(): Promise<void> {
     const { getInstance } = this;
 


### PR DESCRIPTION
Cherry pick https://github.com/DevExpress/DevExtreme/pull/27694