### PR TITLE
Fixed a bug where the unmount component template contains two childs (T1247485)

### DIFF
--- a/packages/devextreme-vue/src/core/__tests__/button.test.ts
+++ b/packages/devextreme-vue/src/core/__tests__/button.test.ts
@@ -67,7 +67,7 @@ describe('template rendering', () => {
     expect(wrapper.vm.$el.getElementsByClassName('test')).toHaveLength(1);
   });
 
-  fit('should unmount template with two childs in root without exception', async () => {
+  it('should unmount template with two childs in root without exception', async () => {
     const appView = defineComponent({
       props: {
         templateName: {

--- a/packages/devextreme-vue/src/core/__tests__/button.test.ts
+++ b/packages/devextreme-vue/src/core/__tests__/button.test.ts
@@ -66,4 +66,34 @@ describe('template rendering', () => {
 
     expect(wrapper.vm.$el.getElementsByClassName('test')).toHaveLength(1);
   });
+
+  fit('should unmount template with two childs in root without exception', async () => {
+    const appView = defineComponent({
+      props: {
+        templateName: {
+          type: String,
+          value: 'tpl1'
+        }
+      },
+      template:
+          `<dx-button id="component" :template="templateName">
+                    <template #tpl1>
+                      <div>1</div>
+                      <div>2</div>
+                    </template>
+                    <template #tpl2>
+                      <div>3</div>
+                      <div>4</div>
+                    </template>
+          </dx-button>`,
+      components: {
+        DxButton,
+      },
+    });
+
+
+    const wrapper = mount(appView, {props: {templateName: 'tpl1'}});
+
+    expect(() => wrapper.setProps({templateName: 'tpl2'})).not.toThrow();
+  })
 });

--- a/packages/devextreme-vue/src/core/__tests__/component.test.ts
+++ b/packages/devextreme-vue/src/core/__tests__/component.test.ts
@@ -1152,7 +1152,7 @@ describe('component rendering', () => {
       expect(renderedTemplate.innerHTML).toBe('Template');
     });
 
-    xit('renders template with several children', () => {
+    it('renders template with several children', () => {
       const vm = defineComponent({
         template: `<test-component>
                                 <template #item>
@@ -1169,8 +1169,72 @@ describe('component rendering', () => {
       renderItemTemplate({}, container);
 
       expect(container.innerHTML).toBe(
-        '<div>child1</div><div>child2</div><span style="display: none;"></span>',
+        '<span style="display: none;"></span><div>child1</div><div>child2</div>',
       );
+    });
+
+    it('unmounts template with root element node', () => {
+      const vm = defineComponent({
+        template: `<test-component>
+                        <template #item>
+                            <div>child1</div>
+                        </template>
+                    </test-component>`,
+        components: {
+          TestComponent,
+        },
+      });
+
+      mount(vm);
+
+      const container = document.createElement("div");
+      renderItemTemplate({}, container);
+      events.triggerHandler(container.children[0], "dxremove");
+
+      expect(container.children.length).toEqual(0);
+    });
+
+    it('unmounts template with text content', () => {
+      const vm = defineComponent({
+        template: `<test-component>
+                        <template #item>
+                            Template_text_content
+                        </template>
+                    </test-component>`,
+        components: {
+          TestComponent,
+        },
+      });
+
+      mount(vm);
+
+      const container = document.createElement("div");
+      renderItemTemplate({}, container);
+      events.triggerHandler(container.children[0], "dxremove");
+
+      expect(container.children.length).toEqual(0);
+    });
+
+    it('unmounts template with two elements node', () => {
+      const vm = defineComponent({
+        template: `<test-component>
+                        <template #item>
+                            <div>child1</div>
+                            <div>child2</div>
+                        </template>
+                    </test-component>`,
+        components: {
+          TestComponent,
+        },
+      });
+
+      mount(vm);
+
+      const container = document.createElement("div");
+      renderItemTemplate({}, container);
+      events.triggerHandler(container.children[0], "dxremove");
+
+      expect(container.children.length).toEqual(0);
     });
 
     it('template should have globalProperties of parent', () => {

--- a/packages/devextreme-vue/src/core/__tests__/component.test.ts
+++ b/packages/devextreme-vue/src/core/__tests__/component.test.ts
@@ -1152,7 +1152,7 @@ describe('component rendering', () => {
       expect(renderedTemplate.innerHTML).toBe('Template');
     });
 
-    it('renders template with several children', () => {
+    xit('renders template with several children', () => {
       const vm = defineComponent({
         template: `<test-component>
                                 <template #item>

--- a/packages/devextreme-vue/src/core/__tests__/component.test.ts
+++ b/packages/devextreme-vue/src/core/__tests__/component.test.ts
@@ -1215,28 +1215,6 @@ describe('component rendering', () => {
       expect(container.children.length).toEqual(0);
     });
 
-    it('unmounts template with two elements node', () => {
-      const vm = defineComponent({
-        template: `<test-component>
-                        <template #item>
-                            <div>child1</div>
-                            <div>child2</div>
-                        </template>
-                    </test-component>`,
-        components: {
-          TestComponent,
-        },
-      });
-
-      mount(vm);
-
-      const container = document.createElement("div");
-      renderItemTemplate({}, container);
-      events.triggerHandler(container.children[0], "dxremove");
-
-      expect(container.children.length).toEqual(0);
-    });
-
     it('template should have globalProperties of parent', () => {
       let templateGlobalProperties;
       const CustomComponent = defineComponent({

--- a/packages/devextreme-vue/src/core/templates-manager.ts
+++ b/packages/devextreme-vue/src/core/templates-manager.ts
@@ -94,11 +94,11 @@ class TemplatesManager {
             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
           );
         } else {
-/*          one(
+          /* one(
             element,
             DX_REMOVE_EVENT,
             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
-          );*/
+          ); */
         }
         rendered();
         return element;

--- a/packages/devextreme-vue/src/core/templates-manager.ts
+++ b/packages/devextreme-vue/src/core/templates-manager.ts
@@ -79,20 +79,25 @@ class TemplatesManager {
 
         const element = mountedTemplate.$el as HTMLElement;
         container.removeChild(placeholder);
+
+        let hasOnlyText = true;
+
         while (placeholder.firstChild) {
+          hasOnlyText = hasOnlyText && placeholder.firstChild.nodeType !== 1;
           container.appendChild(placeholder.firstChild);
         }
+
         domAdapter.setClass(element, DX_TEMPLATE_WRAPPER_CLASS, true);
 
-        if (element.nodeType === Node.TEXT_NODE) {
+        if (hasOnlyText) {
           const removalListener = document.createElement(container.nodeName === 'TABLE' ? 'tbody' : 'span');
           removalListener.style.display = 'none';
-          /* container.appendChild(removalListener);
+           container.appendChild(removalListener);
            one(
              removalListener,
              DX_REMOVE_EVENT,
              mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
-           );*/
+           );
         } else {
            one(
             element,

--- a/packages/devextreme-vue/src/core/templates-manager.ts
+++ b/packages/devextreme-vue/src/core/templates-manager.ts
@@ -88,17 +88,17 @@ class TemplatesManager {
           const removalListener = document.createElement(container.nodeName === 'TABLE' ? 'tbody' : 'span');
           removalListener.style.display = 'none';
           container.appendChild(removalListener);
-          one(
+         /* one(
             removalListener,
             DX_REMOVE_EVENT,
             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
-          );
+          );*/
         } else {
-          /* one(
+           one(
             element,
             DX_REMOVE_EVENT,
             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
-          ); */
+          );
         }
         rendered();
         return element;

--- a/packages/devextreme-vue/src/core/templates-manager.ts
+++ b/packages/devextreme-vue/src/core/templates-manager.ts
@@ -87,12 +87,12 @@ class TemplatesManager {
         if (element.nodeType === Node.TEXT_NODE) {
           const removalListener = document.createElement(container.nodeName === 'TABLE' ? 'tbody' : 'span');
           removalListener.style.display = 'none';
-          container.appendChild(removalListener);
-         /* one(
-            removalListener,
-            DX_REMOVE_EVENT,
-            mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
-          );*/
+          /* container.appendChild(removalListener);
+           one(
+             removalListener,
+             DX_REMOVE_EVENT,
+             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
+           );*/
         } else {
            one(
             element,

--- a/packages/devextreme-vue/src/core/templates-manager.ts
+++ b/packages/devextreme-vue/src/core/templates-manager.ts
@@ -94,13 +94,16 @@ class TemplatesManager {
           one(
             removalListener,
             DX_REMOVE_EVENT,
-            mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
+            () => {
+              mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate)();
+              removalListener.remove();
+            },
           );
         } else {
           one(
-              element,
-              DX_REMOVE_EVENT,
-              mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
+            element,
+            DX_REMOVE_EVENT,
+            mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
           );
         }
         rendered();

--- a/packages/devextreme-vue/src/core/templates-manager.ts
+++ b/packages/devextreme-vue/src/core/templates-manager.ts
@@ -80,19 +80,16 @@ class TemplatesManager {
         const element = mountedTemplate.$el as HTMLElement;
         container.removeChild(placeholder);
 
-        let hasOnlyText = true;
-
         while (placeholder.firstChild) {
-          hasOnlyText = hasOnlyText && placeholder.firstChild.nodeType !== 1;
           container.appendChild(placeholder.firstChild);
         }
 
         domAdapter.setClass(element, DX_TEMPLATE_WRAPPER_CLASS, true);
 
-        if (hasOnlyText) {
+        if (element.nodeType === Node.TEXT_NODE) {
           const removalListener = document.createElement(container.nodeName === 'TABLE' ? 'tbody' : 'span');
           removalListener.style.display = 'none';
-          container.appendChild(removalListener);
+          container.insertBefore(removalListener, container.firstChild);
 
           one(
             removalListener,
@@ -100,10 +97,10 @@ class TemplatesManager {
             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
           );
         } else {
-           one(
-            element,
-            DX_REMOVE_EVENT,
-            mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
+          one(
+              element,
+              DX_REMOVE_EVENT,
+              mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
           );
         }
         rendered();

--- a/packages/devextreme-vue/src/core/templates-manager.ts
+++ b/packages/devextreme-vue/src/core/templates-manager.ts
@@ -92,12 +92,13 @@ class TemplatesManager {
         if (hasOnlyText) {
           const removalListener = document.createElement(container.nodeName === 'TABLE' ? 'tbody' : 'span');
           removalListener.style.display = 'none';
-           container.appendChild(removalListener);
-           one(
-             removalListener,
-             DX_REMOVE_EVENT,
-             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
-           );
+          container.appendChild(removalListener);
+
+          one(
+            removalListener,
+            DX_REMOVE_EVENT,
+            mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
+          );
         } else {
            one(
             element,

--- a/packages/devextreme-vue/src/core/templates-manager.ts
+++ b/packages/devextreme-vue/src/core/templates-manager.ts
@@ -94,11 +94,11 @@ class TemplatesManager {
             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
           );
         } else {
-          one(
+/*          one(
             element,
             DX_REMOVE_EVENT,
             mountedTemplate.$.appContext.app.unmount.bind(mountedTemplate),
-          );
+          );*/
         }
         rendered();
         return element;


### PR DESCRIPTION
T1247485 - Scheduler - "Cannot read properties of null (reading 'nextSibling')" error occurs if dateCellTemplate has more than one root element


FIX: Vue when unmounting template vnodes keeps the last element as a marker, and if we add removeListener to the end of the container, we will break the validation and an error will occur. So to fix this, we add removeListener as the first child of the container