### PR TITLE
Diagram: update the demo after making popup showing synchronous

### DIFF
--- a/apps/demos/Demos/Diagram/OperationRestrictions/Angular/app/app.component.html
+++ b/apps/demos/Demos/Diagram/OperationRestrictions/Angular/app/app.component.html
@@ -1,5 +1,4 @@
 <dx-diagram
-  id="diagram"
   (onRequestEditOperation)="requestEditOperationHandler($event)"
   (onRequestLayoutUpdate)="requestLayoutUpdateHandler($event)"
 >

--- a/apps/demos/Demos/Diagram/OperationRestrictions/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Diagram/OperationRestrictions/Angular/app/app.component.ts
@@ -1,12 +1,12 @@
 import {
-  NgModule, Component, ViewChild, enableProdMode,
+  NgModule, Component, enableProdMode,
 } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import notify from 'devextreme/ui/notify';
 import { ArrayStore } from 'devextreme-angular/common/data';
-import { DxDiagramModule, DxDiagramComponent, DxDiagramTypes } from 'devextreme-angular/ui/diagram';
+import { DxDiagramModule, DxDiagramTypes } from 'devextreme-angular/ui/diagram';
 import { Service } from './app.service';
 
 if (!/localhost/.test(document.location.host)) {
@@ -27,8 +27,6 @@ if (window && window.config?.packageConfigPaths) {
   preserveWhitespaces: true,
 })
 export class AppComponent {
-  @ViewChild(DxDiagramComponent, { static: false }) diagram: DxDiagramComponent;
-
   orgItemsDataSource: ArrayStore;
 
   constructor(service: Service) {
@@ -56,7 +54,7 @@ export class AppComponent {
   }
 
   requestEditOperationHandler(e) {
-    const diagram = this.diagram.instance;
+    const diagram = e.component.instance();
     if (e.operation === 'addShape') {
       if (e.args.shape.type !== 'employee' && e.args.shape.type !== 'team') {
         if (e.reason !== 'checkUIElementAvailability') { this.showToast("You can add only a 'Team' or 'Employee' shape."); }

--- a/apps/demos/Demos/Diagram/OperationRestrictions/React/App.tsx
+++ b/apps/demos/Demos/Diagram/OperationRestrictions/React/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback } from 'react';
 import Diagram, {
   CustomShape, Nodes, AutoLayout, ContextToolbox, Toolbox, PropertiesPanel, Group, type DiagramTypes,
 } from 'devextreme-react/diagram';
@@ -47,10 +47,8 @@ function itemStyleExpr(obj: { Type: string; }) {
 }
 
 export default function App() {
-  const diagramRef = useRef(null);
-
   const onRequestEditOperation = useCallback((e) => {
-    const diagram = diagramRef.current.instance();
+    const diagram = e.component.instance();
     if (e.operation === 'addShape') {
       if (e.args.shape.type !== 'employee' && e.args.shape.type !== 'team') {
         if (e.reason !== 'checkUIElementAvailability') {
@@ -123,7 +121,6 @@ export default function App() {
   return (
     <Diagram
       id="diagram"
-      ref={diagramRef}
       onRequestEditOperation={onRequestEditOperation}
       onRequestLayoutUpdate={onRequestLayoutUpdate}
     >

--- a/apps/demos/Demos/Diagram/OperationRestrictions/ReactJs/App.js
+++ b/apps/demos/Demos/Diagram/OperationRestrictions/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback } from 'react';
 import Diagram, {
   CustomShape,
   Nodes,
@@ -49,9 +49,8 @@ function itemStyleExpr(obj) {
   return { fill: '#bbefcb' };
 }
 export default function App() {
-  const diagramRef = useRef(null);
   const onRequestEditOperation = useCallback((e) => {
-    const diagram = diagramRef.current.instance();
+    const diagram = e.component.instance();
     if (e.operation === 'addShape') {
       if (e.args.shape.type !== 'employee' && e.args.shape.type !== 'team') {
         if (e.reason !== 'checkUIElementAvailability') {
@@ -123,7 +122,6 @@ export default function App() {
   return (
     <Diagram
       id="diagram"
-      ref={diagramRef}
       onRequestEditOperation={onRequestEditOperation}
       onRequestLayoutUpdate={onRequestLayoutUpdate}
     >

--- a/apps/demos/Demos/Diagram/OperationRestrictions/Vue/App.vue
+++ b/apps/demos/Demos/Diagram/OperationRestrictions/Vue/App.vue
@@ -1,7 +1,6 @@
 <template>
   <DxDiagram
     id="diagram"
-    ref="diagram"
     @request-edit-operation="onRequestEditOperation"
     @request-layout-update="onRequestLayoutUpdate"
   >
@@ -56,7 +55,6 @@
   </DxDiagram>
 </template>
 <script setup lang="ts">
-import { ref } from 'vue';
 import {
   DxDiagram,
   DxCustomShape,
@@ -76,7 +74,6 @@ const orgItemsDataSource = new ArrayStore({
   key: 'ID',
   data: service.getOrgItems(),
 });
-const diagram = ref();
 const shapes = ['team', 'employee'] as unknown as DxDiagramTypes.ShapeType[];
 
 const itemStyleExpr = ({ Type }) => ({
@@ -126,7 +123,7 @@ function onRequestEditOperation(e) {
     if (e.args.shape.type === 'team') {
       const connectorIds = e.args.shape.attachedConnectorIds;
       for (i = 0; i < connectorIds.length; i += 1) {
-        if (diagram.value.instance.getItemById(connectorIds[i]).toId !== e.args.shape.id) {
+        if (e.component.instance().getItemById(connectorIds[i]).toId !== e.args.shape.id) {
           if (e.reason !== 'checkUIElementAvailability') {
             showToast('You cannot delete a \'Team\' shape that has a child shape.');
           }

--- a/apps/demos/Demos/Diagram/OperationRestrictions/jQuery/index.js
+++ b/apps/demos/Demos/Diagram/OperationRestrictions/jQuery/index.js
@@ -50,7 +50,7 @@ $(() => {
       }
     },
     onRequestEditOperation(e) {
-      const diagram = $('#diagram').dxDiagram().dxDiagram('instance');
+      const diagram = e.component.instance();
       if (e.operation === 'addShape') {
         if (e.args.shape.type !== 'employee' && e.args.shape.type !== 'team') {
           if (e.reason !== 'checkUIElementAvailability') { showToast("You can add only a 'Team' or 'Employee' shape."); }


### PR DESCRIPTION
After https://github.com/DevExpress/DevExtreme/pull/30317, the React Diagram demo started failing because the callback is now called synchronously, while the ref to the Diagram’s container div is still null. Previously, rendering was asynchronous, giving React enough time to assign the ref.