### PR TITLE
PivotGrid - OLAP - The E4000 error occurs if filterValues contains an item with the "unknown member" value (T1236954)

### DIFF
--- a/packages/devextreme/js/__internal/grids/pivot_grid/xmla_store/m_xmla_store.ts
+++ b/packages/devextreme/js/__internal/grids/pivot_grid/xmla_store/m_xmla_store.ts
@@ -670,7 +670,10 @@ const XmlaStore = Class.inherit((function () {
 
   function preparePathValue(pathValue, dataField?) {
     if (pathValue) {
-      pathValue = isString(pathValue) && pathValue.includes('&') ? pathValue : `[${pathValue}]`;
+      const shouldSkipWrappingPathValue = isString(pathValue) && (
+        pathValue.includes('&') || pathValue.startsWith(`${dataField}.`)
+      );
+      pathValue = shouldSkipWrappingPathValue ? pathValue : `[${pathValue}]`;
 
       if (dataField && pathValue.indexOf(`${dataField}.`) === 0) {
         pathValue = pathValue.slice(dataField.length + 1, pathValue.length);

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.pivotGrid/store.xmla.common.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.pivotGrid/store.xmla.common.tests.js
@@ -321,7 +321,28 @@ QUnit.module('Misc', stubsEnvironment, () => {
         assert.deepEqual(filterExpr, ['(SELECT {[Product].[Category].[Product].[Category]&}on 0']);
     });
 
+    QUnit.test('T1236954. Build a correct filter query when a member has unknown member', function(assert) {
+        this.store.load({
+            values: [{
+                dataField: '[Measures].[Calculated Cost]',
+            }],
+            columns: [{
+                dataField: '[Activities - Activities].[Activities]',
+                filterValues: ['[Activities - Activities].[Activities].[All].UNKNOWNMEMBER',
+                    '[Activities - Activities].[Activities].&[24]',
+                    '[Activities - Activities].[Activities].&[21]'],
+            }],
+            rows: [{
+                dataField: '[Departments - Activities].[Departments]',
+            }],
+        });
 
+        const filterExpr = this.getQuery().match(/\(select(.+?)on 0/gi);
+
+        assert.deepEqual(filterExpr, [
+            '(SELECT {[Activities - Activities].[Activities].[All].UNKNOWNMEMBER,[Activities - Activities].[Activities].&[24],[Activities - Activities].[Activities].&[21]}on 0',
+        ]);
+    });
 });
 
 QUnit.module('getDrillDownItems', stubsEnvironment, () => {


### PR DESCRIPTION
Cherry-pick from https://github.com/DevExpress/DevExtreme/pull/27952