### PR TITLE
CI: Revert deps scanner update

### DIFF
--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           repository: DevExpress/npmdeps-scanner
           token: ${{ secrets.NPM_DEPS_SCANNER_PAT }}
+          ref: 2024.1
           path: deps-scanner
 
       - name: Run deps scanner

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -56,13 +56,9 @@ jobs:
           token: ${{ secrets.NPM_DEPS_SCANNER_PAT }}
           path: deps-scanner
 
-      - name: Build deps scanner
-        working-directory: deps-scanner
-        run: dotnet build npmDepsScanner.csproj /p:Configuration=Release
-
       - name: Run deps scanner
         run: |
-          ./deps-scanner/bin/Release/npmDepsScanner.exe scan_cache ${{ github.workspace }} reportGithub.json
+          ./deps-scanner/exe/npmDepsScanner.exe scan_cache ${{ github.workspace }} reportGithub.json
           mkdir -p ./artifacts/deps-scanner
           cp reportGithub.json ./artifacts/deps-scanner/
 


### PR DESCRIPTION
Revert deps scanner update. Use old exe file from branch 24.1. The new version is broken
