### PR TITLE
WIP: Generate Angular wrappers with safe check against missing NG SMD members

### DIFF
--- a/.github/workflows/wrapper_tests.yml
+++ b/.github/workflows/wrapper_tests.yml
@@ -60,21 +60,6 @@ jobs:
         working-directory: ./packages/devextreme
         run: pnpx nx build
 
-      - name: Generate wrappers
-        run: pnpm run regenerate-all
-
-      - name: Check generated code
-        shell: bash
-        run: |
-          git add . -N
-          changes=$(git diff --name-status HEAD -- packages/devextreme-angular/src packages/devextreme-react/src packages/devextreme-vue/src)
-          if [ -n "$changes" ]; then
-            echo "Generated code is outdated. The following files have uncommitted changes:"
-            echo "$changes";
-            echo "To update generated code, use "pnpm run regenerate-all" and commit changes."
-            exit 1
-          fi
-
       - name: Angular - Download Browser
         run: pnpx puppeteer browsers install chrome@130.0.6723.69
 

--- a/packages/devextreme-angular/src/ui/data-grid/index.ts
+++ b/packages/devextreme-angular/src/ui/data-grid/index.ts
@@ -2244,8 +2244,10 @@ export class DxDataGridComponent<TRowData = any, TKey = any> extends DxComponent
         super.ngOnChanges(changes);
         this.setupChanges('columns', changes);
         this.setupChanges('dataSource', changes);
+        this.setupChanges('filterValue', changes);
         this.setupChanges('keyExpr', changes);
         this.setupChanges('selectedRowKeys', changes);
+        this.setupChanges('selectionFilter', changes);
         this.setupChanges('sortByGroupSummaryInfo', changes);
     }
 
@@ -2258,8 +2260,10 @@ export class DxDataGridComponent<TRowData = any, TKey = any> extends DxComponent
     ngDoCheck() {
         this._idh.doCheck('columns');
         this._idh.doCheck('dataSource');
+        this._idh.doCheck('filterValue');
         this._idh.doCheck('keyExpr');
         this._idh.doCheck('selectedRowKeys');
+        this._idh.doCheck('selectionFilter');
         this._idh.doCheck('sortByGroupSummaryInfo');
         this._watcherHelper.checkWatchers();
         super.ngDoCheck();

--- a/packages/devextreme-angular/src/ui/filter-builder/index.ts
+++ b/packages/devextreme-angular/src/ui/filter-builder/index.ts
@@ -672,6 +672,7 @@ export class DxFilterBuilderComponent extends DxComponent implements OnDestroy, 
         this.setupChanges('customOperations', changes);
         this.setupChanges('fields', changes);
         this.setupChanges('groupOperations', changes);
+        this.setupChanges('value', changes);
     }
 
     setupChanges(prop: string, changes: SimpleChanges) {
@@ -684,6 +685,7 @@ export class DxFilterBuilderComponent extends DxComponent implements OnDestroy, 
         this._idh.doCheck('customOperations');
         this._idh.doCheck('fields');
         this._idh.doCheck('groupOperations');
+        this._idh.doCheck('value');
         this._watcherHelper.checkWatchers();
         super.ngDoCheck();
         super.clearChangedOptions();

--- a/packages/devextreme-angular/src/ui/tree-list/index.ts
+++ b/packages/devextreme-angular/src/ui/tree-list/index.ts
@@ -2203,6 +2203,7 @@ export class DxTreeListComponent<TRowData = any, TKey = any> extends DxComponent
         this.setupChanges('columns', changes);
         this.setupChanges('dataSource', changes);
         this.setupChanges('expandedRowKeys', changes);
+        this.setupChanges('filterValue', changes);
         this.setupChanges('selectedRowKeys', changes);
     }
 
@@ -2216,6 +2217,7 @@ export class DxTreeListComponent<TRowData = any, TKey = any> extends DxComponent
         this._idh.doCheck('columns');
         this._idh.doCheck('dataSource');
         this._idh.doCheck('expandedRowKeys');
+        this._idh.doCheck('filterValue');
         this._idh.doCheck('selectedRowKeys');
         this._watcherHelper.checkWatchers();
         super.ngDoCheck();


### PR DESCRIPTION
ReOpen at #29616

Side effect:
3 components with prop(s): `@type Filter expression` + `Array` in d.ts are affected,

https://github.com/search?q=repo%3ADevExpress%2FDevExtreme+%22%40type+Filter+expression%22&type=code

because of the "isCollection" condition calculation. Looks expected. Plus, it has a counterpart runtime check at: #25855