### PR TITLE
CI: Fix setup-chrome action

### DIFF
--- a/.github/actions/setup-chrome/action.yml
+++ b/.github/actions/setup-chrome/action.yml
@@ -29,6 +29,8 @@ runs:
         CHROME_VERSION: ${{ inputs.chrome-version }}
       run: |
         if [ -n "$CHROME_VERSION" ]; then
+          sudo apt-get update
+          sudo apt-get install libu2f-udev
           curl -L "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" > /tmp/chrome.deb
           sudo dpkg -i /tmp/chrome.deb
           unlink /tmp/chrome.deb


### PR DESCRIPTION
### Cherry-picks
- #27971
- #27972

Chrome version 121 depends on the libu2f-udev package. Previously, there were no issues with the installation, as this package was likely already installed in the runner. After today's update of the ubuntu-latest runner, older versions of chrome stopped installing, but version 128 installs without problems, obviously because it no longer depends on the package. However, almost all checks fail on the new version. Our screenshots are outdated.
