### PR TITLE
HtmlEditor: improve AI Dialog responsiveness

### DIFF
--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -331,6 +331,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
   }
 
   protected _getTryAgainButtonItem(): NamedToolbarItem {
+    const text = isSmallScreen() ? undefined : localizationMessage.format('dxHtmlEditor-aiTryAgain');
     return {
       name: 'tryAgain',
       toolbar: 'bottom',
@@ -339,7 +340,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
       options: {
         stylingMode: 'outlined',
         icon: TRY_AGAIN_BUTTON_ICON,
-        text: localizationMessage.format('dxHtmlEditor-aiTryAgain'),
+        text,
         onClick: () => this._retryExecuteAICommand(),
       },
     };

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -13,6 +13,8 @@ import type dxSelectBox from '@js/ui/select_box';
 import type { Properties as SelectBoxProperties } from '@js/ui/select_box';
 import SelectBox from '@js/ui/select_box';
 import TextArea from '@js/ui/text_area';
+import { isCompact } from '@js/ui/themes';
+import { currentTheme } from '@js/viz/themes';
 import type {
   AICommandExecutor,
   AICommandParamsMap,
@@ -50,6 +52,11 @@ export const TEXT_AREA_MIN_HEIGHT = 64;
 export const TEXT_AREA_MAX_HEIGHT = 128;
 export const REPLACE_DROPDOWN_WIDTH = 150;
 export const ACTION_BUTTON_WIDTH = 110;
+export const COMPACT_ACTION_BUTTON_WIDTH = 100;
+
+function getActionButtonWidth(): number {
+  return isCompact(currentTheme()) ? COMPACT_ACTION_BUTTON_WIDTH : ACTION_BUTTON_WIDTH;
+}
 
 enum DialogState {
   Initial = 'initial',
@@ -348,6 +355,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
   }
 
   protected _getGenerateButtonItem(): NamedToolbarItem {
+    const width = getActionButtonWidth();
     return {
       name: 'generate',
       toolbar: 'bottom',
@@ -357,13 +365,14 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
         type: 'default',
         text: localizationMessage.format('dxHtmlEditor-aiGenerate'),
         stylingMode: 'contained',
-        width: ACTION_BUTTON_WIDTH,
+        width,
         onClick: () => this._executeAICommand(),
       },
     };
   }
 
   protected _getStopButtonItem(): NamedToolbarItem {
+    const width = getActionButtonWidth();
     return {
       name: 'stop',
       toolbar: 'bottom',
@@ -373,7 +382,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
         type: 'default',
         stylingMode: 'contained',
         text: localizationMessage.format('dxHtmlEditor-aiStop'),
-        width: ACTION_BUTTON_WIDTH,
+        width,
         onClick: () => this._stopAICommandExecution(),
       },
     };

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -47,8 +47,8 @@ const AI_DIALOG_COMMANDS_WITH_OPTIONS = ['translate', 'changeStyle', 'changeTone
 
 const POPUP_MIN_WIDTH = 288;
 const POPUP_MAX_WIDTH = 460;
-const TEXT_AREA_MIN_HEIGHT = 64;
-const TEXT_AREA_MAX_HEIGHT = 128;
+export const TEXT_AREA_MIN_HEIGHT = 64;
+export const TEXT_AREA_MAX_HEIGHT = 128;
 export const REPLACE_DROPDOWN_WIDTH = 150;
 export const BUTTON_WIDTH = 100;
 

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -64,6 +64,8 @@ enum ReplaceButtonActions {
   InsertBelow = 'insertBelow',
 }
 
+type NamedToolbarItem = ToolbarItem & { name: string };
+
 export interface AIDialogShowPayload {
   currentCommand: AICommandNameExtended;
   currentCommandOption?: string;
@@ -260,8 +262,9 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
     return AI_DIALOG_CLASS;
   }
 
-  protected _getTitleItem(): ToolbarItem {
+  protected _getTitleItem(): NamedToolbarItem {
     return {
+      name: 'title',
       toolbar: 'top',
       location: 'before',
       template: (data, index, titleElement): void => {
@@ -278,8 +281,9 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
     };
   }
 
-  protected _getReplaceButtonItem(config?: ToolbarItem): ToolbarItem {
+  protected _getReplaceButtonItem(): NamedToolbarItem {
     return {
+      name: 'replace',
       toolbar: 'bottom',
       location: 'after',
       widget: 'dxDropDownButton',
@@ -302,13 +306,13 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
         },
         onItemClick: (e: ItemClickEvent) => this._replaceButtonAction(e),
       },
-      ...config,
     };
   }
 
-  protected _getCopyButtonItem(): ToolbarItem {
+  protected _getCopyButtonItem(): NamedToolbarItem {
     const text = isSmallScreen() ? undefined : localizationMessage.format('dxHtmlEditor-aiCopy');
     return {
+      name: 'copy',
       toolbar: 'bottom',
       location: 'after',
       widget: 'dxButton',
@@ -326,8 +330,9 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
     };
   }
 
-  protected _getTryAgainButtonItem(): ToolbarItem {
+  protected _getTryAgainButtonItem(): NamedToolbarItem {
     return {
+      name: 'tryAgain',
       toolbar: 'bottom',
       location: 'before',
       widget: 'dxButton',
@@ -340,8 +345,9 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
     };
   }
 
-  protected _getGenerateButtonItem(): ToolbarItem {
+  protected _getGenerateButtonItem(): NamedToolbarItem {
     return {
+      name: 'generate',
       toolbar: 'bottom',
       location: 'after',
       widget: 'dxButton',
@@ -354,8 +360,9 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
     };
   }
 
-  protected _getStopButtonItem(config?: ToolbarItem): ToolbarItem {
+  protected _getStopButtonItem(): NamedToolbarItem {
     return {
+      name: 'stop',
       toolbar: 'bottom',
       location: 'after',
       widget: 'dxButton',
@@ -365,11 +372,10 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
         text: localizationMessage.format('dxHtmlEditor-aiStop'),
         onClick: () => this._stopAICommandExecution(),
       },
-      ...config,
     };
   }
 
-  private _getInitialToolbarItems(): ToolbarItem[] {
+  private _getInitialToolbarItems(): NamedToolbarItem[] {
     return [
       this._getTryAgainButtonItem(),
       this._getCopyButtonItem(),
@@ -377,8 +383,8 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
     ];
   }
 
-  protected _getToolbarItems(): ToolbarItem[] {
-    const items: ToolbarItem[] = [this._getTitleItem()];
+  protected _getToolbarItems(): NamedToolbarItem[] {
+    const items: NamedToolbarItem[] = [this._getTitleItem()];
 
     switch (this._dialogState) {
       case DialogState.Initial:

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -276,6 +276,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
       toolbar: 'bottom',
       location: 'after',
       widget: 'dxDropDownButton',
+      locateInMenu: 'auto',
       options: {
         text: localizationMessage.format('dxHtmlEditor-aiReplace'),
         stylingMode: 'contained',
@@ -303,6 +304,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
       toolbar: 'bottom',
       location: 'after',
       widget: 'dxButton',
+      locateInMenu: 'auto',
       options: {
         stylingMode: 'outlined',
         icon: COPY_BUTTON_ICON,

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -13,7 +13,6 @@ import type dxSelectBox from '@js/ui/select_box';
 import type { Properties as SelectBoxProperties } from '@js/ui/select_box';
 import SelectBox from '@js/ui/select_box';
 import TextArea from '@js/ui/text_area';
-import { current, isMaterial } from '@js/ui/themes';
 import type {
   AICommandExecutor,
   AICommandParamsMap,
@@ -50,7 +49,6 @@ const POPUP_MAX_WIDTH = 460;
 export const TEXT_AREA_MIN_HEIGHT = 64;
 export const TEXT_AREA_MAX_HEIGHT = 128;
 export const REPLACE_DROPDOWN_WIDTH = 150;
-export const BUTTON_WIDTH = 100;
 
 enum DialogState {
   Initial = 'initial',
@@ -347,7 +345,6 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
       location: 'after',
       widget: 'dxButton',
       options: {
-        width: isMaterial(current()) ? 106 : 100,
         type: 'default',
         text: localizationMessage.format('dxHtmlEditor-aiGenerate'),
         stylingMode: 'contained',
@@ -362,7 +359,6 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
       location: 'after',
       widget: 'dxButton',
       options: {
-        width: BUTTON_WIDTH,
         type: 'default',
         stylingMode: 'contained',
         text: localizationMessage.format('dxHtmlEditor-aiStop'),

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -307,6 +307,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
   }
 
   protected _getCopyButtonItem(): ToolbarItem {
+    const text = isSmallScreen() ? undefined : localizationMessage.format('dxHtmlEditor-aiCopy');
     return {
       toolbar: 'bottom',
       location: 'after',
@@ -315,7 +316,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
       options: {
         stylingMode: 'outlined',
         icon: COPY_BUTTON_ICON,
-        text: localizationMessage.format('dxHtmlEditor-aiCopy'),
+        text,
         onClick: (): void => {
           const { value } = this._resultTextArea.option();
           // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -49,6 +49,7 @@ const POPUP_MAX_WIDTH = 460;
 export const TEXT_AREA_MIN_HEIGHT = 64;
 export const TEXT_AREA_MAX_HEIGHT = 128;
 export const REPLACE_DROPDOWN_WIDTH = 150;
+export const ACTION_BUTTON_WIDTH = 110;
 
 enum DialogState {
   Initial = 'initial',
@@ -356,6 +357,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
         type: 'default',
         text: localizationMessage.format('dxHtmlEditor-aiGenerate'),
         stylingMode: 'contained',
+        width: ACTION_BUTTON_WIDTH,
         onClick: () => this._executeAICommand(),
       },
     };
@@ -371,6 +373,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
         type: 'default',
         stylingMode: 'contained',
         text: localizationMessage.format('dxHtmlEditor-aiStop'),
+        width: ACTION_BUTTON_WIDTH,
         onClick: () => this._stopAICommandExecution(),
       },
     };

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/aiDialog.ts
@@ -28,6 +28,7 @@ import {
 } from '@ts/ui/html_editor/utils/ai';
 import { TEXTEDITOR_INPUT_CONTAINER_CLASS } from '@ts/ui/text_box/m_text_editor.base';
 
+import { isSmallScreen } from '../utils/small_screen';
 import BaseDialog from './m_baseDialog';
 
 export const AI_DIALOG_CLASS = 'dx-aidialog';
@@ -46,10 +47,10 @@ const AI_DIALOG_COMMANDS_WITH_OPTIONS = ['translate', 'changeStyle', 'changeTone
 
 const POPUP_MIN_WIDTH = 288;
 const POPUP_MAX_WIDTH = 460;
-const REPLACE_DROPDOWN_WIDTH = 150;
 const TEXT_AREA_MIN_HEIGHT = 64;
 const TEXT_AREA_MAX_HEIGHT = 128;
-const BUTTON_WIDTH = 100;
+export const REPLACE_DROPDOWN_WIDTH = 150;
+export const BUTTON_WIDTH = 100;
 
 enum DialogState {
   Initial = 'initial',
@@ -211,12 +212,20 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
 
   protected _renderResultTextArea($container: dxElementWrapper): void {
     const $textArea = $('<div>').appendTo($container);
-    this._resultTextArea = new TextArea($textArea.get(0), {
-      minHeight: TEXT_AREA_MIN_HEIGHT,
+    const screenSpecificOptions = isSmallScreen() ? {
+      maxHeight: '100%',
+      height: '100%',
+      autoResizeEnabled: false,
+    } : {
       maxHeight: TEXT_AREA_MAX_HEIGHT,
       autoResizeEnabled: true,
+    };
+
+    this._resultTextArea = new TextArea($textArea.get(0), {
+      minHeight: TEXT_AREA_MIN_HEIGHT,
       width: '100%',
       readOnly: true,
+      ...screenSpecificOptions,
     });
   }
 
@@ -299,7 +308,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
     };
   }
 
-  protected _getCopyButtonItem(config?: ToolbarItem): ToolbarItem {
+  protected _getCopyButtonItem(): ToolbarItem {
     return {
       toolbar: 'bottom',
       location: 'after',
@@ -315,7 +324,6 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
           navigator?.clipboard?.writeText(value ?? '');
         },
       },
-      ...config,
     };
   }
 
@@ -333,7 +341,7 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
     };
   }
 
-  protected _getGenerateButtonItem(config?: ToolbarItem): ToolbarItem {
+  protected _getGenerateButtonItem(): ToolbarItem {
     return {
       toolbar: 'bottom',
       location: 'after',
@@ -345,7 +353,6 @@ export default class AIDialog extends BaseDialog<AIDialogResult> {
         stylingMode: 'contained',
         onClick: () => this._executeAICommand(),
       },
-      ...config,
     };
   }
 

--- a/packages/devextreme/js/__internal/ui/html_editor/ui/m_baseDialog.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/ui/m_baseDialog.ts
@@ -1,22 +1,13 @@
-import devices from '@js/core/devices';
 import type { dxElementWrapper } from '@js/core/renderer';
 import $ from '@js/core/renderer';
 import type { DeferredObj } from '@js/core/utils/deferred';
 import { Deferred } from '@js/core/utils/deferred';
-import {
-  // @ts-expect-error
-  getCurrentScreenFactor,
-  hasWindow,
-} from '@js/core/utils/window';
 import type { Properties as PopupProperties } from '@js/ui/popup';
 import Popup from '@js/ui/popup';
 
-const DROPDOWN_EDITOR_OVERLAY_CLASS = 'dx-dropdowneditor-overlay';
+import { isSmallScreen } from '../utils/small_screen';
 
-const isSmallScreen = (): boolean => {
-  const screenFactor = hasWindow() ? getCurrentScreenFactor() : null;
-  return devices.real().deviceType === 'phone' || screenFactor === 'xs';
-};
+const DROPDOWN_EDITOR_OVERLAY_CLASS = 'dx-dropdowneditor-overlay';
 abstract class BaseDialog<T = unknown> {
   _$container: dxElementWrapper;
 

--- a/packages/devextreme/js/__internal/ui/html_editor/utils/small_screen.ts
+++ b/packages/devextreme/js/__internal/ui/html_editor/utils/small_screen.ts
@@ -1,0 +1,11 @@
+import devices from '@js/core/devices';
+import {
+  // @ts-expect-error
+  getCurrentScreenFactor,
+  hasWindow,
+} from '@js/core/utils/window';
+
+export const isSmallScreen = (): boolean => {
+  const screenFactor = hasWindow() ? getCurrentScreenFactor() : null;
+  return devices.real().deviceType === 'phone' || screenFactor === 'xs';
+};

--- a/packages/devextreme/testing/helpers/aiDialog.js
+++ b/packages/devextreme/testing/helpers/aiDialog.js
@@ -10,7 +10,6 @@ const LIST_ITEM_CLASS = 'dx-list-item';
 const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
 const SELECTBOX_CLASS = 'dx-selectbox';
 const TEXTAREA_CLASS = 'dx-textarea';
-const TOOLBAR_ITEM_CLASS = 'dx-toolbar-item';
 
 const CLICK_EVENT_NAME = 'dxclick';
 
@@ -136,13 +135,10 @@ export const clickActionButton = (insertionMode) => {
 };
 
 export const getItemByName = (items, name) => items.find((items) => items.name === name);
-export const findButtonByName = ($container, name) => {
-    const $toolbarItems = $container.find(`.${TOOLBAR_ITEM_CLASS}`);
-    const targetToolbarItem = $toolbarItems.filter((_, toolbarItem) => {
-        const toolbarItemConfig = $(toolbarItem).data('dxToolbarItemDataKey');
-        return toolbarItemConfig && toolbarItemConfig.name === name;
-    });
-    return targetToolbarItem.eq(0).find(`.${BUTTON_CLASS}`);
+export const findButtonByName = (popup, name) => {
+    const buttonIndex = getBottomToolbarItems(popup).findIndex((item) => item.name === name);
+    const $bottomToolbar = popup.bottomToolbar();
+    return $($bottomToolbar.find(`.${BUTTON_CLASS}`).eq(buttonIndex));
 };
 
 export const getCommandSelectBoxInstance = ($container) => getDialogSelectBoxes($container).eq(0).dxSelectBox('instance');

--- a/packages/devextreme/testing/helpers/aiDialog.js
+++ b/packages/devextreme/testing/helpers/aiDialog.js
@@ -10,6 +10,7 @@ const LIST_ITEM_CLASS = 'dx-list-item';
 const OVERLAY_CONTENT_CLASS = 'dx-overlay-content';
 const SELECTBOX_CLASS = 'dx-selectbox';
 const TEXTAREA_CLASS = 'dx-textarea';
+const TOOLBAR_ITEM_CLASS = 'dx-toolbar-item';
 
 const CLICK_EVENT_NAME = 'dxclick';
 
@@ -84,8 +85,8 @@ export const getLoadIndicator = ($container) => {
     return $container.find(`.${AI_DIALOG_LOAD_INDICATOR_CLASS}`);
 };
 
-export const getToolbarButtonItems = (popup) => {
-    return popup.option('toolbarItems').filter(item => ['dxButton', 'dxDropDownButton'].includes(item.widget));
+export const getBottomToolbarItems = (popup) => {
+    return popup.option('toolbarItems').filter(item => item.toolbar === 'bottom');
 };
 
 const getDropDownButton = ($container) => {
@@ -134,9 +135,15 @@ export const clickActionButton = (insertionMode) => {
     getDropDownButtonOption(insertionModeToIndexMap[insertionMode]).trigger(CLICK_EVENT_NAME);
 };
 
-export function findButtonByText($container, text) {
-    return $container.find(`.${BUTTON_CLASS}`).filter((_, element) => $(element).text() === text);
-}
+export const getItemByName = (items, name) => items.find((items) => items.name === name);
+export const findButtonByName = ($container, name) => {
+    const $toolbarItems = $container.find(`.${TOOLBAR_ITEM_CLASS}`);
+    const targetToolbarItem = $toolbarItems.filter((_, toolbarItem) => {
+        const toolbarItemConfig = $(toolbarItem).data('dxToolbarItemDataKey');
+        return toolbarItemConfig && toolbarItemConfig.name === name;
+    });
+    return targetToolbarItem.eq(0).find(`.${BUTTON_CLASS}`);
+};
 
 export const getCommandSelectBoxInstance = ($container) => getDialogSelectBoxes($container).eq(0).dxSelectBox('instance');
 export const getOptionSelectBoxInstance = ($container) => getDialogSelectBoxes($container).eq(1).dxSelectBox('instance');

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -741,6 +741,7 @@ QUnit.module('AIDialog', {}, () => {
         },
         afterEach: function() {
             integrationModuleConfig.afterEach.apply(this);
+
             localization.locale(this.initialLocale);
         }
     }, () => {
@@ -902,11 +903,12 @@ QUnit.module('AIDialog', {}, () => {
         },
         afterEach: function() {
             integrationModuleConfig.afterEach.apply(this);
+
             devices.real(this.realDevice);
             this.getDocumentElementStub.restore();
         }
     }, () => {
-        QUnit.test('result textArea  config is correct', function(assert) {
+        QUnit.test('result textArea config is correct', function(assert) {
             const done = assert.async();
 
             showAIDialog(this, {
@@ -1131,6 +1133,7 @@ QUnit.module('compact', {
     },
     afterEach: function() {
         integrationModuleConfig.afterEach.apply(this);
+
         this.isCompactStub.restore();
     }
 }, () => {
@@ -1143,7 +1146,7 @@ QUnit.module('compact', {
         const generateToolbarItem = getItemByName(bottomToolbarItems, 'generate');
         const generateButtonOptions = generateToolbarItem.options;
 
-        assert.strictEqual(generateButtonOptions.width, COMPACT_ACTION_BUTTON_WIDTH, 'width=100px');
+        assert.strictEqual(generateButtonOptions.width, COMPACT_ACTION_BUTTON_WIDTH, 'width is specific');
     });
 
     QUnit.test('stop button should have special width', function(assert) {
@@ -1155,6 +1158,6 @@ QUnit.module('compact', {
         const stopToolbarItem = getItemByName(bottomToolbarItems, 'stop');
         const stopButtonOptions = stopToolbarItem.options;
 
-        assert.strictEqual(stopButtonOptions.width, COMPACT_ACTION_BUTTON_WIDTH, 'width=100px');
+        assert.strictEqual(stopButtonOptions.width, COMPACT_ACTION_BUTTON_WIDTH, 'width is specific');
     });
 });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -728,7 +728,6 @@ QUnit.module('AIDialog', {}, () => {
             this.dictionary = {
                 'dxHtmlEditor-aiGenerate': 'custom generate',
                 'dxHtmlEditor-aiStop': 'custom stop',
-                'dxHtmlEditor-aiTryAgain': 'custom try again',
                 'dxHtmlEditor-aiReplace': 'custom replace',
                 'dxHtmlEditor-aiInsertAbove': 'custom insert above',
                 'dxHtmlEditor-aiInsertBelow': 'custom insert below',
@@ -838,7 +837,6 @@ QUnit.module('AIDialog', {}, () => {
                     stylingMode: 'outlined',
                     icon: 'restore',
                 });
-                assert.strictEqual(tryAgainButtonOptions.text, this.dictionary['dxHtmlEditor-aiTryAgain'], 'text is localized');
 
                 done();
             });
@@ -958,6 +956,36 @@ QUnit.module('AIDialog', {}, () => {
                 done();
             });
         });
+
+        QUnit.test('tryAgain button text is shown and localized', function(assert) {
+            const localizedTryAgainText = 'custom copy';
+            const initialLocale = localization.locale();
+            localization.loadMessages({
+                'ja': {
+                    'dxHtmlEditor-aiTryAgain': localizedTryAgainText,
+                }
+            });
+            localization.locale('ja');
+
+            const done = assert.async();
+
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            this.resolve();
+
+            this.promise.then(() => {
+                const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                const tryAgainToolbarItem = getItemByName(bottomToolbarItems, 'tryAgain');
+                const tryAgainButtonOptions = tryAgainToolbarItem.options;
+
+                assert.strictEqual(tryAgainButtonOptions.text, localizedCopyText, 'text is localized');
+
+                localization.locale(initialLocale);
+                done();
+            });
+        });
     });
 
     QUnit.module('prompt textArea config', {
@@ -1062,6 +1090,27 @@ QUnit.module('AIDialog', {}, () => {
 
                         assert.strictEqual(copyButtonOptions.text, undefined, 'text is not passed');
                         assert.strictEqual(copyButtonOptions.icon, 'copy', 'icon is passed');
+
+                        done();
+                    });
+                });
+
+                QUnit.test('tryAgain button text is not shown', function(assert) {
+                    const done = assert.async();
+
+                    showAIDialog(this, {
+                        config: { currentCommand: 'translate' },
+                    });
+
+                    this.resolve();
+
+                    this.promise.then(() => {
+                        const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                        const copyToolbarItem = getItemByName(bottomToolbarItems, 'tryAgain');
+                        const copyButtonOptions = copyToolbarItem.options;
+
+                        assert.strictEqual(copyButtonOptions.text, undefined, 'text is not passed');
+                        assert.strictEqual(copyButtonOptions.icon, 'restore', 'icon is passed');
 
                         done();
                     });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -954,79 +954,78 @@ QUnit.module('AIDialog', {}, () => {
         });
     });
 
-    QUnit.module('result textArea config on phone', {
-        beforeEach: function() {
-            this.realDevice = devices.real();
-            devices.real({ deviceType: 'phone' });
-            integrationModuleConfig.beforeEach.apply(this);
-        },
-        afterEach: function() {
-            devices.real(this.realDevice);
-            integrationModuleConfig.afterEach.apply(this);
-        }
-    }, () => {
-        QUnit.test('is correct', function(assert) {
-            const done = assert.async();
+    QUnit.module('mobile layout', () => {
+        [{
+            name: 'phone',
+            beforeEach: function() {
+                this.realDevice = devices.real();
+                devices.real({ deviceType: 'phone' });
+                integrationModuleConfig.beforeEach.apply(this);
+            },
+            afterEach: function() {
+                devices.real(this.realDevice);
+                integrationModuleConfig.afterEach.apply(this);
+            }
+        }, {
+            name: 'small screen',
+            beforeEach: function() {
+                this.getDocumentElementStub = sinon.stub(domAdapter, 'getDocumentElement');
+                this.getDocumentElementStub.returns({
+                    clientWidth: 300
+                });
+                integrationModuleConfig.beforeEach.apply(this);
+            },
+            afterEach: function() {
+                this.getDocumentElementStub.restore();
+                integrationModuleConfig.afterEach.apply(this);
+            }
+        }].forEach(moduleConfig => {
+            QUnit.module(moduleConfig.name, moduleConfig, () => {
+                QUnit.test('result textArea config is correct', function(assert) {
+                    const done = assert.async();
 
-            showAIDialog(this, {
-                config: { currentCommand: 'translate' },
-            });
+                    showAIDialog(this, {
+                        config: { currentCommand: 'translate' },
+                    });
 
-            this.resolve();
+                    this.resolve();
 
-            this.promise.then(() => {
-                const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
+                    this.promise.then(() => {
+                        const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
 
-                assertConfig(assert, resultTextAreaInstance.option(), {
-                    minHeight: TEXT_AREA_MIN_HEIGHT,
-                    width: '100%',
-                    readOnly: true,
-                    maxHeight: '100%',
-                    height: '100%',
-                    autoResizeEnabled: false,
+                        assertConfig(assert, resultTextAreaInstance.option(), {
+                            minHeight: TEXT_AREA_MIN_HEIGHT,
+                            width: '100%',
+                            readOnly: true,
+                            maxHeight: '100%',
+                            height: '100%',
+                            autoResizeEnabled: false,
+                        });
+
+
+                        done();
+                    });
                 });
 
+                QUnit.test('copy button text is not shown', function(assert) {
+                    const done = assert.async();
 
-                done();
-            });
-        });
-    });
+                    showAIDialog(this, {
+                        config: { currentCommand: 'translate' },
+                    });
 
-    QUnit.module('result textArea config on small screen', {
-        beforeEach: function() {
-            this.getDocumentElementStub = sinon.stub(domAdapter, 'getDocumentElement');
-            this.getDocumentElementStub.returns({
-                clientWidth: 300
-            });
-            integrationModuleConfig.beforeEach.apply(this);
-        },
-        afterEach: function() {
-            this.getDocumentElementStub.restore();
-            integrationModuleConfig.afterEach.apply(this);
-        }
-    }, () => {
-        QUnit.test('is correct', function(assert) {
-            const done = assert.async();
+                    this.resolve();
 
-            showAIDialog(this, {
-                config: { currentCommand: 'translate' },
-            });
+                    this.promise.then(() => {
+                        const copyToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[1];
+                        const copyButtonOptions = copyToolbarItem.options;
 
-            this.resolve();
+                        assert.strictEqual(copyButtonOptions.text, undefined, 'text is not passed');
+                        assert.strictEqual(copyButtonOptions.icon, 'copy', 'icon is passed');
 
-            this.promise.then(() => {
-                const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
-
-                assertConfig(assert, resultTextAreaInstance.option(), {
-                    minHeight: TEXT_AREA_MIN_HEIGHT,
-                    width: '100%',
-                    readOnly: true,
-                    maxHeight: '100%',
-                    height: '100%',
-                    autoResizeEnabled: false,
+                        done();
+                    });
                 });
-
-                done();
             });
         });
     });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -719,7 +719,7 @@ QUnit.module('AIDialog', {}, () => {
         });
     });
 
-    QUnit.module('button config should be correct for', {
+    QUnit.module('button config', {
         beforeEach: function() {
             integrationModuleConfig.beforeEach.apply(this);
 
@@ -749,7 +749,7 @@ QUnit.module('AIDialog', {}, () => {
             localization.locale(this.initialLocale);
         }
     }, () => {
-        QUnit.test('generate button', function(assert) {
+        QUnit.test('should be correct for generate button', function(assert) {
             showAIDialog(this, {
                 config: { currentCommand: 'askAI' }
             });
@@ -770,7 +770,7 @@ QUnit.module('AIDialog', {}, () => {
             assert.strictEqual(generateButtonOptions.width, BUTTON_WIDTH, 'width is 100 in non-Material');
         });
 
-        QUnit.test('generate button in Material theme', function(assert) {
+        QUnit.test('should have correct width for generate button in Material theme', function(assert) {
             const isMaterialStub = sinon.stub(themes, 'isMaterial');
 
             try {
@@ -789,7 +789,7 @@ QUnit.module('AIDialog', {}, () => {
             }
         });
 
-        QUnit.test('stop button', function(assert) {
+        QUnit.test('should be correct for stop button', function(assert) {
             showAIDialog(this, {
                 config: { currentCommand: 'translate' },
             });
@@ -810,7 +810,7 @@ QUnit.module('AIDialog', {}, () => {
             assert.strictEqual(stopButtonOptions.text, this.dictionary['dxHtmlEditor-aiStop'], 'text is localized');
         });
 
-        QUnit.test('copy button', function(assert) {
+        QUnit.test('should be correct for copy button', function(assert) {
             const done = assert.async();
 
             showAIDialog(this, {
@@ -839,7 +839,7 @@ QUnit.module('AIDialog', {}, () => {
             });
         });
 
-        QUnit.test('try again button', function(assert) {
+        QUnit.test('should be correct for try again button', function(assert) {
             const done = assert.async();
 
             showAIDialog(this, {
@@ -867,7 +867,7 @@ QUnit.module('AIDialog', {}, () => {
             });
         });
 
-        QUnit.test('replace button', function(assert) {
+        QUnit.test('should be correct for replace button', function(assert) {
             const done = assert.async();
 
             showAIDialog(this, {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -16,13 +16,14 @@ import { isPromise } from 'core/utils/type';
 import {
     buildDefaultCommandsMap,
     clickActionButton,
-    findButtonByText,
+    getBottomToolbarItems,
+    findButtonByName,
     getCommandSelectBoxInstance,
+    getItemByName,
     getLoadIndicator,
     getOptionSelectBoxInstance,
     getPromptTextAreaInstance,
     getResultTextAreaInstance,
-    getToolbarButtonItems,
     showAIDialog,
 } from '../../../helpers/aiDialog.js';
 
@@ -219,10 +220,8 @@ QUnit.module('AIDialog', {}, () => {
             showAIDialog(this);
 
             this.promise.then(() => {
-                const $copyButton = findButtonByText(this.$element, 'Copy');
-                const resultTextAreaInstance = this.$element
-                    .find(`.${TEXT_AREA_CLASS}`).eq(1)
-                    .dxTextArea('instance');
+                const $copyButton = findButtonByName(this.$element, 'copy');
+                const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
 
                 resultTextAreaInstance.option({ value: 'Test text' });
 
@@ -242,7 +241,7 @@ QUnit.module('AIDialog', {}, () => {
 
             this.promise.then(() => {
                 const generateSpy = sinon.spy(this.aiDialog, '_executeAICommand');
-                const $tryAgainButton = findButtonByText(this.$element, 'Try again');
+                const $tryAgainButton = findButtonByName(this.$element, 'tryAgain');
 
                 $tryAgainButton.trigger('dxclick');
 
@@ -258,10 +257,10 @@ QUnit.module('AIDialog', {}, () => {
 
             this.setDialogState('generating');
 
-            const toolbarButtonItems = getToolbarButtonItems(this.aiDialogPopup);
-            const buttonTexts = toolbarButtonItems.map(item => item.options.text);
+            const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
 
-            assert.deepEqual(buttonTexts, ['Stop'], 'toolbar contains correct buttons for Ask AI mode');
+            assert.strictEqual(bottomToolbarItems.length, 1, 'one item in bottom toolbar');
+            assert.strictEqual(bottomToolbarItems[0].name, 'stop', 'stop button is shown');
         });
 
         ['replace', 'insertAbove', 'insertBelow'].forEach((mode) => {
@@ -291,16 +290,15 @@ QUnit.module('AIDialog', {}, () => {
             const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
             const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
 
-            const toolbarButtonItems = getToolbarButtonItems(this.aiDialogPopup);
-
-            const generateButtonItem = toolbarButtonItems.find(item => item.options.text === 'Generate');
-            const buttonTexts = toolbarButtonItems.map(item => item.options.text);
+            const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+            const generateButtonItem = getItemByName(bottomToolbarItems, 'generate');
 
             assert.strictEqual(promptTextAreaInstance.option('visible'), true, 'prompt TextArea is visible');
             assert.strictEqual(resultTextAreaInstance.option('visible'), false, 'result TextArea is hidden initially');
             assert.strictEqual(promptTextAreaInstance.option('readOnly'), false, 'prompt TextArea is not readOnly');
 
-            assert.deepEqual(buttonTexts, ['Generate'], 'toolbar contains correct buttons for Ask AI mode');
+            assert.strictEqual(bottomToolbarItems.length, 1, 'single item in bottom toolbar');
+            assert.strictEqual(bottomToolbarItems[0].name, 'generate', 'generate button is shown');
             assert.strictEqual(generateButtonItem.disabled, undefined, 'generate button is not disabled');
         });
 
@@ -320,22 +318,21 @@ QUnit.module('AIDialog', {}, () => {
                 },
             });
 
-            const $generateButton = findButtonByText(this.$element, 'Generate');
+            const $generateButton = findButtonByName(this.$element, 'generate');
             $generateButton.trigger('dxclick');
 
             this.promise.then(() => {
                 const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
                 const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
 
-                const toolbarButtonItems = this.aiDialogPopup.option('toolbarItems').filter(item => ['dxButton', 'dxDropDownButton'].includes(item.widget));
-                const buttonTexts = toolbarButtonItems.map(item => item.options.text);
-                const replaceButtonItem = toolbarButtonItems.find(item => item.options.text === 'Replace');
-                const copyButtonItem = toolbarButtonItems.find(item => item.options.icon === 'copy');
+                const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                const replaceButtonItem = getItemByName(bottomToolbarItems, 'replace');
+                const copyButtonItem = getItemByName(bottomToolbarItems, 'copy');
 
                 assert.strictEqual(promptTextAreaInstance.option('readOnly'), true, 'prompt TextArea is readOnly');
                 assert.strictEqual(resultTextAreaInstance.option('visible'), true, 'result TextArea is visible');
 
-                assert.deepEqual(buttonTexts, ['Try again', 'Copy', 'Replace'], 'toolbar contains correct buttons after generation');
+                assert.strictEqual(bottomToolbarItems.length, 3, '3 buttons are shown: tryAgain, copy and regenerate');
                 assert.strictEqual(replaceButtonItem.disabled, undefined, 'replace button is not disabled');
                 assert.strictEqual(copyButtonItem.disabled, undefined, 'copy button is not disabled');
 
@@ -350,20 +347,20 @@ QUnit.module('AIDialog', {}, () => {
 
             this.setDialogState('generating');
 
-            const $stopButton = findButtonByText(this.$element, 'Stop');
+            const $stopButton = findButtonByName(this.$element, 'stop');
             $stopButton.trigger('dxclick');
 
             const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
             const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
 
-            const toolbarButtonItems = this.aiDialogPopup.option('toolbarItems').filter(item => item.widget === 'dxButton');
-            const buttonTexts = toolbarButtonItems.map(item => item.options.text);
+            const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
 
             assert.strictEqual(promptTextAreaInstance.option('visible'), true, 'prompt TextArea is visible');
             assert.strictEqual(promptTextAreaInstance.option('readOnly'), false, 'prompt TextArea is not readOnly');
             assert.strictEqual(resultTextAreaInstance.option('visible'), false, 'result TextArea is hidden');
 
-            assert.deepEqual(buttonTexts, ['Generate'], 'toolbar reset to Ask AI state with correct buttons');
+            assert.strictEqual(bottomToolbarItems.length, 1, '1 button is rendered');
+            assert.strictEqual(bottomToolbarItems[0].name, 'generate', 'generate button is shown');
         });
 
         QUnit.test('should reset fields when switching to a basic command', function(assert) {
@@ -396,15 +393,15 @@ QUnit.module('AIDialog', {}, () => {
             const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
             const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
 
-            const toolbarButtonItems = this.aiDialogPopup.option('toolbarItems').filter(item => item.widget === 'dxButton');
-            const buttonTexts = toolbarButtonItems.map(item => item.options.text);
+            const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
 
             assert.strictEqual(promptTextAreaInstance.option('visible'), true, 'prompt TextArea is visible');
             assert.strictEqual(promptTextAreaInstance.option('readOnly'), false, 'prompt TextArea is not readOnly');
             assert.strictEqual(resultTextAreaInstance.option('visible'), false, 'result TextArea is hidden');
             assert.strictEqual(optionSelectBoxInstance.option('visible'), false, 'option SelectBox hidden for askAI');
 
-            assert.deepEqual(buttonTexts, ['Generate'], 'toolbar contains correct buttons for Ask AI');
+            assert.strictEqual(bottomToolbarItems.length, 1, '1 button is rendered');
+            assert.strictEqual(bottomToolbarItems[0].name, 'generate', 'generate button is shown');
         });
     });
 
@@ -489,7 +486,7 @@ QUnit.module('AIDialog', {}, () => {
 
             promptTextAreaInstance.option('value', prompt);
 
-            const $generateButton = findButtonByText(this.$element, 'Generate');
+            const $generateButton = findButtonByName(this.$element, 'generate');
             $generateButton.trigger('dxclick');
 
             const param = this.executeStub.firstCall.args[0];
@@ -552,7 +549,7 @@ QUnit.module('AIDialog', {}, () => {
 
             assert.notOk(this.abortSpy.calledOnce, 'abort is not called');
 
-            const $stopButton = findButtonByText(this.$element, 'Stop');
+            const $stopButton = findButtonByName(this.$element, 'stop');
             $stopButton.trigger('dxclick');
 
             assert.ok(this.abortSpy.calledOnce, 'abort is called');
@@ -563,7 +560,7 @@ QUnit.module('AIDialog', {}, () => {
 
             assert.strictEqual(getLoadIndicator(this.$element).length, 1, 'loadindicator is rendered');
 
-            const $stopButton = findButtonByText(this.$element, 'Stop');
+            const $stopButton = findButtonByName(this.$element, 'stop');
             $stopButton.trigger('dxclick');
 
             assert.strictEqual(getLoadIndicator(this.$element).length, 0, 'loadindicator is removed');
@@ -579,16 +576,13 @@ QUnit.module('AIDialog', {}, () => {
             this.resolve('Response');
 
             this.promise.then(() => {
-                const $tryAgain = findButtonByText(this.$element, 'Try again');
+                const $tryAgain = findButtonByName(this.$element, 'tryAgain');
 
                 $tryAgain.trigger('dxclick');
 
                 assert.strictEqual(this.sendRequestStub.callCount, 2, 'sendRequest is called twice');
 
-                const resultTextAreaInstance = this.$element
-                    .find(`.${TEXT_AREA_CLASS}`).eq(1)
-                    .dxTextArea('instance');
-
+                const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
                 assert.strictEqual(resultTextAreaInstance.option('value'), undefined, 'text is empty');
 
                 done();
@@ -623,14 +617,13 @@ QUnit.module('AIDialog', {}, () => {
             this.resolve('response');
 
             this.promise.then(() => {
-                const toolbarButtonItems = getToolbarButtonItems(this.aiDialogPopup);
-                const replaceButton = toolbarButtonItems.find(item => item.options.text === 'Replace');
-                const tryAgainButton = toolbarButtonItems.find(item => item.options.text === 'Try again');
-                const $copyButton = findButtonByText(this.$element, 'Copy');
+                const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                const replaceButton = getItemByName(bottomToolbarItems, 'replace');
+                const tryAgainButton = getItemByName(bottomToolbarItems, 'tryAgain');
 
+                assert.strictEqual(bottomToolbarItems.length, 3, '3 buttons are shown: try again, copy and replace');
                 assert.strictEqual(replaceButton.disabled, undefined);
                 assert.strictEqual(tryAgainButton.disabled, undefined);
-                assert.ok($copyButton.length, 'copy button is visible');
 
                 assert.strictEqual(getLoadIndicator(this.$element).length, 0, 'indicator is removed');
 
@@ -645,22 +638,21 @@ QUnit.module('AIDialog', {}, () => {
             this.reject('Error');
 
             setTimeout(() => {
-                const toolbarButtonItems = getToolbarButtonItems(this.aiDialogPopup);
-                const replaceButton = toolbarButtonItems.find(item => item.options.text === 'Replace');
-                const tryAgainButton = toolbarButtonItems.find(item => item.options.text === 'Try again');
-                const $copyButton = findButtonByText(this.$element, 'Copy');
+                const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                const replaceButton = getItemByName(bottomToolbarItems, 'replace');
+                const tryAgainButton = getItemByName(bottomToolbarItems, 'tryAgain');
                 const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
                 const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
 
-                assert.strictEqual(replaceButton.disabled, undefined);
-                assert.strictEqual(tryAgainButton.disabled, undefined);
-                assert.ok($copyButton.length, 'copy button is visible');
-                assert.strictEqual(resultTextAreaInstance.option('disabled'), false);
-                assert.strictEqual(resultTextAreaInstance.option('readOnly'), true);
-                assert.strictEqual(resultTextAreaInstance.option('visible'), true);
-                assert.strictEqual(promptTextAreaInstance.option('disabled'), true);
-                assert.strictEqual(promptTextAreaInstance.option('readOnly'), false);
-                assert.strictEqual(promptTextAreaInstance.option('visible'), false);
+                assert.strictEqual(bottomToolbarItems.length, 3, '3 buttons in bottom toolbar: tryAgain, copy and replace');
+                assert.strictEqual(replaceButton.disabled, undefined, 'replace button is not disabled');
+                assert.strictEqual(tryAgainButton.disabled, undefined, 'tryAgain button is not disabled');
+                assert.strictEqual(resultTextAreaInstance.option('disabled'), false, 'result textArea is not disabled');
+                assert.strictEqual(resultTextAreaInstance.option('readOnly'), true, 'result textArea is readOnly');
+                assert.strictEqual(resultTextAreaInstance.option('visible'), true, 'result textArea is visible');
+                assert.strictEqual(promptTextAreaInstance.option('disabled'), true), 'promts textArea is disabled';
+                assert.strictEqual(promptTextAreaInstance.option('readOnly'), false, 'result textArea is not readOnly');
+                assert.strictEqual(promptTextAreaInstance.option('visible'), false, 'result textArea is not visible');
                 assert.strictEqual(getLoadIndicator(this.$element).length, 0, 'indicator is removed');
 
                 done();
@@ -672,13 +664,13 @@ QUnit.module('AIDialog', {}, () => {
 
             this.showDialog({ currentCommand: 'askAI' });
 
-            const $generateButton = findButtonByText(this.$element, 'Generate');
+            const $generateButton = findButtonByName(this.$element, 'generate');
             $generateButton.trigger('dxclick');
 
             this.reject('Error');
 
             setTimeout(() => {
-                const $generateButton = findButtonByText(this.$element, 'Generate');
+                const $generateButton = findButtonByName(this.$element, 'generate');
                 const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
                 const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
 
@@ -713,7 +705,7 @@ QUnit.module('AIDialog', {}, () => {
             this.showDialog({ currentCommand: 'askAI' });
 
             const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
-            const generateButton = findButtonByText(this.$element, 'Generate');
+            const generateButton = findButtonByName(this.$element, 'generate');
 
             generateButton.trigger('dxclick');
 
@@ -757,7 +749,8 @@ QUnit.module('AIDialog', {}, () => {
                 config: { currentCommand: 'askAI' }
             });
 
-            const generateButtonItem = getToolbarButtonItems(this.aiDialogPopup)[0];
+            const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+            const generateButtonItem = getItemByName(bottomToolbarItems, 'generate');
             const generateButtonOptions = generateButtonItem.options;
 
             assertConfig(assert, generateButtonItem, {
@@ -777,7 +770,8 @@ QUnit.module('AIDialog', {}, () => {
                 config: { currentCommand: 'translate' },
             });
 
-            const stopToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[0];
+            const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+            const stopToolbarItem = getItemByName(bottomToolbarItems, 'stop');
             const stopButtonOptions = stopToolbarItem.options;
 
             assertConfig(assert, stopToolbarItem, {
@@ -803,7 +797,8 @@ QUnit.module('AIDialog', {}, () => {
             this.resolve();
 
             this.promise.then(() => {
-                const copyToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[1];
+                const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                const copyToolbarItem = getItemByName(bottomToolbarItems, 'copy');
                 const copyButtonOptions = copyToolbarItem.options;
 
                 assertConfig(assert, copyToolbarItem, {
@@ -816,6 +811,7 @@ QUnit.module('AIDialog', {}, () => {
                     stylingMode: 'outlined',
                     icon: 'copy',
                 });
+
                 assert.strictEqual(copyButtonOptions.text, this.dictionary['dxHtmlEditor-aiCopy'], 'text is localized');
 
                 done();
@@ -832,7 +828,8 @@ QUnit.module('AIDialog', {}, () => {
             this.resolve();
 
             this.promise.then(() => {
-                const tryAgainToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[0];
+                const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                const tryAgainToolbarItem = getItemByName(bottomToolbarItems, 'tryAgain');
                 const tryAgainButtonOptions = tryAgainToolbarItem.options;
 
                 assertConfig(assert, tryAgainToolbarItem, {
@@ -860,7 +857,8 @@ QUnit.module('AIDialog', {}, () => {
             this.resolve();
 
             this.promise.then(() => {
-                const replaceToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[2];
+                const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                const replaceToolbarItem = getItemByName(bottomToolbarItems, 'replace');
                 const replaceButtonOptions = replaceToolbarItem.options;
 
                 assertConfig(assert, replaceToolbarItem, {
@@ -1016,7 +1014,8 @@ QUnit.module('AIDialog', {}, () => {
                     this.resolve();
 
                     this.promise.then(() => {
-                        const copyToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[1];
+                        const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                        const copyToolbarItem = getItemByName(bottomToolbarItems, 'copy');
                         const copyButtonOptions = copyToolbarItem.options;
 
                         assert.strictEqual(copyButtonOptions.text, undefined, 'text is not passed');

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -728,7 +728,6 @@ QUnit.module('AIDialog', {}, () => {
             this.dictionary = {
                 'dxHtmlEditor-aiGenerate': 'custom generate',
                 'dxHtmlEditor-aiStop': 'custom stop',
-                'dxHtmlEditor-aiCopy': 'custom copy',
                 'dxHtmlEditor-aiTryAgain': 'custom try again',
                 'dxHtmlEditor-aiReplace': 'custom replace',
                 'dxHtmlEditor-aiInsertAbove': 'custom insert above',
@@ -812,8 +811,6 @@ QUnit.module('AIDialog', {}, () => {
                     icon: 'copy',
                 });
 
-                assert.strictEqual(copyButtonOptions.text, this.dictionary['dxHtmlEditor-aiCopy'], 'text is localized');
-
                 done();
             });
         });
@@ -892,8 +889,23 @@ QUnit.module('AIDialog', {}, () => {
         });
     });
 
-    QUnit.module('textArea config', integrationModuleConfig, () => {
-        QUnit.test('is correct for result textArea', function(assert) {
+    QUnit.module('desktop specific', {
+        beforeEach: function() {
+            this.realDevice = devices.real();
+            this.getDocumentElementStub = sinon.stub(domAdapter, 'getDocumentElement');
+            this.getDocumentElementStub.returns({
+                clientWidth: 1000
+            });
+
+            integrationModuleConfig.beforeEach.apply(this);
+        },
+        afterEach: function() {
+            integrationModuleConfig.afterEach.apply(this);
+            devices.real(this.realDevice);
+            this.getDocumentElementStub.restore();
+        }
+    }, () => {
+        QUnit.test('result textArea  config is correct', function(assert) {
             const done = assert.async();
 
             showAIDialog(this, {
@@ -913,6 +925,36 @@ QUnit.module('AIDialog', {}, () => {
                     autoResizeEnabled: true,
                 });
 
+                done();
+            });
+        });
+
+        QUnit.test('copy button text is shown and localized', function(assert) {
+            const localizedCopyText = 'custom copy';
+            const initialLocale = localization.locale();
+            localization.loadMessages({
+                'ja': {
+                    'dxHtmlEditor-aiCopy': localizedCopyText,
+                }
+            });
+            localization.locale('ja');
+
+            const done = assert.async();
+
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            this.resolve();
+
+            this.promise.then(() => {
+                const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+                const copyToolbarItem = getItemByName(bottomToolbarItems, 'copy');
+                const copyButtonOptions = copyToolbarItem.options;
+
+                assert.strictEqual(copyButtonOptions.text, localizedCopyText, 'text is localized');
+
+                localization.locale(initialLocale);
                 done();
             });
         });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import localization from 'localization';
 import devices from '__internal/core/m_devices';
+import themes from 'ui/themes';
 import domAdapter from '__internal/core/m_dom_adapter';
 import AIDialog, {
     AI_DIALOG_CLASS,
@@ -8,6 +9,7 @@ import AIDialog, {
     AI_DIALOG_CONTENT_CLASS,
     REPLACE_DROPDOWN_WIDTH,
     ACTION_BUTTON_WIDTH,
+    COMPACT_ACTION_BUTTON_WIDTH,
     TEXT_AREA_MIN_HEIGHT,
     TEXT_AREA_MAX_HEIGHT
 } from '__internal/ui/html_editor/ui/aiDialog';
@@ -981,7 +983,7 @@ QUnit.module('AIDialog', {}, () => {
                 const tryAgainToolbarItem = getItemByName(bottomToolbarItems, 'tryAgain');
                 const tryAgainButtonOptions = tryAgainToolbarItem.options;
 
-                assert.strictEqual(tryAgainButtonOptions.text, localizedCopyText, 'text is localized');
+                assert.strictEqual(tryAgainButtonOptions.text, localizedTryAgainText, 'text is localized');
 
                 localization.locale(initialLocale);
                 done();
@@ -1118,5 +1120,41 @@ QUnit.module('AIDialog', {}, () => {
                 });
             });
         });
+    });
+});
+
+QUnit.module('compact', {
+    beforeEach: function() {
+        this.isCompactStub = sinon.stub(themes, 'isCompact').returns(true);
+
+        integrationModuleConfig.beforeEach.apply(this);
+    },
+    afterEach: function() {
+        integrationModuleConfig.afterEach.apply(this);
+        this.isCompactStub.restore();
+    }
+}, () => {
+    QUnit.test('generate button should have special width', function(assert) {
+        showAIDialog(this, {
+            config: { currentCommand: 'askAI' },
+        });
+
+        const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+        const generateToolbarItem = getItemByName(bottomToolbarItems, 'generate');
+        const generateButtonOptions = generateToolbarItem.options;
+
+        assert.strictEqual(generateButtonOptions.width, COMPACT_ACTION_BUTTON_WIDTH, 'width=100px');
+    });
+
+    QUnit.test('stop button should have special width', function(assert) {
+        showAIDialog(this, {
+            config: { currentCommand: 'translate' },
+        });
+
+        const bottomToolbarItems = getBottomToolbarItems(this.aiDialogPopup);
+        const stopToolbarItem = getItemByName(bottomToolbarItems, 'stop');
+        const stopButtonOptions = stopToolbarItem.options;
+
+        assert.strictEqual(stopButtonOptions.width, COMPACT_ACTION_BUTTON_WIDTH, 'width=100px');
     });
 });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import themes from 'ui/themes';
 import localization from 'localization';
 import devices from '__internal/core/m_devices';
 import domAdapter from '__internal/core/m_dom_adapter';
@@ -771,26 +770,6 @@ QUnit.module('AIDialog', {}, () => {
                 type: 'default'
             });
             assert.strictEqual(generateButtonOptions.text, this.dictionary['dxHtmlEditor-aiGenerate'], 'text is localized');
-            assert.strictEqual(generateButtonOptions.width, BUTTON_WIDTH, 'width is 100 in non-Material');
-        });
-
-        QUnit.test('should have correct width for generate button in Material theme', function(assert) {
-            const isMaterialStub = sinon.stub(themes, 'isMaterial');
-
-            try {
-                isMaterialStub.returns(true);
-
-                showAIDialog(this, {
-                    config: { currentCommand: 'askAI' }
-                });
-
-                const generateToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[0];
-                const generateButtonOptions = generateToolbarItem.options;
-
-                assert.strictEqual(generateButtonOptions.width, 106, 'width is 106 in Material');
-            } finally {
-                isMaterialStub.restore();
-            }
         });
 
         QUnit.test('should be correct for stop button', function(assert) {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -220,7 +220,7 @@ QUnit.module('AIDialog', {}, () => {
             showAIDialog(this);
 
             this.promise.then(() => {
-                const $copyButton = findButtonByName(this.$element, 'copy');
+                const $copyButton = findButtonByName(this.aiDialogPopup, 'copy');
                 const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
 
                 resultTextAreaInstance.option({ value: 'Test text' });
@@ -241,7 +241,7 @@ QUnit.module('AIDialog', {}, () => {
 
             this.promise.then(() => {
                 const generateSpy = sinon.spy(this.aiDialog, '_executeAICommand');
-                const $tryAgainButton = findButtonByName(this.$element, 'tryAgain');
+                const $tryAgainButton = findButtonByName(this.aiDialogPopup, 'tryAgain');
 
                 $tryAgainButton.trigger('dxclick');
 
@@ -318,7 +318,7 @@ QUnit.module('AIDialog', {}, () => {
                 },
             });
 
-            const $generateButton = findButtonByName(this.$element, 'generate');
+            const $generateButton = findButtonByName(this.aiDialogPopup, 'generate');
             $generateButton.trigger('dxclick');
 
             this.promise.then(() => {
@@ -347,7 +347,7 @@ QUnit.module('AIDialog', {}, () => {
 
             this.setDialogState('generating');
 
-            const $stopButton = findButtonByName(this.$element, 'stop');
+            const $stopButton = findButtonByName(this.aiDialogPopup, 'stop');
             $stopButton.trigger('dxclick');
 
             const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
@@ -486,7 +486,7 @@ QUnit.module('AIDialog', {}, () => {
 
             promptTextAreaInstance.option('value', prompt);
 
-            const $generateButton = findButtonByName(this.$element, 'generate');
+            const $generateButton = findButtonByName(this.aiDialogPopup, 'generate');
             $generateButton.trigger('dxclick');
 
             const param = this.executeStub.firstCall.args[0];
@@ -549,7 +549,7 @@ QUnit.module('AIDialog', {}, () => {
 
             assert.notOk(this.abortSpy.calledOnce, 'abort is not called');
 
-            const $stopButton = findButtonByName(this.$element, 'stop');
+            const $stopButton = findButtonByName(this.aiDialogPopup, 'stop');
             $stopButton.trigger('dxclick');
 
             assert.ok(this.abortSpy.calledOnce, 'abort is called');
@@ -560,7 +560,7 @@ QUnit.module('AIDialog', {}, () => {
 
             assert.strictEqual(getLoadIndicator(this.$element).length, 1, 'loadindicator is rendered');
 
-            const $stopButton = findButtonByName(this.$element, 'stop');
+            const $stopButton = findButtonByName(this.aiDialogPopup, 'stop');
             $stopButton.trigger('dxclick');
 
             assert.strictEqual(getLoadIndicator(this.$element).length, 0, 'loadindicator is removed');
@@ -576,7 +576,7 @@ QUnit.module('AIDialog', {}, () => {
             this.resolve('Response');
 
             this.promise.then(() => {
-                const $tryAgain = findButtonByName(this.$element, 'tryAgain');
+                const $tryAgain = findButtonByName(this.aiDialogPopup, 'tryAgain');
 
                 $tryAgain.trigger('dxclick');
 
@@ -664,13 +664,13 @@ QUnit.module('AIDialog', {}, () => {
 
             this.showDialog({ currentCommand: 'askAI' });
 
-            const $generateButton = findButtonByName(this.$element, 'generate');
+            const $generateButton = findButtonByName(this.aiDialogPopup, 'generate');
             $generateButton.trigger('dxclick');
 
             this.reject('Error');
 
             setTimeout(() => {
-                const $generateButton = findButtonByName(this.$element, 'generate');
+                const $generateButton = findButtonByName(this.aiDialogPopup, 'generate');
                 const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
                 const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
 
@@ -705,7 +705,7 @@ QUnit.module('AIDialog', {}, () => {
             this.showDialog({ currentCommand: 'askAI' });
 
             const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
-            const generateButton = findButtonByName(this.$element, 'generate');
+            const generateButton = findButtonByName(this.aiDialogPopup, 'generate');
 
             generateButton.trigger('dxclick');
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -894,6 +894,7 @@ QUnit.module('AIDialog', {}, () => {
     QUnit.module('desktop specific', {
         beforeEach: function() {
             this.realDevice = devices.real();
+            devices.real({ deviceType: 'desktop' });
             this.getDocumentElementStub = sinon.stub(domAdapter, 'getDocumentElement');
             this.getDocumentElementStub.returns({
                 clientWidth: 1000

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -1,8 +1,12 @@
 import $ from 'jquery';
+import themes from 'ui/themes';
+import localization from 'localization';
 import AIDialog, {
     AI_DIALOG_CLASS,
     AI_DIALOG_CONTROLS_CLASS,
     AI_DIALOG_CONTENT_CLASS,
+    REPLACE_DROPDOWN_WIDTH,
+    BUTTON_WIDTH
 } from '__internal/ui/html_editor/ui/aiDialog';
 import { AIIntegration } from '__internal/core/ai_integration/core/ai_integration';
 import { isPromise } from 'core/utils/type';
@@ -710,6 +714,198 @@ QUnit.module('AIDialog', {}, () => {
 
             this.promise.then(() => {
                 assert.strictEqual(promptTextAreaInstance.option('disabled'), false, 'not disabled after');
+                done();
+            });
+        });
+    });
+
+    QUnit.module('button config should be correct for', {
+        beforeEach: function() {
+            integrationModuleConfig.beforeEach.apply(this);
+
+            this.initialLocale = localization.locale();
+            this.dictionary = {
+                'dxHtmlEditor-aiGenerate': 'custom generate',
+                'dxHtmlEditor-aiStop': 'custom stop',
+                'dxHtmlEditor-aiCopy': 'custom copy',
+                'dxHtmlEditor-aiTryAgain': 'custom try again',
+                'dxHtmlEditor-aiReplace': 'custom replace',
+                'dxHtmlEditor-aiInsertAbove': 'custom insert above',
+                'dxHtmlEditor-aiInsertBelow': 'custom insert below',
+            };
+            localization.loadMessages({
+                'ja': this.dictionary
+            });
+            localization.locale('ja');
+
+            this.assertConfig = (assert, config, expectations) => {
+                for(const key in expectations) {
+                    assert.strictEqual(config[key], expectations[key], `${key}=expectations[key]`);
+                }
+            };
+        },
+        afterEach: function() {
+            integrationModuleConfig.afterEach.apply(this);
+            localization.locale(this.initialLocale);
+        }
+    }, () => {
+        QUnit.test('generate button', function(assert) {
+            showAIDialog(this, {
+                config: { currentCommand: 'askAI' }
+            });
+
+            const generateButtonItem = getToolbarButtonItems(this.aiDialogPopup)[0];
+            const generateButtonOptions = generateButtonItem.options;
+
+            this.assertConfig(assert, generateButtonItem, {
+                toolbar: 'bottom',
+                location: 'after',
+                widget: 'dxButton'
+            });
+            this.assertConfig(assert, generateButtonOptions, {
+                stylingMode: 'contained',
+                type: 'default'
+            });
+            assert.strictEqual(generateButtonOptions.text, this.dictionary['dxHtmlEditor-aiGenerate'], 'text is localized');
+            assert.strictEqual(generateButtonOptions.width, BUTTON_WIDTH, 'width is 100 in non-Material');
+        });
+
+        QUnit.test('generate button in Material theme', function(assert) {
+            const isMaterialStub = sinon.stub(themes, 'isMaterial');
+
+            try {
+                isMaterialStub.returns(true);
+
+                showAIDialog(this, {
+                    config: { currentCommand: 'askAI' }
+                });
+
+                const generateToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[0];
+                const generateButtonOptions = generateToolbarItem.options;
+
+                assert.strictEqual(generateButtonOptions.width, 106, 'width is 106 in Material');
+            } finally {
+                isMaterialStub.restore();
+            }
+        });
+
+        QUnit.test('stop button', function(assert) {
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            const stopToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[0];
+            const stopButtonOptions = stopToolbarItem.options;
+
+            this.assertConfig(assert, stopToolbarItem, {
+                toolbar: 'bottom',
+                location: 'after',
+                widget: 'dxButton'
+            });
+            this.assertConfig(assert, stopButtonOptions, {
+                stylingMode: 'contained',
+                type: 'default',
+                width: BUTTON_WIDTH
+            });
+            assert.strictEqual(stopButtonOptions.text, this.dictionary['dxHtmlEditor-aiStop'], 'text is localized');
+        });
+
+        QUnit.test('copy button', function(assert) {
+            const done = assert.async();
+
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            this.resolve();
+
+            this.promise.then(() => {
+                const copyToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[1];
+                const copyButtonOptions = copyToolbarItem.options;
+
+                this.assertConfig(assert, copyToolbarItem, {
+                    toolbar: 'bottom',
+                    location: 'after',
+                    widget: 'dxButton',
+                    locateInMenu: 'auto'
+                });
+                this.assertConfig(assert, copyButtonOptions, {
+                    stylingMode: 'outlined',
+                    icon: 'copy',
+                });
+                assert.strictEqual(copyButtonOptions.text, this.dictionary['dxHtmlEditor-aiCopy'], 'text is localized');
+
+                done();
+            });
+        });
+
+        QUnit.test('try again button', function(assert) {
+            const done = assert.async();
+
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            this.resolve();
+
+            this.promise.then(() => {
+                const tryAgainToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[0];
+                const tryAgainButtonOptions = tryAgainToolbarItem.options;
+
+                this.assertConfig(assert, tryAgainToolbarItem, {
+                    toolbar: 'bottom',
+                    location: 'before',
+                    widget: 'dxButton',
+                });
+                this.assertConfig(assert, tryAgainButtonOptions, {
+                    stylingMode: 'outlined',
+                    icon: 'restore',
+                });
+                assert.strictEqual(tryAgainButtonOptions.text, this.dictionary['dxHtmlEditor-aiTryAgain'], 'text is localized');
+
+                done();
+            });
+        });
+
+        QUnit.test('replace button', function(assert) {
+            const done = assert.async();
+
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            this.resolve();
+
+            this.promise.then(() => {
+                const replaceToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[2];
+                const replaceButtonOptions = replaceToolbarItem.options;
+
+                this.assertConfig(assert, replaceToolbarItem, {
+                    toolbar: 'bottom',
+                    location: 'after',
+                    widget: 'dxDropDownButton',
+                    locateInMenu: 'auto'
+                });
+                this.assertConfig(assert, replaceButtonOptions, {
+                    stylingMode: 'contained',
+                    type: 'default',
+                    splitButton: true,
+                    useSelectMode: false,
+                });
+                this.assertConfig(assert, replaceButtonOptions.dropDownOptions, {
+                    width: REPLACE_DROPDOWN_WIDTH
+                });
+                assert.strictEqual(replaceButtonOptions.text, this.dictionary['dxHtmlEditor-aiReplace'], 'text is localized');
+
+                const expectedDropDownItems = [{
+                    id: 'insertAbove',
+                    text: this.dictionary['dxHtmlEditor-aiInsertAbove']
+                }, {
+                    id: 'insertBelow',
+                    text: this.dictionary['dxHtmlEditor-aiInsertBelow']
+                }];
+                assert.deepEqual(replaceButtonOptions.items, expectedDropDownItems, 'items in dropdown are correct');
+
                 done();
             });
         });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -7,7 +7,7 @@ import AIDialog, {
     AI_DIALOG_CONTROLS_CLASS,
     AI_DIALOG_CONTENT_CLASS,
     REPLACE_DROPDOWN_WIDTH,
-    BUTTON_WIDTH,
+    ACTION_BUTTON_WIDTH,
     TEXT_AREA_MIN_HEIGHT,
     TEXT_AREA_MAX_HEIGHT
 } from '__internal/ui/html_editor/ui/aiDialog';
@@ -758,7 +758,8 @@ QUnit.module('AIDialog', {}, () => {
             });
             assertConfig(assert, generateButtonOptions, {
                 stylingMode: 'contained',
-                type: 'default'
+                type: 'default',
+                width: ACTION_BUTTON_WIDTH,
             });
             assert.strictEqual(generateButtonOptions.text, this.dictionary['dxHtmlEditor-aiGenerate'], 'text is localized');
         });
@@ -780,7 +781,7 @@ QUnit.module('AIDialog', {}, () => {
             assertConfig(assert, stopButtonOptions, {
                 stylingMode: 'contained',
                 type: 'default',
-                width: BUTTON_WIDTH
+                width: ACTION_BUTTON_WIDTH,
             });
             assert.strictEqual(stopButtonOptions.text, this.dictionary['dxHtmlEditor-aiStop'], 'text is localized');
         });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -330,7 +330,7 @@ QUnit.module('AIDialog', {}, () => {
                 const toolbarButtonItems = this.aiDialogPopup.option('toolbarItems').filter(item => ['dxButton', 'dxDropDownButton'].includes(item.widget));
                 const buttonTexts = toolbarButtonItems.map(item => item.options.text);
                 const replaceButtonItem = toolbarButtonItems.find(item => item.options.text === 'Replace');
-                const copyButtonItem = toolbarButtonItems.find(item => item.options.text === 'Copy');
+                const copyButtonItem = toolbarButtonItems.find(item => item.options.icon === 'copy');
 
                 assert.strictEqual(promptTextAreaInstance.option('readOnly'), true, 'prompt TextArea is readOnly');
                 assert.strictEqual(resultTextAreaInstance.option('visible'), true, 'result TextArea is visible');
@@ -1001,7 +1001,6 @@ QUnit.module('AIDialog', {}, () => {
                             height: '100%',
                             autoResizeEnabled: false,
                         });
-
 
                         done();
                     });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.htmlEditor/htmlEditorParts/aiDialog.tests.js
@@ -1,12 +1,16 @@
 import $ from 'jquery';
 import themes from 'ui/themes';
 import localization from 'localization';
+import devices from '__internal/core/m_devices';
+import domAdapter from '__internal/core/m_dom_adapter';
 import AIDialog, {
     AI_DIALOG_CLASS,
     AI_DIALOG_CONTROLS_CLASS,
     AI_DIALOG_CONTENT_CLASS,
     REPLACE_DROPDOWN_WIDTH,
-    BUTTON_WIDTH
+    BUTTON_WIDTH,
+    TEXT_AREA_MIN_HEIGHT,
+    TEXT_AREA_MAX_HEIGHT
 } from '__internal/ui/html_editor/ui/aiDialog';
 import { AIIntegration } from '__internal/core/ai_integration/core/ai_integration';
 import { isPromise } from 'core/utils/type';
@@ -83,6 +87,12 @@ const integrationModuleConfig = {
     },
     afterEach() {
         sinon.restore();
+    }
+};
+
+function assertConfig(assert, config, expectations) {
+    for(const key in expectations) {
+        assert.strictEqual(config[key], expectations[key], `${key}=expectations[key]`);
     }
 };
 
@@ -737,12 +747,6 @@ QUnit.module('AIDialog', {}, () => {
                 'ja': this.dictionary
             });
             localization.locale('ja');
-
-            this.assertConfig = (assert, config, expectations) => {
-                for(const key in expectations) {
-                    assert.strictEqual(config[key], expectations[key], `${key}=expectations[key]`);
-                }
-            };
         },
         afterEach: function() {
             integrationModuleConfig.afterEach.apply(this);
@@ -757,12 +761,12 @@ QUnit.module('AIDialog', {}, () => {
             const generateButtonItem = getToolbarButtonItems(this.aiDialogPopup)[0];
             const generateButtonOptions = generateButtonItem.options;
 
-            this.assertConfig(assert, generateButtonItem, {
+            assertConfig(assert, generateButtonItem, {
                 toolbar: 'bottom',
                 location: 'after',
                 widget: 'dxButton'
             });
-            this.assertConfig(assert, generateButtonOptions, {
+            assertConfig(assert, generateButtonOptions, {
                 stylingMode: 'contained',
                 type: 'default'
             });
@@ -797,12 +801,12 @@ QUnit.module('AIDialog', {}, () => {
             const stopToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[0];
             const stopButtonOptions = stopToolbarItem.options;
 
-            this.assertConfig(assert, stopToolbarItem, {
+            assertConfig(assert, stopToolbarItem, {
                 toolbar: 'bottom',
                 location: 'after',
                 widget: 'dxButton'
             });
-            this.assertConfig(assert, stopButtonOptions, {
+            assertConfig(assert, stopButtonOptions, {
                 stylingMode: 'contained',
                 type: 'default',
                 width: BUTTON_WIDTH
@@ -823,13 +827,13 @@ QUnit.module('AIDialog', {}, () => {
                 const copyToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[1];
                 const copyButtonOptions = copyToolbarItem.options;
 
-                this.assertConfig(assert, copyToolbarItem, {
+                assertConfig(assert, copyToolbarItem, {
                     toolbar: 'bottom',
                     location: 'after',
                     widget: 'dxButton',
                     locateInMenu: 'auto'
                 });
-                this.assertConfig(assert, copyButtonOptions, {
+                assertConfig(assert, copyButtonOptions, {
                     stylingMode: 'outlined',
                     icon: 'copy',
                 });
@@ -852,12 +856,12 @@ QUnit.module('AIDialog', {}, () => {
                 const tryAgainToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[0];
                 const tryAgainButtonOptions = tryAgainToolbarItem.options;
 
-                this.assertConfig(assert, tryAgainToolbarItem, {
+                assertConfig(assert, tryAgainToolbarItem, {
                     toolbar: 'bottom',
                     location: 'before',
                     widget: 'dxButton',
                 });
-                this.assertConfig(assert, tryAgainButtonOptions, {
+                assertConfig(assert, tryAgainButtonOptions, {
                     stylingMode: 'outlined',
                     icon: 'restore',
                 });
@@ -880,19 +884,19 @@ QUnit.module('AIDialog', {}, () => {
                 const replaceToolbarItem = getToolbarButtonItems(this.aiDialogPopup)[2];
                 const replaceButtonOptions = replaceToolbarItem.options;
 
-                this.assertConfig(assert, replaceToolbarItem, {
+                assertConfig(assert, replaceToolbarItem, {
                     toolbar: 'bottom',
                     location: 'after',
                     widget: 'dxDropDownButton',
                     locateInMenu: 'auto'
                 });
-                this.assertConfig(assert, replaceButtonOptions, {
+                assertConfig(assert, replaceButtonOptions, {
                     stylingMode: 'contained',
                     type: 'default',
                     splitButton: true,
                     useSelectMode: false,
                 });
-                this.assertConfig(assert, replaceButtonOptions.dropDownOptions, {
+                assertConfig(assert, replaceButtonOptions.dropDownOptions, {
                     width: REPLACE_DROPDOWN_WIDTH
                 });
                 assert.strictEqual(replaceButtonOptions.text, this.dictionary['dxHtmlEditor-aiReplace'], 'text is localized');
@@ -905,6 +909,143 @@ QUnit.module('AIDialog', {}, () => {
                     text: this.dictionary['dxHtmlEditor-aiInsertBelow']
                 }];
                 assert.deepEqual(replaceButtonOptions.items, expectedDropDownItems, 'items in dropdown are correct');
+
+                done();
+            });
+        });
+    });
+
+    QUnit.module('textArea config', integrationModuleConfig, () => {
+        QUnit.test('is correct for result textArea', function(assert) {
+            const done = assert.async();
+
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            this.resolve();
+
+            this.promise.then(() => {
+                const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
+
+                assertConfig(assert, resultTextAreaInstance.option(), {
+                    minHeight: TEXT_AREA_MIN_HEIGHT,
+                    width: '100%',
+                    readOnly: true,
+                    maxHeight: TEXT_AREA_MAX_HEIGHT,
+                    autoResizeEnabled: true,
+                });
+
+                done();
+            });
+        });
+    });
+
+    QUnit.module('prompt textArea config', {
+        beforeEach: function() {
+            this.initialLocale = localization.locale();
+            this.localizedAskAiPlaceholder = 'custom placeholder';
+            localization.loadMessages({
+                'ja': {
+                    'dxHtmlEditor-aiAskPlaceholder': this.localizedAskAiPlaceholder
+                }
+            });
+            localization.locale('ja');
+            integrationModuleConfig.beforeEach.apply(this);
+        },
+        afterEach: function() {
+            localization.locale(this.initialLocale);
+            integrationModuleConfig.afterEach.apply(this);
+        }
+    }, () => {
+        QUnit.test('is correct', function(assert) {
+            showAIDialog(this, {
+                config: { currentCommand: 'askAI' },
+            });
+
+            const promptTextAreaInstance = getPromptTextAreaInstance(this.$element);
+
+            assertConfig(assert, promptTextAreaInstance.option(), {
+                minHeight: TEXT_AREA_MIN_HEIGHT,
+                maxHeight: TEXT_AREA_MAX_HEIGHT,
+                autoResizeEnabled: true,
+                width: '100%',
+                placeholder: this.localizedAskAiPlaceholder,
+            });
+        });
+    });
+
+    QUnit.module('result textArea config on phone', {
+        beforeEach: function() {
+            this.realDevice = devices.real();
+            devices.real({ deviceType: 'phone' });
+            integrationModuleConfig.beforeEach.apply(this);
+        },
+        afterEach: function() {
+            devices.real(this.realDevice);
+            integrationModuleConfig.afterEach.apply(this);
+        }
+    }, () => {
+        QUnit.test('is correct', function(assert) {
+            const done = assert.async();
+
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            this.resolve();
+
+            this.promise.then(() => {
+                const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
+
+                assertConfig(assert, resultTextAreaInstance.option(), {
+                    minHeight: TEXT_AREA_MIN_HEIGHT,
+                    width: '100%',
+                    readOnly: true,
+                    maxHeight: '100%',
+                    height: '100%',
+                    autoResizeEnabled: false,
+                });
+
+
+                done();
+            });
+        });
+    });
+
+    QUnit.module('result textArea config on small screen', {
+        beforeEach: function() {
+            this.getDocumentElementStub = sinon.stub(domAdapter, 'getDocumentElement');
+            this.getDocumentElementStub.returns({
+                clientWidth: 300
+            });
+            integrationModuleConfig.beforeEach.apply(this);
+        },
+        afterEach: function() {
+            this.getDocumentElementStub.restore();
+            integrationModuleConfig.afterEach.apply(this);
+        }
+    }, () => {
+        QUnit.test('is correct', function(assert) {
+            const done = assert.async();
+
+            showAIDialog(this, {
+                config: { currentCommand: 'translate' },
+            });
+
+            this.resolve();
+
+            this.promise.then(() => {
+                const resultTextAreaInstance = getResultTextAreaInstance(this.$element);
+
+                assertConfig(assert, resultTextAreaInstance.option(), {
+                    minHeight: TEXT_AREA_MIN_HEIGHT,
+                    width: '100%',
+                    readOnly: true,
+                    maxHeight: '100%',
+                    height: '100%',
+                    autoResizeEnabled: false,
+                });
 
                 done();
             });


### PR DESCRIPTION
- hardcoded px width for generate and stop buttons is updated
- locateInMenu="auto" is set for copy and generate buttons
- copy and tryAgain button's text is hidden on mobile devices
- result textArea height is set to 100% for mobile devices (and fullScreen mode is used)