### PR TITLE
fix(VueWrapper): correctly sync wrapper classes with classes added by a JS component

### DIFF
--- a/apps/demos/Demos/Chat/AIAndChatbotIntegration/Vue/App.vue
+++ b/apps/demos/Demos/Chat/AIAndChatbotIntegration/Vue/App.vue
@@ -1,9 +1,9 @@
 <template>
   <div
     class="chat-container"
-    :class="{'dx-chat-disabled' : isDisabled == true }"
   >
     <DxChat
+      :class="{'dx-chat-disabled' : isDisabled == true }"
       ref="chatElement"
       :height="710"
       :data-source="dataSource"

--- a/packages/devextreme-vue/src/core/__tests__/textbox.test.ts
+++ b/packages/devextreme-vue/src/core/__tests__/textbox.test.ts
@@ -103,7 +103,7 @@ describe('two-way binding', () => {
     const component = wrapper.getComponent('#component');
     await wrapper.setProps({ customClass: false });
     await nextTick(() => {
-      expect(component.element.classList.toString()).toBe(' dx-show-invalid-badge dx-textbox dx-texteditor dx-editor-outlined dx-texteditor-empty dx-widget');
+      expect(component.element.classList.toString()).toBe('dx-show-invalid-badge dx-textbox dx-texteditor dx-editor-outlined dx-texteditor-empty dx-widget');
     });
   });
 });


### PR DESCRIPTION
**Problem**
Once a dx-class is added dynamically through the Vue's attrs API, it is added but isn’t removed from a DOM element after it should according to dynamic addition/removing logic.

**Solution**
Save previous classes received from the attrs API (because if a dynamic class is added and then removed the attrs API doesn't contain it and we don't know which dx-classes were added by a JS component internal logic or via attrs API) and cleanup them before an update.