### PR TITLE
SelectBox: proposal for combobox option for popup (a11y)

### DIFF
--- a/packages/devextreme/js/__internal/ui/drop_down_editor/m_drop_down_editor.ts
+++ b/packages/devextreme/js/__internal/ui/drop_down_editor/m_drop_down_editor.ts
@@ -552,6 +552,8 @@ const DropDownEditor = TextBox.inherit({
 
     delete popupConfig.closeOnOutsideClick;
 
+    popupConfig.combobox = true; // we specify combobox here because it's always the desired role in dropdown's case
+
     this._popup = this._createComponent(this._$popup, Popup, popupConfig);
 
     this._popup.on({

--- a/packages/devextreme/js/__internal/ui/popup/m_popup.ts
+++ b/packages/devextreme/js/__internal/ui/popup/m_popup.ts
@@ -146,6 +146,7 @@ const Popup = Overlay.inherit({
       useDefaultToolbarButtons: false,
       useFlatToolbarButtons: false,
       autoResizeEnabled: true,
+      combobox: false,
     });
   },
 
@@ -284,7 +285,9 @@ const Popup = Overlay.inherit({
 
     this._toggleContentScrollClass();
 
-    this.$overlayContent().attr('role', 'dialog');
+    const { combobox } = this.option();
+
+    this.$overlayContent().attr('role', combobox ? 'combobox' : 'dialog');
   },
 
   _render() {


### PR DESCRIPTION
We can now set whether popup gets aria role `dialog` or `combobox`. Let's discuss this solution!
(I've commited with --no-verify as eslint considered `combobox` a misspell) 