### PR TITLE
DataGrid - Group summary is not updated when a column is fixed on the right side (T1223764)

### DIFF
--- a/e2e/testcafe-devextreme/tests/dataGrid/fixedColumns.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/fixedColumns.ts
@@ -359,3 +359,58 @@ safeSizeTest('The grid layout should be correct after resizing the window when t
     width: 50,
   }],
 }));
+
+test('DataGrid - Group summary is not updated when a column is fixed on the right side (T1223764)', async (t) => {
+  const dataGrid = new DataGrid('#container');
+  const editCell = dataGrid.getDataRow(1).getDataCell(2);
+
+  await t
+    .click(editCell.element)
+    .typeText(editCell.getEditor().element, '11')
+    .pressKey('enter')
+    .expect(dataGrid.getGroupRow(0).element.textContent)
+    .eql('A: group 0 (Count: 3, Sum of B is 113)');
+}).before(async () => createWidget('dxDataGrid', {
+  dataSource: [
+    { id: 0, A: 'group 0', B: 1 },
+    { id: 1, A: 'group 0', B: 1 },
+    { id: 2, A: 'group 0', B: 1 },
+  ],
+  keyExpr: 'id',
+  repaintChangesOnly: true,
+  columnFixing: { enabled: true },
+  groupPanel: {
+    visible: true,
+  },
+  summary: {
+    recalculateWhileEditing: true,
+    groupItems: [
+      {
+        column: 'B',
+        summaryType: 'count',
+      },
+      {
+        column: 'B',
+        summaryType: 'sum',
+      },
+    ],
+  },
+  editing: {
+    mode: 'cell',
+    allowUpdating: true,
+    allowAdding: true,
+    allowDeleting: true,
+  },
+  columns: [
+    {
+      dataField: 'id',
+      width: 50,
+    }, {
+      dataField: 'A',
+      groupIndex: 0,
+    }, {
+      dataField: 'B',
+      dataType: 'number',
+    },
+  ],
+}));

--- a/e2e/testcafe-devextreme/tests/dataGrid/fixedColumns.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/fixedColumns.ts
@@ -366,10 +366,10 @@ test('DataGrid - Group summary is not updated when a column is fixed on the righ
 
   await t
     .click(editCell.element)
-    .typeText(editCell.getEditor().element, '11')
+    .typeText(editCell.getEditor().element, '5', { replace: true })
     .pressKey('enter')
     .expect(dataGrid.getGroupRow(0).element.textContent)
-    .eql('A: group 0 (Count: 3, Sum of B is 113)');
+    .eql('A: group 0 (Count: 3, Sum of B is 7)');
 }).before(async () => createWidget('dxDataGrid', {
   dataSource: [
     { id: 0, A: 'group 0', B: 1 },

--- a/packages/devextreme/js/__internal/grids/grid_core/column_fixing/m_column_fixing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/column_fixing/m_column_fixing.ts
@@ -97,9 +97,16 @@ const baseFixedColumns = <T extends ModuleType<ColumnsView>>(Base: T) => class B
     const transparentColumnIndex = getTransparentColumnIndex(fixedColumns);
     const transparentColspan = fixedColumns[transparentColumnIndex].colspan;
     const columnIndices = change && change.columnIndices;
+    const rowTypes = change?.items?.map(({ rowType }) => rowType);
 
     if (columnIndices) {
-      change.columnIndices = columnIndices.map((columnIndices) => {
+      change.columnIndices = columnIndices.map((columnIndices, idx) => {
+        const isGroupRow = rowTypes[idx] === 'group';
+
+        if (isGroupRow) {
+          return [...columnIndices];
+        }
+
         if (columnIndices) {
           return columnIndices.map((columnIndex) => {
             if (columnIndex < transparentColumnIndex) {

--- a/packages/devextreme/js/__internal/grids/grid_core/column_fixing/m_column_fixing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/column_fixing/m_column_fixing.ts
@@ -101,9 +101,12 @@ const baseFixedColumns = <T extends ModuleType<ColumnsView>>(Base: T) => class B
 
     if (columnIndices) {
       change.columnIndices = columnIndices.map((columnIndices, idx) => {
-        const isGroupRow = rowTypes[idx] === 'group';
+        const isGroupRow = rowTypes && rowTypes[idx] === 'group';
 
         if (isGroupRow) {
+          if (columnIndices === undefined) {
+            return undefined;
+          }
           return [...columnIndices];
         }
 

--- a/packages/devextreme/js/__internal/grids/grid_core/column_fixing/m_column_fixing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/column_fixing/m_column_fixing.ts
@@ -93,35 +93,47 @@ const baseFixedColumns = <T extends ModuleType<ColumnsView>>(Base: T) => class B
     return super._createCol(column).toggleClass(FIXED_COL_CLASS, !!(this._isFixedTableRendering && (column.fixed || column.command && column.command !== COMMAND_TRANSPARENT)));
   }
 
+  private isIndicesArray(arr): boolean {
+    return Array.isArray(arr) && arr.length > 0;
+  }
+
   private _correctColumnIndicesForFixedColumns(fixedColumns, change) {
+    const columnIndicesArray = change?.columnIndices;
+    if (!this.isIndicesArray(columnIndicesArray)) {
+      return;
+    }
+
     const transparentColumnIndex = getTransparentColumnIndex(fixedColumns);
     const transparentColspan = fixedColumns[transparentColumnIndex].colspan;
-    const columnIndices = change && change.columnIndices;
+    const transparentOffset = transparentColumnIndex + transparentColspan;
     const rowTypes = change?.items?.map(({ rowType }) => rowType);
 
-    if (columnIndices) {
-      change.columnIndices = columnIndices.map((columnIndices, idx) => {
-        const isGroupRow = rowTypes && rowTypes[idx] === 'group';
+    change.columnIndices = columnIndicesArray.map((columnIndices, idx) => {
+      if (!this.isIndicesArray(columnIndices)) {
+        return columnIndices;
+      }
 
-        if (isGroupRow) {
-          if (columnIndices === undefined) {
-            return undefined;
-          }
-          return [...columnIndices];
+      const isGroupRow = rowTypes && rowTypes[idx] === 'group';
+
+      if (isGroupRow) {
+        return [...columnIndices];
+      }
+
+      return columnIndices.reduce((result, colIdx) => {
+        switch (true) {
+          case colIdx < transparentColumnIndex:
+            result.push(colIdx);
+            break;
+          case colIdx >= transparentOffset:
+            result.push(colIdx - transparentColspan + 1);
+            break;
+          default:
+            break;
         }
 
-        if (columnIndices) {
-          return columnIndices.map((columnIndex) => {
-            if (columnIndex < transparentColumnIndex) {
-              return columnIndex;
-            } if (columnIndex >= transparentColumnIndex + transparentColspan) {
-              return columnIndex - transparentColspan + 1;
-            }
-            return -1;
-          }).filter((columnIndex) => columnIndex >= 0);
-        }
-      });
-    }
+        return result;
+      }, []);
+    });
   }
 
   private _partialUpdateFixedTable(fixedColumns, rows) {


### PR DESCRIPTION
See https://supportcenter.devexpress.devx/ticket/details/t1223764/datagrid-group-summary-is-not-updated-when-a-column-is-fixed-on-the-right-side