### PR TITLE
Use version tag for  DevExpress/github-actions

### DIFF
--- a/.github/workflows/_security-alerts.yml
+++ b/.github/workflows/_security-alerts.yml
@@ -36,7 +36,7 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Teams Notification
-        uses: DevExpress/github-actions/send-teams-notification@main
+        uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{ secrets.TEAMS_SECURITY_ALERTS }}
           alerts: ${{ needs.fetch.outputs.alerts }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,7 +84,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.branch }}-${{ matrix.language }}
 
       - name: Teams Notification
-        uses: DevExpress/github-actions/send-teams-notification@main
+        uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{ secrets.TEAMS_HOOK_TMP }}
           alerts: ${{ env.ALERTS }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -399,7 +399,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -207,7 +207,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/paths.yml
+++ b/.github/workflows/paths.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-filter-stubs.yml
+++ b/.github/workflows/pr-filter-stubs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: .md files filter
         id: mdFilesFilter
-        uses: DevExpress/github-actions/pr-filter@main
+        uses: DevExpress/github-actions/pr-filter@v1
         with:
           paths: '**;!apps/**/*.md'
 

--- a/.github/workflows/qunit_tests-additional-renovation.yml
+++ b/.github/workflows/qunit_tests-additional-renovation.yml
@@ -288,7 +288,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/qunit_tests-renovation.yml
+++ b/.github/workflows/qunit_tests-renovation.yml
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/renovation.yml
+++ b/.github/workflows/renovation.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/testcafe_tests.yml
+++ b/.github/workflows/testcafe_tests.yml
@@ -242,7 +242,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/themebuilder_tests.yml
+++ b/.github/workflows/themebuilder_tests.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ts_declarations.yml
+++ b/.github/workflows/ts_declarations.yml
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DevExpress/github-actions/send-teams-notification@main
+      - uses: DevExpress/github-actions/send-teams-notification@v1
         with:
           hook_url: ${{secrets.TEAMS_ALERT}}
           bearer_token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Cherry-picks
- #28058
- #28059
- #28060 
- #28061   

### Practical Value
Using strict semver versions in references to actions will allow to merge changes to [ DevExpress/github-actions](https://github.com/DevExpress/github-actions) without breaking active pipelines

### Before
Shared actions were pulled from the head of the `@main` branch, which is updated each time a PR merged to the [ DevExpress/github-actions](https://github.com/DevExpress/github-actions) repository

### After
Shared actions are pulled with `@v1` tag, which is moved manually and can be rolled back almost instantly