### PR TITLE
CardView - Resolve path to @preact/signals-core in demos

### DIFF
--- a/apps/demos/configs/Angular/config.js
+++ b/apps/demos/configs/Angular/config.js
@@ -156,6 +156,10 @@ window.config = {
     'externals:': '../../../../bundles/externals/',
   },
   map: {
+    //
+    '@preact/signals-core': '../../../../../../node_modules/.pnpm/@preact+signals-core@1.8.0/node_modules/@preact/signals-core/dist/signals-core.js',
+    //
+
     'ts': 'npm:plugin-typescript/lib/plugin.js',
     'typescript': 'npm:typescript/lib/typescript.js',
     'jszip': 'npm:jszip/dist/jszip.min.js',

--- a/apps/demos/configs/React/config.js
+++ b/apps/demos/configs/React/config.js
@@ -49,6 +49,10 @@ window.config = {
   },
   defaultExtension: 'js',
   map: {
+    //
+    '@preact/signals-core': '../../../../../../node_modules/.pnpm/@preact+signals-core@1.8.0/node_modules/@preact/signals-core/dist/signals-core.js',
+    //
+
     'ts': 'npm:plugin-typescript/lib/plugin.js',
     'typescript': 'npm:typescript/lib/typescript.js',
     'jszip': 'npm:jszip/dist/jszip.min.js',

--- a/apps/demos/configs/ReactJs/config.js
+++ b/apps/demos/configs/ReactJs/config.js
@@ -49,6 +49,10 @@ window.config = {
   },
   defaultExtension: 'js',
   map: {
+    //
+    '@preact/signals-core': '../../../../../../node_modules/.pnpm/@preact+signals-core@1.8.0/node_modules/@preact/signals-core/dist/signals-core.js',
+    //
+
     'ts': 'npm:plugin-typescript/lib/plugin.js',
     'typescript': 'npm:typescript/lib/typescript.js',
     'react': 'npm:react/umd/react.development.js',

--- a/apps/demos/configs/Vue/config.js
+++ b/apps/demos/configs/Vue/config.js
@@ -46,6 +46,10 @@ window.config = {
     'externals:': '../../../../bundles/externals/',
   },
   map: {
+    //
+    '@preact/signals-core': '../../../../../../node_modules/.pnpm/@preact+signals-core@1.8.0/node_modules/@preact/signals-core/dist/signals-core.js',
+    //
+
     'vue': 'npm:vue/dist/vue.esm-browser.js',
     '@vue/shared': 'npm:@vue/shared/dist/shared.cjs.prod.js',
     'vue-loader': 'npm:dx-systemjs-vue-browser/index.js',


### PR DESCRIPTION
Initially added at #29430

We need smth like:
- https://github.com/DevExpress/DevExtreme/pull/29430/files#diff-5897ad2df8d10a21cd5f3c7aed850a73c3bfbe5f028f6105df7b4c92bdae1836R198
- https://github.com/DevExpress/DevExtreme/pull/29430/files#diff-fdd545a3e2db6573d33c5a66a34d514cc73fe1549556d124fa94e9657dcc3ca4R230-R231

but inside /apps/demos deps / subfolder, because it should be relative accessible from WG env

The initial commit just confirms a fix

---

Appears after #29455 (under all / framework tests)

Referenced in code:
 `packages\devextreme\js\__internal\grids\new\card_view\header_panel\view.tsx`

```
import { computed, type ReadonlySignal } from '@preact/signals-core';
```

Resolved to the `\node_modules\.pnpm\@preact+signals-core@1.8.0\node_modules\@preact\signals-core\dist\` path

Requested by SystemJs:
`devextreme/__internal/grids/new/card_view/header_panel/view.js`