### PR TITLE
DataGrid - "Cannot read properties of undefined (reading 'values')" error occurs on adding a row to the second page if initial row values are specified in onInitNewRow (T1274123)

### DIFF
--- a/e2e/testcafe-devextreme/tests/dataGrid/editing/initNewRow.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/editing/initNewRow.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import DataGrid from 'devextreme-testcafe-models/dataGrid';
+import { createWidget } from '../../../helpers/createWidget';
+import url from '../../../helpers/getPageUrl';
+
+fixture`initNewRow`
+  .page(url(__dirname, '../../container.html'));
+
+// T1274123
+test('No errors should be thrown if inserting new row after cancelling insert on second page', async (t) => {
+  const dataGrid = new DataGrid('#container');
+
+  await t
+    .click(
+      dataGrid.getHeaderPanel().getAddRowButton(),
+    )
+    .click(
+      dataGrid.getPopupEditForm().cancelButton,
+    );
+
+  await t.click(
+    dataGrid.getHeaderPanel().getAddRowButton(),
+  );
+
+  await t.expect(
+    dataGrid.getPopupEditForm().element.exists,
+  ).ok();
+}).before(async () => {
+  await createWidget('dxDataGrid', {
+    dataSource: [...new Array(40)].map((_, index) => ({ id: index + 1, text: `item ${index + 1}` })),
+    keyExpr: 'id',
+    paging: {
+      pageIndex: 1,
+    },
+    columns: ['id', 'text'],
+    showBorders: true,
+    editing: { mode: 'popup', allowAdding: true },
+    onInitNewRow(e) {
+      e.data.id = 0;
+      e.data.text = 'test';
+    },
+    height: 300,
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -269,6 +269,7 @@ class EditingControllerImpl extends modules.ViewController {
     const needReset = changes?.length;
     if (needReset) {
       this._silentOption(EDITING_CHANGES_OPTION_NAME, []);
+      this._internalState.clear();
     }
   }
 


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
