### PR TITLE
Validator - onInitialized event parameter has incorrect typing (T1269388)

### DIFF
--- a/packages/devextreme-angular/src/ui/validator/index.ts
+++ b/packages/devextreme-angular/src/ui/validator/index.ts
@@ -26,7 +26,7 @@ import {
 
 
 import * as CommonTypes from 'devextreme/common';
-import { EventInfo } from 'devextreme/common/core/events';
+import { DisposingEvent, InitializedEvent, OptionChangedEvent } from 'devextreme/ui/validator';
 
 import DxValidator from 'devextreme/ui/validator';
 
@@ -179,27 +179,27 @@ export class DxValidatorComponent extends DxComponentExtension implements OnDest
 
     /**
     
-     * [descr:DOMComponentOptions.onDisposing]
+     * [descr:dxValidatorOptions.onDisposing]
     
     
      */
-    @Output() onDisposing: EventEmitter<EventInfo<any>>;
+    @Output() onDisposing: EventEmitter<DisposingEvent>;
 
     /**
     
-     * [descr:ComponentOptions.onInitialized]
+     * [descr:dxValidatorOptions.onInitialized]
     
     
      */
-    @Output() onInitialized: EventEmitter<Object>;
+    @Output() onInitialized: EventEmitter<InitializedEvent>;
 
     /**
     
-     * [descr:DOMComponentOptions.onOptionChanged]
+     * [descr:dxValidatorOptions.onOptionChanged]
     
     
      */
-    @Output() onOptionChanged: EventEmitter<Object>;
+    @Output() onOptionChanged: EventEmitter<OptionChangedEvent>;
 
     /**
     

--- a/packages/devextreme-angular/src/ui/validator/index.ts
+++ b/packages/devextreme-angular/src/ui/validator/index.ts
@@ -26,7 +26,7 @@ import {
 
 
 import * as CommonTypes from 'devextreme/common';
-import { DisposingEvent, InitializedEvent, OptionChangedEvent } from 'devextreme/ui/validator';
+import { DisposingEvent, InitializedEvent, OptionChangedEvent, ValidatedEvent } from 'devextreme/ui/validator';
 
 import DxValidator from 'devextreme/ui/validator';
 
@@ -207,7 +207,7 @@ export class DxValidatorComponent extends DxComponentExtension implements OnDest
     
     
      */
-    @Output() onValidated: EventEmitter<Object>;
+    @Output() onValidated: EventEmitter<ValidatedEvent>;
 
     /**
     

--- a/packages/devextreme-react/src/validator.ts
+++ b/packages/devextreme-react/src/validator.ts
@@ -9,7 +9,7 @@ import { ExtensionComponent as BaseComponent } from "./core/extension-component"
 import { IHtmlOptions, ComponentRef, NestedComponentMeta } from "./core/component";
 import NestedOption from "./core/nested-option";
 
-import type { DisposingEvent, InitializedEvent } from "devextreme/ui/validator";
+import type { DisposingEvent, InitializedEvent, ValidatedEvent } from "devextreme/ui/validator";
 import type { ValidationRuleType, ComparisonOperator } from "devextreme/common";
 
 type ReplaceFieldTypes<TSource, TReplacement> = {
@@ -19,6 +19,7 @@ type ReplaceFieldTypes<TSource, TReplacement> = {
 type IValidatorOptionsNarrowedEvents = {
   onDisposing?: ((e: DisposingEvent) => void);
   onInitialized?: ((e: InitializedEvent) => void);
+  onValidated?: ((validatedInfo: ValidatedEvent) => void);
 }
 
 type IValidatorOptions = React.PropsWithChildren<ReplaceFieldTypes<Properties, IValidatorOptionsNarrowedEvents> & IHtmlOptions>

--- a/packages/devextreme-react/src/validator.ts
+++ b/packages/devextreme-react/src/validator.ts
@@ -9,9 +9,19 @@ import { ExtensionComponent as BaseComponent } from "./core/extension-component"
 import { IHtmlOptions, ComponentRef, NestedComponentMeta } from "./core/component";
 import NestedOption from "./core/nested-option";
 
+import type { DisposingEvent, InitializedEvent } from "devextreme/ui/validator";
 import type { ValidationRuleType, ComparisonOperator } from "devextreme/common";
 
-type IValidatorOptions = React.PropsWithChildren<Properties & IHtmlOptions>
+type ReplaceFieldTypes<TSource, TReplacement> = {
+  [P in keyof TSource]: P extends keyof TReplacement ? TReplacement[P] : TSource[P];
+}
+
+type IValidatorOptionsNarrowedEvents = {
+  onDisposing?: ((e: DisposingEvent) => void);
+  onInitialized?: ((e: InitializedEvent) => void);
+}
+
+type IValidatorOptions = React.PropsWithChildren<ReplaceFieldTypes<Properties, IValidatorOptionsNarrowedEvents> & IHtmlOptions>
 
 interface ValidatorRef {
   instance: () => dxValidator;

--- a/packages/devextreme-vue/src/validator.ts
+++ b/packages/devextreme-vue/src/validator.ts
@@ -6,9 +6,9 @@ import {
  DisposingEvent,
  InitializedEvent,
  OptionChangedEvent,
+ ValidatedEvent,
 } from "devextreme/ui/validator";
 import {
- ValidationStatus,
  ValidationRuleType,
  ComparisonOperator,
 } from "devextreme/common";
@@ -42,7 +42,7 @@ const componentConfig = {
     onDisposing: Function as PropType<((e: DisposingEvent) => void)>,
     onInitialized: Function as PropType<((e: InitializedEvent) => void)>,
     onOptionChanged: Function as PropType<((e: OptionChangedEvent) => void)>,
-    onValidated: Function as PropType<((validatedInfo: { brokenRule: CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule, brokenRules: Array<CommonTypes.ValidationRule>, isValid: boolean, name: string, status: ValidationStatus, validationRules: Array<CommonTypes.ValidationRule>, value: Record<string, any> }) => void)>,
+    onValidated: Function as PropType<((validatedInfo: ValidatedEvent) => void)>,
     validationGroup: String,
     validationRules: Array as PropType<Array<CommonTypes.ValidationRule>>,
     width: [Function, Number, String] as PropType<((() => number | string)) | number | string>

--- a/packages/devextreme-vue/src/validator.ts
+++ b/packages/devextreme-vue/src/validator.ts
@@ -2,13 +2,11 @@ import { PropType } from "vue";
 import { defineComponent } from "vue";
 import { prepareExtensionComponentConfig } from "./core/index";
 import Validator, { Properties } from "devextreme/ui/validator";
-import  DOMComponent from "devextreme/core/dom_component";
 import {
- EventInfo,
-} from "devextreme/common/core/events";
-import {
- Component,
-} from "devextreme/core/component";
+ DisposingEvent,
+ InitializedEvent,
+ OptionChangedEvent,
+} from "devextreme/ui/validator";
 import {
  ValidationStatus,
  ValidationRuleType,
@@ -41,9 +39,9 @@ const componentConfig = {
     elementAttr: Object as PropType<Record<string, any>>,
     height: [Function, Number, String] as PropType<((() => number | string)) | number | string>,
     name: String,
-    onDisposing: Function as PropType<((e: EventInfo<any>) => void)>,
-    onInitialized: Function as PropType<((e: { component: Component<any>, element: any }) => void)>,
-    onOptionChanged: Function as PropType<((e: { component: DOMComponent, element: any, fullName: string, model: any, name: string, previousValue: any, value: any }) => void)>,
+    onDisposing: Function as PropType<((e: DisposingEvent) => void)>,
+    onInitialized: Function as PropType<((e: InitializedEvent) => void)>,
+    onOptionChanged: Function as PropType<((e: OptionChangedEvent) => void)>,
     onValidated: Function as PropType<((validatedInfo: { brokenRule: CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule | CommonTypes.ValidationRule, brokenRules: Array<CommonTypes.ValidationRule>, isValid: boolean, name: string, status: ValidationStatus, validationRules: Array<CommonTypes.ValidationRule>, value: Record<string, any> }) => void)>,
     validationGroup: String,
     validationRules: Array as PropType<Array<CommonTypes.ValidationRule>>,

--- a/packages/devextreme/js/ui/validator.d.ts
+++ b/packages/devextreme/js/ui/validator.d.ts
@@ -84,6 +84,7 @@ export interface dxValidatorOptions extends DOMComponentOptions<dxValidator> {
      */
     name?: string;
     /**
+     * @skip
      * @docid
      * @type_function_param1 validatedInfo:{ui/validator:ValidatedEvent}
      * @action

--- a/packages/devextreme/js/ui/validator.d.ts
+++ b/packages/devextreme/js/ui/validator.d.ts
@@ -66,7 +66,7 @@ export type ValidatedEvent = {
     /** @docid _ui_validator_ValidatedEvent.brokenRule */
     brokenRule?: ValidationRule;
     /** @docid _ui_validator_ValidatedEvent.brokenRules */
-    brokenRules?: ValidationRule;
+    brokenRules?: Array<ValidationRule>;
     /** @docid _ui_validator_ValidatedEvent.status */
     status?: ValidationStatus;
 };

