### PR TITLE
CI: Fix all:build script after migration to pnpm 

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,7 +1,9 @@
 name: Pack all DevExtreme npm packages
 
 on:
-  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [24_2]
 
 jobs:
   build:
@@ -42,12 +44,12 @@ jobs:
           pnpm install
 
       - name: Build npm packages
-        run: pnpm run all:pack
+        run: pnpm run all:build
 
       - name: Copy build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: devextreme-npm-packages
           path: |
-            npm/*.tgz
+            artifacts/npm/*.tgz
           retention-days: 1

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,4 +1,4 @@
-name: Pack all DevExtreme npm packages
+name: Build and pack DevExtreme npm packages
 
 on:
   pull_request:

--- a/packages/devextreme/build/gulp/context.js
+++ b/packages/devextreme/build/gulp/context.js
@@ -18,6 +18,6 @@ module.exports = {
     TRANSPILED_PROD_RENOVATION_PATH: 'artifacts/transpiled-renovation-npm',
     TRANSPILED_RENOVATION_PATH: 'artifacts/transpiled-renovation',
     TRANSPILED_PROD_ESM_PATH: 'artifacts/transpiled-esm-npm',
-    SCSS_PACKAGE_PATH: '../../devextreme-scss',
+    SCSS_PACKAGE_PATH: '../devextreme-scss',
     EULA_URL: 'https://js.devexpress.com/Licensing/'
 };

--- a/packages/devextreme/build/gulp/gulp-data-uri.js
+++ b/packages/devextreme/build/gulp/gulp-data-uri.js
@@ -18,7 +18,7 @@ const img = (buffer, ext) => {
 };
 
 const handler = (_, svgEncoding, fileName) => {
-    const relativePath = path.join(__dirname, '..', '..', fileName);
+    const relativePath = path.join(__dirname, '..', '..', '..', 'devextreme-scss', fileName);
     const filePath = path.resolve(relativePath);
     const ext = filePath.split('.').pop();
     const data = fs.readFileSync(filePath);

--- a/tools/scripts/build-all.ts
+++ b/tools/scripts/build-all.ts
@@ -55,7 +55,7 @@ if (!devMode) {
 if (devMode) {
     sh.exec('pnpx nx build devextreme');
 } else {
-    sh.exec('npm run build -w devextreme-scss', sh);
+    sh.exec('pnpx nx build devextreme-scss');
     sh.exec('pnpx nx build-dist devextreme --skipNxCache', {
         env: {
             ...sh.env,

--- a/tools/scripts/build-all.ts
+++ b/tools/scripts/build-all.ts
@@ -22,7 +22,7 @@ const injectDescriptions = () => {
 
     sh.pushd(DOCUMENTATION_TEMP_DIR);
     sh.exec('npm i');
-    sh.exec(`npm run update-topics --artifacts ${INTERNAL_TOOLS_ARTIFACTS}`);
+    sh.exec(`npm run update-topics -- --artifacts ${INTERNAL_TOOLS_ARTIFACTS}`);
     sh.popd();
 
     sh.rm('-rf', DOCUMENTATION_TEMP_DIR);

--- a/tools/scripts/build-all.ts
+++ b/tools/scripts/build-all.ts
@@ -21,8 +21,8 @@ const injectDescriptions = () => {
     sh.exec(`git clone -b ${MAJOR_VERSION} --depth 1 --config core.longpaths=true https://github.com/DevExpress/devextreme-documentation.git ${DOCUMENTATION_TEMP_DIR}`);
 
     sh.pushd(DOCUMENTATION_TEMP_DIR);
-    sh.exec('pnpm i');
-    sh.exec(`pnpm run update-topics --artifacts ${INTERNAL_TOOLS_ARTIFACTS}`);
+    sh.exec('npm i');
+    sh.exec(`npm run update-topics --artifacts ${INTERNAL_TOOLS_ARTIFACTS}`);
     sh.popd();
 
     sh.rm('-rf', DOCUMENTATION_TEMP_DIR);


### PR DESCRIPTION
Add workflow to test all:build script. Use npm (instead of pnpm) to install deps and run scripts in devextreme documentation repo clone. Fix "npm-sass" gulp task
