### PR TITLE
ArrayStore: @inherits from Store (for docs)

### DIFF
--- a/packages/devextreme/js/common/data.d.ts
+++ b/packages/devextreme/js/common/data.d.ts
@@ -110,6 +110,7 @@ export type ArrayStoreOptions<
 
 /**
  * @docid
+ * @inherits Store
  * @namespace DevExpress.common.data
  * @public
  * @options ArrayStoreOptions


### PR DESCRIPTION
Patch for #28486

24_1:  https://github.com/DevExpress/DevExtreme/blob/24_1/packages/devextreme/js/data/array_store.d.ts#L31

Temp fix in docs:
https://github.com/DevExpress/devextreme-documentation/pull/6885/commits/7fae5e1b68265ca3a83bf4389f1238393e34da20
vs
https://github.com/DevExpress/devextreme-documentation/pull/6885/commits/dd87395307c6936600d302ab66a02087311f77d0#diff-c9af822caa00e4558e341bd3f6e93d2067395763cd23404af056eadf5ea3c683L5