### PR TITLE
TreeList - Insertafterkey doesn't work on children nodes (T1247158)

### DIFF
--- a/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
@@ -39,8 +39,11 @@ class EditingController extends editingModule.controllers.editing {
   }
 
   protected _setInsertAfterOrBeforeKey(change, parentKey) {
-    if (parentKey !== undefined && parentKey !== this.option('rootValue')) {
-      change.insertAfterKey = parentKey;
+    const dataSourceAdapter = this._dataController.dataSource();
+    const key = parentKey || dataSourceAdapter?.parentKeyOf(change.data);
+
+    if (key !== undefined && key !== this.option('rootValue')) {
+      change.insertAfterKey = key;
     } else {
       // @ts-expect-error
       super._setInsertAfterOrBeforeKey.apply(this, arguments);
@@ -55,7 +58,8 @@ class EditingController extends editingModule.controllers.editing {
       const rowIndex = gridCoreUtils.getIndexByKey(parentKey, items);
       // @ts-expect-error
       if (rowIndex >= 0 && this._dataController.isRowExpanded(parentKey)) {
-        return rowIndex + 1;
+        // @ts-expect-error
+        return super._getLoadedRowIndex.apply(this, arguments);
       }
       return -1;
     }

--- a/packages/devextreme/testing/testcafe/tests/treeList/editing/editing.ts
+++ b/packages/devextreme/testing/testcafe/tests/treeList/editing/editing.ts
@@ -1,0 +1,59 @@
+import TreeList from 'devextreme-testcafe-models/treeList';
+import url from '../../../helpers/getPageUrl';
+import { createWidget } from '../../../helpers/createWidget';
+
+fixture`Treelist - Editing`.page(url(__dirname, '../../container.html'));
+
+// T1247158
+test('TreeList - Insertafterkey doesn\'t work on children nodes', async (t) => {
+  const treeList = new TreeList('#container');
+  const expectedInsertedRowIndex = 2;
+
+  await t
+    .click(treeList.getDataCell(1, 0).element)
+    .pressKey('ctrl+enter')
+    .expect(treeList.getDataRow(expectedInsertedRowIndex).isInserted)
+    .ok();
+}).before(async () => createWidget('dxTreeList', {
+  dataSource: [
+    {
+      ID: 1,
+      Head_ID: -1,
+      Full_Name: 'John Heart',
+    },
+    {
+      ID: 2,
+      Head_ID: 1,
+      Full_Name: 'Samantha Bright',
+    },
+  ],
+  rootValue: -1,
+  keyExpr: 'ID',
+  parentIdExpr: 'Head_ID',
+  columns: ['Full_Name'],
+  editing: {
+    mode: 'batch',
+    allowAdding: true,
+    allowUpdating: true,
+    useIcons: true,
+  },
+  focusedRowEnabled: true,
+  expandedRowKeys: [1],
+  onKeyDown(e) {
+    if (e.event.ctrlKey && e.event.key === 'Enter') {
+      const currentSelectedParentTaskId = e.component.getNodeByKey(
+        e.component.option('focusedRowKey'),
+      )?.parent?.key;
+      const key = new (window as any).DevExpress.data.Guid().toString();
+      const data = { Head_ID: currentSelectedParentTaskId };
+      e.component.option('editing.changes', [
+        {
+          key,
+          type: 'insert',
+          insertAfterKey: e.component.option('focusedRowKey'),
+          data,
+        },
+      ]);
+    }
+  },
+}));

--- a/packages/devextreme/testing/testcafe/tests/treeList/editing/editing.ts
+++ b/packages/devextreme/testing/testcafe/tests/treeList/editing/editing.ts
@@ -1,4 +1,4 @@
-import TreeList from 'devextreme-testcafe-models/treeList';
+import TreeList from '../../../model/treeList';
 import url from '../../../helpers/getPageUrl';
 import { createWidget } from '../../../helpers/createWidget';
 


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
