### PR TITLE
ContextMenu, Popover: get rid of UserDefinedElement in used types

### DIFF
--- a/packages/devextreme/js/__internal/ui/context_menu/m_context_menu.ts
+++ b/packages/devextreme/js/__internal/ui/context_menu/m_context_menu.ts
@@ -10,7 +10,7 @@ import { addNamespace } from '@js/common/core/events/utils';
 import registerComponent from '@js/core/component_registrator';
 import devices from '@js/core/devices';
 import domAdapter from '@js/core/dom_adapter';
-import { getPublicElement, type UserDefinedElement } from '@js/core/element';
+import { getPublicElement } from '@js/core/element';
 import Guid from '@js/core/guid';
 import type { dxElementWrapper } from '@js/core/renderer';
 import $ from '@js/core/renderer';
@@ -70,7 +70,7 @@ const BORDER_WIDTH = 1;
 
 const window = getWindow();
 
-type ContextMenuTarget = string | UserDefinedElement | undefined;
+type ContextMenuTarget = string | dxElementWrapper | Element | undefined;
 
 type ShowContextMenuEvent = EventInfo<ContextMenu> & {
   target?: ContextMenuTarget;

--- a/packages/devextreme/js/__internal/ui/popover/m_popover.ts
+++ b/packages/devextreme/js/__internal/ui/popover/m_popover.ts
@@ -4,7 +4,7 @@ import eventsEngine from '@js/common/core/events/core/events_engine';
 import { addNamespace } from '@js/common/core/events/utils';
 import registerComponent from '@js/core/component_registrator';
 import domAdapter from '@js/core/dom_adapter';
-import { getPublicElement, type UserDefinedElement } from '@js/core/element';
+import { getPublicElement } from '@js/core/element';
 import type { DefaultOptionsRule } from '@js/core/options/utils';
 import type { dxElementWrapper } from '@js/core/renderer';
 import $ from '@js/core/renderer';
@@ -39,7 +39,7 @@ const POSITION_FLIP_MAP = {
   center: 'center',
 };
 
-type PopoverTarget = string | UserDefinedElement | undefined;
+type PopoverTarget = string | dxElementWrapper | Element | undefined;
 
 export interface PopoverProperties extends Omit<Properties,
 'onTitleRendered' | 'onHidden' | 'onHiding' | 'onShowing' | 'onShown'


### PR DESCRIPTION
Cherry pick of #30148 