### PR TITLE
fix: events engine, return `pointercancel` for the safari (T1260277)

### DIFF
--- a/packages/devextreme/js/__internal/events/pointer/m_mouse.ts
+++ b/packages/devextreme/js/__internal/events/pointer/m_mouse.ts
@@ -17,7 +17,8 @@ const eventMap = {
 
 // due to this https://bugs.webkit.org/show_bug.cgi?id=222632 issue
 if (browser.safari) {
-  eventMap.dxpointercancel += [' ', 'dragstart'].join('');
+  // eslint-disable-next-line no-useless-concat
+  eventMap.dxpointercancel += ' ' + 'dragstart';
 }
 
 const normalizeMouseEvent = function (e) {

--- a/packages/devextreme/js/__internal/events/pointer/m_mouse.ts
+++ b/packages/devextreme/js/__internal/events/pointer/m_mouse.ts
@@ -17,7 +17,7 @@ const eventMap = {
 
 // due to this https://bugs.webkit.org/show_bug.cgi?id=222632 issue
 if (browser.safari) {
-  eventMap.dxpointercancel = 'dragstart';
+  eventMap.dxpointercancel += [' ', 'dragstart'].join('');
 }
 
 const normalizeMouseEvent = function (e) {


### PR DESCRIPTION
Linked to https://github.com/DevExpress/DevExtreme/pull/28541

The `pointercancel` event should also be handled for the safari case because it may be triggered by other processes besides the drag-and-drop process.