### PR TITLE
fix(localization): correctly format number with escaped semicolon (T1275922)

### DIFF
--- a/packages/devextreme/js/common/core/localization/intl/number.js
+++ b/packages/devextreme/js/common/core/localization/intl/number.js
@@ -90,7 +90,9 @@ export default {
             return getFormatter(format)(value);
         }
 
-        return this.callBase.apply(this, arguments);
+        const result = this.callBase.apply(this, arguments);
+
+        return result;
     },
     _getCurrencySymbolInfo: function(currency) {
         const formatter = getCurrencyFormatter(currency);

--- a/packages/devextreme/js/common/core/localization/ldml/number.js
+++ b/packages/devextreme/js/common/core/localization/ldml/number.js
@@ -19,8 +19,36 @@ function getGroupSizes(formatString) {
     });
 }
 
+function splitSignParts(format, separatorChar = ';', escapingChar = ESCAPING_CHAR) {
+    const parts = [];
+    let currentPart = '';
+    let state = 'searchingSeparator';
+
+    for(let i = 0; i < format.length; i++) {
+        const char = format[i];
+        if(state === 'searchingSeparator' && char === escapingChar) {
+            state = 'skippingSeparationInsideEscaping';
+        } else if(state === 'skippingSeparationInsideEscaping' && char === escapingChar) {
+            state = 'searchingSeparator';
+        } else if(state === 'searchingSeparator' && char === separatorChar) {
+            state = 'separating';
+            parts.push(currentPart);
+            currentPart = '';
+        }
+
+        if(state !== 'separating') {
+            currentPart += char;
+        } else {
+            state = 'searchingSeparator';
+        }
+    }
+    parts.push(currentPart);
+
+    return parts;
+}
+
 function getSignParts(format) {
-    const signParts = format.split(';');
+    const signParts = splitSignParts(format);
 
     if(signParts.length === 1) {
         signParts.push('-' + signParts[0]);
@@ -38,7 +66,7 @@ function isPercentFormat(format) {
 }
 
 function removeStubs(str) {
-    return str.replace(/'.+'/g, '');
+    return str.replace(/'[^']*'/g, '');
 }
 
 function getNonRequiredDigitCount(floatFormat) {

--- a/packages/devextreme/js/common/core/localization/number.js
+++ b/packages/devextreme/js/common/core/localization/number.js
@@ -287,7 +287,12 @@ const numberLocalization = dependencyInjector({
         if(!numberConfig) {
             const formatterConfig = this._getSeparators();
             formatterConfig.unlimitedIntegerDigits = format.unlimitedIntegerDigits;
-            return this.convertDigits(getFormatter(format.type, formatterConfig)(value));
+
+            const formatter = getFormatter(format.type, formatterConfig)(value);
+
+            const result = this.convertDigits(formatter);
+
+            return result;
         }
 
         return this._formatNumber(value, numberConfig, format);

--- a/packages/devextreme/testing/tests/DevExpress.localization/ldml.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.localization/ldml.tests.js
@@ -228,6 +228,16 @@ QUnit.module('number formatter', () => {
         assert.strictEqual(getNumberFormatter('#0.00 руб\'.\'')(15), '15.00 руб.', 'special chars was escaped');
     });
 
+    QUnit.test('escaped semicolon in format', function(assert) {
+        const formatter = getNumberFormatter('\';\'plus \';\' 0;minus \';\' 0\';\'');
+
+        assert.strictEqual(formatter(-8), 'minus ; 8;', 'semicolons were escaped');
+        assert.strictEqual(formatter(8), ';plus ; 8', 'semicolons were escaped');
+
+        // T1275922
+        assert.strictEqual(getNumberFormatter('\';\'0')(8), ';8', 'semicolons were escaped');
+    });
+
     QUnit.test('percent formatting with leading zero', function(assert) {
         const formatter = getNumberFormatter('#0.#%;(#0.#%)');
 


### PR DESCRIPTION
<h3><strong>Problem 1</strong></h3>
<p><code>'\\';\\'0’</code> formats the <code>8</code> as <code>‘</code> instead of <code>;8</code></p>
<p><strong>Reason</strong></p>
<p>In the <code>getSignParts</code> used the <code>split</code> without counting that format may contain escaped <code>;</code> .</p>
<blockquote>
<p><strong>‘</strong></p>
<p>Used to quote special characters in a prefix or suffix, for example, <code>&quot;'#'#&quot;</code> formats 123 to <code>&quot;#123&quot;</code>. To create a single quote itself, use two in a row: <code>&quot;# o''clock&quot;</code>.</p>
<p><strong>;</strong></p>
<p>subpattern is formed from the positive pattern with a prefixed - (ASCII U+002D HYPHEN-MINUS).</p>
</blockquote>

</blockquote>
<p><a href="https://unicode.org/reports/tr35/tr35-numbers.html">https://unicode.org/reports/tr35/tr35-numbers.html</a>

<strong>Solution</strong>
Ignore <code>;</code> if it was escaped</p>
<h3><strong>Problem 2</strong></h3>
<p>After adding a more complex case ( <code>'\\';\\'plus \\';\\' 0;minus \\';\\' 0\\';\\''</code>) as a test format I found a new problem.</p>

Expected: | "minus ; 8;"
-- | --
Result: | "minus ; ;"


<p><strong>Reason</strong></p>
<p>This is because the regex <code>/'.+'/g</code>  used in <code>removeStubs</code> finds this:</p>
<p>
<img width="364" alt="image" src="https://github.com/user-attachments/assets/c2ea2357-471a-4e46-bb8d-4bd349f52ed9" />
</p>
<p><strong>Solution</strong></p>
<p>Use the <code>'[^']*'/g</code> regex to get the following result:</p>
<p>
<img width="398" alt="image" src="https://github.com/user-attachments/assets/4e24c398-0149-4a51-b614-4ccef10e4b77" />
</p>
<!-- notionvc: 0d7a26fd-67ef-46b2-b272-b10743df4645 -->