### PR TITLE
CI: Setup dotnet 6 in packages_publishing workflow

### DIFF
--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 


### PR DESCRIPTION
Setup dotnet 6 in packages_publishing workflow (required for internal-tools)