--- a/packages/devextreme/js/ui/validator.d.ts
+++ b/packages/devextreme/js/ui/validator.d.ts
@@ -198,3 +198,34 @@ export type Properties = dxValidatorOptions;
 
 /** @deprecated use Properties instead */
 export type Options = dxValidatorOptions;
+
+///#DEBUG
+// eslint-disable-next-line import/first
+import { CheckedEvents } from '../core';
+
+type EventsIntegrityCheckingHelper = CheckedEvents<Properties, Required<Events>, 'onValidated'>;
+
+/**
+* @hidden
+*/
+type Events = {
+/**
+ * @skip
+ * @docid dxValidatorOptions.onDisposing
+ * @type_function_param1 e:{ui/validator:DisposingEvent}
+ */
+onDisposing?: ((e: DisposingEvent) => void);
+/**
+ * @skip
+ * @docid dxValidatorOptions.onInitialized
+ * @type_function_param1 e:{ui/validator:InitializedEvent}
+ */
+onInitialized?: ((e: InitializedEvent) => void);
+/**
+ * @skip
+ * @docid dxValidatorOptions.onOptionChanged
+ * @type_function_param1 e:{ui/validator:OptionChangedEvent}
+ */
+onOptionChanged?: ((e: OptionChangedEvent) => void);
+};
+///#ENDDEBUG

