### PR TITLE
fix: jQuery integration event types are missing (#29111)

### DIFF
--- a/packages/devextreme/js/integration/jquery.d.ts
+++ b/packages/devextreme/js/integration/jquery.d.ts
@@ -92,7 +92,7 @@ declare module '../core/utils/deferred' {
     interface PromiseType<T> extends JQueryPromise<T> { }
 }
 
-declare module '../common/core/events' {
+declare module '../events/events.types' {
     interface EventType extends JQueryEventObject {
         cancel?: boolean;
     }

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -7657,6 +7657,12 @@ declare module DevExpress.events {
    */
   export interface EventType {}
   /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+   */
+  interface EventType extends JQueryEventObject {
+    cancel?: boolean;
+  }
+  /**
    * [descr:events.triggerHandler(element, event)]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */


### PR DESCRIPTION
cherry-picking https://github.com/DevExpress/DevExtreme/pull/29111