### PR TITLE
Tabs: orientation selector was simplified from :not(.dx-tabs-vertical) to .dx-tabs-horizontal

### DIFF
--- a/packages/devextreme-scss/scss/widgets/base/_tabs.scss
+++ b/packages/devextreme-scss/scss/widgets/base/_tabs.scss
@@ -75,7 +75,7 @@
   }
 }
 
-.dx-tabs:not(.dx-tabs-vertical) .dx-tabs-scrollable .dx-tab {
+.dx-tabs.dx-tabs-horizontal .dx-tabs-scrollable .dx-tab {
   flex-basis: 100%;
   min-width: max-content;
 }
@@ -125,7 +125,7 @@
 }
 
 .dx-rtl {
-  &.dx-tabs:not(.dx-tabs-vertical) {
+  &.dx-tabs.dx-tabs-horizontal{
     flex-direction: row-reverse;
   }
 }

--- a/packages/devextreme-scss/scss/widgets/generic/tabPanel/layout/tab/_base.scss
+++ b/packages/devextreme-scss/scss/widgets/generic/tabPanel/layout/tab/_base.scss
@@ -24,13 +24,13 @@
   }
 }
 
-.dx-tabpanel-tabs .dx-tabs:not(.dx-tabs-vertical) {
+.dx-tabpanel-tabs .dx-tabs.dx-tabs-horizontal {
   .dx-tabpanel-tab {
     max-width: $generic-tabpanel-tabs-item-width;
   }
 }
 
-.dx-tabs-nav-buttons:not(.dx-tabs-vertical) {
+.dx-tabs-nav-buttons.dx-tabs-horizontal {
   .dx-tabpanel-tab {
     width: $generic-tabpanel-tabs-item-width;
     max-width: unset;

--- a/packages/devextreme-scss/scss/widgets/material/tabs/layout/tab/styling-mode/_primary.scss
+++ b/packages/devextreme-scss/scss/widgets/material/tabs/layout/tab/styling-mode/_primary.scss
@@ -15,7 +15,7 @@
 
 
 .dx-tabs-styling-mode-primary {
-  &.dx-tabs:not(.dx-tabs-vertical) .dx-tabs-scrollable .dx-tab {
+  &.dx-tabs.dx-tabs-horizontal .dx-tabs-scrollable .dx-tab {
     flex-basis: auto;
     min-width: $material-tab-min-width;
   }


### PR DESCRIPTION
Cherry-pick of #30150 