--- a/packages/devextreme/js/ui/validator.d.ts
+++ b/packages/devextreme/js/ui/validator.d.ts
@@ -22,23 +22,49 @@ export {
     ValidationStatus,
 };
 
-/** @public */
+/**
+ * @docid _ui_validator_DisposingEvent
+ * @public
+ * @type object
+ * @inherits EventInfo
+ */
 export type DisposingEvent = EventInfo<dxValidator>;
 
-/** @public */
+/**
+ * @docid _ui_validator_InitializedEvent
+ * @public
+ * @type object
+ * @inherits InitializedEventInfo
+ */
 export type InitializedEvent = InitializedEventInfo<dxValidator>;
 
-/** @public */
+/**
+ * @docid _ui_validator_OptionChangedEvent
+ * @public
+ * @type object
+ * @inherits EventInfo,ChangedOptionInfo
+ */
 export type OptionChangedEvent = EventInfo<dxValidator> & ChangedOptionInfo;
 
-/** @public */
+/**
+ * @docid _ui_validator_ValidatedEvent
+ * @public
+ * @type object
+ */
 export type ValidatedEvent = {
+    /** @docid _ui_validator_ValidatedEvent.name */
     name?: string;
+    /** @docid _ui_validator_ValidatedEvent.isValid */
     isValid?: boolean;
+    /** @docid _ui_validator_ValidatedEvent.value */
     value?: any;
+    /** @docid _ui_validator_ValidatedEvent.validationRules */
     validationRules?: Array<ValidationRule>;
+    /** @docid _ui_validator_ValidatedEvent.brokenRule */
     brokenRule?: ValidationRule;
+    /** @docid _ui_validator_ValidatedEvent.brokenRules */
     brokenRules?: ValidationRule;
+    /** @docid _ui_validator_ValidatedEvent.status */
     status?: ValidationStatus;
 };
 
