### PR TITLE
fix: popup title bar shows [object Object] when jQuery 4.0 Beta is used (T1280032)

### DIFF
--- a/packages/devextreme/js/__internal/core/utils/m_dom.ts
+++ b/packages/devextreme/js/__internal/core/utils/m_dom.ts
@@ -82,9 +82,13 @@ export const extractTemplateMarkup = (element) => {
 };
 
 export const normalizeTemplateElement = (element) => {
-  let $element = isDefined(element) && (element.nodeType || isRenderer(element))
-    ? $(element)
-    : $('<div>').html(element).contents();
+  let $element = $();
+
+  if (isDefined(element) && (element.nodeType || isRenderer(element))) {
+    $element = $(element);
+  } else if (typeof element === 'string') {
+    $element = $('<div>').html(element).contents();
+  }
 
   if ($element.length === 1) {
     if ($element.is('script')) {

--- a/packages/devextreme/js/__internal/core/utils/m_dom.ts
+++ b/packages/devextreme/js/__internal/core/utils/m_dom.ts
@@ -86,7 +86,7 @@ export const normalizeTemplateElement = (element) => {
 
   if (isDefined(element) && (element.nodeType || isRenderer(element))) {
     $element = $(element);
-  } else if (typeof element === 'string') {
+  } else if (typeof element !== 'object') {
     $element = $('<div>').html(element).contents();
   }
 

--- a/packages/devextreme/testing/tests/DevExpress.core/utils.dom.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.core/utils.dom.tests.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import domUtils from '__internal/core/utils/m_dom';
+import { EmptyTemplate } from '__internal/core/templates/m_empty_template';
 import support from '__internal/core/utils/m_support';
 import styleUtils from 'core/utils/style';
 import devices from '__internal/core/m_devices';
@@ -7,6 +8,36 @@ import initMobileViewport from 'common/core/environment/init_mobile_viewport';
 import keyboardMock from '../../helpers/keyboardMock.js';
 
 QUnit.module('createMarkup');
+
+QUnit.test('normalizeTemplateElement returns a wrapper if given an element', function(assert) {
+    const domElement = document.createElement('span');
+
+    domElement.innerHTML = 'Some text';
+
+    const $result = domUtils.normalizeTemplateElement(domElement);
+
+    assert.equal($result.length, 1, 'normalizeTemplateElement works with elements');
+    assert.equal($result[0].localName, 'span', 'normalizeTemplateElement works with elements');
+    assert.equal($result.text(), 'Some text', 'normalizeTemplateElement works with elements');
+});
+
+QUnit.test('normalizeTemplateElement returns a wrapper if given an HTML string', function(assert) {
+    const htmlString = '<span>Some text</span>';
+
+    const $result = domUtils.normalizeTemplateElement(htmlString);
+
+    assert.equal($result.length, 1, 'normalizeTemplateElement works with strings');
+    assert.equal($result[0].localName, 'span', 'normalizeTemplateElement works with strings');
+    assert.equal($result.text(), 'Some text', 'normalizeTemplateElement works with strings');
+});
+
+QUnit.test('normalizeTemplateElement returns an empty element for other inputs (T1280032) (jQuery 4)', function(assert) {
+    const template = new EmptyTemplate();
+
+    const $result = domUtils.normalizeTemplateElement(template);
+
+    assert.equal($result.length, 0, 'normalizeTemplateElement works with TemplateBase objects');
+});
 
 QUnit.test('normalizeTemplateElement with script element', function(assert) {
     const domElement = document.createElement('script');
@@ -17,7 +48,6 @@ QUnit.test('normalizeTemplateElement with script element', function(assert) {
 
     assert.equal($result.text(), 'Test', 'template based on script element works fine');
 });
-
 
 QUnit.module('clipboard');
 


### PR DESCRIPTION
In unexpected places, our components rendered `[object Object]` if ran under jQuery 4 Beta:

![image](https://github.com/user-attachments/assets/5ff4f968-29ea-4fc5-8800-f6b25b72cb28)

The customer noticed this in Popup header.
 
#### Cause

When the Popup renders the button, the Template Manager returns the EmptyTemplate
https://github.com/DevExpress/DevExtreme/blob/25_1/packages/devextreme/js/__internal/core/m_template_manager.ts#L147
 
The bad thing happens when we do this normalization with it:
https://github.com/DevExpress/DevExtreme/blob/25_1/packages/devextreme/js/__internal/core/utils/m_dom.ts#L87
 
We actually have always passed objects to `html()` but due to coincidences it worked.
In particular, `$("<div>").html(new EmptyTemplate())` gave the same childless `<div>` in jQuery 3, but in jQuery 4 `html()` returns a div with a child text node `[object, Object]`. This child text node later gets displayed.

> This is the offending jQuery change:
> https://github.com/jquery/jquery/commit/de5398a6ad088dc006b46c6a870a2a053f4cd663#diff-bf178e634ca0deb06cff569a5369f20c09ee63653a75de5ef94815e5cd7a15f3L26
> 
> The issue actually occurs when jQuery calls `.append(new EmptyTemplate())` (which happens inside `html()`).
> 
> We actually want jQuery to `jQuery.merge()` here. Previously, it did so, because the only check was that our `EmptyTemplate` instance is an object.
> 
> Starting from v4, jQuery also expects it to have either the `nodeType` or be an array-like. This is what our `EmptyTemplate` is unable to satisfy, so jQuery goes to line 31 and creates a text node out of the `EmptyTemplate`, which results in `[object, Object]`.
> 
> I suspect this may also happen to any descendants of our `TemplateBase`.
> According to the commit description, the change in jQuery was meant to support Trusted Types (https://web.dev/articles/trusted-types)
 
#### Fix

It looks like we should fix this normalization logic:
https://github.com/DevExpress/DevExtreme/blob/25_1/packages/devextreme/js/__internal/core/utils/m_dom.ts#L84
 
I assume line 86 (`$(element)`) is for elements and jQuery wrappers, and line 87 is for HTML markup strings.
My first instinct was to do `$('<div>').html(element).contents()` with only string values (it's for HTML markup after all).
 
But I quickly discovered that the element parameter here can be a Number as well, and we expect it to turn into a text node just like the strings...
 
So, I decided that we can probably end up with code like in the PR:
1) elements and wrappers go through the first path
2) non-objects go through `html()`
3) otherwise, meaning other object, result in empty wrapper by default.