### PR TITLE
React: Map devextreme modules resolution to relative (npm dep) path (t1256785)

### DIFF
--- a/packages/devextreme-react/tsconfig.json
+++ b/packages/devextreme-react/tsconfig.json
@@ -8,7 +8,10 @@
     "lib": [
       "ES2020",
       "dom"
-    ]
+    ],
+    "paths": {
+      "devextreme/*": ["../devextreme/artifacts/npm/devextreme/*"]
+    }
   },
 
   "include": [


### PR DESCRIPTION
### Cherry-picks
- #28316

Fixes https://supportcenter.devexpress.com/ticket/details/t1256785/

```
declare const DataGrid: ... {
    dataSource?: import("../../devextreme/artifacts/npm/devextreme/data/data_source").DataSourceLike<TRowData, TKey> | null | undefined;
}
```

etc.