### PR TITLE
Core: renderer, `removeAttr` remove an attribute from a set of elements (T1261932)

### DIFF
--- a/packages/devextreme/js/__internal/core/m_renderer_base.ts
+++ b/packages/devextreme/js/__internal/core/m_renderer_base.ts
@@ -115,7 +115,10 @@ initRender.prototype.attr = function (attrName, value) {
 };
 
 initRender.prototype.removeAttr = function (attrName) {
-  this[0] && domAdapter.removeAttribute(this[0], attrName);
+  this.each(function (_, element) {
+    domAdapter.removeAttribute(element, attrName);
+  });
+
   return this;
 };
 

--- a/packages/devextreme/js/core/renderer.d.ts
+++ b/packages/devextreme/js/core/renderer.d.ts
@@ -36,6 +36,14 @@ export interface dxElementWrapper {
 
   detach(): this;
 
+  /**
+   * Iterates over each element in the set of matched elements, executing the provided function for each element.
+   *
+   * @param {(this: Element, index: number, element: Element) => boolean} func - A function to execute for each matched element.
+   *        The function receives the index position of the element in the set and the element itself as arguments.
+   *        If the function returns `false`, the iteration will stop.
+   * @returns {this} The current instance for chaining.
+   */
   each(func: (this: Element, index: number, element: Element) => boolean): this;
 
   empty(): this;
@@ -90,6 +98,12 @@ export interface dxElementWrapper {
 
   remove(element?: Element | dxElementWrapper): this;
 
+  /**
+   * Removes the specified attribute from each element in the set of matched elements.
+   *
+   * @param {string} attrName - The name of the attribute to remove.
+   * @returns {Object} The current instance of `initRender` for chaining.
+   */
   removeAttr(attributeName: string): this;
 
   removeClass(className: string): this;

--- a/packages/devextreme/js/core/renderer.d.ts
+++ b/packages/devextreme/js/core/renderer.d.ts
@@ -36,14 +36,6 @@ export interface dxElementWrapper {
 
   detach(): this;
 
-  /**
-   * Iterates over each element in the set of matched elements, executing the provided function for each element.
-   *
-   * @param {(this: Element, index: number, element: Element) => boolean} func - A function to execute for each matched element.
-   *        The function receives the index position of the element in the set and the element itself as arguments.
-   *        If the function returns `false`, the iteration will stop.
-   * @returns {this} The current instance for chaining.
-   */
   each(func: (this: Element, index: number, element: Element) => boolean): this;
 
   empty(): this;
@@ -98,12 +90,6 @@ export interface dxElementWrapper {
 
   remove(element?: Element | dxElementWrapper): this;
 
-  /**
-   * Removes the specified attribute from each element in the set of matched elements.
-   *
-   * @param {string} attrName - The name of the attribute to remove.
-   * @returns {Object} The current instance of `initRender` for chaining.
-   */
   removeAttr(attributeName: string): this;
 
   removeClass(className: string): this;

--- a/packages/devextreme/testing/tests/DevExpress.core/renderer.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.core/renderer.tests.js
@@ -372,6 +372,21 @@ QUnit.test('Add/remove atribute', function(assert) {
     assert.equal(!!$element.get(0).getAttribute('readonly'), true, 'element readOnly attribute');
     $element.attr('readonly', false);
     assert.equal($element.get(0).getAttribute('readonly'), undefined, 'element readOnly attribute');
+});
 
+QUnit.test('Remove an attribute from the whole set of elements (T1261932)', function(assert) {
+    const fixture = document.getElementById('qunit-fixture');
+
+    const $wrapper = renderer('<div>').html('<div readonly="true">1</div><div readonly="true">2</div>');
+
+    const $allInnerElements = $wrapper.find('div');
+
+    fixture.appendChild($allInnerElements.get(0));
+
+    $allInnerElements.removeAttr('readonly');
+
+    $allInnerElements.each(function(_, element) {
+        assert.equal(element.getAttribute('readonly'), undefined, 'element readOnly attribute');
+    });
 });
 


### PR DESCRIPTION
To reproduce the case in versions `>=24.2` of the devextreme package the `legacyMode` should be enabled in the DataGrid config.

```
  columnFixing: {
      legacyMode: true,
  },
```