@@ -84,7 +110,6 @@ export interface dxValidatorOptions extends DOMComponentOptions<dxValidator> {
      */
     name?: string;
     /**
-     * @skip
      * @docid
      * @type_function_param1 validatedInfo:{ui/validator:ValidatedEvent}
      * @action
@@ -206,19 +231,16 @@ type EventsIntegrityCheckingHelper = CheckedEvents<Properties, Required<Events>,
 */
 type Events = {
 /**
- * @skip
  * @docid dxValidatorOptions.onDisposing
  * @type_function_param1 e:{ui/validator:DisposingEvent}
  */
 onDisposing?: ((e: DisposingEvent) => void);
 /**
- * @skip
  * @docid dxValidatorOptions.onInitialized
  * @type_function_param1 e:{ui/validator:InitializedEvent}
  */
 onInitialized?: ((e: InitializedEvent) => void);
 /**
- * @skip
  * @docid dxValidatorOptions.onOptionChanged
  * @type_function_param1 e:{ui/validator:OptionChangedEvent}
  */

--- a/packages/devextreme/js/ui/validator.d.ts
+++ b/packages/devextreme/js/ui/validator.d.ts
@@ -85,12 +85,7 @@ export interface dxValidatorOptions extends DOMComponentOptions<dxValidator> {
     name?: string;
     /**
      * @docid
-     * @type_function_param1 validatedInfo:Object
-     * @type_function_param1_field value:Object
-     * @type_function_param1_field validationRules:Array<RequiredRule,NumericRule,RangeRule,StringLengthRule,CustomRule,CompareRule,PatternRule,EmailRule,AsyncRule>
-     * @type_function_param1_field brokenRule:RequiredRule|NumericRule|RangeRule|StringLengthRule|CustomRule|CompareRule|PatternRule|EmailRule|AsyncRule
-     * @type_function_param1_field brokenRules:Array<RequiredRule,NumericRule,RangeRule,StringLengthRule,CustomRule,CompareRule,PatternRule,EmailRule,AsyncRule>
-     * @type_function_param1_field status:Enums.ValidationStatus
+     * @type_function_param1 validatedInfo:{ui/validator:ValidatedEvent}
      * @action
      * @public
      */

--- a/packages/devextreme/js/ui/validator.d.ts
+++ b/packages/devextreme/js/ui/validator.d.ts
@@ -56,7 +56,10 @@ export type ValidatedEvent = {
     name?: string;
     /** @docid _ui_validator_ValidatedEvent.isValid */
     isValid?: boolean;
-    /** @docid _ui_validator_ValidatedEvent.value */
+    /**
+     * @docid _ui_validator_ValidatedEvent.value
+     * @type object
+     */
     value?: any;
     /** @docid _ui_validator_ValidatedEvent.validationRules */
     validationRules?: Array<ValidationRule>;

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -30793,7 +30793,7 @@ declare module DevExpress.ui {
       /**
        * [descr:_ui_validator_ValidatedEvent.brokenRules]
        */
-      brokenRules?: DevExpress.common.ValidationRule;
+      brokenRules?: Array<DevExpress.common.ValidationRule>;
       /**
        * [descr:_ui_validator_ValidatedEvent.status]
        */

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -30749,21 +30749,54 @@ declare module DevExpress.ui {
     validate(): DevExpress.ui.dxValidator.ValidationResult;
   }
   module dxValidator {
+    /**
+     * [descr:_ui_validator_DisposingEvent]
+     */
     export type DisposingEvent =
       DevExpress.common.core.events.EventInfo<dxValidator>;
+    /**
+     * [descr:_ui_validator_InitializedEvent]
+     */
     export type InitializedEvent =
       DevExpress.common.core.events.InitializedEventInfo<dxValidator>;
+    /**
+     * [descr:_ui_validator_OptionChangedEvent]
+     */
     export type OptionChangedEvent =
       DevExpress.common.core.events.EventInfo<dxValidator> &
         DevExpress.common.core.events.ChangedOptionInfo;
     export type Properties = dxValidatorOptions;
+    /**
+     * [descr:_ui_validator_ValidatedEvent]
+     */
     export type ValidatedEvent = {
+      /**
+       * [descr:_ui_validator_ValidatedEvent.name]
+       */
       name?: string;
+      /**
+       * [descr:_ui_validator_ValidatedEvent.isValid]
+       */
       isValid?: boolean;
+      /**
+       * [descr:_ui_validator_ValidatedEvent.value]
+       */
       value?: any;
+      /**
+       * [descr:_ui_validator_ValidatedEvent.validationRules]
+       */
       validationRules?: Array<DevExpress.common.ValidationRule>;
+      /**
+       * [descr:_ui_validator_ValidatedEvent.brokenRule]
+       */
       brokenRule?: DevExpress.common.ValidationRule;
+      /**
+       * [descr:_ui_validator_ValidatedEvent.brokenRules]
+       */
       brokenRules?: DevExpress.common.ValidationRule;
+      /**
+       * [descr:_ui_validator_ValidatedEvent.status]
+       */
       status?: DevExpress.common.ValidationStatus;
     };
     export type ValidationResult = dxValidatorResult;


### PR DESCRIPTION
### Cherry-picks
- #28793

Revert #24638
Correct: `ValidatedEvent.brokenRules`: `ValidationRule` -> `Array<ValidationRule>`
Docs: https://github.com/DevExpress/devextreme-documentation/pull/6976