### PR TITLE
DataGrid - Data rows are skipped during Tab navigation if the first column is hidden via hidingPriority (T1228477)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/adaptivity/m_adaptivity.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/adaptivity/m_adaptivity.ts
@@ -106,7 +106,7 @@ export class AdaptiveColumnsController extends modules.ViewController {
 
   private _editingController!: EditingController;
 
-  private _rowsView!: RowsView;
+  protected _rowsView!: RowsView;
 
   private _hiddenColumns: any;
 
@@ -518,7 +518,7 @@ export class AdaptiveColumnsController extends modules.ViewController {
     });
   }
 
-  private _hideVisibleColumnInView({ view, isCommandColumn, visibleIndex }) {
+  protected _hideVisibleColumnInView({ view, isCommandColumn, visibleIndex }) {
     const viewName = view.name;
     let $cellElement;
     const column = this._columnsController.getVisibleColumns()[visibleIndex];

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/const.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/const.ts
@@ -48,4 +48,5 @@ export const FOCUS_TYPE_ROW = 'row';
 export const FOCUS_TYPE_CELL = 'cell';
 
 export const COLUMN_HEADERS_VIEW = 'columnHeadersView';
+export const ROWS_VIEW = 'rowsView';
 export const FUNCTIONAL_KEYS = ['shift', 'control', 'alt'];

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/dom.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/dom.ts
@@ -6,8 +6,14 @@ import { ATTRIBUTES } from './const';
 
 const isDragCell = ($cell) => $cell.attr(ATTRIBUTES.dragCell) !== undefined;
 
+const getFocusableCellSelector = (columnIndex: number): string => [
+  `[${ATTRIBUTES.ariaColIndex}="${columnIndex + 1}"]`,
+  `:not([${ATTRIBUTES.dragCell}])`,
+  ':not([aria-hidden=true])',
+].join('');
+
 const getCellToFocus = ($cellElements, columnIndex) => $cellElements
-  .filter(`[${ATTRIBUTES.ariaColIndex}="${columnIndex + 1}"]:not([${ATTRIBUTES.dragCell}])`)
+  .filter(getFocusableCellSelector(columnIndex))
   .first();
 
 export const GridCoreKeyboardNavigationDom = {

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -68,6 +68,7 @@ import {
   MASTER_DETAIL_CELL_CLASS,
   NON_FOCUSABLE_ELEMENTS_SELECTOR,
   REVERT_BUTTON_CLASS,
+  ROWS_VIEW,
   ROWS_VIEW_CLASS,
   WIDGET_CLASS,
 } from './const';
@@ -1635,7 +1636,6 @@ export class KeyboardNavigationController extends modules.ViewController {
     this._isNeedScroll = false;
     this._focusedCellPosition = {};
     clearTimeout(this._updateFocusTimeout);
-    // @ts-expect-error
     this._focusedView?.renderFocusState({ preventScroll });
   }
 
@@ -2613,7 +2613,9 @@ const rowsView = (Base: ModuleType<RowsView>) => class RowsViewKeyboardExtender 
     }
   }
 
-  private renderFocusState(params) {
+  public renderFocusState(params) {
+    super.renderFocusState(params);
+
     const { preventScroll, pageSizeChanged } = params ?? {};
     const $rowsViewElement = this.element();
 
@@ -2883,6 +2885,13 @@ const adaptiveColumns = (Base: ModuleType<AdaptiveColumnsController>) => class A
 
     if (viewName === COLUMN_HEADERS_VIEW && !isCommandColumn && isCellInHeaderRow($cell)) {
       $cell.removeAttr('tabindex');
+    }
+  }
+
+  protected _hideVisibleColumnInView({ view, isCommandColumn, visibleIndex }) {
+    super._hideVisibleColumnInView({ view, isCommandColumn, visibleIndex });
+    if (view.name === ROWS_VIEW) {
+      this._rowsView.renderFocusState(null);
     }
   }
 };

--- a/packages/devextreme/js/__internal/grids/grid_core/views/m_rows_view.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/views/m_rows_view.ts
@@ -170,6 +170,8 @@ export class RowsView extends ColumnsView {
     }
   }
 
+  public renderFocusState(params) { }
+
   private _getDefaultGroupTemplate(column) {
     const that = this;
     const summaryTexts = that.option('summary.texts');

--- a/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/packages/devextreme/testing/testcafe/tests/dataGrid/keyboardNavigation/keyboardNavigation.functional.ts
@@ -4633,3 +4633,22 @@ test('TreeList/DataGrid - Focus indicator is not visible when the Toolbar includ
   keyExpr: 'field_0',
   showBorders: true,
 }));
+
+test('DataGrid - Data rows are skipped during Tab navigation if the first column is hidden via hidingPriority (T1228477)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+  await t
+    .expect(dataGrid.getDataCell(0, 2).element.getAttribute('tabindex'))
+    .eql('0');
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: getData(3, 5),
+  keyExpr: 'field_0',
+  columns: [{
+    dataField: 'field_0',
+    hidingPriority: 0,
+  }, {
+    dataField: 'field_1',
+    hidingPriority: 1,
+  }, 'field_2', 'field_3', 'field_4'],
+  showBorders: true,
+  width: 300,
+}));

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/adaptiveColumns.tests.js
@@ -1728,7 +1728,7 @@ QUnit.module('AdaptiveColumns', {
         this.clock.tick(10);
 
         // assert
-        assert.ok(this.rowsView._getRowElements.calledOnce);
+        assert.ok(this.rowsView._getRowElements.calledTwice);
     });
 
     QUnit.test('Form has 2 columns in material theme', function(assert) {


### PR DESCRIPTION
Cherry pick https://github.com/DevExpress/DevExtreme/pull/27733