### PR TITLE
HtmlEditorToolbarItem: Generate configuration components for AI commands 

### DIFF
--- a/apps/demos/Demos/HtmlEditor/AITextEditing/Vue/data.ts
+++ b/apps/demos/Demos/HtmlEditor/AITextEditing/Vue/data.ts
@@ -1,3 +1,5 @@
+import type { DxHtmlEditorTypes } from 'devextreme-vue/html-editor';
+
 export const AzureOpenAIConfig = {
   dangerouslyAllowBrowser: true,
   deployment: 'gpt-4o-mini',
@@ -6,7 +8,7 @@ export const AzureOpenAIConfig = {
   apiKey: 'DEMO',
 };
 
-export const commands = [
+export const commands: Array<DxHtmlEditorTypes.AICommand | DxHtmlEditorTypes.AICommandName> = [
   'summarize',
   'proofread',
   'expand',

--- a/packages/devextreme-angular/src/ui/html-editor/index.ts
+++ b/packages/devextreme-angular/src/ui/html-editor/index.ts
@@ -55,8 +55,10 @@ import { DxoTableContextMenuModule } from 'devextreme-angular/ui/nested';
 import { DxiItemModule } from 'devextreme-angular/ui/nested';
 import { DxoTableResizingModule } from 'devextreme-angular/ui/nested';
 import { DxoToolbarModule } from 'devextreme-angular/ui/nested';
+import { DxiCommandModule } from 'devextreme-angular/ui/nested';
 import { DxoVariablesModule } from 'devextreme-angular/ui/nested';
 
+import { DxiHtmlEditorCommandModule } from 'devextreme-angular/ui/html-editor/nested';
 import { DxoHtmlEditorConverterModule } from 'devextreme-angular/ui/html-editor/nested';
 import { DxoHtmlEditorFileUploaderOptionsModule } from 'devextreme-angular/ui/html-editor/nested';
 import { DxoHtmlEditorImageUploadModule } from 'devextreme-angular/ui/html-editor/nested';
@@ -1023,7 +1025,9 @@ export class DxHtmlEditorComponent extends DxComponent implements OnDestroy, Con
     DxiItemModule,
     DxoTableResizingModule,
     DxoToolbarModule,
+    DxiCommandModule,
     DxoVariablesModule,
+    DxiHtmlEditorCommandModule,
     DxoHtmlEditorConverterModule,
     DxoHtmlEditorFileUploaderOptionsModule,
     DxoHtmlEditorImageUploadModule,
@@ -1052,7 +1056,9 @@ export class DxHtmlEditorComponent extends DxComponent implements OnDestroy, Con
     DxiItemModule,
     DxoTableResizingModule,
     DxoToolbarModule,
+    DxiCommandModule,
     DxoVariablesModule,
+    DxiHtmlEditorCommandModule,
     DxoHtmlEditorConverterModule,
     DxoHtmlEditorFileUploaderOptionsModule,
     DxoHtmlEditorImageUploadModule,

--- a/packages/devextreme-angular/src/ui/html-editor/nested/command-dxi.ts
+++ b/packages/devextreme-angular/src/ui/html-editor/nested/command-dxi.ts
@@ -1,0 +1,94 @@
+/* tslint:disable:max-line-length */
+
+
+import {
+    Component,
+    NgModule,
+    Host,
+    SkipSelf,
+    Input
+} from '@angular/core';
+
+
+
+
+import { AICommandNameExtended } from 'devextreme/ui/html_editor';
+
+import {
+    DxIntegrationModule,
+    NestedOptionHost,
+} from 'devextreme-angular/core';
+import { CollectionNestedOption } from 'devextreme-angular/core';
+
+
+@Component({
+    selector: 'dxi-html-editor-command',
+    standalone: true,
+    template: '',
+    styles: [''],
+    imports: [ DxIntegrationModule ],
+    providers: [NestedOptionHost]
+})
+export class DxiHtmlEditorCommandComponent extends CollectionNestedOption {
+    @Input()
+    get name(): AICommandNameExtended {
+        return this._getOption('name');
+    }
+    set name(value: AICommandNameExtended) {
+        this._setOption('name', value);
+    }
+
+    @Input()
+    get options(): any {
+        return this._getOption('options');
+    }
+    set options(value: any) {
+        this._setOption('options', value);
+    }
+
+    @Input()
+    get prompt(): ((param: string) => string) {
+        return this._getOption('prompt');
+    }
+    set prompt(value: ((param: string) => string)) {
+        this._setOption('prompt', value);
+    }
+
+    @Input()
+    get text(): string {
+        return this._getOption('text');
+    }
+    set text(value: string) {
+        this._setOption('text', value);
+    }
+
+
+    protected get _optionPath() {
+        return 'commands';
+    }
+
+
+    constructor(@SkipSelf() @Host() parentOptionHost: NestedOptionHost,
+            @Host() optionHost: NestedOptionHost) {
+        super();
+        parentOptionHost.setNestedOption(this);
+        optionHost.setHost(this, this._fullOptionPath.bind(this));
+    }
+
+
+
+    ngOnDestroy() {
+        this._deleteRemovedOptions(this._fullOptionPath());
+    }
+
+}
+
+@NgModule({
+  imports: [
+    DxiHtmlEditorCommandComponent
+  ],
+  exports: [
+    DxiHtmlEditorCommandComponent
+  ],
+})
+export class DxiHtmlEditorCommandModule { }

--- a/packages/devextreme-angular/src/ui/html-editor/nested/index.ts
+++ b/packages/devextreme-angular/src/ui/html-editor/nested/index.ts
@@ -1,3 +1,4 @@
+export * from './command-dxi';
 export * from './converter';
 export * from './file-uploader-options';
 export * from './image-upload';

--- a/packages/devextreme-angular/src/ui/html-editor/nested/item-dxi.ts
+++ b/packages/devextreme-angular/src/ui/html-editor/nested/item-dxi.ts
@@ -32,6 +32,7 @@ import {
     DxTemplateHost
 } from 'devextreme-angular/core';
 import { CollectionNestedOption } from 'devextreme-angular/core';
+import { DxiHtmlEditorCommandComponent } from './command-dxi';
 
 
 @Component({
@@ -233,6 +234,14 @@ export class DxiHtmlEditorItemComponent extends CollectionNestedOption implement
         return 'items';
     }
 
+
+    @ContentChildren(forwardRef(() => DxiHtmlEditorCommandComponent))
+    get commandsChildren(): QueryList<DxiHtmlEditorCommandComponent> {
+        return this._getOption('commands');
+    }
+    set commandsChildren(value) {
+        this.setChildren('commands', value);
+    }
 
     @ContentChildren(forwardRef(() => DxiHtmlEditorItemComponent))
     get itemsChildren(): QueryList<DxiHtmlEditorItemComponent> {

--- a/packages/devextreme-angular/src/ui/html-editor/nested/item-dxi.ts
+++ b/packages/devextreme-angular/src/ui/html-editor/nested/item-dxi.ts
@@ -19,7 +19,7 @@ import {
 import { DOCUMENT } from '@angular/common';
 
 
-import { dxHtmlEditorTableContextMenuItem, HtmlEditorPredefinedContextMenuItem, HtmlEditorPredefinedToolbarItem } from 'devextreme/ui/html_editor';
+import { dxHtmlEditorTableContextMenuItem, HtmlEditorPredefinedContextMenuItem, HtmlEditorPredefinedToolbarItem, AICommand, AICommandName } from 'devextreme/ui/html_editor';
 import { LocateInMenuMode, ShowTextMode } from 'devextreme/ui/toolbar';
 import { ToolbarItemLocation, ToolbarItemComponent } from 'devextreme/common';
 
@@ -218,6 +218,14 @@ export class DxiHtmlEditorItemComponent extends CollectionNestedOption implement
     }
     set widget(value: ToolbarItemComponent) {
         this._setOption('widget', value);
+    }
+
+    @Input()
+    get commands(): Array<AICommand | AICommandName> {
+        return this._getOption('commands');
+    }
+    set commands(value: Array<AICommand | AICommandName>) {
+        this._setOption('commands', value);
     }
 
 

--- a/packages/devextreme-angular/src/ui/html-editor/nested/toolbar.ts
+++ b/packages/devextreme-angular/src/ui/html-editor/nested/toolbar.ts
@@ -17,7 +17,7 @@ import {
 
 
 
-import { dxHtmlEditorToolbarItem, HtmlEditorPredefinedToolbarItem } from 'devextreme/ui/html_editor';
+import { AIToolbarItem, dxHtmlEditorToolbarItem, HtmlEditorPredefinedToolbarItem } from 'devextreme/ui/html_editor';
 
 import {
     DxIntegrationModule,
@@ -46,10 +46,10 @@ export class DxoHtmlEditorToolbarComponent extends NestedOption implements OnDes
     }
 
     @Input()
-    get items(): Array<dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem> {
+    get items(): Array<AIToolbarItem | dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem> {
         return this._getOption('items');
     }
-    set items(value: Array<dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem>) {
+    set items(value: Array<AIToolbarItem | dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem>) {
         this._setOption('items', value);
     }
 

--- a/packages/devextreme-angular/src/ui/nested/base/button-group-item-dxi.ts
+++ b/packages/devextreme-angular/src/ui/nested/base/button-group-item-dxi.ts
@@ -16,7 +16,7 @@ import { ItemClickEvent } from 'devextreme/ui/drop_down_button';
 import { dxFileManagerContextMenuItem, FileManagerPredefinedContextMenuItem, FileManagerPredefinedToolbarItem } from 'devextreme/ui/file_manager';
 import { ButtonItem, EmptyItem, FormItemComponent, FormItemType, GroupItem, LabelLocation, SimpleItem, TabbedItem } from 'devextreme/ui/form';
 import { GanttPredefinedContextMenuItem, GanttPredefinedToolbarItem } from 'devextreme/ui/gantt';
-import { HtmlEditorPredefinedContextMenuItem, HtmlEditorPredefinedToolbarItem } from 'devextreme/ui/html_editor';
+import { AICommand, AICommandName, HtmlEditorPredefinedContextMenuItem, HtmlEditorPredefinedToolbarItem } from 'devextreme/ui/html_editor';
 import { dxMenuItem } from 'devextreme/ui/menu';
 import { Properties as dxSplitterOptions } from 'devextreme/ui/splitter';
 import { Properties as dxTabPanelOptions } from 'devextreme/ui/tab_panel';
@@ -488,6 +488,13 @@ export abstract class DxiButtonGroupItem extends CollectionNestedOption {
     }
     set formatValues(value: Array<string | number | boolean>) {
         this._setOption('formatValues', value);
+    }
+
+    get commands(): Array<AICommandName | AICommand> {
+        return this._getOption('commands');
+    }
+    set commands(value: Array<AICommandName | AICommand>) {
+        this._setOption('commands', value);
     }
 
     get key(): string {

--- a/packages/devextreme-angular/src/ui/nested/base/data-grid-toolbar.ts
+++ b/packages/devextreme-angular/src/ui/nested/base/data-grid-toolbar.ts
@@ -9,7 +9,7 @@ import { UserDefinedElement } from 'devextreme/core/element';
 import { DataGridPredefinedToolbarItem, dxDataGridToolbarItem } from 'devextreme/ui/data_grid';
 import { dxFileManagerToolbarItem, FileManagerPredefinedToolbarItem } from 'devextreme/ui/file_manager';
 import { dxGanttToolbarItem, GanttPredefinedToolbarItem } from 'devextreme/ui/gantt';
-import { dxHtmlEditorToolbarItem, HtmlEditorPredefinedToolbarItem } from 'devextreme/ui/html_editor';
+import { AIToolbarItem, dxHtmlEditorToolbarItem, HtmlEditorPredefinedToolbarItem } from 'devextreme/ui/html_editor';
 import { dxTreeListToolbarItem, TreeListPredefinedToolbarItem } from 'devextreme/ui/tree_list';
 
 @Component({
@@ -23,10 +23,10 @@ export abstract class DxoDataGridToolbar extends NestedOption {
         this._setOption('disabled', value);
     }
 
-    get items(): Array<dxDataGridToolbarItem | DataGridPredefinedToolbarItem | dxFileManagerToolbarItem | FileManagerPredefinedToolbarItem | dxGanttToolbarItem | GanttPredefinedToolbarItem | dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem | dxTreeListToolbarItem | TreeListPredefinedToolbarItem> {
+    get items(): Array<dxDataGridToolbarItem | DataGridPredefinedToolbarItem | dxFileManagerToolbarItem | FileManagerPredefinedToolbarItem | dxGanttToolbarItem | GanttPredefinedToolbarItem | dxHtmlEditorToolbarItem | AIToolbarItem | HtmlEditorPredefinedToolbarItem | dxTreeListToolbarItem | TreeListPredefinedToolbarItem> {
         return this._getOption('items');
     }
-    set items(value: Array<dxDataGridToolbarItem | DataGridPredefinedToolbarItem | dxFileManagerToolbarItem | FileManagerPredefinedToolbarItem | dxGanttToolbarItem | GanttPredefinedToolbarItem | dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem | dxTreeListToolbarItem | TreeListPredefinedToolbarItem>) {
+    set items(value: Array<dxDataGridToolbarItem | DataGridPredefinedToolbarItem | dxFileManagerToolbarItem | FileManagerPredefinedToolbarItem | dxGanttToolbarItem | GanttPredefinedToolbarItem | dxHtmlEditorToolbarItem | AIToolbarItem | HtmlEditorPredefinedToolbarItem | dxTreeListToolbarItem | TreeListPredefinedToolbarItem>) {
         this._setOption('items', value);
     }
 

--- a/packages/devextreme-angular/src/ui/nested/base/diagram-custom-command-dxi.ts
+++ b/packages/devextreme-angular/src/ui/nested/base/diagram-custom-command-dxi.ts
@@ -7,6 +7,7 @@ import {
 
 import { ToolbarItemLocation } from 'devextreme/common';
 import { Command, CustomCommand } from 'devextreme/ui/diagram';
+import { AICommandNameExtended } from 'devextreme/ui/html_editor';
 
 @Component({
     template: ''
@@ -33,10 +34,10 @@ export abstract class DxiDiagramCustomCommand extends CollectionNestedOption {
         this._setOption('location', value);
     }
 
-    get name(): Command | string {
+    get name(): Command | string | AICommandNameExtended {
         return this._getOption('name');
     }
-    set name(value: Command | string) {
+    set name(value: Command | string | AICommandNameExtended) {
         this._setOption('name', value);
     }
 
@@ -45,5 +46,19 @@ export abstract class DxiDiagramCustomCommand extends CollectionNestedOption {
     }
     set text(value: string) {
         this._setOption('text', value);
+    }
+
+    get options(): any {
+        return this._getOption('options');
+    }
+    set options(value: any) {
+        this._setOption('options', value);
+    }
+
+    get prompt(): Function {
+        return this._getOption('prompt');
+    }
+    set prompt(value: Function) {
+        this._setOption('prompt', value);
     }
 }

--- a/packages/devextreme-angular/src/ui/nested/command-dxi.ts
+++ b/packages/devextreme-angular/src/ui/nested/command-dxi.ts
@@ -36,7 +36,9 @@ import { DxiItemComponent } from './item-dxi';
         'items',
         'location',
         'name',
-        'text'
+        'text',
+        'options',
+        'prompt'
     ]
 })
 export class DxiCommandComponent extends DxiDiagramCustomCommand {

--- a/packages/devextreme-angular/src/ui/nested/item-dxi.ts
+++ b/packages/devextreme-angular/src/ui/nested/item-dxi.ts
@@ -31,6 +31,7 @@ import {
 import { DxiButtonGroupItem } from './base/button-group-item-dxi';
 import { DxiValidationRuleComponent } from './validation-rule-dxi';
 import { DxiTabComponent } from './tab-dxi';
+import { DxiCommandComponent } from './command-dxi';
 import { DxiLocationComponent } from './location-dxi';
 
 
@@ -158,6 +159,14 @@ export class DxiItemComponent extends DxiButtonGroupItem implements AfterViewIni
     }
     set tabsChildren(value) {
         this.setChildren('tabs', value);
+    }
+
+    @ContentChildren(forwardRef(() => DxiCommandComponent))
+    get commandsChildren(): QueryList<DxiCommandComponent> {
+        return this._getOption('commands');
+    }
+    set commandsChildren(value) {
+        this.setChildren('commands', value);
     }
 
     @ContentChildren(forwardRef(() => DxiLocationComponent))

--- a/packages/devextreme-angular/src/ui/nested/item-dxi.ts
+++ b/packages/devextreme-angular/src/ui/nested/item-dxi.ts
@@ -108,6 +108,7 @@ import { DxiLocationComponent } from './location-dxi';
         'acceptedValues',
         'formatName',
         'formatValues',
+        'commands',
         'key',
         'showChevron',
         'linkAttr',

--- a/packages/devextreme-react/src/html-editor.ts
+++ b/packages/devextreme-react/src/html-editor.ts
@@ -8,7 +8,7 @@ import dxHtmlEditor, {
 import { Component as BaseComponent, IHtmlOptions, ComponentRef, NestedComponentMeta } from "./core/component";
 import NestedOption from "./core/nested-option";
 
-import type { ContentReadyEvent, DisposingEvent, FocusInEvent, FocusOutEvent, InitializedEvent, ValueChangedEvent, HtmlEditorImageUploadMode, dxHtmlEditorImageUploadTabItem, HtmlEditorImageUploadTab, dxHtmlEditorTableContextMenuItem, HtmlEditorPredefinedContextMenuItem, HtmlEditorPredefinedToolbarItem, dxHtmlEditorToolbarItem } from "devextreme/ui/html_editor";
+import type { ContentReadyEvent, DisposingEvent, FocusInEvent, FocusOutEvent, InitializedEvent, ValueChangedEvent, HtmlEditorImageUploadMode, dxHtmlEditorImageUploadTabItem, HtmlEditorImageUploadTab, dxHtmlEditorTableContextMenuItem, HtmlEditorPredefinedContextMenuItem, HtmlEditorPredefinedToolbarItem, AICommand, AICommandName, AIToolbarItem, dxHtmlEditorToolbarItem } from "devextreme/ui/html_editor";
 import type { ContentReadyEvent as FileUploaderContentReadyEvent, DisposingEvent as FileUploaderDisposingEvent, InitializedEvent as FileUploaderInitializedEvent, ValueChangedEvent as FileUploaderValueChangedEvent, BeforeSendEvent, DropZoneEnterEvent, DropZoneLeaveEvent, FilesUploadedEvent, OptionChangedEvent, ProgressEvent, UploadAbortedEvent, UploadedEvent, UploadErrorEvent, UploadStartedEvent, UploadHttpMethod, FileUploadMode, dxFileUploaderOptions } from "devextreme/ui/file_uploader";
 import type { ValidationStatus, template, ToolbarItemLocation, ToolbarItemComponent } from "devextreme/common";
 import type { CollectionWidgetItem } from "devextreme/ui/collection/ui.collection_widget.base";
@@ -247,6 +247,7 @@ type IItemProps = React.PropsWithChildren<{
   options?: any;
   showText?: ShowTextMode;
   widget?: ToolbarItemComponent;
+  commands?: Array<AICommand | AICommandName>;
   render?: (...params: any) => React.ReactNode;
   component?: React.ComponentType<any>;
   menuItemRender?: (...params: any) => React.ReactNode;
@@ -443,7 +444,7 @@ const TableResizing = Object.assign<typeof _componentTableResizing, NestedCompon
 // HtmlEditor
 type IToolbarProps = React.PropsWithChildren<{
   container?: any | string;
-  items?: Array<dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem>;
+  items?: Array<AIToolbarItem | dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem>;
   multiline?: boolean;
 }>
 const _componentToolbar = (props: IToolbarProps) => {

--- a/packages/devextreme-react/src/html-editor.ts
+++ b/packages/devextreme-react/src/html-editor.ts
@@ -8,7 +8,7 @@ import dxHtmlEditor, {
 import { Component as BaseComponent, IHtmlOptions, ComponentRef, NestedComponentMeta } from "./core/component";
 import NestedOption from "./core/nested-option";
 
-import type { ContentReadyEvent, DisposingEvent, FocusInEvent, FocusOutEvent, InitializedEvent, ValueChangedEvent, HtmlEditorImageUploadMode, dxHtmlEditorImageUploadTabItem, HtmlEditorImageUploadTab, dxHtmlEditorTableContextMenuItem, HtmlEditorPredefinedContextMenuItem, HtmlEditorPredefinedToolbarItem, AICommand, AICommandName, AIToolbarItem, dxHtmlEditorToolbarItem } from "devextreme/ui/html_editor";
+import type { ContentReadyEvent, DisposingEvent, FocusInEvent, FocusOutEvent, InitializedEvent, ValueChangedEvent, AICommandNameExtended, HtmlEditorImageUploadMode, dxHtmlEditorImageUploadTabItem, HtmlEditorImageUploadTab, dxHtmlEditorTableContextMenuItem, HtmlEditorPredefinedContextMenuItem, HtmlEditorPredefinedToolbarItem, AICommand, AICommandName, AIToolbarItem, dxHtmlEditorToolbarItem } from "devextreme/ui/html_editor";
 import type { ContentReadyEvent as FileUploaderContentReadyEvent, DisposingEvent as FileUploaderDisposingEvent, InitializedEvent as FileUploaderInitializedEvent, ValueChangedEvent as FileUploaderValueChangedEvent, BeforeSendEvent, DropZoneEnterEvent, DropZoneLeaveEvent, FilesUploadedEvent, OptionChangedEvent, ProgressEvent, UploadAbortedEvent, UploadedEvent, UploadErrorEvent, UploadStartedEvent, UploadHttpMethod, FileUploadMode, dxFileUploaderOptions } from "devextreme/ui/file_uploader";
 import type { ValidationStatus, template, ToolbarItemLocation, ToolbarItemComponent } from "devextreme/common";
 import type { CollectionWidgetItem } from "devextreme/ui/collection/ui.collection_widget.base";
@@ -87,6 +87,28 @@ const HtmlEditor = memo(
   ),
 ) as (props: React.PropsWithChildren<IHtmlEditorOptions> & { ref?: Ref<HtmlEditorRef> }) => ReactElement | null;
 
+
+// owners:
+// Item
+type ICommandProps = React.PropsWithChildren<{
+  name?: AICommandNameExtended;
+  options?: any;
+  prompt?: ((param: string) => string);
+  text?: string;
+}>
+const _componentCommand = (props: ICommandProps) => {
+  return React.createElement(NestedOption<ICommandProps>, {
+    ...props,
+    elementDescriptor: {
+      OptionName: "commands",
+      IsCollectionItem: true,
+    },
+  });
+};
+
+const Command = Object.assign<typeof _componentCommand, NestedComponentMeta>(_componentCommand, {
+  componentType: "option",
+});
 
 // owners:
 // HtmlEditor
@@ -260,6 +282,7 @@ const _componentItem = (props: IItemProps) => {
       OptionName: "items",
       IsCollectionItem: true,
       ExpectedChildren: {
+        command: { optionName: "commands", isCollectionItem: true },
         item: { optionName: "items", isCollectionItem: true }
       },
       TemplateProps: [{
@@ -535,6 +558,8 @@ export {
   HtmlEditor,
   IHtmlEditorOptions,
   HtmlEditorRef,
+  Command,
+  ICommandProps,
   Converter,
   IConverterProps,
   FileUploaderOptions,

--- a/packages/devextreme-vue/src/html-editor.ts
+++ b/packages/devextreme-vue/src/html-editor.ts
@@ -23,6 +23,8 @@ import {
  dxHtmlEditorTableResizing,
  dxHtmlEditorToolbar,
  dxHtmlEditorVariables,
+ AICommandNameExtended,
+ AICommandName,
  HtmlEditorImageUploadMode,
  dxHtmlEditorImageUploadTabItem,
  HtmlEditorImageUploadTab,
@@ -30,7 +32,6 @@ import {
  HtmlEditorPredefinedContextMenuItem,
  HtmlEditorPredefinedToolbarItem,
  AICommand,
- AICommandName,
  AIToolbarItem,
  dxHtmlEditorToolbarItem,
 } from "devextreme/ui/html_editor";
@@ -239,6 +240,30 @@ prepareComponentConfig(componentConfig);
 
 const DxHtmlEditor = defineComponent(componentConfig);
 
+
+const DxCommandConfig = {
+  emits: {
+    "update:isActive": null,
+    "update:hoveredElement": null,
+    "update:name": null,
+    "update:options": null,
+    "update:prompt": null,
+    "update:text": null,
+  },
+  props: {
+    name: [Object, String] as PropType<AICommandNameExtended | AICommandName | "custom">,
+    options: {},
+    prompt: Function as PropType<((param: string) => string)>,
+    text: String
+  }
+};
+
+prepareConfigurationComponentConfig(DxCommandConfig);
+
+const DxCommand = defineComponent(DxCommandConfig);
+
+(DxCommand as any).$_optionName = "commands";
+(DxCommand as any).$_isCollectionItem = true;
 
 const DxConverterConfig = {
   emits: {
@@ -495,6 +520,7 @@ const DxItem = defineComponent(DxItemConfig);
 (DxItem as any).$_optionName = "items";
 (DxItem as any).$_isCollectionItem = true;
 (DxItem as any).$_expectedChildren = {
+  command: { isCollectionItem: true, optionName: "commands" },
   item: { isCollectionItem: true, optionName: "items" }
 };
 
@@ -749,6 +775,7 @@ const DxVariables = defineComponent(DxVariablesConfig);
 export default DxHtmlEditor;
 export {
   DxHtmlEditor,
+  DxCommand,
   DxConverter,
   DxFileUploaderOptions,
   DxImageUpload,

--- a/packages/devextreme-vue/src/html-editor.ts
+++ b/packages/devextreme-vue/src/html-editor.ts
@@ -29,6 +29,9 @@ import {
  dxHtmlEditorTableContextMenuItem,
  HtmlEditorPredefinedContextMenuItem,
  HtmlEditorPredefinedToolbarItem,
+ AICommand,
+ AICommandName,
+ AIToolbarItem,
  dxHtmlEditorToolbarItem,
 } from "devextreme/ui/html_editor";
 import {
@@ -437,6 +440,7 @@ const DxItemConfig = {
     "update:acceptedValues": null,
     "update:beginGroup": null,
     "update:closeMenuOnClick": null,
+    "update:commands": null,
     "update:cssClass": null,
     "update:disabled": null,
     "update:formatName": null,
@@ -461,6 +465,7 @@ const DxItemConfig = {
     acceptedValues: Array as PropType<Array<boolean | number | string>>,
     beginGroup: Boolean,
     closeMenuOnClick: Boolean,
+    commands: Array as PropType<Array<AICommand | AICommandName>>,
     cssClass: String,
     disabled: Boolean,
     formatName: String as PropType<HtmlEditorPredefinedToolbarItem | string>,
@@ -659,7 +664,7 @@ const DxToolbarConfig = {
   },
   props: {
     container: {},
-    items: Array as PropType<Array<dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem>>,
+    items: Array as PropType<Array<AIToolbarItem | dxHtmlEditorToolbarItem | HtmlEditorPredefinedToolbarItem>>,
     multiline: Boolean
   }
 };

--- a/packages/devextreme/js/ui/html_editor.d.ts
+++ b/packages/devextreme/js/ui/html_editor.d.ts
@@ -794,7 +794,7 @@ export interface dxHtmlEditorToolbar {
     container?: string | UserDefinedElement;
     /**
      * @docid
-     * @type Array<dxHtmlEditorToolbarItem,Enums.HtmlEditorPredefinedToolbarItem>
+     * @type Array<AIToolbarItem,dxHtmlEditorToolbarItem,Enums.HtmlEditorPredefinedToolbarItem>
      * @public
      */
     items?: Array<ToolbarItem | HtmlEditorPredefinedToolbarItem>;

--- a/packages/devextreme/js/ui/html_editor.d.ts
+++ b/packages/devextreme/js/ui/html_editor.d.ts
@@ -162,6 +162,7 @@ export interface AICustomCommand extends AICommandBase<'custom', string[]> {
  * @docid
  * @public
  * @namespace DevExpress.ui.dxHtmlEditor
+ * @inherits AIChangeStyleCommand,AIChangeToneCommand,AITranslateCommand,AICustomCommand
  */
 export type AICommand =
     | AICommandBase<'summarize', any>
@@ -794,7 +795,7 @@ export interface dxHtmlEditorToolbar {
     container?: string | UserDefinedElement;
     /**
      * @docid
-     * @type Array<AIToolbarItem,dxHtmlEditorToolbarItem,Enums.HtmlEditorPredefinedToolbarItem>
+     * @type Array<dxHtmlEditorToolbarItem,AIToolbarItem,Enums.HtmlEditorPredefinedToolbarItem>
      * @public
      */
     items?: Array<ToolbarItem | HtmlEditorPredefinedToolbarItem>;

--- a/tools/smd-cfg.json
+++ b/tools/smd-cfg.json
@@ -5,6 +5,10 @@
     "mutations": [
         {
             "kind": "remove",
+            "uid": "/ai-integration:AIIntegration"
+        },
+        {
+            "kind": "remove",
             "uid": "/card_view:CardHeader"
         },
         {
@@ -13,7 +17,7 @@
         },
         {
             "kind": "remove",
-            "uid": "/ai-integration:AIIntegration"
+            "uid": "/html_editor:AICommand"
         },
         {
             "kind": "remove",


### PR DESCRIPTION
Add missing AIToolbarItem type, using doctags. Regenerate wrappers. Fix in devextreme-internal-tools is required.
