### PR TITLE
DataGrid: Fix the onFocusedRowChanged event that does not raise  when push API is used to remove a focused row (T1233973)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/m_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/m_data_controller.ts
@@ -597,7 +597,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     this.dataErrorOccurred.fire(e);
   }
 
-  private _handleDataPushed(changes) {
+  protected _handleDataPushed(changes) {
     this.pushed.fire(changes);
   }
 


### PR DESCRIPTION
See https://devexpress.com/issue=T1233973