### PR TITLE
DateBox: Previous input key is added to succeeding input when custom displayFormat is used with useMaskBehavior (T1246215)

### DIFF
--- a/packages/devextreme/js/__internal/ui/date_box/m_date_box.mask.ts
+++ b/packages/devextreme/js/__internal/ui/date_box/m_date_box.mask.ts
@@ -593,6 +593,8 @@ class DateBoxMask extends DateBoxBase {
       this._activePartIndex = getDatePartIndexByPosition(this._dateParts, this._caret().start);
 
       if (!this._isAllSelected()) {
+        this._clearSearchValue();
+
         if (isDefined(this._activePartIndex)) {
           this._caret(this._getActivePartProp('caret'));
         } else {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/datebox.mask.tests.js
@@ -1004,6 +1004,31 @@ module('Events', setupModule, () => {
 
         assert.strictEqual(event.isDefaultPrevented(), true, `the ${DROP_EVENT_NAME} event is prevented`);
     });
+
+    QUnit.test('should clear search value on active part change on click (T1246215)', function(assert) {
+        this.instance.option({
+            displayFormat: 'dd/MM/yyyy HH:mm',
+            useMaskBehavior: true
+        });
+
+        const $input = this.$input;
+        this.keyboard.caret(0);
+        this.$input.trigger('dxclick');
+
+        this.keyboard.type('1');
+
+        const textVal = $input.val();
+        const minutesIndex = textVal.length - 2;
+        this.keyboard.caret({ start: minutesIndex, end: minutesIndex });
+        this.$input.trigger('dxclick');
+        this.keyboard.type('1');
+
+        const finalText = $input.val();
+
+        const minutesPart = finalText.slice(-2);
+
+        assert.strictEqual(minutesPart, '01', 'minutes should be "01"');
+    });
 });
 
 module('Search', setupModule, () => {


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
