### PR TITLE
DataGrid - Move from depeceted 'unload' event to 'visibilitychange' (…

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/state_storing/m_state_storing_core.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/state_storing/m_state_storing_core.ts
@@ -80,7 +80,7 @@ export class StateStoringController extends modules.ViewController {
       }
     };
 
-    eventsEngine.on(getWindow(), 'unload', this._windowUnloadHandler);
+    eventsEngine.on(getWindow(), 'visibilitychange', this._windowUnloadHandler);
 
     return this; // needed by pivotGrid mocks
   }
@@ -103,7 +103,7 @@ export class StateStoringController extends modules.ViewController {
 
   public dispose() {
     clearTimeout(this._savingTimeoutID);
-    eventsEngine.off(getWindow(), 'unload', this._windowUnloadHandler);
+    eventsEngine.off(getWindow(), 'visibilitychange', this._windowUnloadHandler);
   }
 
   private _loadState() {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/stateStoring.tests.js
@@ -77,7 +77,7 @@ QUnit.module('Local storage', {
         assert.ok(!localStorage.getItem('TestNameSpace'), 'state not saved');
 
         // act
-        $(window).trigger('unload');
+        $(window).trigger('visibilitychange');
 
         // assert
         assert.equal(parseInt(JSON.parse(localStorage.getItem('TestNameSpace')).testSetting), 107, 'state saved');


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->

Cherry-pick:

What does the PR change?
Google Chrome Team is going to [deprecate](https://developer.chrome.com/docs/web-platform/deprecating-unload) in near future 'unload' event, best alternative which they suggest is 'visibilitychange' event.

Trello [card](https://trello.com/c/Ev7nNiCw/9528-datagrid-treelist-chrome-issue-unload-event-listeners-are-deprecated-and-will-be-removed)
