### PR TITLE
Remove stepper from the legacy NG config layer

### DIFF
--- a/packages/devextreme-angular/src/ui/nested/base/button-group-item-dxi.ts
+++ b/packages/devextreme-angular/src/ui/nested/base/button-group-item-dxi.ts
@@ -287,10 +287,10 @@ export abstract class DxiButtonGroupItem extends CollectionNestedOption {
         this._setOption('itemType', value);
     }
 
-    get label(): { alignment?: HorizontalAlignment, location?: LabelLocation, showColon?: boolean, template?: any, text?: string | undefined, visible?: boolean } | string {
+    get label(): { alignment?: HorizontalAlignment, location?: LabelLocation, showColon?: boolean, template?: any, text?: string | undefined, visible?: boolean } {
         return this._getOption('label');
     }
-    set label(value: { alignment?: HorizontalAlignment, location?: LabelLocation, showColon?: boolean, template?: any, text?: string | undefined, visible?: boolean } | string) {
+    set label(value: { alignment?: HorizontalAlignment, location?: LabelLocation, showColon?: boolean, template?: any, text?: string | undefined, visible?: boolean }) {
         this._setOption('label', value);
     }
 
@@ -572,20 +572,6 @@ export abstract class DxiButtonGroupItem extends CollectionNestedOption {
     }
     set splitter(value: dxSplitterOptions | undefined) {
         this._setOption('splitter', value);
-    }
-
-    get isValid(): boolean {
-        return this._getOption('isValid');
-    }
-    set isValid(value: boolean) {
-        this._setOption('isValid', value);
-    }
-
-    get optional(): boolean {
-        return this._getOption('optional');
-    }
-    set optional(value: boolean) {
-        this._setOption('optional', value);
     }
 
     get heightRatio(): number {

--- a/packages/devextreme-angular/src/ui/nested/item-dxi.ts
+++ b/packages/devextreme-angular/src/ui/nested/item-dxi.ts
@@ -120,8 +120,6 @@ import { DxiLocationComponent } from './location-dxi';
         'resizable',
         'size',
         'splitter',
-        'isValid',
-        'optional',
         'heightRatio',
         'widthRatio',
         'expanded',

--- a/packages/devextreme-angular/src/ui/stepper/index.ts
+++ b/packages/devextreme-angular/src/ui/stepper/index.ts
@@ -42,19 +42,14 @@ import {
     WatcherHelper
 } from 'devextreme-angular/core';
 
-import { DxiItemModule } from 'devextreme-angular/ui/nested';
 
 import { DxiStepperItemModule } from 'devextreme-angular/ui/stepper/nested';
 
-import { DxiItemComponent } from 'devextreme-angular/ui/nested';
 
 import { DxiStepperItemComponent } from 'devextreme-angular/ui/stepper/nested';
 
 
-/**
- * [descr:dxStepper]
 
- */
 @Component({
     selector: 'dx-stepper',
     standalone: true,
@@ -71,10 +66,7 @@ import { DxiStepperItemComponent } from 'devextreme-angular/ui/stepper/nested';
 export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent implements OnDestroy, OnChanges, DoCheck {
     instance: DxStepper<TItem, TKey> = null;
 
-    /**
-     * [descr:WidgetOptions.accessKey]
     
-     */
     @Input()
     get accessKey(): string | undefined {
         return this._getOption('accessKey');
@@ -84,10 +76,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:dxStepperOptions.activeStateEnabled]
     
-     */
     @Input()
     get activeStateEnabled(): boolean {
         return this._getOption('activeStateEnabled');
@@ -97,10 +86,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:dxStepperOptions.dataSource]
     
-     */
     @Input()
     get dataSource(): Array<dxStepperItem> | DataSource | DataSourceOptions | null | Store | string {
         return this._getOption('dataSource');
@@ -110,10 +96,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:WidgetOptions.disabled]
     
-     */
     @Input()
     get disabled(): boolean {
         return this._getOption('disabled');
@@ -123,10 +106,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:DOMComponentOptions.elementAttr]
     
-     */
     @Input()
     get elementAttr(): Record<string, any> {
         return this._getOption('elementAttr');
@@ -136,10 +116,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:dxStepperOptions.focusStateEnabled]
     
-     */
     @Input()
     get focusStateEnabled(): boolean {
         return this._getOption('focusStateEnabled');
@@ -149,10 +126,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:DOMComponentOptions.height]
     
-     */
     @Input()
     get height(): (() => number | string) | number | string | undefined {
         return this._getOption('height');
@@ -162,10 +136,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:WidgetOptions.hint]
     
-     */
     @Input()
     get hint(): string | undefined {
         return this._getOption('hint');
@@ -175,10 +146,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:dxStepperOptions.hoverStateEnabled]
     
-     */
     @Input()
     get hoverStateEnabled(): boolean {
         return this._getOption('hoverStateEnabled');
@@ -188,10 +156,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:dxStepperOptions.items]
     
-     */
     @Input()
     get items(): Array<dxStepperItem> {
         return this._getOption('items');
@@ -201,10 +166,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:CollectionWidgetOptions.itemTemplate]
     
-     */
     @Input()
     get itemTemplate(): any {
         return this._getOption('itemTemplate');
@@ -214,10 +176,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:dxStepperOptions.linear]
     
-     */
     @Input()
     get linear(): boolean {
         return this._getOption('linear');
@@ -227,10 +186,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:dxStepperOptions.orientation]
     
-     */
     @Input()
     get orientation(): Orientation {
         return this._getOption('orientation');
@@ -240,10 +196,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:DOMComponentOptions.rtlEnabled]
     
-     */
     @Input()
     get rtlEnabled(): boolean {
         return this._getOption('rtlEnabled');
@@ -253,10 +206,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:CollectionWidgetOptions.selectedIndex]
     
-     */
     @Input()
     get selectedIndex(): number {
         return this._getOption('selectedIndex');
@@ -266,10 +216,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:CollectionWidgetOptions.selectedItem]
     
-     */
     @Input()
     get selectedItem(): any {
         return this._getOption('selectedItem');
@@ -279,10 +226,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:dxStepperOptions.selectOnFocus]
     
-     */
     @Input()
     get selectOnFocus(): boolean {
         return this._getOption('selectOnFocus');
@@ -292,10 +236,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:WidgetOptions.tabIndex]
     
-     */
     @Input()
     get tabIndex(): number {
         return this._getOption('tabIndex');
@@ -305,10 +246,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:WidgetOptions.visible]
     
-     */
     @Input()
     get visible(): boolean {
         return this._getOption('visible');
@@ -318,10 +256,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    /**
-     * [descr:DOMComponentOptions.width]
     
-     */
     @Input()
     get width(): (() => number | string) | number | string | undefined {
         return this._getOption('width');
@@ -332,7 +267,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 
     /**
     
-     * [descr:dxStepperOptions.onDisposing]
+     * [descr:undefined]
     
     
      */
@@ -340,7 +275,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 
     /**
     
-     * [descr:dxStepperOptions.onInitialized]
+     * [descr:undefined]
     
     
      */
@@ -348,7 +283,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 
     /**
     
-     * [descr:dxStepperOptions.onItemClick]
+     * [descr:undefined]
     
     
      */
@@ -356,7 +291,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 
     /**
     
-     * [descr:dxStepperOptions.onItemContextMenu]
+     * [descr:undefined]
     
     
      */
@@ -364,7 +299,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 
     /**
     
-     * [descr:dxStepperOptions.onItemRendered]
+     * [descr:undefined]
     
     
      */
@@ -372,7 +307,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 
     /**
     
-     * [descr:dxStepperOptions.onOptionChanged]
+     * [descr:undefined]
     
     
      */
@@ -380,7 +315,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 
     /**
     
-     * [descr:dxStepperOptions.onSelectionChanged]
+     * [descr:undefined]
     
     
      */
@@ -388,7 +323,7 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 
     /**
     
-     * [descr:dxStepperOptions.onSelectionChanging]
+     * [descr:undefined]
     
     
      */
@@ -546,14 +481,6 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
     }
 
 
-    @ContentChildren(DxiItemComponent)
-    get itemsLegacyChildren(): QueryList<DxiItemComponent> {
-        return this._getOption('items');
-    }
-    set itemsLegacyChildren(value) {
-        this._setChildren('items', value, 'DxiItemComponent');
-    }
-
 
 
 
@@ -644,14 +571,12 @@ export class DxStepperComponent<TItem = any, TKey = any> extends DxComponent imp
 @NgModule({
   imports: [
     DxStepperComponent,
-    DxiItemModule,
     DxiStepperItemModule,
     DxIntegrationModule,
     DxTemplateModule
   ],
   exports: [
     DxStepperComponent,
-    DxiItemModule,
     DxiStepperItemModule,
     DxTemplateModule
   ]

--- a/tools/ng-smd-cfg.json
+++ b/tools/ng-smd-cfg.json
@@ -5,11 +5,15 @@
     "mutations": [
         {
             "kind": "remove",
-            "uid": "/card_view"
+            "uid": "/card_view:"
         },
         {
             "kind": "remove",
             "uid": "/scheduler:Toolbar"
+        },
+        {
+            "kind": "remove",
+            "uid": "/stepper:"
         }
     ]
 }


### PR DESCRIPTION
This PR reverts changes in "old" nested components (src/ui/nested) introduced in:
https://github.com/DevExpress/DevExtreme/pull/29242
https://github.com/DevExpress/DevExtreme/pull/29316
https://github.com/DevExpress/DevExtreme/commit/1154eaf6ae671e8b478dbe06aaced3241eadda2f#diff-f9a208a3236ae138e062d9ea3dd55779f8f43f3772332b17d9c674c8bd3df446R262