### PR TITLE
Bootstrap: Bump to 5.3.3 and remove from /packages/devextreme/

### DIFF
--- a/packages/devextreme-themebuilder/package.json
+++ b/packages/devextreme-themebuilder/package.json
@@ -21,7 +21,7 @@
     "pack": "cd dist && pnpm pack"
   },
   "peerDependencies": {
-    "bootstrap": "npm:bootstrap@^5.3.0"
+    "bootstrap": "npm:bootstrap@^5.3.3"
   },
   "dependencies": {
     "autoprefixer": "^10.4.7",

--- a/packages/devextreme-themebuilder/src/modules/bootstrap-extractor.ts
+++ b/packages/devextreme-themebuilder/src/modules/bootstrap-extractor.ts
@@ -87,7 +87,7 @@ export default class BootstrapExtractor {
     }
 
     const result = `${functions}
-${variables.replace('@import "variables-dark";', '')}
+${this.getVariables(variables)}
 ${variablesDark}
 ${this.input}
 ${this.getSetterServiceCode('!default')}
@@ -102,6 +102,10 @@ ${this.getCollectorServiceCode()}`;
       + this.input
       + this.getCollectorServiceCode(),
     );
+  }
+
+  getVariables(variables: string): string {
+    return variables.replace(/^@import "variables-dark";.*$/gm, '');
   }
 
   getFilePath(fileName: string): string {

--- a/packages/devextreme-themebuilder/src/modules/bootstrap-extractor.ts
+++ b/packages/devextreme-themebuilder/src/modules/bootstrap-extractor.ts
@@ -87,7 +87,7 @@ export default class BootstrapExtractor {
     }
 
     const result = `${functions}
-${variables.replace('@import "variables-dark";', '')}
+${variables}
 ${variablesDark}
 ${this.input}
 ${this.getSetterServiceCode('!default')}

--- a/packages/devextreme-themebuilder/src/modules/bootstrap-extractor.ts
+++ b/packages/devextreme-themebuilder/src/modules/bootstrap-extractor.ts
@@ -87,7 +87,7 @@ export default class BootstrapExtractor {
     }
 
     const result = `${functions}
-${variables}
+${variables.replace('@import "variables-dark";', '')}
 ${variablesDark}
 ${this.input}
 ${this.getSetterServiceCode('!default')}

--- a/packages/devextreme-themebuilder/tests/modules/bootstrap-extractor.test.ts
+++ b/packages/devextreme-themebuilder/tests/modules/bootstrap-extractor.test.ts
@@ -50,7 +50,7 @@ describe('BootstrapExtractor', () => {
 
     expect(await extractor.sassProcessor())
       .toBe(`${functions.toString()}
-${variables.toString()}
+${extractor.getVariables(variables.toString())}
 ${variablesDark.toString()}
 ${testSassString}
 ${setterServiceCode}

--- a/packages/devextreme/package.json
+++ b/packages/devextreme/package.json
@@ -65,7 +65,7 @@
     "axe-core": "4.10.0",
     "babel-plugin-add-module-exports": "1.0.4",
     "babel-plugin-inferno": "6.7.1",
-    "bootstrap": "5.3.2",
+    "bootstrap": "5.3.3",
     "cldr-core": "41.0.0",
     "cldr-numbers-full": "41.0.0",
     "cldrjs": "0.5.5",

--- a/packages/devextreme/package.json
+++ b/packages/devextreme/package.json
@@ -65,7 +65,6 @@
     "axe-core": "4.10.0",
     "babel-plugin-add-module-exports": "1.0.4",
     "babel-plugin-inferno": "6.7.1",
-    "bootstrap": "5.3.3",
     "cldr-core": "41.0.0",
     "cldr-numbers-full": "41.0.0",
     "cldrjs": "0.5.5",

--- a/packages/devextreme/testing/tests/Bootstrap Integration/widget_bundled.tests.js
+++ b/packages/devextreme/testing/tests/Bootstrap Integration/widget_bundled.tests.js
@@ -17,7 +17,7 @@ QUnit.testStart(function() {
 
 executeAsyncMock.setup();
 
-const BOOTSTRAP_CSS_URL = window.ROOT_URL + 'packages/devextreme/node_modules/bootstrap/dist/css/bootstrap.css';
+const BOOTSTRAP_CSS_URL = window.ROOT_URL + 'packages/devextreme-themebuilder/node_modules/bootstrap/dist/css/bootstrap.css';
 
 const applyBootstrap = (function() {
     let styles = null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,9 +890,6 @@ importers:
       babel-plugin-inferno:
         specifier: 6.7.1
         version: 6.7.1(@babel/core@7.23.9)
-      bootstrap:
-        specifier: 5.3.3
-        version: 5.3.3(@popperjs/core@2.11.8)
       cldr-core:
         specifier: 41.0.0
         version: 41.0.0
@@ -20357,15 +20354,13 @@ snapshots:
     transitivePeerDependencies:
       - '@parcel/core'
 
-  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)':
+  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.11)
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
       '@parcel/logger': 2.12.0
       '@parcel/utils': 2.12.0
       lmdb: 2.8.5
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@parcel/codeframe@2.12.0':
     dependencies:
@@ -20425,7 +20420,7 @@ snapshots:
   '@parcel/core@2.12.0(@swc/helpers@0.5.11)':
     dependencies:
       '@mischnic/json-sourcemap': 0.1.1
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))
       '@parcel/diagnostic': 2.12.0
       '@parcel/events': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
@@ -20840,7 +20835,7 @@ snapshots:
 
   '@parcel/types@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)':
     dependencies:
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))
       '@parcel/diagnostic': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -891,8 +891,8 @@ importers:
         specifier: 6.7.1
         version: 6.7.1(@babel/core@7.23.9)
       bootstrap:
-        specifier: 5.3.2
-        version: 5.3.2(@popperjs/core@2.11.8)
+        specifier: 5.3.3
+        version: 5.3.3(@popperjs/core@2.11.8)
       cldr-core:
         specifier: 41.0.0
         version: 41.0.0
@@ -1508,8 +1508,8 @@ importers:
         specifier: ^10.4.7
         version: 10.4.17(postcss@8.4.38)
       bootstrap:
-        specifier: npm:bootstrap@^5.3.0
-        version: 5.3.2(@popperjs/core@2.11.8)
+        specifier: npm:bootstrap@^5.3.3
+        version: 5.3.3(@popperjs/core@2.11.8)
       clean-css:
         specifier: ^5.3.0
         version: 5.3.3
@@ -6714,8 +6714,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  bootstrap@5.3.2:
-    resolution: {integrity: sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==}
+  bootstrap@5.3.3:
+    resolution: {integrity: sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==}
     peerDependencies:
       '@popperjs/core': ^2.11.8
 
@@ -20357,13 +20357,15 @@ snapshots:
     transitivePeerDependencies:
       - '@parcel/core'
 
-  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))':
+  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.11)
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
       '@parcel/logger': 2.12.0
       '@parcel/utils': 2.12.0
       lmdb: 2.8.5
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@parcel/codeframe@2.12.0':
     dependencies:
@@ -20423,7 +20425,7 @@ snapshots:
   '@parcel/core@2.12.0(@swc/helpers@0.5.11)':
     dependencies:
       '@mischnic/json-sourcemap': 0.1.1
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
       '@parcel/diagnostic': 2.12.0
       '@parcel/events': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
@@ -20838,7 +20840,7 @@ snapshots:
 
   '@parcel/types@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)':
     dependencies:
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
       '@parcel/diagnostic': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.11))(@swc/helpers@0.5.11)
@@ -24516,7 +24518,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  bootstrap@5.3.2(@popperjs/core@2.11.8):
+  bootstrap@5.3.3(@popperjs/core@2.11.8):
     dependencies:
       '@popperjs/core': 2.11.8
 
@@ -29749,7 +29751,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.4.17)(@types/node@20.12.8)(typescript@5.4.5))
+      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.4.17(@swc/helpers@0.5.11))(@types/node@20.12.8)(typescript@5.4.5))
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -30047,7 +30049,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.4.17)(@types/node@20.12.8)(typescript@5.4.5)):
+  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.4.17(@swc/helpers@0.5.11))(@types/node@20.12.8)(typescript@5.4.5)):
     dependencies:
       '@babel/traverse': 7.24.5
       '@jest/environment': 26.6.2

--- a/tools/scripts/build-all.ts
+++ b/tools/scripts/build-all.ts
@@ -72,7 +72,7 @@ sh.pushd(path.join(ROOT_DIR, 'packages/devextreme/artifacts'));
 sh.popd();
 
 // TODO: maybe we should add bootstrap to vendors
-const BOOTSTRAP_DIR = path.join(ROOT_DIR, 'packages', 'devextreme', 'node_modules', 'bootstrap', 'dist');
+const BOOTSTRAP_DIR = path.join(ROOT_DIR, 'packages', 'devextreme-themebuilder', 'node_modules', 'bootstrap', 'dist');
 sh.cp([path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.js'), path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.min.js')], JS_ARTIFACTS);
 sh.cp([path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.css'), path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.min.css')], CSS_ARTIFACTS);
 


### PR DESCRIPTION
Found Occurrences:

/packages/
- devextreme
- devextreme-themebuilder

Prev similar bumps & affected places:
- #26205
- #28184

Extra Occurrences:
- https://github.com/DevExpress/DevExtreme/blob/24_2/tools/scripts/build-all.ts#L75 (copy `/bootstrap/dist/` to `/artifacts/js/`)
- https://github.com/DevExpress/DevExtreme/blob/24_2/packages/devextreme/testing/tests/Bootstrap%20Integration/widget_bundled.tests.js#L20 (a separate test)

Summary:
- Bump the `bootstrap` dep to v5.3.3
- Keep it inside the `/packages/devextreme-themebuilder/` package sub folder only. Refer to `/bootstrap/dist/` using the `packages/devextreme-themebuilder/node_modules/bootstrap/dist/` sub path

- (Bonus): Correct the sass processor (i.e., do not import the `variables-dark` var safely), because the `/scss/_variables.scss` file content (the last line) is changed:

[Bootstrap 5.3.3](https://blog.getbootstrap.com/2024/02/20/bootstrap-5-3-3/)

> Now, _variables.scss will automatically import _variables-dark.scss

[@import "variables-dark"; // TODO: can be removed safely in v6, only here to avoid breaking changes in v5.3](https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss#L1751)

