### PR TITLE
Add missing param doctags - counter part for type doctags overriding DateLike type

### DIFF
--- a/packages/devextreme/js/ui/calendar.d.ts
+++ b/packages/devextreme/js/ui/calendar.d.ts
@@ -230,6 +230,7 @@ export default class dxCalendar extends Editor<dxCalendarOptions> {
      * @docid
      * @publicName reset(value)
      * @public
+     * @param1 value:Date|number|string|Array<Date|number|string|null>|null
      */
     reset(value?: DateLike | Array<Date | number | string | null>): void;
 }

--- a/packages/devextreme/js/ui/date_box.d.ts
+++ b/packages/devextreme/js/ui/date_box.d.ts
@@ -393,6 +393,7 @@ export default class dxDateBox extends DateBoxBase<Properties> {
      * @docid
      * @publicName reset(value)
      * @public
+     * @param1 value:Date|number|string|null
      */
     reset(value?: DateLike): void;
 }


### PR DESCRIPTION
Add missing param doctags - counter part for [type doctags](https://github.com/DevExpress/DevExtreme/pull/29494/files#diff-df90dfb345a4970bdb29ea009f684beecdcc903014bc4ba79d146058687e14dcR208) overriding DateLike type

This is a patch for https://github.com/DevExpress/DevExtreme/pull/29494 to avoid degradation of types in documentation. See example of bad generation here: https://github.com/DevExpress/devextreme-documentation/pull/7232/files#diff-99c3cedaf982366328911a5614591c26bbe36f9e04d91b6543d8404f571b216cR8