### PR TITLE
Add support all options of collator sensitivity for filtering

### DIFF
--- a/packages/devextreme/js/core/utils/data.js
+++ b/packages/devextreme/js/core/utils/data.js
@@ -198,13 +198,17 @@ export const toComparable = function(value, caseSensitive, options = {}) {
 
     if(value && value instanceof Class && value.valueOf) {
         value = value.valueOf();
-    } else if(typeof value === 'string' && collatorSensitivity === 'base') {
+    } else if(typeof value === 'string' && (collatorSensitivity === 'base' || collatorSensitivity === 'case')) {
         const REMOVE_DIACRITICAL_MARKS_REGEXP = /[\u0300-\u036f]/g;
 
-        value = toLowerCase(value, options).normalize('NFD').replace(REMOVE_DIACRITICAL_MARKS_REGEXP, '');
+        if(collatorSensitivity === 'base') {
+            value = toLowerCase(value, options);
+        }
+
+        value = value.normalize('NFD').replace(REMOVE_DIACRITICAL_MARKS_REGEXP, '');
     }
 
-    const isCaseSensitive = caseSensitive || collatorSensitivity === 'case';
+    const isCaseSensitive = caseSensitive || collatorSensitivity === 'case' || collatorSensitivity === 'variant';
 
     if(typeof value === 'string' && !isCaseSensitive) {
         const locale = options?.locale?.toLowerCase();

--- a/packages/devextreme/testing/tests/DevExpress.data/queryArray.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.data/queryArray.tests.js
@@ -350,19 +350,54 @@ QUnit.test('filter with functional getter', function(assert) {
     });
 });
 
-QUnit.test('filter with undefined "langParams"', function(assert) {
-    const input = [{ ID: 'AAA', Name: 'Name 2' }, { ID: 'aaa', Name: 'Name 3' }];
-    const filterLength = QUERY(input).filter(['ID', '=', 'aaa']).toArray().length;
-    assert.equal(filterLength, 2);
+QUnit.test('filter with undefined "langParams" (behaviour like collatorOptions.sensitivity set to "accent")', function(assert) {
+    const input = [{ ID: 'AAA' }, { ID: 'aaa' }, { ID: 'ááá' }, { ID: 'bbb' }];
+    const array = QUERY(input).filter(['ID', '=', 'aaa']).toArray();
+
+    assert.equal(array.length, 2);
+    assert.equal(array[0].ID, 'AAA');
+    assert.equal(array[1].ID, 'aaa');
+});
+
+QUnit.test('filter with collatorOptions.sensitivity set to "accent"', function(assert) {
+    const input = [{ ID: 'AAA' }, { ID: 'aaa' }, { ID: 'ááá' }, { ID: 'bbb' }];
+
+    const array = QUERY(input, {
+        langParams: {
+            collatorOptions: {
+                sensitivity: 'accent'
+            }
+        }
+    }).filter(['ID', '=', 'aaa']).toArray();
+
+    assert.equal(array.length, 2);
+    assert.equal(array[0].ID, 'AAA');
+    assert.equal(array[1].ID, 'aaa');
 });
 
 QUnit.test('filter with collatorOptions.sensitivity set to "case"', function(assert) {
-    const input = [{ ID: 'AAA', Name: 'Name 2' }, { ID: 'aaa', Name: 'Name 3' }];
+    const input = [{ ID: 'AAA' }, { ID: 'aaa' }, { ID: 'ááá' }, { ID: 'bbb' }];
 
     const array = QUERY(input, {
         langParams: {
             collatorOptions: {
                 sensitivity: 'case'
+            }
+        }
+    }).filter(['ID', '=', 'aaa']).toArray();
+
+    assert.equal(array.length, 2);
+    assert.equal(array[0].ID, 'aaa');
+    assert.equal(array[1].ID, 'ááá');
+});
+
+QUnit.test('filter with collatorOptions.sensitivity set to "variant"', function(assert) {
+    const input = [{ ID: 'AAA' }, { ID: 'aaa' }, { ID: 'ááá' }, { ID: 'bbb' }];
+
+    const array = QUERY(input, {
+        langParams: {
+            collatorOptions: {
+                sensitivity: 'variant'
             }
         }
     }).filter(['ID', '=', 'aaa']).toArray();


### PR DESCRIPTION
according [specification ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#parameters)of **sensitivity** option filtering must works like this: 

base -> a ≠ b, a = á, a = A
accent -> a ≠ b, a ≠ á, a = A (our default filtering)
case -> a ≠ b, a = á, a ≠ A
variant -> a ≠ b, a ≠ á, a ≠ A