### PR TITLE
Form: remove deprecated `resetValues` method

### DIFF
--- a/packages/devextreme/js/__internal/ui/form/m_form.ts
+++ b/packages/devextreme/js/__internal/ui/form/m_form.ts
@@ -1365,10 +1365,6 @@ class Form extends Widget<FormProperties> {
     this._clear();
   }
 
-  resetValues() {
-    this._clear();
-  }
-
   reset(editorsData) {
     this.updateRunTimeInfoForEachEditor((editor) => {
       const editorName = editor.option('name');

--- a/packages/devextreme/js/ui/form.d.ts
+++ b/packages/devextreme/js/ui/form.d.ts
@@ -360,13 +360,6 @@ export default class dxForm extends Widget<dxFormOptions> {
     clear(): void;
     /**
      * @docid
-     * @publicName resetValues()
-     * @public
-     * @deprecated dxForm.clear
-     */
-    resetValues(): void;
-    /**
-     * @docid
      * @publicName reset(editorsData)
      * @param1 editorsData:object
      * @public

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -18476,11 +18476,6 @@ declare module DevExpress.ui {
      */
     clear(): void;
     /**
-     * [descr:dxForm.resetValues()]
-     * @deprecated [depNote:dxForm.resetValues()]
-     */
-    resetValues(): void;
-    /**
      * [descr:dxForm.reset(editorsData)]
      */
     reset(editorsData?: Record<string, any>): void;


### PR DESCRIPTION
Docs:
- https://github.com/DevExpress/devextreme-documentation/pull/7744